### PR TITLE
Enable building the distributed backend

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
             ~/.stack
           key: ${{ runner.os }}
       - name: Install build prerequisites
-        run: sudo apt-get install -qy alex gcc happy haskell-stack libkqueue-dev libutf8proc-dev make
+        run: sudo apt-get install -qy alex gcc happy haskell-stack libkqueue-dev libprotobuf-c-dev libutf8proc-dev make
       - name: Install GHC && build dependencies
         run: cd ${{ github.workspace }}/compiler && make package.yaml && stack build --only-dependencies
       - name: Build actonc

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
             ~/.stack
           key: ${{ runner.os }}
       - name: Install build prerequisites
-        run: brew install haskell-stack protobuf-c
+        run: brew install haskell-stack protobuf-c util-linux
       - name: Install GHC && build dependencies
         run: cd ${{ github.workspace }}/compiler && make package.yaml && stack build --only-dependencies
       - name: Build actonc

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
             ~/.stack
           key: ${{ runner.os }}
       - name: Install build prerequisites
-        run: brew install haskell-stack protobuf-c util-linux
+        run: brew install argp-standalone haskell-stack protobuf-c util-linux
       - name: Install GHC && build dependencies
         run: cd ${{ github.workspace }}/compiler && make package.yaml && stack build --only-dependencies
       - name: Build actonc

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
             ~/.stack
           key: ${{ runner.os }}
       - name: Install build prerequisites
-        run: brew install haskell-stack
+        run: brew install haskell-stack protobuf-c
       - name: Install GHC && build dependencies
         run: cd ${{ github.workspace }}/compiler && make package.yaml && stack build --only-dependencies
       - name: Build actonc

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 all:
+	$(MAKE) -C backend
 	$(MAKE) -C compiler install
 	$(MAKE) -C modules
 	$(MAKE) -C builtin
@@ -11,6 +12,7 @@ test:
 
 clean:
 	rm -f actonc
+	$(MAKE) -C backend clean
 	$(MAKE) -C compiler clean
 	$(MAKE) -C modules clean
 	$(MAKE) -C builtin clean

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ work fairly well.
 ### Debian
 Install prerequisites
 ```
-apt install alex gcc happy haskell-stack libkqueue-dev libutf8proc-dev make
+apt install alex gcc happy haskell-stack libkqueue-dev libprotobuf-c-dev libutf8proc-dev make
 ```
 
 ## Build instructions

--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ Install prerequisites
 apt install alex gcc happy haskell-stack libkqueue-dev libprotobuf-c-dev libutf8proc-dev make
 ```
 
+### Mac OS X
+
+```
+brew install haskell-stack protobuf-c util-linux
+```
+
+
 ## Build instructions
 
 To build the project, simply run:

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ apt install alex gcc happy haskell-stack libkqueue-dev libprotobuf-c-dev libutf8
 ### Mac OS X
 
 ```
-brew install haskell-stack protobuf-c util-linux
+brew install argp-standalone haskell-stack protobuf-c util-linux
 ```
 
 

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -16,11 +16,13 @@ endif
 CFLAGS:=$(JEM_FLAGS) -Wno-int-to-pointer-cast -Wno-pointer-to-int-cast -g -O0
 LIBS:=$(JEM_LIBS)
 
-LFLAGS=#-luuid#-latomic -lm
+LFLAGS=-luuid#-latomic -lm
 
 LIBDIR=../lib
 
 SUBDIRS = failure_detector
+
+all: failure_detector skiplist_test libdb libcomm db_unit_tests queue_unit_tests actor_ring_tests_local actor_ring_tests_remote client server
 
 .PHONY: subdirs $(SUBDIRS)
 
@@ -29,7 +31,6 @@ subdirs: $(SUBDIRS)
 $(SUBDIRS):
 	$(MAKE) -C $@
 
-all: failure_detector skiplist_test libdb libcomm db_unit_tests queue_unit_tests actor_ring_tests_local actor_ring_tests_remote client server
 
 db.o:
 	cc db.c -c -I src $(LFLAGS) $(CFLAGS)
@@ -39,7 +40,7 @@ queue.o:
 
 skiplist.o:
 	cc skiplist.c -c -I src $(LFLAGS) $(CFLAGS)
-	
+
 # vector_clock.o:
 # 	cc failure_detector/vector_clock.c -c -I src $(LFLAGS) $(CFLAGS)
 
@@ -51,7 +52,7 @@ txns.o:
 
 comm.o:
 	cc comm.c -c -I src $(LFLAGS) $(CFLAGS)
-	
+
 client_api.o:
 	cc client_api.c -c -I src $(LFLAGS) $(CFLAGS)
 
@@ -87,13 +88,13 @@ actor_ring_tests_local: actor_ring_tests_local.c libdb
 		-ldb -lvc -lremote -lprotobuf-c $(LFLAGS) -pthread \
 		$(LIBS) \
 		-o actor_ring_tests_local
-		
+
 skiplist_test: skiplist_test.c skiplist.c
 	cc skiplist_test.c skiplist.c \
 		$(CFLAGS) -I ../src \
 		$(LFLAGS) -L/usr/local/opt/util-linux/lib \
 		-o skiplist_test
-		
+
 client: client.c libdb libdbclient
 	cc client.c \
 	 $(CFLAGS) \
@@ -103,7 +104,7 @@ client: client.c libdb libdbclient
 server: server.c libdb failure_detector
 	cc server.c \
 	 $(CFLAGS) \
-	 -L $(LIBDIR) -L/usr/local/opt/util-linux/lib -lremote -lcomm -ldb -lvc -lprotobuf-c -largp -pthread -luuid \
+	 -L $(LIBDIR) -L/usr/local/opt/util-linux/lib -lremote -lcomm -ldb -lvc -lprotobuf-c -pthread -luuid \
 	 -o server
 
 actor_ring_tests_remote: actor_ring_tests_remote.c libdb libdbclient failure_detector

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -20,6 +20,13 @@ LFLAGS=-luuid#-latomic -lm
 
 LIBDIR=../lib
 
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+	LARGP=-largp
+else
+	LARGP=
+endif
+
 SUBDIRS = failure_detector
 
 all: failure_detector skiplist_test libdb libcomm db_unit_tests queue_unit_tests actor_ring_tests_local actor_ring_tests_remote client server
@@ -97,13 +104,13 @@ skiplist_test: skiplist_test.c skiplist.c
 
 client: client.c libdb libdbclient
 	cc client.c \
-	 $(CFLAGS) \
+	 $(CFLAGS) $(LARGP) \
 	 -L $(LIBDIR) -L/usr/local/opt/util-linux/lib -ldbclient -lremote -lcomm -ldb -lvc -lprotobuf-c -pthread -luuid \
 	 -o client
 
 server: server.c libdb failure_detector
 	cc server.c \
-	 $(CFLAGS) \
+	 $(CFLAGS) $(LARGP) \
 	 -L $(LIBDIR) -L/usr/local/opt/util-linux/lib -lremote -lcomm -ldb -lvc -lprotobuf-c -pthread -luuid \
 	 -o server
 

--- a/backend/failure_detector/Makefile
+++ b/backend/failure_detector/Makefile
@@ -16,7 +16,7 @@ endif
 CFLAGS:=$(JEM_FLAGS) -Wno-int-to-pointer-cast -Wno-pointer-to-int-cast -g -O0
 LIBS:=$(JEM_LIBS)
 
-LFLAGS=#-luuid#-latomic -lm
+LFLAGS=-luuid#-latomic -lm
 
 LIBDIR=../../lib
 
@@ -27,7 +27,7 @@ vector_clock.o:
 
 db_messages.pb-c.c: db_messages.proto
 	protoc-c --c_out=. db_messages.proto
-	
+
 db_messages.pb-c.o: db_messages.pb-c.c
 	cc db_messages.pb-c.c -c $(LFLAGS) $(CFLAGS)
 
@@ -51,7 +51,7 @@ libremote: db_messages.pb-c.o cells.o db_queries.o fd.o $(LIBDIR)
 
 db_messages_test: db_messages_test.c libremote libvc
 	cc db_messages_test.c \
-		$(CFLAGS) -I ../src -I/usr/local/include \
+		$(CFLAGS) -I ../src -I/usr/local/include -I/usr/include \
 		-L $(LIBDIR) -L/usr/local/lib -L/usr/local/opt/util-linux/lib -lvc -lremote -pthread -lprotobuf-c $(LFLAGS) \
 		$(LIBS) \
 		-o db_messages_test

--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -343,9 +343,7 @@ buildExecutable env args paths task
         (sc,_)              = Acton.QuickType.schemaOf env (A.eQVar qn)
         outbase             = sysFile paths mn
         rootFile            = outbase ++ ".root.c"
-        -- enable for distributed backend support
-        --libFiles            = " -L " ++ joinPath [sysPath paths,"lib"] ++ " -lutf8proc -ldbclient -lremote -lcomm -ldb -lvc -lprotobuf-c -lActon "
-        libFiles            = " -L " ++ joinPath [sysPath paths,"lib"] ++ " -lutf8proc -lActon "
+        libFiles            = " -L " ++ joinPath [sysPath paths,"lib"] ++ " -lutf8proc -ldbclient -lremote -lcomm -ldb -lvc -lprotobuf-c -lActon "
         binFile             = dropExtension srcbase
         Just srcbase        = srcFile paths mn
         gccCmd              = "gcc -g -I /usr/include/kqueue -I" ++ sysPath paths ++ libFiles ++ rootFile ++ " -o" ++ binFile


### PR DESCRIPTION
This enabling building the distributed backend, including installing the pre-requisites, which differ a tad between Linux and OS X.