### PR TITLE
Make Acton work on Linux

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,5 +46,5 @@ jobs:
         run: cd ${{ github.workspace }}/compiler && make package.yaml && stack build --only-dependencies
       - name: Build actonc
         run: make -C ${{ github.workspace }}
-#      - name: Run tests
-#        run: make -C ${{ github.workspace }} test
+      - name: Run tests
+        run: make -C ${{ github.workspace }} test

--- a/builtin/bool.h
+++ b/builtin/bool.h
@@ -20,6 +20,6 @@ $bool $bool$new($value);
 $bool to$bool(long b);
 long from$bool($bool b);
 
-$bool $True, $False;
+extern $bool $True, $False;
 
 $bool $default__bool__($value);

--- a/builtin/minienv.c
+++ b/builtin/minienv.c
@@ -14,6 +14,9 @@
 
 #include "minienv.h"
 
+int kq;
+struct FileDescriptorData fd_data[MAX_FD];
+
 static void $init_FileDescriptorData(int fd) {
   fd_data[fd].kind = nohandler;
   bzero(fd_data[fd].buffer,BUF_SIZE);

--- a/builtin/minienv.h
+++ b/builtin/minienv.h
@@ -71,8 +71,8 @@ struct FileDescriptorData {
   int bufused;             //        -"-          ; nr of read chars in buffer. Equal to BUF_SIZE except before first read and (possibly) after last read.
 };
 
-struct FileDescriptorData fd_data[MAX_FD];
-int kq;
+extern struct FileDescriptorData fd_data[MAX_FD];
+extern int kq;
 
 void setupConnection (int fd);
 $str $getName(int fd);

--- a/builtin/serialize.h
+++ b/builtin/serialize.h
@@ -79,6 +79,6 @@ struct $Hashable$WORD {
     struct $Hashable$WORD$class *$class;
 };
 
-struct $Hashable$WORD$class $Hashable$WORD$methods;
+extern struct $Hashable$WORD$class $Hashable$WORD$methods;
 $Hashable$WORD $Hashable$WORD$new();
-struct $Hashable$WORD *$Hashable$WORD$witness;
+extern struct $Hashable$WORD *$Hashable$WORD$witness;


### PR DESCRIPTION
This avoids some multiple definition errors we see on Linux (Debian buster, gcc 10.2) and with it, the test suit passes.

This builds upon the fixes in #14. Using two PRs to let the work be reviewed independently.