### PR TITLE
Split make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
-all:
-	$(MAKE) -C backend
+all: compiler rts
+
+compiler:
 	$(MAKE) -C compiler install
+
+backend:
+	$(MAKE) -C backend
+
+rts: backend
 	$(MAKE) -C modules
 	$(MAKE) -C builtin
 	$(MAKE) -C rts
@@ -10,14 +16,20 @@ all:
 test:
 	$(MAKE) -C test
 
-clean:
+clean: clean-compiler clean-backend clean-rts
+
+clean-compiler:
 	rm -f actonc
-	$(MAKE) -C backend clean
 	$(MAKE) -C compiler clean
+
+clean-backend:
+	$(MAKE) -C backend clean
+
+clean-rts:
 	$(MAKE) -C modules clean
 	$(MAKE) -C builtin clean
 	$(MAKE) -C rts clean
 	$(MAKE) -C math clean
 	$(MAKE) -C numpy clean
 
-.PHONY: all clean test
+.PHONY: all compiler backend rts clean clean-compiler clean-backend clean-rts test


### PR DESCRIPTION
This makes it easier to recompile parts of Acton when we've only
modified one part.

A proper declarative Makefile would make this redundant, but until we
have that in place, this makes it a lot easier to iterate on changes.