### PR TITLE
Add Github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank_issue.md
+++ b/.github/ISSUE_TEMPLATE/blank_issue.md
@@ -1,0 +1,4 @@
+---
+name: Blank Issue
+about: Create a blank issue.
+---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,49 @@
+---
+name: "\U0001F41E  Bug Report"
+about: Create a bug report for Acton.
+labels: bug
+---
+<!--
+Before opening a new issue, please search existing issues:  https://github.com/actonlang/acton/issues
+
+Thank you for filing a bug report! 🐛 Please provide a short summary of the bug,
+along with any information you feel relevant to replicating the bug.
+-->
+
+**What did you do?**
+
+I tried this code:
+
+```Acton
+<code>
+```
+
+**What did you expect to happen?**
+
+I expected to see this happen: *explanation*
+
+```
+<expected output>
+```
+
+
+**What actually happened?**
+
+<!-- Please include the actual, raw output -->
+
+Instead, this happened: *explanation*
+
+```
+<actual output>
+```
+
+### Meta
+<!--
+If you're using a released version of the compiler, you should also check if the
+bug also exists in the beta or nightly versions.
+-->
+
+`actonc --version`:
+```
+<version>
+```

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 🗣 Ask a Question, Discuss
+    url: https://github.com/actonlang/acton/discussions
+    about: Please ask and answer questions about Acton using GitHub discussions.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,42 @@
+---
+name: Feature / Enhancement Request
+about: Suggest a new idea / feature enhancement for Acton.
+labels: enhancement
+---
+<!--
+Before opening a new issue, please search existing issues:  https://github.com/actonlang/acton/issues
+-->
+
+**Is your request related to a problem?**
+
+<!--
+  Provide a clear and concise description of what the problem is.
+  Ex. I have an issue when [...]
+-->
+
+(Write your answer here.)
+
+**Describe the solution you'd like**
+
+<!--
+  Provide a clear and concise description of what you want to happen.
+-->
+
+(Describe your proposed solution here.)
+
+**Describe alternatives you've considered**
+
+<!--
+  Let us know about other solutions you've tried or researched.
+-->
+
+(Write your answer here.)
+
+**Additional context**
+
+<!--
+  Is there anything else you can add about the proposal?
+  You might want to link to related issues here if you haven't already.
+-->
+
+(Write your answer here.)


### PR DESCRIPTION
There should now be four choices when creating a new issue:
- bug report
- feature request
- blank issue
- ask a question (redirecting to github discussions)