### PR TITLE
Add cc version information to --version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Added
+- `--version --verbose` will print verbose version information
+- internal compiler errors now include information about the C compiler (cc)
+
+
 ## [0.4.0](https://github.com/actonlang/acton/releases/tag/v0.4.0) (2021-07-23)
 
 ### Added


### PR DESCRIPTION
Change --version to print a simple version string for acton:

  acton 0.3.0.20210726.13.3.29

--version --verbose will include more information, like the cc version:

  acton 0.3.0.20210726.13.3.29
  compiled by ghc 8.10 on linux x86_64
  cc: cc (Debian 10.2.1-6) 10.2.1 20210110

We also include the cc version in the internal compiler error messages
as extra information. Also, printing of internal compiler error messages
has been lifted out into its own function.