### PR TITLE
rts: Add runtime args for DDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Added
+- distributed database backend is enabled in the RTS
+  - this was previously a build time flag
+  - it is now run time configuration via `--rts-ddb-host` and `--rts-ddb-port`
+  - see `examples/count` for a demo and instructions
+- RTS now has a `--rts-verbose` argument to make it more chatty
 
 ## [0.4.2](https://github.com/actonlang/acton/releases/tag/v0.4.2) (2021-08-05)
 

--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -382,7 +382,7 @@ buildExecutable env args paths task
         (sc,_)              = Acton.QuickType.schemaOf env (A.eQVar qn)
         outbase             = sysFile paths mn
         rootFile            = outbase ++ ".root.c"
-        libFilesBase        = " -L" ++ joinPath [sysPath paths,"lib"] ++ " -ldbclient -lremote -lcomm -ldb -lvc -lprotobuf-c -lActonProject -lActon -lm -lpthread -lutf8proc"
+        libFilesBase        = " -L" ++ joinPath [sysPath paths,"lib"] ++ " -lActonProject -lActon -ldbclient -lremote -luuid -lcomm -ldb -lprotobuf-c -lutf8proc -lvc -lpthread -lm"
 #if defined(linux_HOST_OS)
         libFiles            = libFilesBase ++  " -lkqueue"
 #elif defined(darwin_HOST_OS)

--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -382,11 +382,11 @@ buildExecutable env args paths task
         (sc,_)              = Acton.QuickType.schemaOf env (A.eQVar qn)
         outbase             = sysFile paths mn
         rootFile            = outbase ++ ".root.c"
-        libFilesBase        = " -L" ++ joinPath [sysPath paths,"lib"] ++ " -lActonProject -lActon -ldbclient -lremote -luuid -lcomm -ldb -lprotobuf-c -lutf8proc -lvc -lpthread -lm"
+        libFilesBase        = " -L" ++ joinPath [sysPath paths,"lib"] ++ " -lActonProject -lActon -ldbclient -lremote -luuid -lcomm -ldb -lvc -lprotobuf-c -lutf8proc -lpthread -lm"
 #if defined(linux_HOST_OS)
-        libFiles            = libFilesBase ++  " -lkqueue"
+        libFiles            = libFilesBase ++ " -lkqueue"
 #elif defined(darwin_HOST_OS)
-        libFiles            = libFilesBase
+        libFiles            = libFilesBase ++ " -L/usr/local/opt/util-linux/lib "
 -- Do we support anything else? Do a default clause for now...
 #else
         libFiles            = libFilesBase

--- a/examples/count.act
+++ b/examples/count.act
@@ -1,0 +1,52 @@
+# This is a simple illustration for demoing how the Acton RTS can persist its
+# run time state in the Acton distributed database backend. First start the
+# database:
+#
+#   ./server -p 32000 -m 34000 -s 127.0.0.1:34000
+#   ./server -p 32001 -m 34001 -s 127.0.0.1:34000
+#   ./server -p 32002 -m 34002 -s 127.0.0.1:34000
+#
+# Then compile and run this program. Abort its current invocation with ^C, then
+# restart the program and note how it will resume its state from the database
+# before counting further.
+#
+#   kll@Boxy:~/acton/examples$ ../actonc --root main count.act
+#   kll@Boxy:~/acton/examples$ ./count --rts-ddb-host localhost --rts-verbose
+#   Acton RTS: using distributed database backend (DDB): localhost:32000
+#   Acton RTS: checking for previous actor state in DDB... done
+#   0
+#   1
+#   2
+#   3
+#   4
+#   ^C
+#   kll@Boxy:~/acton/examples$ ./count --rts-ddb-host localhost --rts-verbose
+#   Acton RTS: using distributed database backend (DDB): localhost:32000
+#   Acton RTS: checking for previous actor state in DDB... done
+#   Acton RTS: restoring actor state from DDB... done
+#   5
+#   6
+#   7
+#   8
+#   ^C
+#   kll@Boxy:~/acton/examples$ ./count --rts-ddb-host localhost --rts-verbose
+#
+actor main(env):
+    var i = 0;
+    var count_to = 0
+
+    if len(env.argv) > 2:
+        print("Usage: count COUNT")
+        await async env.exit(1)
+
+    if len(env.argv) > 1:
+        count_to = int(env.argv[1])
+
+    def _work():
+        print(i)
+        if count_to and i == count_to:
+            await async env.exit(0)
+        i += 1
+        after 1: _work()
+
+    _work()

--- a/rts/rts.c
+++ b/rts/rts.c
@@ -641,7 +641,7 @@ void BOOTSTRAP(int argc, char *argv[]) {
     clock_gettime(CLOCK_MONOTONIC, &now);
     $Msg m = $NEW($Msg, ancestor0, &$NewRoot$cont, now.tv_sec, &$WriteRoot$cont);
 
-    if (db != NULL) {
+    if (db) {
         create_db_queue(env_actor->$globkey);
         create_db_queue(ancestor0->$globkey);
         int ret = remote_enqueue_in_txn(($WORD*)&m->$globkey, 1, NULL, 0, MSG_QUEUE, (WORD)ancestor0->$globkey, NULL, db);
@@ -758,7 +758,7 @@ void FLUSH_outgoing($Actor self, uuid_t *txnid) {
             ENQ_timed(m);
             dest = 0;
         }
-        if (db != NULL) {
+        if (db) {
             int ret = remote_enqueue_in_txn(($WORD*)&m->$globkey, 1, NULL, 0, MSG_QUEUE, (WORD)dest, txnid, db);
             //if (dest)
             //    printf("   # enqueue msg %ld to queue %ld returns %d\n", m->$globkey, dest, ret);
@@ -1058,7 +1058,7 @@ void serialize_actor($Actor a, uuid_t *txnid) {
 void FLUSH_offspring($Actor current, uuid_t *txnid) {
     $Actor a = current->$offspring;
     while (a) {
-        if (db != NULL) {
+        if (db) {
             create_db_queue(a->$globkey);
             a->$consume_hd = 0;
             serialize_actor(a, txnid);
@@ -1087,7 +1087,7 @@ void *main_loop(void *arg) {
             $R r = cont->$class->__call__(cont, val);
             switch (r.tag) {
                 case $RDONE: {
-                    if (db != NULL) {
+                    if (db) {
                         uuid_t * txnid = remote_new_txn(db);
                         current->$consume_hd++;
                         serialize_actor(current, txnid);
@@ -1138,7 +1138,7 @@ void *main_loop(void *arg) {
                     break;
                 }
                 case $RWAIT: {
-                    if (db != NULL) {
+                    if (db) {
                         uuid_t * txnid = remote_new_txn(db);
                         serialize_actor(current, txnid);
                         FLUSH_outgoing(current, txnid);
@@ -1169,7 +1169,7 @@ void *main_loop(void *arg) {
                 if (ENQ_msg(m, m->$to)) {
                     ENQ_ready(m->$to);
                 }
-                if (db != NULL) {
+                if (db) {
                     uuid_t *txnid = remote_new_txn(db);
                     timer_consume_hd++;
 
@@ -1273,7 +1273,7 @@ int main(int argc, char **argv) {
     int new_argc_dst = 0;
     // stop scanning once we've seen '--', passing the rest verbatim
     int opt_scan = 1;
-    for(int i = 0; i < argc; ++i) {
+    for (int i = 0; i < argc; ++i) {
         if (strcmp(argv[i], "--") == 0) opt_scan = 0;
         if (opt_scan) {
             for (int j = 0; j < lo_len; j++) {
@@ -1308,7 +1308,7 @@ int main(int argc, char **argv) {
         add_server_to_membership(ddb_host, ddb_port, db, &seed);
     }
 
-    if (db != NULL) {
+    if (db) {
         snode_t* start_row = NULL, * end_row = NULL;
         if (verbose) printf("Acton RTS: checking for previous actor state in DDB... ");
         fflush(stdout);

--- a/rts/rts.c
+++ b/rts/rts.c
@@ -1280,14 +1280,11 @@ int main(int argc, char **argv) {
                 // compare at +2 since in argv it is --foo while only foo in long_options
                 if (strcmp(argv[i]+2, long_options[j].name) == 0) {
                     if (long_options[j].has_arg == 1) i++;
-                    goto cnt; // abort inner loop
+                    goto cnt; // continue on outer loop
                 }
             }
         }
-        size_t length = strlen(argv[i])+1;
-        new_argv[new_argc_dst] = malloc(length);
-        memcpy(new_argv[new_argc_dst], argv[i], length);
-        new_argc_dst += 1;
+        new_argv[new_argc_dst++] = argv[i];
         cnt:;
     }
     new_argv[new_argc] = NULL;

--- a/rts/rts.c
+++ b/rts/rts.c
@@ -23,16 +23,18 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <uuid/uuid.h>
+#include <getopt.h>
 
 #include "rts.h"
 #include "../builtin/minienv.h"
 
-#define WITH_BACKEND 0
+// We want to pass through unknown arguments, so tell getopt to ignore invalid
+// (unknown to it) options
+extern int opterr;
+int opterr = 0;
 
-#if WITH_BACKEND
 #include "../backend/client_api.h"
 #include "../backend/fastrand.h"
-#endif
 
 #ifdef __gnu_linux__
     #define IS_GNU_LINUX
@@ -140,15 +142,13 @@ int64_t get_next_key() {
     return res;
 }
 
-#if WITH_BACKEND
 #define ACTORS_TABLE    ($WORD)0
 #define MSGS_TABLE      ($WORD)1
 #define MSG_QUEUE       ($WORD)2
 
 #define TIMER_QUEUE     0           // Special key in table MSG_QUEUE
 
-remote_db_t * db;
-#endif
+remote_db_t * db = NULL;
 
 ////////////////////////////////////////////////////////////////////////////////////////
 
@@ -619,7 +619,6 @@ struct $Cont $WriteRoot$cont = {
 };
 ////////////////////////////////////////////////////////////////////////////////////////
 
-#if WITH_BACKEND
 void dummy_callback(queue_callback_args * qca) { }
 
 void create_db_queue(long key) {
@@ -630,7 +629,6 @@ void create_db_queue(long key) {
 	ret = remote_subscribe_queue(($WORD)key, 0, 0, MSG_QUEUE, ($WORD)key, qc, &prev_read_head, &prev_consume_head, db);
     //printf("   # Subscribe queue %ld returns %d\n", key, ret);
 }
-#endif
 
 void BOOTSTRAP(int argc, char *argv[]) {
     $list args = $list$new(NULL,NULL);
@@ -643,12 +641,12 @@ void BOOTSTRAP(int argc, char *argv[]) {
     clock_gettime(CLOCK_MONOTONIC, &now);
     $Msg m = $NEW($Msg, ancestor0, &$NewRoot$cont, now.tv_sec, &$WriteRoot$cont);
 
-#if WITH_BACKEND
-    create_db_queue(env_actor->$globkey);
-    create_db_queue(ancestor0->$globkey);
-    int ret = remote_enqueue_in_txn(($WORD*)&m->$globkey, 1, NULL, 0, MSG_QUEUE, (WORD)ancestor0->$globkey, NULL, db);
-    //printf("   # enqueue bootstrap msg %ld to ancestor0 queue %ld returns %d\n", m->$globkey, ancestor0->$globkey, ret);
-#endif
+    if (db != NULL) {
+        create_db_queue(env_actor->$globkey);
+        create_db_queue(ancestor0->$globkey);
+        int ret = remote_enqueue_in_txn(($WORD*)&m->$globkey, 1, NULL, 0, MSG_QUEUE, (WORD)ancestor0->$globkey, NULL, db);
+        //printf("   # enqueue bootstrap msg %ld to ancestor0 queue %ld returns %d\n", m->$globkey, ancestor0->$globkey, ret);
+    }
 
     if (ENQ_msg(m, ancestor0)) {
         ENQ_ready(ancestor0);
@@ -760,20 +758,19 @@ void FLUSH_outgoing($Actor self, uuid_t *txnid) {
             ENQ_timed(m);
             dest = 0;
         }
-#if WITH_BACKEND
-        int ret = remote_enqueue_in_txn(($WORD*)&m->$globkey, 1, NULL, 0, MSG_QUEUE, (WORD)dest, txnid, db);
-        //if (dest)
-        //    printf("   # enqueue msg %ld to queue %ld returns %d\n", m->$globkey, dest, ret);
-        //else
-        //    printf("   # enqueue msg %ld to TIMER_QUEUE returns %d\n", m->$globkey, ret);
-#endif
+        if (db != NULL) {
+            int ret = remote_enqueue_in_txn(($WORD*)&m->$globkey, 1, NULL, 0, MSG_QUEUE, (WORD)dest, txnid, db);
+            //if (dest)
+            //    printf("   # enqueue msg %ld to queue %ld returns %d\n", m->$globkey, dest, ret);
+            //else
+            //    printf("   # enqueue msg %ld to TIMER_QUEUE returns %d\n", m->$globkey, ret);
+        }
         m = next;
     }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////
 
-#if WITH_BACKEND
 $dict globdict = NULL;
 
 $WORD try_globdict($WORD w) {
@@ -1057,19 +1054,18 @@ void serialize_actor($Actor a, uuid_t *txnid) {
         out = out->$next;
     }
 }
-#endif
 
 void FLUSH_offspring($Actor current, uuid_t *txnid) {
     $Actor a = current->$offspring;
     while (a) {
-#if WITH_BACKEND
-        create_db_queue(a->$globkey);
-        a->$consume_hd = 0;
-        serialize_actor(a, txnid);
-        FLUSH_outgoing(a, txnid);
-#else
-        FLUSH_outgoing(a, NULL);
-#endif
+        if (db != NULL) {
+            create_db_queue(a->$globkey);
+            a->$consume_hd = 0;
+            serialize_actor(a, txnid);
+            FLUSH_outgoing(a, txnid);
+        } else {
+            FLUSH_outgoing(a, NULL);
+        }
         $Actor b = a;
         a = a->$next;
         b->$next = NULL;
@@ -1091,29 +1087,29 @@ void *main_loop(void *arg) {
             $R r = cont->$class->__call__(cont, val);
             switch (r.tag) {
                 case $RDONE: {
-#if WITH_BACKEND
-                    uuid_t * txnid = remote_new_txn(db);
-                    current->$consume_hd++;
-                    serialize_actor(current, txnid);
-                    FLUSH_outgoing(current, txnid);
-                    serialize_msg(current->$msg, txnid);
-                    FLUSH_offspring(current, txnid);
+                    if (db != NULL) {
+                        uuid_t * txnid = remote_new_txn(db);
+                        current->$consume_hd++;
+                        serialize_actor(current, txnid);
+                        FLUSH_outgoing(current, txnid);
+                        serialize_msg(current->$msg, txnid);
+                        FLUSH_offspring(current, txnid);
 
-                    long key = current->$globkey;
-                    snode_t *m_start, *m_end;
-                    int entries_read = 0;
-                    int64_t read_head = -1;
-                    int ret0 = remote_read_queue_in_txn(($WORD)key, 0, 0, MSG_QUEUE, ($WORD)key, 1, &entries_read, &read_head, &m_start, &m_end, NULL, db);
-                    //printf("   # dummy read msg from queue %ld returns %d, entries read: %d\n", key, ret0, entries_read);
+                        long key = current->$globkey;
+                        snode_t *m_start, *m_end;
+                        int entries_read = 0;
+                        int64_t read_head = -1;
+                        int ret0 = remote_read_queue_in_txn(($WORD)key, 0, 0, MSG_QUEUE, ($WORD)key, 1, &entries_read, &read_head, &m_start, &m_end, NULL, db);
+                        //printf("   # dummy read msg from queue %ld returns %d, entries read: %d\n", key, ret0, entries_read);
 
-                    int ret = remote_consume_queue_in_txn(($WORD)key, 0, 0, MSG_QUEUE, ($WORD)key, read_head, txnid, db);
-                    //printf("   # consume msg %ld from queue %ld returns %d\n", m->$globkey, key, ret);
-                    remote_commit_txn(txnid, db);
-                    //printf("############## Commit\n\n");
-#else
-                    FLUSH_outgoing(current, NULL);
-                    FLUSH_offspring(current, NULL);
-#endif
+                        int ret = remote_consume_queue_in_txn(($WORD)key, 0, 0, MSG_QUEUE, ($WORD)key, read_head, txnid, db);
+                        //printf("   # consume msg %ld from queue %ld returns %d\n", m->$globkey, key, ret);
+                        remote_commit_txn(txnid, db);
+                        //printf("############## Commit\n\n");
+                    } else {
+                        FLUSH_outgoing(current, NULL);
+                        FLUSH_offspring(current, NULL);
+                    }
 
                     m->$value = r.value;                 // m->value holds the response,
                     $Actor b = FREEZE_waiting(m);        // so set m->cont = NULL and stop further m->waiting additions
@@ -1142,18 +1138,18 @@ void *main_loop(void *arg) {
                     break;
                 }
                 case $RWAIT: {
-#if WITH_BACKEND
-                    uuid_t * txnid = remote_new_txn(db);
-                    serialize_actor(current, txnid);
-                    FLUSH_outgoing(current, txnid);
-                    serialize_msg(current->$msg, txnid);
-                    FLUSH_offspring(current, txnid);
-                    remote_commit_txn(txnid, db);
-                    //printf("############## Commit\n\n");
-#else
-                    FLUSH_outgoing(current, NULL);
-                    FLUSH_offspring(current, NULL);
-#endif
+                    if (db != NULL) {
+                        uuid_t * txnid = remote_new_txn(db);
+                        serialize_actor(current, txnid);
+                        FLUSH_outgoing(current, txnid);
+                        serialize_msg(current->$msg, txnid);
+                        FLUSH_offspring(current, txnid);
+                        remote_commit_txn(txnid, db);
+                        //printf("############## Commit\n\n");
+                    } else {
+                        FLUSH_outgoing(current, NULL);
+                        FLUSH_offspring(current, NULL);
+                    }
                     m->$cont = r.cont;
                     $Msg x = ($Msg)r.value;
                     if (ADD_waiting(current, x)) {      // x->cont != NULL: x is still being processed so current was added to x->waiting
@@ -1173,24 +1169,24 @@ void *main_loop(void *arg) {
                 if (ENQ_msg(m, m->$to)) {
                     ENQ_ready(m->$to);
                 }
-#if WITH_BACKEND
-                uuid_t *txnid = remote_new_txn(db);
-                timer_consume_hd++;
+                if (db != NULL) {
+                    uuid_t *txnid = remote_new_txn(db);
+                    timer_consume_hd++;
 
-                long key = TIMER_QUEUE;
-                snode_t *m_start, *m_end;
-                int entries_read = 0;
-                int64_t read_head = -1;
-                int ret0 = remote_read_queue_in_txn(($WORD)key, 0, 0, MSG_QUEUE, ($WORD)key, 1, &entries_read, &read_head, &m_start, &m_end, NULL, db);
-                //printf("   # dummy read msg from TIMER_QUEUE returns %d, entries read: %d\n", ret0, entries_read);
+                    long key = TIMER_QUEUE;
+                    snode_t *m_start, *m_end;
+                    int entries_read = 0;
+                    int64_t read_head = -1;
+                    int ret0 = remote_read_queue_in_txn(($WORD)key, 0, 0, MSG_QUEUE, ($WORD)key, 1, &entries_read, &read_head, &m_start, &m_end, NULL, db);
+                    //printf("   # dummy read msg from TIMER_QUEUE returns %d, entries read: %d\n", ret0, entries_read);
 
-                int ret = remote_consume_queue_in_txn(($WORD)key, 0, 0, MSG_QUEUE, ($WORD)key, read_head, txnid, db);
-                //printf("   # consume msg %ld from TIMER_QUEUE returns %d\n", m->$globkey, ret);
-                int ret2 = remote_enqueue_in_txn(($WORD*)&m->$globkey, 1, NULL, 0, MSG_QUEUE, (WORD)m->$to->$globkey, txnid, db);
-                //printf("   # (timed) enqueue msg %ld to queue %ld returns %d\n", m->$globkey, m->$to->$globkey, ret2);
-                remote_commit_txn(txnid, db);
-                //printf("############## Commit\n\n");
-#endif
+                    int ret = remote_consume_queue_in_txn(($WORD)key, 0, 0, MSG_QUEUE, ($WORD)key, read_head, txnid, db);
+                    //printf("   # consume msg %ld from TIMER_QUEUE returns %d\n", m->$globkey, ret);
+                    int ret2 = remote_enqueue_in_txn(($WORD*)&m->$globkey, 1, NULL, 0, MSG_QUEUE, (WORD)m->$to->$globkey, txnid, db);
+                    //printf("   # (timed) enqueue msg %ld to queue %ld returns %d\n", m->$globkey, m->$to->$globkey, ret2);
+                    remote_commit_txn(txnid, db);
+                    //printf("############## Commit\n\n");
+                }
             } else {
                 if  ((int)arg==0) {
                     $eventloop();
@@ -1226,6 +1222,31 @@ void $register_rts () {
 ////////////////////////////////////////////////////////////////////////////////////////
 
 int main(int argc, char **argv) {
+    int ch = 0;
+    char *ddb_host = NULL;
+    int ddb_port = 32000;
+    int verbose = 0;
+
+    static struct option long_options[] = {
+        {"rts-verbose", no_argument, NULL, 'v'},
+        {"rts-ddb-host", required_argument, NULL, 'h'},
+        {"rts-ddb-port", required_argument, NULL, 'p'},
+        {NULL, 0, NULL, 0}
+    };
+    while ((ch = getopt_long(argc, argv, "", long_options, NULL)) != -1) {
+        switch (ch) {
+        case 'h':
+            ddb_host = optarg;
+            break;
+        case 'p':
+            ddb_port = atoi(optarg);
+            break;
+        case 'v':
+            verbose = 1;
+            break;
+        }
+    }
+
     long num_cores = sysconf(_SC_NPROCESSORS_ONLN);
     //    printf("%ld worker threads\n", num_cores);
     kq = kqueue();
@@ -1234,28 +1255,34 @@ int main(int argc, char **argv) {
     $register_rts();
     $ROOTINIT();
 
-#if WITH_BACKEND
     unsigned int seed;
-    GET_RANDSEED(&seed, 0);
-    db = get_remote_db(1);
-    add_server_to_membership("localhost", 32000, db, &seed);
-    
-    snode_t* start_row = NULL, * end_row = NULL;
-    int no_items = remote_read_full_table_in_txn(&start_row, &end_row, ACTORS_TABLE, NULL, db);
-    //printf("Found %d existing actors\n", no_items);
-    if (no_items > 0) {
-        printf("# (restoring system)\n");
-        deserialize_system(start_row);
-    } else {
-        int indices[] = {0};
-        db_schema_t* db_schema = db_create_schema(NULL, 1, indices, 1, indices, 0, indices, 0);
-        create_db_queue(TIMER_QUEUE);
-        timer_consume_hd = 0;
-        BOOTSTRAP(argc, argv);
+    if (ddb_host) {
+        if (verbose) printf("Acton RTS: using distributed database backend (DDB): %s:%d\n", ddb_host, ddb_port);
+        GET_RANDSEED(&seed, 0);
+        db = get_remote_db(1);
+        add_server_to_membership(ddb_host, ddb_port, db, &seed);
     }
-#else
-    BOOTSTRAP(argc, argv);
-#endif
+
+    if (db != NULL) {
+        snode_t* start_row = NULL, * end_row = NULL;
+        if (verbose) printf("Acton RTS: checking for previous actor state in DDB... ");
+        fflush(stdout);
+        int no_items = remote_read_full_table_in_txn(&start_row, &end_row, ACTORS_TABLE, NULL, db);
+        if (verbose) printf("done\n");
+        //printf("Found %d existing actors\n", no_items);
+        if (no_items > 0) {
+            if (verbose) printf("Acton RTS: restoring actor state from DDB... ");
+            fflush(stdout);
+            deserialize_system(start_row);
+            if (verbose) printf("done\n");
+        } else {
+            int indices[] = {0};
+            db_schema_t* db_schema = db_create_schema(NULL, 1, indices, 1, indices, 0, indices, 0);
+            create_db_queue(TIMER_QUEUE);
+            timer_consume_hd = 0;
+        }
+    }
+    BOOTSTRAP(new_argc, new_argv);
 
     pthread_key_create(&self_key, NULL);
     // start worker threads, one per CPU

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,2 +1,30 @@
+DDB_SERVER=../backend/server
 test:
 	$(MAKE) -C regression
+
+ddb_start:
+	$(DDB_SERVER) -p 32000 -m 34000 -s 127.0.0.1:34000 >db1.log 2>&1 &
+	sleep 0.1
+	$(DDB_SERVER) -p 32001 -m 34001 -s 127.0.0.1:34000 >db2.log 2>&1 &
+	sleep 0.1
+	$(DDB_SERVER) -p 32002 -m 34002 -s 127.0.0.1:34000 >db3.log 2>&1 &
+	sleep 0.1
+
+ddb_stop:
+	-pkill -f "server.*-s 127.0.0.1.34000"
+
+# This is a really naive test. We don't even check the output of the program so
+# we do not check that the actual persistence and restoration of state is
+# working. We assume that stuff will attempt to do its business and if anything
+# goes wrong, it will have catastrophic failure so that something will return an
+# incorrect return code and this test case can fail. This should really be
+# improved upon :)
+ddb_count:
+	$(MAKE) ddb_start
+	../actonc --root main count.act
+	./count 8 --rts-verbose --rts-ddb-host 127.0.0.1 &
+	sleep 5
+	pkill -f count.8
+	sleep 1
+	./count 8 --rts-verbose --rts-ddb-host 127.0.0.1
+	$(MAKE) ddb_stop

--- a/test/Makefile
+++ b/test/Makefile
@@ -28,3 +28,10 @@ ddb_count:
 	sleep 1
 	./count 8 --rts-verbose --rts-ddb-host 127.0.0.1
 	$(MAKE) ddb_stop
+
+
+argv:
+	../actonc --root main argv.act
+	./argv --rts-verbose foo --bar --rts-verbose
+
+.PHONY: argv

--- a/test/argv.act
+++ b/test/argv.act
@@ -1,0 +1,12 @@
+actor main(env):
+    var exp = ["./argv", "foo", "--bar"]
+    var i = 0
+    print("Expected:", exp)
+    print("env.argv:", env.argv)
+    for arg in env.argv:
+        if arg != exp[i]:
+            print("Oh noes:", arg, "!=", exp[i])
+            await async env.exit(1)
+        i += 1
+    print("All is well")
+    await async env.exit(0)

--- a/test/count.act
+++ b/test/count.act
@@ -1,0 +1,12 @@
+actor main(env):
+    var i = 0;
+    var count_to = int(env.args[-1])
+
+    def _work():
+        print(i)
+        if count_to and i == count_to:
+            await async env.exit(0)
+        i += 1
+        after 1: _work()
+
+    _work()


### PR DESCRIPTION
It is now possible to configure the RTS to use the distributed database
backend for storing the run time state of actors. It was previously
enabled through a build time flag and the database host and port was
hard-coded. There are two run time options:

--rts-ddb-host, the hostname to connect to
--rts-ddb-port, the TCP port to connect to, default is 32000

A third option, --rts-verbose, was also added to make the RTS a bit more
chatty about it is doing, in particular in regards to the backend.

An example, examples/count_forever, is added that shows how run time state persistence and restoration works.

I have been contemplating whether I should modify argc & argv before I pass it into the Acton application. My initial thought was no, let's not. Let's simply "reserve" that arguments starting with `--rts-` are for the run time system but still pass them on. This makes it possible for an Acton program to see how the RTS is started. But then I was thinking that we probably want to allow RTS introspection from an Acton program by `import acton.rts` and then something something. We don't have that though, so I figured passing args is fine... and as I was modifying I couldn't really make up my mind. Right now I feel I'm leaning towards stripping the rts args and passing modified versions of argc & argv to the Acton program but we don't have to do that in this PR either. This is already a marked improvement on things. Rome wasn't built in a day.

Do we need a test case? We already test that programs work without the RTS. I suppose we could write some simple program that works with the RTS. Again though, that could come in a different PR too.