### PR TITLE
Fix integer subtraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - `--version --verbose` will print verbose version information
 - internal compiler errors now include information about the C compiler (cc)
 
+### Fixed
+- integer subtraction has been fixed
+  - wrong order of operators would previously return wildly incorrect results
+
 
 ## [0.4.0](https://github.com/actonlang/acton/releases/tag/v0.4.0) (2021-07-23)
 

--- a/builtin/__builtin__.h
+++ b/builtin/__builtin__.h
@@ -1056,8 +1056,8 @@ $Rational $Rational$new();
 
 struct $Integral {
     $Integral$class $class;
-    $Logical w$Logical;
     $Minus w$Minus;
+    $Logical w$Logical;
 };
 
 struct $Integral$class {
@@ -1637,8 +1637,8 @@ $int $Hashable$str$__hash__ ($Hashable$str, $str);
 
 struct $Integral$int {
     $Integral$int$class $class;
-    $Logical w$Logical;
     $Minus w$Minus;
+    $Logical w$Logical;
 };
 
 struct $Integral$int$class {

--- a/builtin/int.c
+++ b/builtin/int.c
@@ -438,7 +438,7 @@ struct $Integral$int$class $Integral$int$methods = {
     $Integral$int$__invert__
 };
 
-struct $Integral$int $Integral$int_instance = {&$Integral$int$methods, ($Logical)&$Logical$int_instance, ($Minus)&$Minus$int_instance};
+struct $Integral$int $Integral$int_instance = {&$Integral$int$methods, ($Minus)&$Minus$int_instance, ($Logical)&$Logical$int_instance};
 $Integral$int $Integral$int$witness = &$Integral$int_instance;
 
 struct $Logical$int$class $Logical$int$methods =  {

--- a/test/regression/arithmetic_add.act
+++ b/test/regression/arithmetic_add.act
@@ -1,0 +1,12 @@
+actor main(env):
+    def testEqual(a, b, msg):
+        if a == b:
+            print(msg, "=", a, "as expected (", b, ")")
+        if a != b:
+            print("Assertion error:", a, "!=", b, "(" + msg + ")")
+            await async env.exit(1)
+
+    testEqual(0+1, 1, "0+1")
+    testEqual(1+2, 3, "1+2")
+
+    await async env.exit(0)

--- a/test/regression/arithmetic_divide.act
+++ b/test/regression/arithmetic_divide.act
@@ -1,0 +1,11 @@
+actor main(env):
+    def testEqual(a, b, msg):
+        if a == b:
+            print(msg, "=", a, "as expected (", b, ")")
+        if a != b:
+            print("Assertion error:", a, "!=", b, "(" + msg + ")")
+            await async env.exit(1)
+
+    testEqual(8/2, 4, "8/2")
+    testEqual(32/4, 8, "32/4")
+    await async env.exit(0)

--- a/test/regression/arithmetic_multiply.act
+++ b/test/regression/arithmetic_multiply.act
@@ -1,0 +1,12 @@
+actor main(env):
+    def testEqual(a, b, msg):
+        if a == b:
+            print(msg, "=", a, "as expected (", b, ")")
+        if a != b:
+            print("Assertion error:", a, "!=", b, "(" + msg + ")")
+            await async env.exit(1)
+
+    testEqual(4*5, 20, "4*5")
+    testEqual(112*3, 336, "112*3")
+
+    await async env.exit(0)

--- a/test/regression/arithmetic_subtract.act
+++ b/test/regression/arithmetic_subtract.act
@@ -1,0 +1,12 @@
+actor main(env):
+    def testEqual(a, b, msg):
+        if a == b:
+            print(msg, "=", a, "as expected (", b, ")")
+        if a != b:
+            print("Assertion error:", a, "!=", b, "(" + msg + ")")
+            await async env.exit(1)
+
+    testEqual(5-3, 2, "5-3")
+    testEqual(432-75, 357, "432-75")
+
+    await async env.exit(0)

--- a/test/regression/subtract_off_by_one.act
+++ b/test/regression/subtract_off_by_one.act
@@ -1,5 +1,0 @@
-actor main(env):
-    if 5-3 != 2:
-        await async env.exit(1)
-
-    await async env.exit(0)


### PR DESCRIPTION
Wrong order of operators meant simple subtraction would return wildly
incorrect results. Now righted the order! Order has been restored to the
galaxy.

Test cases have been added, pushed in a separate commit so we can see how the tests fails before the fix.