### PR TITLE
Link Acton libs in right order

### DIFF
--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -382,7 +382,7 @@ buildExecutable env args paths task
         (sc,_)              = Acton.QuickType.schemaOf env (A.eQVar qn)
         outbase             = sysFile paths mn
         rootFile            = outbase ++ ".root.c"
-        libFilesBase        = " -L" ++ joinPath [sysPath paths,"lib"] ++ " -ldbclient -lremote -lcomm -ldb -lvc -lprotobuf-c -lActon -lActonProject -lm -lpthread -lutf8proc"
+        libFilesBase        = " -L" ++ joinPath [sysPath paths,"lib"] ++ " -ldbclient -lremote -lcomm -ldb -lvc -lprotobuf-c -lActonProject -lActon -lm -lpthread -lutf8proc"
 #if defined(linux_HOST_OS)
         libFiles            = libFilesBase ++  " -lkqueue"
 #elif defined(darwin_HOST_OS)


### PR DESCRIPTION
We got to link with libActonProject first, since this is where our
project specific things are, which can reference things (builtins /
stdlib) in libActon. This means -lActonProject goes before -lActon!