### PR TITLE
Add simple time module

### DIFF
--- a/modules/Makefile
+++ b/modules/Makefile
@@ -7,6 +7,9 @@ __builtin__.ty: __builtin__.act
 math.ty: math.act __builtin__.ty
 	$(ACTONC) --stub math.act
 
+time.ty: time.act __builtin__.ty
+	$(ACTONC) --stub time.act
+
 numpy.ty: numpy.act math.ty
 	$(ACTONC) --stub numpy.act
 

--- a/modules/time.act
+++ b/modules/time.act
@@ -1,0 +1,36 @@
+# Copyright (C) 2019-2021 Data Ductus AB
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+#    may be used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+protocol RealFuns:
+    @staticmethod
+    time       : (Self) -> Self
+
+extension float (RealFuns): pass
+
+def time(x):
+   return RealFuns.time(x)

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,2 +1,10 @@
+ACTONC=../actonc
+
 test:
 	$(MAKE) -C regression
+
+time:
+	$(ACTONC) --root main time.act
+	./time $(shell date "+%s")
+
+.PHONY: time

--- a/test/time.act
+++ b/test/time.act
@@ -1,0 +1,11 @@
+import time
+
+actor main(env):
+    var now = int(time.time(0))
+    var now_seconds = (int(now / 1000000000))
+    var diff = now_seconds - int(env.argv[1])
+    print("diff:", diff)
+    if int(diff) > 5:
+        print("ERROR: diff seems too large, time.time() should be roughly same as provided UNIX timestamp input")
+        await async env.exit(1)
+    await async env.exit(0)

--- a/time/Makefile
+++ b/time/Makefile
@@ -1,0 +1,13 @@
+ifeq ($(shell uname -s),Linux)
+CFLAGS += -I/usr/include/kqueue
+endif
+
+all: time.o
+
+time.o: time.h time.c
+	cc $(CFLAGS) -I.. -c time.c
+	ar rc ../lib/libActon.a time.o
+	cp time.h ../modules
+
+clean:
+	rm -f time.o

--- a/time/time.c
+++ b/time/time.c
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2019-2021 Data Ductus AB
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "time/time.h"
+#include <time.h>
+
+
+$NoneType time$$RealFuns$__init__ (time$$RealFuns w$self) {
+    return $None;
+}
+time$$RealFuns time$$RealFuns$new() {
+    time$$RealFuns $tmp = malloc(sizeof(struct time$$RealFuns));
+    $tmp->$class = &time$$RealFuns$methods;
+    time$$RealFuns$methods.__init__($tmp);
+    return $tmp;
+}
+struct time$$RealFuns$class time$$RealFuns$methods;
+$NoneType time$$RealFuns$float$__init__ (time$$RealFuns$float w$self) {
+    time$$RealFuns$methods.__init__((time$$RealFuns)w$self);
+    return $None;
+}
+
+$NoneType time$$RealFuns$float$__serialize__(time$$RealFuns$float wit, $Serial$state state) {
+    return $None;
+}
+
+time$$RealFuns$float time$$RealFuns$float$__deserialize__(time$$RealFuns$float wit, $Serial$state state) {
+    time$$RealFuns$float res = $DNEW(time$$RealFuns$float,state);
+    return res;
+}
+$str time$$RealFuns$float$time(time$$RealFuns$float wit, $float x) {
+  struct timespec ts;
+  if (clock_gettime(CLOCK_REALTIME, &ts) == -1) {
+    perror("clock_gettime");
+    exit(EXIT_FAILURE);
+  }
+  return to$int(ts.tv_sec * 1000000000 + ts.tv_nsec);
+}
+
+time$$RealFuns$float time$$RealFuns$float$new() {
+    time$$RealFuns$float $tmp = malloc(sizeof(struct time$$RealFuns$float));
+    $tmp->$class = &time$$RealFuns$float$methods;
+    time$$RealFuns$float$methods.__init__($tmp);
+    return $tmp;
+}
+struct time$$RealFuns$float$class time$$RealFuns$float$methods;
+int time$$done$ = 0;
+void time$$__init__ () {
+    if (time$$done$) return;
+    time$$done$ = 1;
+    {
+        time$$RealFuns$methods.$GCINFO = "time$$RealFuns";
+        time$$RealFuns$methods.$superclass = NULL;
+        time$$RealFuns$methods.__init__ = time$$RealFuns$__init__;
+        $register(&time$$RealFuns$methods);
+    }
+    {
+        time$$RealFuns$float$methods.$GCINFO = "time$$RealFuns$float";
+        time$$RealFuns$float$methods.$superclass = ($Super$class)&time$$RealFuns$methods;
+        time$$RealFuns$float$methods.__serialize__ = time$$RealFuns$float$__serialize__,
+        time$$RealFuns$float$methods.__deserialize__ = time$$RealFuns$float$__deserialize__,
+        time$$RealFuns$float$methods.__bool__ = ($bool (*)(time$$RealFuns$float))$default__bool__,
+        time$$RealFuns$float$methods.__str__ = ($str (*)(time$$RealFuns$float))$default__str__,
+        time$$RealFuns$float$methods.__init__ = time$$RealFuns$float$__init__;
+        time$$RealFuns$float$methods.time = time$$RealFuns$float$time;
+        $register(&time$$RealFuns$float$methods);
+    }
+}
+
+$WORD time$$time (time$$RealFuns wit, $WORD x) {
+  return wit->$class->time(wit,x);
+}

--- a/time/time.h
+++ b/time/time.h
@@ -1,0 +1,42 @@
+#pragma once
+#include "builtin/builtin.h"
+#include "builtin/minienv.h"
+#include "rts/rts.h"
+struct time$$RealFuns;
+typedef struct time$$RealFuns *time$$RealFuns;
+struct time$$RealFuns$class {
+    char *$GCINFO;
+    $int $class_id;
+    $Super$class $superclass;
+    $NoneType (*__init__) (time$$RealFuns);
+    $NoneType (*__serialize__) (time$$RealFuns, $Serial$state);
+    time$$RealFuns (*__deserialize__) (time$$RealFuns, $Serial$state);
+    $bool (*__bool__)(time$$RealFuns);
+    $str (*__str__)(time$$RealFuns);
+    $WORD (*time) (time$$RealFuns, $WORD);
+};
+struct time$$RealFuns {
+    struct time$$RealFuns$class *$class;
+};
+extern struct time$$RealFuns$class time$$RealFuns$methods;
+time$$RealFuns time$$RealFuns$new();
+struct time$$RealFuns$float;
+typedef struct time$$RealFuns$float *time$$RealFuns$float;
+struct time$$RealFuns$float$class {
+    char *$GCINFO;
+    $int $class_id;
+    $Super$class $superclass;
+    $NoneType (*__init__) (time$$RealFuns$float);
+    $NoneType (*__serialize__) (time$$RealFuns$float, $Serial$state);
+    time$$RealFuns$float (*__deserialize__) (time$$RealFuns$float, $Serial$state);
+    $bool (*__bool__)(time$$RealFuns$float);
+    $str (*__str__)(time$$RealFuns$float);
+    int (*time) (time$$RealFuns$float, $float);
+};
+struct time$$RealFuns$float {
+    struct time$$RealFuns$float$class *$class;
+};
+extern struct time$$RealFuns$float$class time$$RealFuns$float$methods;
+time$$RealFuns$float time$$RealFuns$float$new();
+$WORD time$$time (time$$RealFuns, $WORD);
+void time$$__init__ ();


### PR DESCRIPTION
This adds a time module to Acton. It exposes a single function, time(x),
which returns the current time as an integer with nanosecond precision.

time(x) currently takes an argument, though its value is irrelevant.
It's a dummy. I tried to remove the argument but  that breaks the build
and I don't get why. Halp.

I'm not sure how we should design our time module. Like we can model it
directly on Python's time module or we can do something else...
something better!? It's low level enough that I'm not sure it matters
making it more Pythonic / Actonic.

There is a simple test of time.time(x).

Closes #18 

## TODO
- [ ] remove argument from `time.time()`
- [ ] sanity check the code by @nordlander or @sydow 