### PR TITLE
Build & upload release artifacts in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
-name: Compile
+name: Test
 on: [push]
 jobs:
-  build-and-test-on-macosx:
+  test-darwin:
     runs-on: macos-latest
     steps:
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
@@ -22,10 +22,17 @@ jobs:
         run: cd ${{ github.workspace }}/compiler && make package.yaml && stack build --only-dependencies
       - name: Build actonc
         run: make -C ${{ github.workspace }}
+      - name: Build a release
+        run: make -C ${{ github.workspace }} release
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: acton-darwin
+          path: ${{ github.workspace }}/acton-darwin-x86_64*
       - name: Run tests
         run: make -C ${{ github.workspace }} test
 
-  build-and-test-on-linux:
+  test-linux:
     runs-on: ubuntu-latest
     steps:
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
@@ -46,5 +53,12 @@ jobs:
         run: cd ${{ github.workspace }}/compiler && make package.yaml && stack build --only-dependencies
       - name: Build actonc
         run: make -C ${{ github.workspace }}
+      - name: Build a release
+        run: make -C ${{ github.workspace }} release
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: acton-linux
+          path: ${{ github.workspace }}/acton-linux-x86_64*
       - name: Run tests
         run: make -C ${{ github.workspace }} test

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+include common.mk
+
 all: compiler rts
 
 compiler:
@@ -32,4 +34,17 @@ clean-rts:
 	$(MAKE) -C math clean
 	$(MAKE) -C numpy clean
 
-.PHONY: all compiler backend rts clean clean-compiler clean-backend clean-rts test
+ARCH=$(shell uname -s -m | sed -e 's/ /-/' | tr '[A-Z]' '[a-z]')
+RELEASE_MANIFEST=actonc backend builtin lib math modules numpy rts
+GNU_TAR := $(shell ls --version 2>&1 | grep GNU >/dev/null 2>&1; echo $$?)
+ifeq ($(GNU_TAR),0)
+TAR_TRANSFORM_OPT=--transform 's,^,acton/,'
+else
+TAR_TRANSFORM_OPT=-s ,^,acton/,
+endif
+acton-$(ARCH)-$(VERSION).tar.bz2:
+	tar jcvf $@ $(TAR_TRANSFORM_OPT) $(RELEASE_MANIFEST)
+
+release: acton-$(ARCH)-$(VERSION).tar.bz2
+
+.PHONY: all compiler backend rts clean clean-compiler clean-backend clean-rts test release acton-$(ARCH)-$(VERSION).tar.bz2


### PR DESCRIPTION
This adds a new make target to produce a tar ball of Acton. We run this
in CI and upload the result as an artifact.

Part of #4.