### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -1,10 +1,9 @@
-name: Test
+name: Release
+
 on:
   push:
-    branches:
-      - '**'
-    tags-ignore:
-      - '**'
+    tags:
+      - "v*.*"
 
 jobs:
   test-darwin:
@@ -69,11 +68,7 @@ jobs:
       - name: Run tests
         run: make -C ${{ github.workspace }} test
 
-# If we are on the main branch, we'll create or update a pre-release called
-# 'tip' which holds the latest build output from the main branch!
-  pre-release-tip:
-    # Only run on the main branch
-    if: github.ref == 'refs/heads/main'
+  release:
     runs-on: ubuntu-latest
     needs: [test-darwin, test-linux]
     steps:
@@ -88,27 +83,15 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: acton-linux
-      - name: "Update tip release with artifacts, overwriting earlier artifacts and force pushing the 'tip' tag"
-        uses: eine/tip@master
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          tag: tip
-          rm: True
-          files: acton*.tar*
-      - name: "Workaround for changelog extractor that looks for number versions in headlines, which won't work for 'Unreleased'"
-        run: sed -i -e 's/^## Unreleased/## [999.9] Unreleased\nThis is an unreleased snapshot built from the main branch. Like a nightly but more up to date./' CHANGELOG.md
       - name: "Extract release notes"
         id: extract-release-notes
         uses: ffurrer2/extract-release-notes@v1
-      - name: "Update 'tip' release notes"
+      - name: "Create release"
         uses: ncipollo/release-action@v1
         with:
           allowUpdates: true
           artifacts: acton*.tar*
           body: ${{ steps.extract-release-notes.outputs.release_notes }}
           draft: false
-          prerelease: true
-          name: "tip"
-          tag: "tip"
           token: ${{ secrets.GITHUB_TOKEN }}
           replacesArtifacts: true

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ multiple computers to participate in running one logical Acton system. Actors
 can migrate between compute nodes for load sharing purposes and similar. The RTS
 offers exactly once delivery guarantees. Through checkpointing of actor states
 to a distributed database, the failure of individual compute nodes can be
-recovered by restoring actor state.
+recovered by restoring actor state. Your system can run forever!
 
 NOTE: Acton is in an experimental phase and although much of the syntax has been
 worked out, there may be changes.
@@ -32,37 +32,87 @@ for long running tasks. However, for smaller shorter lived processes, it can
 work fairly well.
 
 
-# Building
+# Getting started with Acton
 
-## Build dependencies
+Acton is published as GitHub Releases. Download a tar ball from [the Release
+page](https://github.com/actonlang/acton/releases). Pick the latest stable
+versioned release.
 
-- stack
-- git
-- make (GNU)
-- gcc
+In case you are looking to live on the bleeding edge or have been asked by a
+developer (in case you ran into a bug) you can pick `tip`, which is built
+directly from the `main` branch.
+
+Extract the Acton tar ball:
+```
+$ tar jxvf acton-*
+```
+
+## `actonc` dependencies
+In order to compile Acton programs using `actonc` you need to install the
+following prerequisites:
 
 ### Debian
-Install prerequisites
+```
+apt install gcc libkqueue-dev libprotobuf-c-dev libutf8proc-dev
+```
+
+### Mac OS X
+```
+brew install protobuf-c util-linux
+```
+
+## Compiling an Acton program
+
+Enter the Acton examples directory, compile the hello world program and run:
+```
+$ cd acton/examples
+$ ../actonc --root main helloworld.act
+$ ./helloworld
+Hello, world!
+```
+
+## Running Acton programs
+The final program produced by the Acton compiler is a self contained binary.
+Thus it has no run time dependencies. The `helloworld` binary built in the
+above example can be shipped to another machine, that does not have `actonc` or
+any of its dependencies installed, and still run. Like any other binary, it is
+naturally OS and arch dependent though.
+
+## And then...?
+Go read the [tutorial!](docs/tutorial/index.html)
+
+# Building the Acton system from source
+If you want to mess around with Acton itself, like hack on the compiler or add
+to the standard library of modules you will need to build the Acton system from
+source.
+
+## Get the code
+```
+git clone git@github.com:actonlang/acton.git
+```
+
+## Build dependencies
+Install the build time dependencies. This also includes the dependencies for
+using `actonc` to compile Acton programs.
+
+### Debian
 ```
 apt install alex gcc happy haskell-stack libkqueue-dev libprotobuf-c-dev libutf8proc-dev make
 ```
 
 ### Mac OS X
-
 ```
 brew install argp-standalone haskell-stack protobuf-c util-linux
 ```
 
-
-## Build instructions
-
-To build the project, simply run:
-
+## Building the Acton system
+Simply run `make` in the project root:
 ```
 make
 ```
 
 ## Running tests
+You can run the test suite through:
 ```
 make -C test
 ```


### PR DESCRIPTION
The test workflow, when run on the main branch, produces a release which
has been known as `latest`. It is now called `tip` to avoid confusion
when talking about the "latest release" - would that be `latest` or the
latest release with a proper version number? `tip` is easier and still
distinguishes this from a nightly, which it is not.

The new release workflow is essentially a copy of the test action but with
smaller variations like the tag is not statically set to 'tip' (was
'latest') but is based on the tag that is pushed. The trigger is of
course the pushing of a tag rather than any branch.

The test action is changed to ignore tags. The pre-release-tip job is
also changed to once again (I used this in early testing) use eine/tip,
since that action? will force push the tip tag. We still need the other
release creation job to set the title, body etc though. It's a little
redundant but easier than writing our own thing that fixes it all.

Now that we have releases, the top level README has been updated to
encourage using these pre built releases for users getting started
rather than having to compile the Acton system themselves.

Closes #4 