### PR TITLE
Fix version number for releases

### DIFF
--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v*.*"
 
+env:
+  BUILD_RELEASE: 1
+
 jobs:
   test-darwin:
     runs-on: macos-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Fixed
+- versioned releases now use correct version number, like `0.4.1` rather than
+  the version style used for `tip` releases which include the date & time, like
+  `0.4.1.2021.08.05.12.15.37`
+
+
 ## [0.4.1](https://github.com/actonlang/acton/releases/tag/v0.4.1) (2021-08-05)
 
 ### Added


### PR DESCRIPTION
This instructs make to not include the date & time in the version string
but just the version, like v0.4.1

Closes #35.