### PR TITLE
Make tip releases available via stable URL

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,9 @@ jobs:
 
 # If we are on the main branch, we'll create or update a pre-release called
 # 'tip' which holds the latest build output from the main branch!
+# We upload artifacts twice, first with the version number held in the filename
+# and a second time after being renamed to remove the version number in the
+# filename, thus providing a stable URL for downloading the tip tar balls.
   pre-release-tip:
     # Only run on the main branch
     if: github.ref == 'refs/heads/main'
@@ -95,12 +98,16 @@ jobs:
           tag: tip
           rm: True
           files: acton*.tar*
+      - name: "Remove version number from darwin tar ball"
+        run: mv acton-darwin-x86_64*tar.bz2 acton-darwin-x86_64.tar.bz2
+      - name: "Remove version number from darwin tar ball"
+        run: mv acton-linux-x86_64*tar.bz2 acton-linux-x86_64.tar.bz2
       - name: "Workaround for changelog extractor that looks for number versions in headlines, which won't work for 'Unreleased'"
         run: sed -i -e 's/^## Unreleased/## [999.9] Unreleased\nThis is an unreleased snapshot built from the main branch. Like a nightly but more up to date./' CHANGELOG.md
       - name: "Extract release notes"
         id: extract-release-notes
         uses: ffurrer2/extract-release-notes@v1
-      - name: "Update 'tip' release notes"
+      - name: "Update 'tip' release notes and upload renamed artifacts"
         uses: ncipollo/release-action@v1
         with:
           allowUpdates: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Added
+- `tip` releases are now available at stable URLs:
+  - https://github.com/actonlang/acton/releases/download/tip/acton-darwin-x86_64.tar.bz2
+  - https://github.com/actonlang/acton/releases/download/tip/acton-linux-x86_64.tar.bz2
+
 ### Fixed
 - versioned releases now use correct version number, like `0.4.1` rather than
   the version style used for `tip` releases which include the date & time, like


### PR DESCRIPTION
This should make the tip releases available with a stable URL:

- https://github.com/actonlang/acton/releases/download/tip/acton-darwin-x86_64.tar.bz2
- https://github.com/actonlang/acton/releases/download/tip/acton-linux-x86_64.tar.bz2

The old URL style that includes the version number still remains. We are
just uploading the assets twice!

Closes #64.