### PR TITLE
Include date & time in tip release filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 - versioned releases now use correct version number, like `0.4.1` rather than
   the version style used for `tip` releases which include the date & time, like
   `0.4.1.2021.08.05.12.15.37`
+- tip release tar balls now reflect the full tip version in the filename
+  - like `acton-linux-x86_64-0.4.1.20210805.13.46.55.tar.bz2`
+  - previously, it would just be `acton-linux-x86_64-0.4.1.tar.bz2`, making it
+    difficult to differentiate against the proper 0.4.1 or other nightlies
 
 
 ## [0.4.1](https://github.com/actonlang/acton/releases/tag/v0.4.1) (2021-08-05)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 include common.mk
 
+VERSION_INFO=$(subst acton ,,$(shell ./actonc --version DUMMY))
+
 all: compiler rts
 
 compiler:
@@ -42,9 +44,9 @@ TAR_TRANSFORM_OPT=--transform 's,^,acton/,'
 else
 TAR_TRANSFORM_OPT=-s ,^,acton/,
 endif
-acton-$(ARCH)-$(VERSION).tar.bz2:
+acton-$(ARCH)-$(VERSION_INFO).tar.bz2:
 	tar jcvf $@ $(TAR_TRANSFORM_OPT) $(RELEASE_MANIFEST)
 
-release: acton-$(ARCH)-$(VERSION).tar.bz2
+release: acton-$(ARCH)-$(VERSION_INFO).tar.bz2
 
 .PHONY: all compiler backend rts clean clean-compiler clean-backend clean-rts test release acton-$(ARCH)-$(VERSION).tar.bz2


### PR DESCRIPTION
tip releases already include the date and time in the version, like so:

  $ ./actonc --version FOO
  acton 0.4.1.20210805.13.46.55

The filename of a tip release would not reflect that, it would just be
called like `acton-linux-x86_64-0.4.1.tar.bz2`. This changes so that the
filename will be `acton-linux-x86_64-0.4.1.20210805.13.46.55.tar.bz2`,
which should make it easier for folks that often download tip releases
to differentiate them from each other.

Closes #63.