### PR TITLE
Change --path to --syspath

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ math/math.o: math/math.c math/math.h
 	cc $(CFLAGS) -I. -c $< -o$@
 
 
-ACTONC=dist/actonc --path .
+ACTONC=dist/actonc --syspath .
 TYMODULES=modules/__builtin__.ty modules/math.ty modules/numpy.ty modules/time.ty
 modules/math.h: math/math.h
 	cp $< $@

--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -86,7 +86,7 @@ getArgs         = Args
                     <*> switch (long "verbose" <> help "Print progress info during execution")
                     <*> switch (long "version" <> help "Show version information")
                     <*> switch (long "stub"    <> help "Stub (.ty) file generation only")
-                    <*> strOption (long "path" <> metavar "TARGETDIR" <> value "" <> showDefault)
+                    <*> strOption (long "syspath" <> metavar "TARGETDIR" <> value "" <> showDefault)
                     <*> strOption (long "root" <> value "" <> showDefault)
                     <*> argument str (metavar "FILE")
 


### PR DESCRIPTION
I think this just makes it clearer what it actually is. It is the path
to where the Acton system lives, syspath! The internal variable is
called syspath so this also aligns with that.

Closes #90.