### PR TITLE
Add acton.rts.sleep() function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,12 @@ modules/numpy.ty: modules/numpy.act modules/math.ty actonc
 modules/time.ty: modules/time.act modules/time.h actonc
 	$(ACTONC) $< --stub
 
+modules/acton/rts.ty: modules/acton/rts.act modules/time.h actonc
+	$(ACTONC) $< --stub
+
+modules/acton/acton$$rts.o: modules/acton/rts.c modules/acton/rts.h actonc
+	cc $(CFLAGS) -I. -c $< -o$(subst $,\$,$@)
+
 
 # /numpy ------------------------------------------------
 MODULES += numpy/numpy.o
@@ -87,8 +93,8 @@ numpy/numpy.o: numpy/numpy.c numpy/numpy.h numpy/init.h numpy/init.c \
 # /lib --------------------------------------------------
 LIBS=lib/libActon.a lib/libcomm.a lib/libdb.a lib/libdbclient.a lib/libremote.a lib/libvc.a
 
-lib/libActon.a: builtin/builtin.o builtin/minienv.o math/math.o numpy/numpy.o rts/empty.o rts/rts.o time/time.o
-	ar rcs $@ $^
+lib/libActon.a: builtin/builtin.o builtin/minienv.o math/math.o numpy/numpy.o rts/empty.o rts/rts.o time/time.o modules/acton/acton$$rts.o
+	ar rcs $@ $(subst $,\$,$^)
 
 lib/libcomm.a: backend/comm.o rts/empty.o
 	ar rcs $@ $^
@@ -158,7 +164,7 @@ clean-rts:
 	rm -f $(MODULES) $(LIBS) $(TYMODULES) modules/math.h modules/numpy.h
 
 clean-dist:
-	rm dist/lib dist/modules dist/builtin dist/rts
+	rm -rf dist/lib dist/modules dist/builtin dist/rts
 
 ARCH=$(shell uname -s -m | sed -e 's/ /-/' | tr '[A-Z]' '[a-z]')
 GNU_TAR := $(shell ls --version 2>&1 | grep GNU >/dev/null 2>&1; echo $$?)

--- a/modules/acton/rts.act
+++ b/modules/acton/rts.act
@@ -1,0 +1,10 @@
+# sleep is sort of dangerous - it will actually put the RTS thread executing the
+# actor calling this function to sleep. This could be seen as ultrabad, like we
+# would want to just pause execution of one actor and let the RTS thread process
+# other actors meanwhile. There would be room for such a function, however, the
+# acton.rts.sleep() is deliberately putting the RTS thread to sleep. This is a
+# simple way of simulating heavy work without actually doing the heavy work, so
+# in a benchmark we can pretend some actors are doing relatively heavy work, yet
+# our CPU usage will be lower, so this is like laptop airplane mode friendly
+# (consumes less battery).
+sleep : (float) -> None

--- a/modules/acton/rts.c
+++ b/modules/acton/rts.c
@@ -1,0 +1,12 @@
+#include "modules/acton/rts.h"
+#include <unistd.h>
+$NoneType acton$rts$$sleep ($float sleep_time) {
+    int to_sleep = sleep_time->val*1000000;
+    usleep(to_sleep);
+    return $None;
+}
+int acton$rts$$done$ = 0;
+void acton$rts$$__init__ () {
+    if (acton$rts$$done$) return;
+    acton$rts$$done$ = 1;
+}

--- a/modules/acton/rts.h
+++ b/modules/acton/rts.h
@@ -1,0 +1,6 @@
+#pragma once
+#include "builtin/builtin.h"
+#include "builtin/minienv.h"
+#include "rts/rts.h"
+$NoneType acton$rts$$sleep ($float);
+void acton$rts$$__init__ ();

--- a/test/Makefile
+++ b/test/Makefile
@@ -35,6 +35,10 @@ argv:
 	$(ACTONC) --root main argv.act
 	./argv --rts-verbose foo --bar --rts-verbose
 
+rts_sleep:
+	$(ACTONC) --root main $@.act
+	./$@
+
 time:
 	$(ACTONC) --root main time.act
 	./time $(shell date "+%s")

--- a/test/rts_sleep.act
+++ b/test/rts_sleep.act
@@ -1,0 +1,5 @@
+import acton.rts
+
+actor main(env):
+    acton.rts.sleep(1.337)
+    await async env.exit(0)


### PR DESCRIPTION
Which implies we are adding the acton.rts module too! There's a simple
test case added.

I don't know where to write documentation, like it would be nice to have
a docstring under the function but there's no function defined in Acton!
Just a function type signature, so no place to put the docstring from
which we can later generate documentation. I added a big comment for
now.

As stated in this comment, acton.rts.sleep() is sort of bad and
shouldn't normally be used, but it is deliberately implemented the way
it is and can be useful for benchmarking scenarios and similar.

Closes #91.