### PR TITLE
Add random module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,13 @@ modules/math.o: modules/math.c modules/math.h
 modules/numpy.ty: modules/numpy.act modules/math.ty actonc
 	$(ACTONC) $< --stub
 
+MODULES += modules/random.o
+modules/random.ty: modules/random.act modules/random.h actonc
+	$(ACTONC) $< --stub
+
+modules/random.o: modules/random.c modules/random.h
+	cc $(CFLAGS) -I. -c $< -o$(subst $,\$,$@)
+
 MODULES += modules/time.o
 modules/time.ty: modules/time.act modules/time.h actonc
 	$(ACTONC) $< --stub
@@ -91,7 +98,7 @@ numpy/numpy.o: numpy/numpy.c numpy/numpy.h numpy/init.h numpy/init.c \
 # /lib --------------------------------------------------
 LIBS=lib/libActon.a lib/libcomm.a lib/libdb.a lib/libdbclient.a lib/libremote.a lib/libvc.a
 
-lib/libActon.a: builtin/builtin.o builtin/minienv.o modules/math.o numpy/numpy.o rts/empty.o rts/rts.o modules/time.o modules/acton/acton$$rts.o
+lib/libActon.a: builtin/builtin.o builtin/minienv.o modules/math.o numpy/numpy.o rts/empty.o rts/rts.o modules/time.o modules/acton/acton$$rts.o $(MODULES)
 	ar rcs $@ $(subst $,\$,$^)
 
 lib/libcomm.a: backend/comm.o rts/empty.o

--- a/modules/random.act
+++ b/modules/random.act
@@ -1,0 +1,1 @@
+randint : (int, int) -> int

--- a/modules/random.c
+++ b/modules/random.c
@@ -1,0 +1,42 @@
+#include "modules/random.h"
+#include <stdlib.h>
+
+// NOTE: the standard srand / rand functions are not thread safe, but what does
+// that really mean in this context? While we could use thread safe functions
+// for deterministic random numbers (based on the seed), we won't guarantee
+// deterministic scheduling of actors on our RTS threads and so there still
+// would not be a guarantee for thread safe random numbers. Also, having to call
+// srand to seed reflects the C implementation, which we're not keen on doing -
+// rather we want it Pythonic - you should be able to get a random number with a
+// single call to random.randint(1, 3). So instead we just seed on startup with
+// the time, which is prolly good enough for now. In a future, we could cook up
+// something better.
+
+$int random$$randint ($int min, $int max) {
+    // ensure we have a valid range where min is smaller than max
+    if (min->val > max->val) {
+        RAISE((($Exception)$ValueError$new(to$str("min value must be smaller than max"))));
+    }
+    // upper end of the range we want when "based to 0"
+    int range = max->val - min->val;
+    // chop off all values that would cause skew, leaving only things within the
+    // range that maps up to a multiple of the specified range
+    int end = RAND_MAX / range;
+    // new end
+    end *= range;
+    // run rand() until we get a value below end
+    int r;
+    // spin getting new values until we find one in range
+    while ((r = rand()) >= end);
+    // normalize back to the requested range
+    return to$int(min->val + r%range);
+}
+
+int random$$done$ = 0;
+int random$$seeded = 0;
+void random$$__init__ () {
+    // default to just seeding
+    srand(time(NULL));
+    if (random$$done$) return;
+    random$$done$ = 1;
+}

--- a/modules/random.h
+++ b/modules/random.h
@@ -1,0 +1,6 @@
+#pragma once
+#include "builtin/builtin.h"
+#include "builtin/minienv.h"
+#include "rts/rts.h"
+$int random$$randint ($int, $int);
+void random$$__init__ ();

--- a/test/Makefile
+++ b/test/Makefile
@@ -35,6 +35,10 @@ argv:
 	$(ACTONC) --root main argv.act
 	./argv --rts-verbose foo --bar --rts-verbose
 
+test_random:
+	$(ACTONC) --root main $@.act
+	./$@
+
 rts_sleep:
 	$(ACTONC) --root main $@.act
 	./$@
@@ -43,4 +47,4 @@ time:
 	$(ACTONC) --root main time.act
 	./time $(shell date "+%s")
 
-.PHONY: argv time
+.PHONY: argv test_random rts_sleep time

--- a/test/test_random.act
+++ b/test/test_random.act
@@ -1,0 +1,55 @@
+import random
+
+def check_random_distribution(min, max, total):
+    print("Checking distribution of", total, "random numbers between", min, "and", max, "are within 10% of an even distribution")
+    num_range = max - min
+    stats = {}
+    for i in range(0, total, 1):
+        r = random.randint(min, max)
+        if r not in stats:
+            stats[r] = 0
+        stats[r] += 1
+    exp_count = total / num_range
+    slack = 0.1
+    exp_min = exp_count * (1-slack)
+    exp_max = exp_count * (1+slack)
+    for n, v in stats.items():
+        if v < exp_min:
+            print("n", n, "with a count of", v, "is below expected value of", exp_min)
+        if v > exp_max:
+            print("n", n, "with a count of", v, "is above expected value of", exp_max)
+        #if n > (expected_count * 1.1) or n < (expected_count * 0.9):
+            #print("n", n, " outside of expected range (", (expected_count*0.9), "-", (expected_count*1.1), "):", stats[n])
+
+
+actor main(env):
+    print("Checking that 100k random numbers are within the specified range")
+    for i in range(0, 100000, 1):
+        r = random.randint(0, 1234)
+        if r < 0:
+            print("Got a random number outside range: ", r, "min 0 / max 1234")
+            await async env.exit(1)
+
+    print("Checking that 100k random numbers are within the specified range")
+    for i in range(0, 100000, 1):
+        r = random.randint(1293862, 97309358)
+        if r < 0:
+            print("Got a random number outside range: ", r, "min 1293862 / max 97309358")
+            await async env.exit(1)
+
+    check_random_distribution(500, 1000, 1*1000*1000)
+
+
+    print("Printing some random numbers for show:")
+    print(random.randint(0, 1234))
+    print(random.randint(0, 1234))
+    print(random.randint(0, 1234))
+    print(random.randint(0, 1234))
+    print(random.randint(0, 1234))
+    print(random.randint(34560, 9281234))
+    print(random.randint(34560, 9281234))
+    print(random.randint(34560, 9281234))
+    print(random.randint(34560, 9281234))
+    print(random.randint(34560, 9281234))
+
+    await async env.exit(0)


### PR DESCRIPTION
This adds a random module with a single function called randint(min,
max) that returns a pseudo-random number between min and max. It's using
the basic srand() / rand() for simplicity, portability and speed (we
don't need true randomness). To make it more idiomatic Pythonic I
decided to just use time() as the initial seed, which is set up when
initializing the module.

The code avoids skew and should return good random numbers. Not
cryptographically secure in any way but still not skewed in anyway.

The Acton RTS uses threads to execute actors. rand() is not thread safe,
but I don't think that matters here. AFAIK, since rand() is a PRNG, it
actually means rand() is a deterministic function based on the initial
seed. It is not thread safe and by that, I think it is meant that it
will not act deterministically when invoked across multiple threads,
since it shares state. However, given that the Acton RTS does not give
any guarantees on how actors are scheduled against RTS threads, and thus
OS threads, even a thread safe random library wouldn't be deterministic
at the actor level. Thus, this sort of thread safety does not matter.
The only important thing is that it doesn't outright crash when invoked
by two concurrent threads but I don't think that's the case, heh.

There's a simple test case that asks for 100k random values to ensure
they are not outside of the specified range. We also do a check to
ensure that we get a roughly even spread of numbers by asking for 1
million numbers between 500 and 1000. The result should be within 10% of
an even spread to pass. Certainly possible to make something much
fancier than that, but this is good enough for now I think.

Closes #87.