### PR TITLE
Workaround build problem when running DDB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,8 @@ release: dist
 
 dist: actonc backend rts
 	mkdir -p dist/lib dist/modules dist/builtin dist/rts
-	cp backend/server dist/actondb
+	cp backend/server backend/actondb
+	mv backend/actondb dist/
 	cp lib/*.a dist/lib/
 	cp builtin/*.h dist/builtin/
 	cp rts/rts.h dist/rts/rts.h


### PR DESCRIPTION
Linux (and likely other) systems will prevent copying a file to a
destination that is currently being run. I've run into this a bunch of
times with the actondb executable where I am running it locally for
testing and then run make in the acton repo, which copies backend/server
to dist/actondb. If actondb was running, the system would refuse this as
the system does not allow modifying a running program. By moving it in
place we work around the issue.