### PR TITLE
Add test of acton.rts.sleep()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ builtin/minienv.o: builtin/minienv.c builtin/minienv.h builtin/builtin.o
 
 
 ACTONC=dist/actonc --syspath .
-TYMODULES=modules/__builtin__.ty modules/math.ty modules/numpy.ty modules/time.ty
+TYMODULES=modules/__builtin__.ty modules/acton/rts.ty modules/math.ty modules/numpy.ty modules/time.ty
 
 modules/numpy.h: numpy/numpy.h
 	cp $< $@

--- a/test/Makefile
+++ b/test/Makefile
@@ -35,6 +35,10 @@ argv:
 	$(ACTONC) --root main argv.act
 	./argv --rts-verbose foo --bar --rts-verbose
 
+test_acton_rts_sleep:
+	$(ACTONC) --root main $@.act
+	./$@
+
 test_random:
 	$(ACTONC) --root main $@.act
 	./$@
@@ -47,4 +51,4 @@ time:
 	$(ACTONC) --root main time.act
 	./time $(shell date "+%s")
 
-.PHONY: argv test_random rts_sleep time
+.PHONY: argv test_acton_rts_sleep test_random rts_sleep time


### PR DESCRIPTION
Turns out we didn't have a test case and as a result it appears we've
missed to compile the .ty file. I had it manually compiled locally and
never noticed...