### PR TITLE
Enable tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ builtin/minienv.o: builtin/minienv.c builtin/minienv.h builtin/builtin.o
 
 
 ACTONC=dist/actonc --syspath .
-TYMODULES=modules/__builtin__.ty modules/acton/rts.ty modules/math.ty modules/numpy.ty modules/time.ty
+TYMODULES=modules/__builtin__.ty modules/acton/rts.ty modules/math.ty modules/numpy.ty modules/random.ty modules/time.ty
 
 modules/numpy.h: numpy/numpy.h
 	cp $< $@

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,6 +1,15 @@
 ACTONC=../dist/actonc
 DDB_SERVER=../backend/server
-test:
+TESTS= \
+	argv \
+	test_acton_rts_sleep \
+	test_random \
+	rts_sleep \
+	time \
+	regression
+test: $(TESTS)
+
+regression:
 	$(MAKE) -C regression
 
 ddb_start:
@@ -51,4 +60,4 @@ time:
 	$(ACTONC) --root main time.act
 	./time $(shell date "+%s")
 
-.PHONY: argv test_acton_rts_sleep test_random rts_sleep time
+.PHONY: argv test_acton_rts_sleep test_random regression rts_sleep time

--- a/test/test_acton_rts_sleep.act
+++ b/test/test_acton_rts_sleep.act
@@ -1,0 +1,14 @@
+import acton.rts
+import time
+
+actor main(env):
+    def work():
+        t1 = time.time()
+        acton.rts.sleep(1)
+        t2 = time.time()
+        diff = (t2-t1) / 1000000000
+        if diff < 1:
+            print("Sleep seems to have been below 1 second :(")
+            await async env.exit(1)
+    work()
+    await async env.exit(0)


### PR DESCRIPTION
I've gone under the assumption that tests in the test/ directory were
automatically run based on how it looked previously. Since we moved some
tests under test/regression/, this is no longer true. Only tests in the
regression folder are run automatically.

Now enabling the tests we have, which also showed how I forgot to git
add the acton.rts.sleep() test. That's what happens when you try to cook
and code at the same time ;)