### PR TITLE
Reduce output clutter from running tests

### DIFF
--- a/test/regression/Makefile
+++ b/test/regression/Makefile
@@ -31,6 +31,8 @@ SUCCESS_TESTS=$(filter-out $(ALL_FAILING),$(TESTS))
 test: $(TESTS)
 
 $(SUCCESS_TESTS):
+	@echo ""
+	@echo "== Running test: $@"
 	$(ACTONC) $@.act --root main
 	./$@
 
@@ -39,11 +41,15 @@ $(SUCCESS_TESTS):
 # easily fixed by simply removing it from the FAILING_COMPILATION or
 # FAILING_RUNNING variable.
 $(FAILING_COMPILATION):
-	! $(ACTONC) $@.act --root main
+	@echo ""
+	@echo "== Running negative test (expecting compilation failure): $@"
+	! $(ACTONC) $@.act --root main >/dev/null 2>&1
 
 $(FAILING_RUNNING):
-	$(ACTONC) $@.act --root main
-	! ./$@
+	@echo ""
+	@echo "== Running negative test (expecting run time failure): $@"
+	$(ACTONC) $@.act --root main >/dev/null 2>&1
+	! ./$@ >/dev/null 2>&1
 
 13-print-actor-method:
 	$(ACTONC) $@.act --root main


### PR DESCRIPTION
Most of the test output, in particular when running the negative tests
that we expect to fail compilation, produce rather verbose output and it
can be difficult to differentiate an actual error from a currently
expected error (in a negative test). Thus, we now reduce this output
clutter by piping stdout and stderr to /dev/null. There's also a small
header in front of each test that makes it easier to keep them apart.