### PR TITLE
Do not clean away modules/math.h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - An actor method (callback) can now be passed as an argument to another actor
   method
   - This previously lead to a segmentation fault but has now been fixed.
+- Avoid cleaning away modules/math.h
+  - This was due to an outdated makefile cleaning target
 
 ## [0.5.1](https://github.com/actonlang/acton/releases/tag/v0.5.1) (2021-08-24)
 

--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ clean-backend:
 	$(MAKE) -C backend clean
 
 clean-rts:
-	rm -f $(MODULES) $(LIBS) $(TYMODULES) modules/math.h modules/numpy.h
+	rm -f $(MODULES) $(LIBS) $(TYMODULES) modules/numpy.h
 
 clean-dist:
 	rm -rf dist/lib dist/modules dist/builtin dist/rts


### PR DESCRIPTION
Previously the math module lived in a math/ subdirectory and
modules/math.h was just a copy of math/math.h. We recently moved simple
modules like math to live directly in modules/, and thus, modules/math.h
is now the real file. We should not remove it when cleaning!