### PR TITLE
Treat warnings as errors

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -1,4 +1,4 @@
-ACTONC=../dist/actonc
+ACTONC=../dist/actonc --cpedantic
 DDB_SERVER=../backend/server
 TESTS= \
 	argv \


### PR DESCRIPTION
There are currently some warnings being produced when compiling the C
code generated by actonc. We believe this likely indicates bugs and
thus, by treating these warnings as errors we are able to detect such
situations earlier. There are situations where the warnings are
irrelevant, but we should probably explicitly disable those warnings in
that case.