### PR TITLE
Fix asprintf warning

### DIFF
--- a/builtin/builtin.h
+++ b/builtin/builtin.h
@@ -1,4 +1,9 @@
 #pragma once
+#ifdef __linux__
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE 1
+#endif
+#endif
 
 #include <stdlib.h>
 #include <stddef.h>


### PR DESCRIPTION
asprintf isn't available unless GNU_SOURCE is defined, so we define that in the right place. This fixes asprintf warnings I've seen on the #138 branch as a result of doing certain print()s.

Closes #148.