### PR TITLE
Add broken after regression

### DIFF
--- a/test/regression/178-after.act
+++ b/test/regression/178-after.act
@@ -1,0 +1,24 @@
+import acton.rts
+
+actor counter(env):
+    var i = 0
+    def test():
+        print("counter actor in test, i:", i)
+        if i > 1:
+            print("counter actor finished in time, exiting happily")
+            await async env.exit(0)
+        i += 1
+        after 1: test()
+
+actor error_exiter(env):
+    def test():
+        print("error actor sleeping for 5 seconds")
+        acton.rts.sleep(5)
+        print("error actor finished sleeping, exiting with error")
+        await async env.exit(1)
+
+actor main(env):
+    var c = counter(env)
+    c.test()
+    var e = error_exiter(env)
+    e.test()

--- a/test/regression/Makefile
+++ b/test/regression/Makefile
@@ -21,6 +21,7 @@ FAILING_COMPILATION= \
 	triquotes-across-lines
 FAILING_RUNNING= \
 	125-async-actor-method-call \
+	178-after \
 	segfault \
 	subtract_off_by_one
 ALL_FAILING=$(FAILING_COMPILATION) $(FAILING_RUNNING)


### PR DESCRIPTION
This actually acts a little funny on main HEAD right now, showing the output from both actors but it sure hasn't been able to run the after stuff on the counter actor as it should, showing the error. Testing this on an older commit, it is working as expected.

The test might not be great as it relies on acton.rts.sleep() working and not interfering with the scheduling of the other thread... it's not as minimal as it could be, but on the other hand, it does show a problem in a not entirely unrealistic setting.