### PR TITLE
Add RTS debug mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,9 +103,12 @@ numpy/numpy.o: numpy/numpy.c numpy/numpy.h numpy/init.h numpy/init.c \
 
 
 # /lib --------------------------------------------------
-LIBS=lib/libActon.a lib/libcomm.a lib/libdb.a lib/libdbclient.a lib/libremote.a lib/libvc.a
+LIBS=lib/libActon.a lib/libActonRTSdebug.a lib/libcomm.a lib/libdb.a lib/libdbclient.a lib/libremote.a lib/libvc.a
 
 lib/libActon.a: builtin/builtin.o builtin/minienv.o modules/math.o numpy/numpy.o rts/empty.o rts/rts.o modules/time.o modules/acton/acton$$rts.o $(MODULES)
+	ar rcs $@ $(subst $,\$,$^)
+
+lib/libActonRTSdebug.a: rts/rts-debug.o
 	ar rcs $@ $(subst $,\$,$^)
 
 lib/libcomm.a: backend/comm.o rts/empty.o
@@ -128,6 +131,12 @@ lib/libvc.a: backend/failure_detector/vector_clock.o
 MODULES += rts/rts.o rts/empty.o
 rts/rts.o: rts/rts.c rts/rts.h
 	cc $(CFLAGS) -g -Wno-int-to-void-pointer-cast \
+		-Wno-unused-result \
+		-pthread \
+		-c -O3 $< -o $@
+
+rts/rts-debug.o: rts/rts.c rts/rts.h
+	cc $(CFLAGS) -DRTS_DEBUG -g -Wno-int-to-void-pointer-cast \
 		-Wno-unused-result \
 		-pthread \
 		-c -O3 $< -o $@

--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -51,23 +51,24 @@ import qualified System.Exit
 import qualified Paths_acton
 
 data Args       = Args {
-                    parse   :: Bool,
-                    kinds   :: Bool,
-                    types   :: Bool,
-                    sigs    :: Bool,
-                    norm    :: Bool,
-                    deact   :: Bool,
-                    cps     :: Bool,
-                    llift   :: Bool,
-                    hgen    :: Bool,
-                    cgen    :: Bool,
-                    ccmd    :: Bool,
-                    verbose :: Bool,
-                    version :: Bool,
-                    stub    :: Bool,
-                    syspath :: String,
-                    root    :: String,
-                    file    :: String
+                    parse     :: Bool,
+                    kinds     :: Bool,
+                    types     :: Bool,
+                    sigs      :: Bool,
+                    norm      :: Bool,
+                    deact     :: Bool,
+                    cps       :: Bool,
+                    llift     :: Bool,
+                    hgen      :: Bool,
+                    cgen      :: Bool,
+                    ccmd      :: Bool,
+                    verbose   :: Bool,
+                    version   :: Bool,
+                    stub      :: Bool,
+                    rts_debug :: Bool,
+                    syspath   :: String,
+                    root      :: String,
+                    file      :: String
                 }
                 deriving Show
 
@@ -86,6 +87,7 @@ getArgs         = Args
                     <*> switch (long "verbose" <> help "Print progress info during execution")
                     <*> switch (long "version" <> help "Show version information")
                     <*> switch (long "stub"    <> help "Stub (.ty) file generation only")
+                    <*> switch (long "rts-debug"<> help "Include RTS debug support in output program")
                     <*> strOption (long "syspath" <> metavar "TARGETDIR" <> value "" <> showDefault)
                     <*> strOption (long "root" <> value "" <> showDefault)
                     <*> argument str (metavar "FILE")
@@ -385,7 +387,8 @@ buildExecutable env args paths task
         (sc,_)              = Acton.QuickType.schemaOf env (A.eQVar qn)
         outbase             = sysFile paths mn
         rootFile            = outbase ++ ".root.c"
-        libFilesBase        = " -L" ++ joinPath [sysPath paths,"lib"] ++ " -lActonProject -lActon -ldbclient -lremote -luuid -lcomm -ldb -lvc -lprotobuf-c -lutf8proc -lpthread -lm"
+        libRTSarg           = if (rts_debug args) then " -lActonRTSdebug " else " "
+        libFilesBase        = " -L" ++ joinPath [sysPath paths,"lib"] ++ libRTSarg ++ " -lActonProject -lActon -ldbclient -lremote -luuid -lcomm -ldb -lvc -lprotobuf-c -lutf8proc -lpthread -lm"
 #if defined(linux_HOST_OS)
         libFiles            = libFilesBase ++ " -lkqueue"
 #elif defined(darwin_HOST_OS)


### PR DESCRIPTION
This enables various debug printing while the RTS is running. It is very
detailed and will most definitely have a major performance impact. Thus,
it can only be used for debugging purposes in controlled environments.
Debug output is enabled with the --rts-debug option.

To completely eliminate any overhead in normal operations the debug
prints are not just conditioned on the runtime --rts-debug flag but are
also conditioned behind a build time flag. We build the rts lib twice,
once with the flag enabled and once without. actonc chooses which one to
link with when compiling the .act file. That is, given the program
helloworld.act, to run with debug output, we first have to compile with:

  $ actonc --rts-debug --root main helloworld.act

Then also run the program itself with:

  $ ./helloworld --rts-debug

If helloworld was not compiled with --rts-debug, we will get an error:

  $ ./helloworld --rts-debug
  ERROR: RTS debug not supported.
  HINT: Recompile this program using: actonc --rts-debug ...
  $

Closes #172.