### PR TITLE
Use runtime exception in time module

### DIFF
--- a/builtin/exceptions.c
+++ b/builtin/exceptions.c
@@ -331,6 +331,10 @@ $OSError $OSError$__deserialize__($OSError self, $Serial$state state) {
 struct $OSError$class $OSError$methods = {"$OSError",UNASSIGNED,($Super$class)&$Exception$methods,$OSError$__init__,
                                           $OSError$__serialize__,$OSError$__deserialize__,$OSError$__bool__,$OSError$__str__};
 //////////////////////////////////////////////////////////////////////////////////////////////
+$RuntimeError $RuntimeError$new($str error_message) {
+    return $NEW($RuntimeError, error_message);
+}
+
 void $RuntimeError$__init__($RuntimeError self, $str error_message) {
   self->error_message = error_message;
 };

--- a/modules/time.c
+++ b/modules/time.c
@@ -3,7 +3,7 @@
 $float time$$monotonic () {
     struct timespec ts;
     if (clock_gettime(CLOCK_MONOTONIC, &ts) == -1) {
-        $RAISE((($BaseException)$ValueError$new(to$str("Unable to get time"))));
+        $RAISE((($BaseException)$RuntimeError$new(to$str("Unable to get time"))));
     }
     return to$float(ts.tv_sec + ts.tv_nsec);
 }
@@ -11,7 +11,7 @@ $float time$$monotonic () {
 $int time$$monotonic_ns () {
     struct timespec ts;
     if (clock_gettime(CLOCK_MONOTONIC, &ts) == -1) {
-        $RAISE((($BaseException)$ValueError$new(to$str("Unable to get time"))));
+        $RAISE((($BaseException)$RuntimeError$new(to$str("Unable to get time"))));
     }
     return to$int(ts.tv_sec * 1000000000 + ts.tv_nsec);
 }
@@ -19,7 +19,7 @@ $int time$$monotonic_ns () {
 $float time$$time () {
     struct timespec ts;
     if (clock_gettime(CLOCK_REALTIME, &ts) == -1) {
-        $RAISE((($BaseException)$ValueError$new(to$str("Unable to get time"))));
+        $RAISE((($BaseException)$RuntimeError$new(to$str("Unable to get time"))));
     }
     return to$float(ts.tv_sec + 0.000000001*ts.tv_nsec);
 }
@@ -27,7 +27,7 @@ $float time$$time () {
 $int time$$time_ns () {
     struct timespec ts;
     if (clock_gettime(CLOCK_REALTIME, &ts) == -1) {
-        $RAISE((($BaseException)$ValueError$new(to$str("Unable to get time"))));
+        $RAISE((($BaseException)$RuntimeError$new(to$str("Unable to get time"))));
     }
     return to$int(ts.tv_sec * 1000000000 + ts.tv_nsec);
 }


### PR DESCRIPTION
This it what Python's time module raises, so let's mimic it rather than
using ValueError (I freestyled that).