### PR TITLE
Install libbsd-dev on Linux in release workflow

### DIFF
--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -56,7 +56,7 @@ jobs:
             ~/.stack
           key: ${{ runner.os }}
       - name: Install build prerequisites
-        run: sudo apt-get install -qy alex gcc happy haskell-stack libkqueue-dev libprotobuf-c-dev libutf8proc-dev make
+        run: sudo apt-get install -qy alex gcc happy haskell-stack libbsd-dev libkqueue-dev libprotobuf-c-dev libutf8proc-dev make
       - name: Install GHC && build dependencies
         run: cd ${{ github.workspace }}/compiler && make package.yaml && stack build --only-dependencies
       - name: Build actonc


### PR DESCRIPTION
I added this to the test workflow but forgot to add it for the release
workflow, so when we now actually try to build a release it fails miserably :/