### PR TITLE
Build on debian sid

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,8 @@ jobs:
 
   test-linux:
     runs-on: ubuntu-latest
+    container:
+      image: debian:sid
     steps:
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
       - run: echo "🐧 This job is now running on a ${{ runner.os }} server hosted by GitHub!"
@@ -53,21 +55,24 @@ jobs:
           path: |
             ~/.stack
           key: ${{ runner.os }}
+      - run: apt-get update
       - name: Install build prerequisites
-        run: sudo apt-get install -qy alex gcc happy haskell-stack libbsd-dev libkqueue-dev libprotobuf-c-dev libutf8proc-dev make uuid-dev zlib1g-dev
+        run: apt-get install -qy alex bzip2 gcc happy haskell-stack libbsd-dev libkqueue-dev libprotobuf-c-dev libutf8proc-dev make uuid-dev zlib1g-dev
+      - name: chown our home dir to avoid stack complaining
+        run: chown -R root:root /github/home
       - name: Install GHC && build dependencies
-        run: cd ${{ github.workspace }}/compiler && make package.yaml && stack build --only-dependencies
+        run: cd ${GITHUB_WORKSPACE}/compiler && make package.yaml && stack build --only-dependencies
       - name: Build actonc
-        run: make -C ${{ github.workspace }}
+        run: make -C ${GITHUB_WORKSPACE}
       - name: Build a release
-        run: make -C ${{ github.workspace }} release
+        run: make -C ${GITHUB_WORKSPACE} release
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
           name: acton-linux
           path: ${{ github.workspace }}/acton-linux-x86_64*
       - name: Run tests
-        run: make -C ${{ github.workspace }} test
+        run: make -C ${GITHUB_WORKSPACE} test
 
 # If we are on the main branch, we'll create or update a pre-release called
 # 'tip' which holds the latest build output from the main branch!


### PR DESCRIPTION
Instead of running on pesky ubuntu, we switch to Debian :)

Debian sid has a newer libkqueue-dev that we are after.

It is potentially bad to run debian sid, maybe we want to stick to like debian stable (11 / bullseye) but let's see. For now, this is probably the best way of getting a recent enough version of libkqueue-dev. Once we move to native epoll or uring, we won't need it anyway so can switch to another debian version.

We want to build .deb files on debian, so I prefer trying to align the different CI jobs on fewer distribution versions...