### PR TITLE
Add dependency on $(ACTONC) when actonc is used

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,11 +74,11 @@ dist/types/__builtin__.ty: stdlib/out/types/__builtin__.ty
 	@mkdir -p $(dir $@)
 	cp $< $@
 
-stdlib/out/types/__builtin__.ty: stdlib/src/__builtin__.act
+stdlib/out/types/__builtin__.ty: stdlib/src/__builtin__.act $(ACTONC)
 	@mkdir -p $(dir $@)
 	$(ACTONC) $< --stub
 
-stdlib/out/types/%.ty: stdlib/src/%.act dist/types/__builtin__.ty
+stdlib/out/types/%.ty: stdlib/src/%.act dist/types/__builtin__.ty $(ACTONC)
 	@mkdir -p $(dir $@)
 	$(ACTONC) $< --stub
 


### PR DESCRIPTION
I believe this completes the DAG for targets where actonc is used. It is
now possible to run make -j32 or so to build Acton in parallel.