### PR TITLE
Fix artifact name

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,10 +81,10 @@ jobs:
       - run: echo "Doing a release, yay! 🎉"
       - name: "Check out repository code"
         uses: actions/checkout@v2
-      - name: "Download artifacts for darwin"
+      - name: "Download artifacts for darwin / macos-11"
         uses: actions/download-artifact@v2
         with:
-          name: acton-darwin
+          name: acton-macos-11
       - name: "Download artifacts for linux"
         uses: actions/download-artifact@v2
         with:


### PR DESCRIPTION
We changed it to macos-XX.YY. We just upload the one from macos-11 for
now, not sure if there is a point in uploading the one from macos-10.15
too?