### PR TITLE
Remove dependency on libkqueue

### DIFF
--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -54,7 +54,7 @@ jobs:
           key: ${{ runner.os }}
       - run: apt-get update
       - name: Install build prerequisites
-        run: apt-get install -qy alex bzip2 gcc happy haskell-stack libbsd-dev libkqueue-dev libprotobuf-c-dev libutf8proc-dev make uuid-dev zlib1g-dev
+        run: apt-get install -qy alex bzip2 gcc happy haskell-stack libbsd-dev libprotobuf-c-dev libutf8proc-dev make uuid-dev zlib1g-dev
       - name: chown our home dir to avoid stack complaining
         run: chown -R root:root /github/home
       - name: Build Acton

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
           key: ${{ runner.os }}
       - run: apt-get update
       - name: Install build prerequisites
-        run: apt-get install -qy alex bzip2 gcc happy haskell-stack libbsd-dev libkqueue-dev libprotobuf-c-dev libutf8proc-dev make uuid-dev zlib1g-dev
+        run: apt-get install -qy alex bzip2 gcc happy haskell-stack libbsd-dev libprotobuf-c-dev libutf8proc-dev make uuid-dev zlib1g-dev
       - name: chown our home dir to avoid stack complaining
         run: chown -R root:root /github/home
       - name: Build Acton

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ dependencies for your platform.
 
 #### Debian
 ```
-apt install gcc libkqueue-dev libprotobuf-c-dev libutf8proc-dev
+apt install gcc libprotobuf-c-dev libutf8proc-dev
 ```
 
 #### Mac OS X
@@ -130,7 +130,7 @@ using `actonc` to compile Acton programs.
 
 ### Debian
 ```
-apt install alex gcc happy haskell-stack libbsd-dev libkqueue-dev libprotobuf-c-dev libutf8proc-dev make uuid-dev zlib1g-dev
+apt install alex gcc happy haskell-stack libbsd-dev libprotobuf-c-dev libutf8proc-dev make uuid-dev zlib1g-dev
 ```
 
 ### Mac OS X

--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -361,7 +361,7 @@ runRestPasses args paths env0 parsed = do
                               hFile = outbase ++ ".h"
                               oFile = joinPath [projLib paths, n++".o"]
                               aFile = joinPath [projLib paths, "libActonProject.a"]
-                              gccCmd = "gcc " ++ pedantArg ++ " -g -c -I/usr/include/kqueue -I" ++ projOut paths ++ " -I" ++ sysPath paths ++ " -o" ++ oFile ++ " " ++ cFile
+                              gccCmd = "gcc " ++ pedantArg ++ " -g -c -I" ++ projOut paths ++ " -I" ++ sysPath paths ++ " -o" ++ oFile ++ " " ++ cFile
                               arCmd = "ar rcs " ++ aFile ++ " " ++ oFile
                           writeFile hFile h
                           writeFile cFile c
@@ -416,11 +416,8 @@ buildExecutable env args paths task
         rootFile            = outbase ++ ".root.c"
         libRTSarg           = if (rts_debug args) then " -lActonRTSdebug " else " "
         libFilesBase        = " -L" ++ projLib paths ++ " -L" ++ sysLib paths ++ libRTSarg ++ " -lActonProject -lActon -ldbclient -lremote -luuid -lcomm -ldb -lvc -lprotobuf-c -lutf8proc -lpthread -lm"
-#if defined(linux_HOST_OS)
-        libFiles            = libFilesBase ++ " -lkqueue"
-#elif defined(darwin_HOST_OS)
+#if defined(darwin_HOST_OS)
         libFiles            = libFilesBase ++ " -L/usr/local/opt/util-linux/lib "
--- Do we support anything else? Do a default clause for now...
 #else
         libFiles            = libFilesBase
 #endif
@@ -428,4 +425,4 @@ buildExecutable env args paths task
         binFile             = joinPath [binDir paths, binFilename]
         srcbase             = srcFile paths mn
         pedantArg           = if (cpedantic args) then "-Werror" else ""
-        gccCmd              = "gcc " ++ pedantArg ++ " -g -I/usr/include/kqueue -I" ++ projOut paths ++ " -I" ++ sysPath paths ++ " " ++ rootFile ++ " -o" ++ binFile ++ libFiles
+        gccCmd              = "gcc " ++ pedantArg ++ " -g -I" ++ projOut paths ++ " -I" ++ sysPath paths ++ " " ++ rootFile ++ " -o" ++ binFile ++ libFiles


### PR DESCRIPTION
The Acton RTS was written for kqueue on MacOS. We got it running on
Linux by using a shim called libkqueue which pretends to be kqueue
towards the application but translates these calls into epoll on Linux.

We ran into some problems, which we thought were related to libkqueue
but ultimately turned out to be something else. As we did ascribe those
problems to libkqueue, we resorted to replacing it with epoll.

It turned out that libkqueue wasn't the problem, but switching to native
epoll is a good thing, so all's well!