### PR TITLE
Remove some gitignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,3 @@
-# Ignore all
-*
-
-# Unignore all with extensions
-!*.*
-
-# Unignore all dirs
-!*/
-
 *~
 *.o
 *.a
@@ -17,9 +8,6 @@
 **/*.o
 **/a.out
 .cabal-sandbox/
-kernel
-test_io
-actonc
 compiler/actonc
 compiler/package.yaml
 compiler/tests/*.ty


### PR DESCRIPTION
We don't actually ignore all these files, in particular the Makefile and
.github directory. Using ripgrep and similar to search in this project
directory will honor .gitignore and thus not include these files in the
search results. Since we want them in there, I'm changing the ignores.