### PR TITLE
Build debian package

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,6 +72,33 @@ jobs:
       - name: Run tests
         run: make -C ${GITHUB_WORKSPACE} test
 
+  build-debs:
+    runs-on: ubuntu-latest
+    container:
+      image: debian:sid
+    steps:
+      - name: Set BUILD_RELEASE when we are building for a version tag
+        run: |
+          echo "BUILD_RELEASE=1" >> $GITHUB_ENV
+        if: startsWith(github.ref, 'refs/tags/v')
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Update packages
+        run: apt-get update
+      - name: Install build prerequisites
+        run: apt-get install -qy alex build-essential debhelper devscripts gcc happy haskell-stack libbsd-dev libkqueue-dev libprotobuf-c-dev libutf8proc-dev make uuid-dev zlib1g-dev
+      - name: Build Debian packages
+        run: make -C ${GITHUB_WORKSPACE} debs BUILD_RELEASE=${{ env.BUILD_RELEASE }}
+      - run: echo ${{ github.workspace }}
+      - id: artifact_dir
+        run: echo "::set-output name=dir::$(dirname ${{ github.workspace }})"
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: acton-debian
+          path: ${{ steps.artifact_dir.outputs.dir }}/acton_*.deb
+          if-no-files-found: error
+
 
   # If we are on the main branch, we'll create or update a pre-release called
   # 'tip' which holds the latest build output from the main branch!  We upload
@@ -83,7 +110,7 @@ jobs:
     # TODO: ensure we do NOT run when on a version tag. I think this github.ref already ensures that, since if we are run for when being pushed to the main branch, with no tag, the ref will be 'refs/head/main' whereas if we are pushed as part of a tag, it will be 'refs/tag/vXXX'
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    needs: [test-darwin, test-linux]
+    needs: [test-darwin, test-linux, build-debs]
     steps:
       - run: echo "Doing a release, yay! 🎉"
       - name: "Delete current tip release & tag"
@@ -99,10 +126,14 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: acton-macos-11
-      - name: "Download artifacts for linux"
+      - name: "Download artifacts for Linux"
         uses: actions/download-artifact@v2
         with:
           name: acton-linux
+      - name: "Download artifacts for Debian Linux"
+        uses: actions/download-artifact@v2
+        with:
+          name: acton-debian
       - name: "Workaround for changelog extractor that looks for number versions in headlines, which won't work for 'Unreleased'"
         run: sed -i -e 's/^## Unreleased/## [999.9] Unreleased\nThis is an unreleased snapshot built from the main branch. Like a nightly but more up to date./' CHANGELOG.md
       - name: "Extract release notes"
@@ -112,7 +143,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           allowUpdates: true
-          artifacts: acton*.tar*
+          artifacts: "acton*.tar*,acton*deb"
           body: ${{ steps.extract-release-notes.outputs.release_notes }}
           draft: false
           prerelease: true
@@ -146,17 +177,21 @@ jobs:
   release:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
-    needs: [test-darwin, test-linux]
+    needs: [test-darwin, test-linux, build-debs]
     steps:
       - uses: actions/checkout@v2
       - name: "Download artifacts for darwin / macos-11"
         uses: actions/download-artifact@v2
         with:
           name: acton-macos-11
-      - name: "Download artifacts for linux"
+      - name: "Download artifacts for Linux"
         uses: actions/download-artifact@v2
         with:
           name: acton-linux
+      - name: "Download artifacts for Debian Linux"
+        uses: actions/download-artifact@v2
+        with:
+          name: acton-debian
       - name: "Extract release notes"
         id: extract-release-notes
         uses: ffurrer2/extract-release-notes@v1
@@ -164,7 +199,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           allowUpdates: true
-          artifacts: acton*.tar*
+          artifacts: "acton*.tar*,acton*deb"
           body: ${{ steps.extract-release-notes.outputs.release_notes }}
           draft: false
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -24,5 +24,5 @@ install: build
 	stack --local-bin-path=$(ACTON_BINDIR) install 2>/dev/null
 
 clean:
-	stack clean
-	rm -f $(ACTON_BINDIR)/actonc package.yaml
+	-stack clean
+	rm -f $(ACTON_BINDIR)/actonc package.yaml acton.cabal

--- a/debian/changelog.in
+++ b/debian/changelog.in
@@ -1,0 +1,5 @@
+acton (VERSION) unstable; urgency=medium
+
+  * See CHANGELOG.md
+
+ -- Kristian Larsson <kristian@spritelink.net>  Mon, 13 Sep 2021 22:06:08 +0200

--- a/debian/control
+++ b/debian/control
@@ -1,0 +1,30 @@
+Source: acton
+Section: devel
+Priority: optional
+Maintainer: Kristian Larsson <kristian@spritelink.net>
+Build-Depends:
+ alex,
+ debhelper-compat (= 13),
+ gcc,
+ happy,
+ haskell-stack,
+ libbsd-dev,
+ libkqueue-dev,
+ libprotobuf-c-dev,
+ libutf8proc-dev,
+ make
+Standards-Version: 4.6.0
+Homepage: http://www.acton-lang.org
+Rules-Requires-Root: no
+
+Package: acton
+Architecture: any
+Depends:
+ ${shlibs:Depends},
+ ${misc:Depends},
+ gcc,
+ libkqueue-dev,
+ libprotobuf-c-dev,
+ libutf8proc-dev
+Description: Acton Programming Language
+ An awesome programming language.

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,0 +1,43 @@
+Package created by Kristian Larsson (kll)
+ on Sun, 12 Sep 2021 08:23:00 +0200.
+
+Upstream Author:
+
+    Johan Nordlander (nordlander)
+    Andrei Agapi (aagapi)
+    Kristian Larsson (kll)
+
+Files: *
+Copyright:
+    2019-2021 Data Ductus AB
+    2019-2021 Deutsche Telekom AG
+License: BSD-3-clause
+
+License: BSD-3-clause
+  Copyright (C) 2019-2021 Data Ductus AB
+  Copyright (C) 2019-2021 Deutsche Telekom AG
+  
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+  
+  1. Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+  
+  2. Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+  
+  3. Neither the name of the copyright holder nor the names of its contributors
+  may be used to endorse or promote products derived from this software without
+  specific prior written permission.
+  
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/debian/rules
+++ b/debian/rules
@@ -1,0 +1,26 @@
+#!/usr/bin/make -f
+# See debhelper(7) (uncomment to enable)
+# output every command that modifies files on the build system.
+export DH_VERBOSE = 1
+
+# see FEATURE AREAS in dpkg-buildflags(1)
+#export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+
+# see ENVIRONMENT in dpkg-buildflags(1)
+# package maintainers to append CFLAGS
+#export DEB_CFLAGS_MAINT_APPEND  = -Wall -pedantic
+# package maintainers to append LDFLAGS
+#export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
+
+
+%:
+	dh $@
+
+override_dh_auto_test:
+	@echo "Skipping tests"
+
+# dh_make generated override targets
+# This is example for Cmake (See https://bugs.debian.org/641051 )
+#override_dh_auto_configure:
+#	dh_auto_configure -- \
+#	-DCMAKE_LIBRARY_PATH=$(DEB_HOST_MULTIARCH)

--- a/debian/watch
+++ b/debian/watch
@@ -1,0 +1,6 @@
+version=4
+
+# GitHub hosted projects
+opts="filenamemangle=s%(?:.*?)?v?(\d[\d.]*)\.tar\.gz%<project>-$1.tar.gz%" \
+   https://github.com/actonlang/acton/tags \
+   (?:.*?/)?v?(\d[\d.]*)\.tar\.gz debian uupdate

--- a/test/test_json.act
+++ b/test/test_json.act
@@ -1,0 +1,12 @@
+import json
+
+actor main(env):
+    def test():
+
+        a = '{ "foo": 1 }'
+        js = json.loads(a)
+        print(str(js["foo"]))
+
+    test()
+
+    await async env.exit(0)


### PR DESCRIPTION
This adds new make targets to build a .deb. We invoke this from CI and upload the resulting .deb as an artifact.

The only caveat is that the pre-release .debs do not reflect the actual version number, for example, actonc will report like 0.6.0.202010919.143412 whereas the .deb file will be just 0.6.0. This is due to the order in which this information is known. We currently generate this build date when compiling the acton compiler but the .deb build process needs to know about it up front. To make it work, we have to move when we generate this. We should take care to not rebuild unless something has actually changed, something that's not just the version number. Not sure if this is possible or not!? Anyway, that's for another issue.

Fixes #60.