### PR TITLE
Fixed constraint grouping to also consider free environment types variables.

### DIFF
--- a/compiler/Acton/Env.hs
+++ b/compiler/Acton/Env.hs
@@ -743,6 +743,9 @@ allProtos env               = reverse locals ++ concat [ protos m (lookupMod m e
 allConAttr                  :: EnvF x -> Name -> [Type]
 allConAttr env n            = [ tCon tc | tc <- allCons env, n `elem` allAttrs env tc ]
 
+allConAttrFree              :: EnvF x -> Name -> [TVar]
+allConAttrFree env n        = concat [ tyfree $ fst $ findAttr' env tc n | tc <- allCons env, n `elem` allAttrs env tc ]
+
 allProtoAttr                :: EnvF x -> Name -> [Type]
 allProtoAttr env n          = [ tCon p | p <- allProtos env, n `elem` allAttrs env p ]
 


### PR DESCRIPTION
The constraint solver frequently splits constraint sets into independent groups with no common type variables.
Closing each group with respect to this invariant is straightforward, with the exception of the internal Sel
and Mut constraints. Since these constraints are solved by picking a type from the environment that contains
the required attribute, free variables in that attribute's type might end up in the solution even if those
variables weren't part of the the original constraint set. Previously the closure operation didn't include
the possibility that constraints might relate via such indirectly shared type variables, but this has now
been fixed.

(Note: only class attributes need to be considered in this extended closure operation, since protocol
attributes cannot contain free type variables due of their complete type signatures.)