### PR TITLE
Fixed rts bug causing disorder in a message's waiting list...

### DIFF
--- a/rts/rts.c
+++ b/rts/rts.c
@@ -1135,10 +1135,11 @@ void *main_loop(void *arg) {
                     while (b) {
                         b->$msg->$value = r.value;
                         b->$waitsfor = NULL;
+                        $Actor c = b->$next;
                         ENQ_ready(b);
                         new_work();
                         rtsd_printf(LOGPFX "## Waking up actor %ld : %s\n", b->$globkey, b->$class->$GCINFO);
-                        b = b->$next;
+                        b = c;
                     }
                     rtsd_printf(LOGPFX "## DONE actor %ld : %s\n", current->$globkey, current->$class->$GCINFO);
                     if (DEQ_msg(current)) {


### PR DESCRIPTION
... when actors are woken up under high load.

A linked list element can't be inserted in another list while one is iterating over the original list.
At least not without making a local copy of the element's link before inserting. Rather elementary,
yet that's precisely what the code for waking up actors waiting on a message failed to do. Truly
embarrassing, but at least it's fixed now.

Fixes #283.