### PR TITLE
Remove dependency on libkqueue

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Update packages
         run: apt-get update
       - name: Install build prerequisites
-        run: apt-get install -qy alex build-essential debhelper devscripts gcc happy haskell-stack libbsd-dev libkqueue-dev libprotobuf-c-dev libutf8proc-dev make uuid-dev zlib1g-dev
+        run: apt-get install -qy alex build-essential debhelper devscripts gcc happy haskell-stack libbsd-dev libprotobuf-c-dev libutf8proc-dev make uuid-dev zlib1g-dev
       - name: Build Debian packages
         run: make -C ${GITHUB_WORKSPACE} debs BUILD_RELEASE=${{ env.BUILD_RELEASE }}
       - run: echo ${{ github.workspace }}

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,6 @@ Build-Depends:
  happy,
  haskell-stack,
  libbsd-dev,
- libkqueue-dev,
  libprotobuf-c-dev,
  libutf8proc-dev,
  make
@@ -23,7 +22,6 @@ Depends:
  ${shlibs:Depends},
  ${misc:Depends},
  gcc,
- libkqueue-dev,
  libprotobuf-c-dev,
  libutf8proc-dev
 Description: Acton Programming Language


### PR DESCRIPTION
Since switching to epoll on Linux we don't need libkqueue anymore.
Removing installation of it!