### PR TITLE
Remove dep/install of happy & alex

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ using `actonc` to compile Acton programs.
 
 ### Debian
 ```
-apt install alex gcc happy haskell-stack libbsd-dev libprotobuf-c-dev libutf8proc-dev make uuid-dev zlib1g-dev
+apt install gcc haskell-stack libbsd-dev libprotobuf-c-dev libutf8proc-dev make uuid-dev zlib1g-dev
 ```
 
 ### Mac OS X

--- a/debian/control
+++ b/debian/control
@@ -3,10 +3,8 @@ Section: devel
 Priority: optional
 Maintainer: Kristian Larsson <kristian@spritelink.net>
 Build-Depends:
- alex,
  debhelper-compat (= 13),
  gcc,
- happy,
  haskell-stack,
  libbsd-dev,
  libprotobuf-c-dev,


### PR DESCRIPTION
They are pulled in via Haskell stack, so no need to install via apt.

Fixes #297.