### PR TITLE
Use cc & $(CC)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,10 +54,10 @@ ENV_FILES=$(wildcard builtin/minienv.*)
 BUILTIN_HFILES=$(filter-out $(ENV_FILES),$(wildcard builtin/*.h))
 BUILTIN_CFILES=$(filter-out $(ENV_FILES),$(wildcard builtin/*.c))
 builtin/builtin.o: builtin/builtin.c $(BUILTIN_HFILES) $(BUILTIN_CFILES)
-	cc $(CFLAGS) -Wno-unused-result -c -O3 $< -o$@
+	$(CC) $(CFLAGS) -Wno-unused-result -c -O3 $< -o$@
 
 builtin/minienv.o: builtin/minienv.c builtin/minienv.h builtin/builtin.o
-	cc $(CFLAGS) -c -O3 $< -o$@
+	$(CC) $(CFLAGS) -c -O3 $< -o$@
 
 # Building the builtin, rts and stdlib is a little tricky as we have to be
 # careful about order. First comes the __builtin__.act file,
@@ -82,7 +82,7 @@ stdlib/out/types/%.h: stdlib/src/%.h
 
 stdlib/out/release/%.o: stdlib/src/%.c
 	@mkdir -p $(dir $@)
-	cc $(CFLAGS) -I. -Istdlib/ -Istdlib/out/ -c $< -o$@
+	$(CC) $(CFLAGS) -I. -Istdlib/ -Istdlib/out/ -c $< -o$@
 
 NUMPY_CFILES=$(wildcard stdlib/c_src/numpy/*.h)
 ifeq ($(shell uname -s),Linux)
@@ -90,7 +90,7 @@ NUMPY_CFLAGS+=-lbsd -ldl -lmd
 endif
 stdlib/out/release/numpy.o: stdlib/src/numpy.c stdlib/src/numpy.h stdlib/out/types/math.h $(NUMPY_CFILES) stdlib/out/release/math.o
 	@mkdir -p $(dir $@)
-	cc $(CFLAGS) -Wno-unused-result -r -I. -Istdlib/out/ $< -o$@ $(NUMPY_CFLAGS) stdlib/out/release/math.o
+	$(CC) $(CFLAGS) -Wno-unused-result -r -I. -Istdlib/out/ $< -o$@ $(NUMPY_CFLAGS) stdlib/out/release/math.o
 
 # /lib --------------------------------------------------
 ARCHIVES=lib/libActon.a lib/libActonRTSdebug.a lib/libcomm.a lib/libdb.a lib/libdbclient.a lib/libremote.a lib/libvc.a
@@ -129,22 +129,22 @@ lib/libvc.a: backend/failure_detector/vector_clock.o
 
 # /rts --------------------------------------------------
 rts/rts.o: rts/rts.c rts/rts.h
-	cc $(CFLAGS) -Wno-int-to-void-pointer-cast \
+	$(CC) $(CFLAGS) -Wno-int-to-void-pointer-cast \
 		-Wno-unused-result \
 		-pthread \
 		-c -O3 $< -o $@
 
 rts/rts-debug.o: rts/rts.c rts/rts.h
-	cc $(CFLAGS) -DRTS_DEBUG -Wno-int-to-void-pointer-cast \
+	$(CC) $(CFLAGS) -DRTS_DEBUG -Wno-int-to-void-pointer-cast \
 		-Wno-unused-result \
 		-pthread \
 		-c -O3 $< -o $@
 
 rts/empty.o: rts/empty.c
-	cc $(CFLAGS) -c $< -o $@
+	$(CC) $(CFLAGS) -c $< -o $@
 
 rts/pingpong: rts/pingpong.c rts/pingpong.h rts/rts.o
-	cc $(CFLAGS) -Wno-int-to-void-pointer-cast \
+	$(CC) $(CFLAGS) -Wno-int-to-void-pointer-cast \
 		-L lib \
 		-lutf8proc -ldbclient -lremote -lcomm -ldb -lvc -lprotobuf-c \
 		rts/rts.o \

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -28,10 +28,10 @@ endif
 all: $(LIBDIR)/libcomm.a $(LIBDIR)/libdb.a $(LIBDIR)/libdbclient.a $(LIBDIR)/libremote.a $(LIBDIR)/libvc.a client server
 
 %.o: %.c
-	cc $^ -c $(LFLAGS) $(CFLAGS) -o $@
+	$(CC) $^ -c $(LFLAGS) $(CFLAGS) -o $@
 
 failure_detector/%.o: failure_detector/%.c
-	cc $^ -c $(LFLAGS) $(CFLAGS) -o $@
+	$(CC) $^ -c $(LFLAGS) $(CFLAGS) -o $@
 
 failure_detector/db_messages.pb-c.c: failure_detector/db_messages.proto
 	protoc-c --c_out=$@ $^
@@ -54,13 +54,13 @@ $(LIBDIR)/libvc.a:
 .PHONY: $(LIBDIR)/libcomm.a $(LIBDIR)/libdb.a $(LIBDIR)/libdbclient.a
 
 client: client.c $(LIBDIR)/libdb.a $(LIBDIR)/libdbclient.a $(LIBDIR)/libremote.a $(LIBDIR)/libcomm.a $(LIBDIR)/libvc.a
-	cc client.c \
+	$(CC) client.c \
 	 $(CFLAGS) $(LARGP) \
 	 -L $(LIBDIR) -L/usr/local/opt/util-linux/lib -ldbclient -lremote -lcomm -ldb -lvc -lprotobuf-c -pthread -luuid \
 	 -o client
 
 server: server.c failure_detector $(LIBDIR)/libremote.a $(LIBDIR)/libcomm.a $(LIBDIR)/libdb.a $(LIBDIR)/libvc.a
-	cc server.c \
+	$(CC) server.c \
 	 $(CFLAGS) $(LARGP) \
 	 -L $(LIBDIR) -L/usr/local/opt/util-linux/lib -lremote -lcomm -ldb -lvc -lprotobuf-c -pthread -luuid \
 	 -o server
@@ -78,41 +78,41 @@ test: $(TESTS)
 	./skiplist_test
 
 failure_detector/db_messages_test: failure_detector/db_messages_test.c $(LIBDIR)/libremote.a $(LIBDIR)/libvc.a
-	cc $^ \
+	$(CC) $^ \
 		$(CFLAGS) -I/usr/local/include -I/usr/include \
 		-L $(LIBDIR) -L/usr/local/lib -L/usr/local/opt/util-linux/lib -lvc -lremote -pthread -lprotobuf-c $(LFLAGS) \
 		$(LIBS) \
 		-o $@
 
 actor_ring_tests_local: actor_ring_tests_local.c $(LIBDIR)/libdb.a
-	cc actor_ring_tests_local.c \
+	$(CC) actor_ring_tests_local.c \
 		$(CFLAGS) -I ../src -L $(LIBDIR) -L/usr/local/opt/util-linux/lib \
 		-ldb -lvc -lremote -lprotobuf-c $(LFLAGS) -pthread \
 		$(LIBS) \
 		-o actor_ring_tests_local
 
 actor_ring_tests_remote: actor_ring_tests_remote.c $(LIBDIR)/libdb.a $(LIBDIR)/libdbclient.a failure_detector
-	cc actor_ring_tests_remote.c \
+	$(CC) actor_ring_tests_remote.c \
 	 $(CFLAGS) \
 	 -L $(LIBDIR) -L/usr/local/opt/util-linux/lib -ldbclient -lremote -lcomm -ldb -lvc -lprotobuf-c -pthread -luuid \
 	 -o actor_ring_tests_remote
 
 db_unit_tests: db_unit_tests.c $(LIBDIR)/libdb.a
-	cc -std=c11 db_unit_tests.c \
+	$(CC) -std=c11 db_unit_tests.c \
 		$(CFLAGS) -I ../src -L $(LIBDIR) -L/usr/local/opt/util-linux/lib \
 		-ldb -lvc $(LFLAGS) -pthread \
 		$(LIBS) \
 		-o db_unit_tests
 
 queue_unit_tests: queue_unit_tests.c $(LIBDIR)/libdb.a
-	cc queue_unit_tests.c \
+	$(CC) queue_unit_tests.c \
 		$(CFLAGS) -I ../src -L $(LIBDIR) -L/usr/local/opt/util-linux/lib \
 		-ldb -lvc -lremote -lprotobuf-c $(LFLAGS) -pthread \
 		$(LIBS) \
 		-o queue_unit_tests
 
 skiplist_test: skiplist_test.c skiplist.c
-	cc skiplist_test.c skiplist.c \
+	$(CC) skiplist_test.c skiplist.c \
 		$(CFLAGS) -I ../src \
 		$(LFLAGS) -L/usr/local/opt/util-linux/lib \
 		-o skiplist_test

--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -361,14 +361,14 @@ runRestPasses args paths env0 parsed = do
                               hFile = outbase ++ ".h"
                               oFile = joinPath [projLib paths, n++".o"]
                               aFile = joinPath [projLib paths, "libActonProject.a"]
-                              gccCmd = "gcc " ++ pedantArg ++ " -g -c -I" ++ projOut paths ++ " -I" ++ sysPath paths ++ " -o" ++ oFile ++ " " ++ cFile
+                              ccCmd = "cc " ++ pedantArg ++ " -g -c -I" ++ projOut paths ++ " -I" ++ sysPath paths ++ " -o" ++ oFile ++ " " ++ cFile
                               arCmd = "ar rcs " ++ aFile ++ " " ++ oFile
                           writeFile hFile h
                           writeFile cFile c
                           iff (ccmd args) $ do
-                              putStrLn gccCmd
+                              putStrLn ccCmd
                               putStrLn arCmd
-                          (_,_,_,hdl) <- createProcess (shell $ gccCmd ++ " && " ++ arCmd)
+                          (_,_,_,hdl) <- createProcess (shell $ ccCmd ++ " && " ++ arCmd)
                           returnCode <- waitForProcess hdl
                           case returnCode of
                               ExitSuccess -> return()
@@ -397,8 +397,8 @@ buildExecutable env args paths task
                                       c <- Acton.CodeGen.genRoot env qn' t
                                       writeFile rootFile c
                                       iff (ccmd args) $ do
-                                          putStrLn gccCmd
-                                      (_,_,_,hdl) <- createProcess (shell gccCmd)
+                                          putStrLn ccCmd
+                                      (_,_,_,hdl) <- createProcess (shell ccCmd)
                                       returnCode <- waitForProcess hdl
                                       case returnCode of
                                           ExitSuccess -> return()
@@ -425,4 +425,4 @@ buildExecutable env args paths task
         binFile             = joinPath [binDir paths, binFilename]
         srcbase             = srcFile paths mn
         pedantArg           = if (cpedantic args) then "-Werror" else ""
-        gccCmd              = "gcc " ++ pedantArg ++ " -g -I" ++ projOut paths ++ " -I" ++ sysPath paths ++ " " ++ rootFile ++ " -o" ++ binFile ++ libFiles
+        ccCmd               = "cc " ++ pedantArg ++ " -g -I" ++ projOut paths ++ " -I" ++ sysPath paths ++ " " ++ rootFile ++ " -o" ++ binFile ++ libFiles


### PR DESCRIPTION
We change so that actonc uses cc rather than gcc per default.

In our own makefiles we use $(CC) which most of the time means cc but does make it possible for people to choose. It's sort of good makefile practice...

Closes #40.