### PR TITLE
Fix deb version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -320,4 +320,4 @@ debian/changelog: debian/changelog.in CHANGELOG.md
 
 .PHONY: debs
 debs: debian/changelog
-	debuild -i -us -uc -b
+	debuild --preserve-envvar VERSION_INFO -i -us -uc -b


### PR DESCRIPTION
Finally! We now align the version contained in actonc, displayed with
actonc --version and the version of the deb package!

We compute the VERSION_INFO once and then pass it into the debian build
process to tag the inside content.

Fixes #271.