### PR TITLE
Store all .deb related artifacts in deb dir

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,14 +89,19 @@ jobs:
         run: apt-get install -qy alex build-essential debhelper devscripts gcc happy haskell-stack libbsd-dev libprotobuf-c-dev libutf8proc-dev make uuid-dev zlib1g-dev
       - name: Build Debian packages
         run: make -C ${GITHUB_WORKSPACE} debs BUILD_RELEASE=${{ env.BUILD_RELEASE }}
-      - run: echo ${{ github.workspace }}
+      - id: vars
+        run: echo "::set-output name=debdir::$(realpath ${GITHUB_WORKSPACE}/../deb)"
+      - run: mkdir -p ${{ steps.vars.outputs.debdir }}
+      - run: mv ${{ steps.vars.outputs.debdir }}/../acton_* ${{ steps.vars.outputs.debdir }}/../acton-dbgsym_* ${{ steps.vars.outputs.debdir }}/
       - id: artifact_dir
         run: echo "::set-output name=dir::$(dirname ${{ github.workspace }})"
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
           name: acton-debian
-          path: ${{ steps.artifact_dir.outputs.dir }}/acton_*.deb
+          # Using a wildcard and then deb here to force the entire directory to
+          # be part of resulting artifact.
+          path: ${{ steps.artifact_dir.outputs.dir }}/*deb/
           if-no-files-found: error
 
 


### PR DESCRIPTION
We used to only store the actual .deb file as an artifact but there are
more files produced as part of the .deb build target. We now store all
of them in a deb/ directory and save that directory as an artifact. This
should make it easier to restore and finally add the files to a apt repo.