### PR TITLE
Depend on non-dev libraries

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,7 @@ Depends:
  ${shlibs:Depends},
  ${misc:Depends},
  gcc,
- libprotobuf-c-dev,
- libutf8proc-dev
+ libprotobuf-c1,
+ libutf8proc2
 Description: Acton Programming Language
  An awesome programming language.


### PR DESCRIPTION
We don't need the -dev libraries at run time, only as Build-Depends.

Fixes #299.