### PR TITLE
Automatically update homebrew repo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -250,3 +250,36 @@ jobs:
           draft: false
           token: ${{ secrets.GITHUB_TOKEN }}
           replacesArtifacts: true
+
+
+  # Update our homebrew tap
+  update-homebrew:
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    needs: [test-darwin, test-linux]
+    steps:
+      - name: "Get the version"
+        id: get_version
+        run: echo ::set-output name=version::$(echo $GITHUB_REF | cut -d / -f 3)
+      - run: wget https://github.com/actonlang/acton/archive/refs/tags/${{ steps.get_version.outputs.version }}.tar.gz
+      - run: sha256sum ${{ steps.get_version.outputs.version }}.tar.gz
+      - id: shasum
+        run: echo "::set-output name=sum::$(sha256sum ${{ steps.get_version.outputs.version }}.tar.gz | cut -d' ' -f1)"
+      - name: "Check out code of our brew repo"
+        uses: actions/checkout@v2
+        with:
+          repository: actonlang/homebrew-acton
+      - name: "Update brew formula for acton with new version"
+        run: |
+          sed -i -e 's,^  url.*,  url "https://github.com/actonlang/acton/archive/refs/tags/${{ steps.get_version.outputs.version }}.tar.gz",' -e 's/^  sha256.*/  sha256 "${{ steps.shasum.outputs.sum }}"/' Formula/acton.rb
+      - name: "Create Pull Request"
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.ACTBOT_PAT }}
+          branch: acton-${{ steps.get_version.outputs.version }}
+          title: "acton ${{ steps.get_version.outputs.version }}"
+          body: |
+            Automatic update triggered by release on actonlang/acton.
+          committer: Acton Bot <actbot@acton-lang.org>
+          commit-message: "acton ${{ steps.get_version.outputs.version }}"
+          signoff: false


### PR DESCRIPTION
We can now automatically update the homebrew repo when new versions of
Acton become available.

Fixes #235.