### PR TITLE
Get rid of make warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,9 +137,13 @@ STDLIB_OFILES=$(subst src,out/release,$(STDLIB_CFILES:.c=.o))
 STDLIB_ACTS=$(not-in $(STDLIB_ACTFILES),$(STDLIB_CFILES))
 
 # __builtin__.ty is special, it even has special handling in actonc. Essentially
-# all other modules depend on it, so it must be compiled first, which is why we
-# specify it as a dependency. This rule also builds __builtin__.ty but make is
-# clever enough to cancel out a dependency on itself.
+# all other modules depend on it, so it must be compiled first. The rule below
+# is actually capable of building __builtin__.ty too but to avoid an extra
+# warning we have a dedicated target for it.
+stdlib/out/types/__builtin__.ty: stdlib/src/__builtin__.act $(ACTONC)
+	@mkdir -p $(dir $@)
+	$(ACTONC) $< --stub
+
 stdlib/out/types/%.ty: stdlib/src/%.act dist/types/__builtin__.ty $(ACTONC)
 	@mkdir -p $(dir $@)
 	$(ACTONC) $< --stub


### PR DESCRIPTION
Warnings make Johan nervous. It was really a cosmetic one but let's calm
him by getting rid of it.

We had a cyclic dependency in our make target definition. The target was
for a wildcard and all .ty files depend on __builtin__.ty, but they are
all built by the same target. Make is clever enough to figure out that
__builtin__.ty cannot depend on itself, so it drops the dependency and
then proceeds to build __builtin__.ty first, as it should. But it also
prints a warning.

By adding an explicit target for __builtin__.ty we get rid of the
warning. Otherwise we accomplish exactly the same thing.