### PR TITLE
Version GitHub Actions cache key

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           path: |
             ~/.stack
-          key: ${{ matrix.os }}
+          key: ${{ matrix.os }}-${{ secrets.CACHE_VERSION }}
       - name: "Install build prerequisites"
         run: brew install argp-standalone haskell-stack protobuf-c util-linux
       - name: "Build Acton"
@@ -57,7 +57,7 @@ jobs:
         with:
           path: |
             ~/.stack
-          key: ${{ runner.os }}
+          key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}
       - name: "Install build prerequisites"
         run: |
           apt-get update


### PR DESCRIPTION
This makes it possible to bump the key, which is a secret variable, to
clear the cache.