### PR TITLE
Run CI for all PRS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Build, Test & Release
 
-on: [push]
+on: [push,pull_request]
 
 # NOTE: Jobs for version tagged releases just pattern match on any tag starting
 # with 'v'. That's probably a version tag, but could be something else. Is there


### PR DESCRIPTION
"push" triggers for any push to the Acton repository. With the
triangular git flow, PRs will be opened from a branch on a fork. To run
CI for those PRs we cannot use the "push" trigger but will have to use
the pull_request trigger.

We now use both triggers, which means we will see "duplicate" tests run,
but that's okay for now.