### PR TITLE
Fix sed version check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -301,7 +301,7 @@ clean-distribution:
 # == release ==
 # This is where we take our distribution and turn it into a release tar ball
 ARCH=$(shell uname -s -m | sed -e 's/ /-/' | tr '[A-Z]' '[a-z]')
-GNU_TAR := $(shell ls --version 2>&1 | grep GNU >/dev/null 2>&1; echo $$?)
+GNU_TAR := $(shell sed --version 2>&1 | grep GNU >/dev/null 2>&1; echo $$?)
 ifeq ($(GNU_TAR),0)
 TAR_TRANSFORM_OPT=--transform 's,^dist,acton,'
 else


### PR DESCRIPTION
If we want to check for a GNU sed we should probably run sed and not ls
;) In reality though, this has worked since if you have a GNU sed you
likely have a GNU ls too. A decent proxy.

Fixes #213.