### PR TITLE
Add --numeric-version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -308,7 +308,7 @@ else
 TAR_TRANSFORM_OPT=-s ,^dist,acton,
 endif
 
-ACTONC_VERSION=$(shell $(ACTONC) --version 2>/dev/null | head -n1 | cut -d' ' -f2)
+ACTONC_VERSION=$(shell $(ACTONC) --numeric-version 2>/dev/null)
 .PHONY: acton-$(ARCH)-$(ACTONC_VERSION).tar.bz2
 acton-$(ARCH)-$(ACTONC_VERSION).tar.bz2:
 	tar jcvf $@ $(TAR_TRANSFORM_OPT) --exclude .gitignore dist

--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -73,7 +73,8 @@ data Args       = Args {
                 }
                 deriving Show
 
-getArgs cv      = infoOption cv (long "version" <> help "Show version information")
+getArgs ver     = infoOption (showVersion Paths_acton.version) (long "numeric-version" <> help "Show numeric version")
+                  <*> infoOption ver (long "version" <> help "Show version information")
                   <*>
                   (Args
                     <$> switch (long "parse"   <> help "Show the result of parsing")


### PR DESCRIPTION
This adds a --numeric-version to actonc and makes use of it in the main Makefile.

Closes #220.