### PR TITLE
Fix protoc-c invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ backend/failure_detector/%.o: backend/failure_detector/%.c
 	$(CC) -o$@ $< -c $(CFLAGS)
 
 backend/failure_detector/db_messages.pb-c.c: backend/failure_detector/db_messages.proto
-	protoc-c --c_out=$@ $<
+	cd $(dir $@) && protoc-c --c_out=. $(notdir $<)
 
 # backend tests
 BACKEND_TESTS=backend/failure_detector/db_messages_test \


### PR DESCRIPTION
This was just plain wrong. Also protoc-c uses relative file locations,
so if we call protoc-c with a long file path, that is going to reflect
in the output.

The output is committed to git, so we should generate something that is
fairly similar. We now do!