### PR TITLE
Skip protobuf generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,11 @@ backend/%.o: backend/%.c
 backend/failure_detector/%.o: backend/failure_detector/%.c
 	$(CC) -o$@ $< -c $(CFLAGS)
 
+# This target is just to override the above target and turn it into a NOP for
+# the protobuf files. We have the generated files committed to git, so this
+# isn't something we normally want to regenerate anyway.
 backend/failure_detector/db_messages.pb-c.c: backend/failure_detector/db_messages.proto
-	cd $(dir $@) && protoc-c --c_out=. $(notdir $<)
+	true
 
 # backend tests
 BACKEND_TESTS=backend/failure_detector/db_messages_test \


### PR DESCRIPTION
I previously added this target as it was required to override the one
above it that is a generic target for all the .c files in the
failure_detector directory. When I added, I implemented an actual target
that generates these .c files from the .proto file.

However, our strategy here is not to generate these files on every
build. Rather, we generate them once and have the output checked into
git. Thus, I've turned this target into a no-op instead.

Anyone wishing to regenerate the files can do so manually and check in
the resulting files in git.