### PR TITLE
Add some MacOS Apple M1 / arm64 / aarch64 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,23 @@ LDFLAGS+=-L$(dir $(JEM_LIB))
 LDLIBS+=-ljemalloc
 endif
 
+# -- Apple Mac OS X ------------------------------------------------------------
 ifeq ($(shell uname -s),Darwin)
-LDFLAGS+=-L/usr/local/opt/util-linux/lib
 LDLIBS+=-largp
+
+# -- M1
+ifeq ($(shell uname -m),arm64)
+CFLAGS += -I/opt/homebrew/include
+LDFLAGS += -L/opt/homebrew/opt/util-linux/lib -L/opt/homebrew/lib
 endif
+
+# -- Intel CPU
+ifeq ($(shell uname -m),x86_64)
+LDFLAGS += -L/usr/local/opt/util-linux/lib
+endif
+
+endif # -- END: Apple Mac OS X -------------------------------------------------
+
 
 ifeq ($(shell uname -s),Linux)
 CFLAGS += -Werror

--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -422,7 +422,9 @@ buildExecutable env args paths task
         rootFile            = outbase ++ ".root.c"
         libRTSarg           = if (dev args) then " -lActonRTSdebug " else " "
         libFilesBase        = " -L" ++ projLib paths ++ " -L" ++ sysLib paths ++ libRTSarg ++ " -lActonProject -lActon -lActonDB -luuid -lprotobuf-c -lutf8proc -lpthread -lm"
-#if defined(darwin_HOST_OS)
+#if defined(darwin_HOST_OS) && defined(aarch64_HOST_ARCH)
+        libFiles            = libFilesBase ++ " -L/opt/homebrew/opt/util-linux/lib -L/opt/homebrew/lib "
+#elif defined(darwin_HOST_OS) && defined(x86_64_HOST_ARCH)
         libFiles            = libFilesBase ++ " -L/usr/local/opt/util-linux/lib "
 #else
         libFiles            = libFilesBase


### PR DESCRIPTION
This adds some basic support for building Acton on the Apple M1 silicon.

Also found that I mostly need #382.