### PR TITLE
Do not run CI on push to branches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,12 @@
 name: Build, Test & Release
 
-on: [push,pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+    tags:
+      - v*
 
 # NOTE: Jobs for version tagged releases just pattern match on any tag starting
 # with 'v'. That's probably a version tag, but could be something else. Is there


### PR DESCRIPTION
We have been getting duplicate GH Actions run because we trigger both on
the push to a branch and when a pull request is created.

We must have the pull_request trigger since otherwise we wouldn't run
our Action for forks, and any normal user will fork acton to submit code.

Running on any push has been convenient, as all you need to do for GH
Actions to run is to push! It wouldn't wait for you to create a PR or
whatever. However, since a PR must be created in order to merge the
code, it's never been a question of /if/ but of /when/ certain jobs
would run.

The result has been that we get duplicate builds and it's just sort of
annoying and consumes resources.

Now changing so that we only build on pushes to the main branch and to
tags starting with 'v' plus for any branch that a PR is created for.