### PR TITLE
Switch linux test to run on Ubuntu 18.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,9 +48,7 @@ jobs:
 
 
   test-linux:
-    runs-on: ubuntu-latest
-    container:
-      image: debian:bullseye
+    runs-on: ubuntu-18.04
     steps:
       - name: "Set BUILD_RELEASE when we are building for a version tag"
         run: |
@@ -66,10 +64,8 @@ jobs:
           key: ${{ runner.os }}-${{ secrets.CACHE_VERSION }}
       - name: "Install build prerequisites"
         run: |
-          apt-get update
-          apt-get install -qy bzip2 gcc haskell-stack libbsd-dev libprotobuf-c-dev libutf8proc-dev make uuid-dev zlib1g-dev
-      - name: chown our home dir to avoid stack complaining
-        run: chown -R root:root /github/home
+          sudo apt-get update
+          sudo apt-get install -qy bzip2 clang haskell-stack libbsd-dev libprotobuf-c-dev libutf8proc-dev make uuid-dev zlib1g-dev
       - name: "Build Acton"
         run: make -j2 -C ${GITHUB_WORKSPACE} BUILD_RELEASE=${{ env.BUILD_RELEASE }}
       - name: "Build a release"


### PR DESCRIPTION
We continue building the .deb files on Debian but the standard Linux
test is better run on Ubuntu 18.04, since it is an older platform, so we
cover more ground than running everything on Debian.

The homogeneity we had with debian was mostly because it was simple. Now
that it is working we want to improve coverage across versions etc.