### PR TITLE
Expand on dev / rel compiler profiles

### DIFF
--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -431,14 +431,14 @@ buildExecutable env args paths task
         libPaths            = libPathsBase
         ccArgs              = " -no-pie "
 #endif
-        libRTSarg           = if (dev args) then " -lActonRTSdebug " else ""
-        libFiles            = libRTSarg ++ " -lActonProject -lActon -lActonDB -luuid -lprotobuf-c -lutf8proc -lpthread -lm"
+        libActonArg         = if (dev args) then "-lActon_dev" else "-lActon_rel"
+        libFiles            = " -lActonProject " ++ libActonArg ++ " -lActonDB -luuid -lprotobuf-c -lutf8proc -lpthread -lm"
         binFilename         = takeFileName $ dropExtension srcbase
         binFile             = joinPath [binDir paths, binFilename]
         srcbase             = srcFile paths mn
         pedantArg           = if (cpedantic args) then "-Werror" else ""
         ccCmd               = ("cc " ++ ccArgs ++ pedantArg ++
-                               (if (dev args) then " -g " else "") ++
+                               (if (dev args) then " -g " else " -O3 ") ++
                                " -I" ++ projOut paths ++
                                " -I" ++ sysPath paths ++
                                " " ++ rootFile ++


### PR DESCRIPTION
We now have two libAction:
- libActon_dev, for the development profile
- libActon_rel, for the release profile

This is more consistent than the previous solution where we always used
libActon and override certain modules (rts.o) that were specially
compiled with libActonRTSdebug. The two new archives are complete and do
not rely on each other in any way.

Thus, actonc will now link using libActon_dev OR libActon_rel.

All o-files are now compiled as a _dev.o and _rel.o file, using
CFLAGS_DEV and CFLAGS_REL for the respective flags. Right now, those are
-g for dev mode and -O3 for release mode.

Fixes #399