### PR TITLE
Rename & always set compiler profile variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ There are currently known regressions:
   - Mac on M1 users, simple do: `brew install actonlang/acton/acton`
   - No pre-built binary packages ("bottles") as our build environment cannot
     build those, but it is automatically built from source
+    
+### Fixed
+- `actonc` compiler profiles fully implemented [#403]
+  - previously, `--dev` only used to enable RTS debug
+  - now, all libraries are compiled twice, for dev and rel, and packaged up into
+    libActon_dev and libActon_rel archives
+  - dev mode is compiled with debug symbols (`-g`)
+  - release mode is using optimized code (`-O3`)
+  - final program binary is also compiled with the same flags
 
 
 ## [0.7.1] (2021-11-23)
@@ -594,6 +603,7 @@ then, this second incarnation has been in focus and 0.2.0 was its first version.
 [#384]: https://github.com/actonlang/acton/pull/384
 [#385]: https://github.com/actonlang/acton/pull/385
 [#390]: https://github.com/actonlang/acton/pull/390
+[#403]: https://github.com/actonlang/acton/pull/403
 [0.3.0]: https://github.com/actonlang/acton/releases/tag/v0.3.0
 [0.4.0]: https://github.com/actonlang/acton/compare/v0.3.0...v0.4.0
 [0.4.1]: https://github.com/actonlang/acton/compare/v0.4.0...v0.4.1

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ export VERSION_INFO?=$(VERSION).$(BUILD_TIME)
 endif
 
 CFLAGS+= -I. -Ideps -Wno-int-to-pointer-cast -Wno-pointer-to-int-cast
-CFLAGS_REL= -O3
-CFLAGS_DEV= -g
+CFLAGS_REL= -O3 -DREL
+CFLAGS_DEV= -g -DDEV
 LDFLAGS+=-Llib
 LDLIBS+=-lprotobuf-c -luuid -lm -lpthread
 
@@ -240,7 +240,7 @@ lib/libActonDB.a: $(BACKEND_OFILES)
 
 # /rts --------------------------------------------------
 rts/rts_dev.o: rts/rts.c rts/rts.h
-	$(CC) $(CFLAGS) $(CFLAGS_DEV) -DRTS_DEBUG \
+	$(CC) $(CFLAGS) $(CFLAGS_DEV) \
 		-Wno-int-to-void-pointer-cast -Wno-unused-result \
 		$(LDLIBS) \
 		-c $< -o $@

--- a/rts/rts.c
+++ b/rts/rts.c
@@ -98,7 +98,7 @@ static const char *WT_State_name[] = {"poof", "work", "idle", "sleep"};
 #define LOGPFX "**RTS** "
 #define rtsv_printf(...) if (rts_verbose) printf(__VA_ARGS__)
 
-#ifdef RTS_DEBUG
+#ifdef DEV
 #define rtsd_printf(...) if (rts_debug) printf(__VA_ARGS__)
 #else
 #define rtsd_printf(...)
@@ -1453,7 +1453,7 @@ int main(int argc, char **argv) {
         switch (ch) {
             case 'd':
                 new_argc--;
-                #ifndef RTS_DEBUG
+                #ifndef DEV
                 fprintf(stderr, "ERROR: RTS debug not supported.\n");
                 fprintf(stderr, "HINT: Recompile this program using: actonc --rts-debug ...\n");
                 exit(1);


### PR DESCRIPTION
We now always set the variables DEV or REL depending on if we are in dev
or release profile. Replaced the use of RTS_DEBUG with DEV.