### PR TITLE
Align $Actor "subclass" structs

### DIFF
--- a/builtin/minienv.h
+++ b/builtin/minienv.h
@@ -344,8 +344,6 @@ struct $Env {
     $Actor $next;
     $Msg $msg;
     $Msg $outgoing;
-    $Actor $offspring;
-    $Actor $uterus;
     $Msg $waitsfor;
     $int64 $consume_hd;
     $Catcher $catcher;
@@ -374,8 +372,6 @@ struct $Connection {
     $Actor $next;
     $Msg $msg;
     $Msg $outgoing;
-    $Actor $offspring;
-    $Actor $uterus;
     $Msg $waitsfor;
     $int64 $consume_hd;
     $Catcher $catcher;
@@ -402,8 +398,6 @@ struct $RFile {
     $Actor $next;
     $Msg $msg;
     $Msg $outgoing;
-    $Actor $offspring;
-    $Actor $uterus;
     $Msg $waitsfor;
     $int64 $consume_hd;
     $Catcher $catcher;
@@ -430,8 +424,6 @@ struct $WFile {
     $Actor $next;
     $Msg $msg;
     $Msg $outgoing;
-    $Actor $offspring;
-    $Actor $uterus;
     $Msg $waitsfor;
     $int64 $consume_hd;
     $Catcher $catcher;

--- a/compiler/Acton/Prim.hs
+++ b/compiler/Acton/Prim.hs
@@ -141,8 +141,6 @@ clActor cls def sig = cls [] (leftpath [cValue]) te
   where te          = [ (primKW "next",       sig (monotype tActor) Property),
                         (primKW "msg",        sig (monotype (tMsg tWild)) Property),
                         (primKW "outgoing",   sig (monotype (tMsg tWild)) Property),
-                        (primKW "offspring",  sig (monotype tActor) Property),
-                        (primKW "uterus",     sig (monotype tActor) Property),
                         (primKW "waitsfor",   sig (monotype (tMsg tWild)) Property),
                         (primKW "consume_hd", sig (monotype $ tCon $ TC (gPrim "int64") []) Property),
                         (primKW "catcher",    sig (monotype $ tCon $ TC (gPrim "Catcher") []) Property),


### PR DESCRIPTION
We changed the definition of $Actor but failed to update "subclasses"
like $Env etc. Now aligned!

Fixes #209.