### PR TITLE
Move note to Fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,8 @@
     fixed [#419]
   - Passing option arguments with =, like `--rts-wthreads=8` now works
 - Various fixes to C lib wrapping document [#418]
-
-### Changed
 - Renamed minienv to env [#417]
+  - Only internal change, does not influence what a user of Acton sees
 
 
 ## [0.7.2] (2021-12-15)


### PR DESCRIPTION
I think Changed is meant to convey user visible changes. This is
internal, so putting under Fixed.