### PR TITLE
Enable CI test of simple app together with the database

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -1,9 +1,8 @@
 ACTONC=../dist/bin/actonc --cpedantic
-DDB_SERVER=../backend/server
+DDB_SERVER=../dist/bin/actondb
 TESTS= \
-	rts/argv1 \
-	rts/argv2 \
-	rts/argv3 \
+	$(RTS_TESTS) \
+	ddb_count \
 	test_acton_rts_sleep \
 	test_random \
 	test_time \
@@ -18,10 +17,10 @@ regression:
 ddb_start:
 	$(DDB_SERVER) -p 32000 -m 34000 -s 127.0.0.1:34000 >db1.log 2>&1 &
 	sleep 0.1
-	$(DDB_SERVER) -p 32001 -m 34001 -s 127.0.0.1:34000 >db2.log 2>&1 &
-	sleep 0.1
-	$(DDB_SERVER) -p 32002 -m 34002 -s 127.0.0.1:34000 >db3.log 2>&1 &
-	sleep 0.1
+#	$(DDB_SERVER) -p 32001 -m 34001 -s 127.0.0.1:34000 >db2.log 2>&1 &
+#	sleep 0.1
+#	$(DDB_SERVER) -p 32002 -m 34002 -s 127.0.0.1:34000 >db3.log 2>&1 &
+#	sleep 0.1
 
 ddb_stop:
 	-pkill -f "server.*-s 127.0.0.1.34000"
@@ -33,15 +32,19 @@ ddb_stop:
 # incorrect return code and this test case can fail. This should really be
 # improved upon :)
 ddb_count:
+	$(MAKE) ddb_stop
 	$(MAKE) ddb_start
 	$(ACTONC) --root main count.act
-	./count 8 --rts-verbose --rts-ddb-host 127.0.0.1 &
+	./count 8 --rts-verbose --rts-ddb-host 127.0.0.1 --rts-ddb-replication 1 &
 	sleep 5
 	pkill -f count.8
 	sleep 1
-	./count 8 --rts-verbose --rts-ddb-host 127.0.0.1
+	./count 8 --rts-verbose --rts-ddb-host 127.0.0.1 --rts-ddb-replication 1
 	$(MAKE) ddb_stop
 
+
+# -- RTS --
+RTS_TESTS = rts/argv1 rts/argv2 rts/argv3
 
 # Test normal argument parsing
 rts/argv1:
@@ -60,6 +63,7 @@ rts/argv3:
 	$(ACTONC) --root main $@.act
 	./$@ --rts-wthreads 2>&1 | grep "ERROR: --rts-wthreads requires an argument."
 	@echo "Test success, saw expected error message"
+
 
 test_acton_rts_sleep:
 	$(ACTONC) --root main $@.act

--- a/test/Makefile
+++ b/test/Makefile
@@ -15,7 +15,7 @@ regression:
 	$(MAKE) -C regression
 
 ddb_start:
-	$(DDB_SERVER) -p 32000 -m 34000 -s 127.0.0.1:34000 >db1.log 2>&1 &
+	$(DDB_SERVER) -p 32000 -m 34000 -s 127.0.0.1:34000 >db1.log 2>&1 & echo $$! > db1.pid
 	sleep 0.1
 #	$(DDB_SERVER) -p 32001 -m 34001 -s 127.0.0.1:34000 >db2.log 2>&1 &
 #	sleep 0.1
@@ -23,7 +23,9 @@ ddb_start:
 #	sleep 0.1
 
 ddb_stop:
-	-pkill -f "server.*-s 127.0.0.1.34000"
+	-kill $$(cat db1.pid); rm db1.pid
+	-pkill -f "actondb.*-s 127.0.0.1.34000"
+
 
 # This is a really naive test. We don't even check the output of the program so
 # we do not check that the actual persistence and restoration of state is

--- a/test/Makefile
+++ b/test/Makefile
@@ -37,11 +37,11 @@ ddb_count:
 	$(MAKE) ddb_stop
 	$(MAKE) ddb_start
 	$(ACTONC) --root main count.act
-	./count 8 --rts-verbose --rts-ddb-host 127.0.0.1 --rts-ddb-replication 1 &
-	sleep 5
-	pkill -f count.8
-	sleep 1
-	./count 8 --rts-verbose --rts-ddb-host 127.0.0.1 --rts-ddb-replication 1
+#	./count 8 --rts-verbose --rts-ddb-host 127.0.0.1 --rts-ddb-replication 1 &
+#	sleep 5
+#	pkill -f count.8
+#	sleep 1
+	./count 1 --rts-verbose --rts-ddb-host 127.0.0.1 --rts-ddb-replication 1
 	$(MAKE) ddb_stop
 
 

--- a/test/count.act
+++ b/test/count.act
@@ -1,6 +1,6 @@
 actor main(env):
     var i = 0;
-    var count_to = int(env.args[-1])
+    var count_to = int(env.argv[1])
 
     def _work():
         print(i)


### PR DESCRIPTION
This enables a very basic test of the RTS together with the distributed database.

Replication seems to be broken right now (#409) so we use a single DB node and resumption also appears broken (#408) so that's disabled too. We just start a simple app and tell the RTS to use the DB to save state. We don't verify that it actually does, like it could just be a giant NOOP, but we assume that we have done enough things correctly that we do attempt to use the DB and second that any failures will be catastrophic, crashing the application or similarly which we will notice and fail the entire test.

Related to #225. This is like a mini-version of that.