### PR TITLE
Add DDB test harness

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
       - name: "Install build prerequisites"
         run: |
           apt-get update
-          apt-get install -qy bzip2 gcc haskell-stack libbsd-dev libprotobuf-c-dev libutf8proc-dev make uuid-dev zlib1g-dev
+          apt-get install -qy bzip2 gcc haskell-stack libbsd-dev libprotobuf-c-dev libutf8proc-dev make python3 uuid-dev zlib1g-dev
       - name: chown our home dir to avoid stack complaining
         run: chown -R root:root /github/home
       - name: "Build Acton"

--- a/backend/actondb.c
+++ b/backend/actondb.c
@@ -2179,6 +2179,13 @@ int main(int argc, char **argv) {
   char msg_buf[1024];
   int verbosity = SERVER_VERBOSITY;
 
+  // Disable buffering of stdout. This is necessary for testing actondb since we
+  // rely on reading log output on stdout to know the status of the server. We
+  // should ideally replace this with a better way of reading the server status,
+  // in which case we can remove this line and return to having buffered stdout.
+  // Unbuffered stdout isn't a huge deal since we don't write that much.
+  setbuf(stdout, NULL);
+
   const char *argp_program_version = "ddb server 1.0";
 
   static struct argp_option options[] =

--- a/test/Makefile
+++ b/test/Makefile
@@ -2,47 +2,34 @@ ACTONC=../dist/bin/actonc --cpedantic
 DDB_SERVER=../dist/bin/actondb
 TESTS= \
 	$(RTS_TESTS) \
-	ddb_count \
+	$(DDB_TESTS) \
 	test_acton_rts_sleep \
 	test_random \
 	test_time \
 	rts_sleep \
 	regression \
 	stdlib/test_numpy
-test: $(TESTS)
+test:
+	$(MAKE) $(TESTS)
 
 regression:
 	$(MAKE) -C regression
 
-ddb_start:
-	$(DDB_SERVER) -p 32000 -m 34000 -s 127.0.0.1:34000 >db1.log 2>&1 & echo $$! > db1.pid
-	sleep 0.1
-#	$(DDB_SERVER) -p 32001 -m 34001 -s 127.0.0.1:34000 >db2.log 2>&1 &
-#	sleep 0.1
-#	$(DDB_SERVER) -p 32002 -m 34002 -s 127.0.0.1:34000 >db3.log 2>&1 &
-#	sleep 0.1
 
-ddb_stop:
-	-kill $$(cat db1.pid); rm db1.pid
-	-pkill -f "actondb.*-s 127.0.0.1.34000"
+foo:
+	@echo $(TESTS)
 
+DDB_TESTS=test_db_membership test_db_app
+.PHONY: test_db_membership test_db_app
+# Starts up a database cluster and checks membership
+test_db_membership:
+	./test_db.py --db-nodes 3
 
-# This is a really naive test. We don't even check the output of the program so
-# we do not check that the actual persistence and restoration of state is
-# working. We assume that stuff will attempt to do its business and if anything
-# goes wrong, it will have catastrophic failure so that something will return an
-# incorrect return code and this test case can fail. This should really be
-# improved upon :)
-ddb_count:
-	$(MAKE) ddb_stop
-	$(MAKE) ddb_start
-	$(ACTONC) --root main count.act
-#	./count 8 --rts-verbose --rts-ddb-host 127.0.0.1 --rts-ddb-replication 1 &
-#	sleep 5
-#	pkill -f count.8
-#	sleep 1
-	./count 1 --rts-verbose --rts-ddb-host 127.0.0.1 --rts-ddb-replication 1
-	$(MAKE) ddb_stop
+# Starts up a database cluster and
+# Currently using a single (1) DB node since replication is b0rked!
+test_db_app:
+	$(ACTONC) --root main test_db.act
+	./test_db.py --db-nodes 1 --app ./test_db
 
 
 # -- RTS --

--- a/test/test_db.act
+++ b/test/test_db.act
@@ -1,0 +1,27 @@
+# Basic test case of the Acton RTS together with the database backend. We want
+# to focus on things that lead to database interaction, so in essence calling
+# actor methods / sending methods and execution of continuations. We also want
+# to test the timer queue.
+#
+# main -> Foo."init" -> timerQ after 0 -> Foo.callback() -> main.final() -> exit
+
+
+actor Foo(cb_method):
+    def callback():
+        print("Calling cb_method()")
+        cb_method()
+
+    print("Scheduling after 0")
+    after 0: callback()
+
+actor main(env):
+    def final():
+        print("In final method")
+        print("exiting...")
+        await async env.exit(0)
+
+    def test():
+        print("Creating Foo() instance")
+        f = Foo(final)
+
+    test()

--- a/test/test_db.py
+++ b/test/test_db.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+
+import logging
+import os
+import locale
+import re
+import subprocess
+import sys
+import time
+import select
+
+ACTONDB="../dist/bin/actondb"
+BASEPORT=32001
+
+def parse_membership(line):
+    m = re.match(".*Membership_agreement_msg.type=(?P<type>[^,]+), ack_status=(?P<ack_status>[^,]+), nonce=(?P<nonce>[0-9]+), Membership\((?P<membership>(Node\(.*?\))+), , VC\(.*?\)\), local_view_disagrees=(?P<local_view_disagrees>.)", line)
+    membership = []
+    if m is not None:
+        for node in re.findall(r"Node\((.*?)\)(, )?", m.group('membership')):
+            res = dict(map(lambda x: x.split('='), node[0].split(', ')))
+            membership.append(res)
+        return {
+            'type': m.group('type'),
+            'ack_status': m.group('ack_status'),
+            'nonce': m.group('nonce'),
+            'local_view_disagrees': m.group('local_view_disagrees'),
+            'membership': membership
+        }
+    raise ValueError("Unable to parse Membership agreement")
+
+
+
+class Db:
+    def __repr__(self):
+        return f"Db{self.idx}"
+
+    def __init__(self, idx):
+        self.idx = idx
+        self.name = f"Db{idx}"
+        #print(f"Starting {self.name}")
+        self.p = None
+        self.running = False
+
+    def start(self):
+        args = [ACTONDB, "-p", f"32{self.idx:03d}", "-m", f"34{self.idx:03d}",
+                "-s", "127.0.0.1:34000"]
+        self.p = subprocess.Popen(
+            [ACTONDB, "-p", f"32{self.idx:03d}", "-m", f"34{self.idx:03d}", "-s", "127.0.0.1:34000"],
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        os.set_blocking(self.p.stdout.fileno(), False)
+
+        while True:
+            line = self.p.stdout.readline().decode(locale.getpreferredencoding(False)).strip()
+            if re.match("SERVER: Started", line):
+                self.running = True
+                break
+
+
+    def stop(self):
+        self.p.kill()
+        self.p.wait() # wait for the child process to exit
+
+
+    def await_membership(self):
+        # Try reading & looking for our expected result for some time before
+        # giving up
+        st = time.time()
+        lines = []
+        # Read in all buffered lines
+        while True:
+            line = self.p.stdout.readline().decode(locale.getpreferredencoding(False)).strip()
+            if re.match("SERVER: Installed new agreed", line):
+                return parse_membership(line)
+
+
+class App:
+    def __repr__(self):
+        return f"App[{self.name}]"
+
+    def __init__(self, app_path, app_args=None):
+        self.path = app_path
+        if app_args is not None:
+            self.args = app_args
+        else:
+            self.args = []
+        self.name = "fjong"
+        self.p = None
+
+    def start(self):
+        cmd = [self.path, "--rts-ddb-host", "localhost", "--rts-ddb-replication", "1", "--rts-verbose", *self.args]
+        print("RUNNING:", cmd)
+        self.p = subprocess.Popen(cmd, stdin=subprocess.PIPE,
+                                  stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        #os.set_blocking(self.p.stdout.fileno(), False)
+
+    def wait(self):
+        print("Waiting for application...")
+        while True:
+            print("fjong..")
+            line = self.p.stdout.readline().decode(locale.getpreferredencoding(False)).strip()
+            print(line)
+            if line == '':
+                break
+        self.p.wait()
+
+    def stop(self):
+        pass
+
+
+class DbCluster:
+    def __init__(self, num=3):
+        self.num = num
+
+    def start(self):
+        """Start up a cluster of num nodes and ensure that memberships look alright
+        """
+        log = logging.getLogger()
+
+        log.debug("Starting database servers")
+        self.dbs=[Db(0)]
+        self.dbs[0].start()
+
+        allgood = True
+
+        for i in range(1, self.num):
+            log.debug(f"Starting instance {i}")
+            # Create & start new instance
+            dbn = Db(i)
+            dbn.start()
+            self.dbs.append(dbn)
+
+            # Now go through all existing nodes and ensure all have new membership
+            expected = None
+            for db in self.dbs:
+                mbs = db.await_membership()
+                #log.debug(f"Membership info for {db}: {mbs}")
+                if expected is None:
+                    log.debug(f"Using Membership info from {db} as expected")
+                    expected = mbs
+                else:
+                    if mbs == expected:
+                        log.debug(f"Membership info for {db} is as expected")
+                        pass
+                    else:
+                        log.error(f"Membership info for {db} seems incorrect")
+                        allgood = False
+        return allgood
+
+
+    def stop(self):
+        log.debug("Stopping database servers")
+        for dbn in self.dbs:
+            dbn.stop()
+
+
+
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--app")
+    parser.add_argument("--db-nodes", type=int, default=3)
+    parser.add_argument("--repeat", type=int, default=1)
+    args = parser.parse_args()
+
+    # set logging format
+    LOG_FORMAT = "%(asctime)s: %(module)-10s %(levelname)-8s %(message)s"
+    # setup basic logging
+    logging.basicConfig(format=LOG_FORMAT)
+
+    log = logging.getLogger()
+    log.setLevel(logging.INFO)
+    log.setLevel(logging.DEBUG)
+
+    allgood = True
+
+    for i in range(args.repeat):
+        log.info(f"-- Round {i}")
+
+        dbc = DbCluster(args.db_nodes)
+
+        if not dbc.start():
+            allgood = False
+
+        if args.app:
+            cmd = [args.app, "--rts-verbose", "--rts-ddb-host", "localhost", "--rts-ddb-replication", str(args.db_nodes)]
+            log.debug(f"Starting application: {' '.join(cmd)}")
+            res = subprocess.run(cmd, capture_output=True)
+            if re.search("No quorum", res.stderr.decode(locale.getpreferredencoding(False))):
+                log.error(f"DB Quorum error: {res}")
+            elif res.returncode == 0:
+                log.debug("Application exited successfully")
+            else:
+                log.error("Non-0 return code:", res)
+                allgood = False
+
+        if not dbc.stop():
+            allgood = False
+
+    sys.exit(allgood)


### PR DESCRIPTION
test_db.py is a new script that can orchestrate the setup and testing of
an Acton application together with the distributed database. Multiple
database nodes are started and their status read (from stdout) to ensure
that they agree on their membership before proceeding to run the Acton
application, specifying arguments to use the database backend.

There's an accompanying Acton application, test_db.act, that is written
to be a small and simple test of the database. By calling actor methods
on other actors, we exercise the database, since each call becomes a
message and continuation. We also check that the timer queue works by
invoking one method with after 0:

Resumption of the application is not tested since that is currently
broken. We also do not test running the application with a replication
higher than 1, since that is also broken.

Trying to use a higher replication factor fails but unfortunately this
is not reflected by the application exiting with an error code, rather
we just get some error messages on stderr. The test harness checks for
these, so running with --db-nodes=3 for example will result in a test
failure.

At the very least, this should stop us from introducing new regressions
that affect the use of the database backend from the RTS.

This replaces the earlier hacked up ddb_count test that was driven by a
Makefile, since this new script is better in pretty much all regards.

Fixes #225.