### PR TITLE
Add clang-format config file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,6 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+ColumnLimit: 0
+AlignConsecutiveMacros: true
+IndentCaseLabels: true
+SortIncludes: false

--- a/builtin/Iterator.c
+++ b/builtin/Iterator.c
@@ -13,11 +13,11 @@
  */
 
 $Iterator $Iterable$Iterator_iter($Iterable$Iterator wit, $Iterator self) {
-  return self;
+    return self;
 }
 
 $Iterable$Iterator $Iterable$Iterator$new() {
-  return $NEW($Iterable$Iterator);
+    return $NEW($Iterable$Iterator);
 }
 
 struct $Iterable$Iterator$class $Iterable$Iterator$methods = {
@@ -27,31 +27,29 @@ struct $Iterable$Iterator$class $Iterable$Iterator$methods = {
     (void (*)($Iterable$Iterator))$default__init__,
     $Iterable$Iterator$__serialize__,
     $Iterable$Iterator$__deserialize__,
-    ($bool (*)($Iterable$Iterator))$default__bool__,
-    ($str (*)($Iterable$Iterator))$default__str__,
-    $Iterable$Iterator_iter
-};
+    ($bool(*)($Iterable$Iterator))$default__bool__,
+    ($str(*)($Iterable$Iterator))$default__str__,
+    $Iterable$Iterator_iter};
 
 struct $Iterable$Iterator $Iterable$Iterator_instance = {&$Iterable$Iterator$methods};
 $Iterable$Iterator $Iterable$Iterator$witness = &$Iterable$Iterator_instance;
 
-
-struct $Iterator$class $Iterator$methods = {"$Iterator",UNASSIGNED,NULL,NULL,NULL,NULL,NULL,NULL,NULL}; // $Iterator is an abstract class
+struct $Iterator$class $Iterator$methods = {"$Iterator", UNASSIGNED, NULL, NULL, NULL, NULL, NULL, NULL, NULL}; // $Iterator is an abstract class
 struct $Iterator $Iterator_instance = {&$Iterator$methods};
 struct $Iterator *$Iterator$witness = &$Iterator_instance;
 
-void $Iterable$Iterator$__serialize__( $Iterable$Iterator self, $Serial$state state) {
+void $Iterable$Iterator$__serialize__($Iterable$Iterator self, $Serial$state state) {
 }
 
 $Iterable$Iterator $Iterable$Iterator$__deserialize__($Iterable$Iterator self, $Serial$state state) {
-   $Iterable$Iterator res = $DNEW($Iterable$Iterator,state);
-   return res;
+    $Iterable$Iterator res = $DNEW($Iterable$Iterator, state);
+    return res;
 }
 
 $bool $Iterable$Iterator$__eq__($Iterable$Iterator wit, $complex a, $complex b) {
-  return to$bool(creal(a->val) == creal(b->val) && cimag(a->val) == cimag(b->val));
+    return to$bool(creal(a->val) == creal(b->val) && cimag(a->val) == cimag(b->val));
 }
 
 $WORD $next($Iterator it) {
-  return it->$class->__next__(it);
+    return it->$class->__next__(it);
 }

--- a/builtin/Iterator.h
+++ b/builtin/Iterator.h
@@ -1,19 +1,20 @@
 #pragma once
 
 struct $Iterator$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)($Iterator);
-  void (*__serialize__)($Iterator,$Serial$state);
-  $Iterator (*__deserialize__)($Iterator,$Serial$state);
-  $bool (*__bool__)($Iterator);
-  $str (*__str__)($Iterator);
-  $WORD (*__next__)($Iterator);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)($Iterator);
+    void (*__serialize__)($Iterator, $Serial$state);
+    $Iterator (*__deserialize__)($Iterator, $Serial$state);
+    $bool (*__bool__)($Iterator);
+    $str (*__str__)($Iterator);
+    $WORD (*__next__)
+    ($Iterator);
 };
 
 struct $Iterator {
-  struct $Iterator$class *$class;
+    struct $Iterator$class *$class;
 };
 
 extern struct $Iterable$Iterator$class $Iterable$Iterator$methods;

--- a/builtin/__builtin__.c
+++ b/builtin/__builtin__.c
@@ -15,356 +15,351 @@
 #include "builtin.h"
 
 $WORD $Eq$__ne__($Eq wit, $WORD a, $WORD b) {
-  return to$bool(!wit->$class->__eq__(wit,a,b)->val);
+    return to$bool(!wit->$class->__eq__(wit, a, b)->val);
 }
 
 $WORD $Ord$__gt__($Ord wit, $WORD a, $WORD b) {
-  return wit->$class->__lt__(wit,b,a);
+    return wit->$class->__lt__(wit, b, a);
 }
 
 $WORD $Ord$__ge__($Ord wit, $WORD a, $WORD b) {
-  return wit->$class->__le__(wit,b,a);
+    return wit->$class->__le__(wit, b, a);
 }
 
-$WORD $Plus$__iadd__ ($Plus wit, $WORD a, $WORD b) {
+$WORD $Plus$__iadd__($Plus wit, $WORD a, $WORD b) {
     return wit->$class->__add__(wit, a, b);
 }
 
-$WORD $Minus$__isub__ ($Minus wit, $WORD a, $WORD b) {
+$WORD $Minus$__isub__($Minus wit, $WORD a, $WORD b) {
     return wit->$class->__sub__(wit, a, b);
 }
 
-$WORD $Logical$__iand__ ($Logical wit, $WORD a, $WORD b) {
+$WORD $Logical$__iand__($Logical wit, $WORD a, $WORD b) {
     return wit->$class->__and__(wit, a, b);
 }
 
-$WORD $Logical$__ior__ ($Logical wit, $WORD a, $WORD b) {
+$WORD $Logical$__ior__($Logical wit, $WORD a, $WORD b) {
     return wit->$class->__or__(wit, a, b);
 }
 
-$WORD $Logical$__ixor__ ($Logical wit, $WORD a, $WORD b) {
+$WORD $Logical$__ixor__($Logical wit, $WORD a, $WORD b) {
     return wit->$class->__xor__(wit, a, b);
 }
 
-$WORD $Times$__imul__ ($Times wit, $WORD a, $WORD b) {
+$WORD $Times$__imul__($Times wit, $WORD a, $WORD b) {
     return wit->$class->__mul__(wit, a, b);
 }
 
-$WORD $Div$__itruediv__ ($Div wit, $WORD a, $WORD b) {
+$WORD $Div$__itruediv__($Div wit, $WORD a, $WORD b) {
     return wit->$class->__truediv__(wit, a, b);
 }
 
-$WORD $Number$__ipow__ ($Number wit, $WORD a, $WORD b) {
+$WORD $Number$__ipow__($Number wit, $WORD a, $WORD b) {
     return wit->$class->__pow__(wit, a, b);
 }
 
-$WORD $Integral$__ifloordiv__ ($Integral wit, $WORD a, $WORD b) {
+$WORD $Integral$__ifloordiv__($Integral wit, $WORD a, $WORD b) {
     return wit->$class->__floordiv__(wit, a, b);
 }
 
-$WORD $Integral$__imod__ ($Integral wit, $WORD a, $WORD b) {
+$WORD $Integral$__imod__($Integral wit, $WORD a, $WORD b) {
     return wit->$class->__mod__(wit, a, b);
 }
 
-$WORD $Integral$__ilshift__ ($Integral wit, $WORD a, $int b) {
+$WORD $Integral$__ilshift__($Integral wit, $WORD a, $int b) {
     return wit->$class->__lshift__(wit, a, b);
 }
 
-$WORD $Integral$__irshift__ ($Integral wit, $WORD a, $int b) {
+$WORD $Integral$__irshift__($Integral wit, $WORD a, $int b) {
     return wit->$class->__rshift__(wit, a, b);
 }
 
-struct $Eq$class $Eq$methods = {"$Eq$class", UNASSIGNED, NULL, (void (*)($Eq))$default__init__, NULL, NULL, ($bool (*)($Eq))$default__bool__,  ($str (*)($Eq))$default__str__,
+struct $Eq$class $Eq$methods = {"$Eq$class", UNASSIGNED, NULL, (void (*)($Eq))$default__init__, NULL, NULL, ($bool(*)($Eq))$default__bool__, ($str(*)($Eq))$default__str__,
                                 NULL, NULL};
 
 $Eq $Eq$new() {
-  $Eq res = malloc(sizeof(struct $Eq));
-  res->$class = &$Eq$methods;
-  return res;
+    $Eq res = malloc(sizeof(struct $Eq));
+    res->$class = &$Eq$methods;
+    return res;
 }
 
-struct $Ord$class $Ord$methods = {"$Ord$class", UNASSIGNED, ($Super$class)&$Eq$methods, (void (*)($Ord))$default__init__, NULL, NULL, ($bool (*)($Ord))$default__bool__,  ($str (*)($Ord))$default__str__,
+struct $Ord$class $Ord$methods = {"$Ord$class", UNASSIGNED, ($Super$class)&$Eq$methods, (void (*)($Ord))$default__init__, NULL, NULL, ($bool(*)($Ord))$default__bool__, ($str(*)($Ord))$default__str__,
                                   NULL, NULL, NULL, NULL, NULL, NULL};
 
 $Ord $Ord$new() {
-  $Ord res = malloc(sizeof(struct $Eq));
-  res->$class = &$Ord$methods;
-  return res;
+    $Ord res = malloc(sizeof(struct $Eq));
+    res->$class = &$Ord$methods;
+    return res;
 }
 
-struct $Logical$class $Logical$methods = {"$Logical$class", UNASSIGNED, NULL, (void (*)($Logical))$default__init__, NULL, NULL, ($bool (*)($Logical))$default__bool__,  ($str (*)($Logical))$default__str__,
+struct $Logical$class $Logical$methods = {"$Logical$class", UNASSIGNED, NULL, (void (*)($Logical))$default__init__, NULL, NULL, ($bool(*)($Logical))$default__bool__, ($str(*)($Logical))$default__str__,
                                           NULL, NULL, NULL};
 
 $Logical $Logical$new() {
-  $Logical res = malloc(sizeof(struct $Logical));
-  res->$class = &$Logical$methods;
-  return res;
+    $Logical res = malloc(sizeof(struct $Logical));
+    res->$class = &$Logical$methods;
+    return res;
 }
 
-struct $Plus$class $Plus$methods = {"$Plus$class", UNASSIGNED, NULL, (void (*)($Plus))$default__init__, NULL, NULL, ($bool (*)($Plus))$default__bool__,  ($str (*)($Plus))$default__str__,
+struct $Plus$class $Plus$methods = {"$Plus$class", UNASSIGNED, NULL, (void (*)($Plus))$default__init__, NULL, NULL, ($bool(*)($Plus))$default__bool__, ($str(*)($Plus))$default__str__,
                                     NULL, $Plus$__iadd__};
 
 $Plus $Plus$new() {
-  $Plus res = malloc(sizeof(struct $Plus));
-  res->$class = &$Plus$methods;
-  return res;
+    $Plus res = malloc(sizeof(struct $Plus));
+    res->$class = &$Plus$methods;
+    return res;
 }
 
-struct $Times$class $Times$methods = {"$Times$class", UNASSIGNED, NULL, (void (*)($Times))$default__init__, NULL, NULL, ($bool (*)($Times))$default__bool__,  ($str (*)($Times))$default__str__,
-                                      NULL, ($WORD (*)($Times,$WORD,$WORD))$Plus$__iadd__, $Times$__imul__};
+struct $Times$class $Times$methods = {"$Times$class", UNASSIGNED, NULL, (void (*)($Times))$default__init__, NULL, NULL, ($bool(*)($Times))$default__bool__, ($str(*)($Times))$default__str__,
+                                      NULL, ($WORD(*)($Times, $WORD, $WORD))$Plus$__iadd__, $Times$__imul__};
 
 $Times $Times$new() {
-  $Times res = malloc(sizeof(struct $Times));
-  res->$class = &$Times$methods;
-  return res;
+    $Times res = malloc(sizeof(struct $Times));
+    res->$class = &$Times$methods;
+    return res;
 }
 
-struct $Div$class $Div$methods = {"$Div$class", UNASSIGNED, NULL, (void (*)($Div))$default__init__, NULL, NULL, ($bool (*)($Div))$default__bool__,  ($str (*)($Div))$default__str__,
-                                    NULL, $Div$__itruediv__};
+struct $Div$class $Div$methods = {"$Div$class", UNASSIGNED, NULL, (void (*)($Div))$default__init__, NULL, NULL, ($bool(*)($Div))$default__bool__, ($str(*)($Div))$default__str__,
+                                  NULL, $Div$__itruediv__};
 
 $Div $Div$new() {
-  $Div res = malloc(sizeof(struct $Div));
-  res->$class = &$Div$methods;
-  return res;
+    $Div res = malloc(sizeof(struct $Div));
+    res->$class = &$Div$methods;
+    return res;
 }
 
-struct $Minus$class $Minus$methods = {"$Minus$class", UNASSIGNED, NULL, (void (*)($Minus))$default__init__, NULL, NULL, ($bool (*)($Minus))$default__bool__,  ($str (*)($Minus))$default__str__,
+struct $Minus$class $Minus$methods = {"$Minus$class", UNASSIGNED, NULL, (void (*)($Minus))$default__init__, NULL, NULL, ($bool(*)($Minus))$default__bool__, ($str(*)($Minus))$default__str__,
                                       NULL, $Minus$__isub__};
 
 $Minus $Minus$new() {
-  $Minus res = malloc(sizeof(struct $Minus));
-  res->$class = &$Minus$methods;
-  return res;
+    $Minus res = malloc(sizeof(struct $Minus));
+    res->$class = &$Minus$methods;
+    return res;
 }
 
-struct $Hashable$class $Hashable$methods = {"$Hashable$class", UNASSIGNED, NULL, (void (*)($Hashable))$default__init__, NULL, NULL, ($bool (*)($Hashable))$default__bool__,  ($str (*)($Hashable))$default__str__,
+struct $Hashable$class $Hashable$methods = {"$Hashable$class", UNASSIGNED, NULL, (void (*)($Hashable))$default__init__, NULL, NULL, ($bool(*)($Hashable))$default__bool__, ($str(*)($Hashable))$default__str__,
                                             NULL, NULL, NULL};
 
 $Hashable $Hashable$new() {
-  $Hashable res = malloc(sizeof(struct $Hashable));
-  res->$class = &$Hashable$methods;
-  return res;
+    $Hashable res = malloc(sizeof(struct $Hashable));
+    res->$class = &$Hashable$methods;
+    return res;
 }
 
 static void $Indexed$__init__($Indexed self, $Eq w$Eq$A$Indexed) {
-  self->w$Eq$A$Indexed = w$Eq$A$Indexed;
+    self->w$Eq$A$Indexed = w$Eq$A$Indexed;
 }
 
-struct $Indexed$class $Indexed$methods = {"$Indexed$class", UNASSIGNED, NULL, $Indexed$__init__, NULL, NULL, ($bool (*)($Indexed))$default__bool__,  ($str (*)($Indexed))$default__str__,
+struct $Indexed$class $Indexed$methods = {"$Indexed$class", UNASSIGNED, NULL, $Indexed$__init__, NULL, NULL, ($bool(*)($Indexed))$default__bool__, ($str(*)($Indexed))$default__str__,
                                           NULL, NULL, NULL};
 
 $Indexed $Indexed$new($Eq w$Eq$A$Indexed) {
-  $Indexed res = malloc(sizeof(struct $Indexed));
-  res->$class = &$Indexed$methods;
-  res->w$Eq$A$Indexed = w$Eq$A$Indexed;
-  return res;
+    $Indexed res = malloc(sizeof(struct $Indexed));
+    res->$class = &$Indexed$methods;
+    res->w$Eq$A$Indexed = w$Eq$A$Indexed;
+    return res;
 }
 
-struct $Sliceable$class $Sliceable$methods = {"$Sliceable$class", UNASSIGNED, ($Super$class)&$Indexed$methods, (void (*)($Sliceable))$default__init__, NULL, NULL, ($bool (*)($Sliceable))$default__bool__,  ($str (*)($Sliceable))$default__str__,
+struct $Sliceable$class $Sliceable$methods = {"$Sliceable$class", UNASSIGNED, ($Super$class)&$Indexed$methods, (void (*)($Sliceable))$default__init__, NULL, NULL, ($bool(*)($Sliceable))$default__bool__, ($str(*)($Sliceable))$default__str__,
                                               NULL, NULL, NULL, NULL, NULL, NULL};
 
 $Sliceable $Sliceable$new() {
-  $Sliceable res = malloc(sizeof(struct $Sliceable));
-  res->$class = &$Sliceable$methods;
-  return res;
+    $Sliceable res = malloc(sizeof(struct $Sliceable));
+    res->$class = &$Sliceable$methods;
+    return res;
 }
 
-struct $Iterable$class $Iterable$methods = {"$Iterable$class", UNASSIGNED, NULL, (void (*)($Iterable))$default__init__, NULL, NULL, ($bool (*)($Iterable))$default__bool__,  ($str (*)($Iterable))$default__str__,
+struct $Iterable$class $Iterable$methods = {"$Iterable$class", UNASSIGNED, NULL, (void (*)($Iterable))$default__init__, NULL, NULL, ($bool(*)($Iterable))$default__bool__, ($str(*)($Iterable))$default__str__,
                                             NULL};
 
 $Iterable $Iterable$new() {
-  $Iterable res = malloc(sizeof(struct $Iterable));
-  res->$class = &$Iterable$methods;
-  return res;
+    $Iterable res = malloc(sizeof(struct $Iterable));
+    res->$class = &$Iterable$methods;
+    return res;
 }
 
-struct $Collection$class $Collection$methods = {"$Collection$class", UNASSIGNED, ($Super$class)&$Iterable$methods, (void (*)($Collection))$default__init__, NULL, NULL, ($bool (*)($Collection))$default__bool__,  ($str (*)($Collection))$default__str__,
+struct $Collection$class $Collection$methods = {"$Collection$class", UNASSIGNED, ($Super$class)&$Iterable$methods, (void (*)($Collection))$default__init__, NULL, NULL, ($bool(*)($Collection))$default__bool__, ($str(*)($Collection))$default__str__,
                                                 NULL, NULL, NULL};
 
 $Collection $Collection$new() {
-  $Collection res = malloc(sizeof(struct $Collection));
-  res->$class = &$Collection$methods;
-  return res;
+    $Collection res = malloc(sizeof(struct $Collection));
+    res->$class = &$Collection$methods;
+    return res;
 }
 
 static void $Container$__init__($Container self, $Eq w$Eq$A$Container) {
-  self->w$Eq$A$Container = w$Eq$A$Container;
+    self->w$Eq$A$Container = w$Eq$A$Container;
 }
 
-struct $Container$class $Container$methods = {"$Container$class", UNASSIGNED, ($Super$class)&$Collection$methods, $Container$__init__, NULL, NULL, ($bool (*)($Container))$default__bool__,  ($str (*)($Container))$default__str__,
+struct $Container$class $Container$methods = {"$Container$class", UNASSIGNED, ($Super$class)&$Collection$methods, $Container$__init__, NULL, NULL, ($bool(*)($Container))$default__bool__, ($str(*)($Container))$default__str__,
                                               NULL, NULL, NULL, NULL, NULL};
 
 $Container $Container$new($Eq w$Eq$A$Container) {
-  $Container res = malloc(sizeof(struct $Container));
-  res->$class = &$Container$methods;
-  res->w$Eq$A$Container = w$Eq$A$Container;
-  return res;
+    $Container res = malloc(sizeof(struct $Container));
+    res->$class = &$Container$methods;
+    res->w$Eq$A$Container = w$Eq$A$Container;
+    return res;
 }
 
 static void $Sequence$__init__($Sequence self) {
-  self->w$Collection = $Collection$new();
-  self->w$Times = $Times$new();
+    self->w$Collection = $Collection$new();
+    self->w$Times = $Times$new();
 }
 
-struct $Sequence$class $Sequence$methods = {"$Sequence$class", UNASSIGNED, ($Super$class)&$Sliceable$methods, $Sequence$__init__, NULL, NULL, ($bool (*)($Sequence))$default__bool__,  ($str (*)($Sequence))$default__str__,
+struct $Sequence$class $Sequence$methods = {"$Sequence$class", UNASSIGNED, ($Super$class)&$Sliceable$methods, $Sequence$__init__, NULL, NULL, ($bool(*)($Sequence))$default__bool__, ($str(*)($Sequence))$default__str__,
                                             NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL};
 
 $Sequence $Sequence$new() {
-  $Sequence res = malloc(sizeof(struct $Sequence));
-  res->$class = &$Sequence$methods;
-  res->w$Collection = $Collection$new();
-  res->w$Times = $Times$new();
-  return res;
+    $Sequence res = malloc(sizeof(struct $Sequence));
+    res->$class = &$Sequence$methods;
+    res->w$Collection = $Collection$new();
+    res->w$Times = $Times$new();
+    return res;
 }
 
 void $Mapping$__init__($Mapping self, $Eq w$Eq$A$Mapping) {
-  self->w$Indexed = $Indexed$new(w$Eq$A$Mapping);
-  self->w$Eq$A$Mapping = w$Eq$A$Mapping;
+    self->w$Indexed = $Indexed$new(w$Eq$A$Mapping);
+    self->w$Eq$A$Mapping = w$Eq$A$Mapping;
 }
 
-struct $Mapping$class $Mapping$methods = {"$Mapping$class", UNASSIGNED, ($Super$class)&$Container$methods, $Mapping$__init__, NULL, NULL, ($bool (*)($Mapping))$default__bool__,  ($str (*)($Mapping))$default__str__,
+struct $Mapping$class $Mapping$methods = {"$Mapping$class", UNASSIGNED, ($Super$class)&$Container$methods, $Mapping$__init__, NULL, NULL, ($bool(*)($Mapping))$default__bool__, ($str(*)($Mapping))$default__str__,
                                           NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL};
 
 $Mapping $Mapping$new($Eq w$Eq$A$Mapping) {
-  $Mapping res = malloc(sizeof(struct $Mapping));
-  res->$class = &$Mapping$methods;
-  res->w$Indexed = $Indexed$new(w$Eq$A$Mapping);
-  res->w$Eq$A$Mapping = w$Eq$A$Mapping;
-  return res;
+    $Mapping res = malloc(sizeof(struct $Mapping));
+    res->$class = &$Mapping$methods;
+    res->w$Indexed = $Indexed$new(w$Eq$A$Mapping);
+    res->w$Eq$A$Mapping = w$Eq$A$Mapping;
+    return res;
 }
 
 void $Set$__init__($Set self, $Eq w$Eq$A$Set) {
-  self->w$Ord = $Ord$new();
-  self->w$Logical = $Logical$new();
-  self->w$Minus = $Minus$new();
-  self->w$Eq$A$Set = w$Eq$A$Set;
+    self->w$Ord = $Ord$new();
+    self->w$Logical = $Logical$new();
+    self->w$Minus = $Minus$new();
+    self->w$Eq$A$Set = w$Eq$A$Set;
 }
-  
-struct $Set$class $Set$methods = {"$Set$class", UNASSIGNED, ($Super$class)&$Container$methods, $Set$__init__, NULL, NULL, ($bool (*)($Set))$default__bool__,  ($str (*)($Set))$default__str__,
-                                NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL};
+
+struct $Set$class $Set$methods = {"$Set$class", UNASSIGNED, ($Super$class)&$Container$methods, $Set$__init__, NULL, NULL, ($bool(*)($Set))$default__bool__, ($str(*)($Set))$default__str__,
+                                  NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL};
 
 $Set $Set$new($Eq w$Eq$A$Set) {
-  $Set res = malloc(sizeof(struct $Set));
-  res->$class = &$Set$methods;
-  res->w$Ord = $Ord$new();
-  res->w$Logical = $Logical$new();
-  res->w$Minus = $Minus$new();
-  res->w$Eq$A$Set = w$Eq$A$Set;
- return res;
+    $Set res = malloc(sizeof(struct $Set));
+    res->$class = &$Set$methods;
+    res->w$Ord = $Ord$new();
+    res->w$Logical = $Logical$new();
+    res->w$Minus = $Minus$new();
+    res->w$Eq$A$Set = w$Eq$A$Set;
+    return res;
 }
 
 void $Number$__init__($Number self) {
-  self->w$Minus = $Minus$new();
+    self->w$Minus = $Minus$new();
 }
 
-struct $Number$class $Number$methods = {"$Number$class", UNASSIGNED, ($Super$class)&$Times$methods, $Number$__init__, NULL, NULL, ($bool (*)($Number))$default__bool__,  ($str (*)($Number))$default__str__,
-                                        NULL, ($WORD (*)($Number,$WORD,$WORD))$Plus$__iadd__, NULL, ($WORD (*)($Number,$WORD,$WORD))$Plus$__iadd__, NULL, NULL, NULL, $Number$__ipow__, NULL, NULL, NULL, NULL, NULL, NULL};
-
+struct $Number$class $Number$methods = {"$Number$class", UNASSIGNED, ($Super$class)&$Times$methods, $Number$__init__, NULL, NULL, ($bool(*)($Number))$default__bool__, ($str(*)($Number))$default__str__,
+                                        NULL, ($WORD(*)($Number, $WORD, $WORD))$Plus$__iadd__, NULL, ($WORD(*)($Number, $WORD, $WORD))$Plus$__iadd__, NULL, NULL, NULL, $Number$__ipow__, NULL, NULL, NULL, NULL, NULL, NULL};
 
 $Number $Number$new() {
-  $Number res = malloc(sizeof(struct $Number));
-  res->$class = &$Number$methods;
-  res->w$Minus = $Minus$new();
-  return res;
+    $Number res = malloc(sizeof(struct $Number));
+    res->$class = &$Number$methods;
+    res->w$Minus = $Minus$new();
+    return res;
 }
 
-
-struct $Real$class $Real$methods = {"$Real$class", UNASSIGNED, ($Super$class)&$Number$methods, (void (*)($Real))$default__init__, NULL, NULL, ($bool (*)($Real))$default__bool__,  ($str (*)($Real))$default__str__,
-                                    NULL, ($WORD (*)($Real,$WORD,$WORD))$Plus$__iadd__, NULL, ($WORD (*)($Real,$WORD,$WORD))$Times$__imul__, NULL, NULL, NULL, ($WORD (*)($Real,$WORD,$WORD))$Number$__ipow__, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL};
-
+struct $Real$class $Real$methods = {"$Real$class", UNASSIGNED, ($Super$class)&$Number$methods, (void (*)($Real))$default__init__, NULL, NULL, ($bool(*)($Real))$default__bool__, ($str(*)($Real))$default__str__,
+                                    NULL, ($WORD(*)($Real, $WORD, $WORD))$Plus$__iadd__, NULL, ($WORD(*)($Real, $WORD, $WORD))$Times$__imul__, NULL, NULL, NULL, ($WORD(*)($Real, $WORD, $WORD))$Number$__ipow__, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL};
 
 $Real $Real$new() {
-  $Real res = malloc(sizeof(struct $Real));
-  res->$class = &$Real$methods;
-  return res;
+    $Real res = malloc(sizeof(struct $Real));
+    res->$class = &$Real$methods;
+    return res;
 }
 
-struct $Rational$class $Rational$methods = {"$Rational$class", UNASSIGNED, ($Super$class)&$Real$methods, (void (*)($Rational))$default__init__, NULL, NULL, ($bool (*)($Rational))$default__bool__,  ($str (*)($Rational))$default__str__,
-                                            NULL, ($WORD (*)($Rational,$WORD,$WORD))$Plus$__iadd__, NULL,  ($WORD (*)($Rational,$WORD,$WORD))$Times$__imul__, NULL, NULL, NULL, ($WORD (*)($Rational,$WORD,$WORD))$Number$__ipow__, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL};
-
+struct $Rational$class $Rational$methods = {"$Rational$class", UNASSIGNED, ($Super$class)&$Real$methods, (void (*)($Rational))$default__init__, NULL, NULL, ($bool(*)($Rational))$default__bool__, ($str(*)($Rational))$default__str__,
+                                            NULL, ($WORD(*)($Rational, $WORD, $WORD))$Plus$__iadd__, NULL, ($WORD(*)($Rational, $WORD, $WORD))$Times$__imul__, NULL, NULL, NULL, ($WORD(*)($Rational, $WORD, $WORD))$Number$__ipow__, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL};
 
 $Rational $Rational$new() {
-  $Rational res = malloc(sizeof(struct $Rational));
-  res->$class = &$Rational$methods;
-  return res;
+    $Rational res = malloc(sizeof(struct $Rational));
+    res->$class = &$Rational$methods;
+    return res;
 }
 
 void $Integral$__init__($Integral self) {
-  self->w$Logical = $Logical$new();
-  self->w$Minus = $Minus$new();
+    self->w$Logical = $Logical$new();
+    self->w$Minus = $Minus$new();
 }
-  
-struct $Integral$class $Integral$methods = {"$Integral$class", UNASSIGNED, ($Super$class)&$Rational$methods, $Integral$__init__, NULL, NULL, ($bool (*)($Integral))$default__bool__,  ($str (*)($Integral))$default__str__,
-                                            NULL,  ($WORD (*)($Integral,$WORD,$WORD))$Plus$__iadd__, NULL,  ($WORD (*)($Integral,$WORD,$WORD))$Times$__imul__, NULL, NULL, NULL,  ($WORD (*)($Integral,$WORD,$WORD))$Number$__ipow__, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, $Integral$__ifloordiv__, $Integral$__imod__, $Integral$__ilshift__, $Integral$__irshift__, NULL};
+
+struct $Integral$class $Integral$methods = {"$Integral$class", UNASSIGNED, ($Super$class)&$Rational$methods, $Integral$__init__, NULL, NULL, ($bool(*)($Integral))$default__bool__, ($str(*)($Integral))$default__str__,
+                                            NULL, ($WORD(*)($Integral, $WORD, $WORD))$Plus$__iadd__, NULL, ($WORD(*)($Integral, $WORD, $WORD))$Times$__imul__, NULL, NULL, NULL, ($WORD(*)($Integral, $WORD, $WORD))$Number$__ipow__, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, $Integral$__ifloordiv__, $Integral$__imod__, $Integral$__ilshift__, $Integral$__irshift__, NULL};
 
 $Integral $Integral$new() {
-  $Integral res = malloc(sizeof(struct $Integral));
-  res->$class = &$Integral$methods;
-  res->w$Logical = $Logical$new();
-  res->w$Minus = $Minus$new();
- return res;
+    $Integral res = malloc(sizeof(struct $Integral));
+    res->$class = &$Integral$methods;
+    res->w$Logical = $Logical$new();
+    res->w$Minus = $Minus$new();
+    return res;
 }
 
 void $register_builtin_protocols() {
-  $register(&$Eq$methods);
-  $register(&$Ord$methods);
-  $register(&$Logical$methods);
-  $register(&$Plus$methods);
-  $register(&$Times$methods);
-  $register(&$Div$methods);
-  $register(&$Minus$methods);
-  $register(&$Hashable$methods);
-  $register(&$Indexed$methods);
-  $register(&$Sliceable$methods);
-  $register(&$Iterable$methods);
-  $register(&$Collection$methods);
-  $register(&$Container$methods);
-  $register(&$Sequence$methods);
-  $register(&$Mapping$methods);
-  $register(&$Set$methods);
-  $register(&$Number$methods);
-  $register(&$Real$methods);
-  $register(&$Rational$methods);
-  $register(&$Sequence$list$methods);
-  $register(&$Collection$list$methods);
-  $register(&$Times$list$methods);
-  $register(&$Container$list$methods);
-  $register(&$Mapping$dict$methods);
-  $register(&$Indexed$dict$methods);
-  $register(&$Set$set$methods);
-  $register(&$Ord$set$methods);
-  $register(&$Logical$set$methods);
-  $register(&$Minus$set$methods);
-  $register(&$Iterable$Iterator$methods);
-  $register(&$Ord$str$methods);
-  $register(&$Container$str$methods);
-  $register(&$Sliceable$str$methods);
-  $register(&$Times$str$methods);
-  $register(&$Hashable$str$methods);
-  $register(&$Integral$int$methods);
-  $register(&$Logical$int$methods);
-  $register(&$Minus$int$methods);
-  $register(&$Ord$int$methods);
-  $register(&$Hashable$int$methods);
-  $register(&$Real$float$methods);
-  $register(&$Div$float$methods);
-  $register(&$Minus$float$methods);
-  $register(&$Ord$float$methods);
-  $register(&$Hashable$float$methods);
-  $register(&$Number$complex$methods);
-  $register(&$Div$complex$methods);
-  $register(&$Minus$complex$methods);
-  $register(&$Eq$complex$methods);
-  $register(&$Hashable$complex$methods);
-  $register(&$Iterable$range$methods);
-  $register(&$Iterable$tuple$methods);
-  $register(&$Sliceable$tuple$methods);
-  $register(&$Hashable$tuple$methods);
-  $register(&$Ord$bytearray$methods);
-  $register(&$Sequence$bytearray$methods);
-  $register(&$Collection$bytearray$methods);
-  $register(&$Times$bytearray$methods);
-  $register(&$Container$bytearray$methods);
-  $register(&$Hashable$WORD$methods);
-  
+    $register(&$Eq$methods);
+    $register(&$Ord$methods);
+    $register(&$Logical$methods);
+    $register(&$Plus$methods);
+    $register(&$Times$methods);
+    $register(&$Div$methods);
+    $register(&$Minus$methods);
+    $register(&$Hashable$methods);
+    $register(&$Indexed$methods);
+    $register(&$Sliceable$methods);
+    $register(&$Iterable$methods);
+    $register(&$Collection$methods);
+    $register(&$Container$methods);
+    $register(&$Sequence$methods);
+    $register(&$Mapping$methods);
+    $register(&$Set$methods);
+    $register(&$Number$methods);
+    $register(&$Real$methods);
+    $register(&$Rational$methods);
+    $register(&$Sequence$list$methods);
+    $register(&$Collection$list$methods);
+    $register(&$Times$list$methods);
+    $register(&$Container$list$methods);
+    $register(&$Mapping$dict$methods);
+    $register(&$Indexed$dict$methods);
+    $register(&$Set$set$methods);
+    $register(&$Ord$set$methods);
+    $register(&$Logical$set$methods);
+    $register(&$Minus$set$methods);
+    $register(&$Iterable$Iterator$methods);
+    $register(&$Ord$str$methods);
+    $register(&$Container$str$methods);
+    $register(&$Sliceable$str$methods);
+    $register(&$Times$str$methods);
+    $register(&$Hashable$str$methods);
+    $register(&$Integral$int$methods);
+    $register(&$Logical$int$methods);
+    $register(&$Minus$int$methods);
+    $register(&$Ord$int$methods);
+    $register(&$Hashable$int$methods);
+    $register(&$Real$float$methods);
+    $register(&$Div$float$methods);
+    $register(&$Minus$float$methods);
+    $register(&$Ord$float$methods);
+    $register(&$Hashable$float$methods);
+    $register(&$Number$complex$methods);
+    $register(&$Div$complex$methods);
+    $register(&$Minus$complex$methods);
+    $register(&$Eq$complex$methods);
+    $register(&$Hashable$complex$methods);
+    $register(&$Iterable$range$methods);
+    $register(&$Iterable$tuple$methods);
+    $register(&$Sliceable$tuple$methods);
+    $register(&$Hashable$tuple$methods);
+    $register(&$Ord$bytearray$methods);
+    $register(&$Sequence$bytearray$methods);
+    $register(&$Collection$bytearray$methods);
+    $register(&$Times$bytearray$methods);
+    $register(&$Container$bytearray$methods);
+    $register(&$Hashable$WORD$methods);
 }

--- a/builtin/__builtin__.h
+++ b/builtin/__builtin__.h
@@ -502,7 +502,6 @@ typedef struct $Hashable$WORD *$Hashable$WORD;
 struct $Hashable$WORD$class;
 typedef struct $Hashable$WORD$class *$Hashable$WORD$class;
 
-
 // $Eq ////////////////////////////////////////////////////////////
 
 struct $Eq {
@@ -514,8 +513,8 @@ struct $Eq$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Eq);
-    void (*__serialize__)($Eq,$Serial$state);
-    $Eq (*__deserialize__)($Eq,$Serial$state);
+    void (*__serialize__)($Eq, $Serial$state);
+    $Eq (*__deserialize__)($Eq, $Serial$state);
     $bool (*__bool__)($Eq);
     $str (*__str__)($Eq);
     $bool (*__eq__)($Eq, $WORD, $WORD);
@@ -537,8 +536,8 @@ struct $Ord$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Ord);
-    void (*__serialize__)($Ord,$Serial$state);
-    $Ord (*__deserialize__)($Ord,$Serial$state);
+    void (*__serialize__)($Ord, $Serial$state);
+    $Ord (*__deserialize__)($Ord, $Serial$state);
     $bool (*__bool__)($Ord);
     $str (*__str__)($Ord);
     $bool (*__eq__)($Ord, $WORD, $WORD);
@@ -565,16 +564,22 @@ struct $Logical$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Logical);
-    void (*__serialize__)($Logical,$Serial$state);
-    $Logical (*__deserialize__)($Logical,$Serial$state);
+    void (*__serialize__)($Logical, $Serial$state);
+    $Logical (*__deserialize__)($Logical, $Serial$state);
     $bool (*__bool__)($Logical);
     $str (*__str__)($Logical);
-    $WORD (*__and__)($Logical, $WORD, $WORD);
-    $WORD (*__or__)($Logical, $WORD, $WORD);
-    $WORD (*__xor__)($Logical, $WORD, $WORD);
-    $WORD (*__iand__)($Logical, $WORD, $WORD);
-    $WORD (*__ior__)($Logical, $WORD, $WORD);
-    $WORD (*__ixor__)($Logical, $WORD, $WORD);
+    $WORD (*__and__)
+    ($Logical, $WORD, $WORD);
+    $WORD (*__or__)
+    ($Logical, $WORD, $WORD);
+    $WORD (*__xor__)
+    ($Logical, $WORD, $WORD);
+    $WORD (*__iand__)
+    ($Logical, $WORD, $WORD);
+    $WORD (*__ior__)
+    ($Logical, $WORD, $WORD);
+    $WORD (*__ixor__)
+    ($Logical, $WORD, $WORD);
 };
 
 $WORD $Logical$__iand__($Logical, $WORD, $WORD);
@@ -595,15 +600,17 @@ struct $Plus$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Plus);
-    void (*__serialize__)($Plus,$Serial$state);
-    $Plus (*__deserialize__)($Plus,$Serial$state);
+    void (*__serialize__)($Plus, $Serial$state);
+    $Plus (*__deserialize__)($Plus, $Serial$state);
     $bool (*__bool__)($Plus);
     $str (*__str__)($Plus);
-    $WORD (*__add__)($Plus, $WORD, $WORD);
-    $WORD (*__iadd__)($Plus, $WORD, $WORD);
+    $WORD (*__add__)
+    ($Plus, $WORD, $WORD);
+    $WORD (*__iadd__)
+    ($Plus, $WORD, $WORD);
 };
 
-$WORD $Plus$__iadd__ ($Plus, $WORD, $WORD);
+$WORD $Plus$__iadd__($Plus, $WORD, $WORD);
 
 extern struct $Plus$class $Plus$methods;
 $Plus $Plus$new();
@@ -619,17 +626,21 @@ struct $Times$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Times);
-    void (*__serialize__)($Times,$Serial$state);
-    $Times (*__deserialize__)($Times,$Serial$state);
+    void (*__serialize__)($Times, $Serial$state);
+    $Times (*__deserialize__)($Times, $Serial$state);
     $bool (*__bool__)($Times);
     $str (*__str__)($Times);
-    $WORD (*__add__)($Times, $WORD, $WORD);
-    $WORD (*__iadd__)($Times, $WORD, $WORD);
-    $WORD (*__mul__)($Times, $WORD, $WORD);
-    $WORD (*__imul__)($Times, $WORD, $WORD);
+    $WORD (*__add__)
+    ($Times, $WORD, $WORD);
+    $WORD (*__iadd__)
+    ($Times, $WORD, $WORD);
+    $WORD (*__mul__)
+    ($Times, $WORD, $WORD);
+    $WORD (*__imul__)
+    ($Times, $WORD, $WORD);
 };
 
-$WORD $Times$__imul__ ($Times, $WORD, $WORD);
+$WORD $Times$__imul__($Times, $WORD, $WORD);
 
 extern struct $Times$class $Times$methods;
 $Times $Times$new();
@@ -645,15 +656,17 @@ struct $Div$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Div);
-    void (*__serialize__)($Div,$Serial$state);
-    $Div (*__deserialize__)($Div,$Serial$state);
+    void (*__serialize__)($Div, $Serial$state);
+    $Div (*__deserialize__)($Div, $Serial$state);
     $bool (*__bool__)($Div);
     $str (*__str__)($Div);
-    $WORD (*__truediv__)($Div, $WORD, $WORD);
-    $WORD (*__itruediv__)($Div, $WORD, $WORD);
+    $WORD (*__truediv__)
+    ($Div, $WORD, $WORD);
+    $WORD (*__itruediv__)
+    ($Div, $WORD, $WORD);
 };
 
-$WORD $Div$__itruediv__ ($Div, $WORD, $WORD);
+$WORD $Div$__itruediv__($Div, $WORD, $WORD);
 
 extern struct $Div$class $Div$methods;
 $Div $Div$new();
@@ -669,15 +682,17 @@ struct $Minus$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Minus);
-    void (*__serialize__)($Minus,$Serial$state);
-    $Minus (*__deserialize__)($Minus,$Serial$state);
+    void (*__serialize__)($Minus, $Serial$state);
+    $Minus (*__deserialize__)($Minus, $Serial$state);
     $bool (*__bool__)($Minus);
     $str (*__str__)($Minus);
-    $WORD (*__sub__)($Minus, $WORD, $WORD);
-    $WORD (*__isub__)($Minus, $WORD, $WORD);
+    $WORD (*__sub__)
+    ($Minus, $WORD, $WORD);
+    $WORD (*__isub__)
+    ($Minus, $WORD, $WORD);
 };
 
-$WORD $Minus$__isub__ ($Minus, $WORD, $WORD);
+$WORD $Minus$__isub__($Minus, $WORD, $WORD);
 
 extern struct $Minus$class $Minus$methods;
 $Minus $Minus$new();
@@ -693,8 +708,8 @@ struct $Hashable$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Hashable);
-    void (*__serialize__)($Hashable,$Serial$state);
-    $Hashable (*__deserialize__)($Hashable,$Serial$state);
+    void (*__serialize__)($Hashable, $Serial$state);
+    $Hashable (*__deserialize__)($Hashable, $Serial$state);
     $bool (*__bool__)($Hashable);
     $str (*__str__)($Hashable);
     $bool (*__eq__)($Hashable, $WORD, $WORD);
@@ -717,11 +732,12 @@ struct $Indexed$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Indexed, $Eq);
-    void (*__serialize__)($Indexed,$Serial$state);
-    $Indexed (*__deserialize__)($Indexed,$Serial$state);
+    void (*__serialize__)($Indexed, $Serial$state);
+    $Indexed (*__deserialize__)($Indexed, $Serial$state);
     $bool (*__bool__)($Indexed);
     $str (*__str__)($Indexed);
-    $WORD (*__getitem__)($Indexed, $WORD, $WORD);
+    $WORD (*__getitem__)
+    ($Indexed, $WORD, $WORD);
     void (*__setitem__)($Indexed, $WORD, $WORD, $WORD);
     void (*__delitem__)($Indexed, $WORD, $WORD);
 };
@@ -740,15 +756,17 @@ struct $Sliceable$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Sliceable);
-    void (*__serialize__)($Sliceable,$Serial$state);
-    $Sliceable (*__deserialize__)($Sliceable,$Serial$state);
+    void (*__serialize__)($Sliceable, $Serial$state);
+    $Sliceable (*__deserialize__)($Sliceable, $Serial$state);
     $bool (*__bool__)($Sliceable);
     $str (*__str__)($Sliceable);
-    $WORD (*__getitem__)($Sliceable, $WORD, $int);
+    $WORD (*__getitem__)
+    ($Sliceable, $WORD, $int);
     void (*__setitem__)($Sliceable, $WORD, $int, $WORD);
     void (*__delitem__)($Sliceable, $WORD, $int);
-    $WORD (*__getslice__)($Sliceable, $WORD, $slice);
-   void (*__setslice__)($Sliceable, $WORD, $Iterable, $slice, $WORD);
+    $WORD (*__getslice__)
+    ($Sliceable, $WORD, $slice);
+    void (*__setslice__)($Sliceable, $WORD, $Iterable, $slice, $WORD);
     void (*__delslice__)($Sliceable, $WORD, $slice);
 };
 
@@ -766,8 +784,8 @@ struct $Iterable$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Iterable);
-    void (*__serialize__)($Iterable,$Serial$state);
-    $Iterable (*__deserialize__)($Iterable,$Serial$state);
+    void (*__serialize__)($Iterable, $Serial$state);
+    $Iterable (*__deserialize__)($Iterable, $Serial$state);
     $bool (*__bool__)($Iterable);
     $str (*__str__)($Iterable);
     $Iterator (*__iter__)($Iterable, $WORD);
@@ -787,12 +805,13 @@ struct $Collection$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Collection);
-    void (*__serialize__)($Collection,$Serial$state);
-    $Collection (*__deserialize__)($Collection,$Serial$state);
+    void (*__serialize__)($Collection, $Serial$state);
+    $Collection (*__deserialize__)($Collection, $Serial$state);
     $bool (*__bool__)($Collection);
     $str (*__str__)($Collection);
     $Iterator (*__iter__)($Collection, $WORD);
-    $WORD (*__fromiter__)($Collection, $Iterable, $WORD);
+    $WORD (*__fromiter__)
+    ($Collection, $Iterable, $WORD);
     $int (*__len__)($Collection, $WORD);
 };
 
@@ -811,12 +830,13 @@ struct $Container$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Container, $Eq);
-    void (*__serialize__)($Container,$Serial$state);
-    $Container (*__deserialize__)($Container,$Serial$state);
+    void (*__serialize__)($Container, $Serial$state);
+    $Container (*__deserialize__)($Container, $Serial$state);
     $bool (*__bool__)($Container);
     $str (*__str__)($Container);
     $Iterator (*__iter__)($Container, $WORD);
-    $WORD (*__fromiter__)($Container, $Iterable, $WORD);
+    $WORD (*__fromiter__)
+    ($Container, $Iterable, $WORD);
     $int (*__len__)($Container, $WORD);
     $bool (*__contains__)($Container, $WORD, $WORD);
     $bool (*__containsnot__)($Container, $WORD, $WORD);
@@ -837,14 +857,16 @@ struct $Sequence$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Sequence);
-    void (*__serialize__)($Sequence,$Serial$state);
-    $Sequence (*__deserialize__)($Sequence,$Serial$state);
+    void (*__serialize__)($Sequence, $Serial$state);
+    $Sequence (*__deserialize__)($Sequence, $Serial$state);
     $bool (*__bool__)($Sequence);
     $str (*__str__)($Sequence);
-    $WORD (*__getitem__)($Sequence, $WORD, $int);
+    $WORD (*__getitem__)
+    ($Sequence, $WORD, $int);
     void (*__setitem__)($Sequence, $WORD, $int, $WORD);
     void (*__delitem__)($Sequence, $WORD, $int);
-    $WORD (*__getslice__)($Sequence, $WORD, $slice);
+    $WORD (*__getslice__)
+    ($Sequence, $WORD, $slice);
     void (*__setslice__)($Sequence, $WORD, $Iterable, $slice, $WORD);
     void (*__delslice__)($Sequence, $WORD, $slice);
     $Iterator (*__reversed__)($Sequence, $WORD);
@@ -869,16 +891,18 @@ struct $Mapping$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Mapping, $Eq);
-    void (*__serialize__)($Mapping,$Serial$state);
-    $Mapping (*__deserialize__)($Mapping,$Serial$state);
+    void (*__serialize__)($Mapping, $Serial$state);
+    $Mapping (*__deserialize__)($Mapping, $Serial$state);
     $bool (*__bool__)($Mapping);
     $str (*__str__)($Mapping);
     $Iterator (*__iter__)($Mapping, $WORD);
-    $WORD (*__fromiter__)($Mapping, $Iterable, $WORD);
+    $WORD (*__fromiter__)
+    ($Mapping, $Iterable, $WORD);
     $int (*__len__)($Mapping, $WORD);
     $bool (*__contains__)($Mapping, $WORD, $WORD);
     $bool (*__containsnot__)($Mapping, $WORD, $WORD);
-    $WORD (*get)($Mapping, $WORD, $WORD, $WORD);
+    $WORD (*get)
+    ($Mapping, $WORD, $WORD, $WORD);
     $Iterator (*keys)($Mapping, $WORD);
     $Iterator (*values)($Mapping, $WORD);
     $Iterator (*items)($Mapping, $WORD);
@@ -905,19 +929,21 @@ struct $Set$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Set, $Eq);
-    void (*__serialize__)($Set,$Serial$state);
-    $Set (*__deserialize__)($Set,$Serial$state);
+    void (*__serialize__)($Set, $Serial$state);
+    $Set (*__deserialize__)($Set, $Serial$state);
     $bool (*__bool__)($Set);
     $str (*__str__)($Set);
     $Iterator (*__iter__)($Set, $WORD);
-    $WORD (*__fromiter__)($Set, $Iterable, $WORD);
+    $WORD (*__fromiter__)
+    ($Set, $Iterable, $WORD);
     $int (*__len__)($Set, $WORD);
     $bool (*__contains__)($Set, $WORD, $WORD);
     $bool (*__containsnot__)($Set, $WORD, $WORD);
     $bool (*isdisjoint)($Set, $WORD, $WORD);
     void (*add)($Set, $WORD, $WORD);
     void (*discard)($Set, $WORD, $WORD);
-    $WORD (*pop)($Set, $WORD);
+    $WORD (*pop)
+    ($Set, $WORD);
 };
 
 extern struct $Set$class $Set$methods;
@@ -934,26 +960,39 @@ struct $Number$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Number);
-    void (*__serialize__)($Number,$Serial$state);
-    $Number (*__deserialize__)($Number,$Serial$state);
+    void (*__serialize__)($Number, $Serial$state);
+    $Number (*__deserialize__)($Number, $Serial$state);
     $bool (*__bool__)($Number);
     $str (*__str__)($Number);
-    $WORD (*__add__)($Number, $WORD, $WORD);
-    $WORD (*__iadd__)($Number, $WORD, $WORD);
-    $WORD (*__mul__)($Number, $WORD, $WORD);
-    $WORD (*__imul__)($Number, $WORD, $WORD);
-    $WORD (*__fromatom__)($Number,$atom);
+    $WORD (*__add__)
+    ($Number, $WORD, $WORD);
+    $WORD (*__iadd__)
+    ($Number, $WORD, $WORD);
+    $WORD (*__mul__)
+    ($Number, $WORD, $WORD);
+    $WORD (*__imul__)
+    ($Number, $WORD, $WORD);
+    $WORD (*__fromatom__)
+    ($Number, $atom);
     $complex (*__complx__)($Number, $WORD);
-  //    $WORD (*__truediv__)($Number, $WORD, $WORD);
-    $WORD (*__pow__)($Number, $WORD, $WORD);
-  //    $WORD (*__itruediv__)($Number, $WORD, $WORD);
-    $WORD (*__ipow__)($Number, $WORD, $WORD);
-    $WORD (*__neg__)($Number, $WORD);
-    $WORD (*__pos__)($Number, $WORD);
-    $WORD (*real)($Number, $WORD, $Real);
-    $WORD (*imag)($Number, $WORD, $Real);
-    $WORD (*__abs__)($Number, $WORD, $Real);
-    $WORD (*conjugate)($Number, $WORD);
+    //    $WORD (*__truediv__)($Number, $WORD, $WORD);
+    $WORD (*__pow__)
+    ($Number, $WORD, $WORD);
+    //    $WORD (*__itruediv__)($Number, $WORD, $WORD);
+    $WORD (*__ipow__)
+    ($Number, $WORD, $WORD);
+    $WORD (*__neg__)
+    ($Number, $WORD);
+    $WORD (*__pos__)
+    ($Number, $WORD);
+    $WORD (*real)
+    ($Number, $WORD, $Real);
+    $WORD (*imag)
+    ($Number, $WORD, $Real);
+    $WORD (*__abs__)
+    ($Number, $WORD, $Real);
+    $WORD (*conjugate)
+    ($Number, $WORD);
 };
 
 //$WORD $Number$__itruediv__($Number, $WORD, $WORD);
@@ -961,7 +1000,6 @@ $WORD $Number$__ipow__($Number, $WORD, $WORD);
 
 extern struct $Number$class $Number$methods;
 $Number $Number$new();
-
 
 // $Real ////////////////////////////////////////////////////////////
 
@@ -974,31 +1012,48 @@ struct $Real$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Real);
-    void (*__serialize__)($Real,$Serial$state);
-    $Real (*__deserialize__)($Real,$Serial$state);
+    void (*__serialize__)($Real, $Serial$state);
+    $Real (*__deserialize__)($Real, $Serial$state);
     $bool (*__bool__)($Real);
     $str (*__str__)($Real);
-    $WORD (*__add__)($Real, $WORD, $WORD);
-    $WORD (*__iadd__)($Real, $WORD, $WORD);
-    $WORD (*__mul__)($Real, $WORD, $WORD);
-    $WORD (*__imul__)($Real, $WORD, $WORD);
-    $WORD (*__fromatom__)($Real,$atom);
+    $WORD (*__add__)
+    ($Real, $WORD, $WORD);
+    $WORD (*__iadd__)
+    ($Real, $WORD, $WORD);
+    $WORD (*__mul__)
+    ($Real, $WORD, $WORD);
+    $WORD (*__imul__)
+    ($Real, $WORD, $WORD);
+    $WORD (*__fromatom__)
+    ($Real, $atom);
     $complex (*__complx__)($Real, $WORD);
-  //    $WORD (*__truediv__)($Real, $WORD, $WORD);
-    $WORD (*__pow__)($Real, $WORD, $WORD);
-  //    $WORD (*__itruediv__)($Real, $WORD, $WORD);
-    $WORD (*__ipow__)($Real, $WORD, $WORD);
-    $WORD (*__neg__)($Real, $WORD);
-    $WORD (*__pos__)($Real, $WORD);
-    $WORD (*real)($Real, $WORD, $Real);
-    $WORD (*imag)($Real, $WORD, $Real);
-    $WORD (*__abs__)($Real, $WORD, $Real);
-    $WORD (*conjugate)($Real, $WORD);
+    //    $WORD (*__truediv__)($Real, $WORD, $WORD);
+    $WORD (*__pow__)
+    ($Real, $WORD, $WORD);
+    //    $WORD (*__itruediv__)($Real, $WORD, $WORD);
+    $WORD (*__ipow__)
+    ($Real, $WORD, $WORD);
+    $WORD (*__neg__)
+    ($Real, $WORD);
+    $WORD (*__pos__)
+    ($Real, $WORD);
+    $WORD (*real)
+    ($Real, $WORD, $Real);
+    $WORD (*imag)
+    ($Real, $WORD, $Real);
+    $WORD (*__abs__)
+    ($Real, $WORD, $Real);
+    $WORD (*conjugate)
+    ($Real, $WORD);
     $float (*__float__)($Real, $WORD);
-    $WORD (*__trunc__)($Real, $WORD, $Integral);
-    $WORD (*__floor__)($Real, $WORD, $Integral);
-    $WORD (*__ceil__)($Real, $WORD, $Integral);
-    $WORD (*__round__)($Real, $WORD, $int);
+    $WORD (*__trunc__)
+    ($Real, $WORD, $Integral);
+    $WORD (*__floor__)
+    ($Real, $WORD, $Integral);
+    $WORD (*__ceil__)
+    ($Real, $WORD, $Integral);
+    $WORD (*__round__)
+    ($Real, $WORD, $int);
 };
 
 extern struct $Real$class $Real$methods;
@@ -1006,7 +1061,7 @@ $Real $Real$new();
 
 // $RealFloat ///////////////////////////////////////////////////////////
 
-#define $RealFloat $Real
+#define $RealFloat          $Real
 #define $RealFloat$new(...) $Real$new(__VA_ARGS__)
 
 // $Rational ////////////////////////////////////////////////////////////
@@ -1020,33 +1075,52 @@ struct $Rational$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Rational);
-    void (*__serialize__)($Rational,$Serial$state);
-    $Rational (*__deserialize__)($Rational,$Serial$state);
+    void (*__serialize__)($Rational, $Serial$state);
+    $Rational (*__deserialize__)($Rational, $Serial$state);
     $bool (*__bool__)($Rational);
     $str (*__str__)($Rational);
-    $WORD (*__add__)($Rational, $WORD, $WORD);
-    $WORD (*__iadd__)($Rational, $WORD, $WORD);
-    $WORD (*__mul__)($Rational, $WORD, $WORD);
-    $WORD (*__imul__)($Rational, $WORD, $WORD);
-    $WORD (*__fromatom__)($Rational,$atom);
+    $WORD (*__add__)
+    ($Rational, $WORD, $WORD);
+    $WORD (*__iadd__)
+    ($Rational, $WORD, $WORD);
+    $WORD (*__mul__)
+    ($Rational, $WORD, $WORD);
+    $WORD (*__imul__)
+    ($Rational, $WORD, $WORD);
+    $WORD (*__fromatom__)
+    ($Rational, $atom);
     $complex (*__complx__)($Rational, $WORD);
-  //    $WORD (*__truediv__)($Rational, $WORD, $WORD);
-    $WORD (*__pow__)($Rational, $WORD, $WORD);
-  //    $WORD (*__itruediv__)($Rational, $WORD, $WORD);
-    $WORD (*__ipow__)($Rational, $WORD, $WORD);
-    $WORD (*__neg__)($Rational, $WORD);
-    $WORD (*__pos__)($Rational, $WORD);
-    $WORD (*real)($Rational, $WORD, $Real);
-    $WORD (*imag)($Rational, $WORD, $Real);
-    $WORD (*__abs__)($Rational, $WORD, $Real);
-    $WORD (*conjugate)($Rational, $WORD);
+    //    $WORD (*__truediv__)($Rational, $WORD, $WORD);
+    $WORD (*__pow__)
+    ($Rational, $WORD, $WORD);
+    //    $WORD (*__itruediv__)($Rational, $WORD, $WORD);
+    $WORD (*__ipow__)
+    ($Rational, $WORD, $WORD);
+    $WORD (*__neg__)
+    ($Rational, $WORD);
+    $WORD (*__pos__)
+    ($Rational, $WORD);
+    $WORD (*real)
+    ($Rational, $WORD, $Real);
+    $WORD (*imag)
+    ($Rational, $WORD, $Real);
+    $WORD (*__abs__)
+    ($Rational, $WORD, $Real);
+    $WORD (*conjugate)
+    ($Rational, $WORD);
     $float (*__float__)($Rational, $WORD);
-    $WORD (*__trunc__)($Rational, $WORD, $Integral);
-    $WORD (*__floor__)($Rational, $WORD, $Integral);
-    $WORD (*__ceil__)($Rational, $WORD, $Integral);
-    $WORD (*__round__)($Rational, $WORD, $int);
-    $WORD (*numerator)($Rational, $WORD, $Integral);
-    $WORD (*denominator)($Rational, $WORD, $Integral);
+    $WORD (*__trunc__)
+    ($Rational, $WORD, $Integral);
+    $WORD (*__floor__)
+    ($Rational, $WORD, $Integral);
+    $WORD (*__ceil__)
+    ($Rational, $WORD, $Integral);
+    $WORD (*__round__)
+    ($Rational, $WORD, $int);
+    $WORD (*numerator)
+    ($Rational, $WORD, $Integral);
+    $WORD (*denominator)
+    ($Rational, $WORD, $Integral);
 };
 
 extern struct $Rational$class $Rational$methods;
@@ -1065,45 +1139,73 @@ struct $Integral$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Integral);
-    void (*__serialize__)($Integral,$Serial$state);
-    $Integral (*__deserialize__)($Integral,$Serial$state);
+    void (*__serialize__)($Integral, $Serial$state);
+    $Integral (*__deserialize__)($Integral, $Serial$state);
     $bool (*__bool__)($Integral);
     $str (*__str__)($Integral);
-    $WORD (*__add__)($Integral, $WORD, $WORD);
-    $WORD (*__iadd__)($Integral, $WORD, $WORD);
-    $WORD (*__mul__)($Integral, $WORD, $WORD);
-    $WORD (*__imul__)($Integral, $WORD, $WORD);
-    $WORD (*__fromatom__)($Integral,$atom);
+    $WORD (*__add__)
+    ($Integral, $WORD, $WORD);
+    $WORD (*__iadd__)
+    ($Integral, $WORD, $WORD);
+    $WORD (*__mul__)
+    ($Integral, $WORD, $WORD);
+    $WORD (*__imul__)
+    ($Integral, $WORD, $WORD);
+    $WORD (*__fromatom__)
+    ($Integral, $atom);
     $complex (*__complx__)($Integral, $WORD);
-  //    $WORD (*__truediv__)($Integral, $WORD, $WORD);
-    $WORD (*__pow__)($Integral, $WORD, $WORD);
-  //    $WORD (*__itruediv__)($Integral, $WORD, $WORD);
-    $WORD (*__ipow__)($Integral, $WORD, $WORD);
-    $WORD (*__neg__)($Integral, $WORD);
-    $WORD (*__pos__)($Integral, $WORD);
-    $WORD (*real)($Integral, $WORD, $Real);
-    $WORD (*imag)($Integral, $WORD, $Real);
-    $WORD (*__abs__)($Integral, $WORD, $Real);
-    $WORD (*conjugate)($Integral, $WORD);
+    //    $WORD (*__truediv__)($Integral, $WORD, $WORD);
+    $WORD (*__pow__)
+    ($Integral, $WORD, $WORD);
+    //    $WORD (*__itruediv__)($Integral, $WORD, $WORD);
+    $WORD (*__ipow__)
+    ($Integral, $WORD, $WORD);
+    $WORD (*__neg__)
+    ($Integral, $WORD);
+    $WORD (*__pos__)
+    ($Integral, $WORD);
+    $WORD (*real)
+    ($Integral, $WORD, $Real);
+    $WORD (*imag)
+    ($Integral, $WORD, $Real);
+    $WORD (*__abs__)
+    ($Integral, $WORD, $Real);
+    $WORD (*conjugate)
+    ($Integral, $WORD);
     $float (*__float__)($Integral, $WORD);
-    $WORD (*__trunc__)($Integral, $WORD, $Integral);
-    $WORD (*__floor__)($Integral, $WORD, $Integral);
-    $WORD (*__ceil__)($Integral, $WORD, $Integral);
-    $WORD (*__round__)($Integral, $WORD, $int);
-    $WORD (*numerator)($Integral, $WORD, $Integral);
-    $WORD (*denominator)($Integral, $WORD, $Integral);
+    $WORD (*__trunc__)
+    ($Integral, $WORD, $Integral);
+    $WORD (*__floor__)
+    ($Integral, $WORD, $Integral);
+    $WORD (*__ceil__)
+    ($Integral, $WORD, $Integral);
+    $WORD (*__round__)
+    ($Integral, $WORD, $int);
+    $WORD (*numerator)
+    ($Integral, $WORD, $Integral);
+    $WORD (*denominator)
+    ($Integral, $WORD, $Integral);
     $int (*__int__)($Integral, $WORD);
     $int (*__index__)($Integral, $WORD);
     $tuple (*__divmod__)($Integral, $WORD, $WORD);
-    $WORD (*__floordiv__)($Integral, $WORD, $WORD);
-    $WORD (*__mod__)($Integral, $WORD, $WORD);
-    $WORD (*__lshift__)($Integral, $WORD, $int);
-    $WORD (*__rshift__)($Integral, $WORD, $int);
-    $WORD (*__ifloordiv__)($Integral, $WORD, $WORD);
-    $WORD (*__imod__)($Integral, $WORD, $WORD);
-    $WORD (*__ilshift__)($Integral, $WORD, $int);
-    $WORD (*__irshift__)($Integral, $WORD, $int);
-    $WORD (*__invert__)($Integral, $WORD);
+    $WORD (*__floordiv__)
+    ($Integral, $WORD, $WORD);
+    $WORD (*__mod__)
+    ($Integral, $WORD, $WORD);
+    $WORD (*__lshift__)
+    ($Integral, $WORD, $int);
+    $WORD (*__rshift__)
+    ($Integral, $WORD, $int);
+    $WORD (*__ifloordiv__)
+    ($Integral, $WORD, $WORD);
+    $WORD (*__imod__)
+    ($Integral, $WORD, $WORD);
+    $WORD (*__ilshift__)
+    ($Integral, $WORD, $int);
+    $WORD (*__irshift__)
+    ($Integral, $WORD, $int);
+    $WORD (*__invert__)
+    ($Integral, $WORD);
 };
 
 $WORD $Integral$__ifloordiv__($Integral, $WORD, $WORD);
@@ -1126,11 +1228,12 @@ struct $Sequence$list$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Sequence$list);
-    void (*__serialize__)($Sequence$list,$Serial$state);
-    $Sequence$list (*__deserialize__)($Sequence$list,$Serial$state);
+    void (*__serialize__)($Sequence$list, $Serial$state);
+    $Sequence$list (*__deserialize__)($Sequence$list, $Serial$state);
     $bool (*__bool__)($Sequence$list);
     $str (*__str__)($Sequence$list);
-    $WORD (*__getitem__)($Sequence$list, $list, $int);
+    $WORD (*__getitem__)
+    ($Sequence$list, $list, $int);
     void (*__setitem__)($Sequence$list, $list, $int, $WORD);
     void (*__delitem__)($Sequence$list, $list, $int);
     $list (*__getslice__)($Sequence$list, $list, $slice);
@@ -1142,19 +1245,19 @@ struct $Sequence$list$class {
     void (*reverse)($Sequence$list, $list);
 };
 
-void $Sequence$list$__init__ ($Sequence$list);
+void $Sequence$list$__init__($Sequence$list);
 void $Sequence$list$__serialize__($Sequence$list, $Serial$state);
 $Sequence$list $Sequence$list$__deserialize__($Sequence$list, $Serial$state);
-$WORD $Sequence$list$__getitem__ ($Sequence$list, $list, $int);
-void $Sequence$list$__setitem__ ($Sequence$list, $list, $int, $WORD);
-void $Sequence$list$__delitem__ ($Sequence$list, $list, $int);
-$list $Sequence$list$__getslice__ ($Sequence$list, $list, $slice);
-void $Sequence$list$__setslice__ ($Sequence$list, $list, $Iterable, $slice, $WORD);
-void $Sequence$list$__delslice__ ($Sequence$list, $list, $slice);
-$Iterator $Sequence$list$__reversed__ ($Sequence$list, $list);
-void $Sequence$list$insert ($Sequence$list, $list, $int, $WORD);
-void $Sequence$list$append ($Sequence$list, $list, $WORD);
-void $Sequence$list$reverse ($Sequence$list, $list);
+$WORD $Sequence$list$__getitem__($Sequence$list, $list, $int);
+void $Sequence$list$__setitem__($Sequence$list, $list, $int, $WORD);
+void $Sequence$list$__delitem__($Sequence$list, $list, $int);
+$list $Sequence$list$__getslice__($Sequence$list, $list, $slice);
+void $Sequence$list$__setslice__($Sequence$list, $list, $Iterable, $slice, $WORD);
+void $Sequence$list$__delslice__($Sequence$list, $list, $slice);
+$Iterator $Sequence$list$__reversed__($Sequence$list, $list);
+void $Sequence$list$insert($Sequence$list, $list, $int, $WORD);
+void $Sequence$list$append($Sequence$list, $list, $WORD);
+void $Sequence$list$reverse($Sequence$list, $list);
 
 // $Collection$list ////////////////////////////////////////////////////////////
 
@@ -1168,8 +1271,8 @@ struct $Collection$list$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Collection$list, $Sequence);
-    void (*__serialize__)($Collection$list,$Serial$state);
-    $Collection$list (*__deserialize__)($Collection$list,$Serial$state);
+    void (*__serialize__)($Collection$list, $Serial$state);
+    $Collection$list (*__deserialize__)($Collection$list, $Serial$state);
     $bool (*__bool__)($Collection$list);
     $str (*__str__)($Collection$list);
     $Iterator (*__iter__)($Collection$list, $list);
@@ -1177,12 +1280,12 @@ struct $Collection$list$class {
     $int (*__len__)($Collection$list, $list);
 };
 
-void $Collection$list$__init__ ($Collection$list, $Sequence);
+void $Collection$list$__init__($Collection$list, $Sequence);
 void $Collection$list$__serialize__($Collection$list, $Serial$state);
 $Collection$list $Collection$list$__deserialize__($Collection$list, $Serial$state);
-$Iterator $Collection$list$__iter__ ($Collection$list, $list);
-$list $Collection$list$__fromiter__ ($Collection$list, $Iterable, $WORD);
-$int $Collection$list$__len__ ($Collection$list, $list);
+$Iterator $Collection$list$__iter__($Collection$list, $list);
+$list $Collection$list$__fromiter__($Collection$list, $Iterable, $WORD);
+$int $Collection$list$__len__($Collection$list, $list);
 
 // $Times$list ////////////////////////////////////////////////////////////
 
@@ -1196,8 +1299,8 @@ struct $Times$list$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Times$list, $Sequence);
-    void (*__serialize__)($Times$list,$Serial$state);
-    $Times$list (*__deserialize__)($Times$list,$Serial$state);
+    void (*__serialize__)($Times$list, $Serial$state);
+    $Times$list (*__deserialize__)($Times$list, $Serial$state);
     $bool (*__bool__)($Times$list);
     $str (*__str__)($Times$list);
     $list (*__add__)($Times$list, $list, $list);
@@ -1206,10 +1309,10 @@ struct $Times$list$class {
     $list (*__imul__)($Times$list, $list, $int);
 };
 
-void $Times$list$__init__ ($Times$list, $Sequence);
+void $Times$list$__init__($Times$list, $Sequence);
 void $Times$list$__serialize__($Times$list, $Serial$state);
 $Times$list $Times$list$__deserialize__($Times$list, $Serial$state);
-$list $Times$list$__add__ ($Times$list, $list, $list);
+$list $Times$list$__add__($Times$list, $list, $list);
 $list $Times$list$__mul__($Times$list, $list, $int);
 
 // $Container$list ////////////////////////////////////////////////////////////
@@ -1224,8 +1327,8 @@ struct $Container$list$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Container$list, $Eq);
-    void (*__serialize__)($Container$list,$Serial$state);
-    $Container$list (*__deserialize__)($Container$list,$Serial$state);
+    void (*__serialize__)($Container$list, $Serial$state);
+    $Container$list (*__deserialize__)($Container$list, $Serial$state);
     $bool (*__bool__)($Container$list);
     $str (*__str__)($Container$list);
     $Iterator (*__iter__)($Container$list, $list);
@@ -1235,14 +1338,14 @@ struct $Container$list$class {
     $bool (*__containsnot__)($Container$list, $list, $WORD);
 };
 
-void $Container$list$__init__ ($Container$list, $Eq);
+void $Container$list$__init__($Container$list, $Eq);
 void $Container$list$__serialize__($Container$list, $Serial$state);
 $Container$list $Container$list$__deserialize__($Container$list, $Serial$state);
-$Iterator $Container$list$__iter__ ($Container$list, $list);
-$list $Container$list$__fromiter__ ($Container$list, $Iterable, $WORD);
-$int $Container$list$__len__ ($Container$list, $list);
-$bool $Container$list$__contains__ ($Container$list, $list, $WORD);
-$bool $Container$list$__containsnot__ ($Container$list, $list, $WORD);
+$Iterator $Container$list$__iter__($Container$list, $list);
+$list $Container$list$__fromiter__($Container$list, $Iterable, $WORD);
+$int $Container$list$__len__($Container$list, $list);
+$bool $Container$list$__contains__($Container$list, $list, $WORD);
+$bool $Container$list$__containsnot__($Container$list, $list, $WORD);
 
 // $Mapping$dict ////////////////////////////////////////////////////////////
 
@@ -1258,8 +1361,8 @@ struct $Mapping$dict$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Mapping$dict, $Hashable);
-    void (*__serialize__)($Mapping$dict,$Serial$state);
-    $Mapping$dict (*__deserialize__)($Mapping$dict,$Serial$state);
+    void (*__serialize__)($Mapping$dict, $Serial$state);
+    $Mapping$dict (*__deserialize__)($Mapping$dict, $Serial$state);
     $bool (*__bool__)($Mapping$dict);
     $str (*__str__)($Mapping$dict);
     $Iterator (*__iter__)($Mapping$dict, $dict);
@@ -1267,7 +1370,8 @@ struct $Mapping$dict$class {
     $int (*__len__)($Mapping$dict, $dict);
     $bool (*__contains__)($Mapping$dict, $dict, $WORD);
     $bool (*__containsnot__)($Mapping$dict, $dict, $WORD);
-    $WORD (*get)($Mapping$dict, $dict, $WORD, $WORD);
+    $WORD (*get)
+    ($Mapping$dict, $dict, $WORD, $WORD);
     $Iterator (*keys)($Mapping$dict, $dict);
     $Iterator (*values)($Mapping$dict, $dict);
     $Iterator (*items)($Mapping$dict, $dict);
@@ -1276,21 +1380,21 @@ struct $Mapping$dict$class {
     void (*setdefault)($Mapping$dict, $dict, $WORD, $WORD);
 };
 
-void $Mapping$dict$__init__ ($Mapping$dict, $Hashable);
+void $Mapping$dict$__init__($Mapping$dict, $Hashable);
 void $Mapping$dict$__serialize__($Mapping$dict, $Serial$state);
 $Mapping$dict $Mapping$dict$__deserialize__($Mapping$dict, $Serial$state);
-$Iterator $Mapping$dict$__iter__ ($Mapping$dict, $dict);
-$dict $Mapping$dict$__fromiter__ ($Mapping$dict, $Iterable, $WORD);
-$int $Mapping$dict$__len__ ($Mapping$dict, $dict);
-$bool $Mapping$dict$__contains__ ($Mapping$dict, $dict, $WORD);
-$bool $Mapping$dict$__containsnot__ ($Mapping$dict, $dict, $WORD);
-$WORD $Mapping$dict$get ($Mapping$dict, $dict, $WORD, $WORD);
-$Iterator $Mapping$dict$keys ($Mapping$dict, $dict);
-$Iterator $Mapping$dict$values ($Mapping$dict, $dict);
-$Iterator $Mapping$dict$items ($Mapping$dict, $dict);
-void $Mapping$dict$update ($Mapping$dict, $dict, $Iterable, $WORD);
-$tuple $Mapping$dict$popitem ($Mapping$dict, $dict);
-void $Mapping$dict$setdefault ($Mapping$dict, $dict, $WORD, $WORD);
+$Iterator $Mapping$dict$__iter__($Mapping$dict, $dict);
+$dict $Mapping$dict$__fromiter__($Mapping$dict, $Iterable, $WORD);
+$int $Mapping$dict$__len__($Mapping$dict, $dict);
+$bool $Mapping$dict$__contains__($Mapping$dict, $dict, $WORD);
+$bool $Mapping$dict$__containsnot__($Mapping$dict, $dict, $WORD);
+$WORD $Mapping$dict$get($Mapping$dict, $dict, $WORD, $WORD);
+$Iterator $Mapping$dict$keys($Mapping$dict, $dict);
+$Iterator $Mapping$dict$values($Mapping$dict, $dict);
+$Iterator $Mapping$dict$items($Mapping$dict, $dict);
+void $Mapping$dict$update($Mapping$dict, $dict, $Iterable, $WORD);
+$tuple $Mapping$dict$popitem($Mapping$dict, $dict);
+void $Mapping$dict$setdefault($Mapping$dict, $dict, $WORD, $WORD);
 
 // $Indexed$dict ////////////////////////////////////////////////////////////
 
@@ -1306,21 +1410,22 @@ struct $Indexed$dict$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Indexed$dict, $Mapping, $Eq);
-    void (*__serialize__)($Indexed$dict,$Serial$state);
-    $Indexed$dict (*__deserialize__)($Indexed$dict,$Serial$state);
+    void (*__serialize__)($Indexed$dict, $Serial$state);
+    $Indexed$dict (*__deserialize__)($Indexed$dict, $Serial$state);
     $bool (*__bool__)($Indexed$dict);
     $str (*__str__)($Indexed$dict);
-    $WORD (*__getitem__)($Indexed$dict, $dict, $WORD);
+    $WORD (*__getitem__)
+    ($Indexed$dict, $dict, $WORD);
     void (*__setitem__)($Indexed$dict, $dict, $WORD, $WORD);
     void (*__delitem__)($Indexed$dict, $dict, $WORD);
 };
 
-void $Indexed$dict$__init__ ($Indexed$dict, $Mapping, $Eq);
+void $Indexed$dict$__init__($Indexed$dict, $Mapping, $Eq);
 void $Indexed$dict$__serialize__($Indexed$dict, $Serial$state);
 $Indexed$dict $Indexed$dict$__deserialize__($Indexed$dict, $Serial$state);
-$WORD $Indexed$dict$__getitem__ ($Indexed$dict, $dict, $WORD);
-void $Indexed$dict$__setitem__ ($Indexed$dict, $dict, $WORD, $WORD);
-void $Indexed$dict$__delitem__ ($Indexed$dict, $dict, $WORD);
+$WORD $Indexed$dict$__getitem__($Indexed$dict, $dict, $WORD);
+void $Indexed$dict$__setitem__($Indexed$dict, $dict, $WORD, $WORD);
+void $Indexed$dict$__delitem__($Indexed$dict, $dict, $WORD);
 
 // $Set$set ////////////////////////////////////////////////////////////
 
@@ -1338,8 +1443,8 @@ struct $Set$set$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Set$set, $Hashable);
-    void (*__serialize__)($Set$set,$Serial$state);
-    $Set$set (*__deserialize__)($Set$set,$Serial$state);
+    void (*__serialize__)($Set$set, $Serial$state);
+    $Set$set (*__deserialize__)($Set$set, $Serial$state);
     $bool (*__bool__)($Set$set);
     $str (*__str__)($Set$set);
     $Iterator (*__iter__)($Set$set, $set);
@@ -1350,21 +1455,22 @@ struct $Set$set$class {
     $bool (*isdisjoint)($Set$set, $set, $set);
     void (*add)($Set$set, $set, $WORD);
     void (*discard)($Set$set, $set, $WORD);
-    $WORD (*pop)($Set$set, $set);
+    $WORD (*pop)
+    ($Set$set, $set);
 };
 
-void $Set$set$__init__ ($Set$set, $Hashable);
+void $Set$set$__init__($Set$set, $Hashable);
 void $Set$set$__serialize__($Set$set, $Serial$state);
 $Set$set $Set$set$__deserialize__($Set$set, $Serial$state);
-$Iterator $Set$set$__iter__ ($Set$set, $set);
-$set $Set$set$__fromiter__ ($Set$set, $Iterable, $WORD);
-$int $Set$set$__len__ ($Set$set, $set);
-$bool $Set$set$__contains__ ($Set$set, $set, $WORD);
-$bool $Set$set$__containsnot__ ($Set$set, $set, $WORD);
-$bool $Set$set$isdisjoint ($Set$set, $set, $set);
-void $Set$set$add ($Set$set, $set, $WORD);
-void $Set$set$discard ($Set$set, $set, $WORD);
-$WORD $Set$set$pop ($Set$set, $set);
+$Iterator $Set$set$__iter__($Set$set, $set);
+$set $Set$set$__fromiter__($Set$set, $Iterable, $WORD);
+$int $Set$set$__len__($Set$set, $set);
+$bool $Set$set$__contains__($Set$set, $set, $WORD);
+$bool $Set$set$__containsnot__($Set$set, $set, $WORD);
+$bool $Set$set$isdisjoint($Set$set, $set, $set);
+void $Set$set$add($Set$set, $set, $WORD);
+void $Set$set$discard($Set$set, $set, $WORD);
+$WORD $Set$set$pop($Set$set, $set);
 
 // $Ord$set ////////////////////////////////////////////////////////////
 
@@ -1378,8 +1484,8 @@ struct $Ord$set$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Ord$set, $Set);
-    void (*__serialize__)($Ord$set,$Serial$state);
-    $Ord$set (*__deserialize__)($Ord$set,$Serial$state);
+    void (*__serialize__)($Ord$set, $Serial$state);
+    $Ord$set (*__deserialize__)($Ord$set, $Serial$state);
     $bool (*__bool__)($Ord$set);
     $str (*__str__)($Ord$set);
     $bool (*__eq__)($Ord$set, $set, $set);
@@ -1390,15 +1496,15 @@ struct $Ord$set$class {
     $bool (*__ge__)($Ord$set, $set, $set);
 };
 
-void $Ord$set$__init__ ($Ord$set, $Set);
+void $Ord$set$__init__($Ord$set, $Set);
 void $Ord$set$__serialize__($Ord$set, $Serial$state);
 $Ord$set $Ord$set$__deserialize__($Ord$set, $Serial$state);
-$bool $Ord$set$__eq__ ($Ord$set, $set, $set);
-$bool $Ord$set$__ne__ ($Ord$set, $set, $set);
-$bool $Ord$set$__lt__ ($Ord$set, $set, $set);
-$bool $Ord$set$__le__ ($Ord$set, $set, $set);
-$bool $Ord$set$__gt__ ($Ord$set, $set, $set);
-$bool $Ord$set$__ge__ ($Ord$set, $set, $set);
+$bool $Ord$set$__eq__($Ord$set, $set, $set);
+$bool $Ord$set$__ne__($Ord$set, $set, $set);
+$bool $Ord$set$__lt__($Ord$set, $set, $set);
+$bool $Ord$set$__le__($Ord$set, $set, $set);
+$bool $Ord$set$__gt__($Ord$set, $set, $set);
+$bool $Ord$set$__ge__($Ord$set, $set, $set);
 
 // $Logical$set ////////////////////////////////////////////////////////////
 
@@ -1412,8 +1518,8 @@ struct $Logical$set$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Logical$set, $Set);
-    void (*__serialize__)($Logical$set,$Serial$state);
-    $Logical$set (*__deserialize__)($Logical$set,$Serial$state);
+    void (*__serialize__)($Logical$set, $Serial$state);
+    $Logical$set (*__deserialize__)($Logical$set, $Serial$state);
     $bool (*__bool__)($Logical$set);
     $str (*__str__)($Logical$set);
     $set (*__and__)($Logical$set, $set, $set);
@@ -1424,12 +1530,12 @@ struct $Logical$set$class {
     $set (*__ixor__)($Logical$set, $set, $set);
 };
 
-void $Logical$set$__init__ ($Logical$set, $Set);
+void $Logical$set$__init__($Logical$set, $Set);
 void $Logical$set$__serialize__($Logical$set, $Serial$state);
 $Logical$set $Logical$set$__deserialize__($Logical$set, $Serial$state);
-$set $Logical$set$__and__ ($Logical$set, $set, $set);
-$set $Logical$set$__or__ ($Logical$set, $set, $set);
-$set $Logical$set$__xor__ ($Logical$set, $set, $set);
+$set $Logical$set$__and__($Logical$set, $set, $set);
+$set $Logical$set$__or__($Logical$set, $set, $set);
+$set $Logical$set$__xor__($Logical$set, $set, $set);
 
 // $Minus$set ////////////////////////////////////////////////////////////
 
@@ -1443,18 +1549,18 @@ struct $Minus$set$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Minus$set, $Set);
-    void (*__serialize__)($Minus$set,$Serial$state);
-    $Minus$set (*__deserialize__)($Minus$set,$Serial$state);
+    void (*__serialize__)($Minus$set, $Serial$state);
+    $Minus$set (*__deserialize__)($Minus$set, $Serial$state);
     $bool (*__bool__)($Minus$set);
     $str (*__str__)($Minus$set);
     $set (*__sub__)($Minus$set, $set, $set);
     $set (*__isub__)($Minus$set, $set, $set);
 };
 
-void $Minus$set$__init__ ($Minus$set, $Set);
+void $Minus$set$__init__($Minus$set, $Set);
 void $Minus$set$__serialize__($Minus$set, $Serial$state);
 $Minus$set $Minus$set$__deserialize__($Minus$set, $Serial$state);
-$set $Minus$set$__sub__ ($Minus$set, $set, $set);
+$set $Minus$set$__sub__($Minus$set, $set, $set);
 
 // $Iterable$Iterator ////////////////////////////////////////////////////////////
 
@@ -1467,19 +1573,18 @@ struct $Iterable$Iterator$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Iterable$Iterator);
-    void (*__serialize__)($Iterable$Iterator,$Serial$state);
-    $Iterable$Iterator (*__deserialize__)($Iterable$Iterator,$Serial$state);
+    void (*__serialize__)($Iterable$Iterator, $Serial$state);
+    $Iterable$Iterator (*__deserialize__)($Iterable$Iterator, $Serial$state);
     $bool (*__bool__)($Iterable$Iterator);
     $str (*__str__)($Iterable$Iterator);
     $Iterator (*__iter__)($Iterable$Iterator, $Iterator);
 };
 
-void $Iterable$Iterator$__init__ ($Iterable$Iterator);
+void $Iterable$Iterator$__init__($Iterable$Iterator);
 void $Iterable$Iterator$__serialize__($Iterable$Iterator, $Serial$state);
 $Iterable$Iterator $Iterable$Iterator$__deserialize__($Iterable$Iterator, $Serial$state);
-$Iterator $Iterable$Iterator$__iter__ ($Iterable$Iterator, $Iterator);
+$Iterator $Iterable$Iterator$__iter__($Iterable$Iterator, $Iterator);
 
- 
 // $Ord$str ////////////////////////////////////////////////////////////
 
 struct $Ord$str {
@@ -1491,8 +1596,8 @@ struct $Ord$str$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Ord$str);
-    void (*__serialize__)($Ord$str,$Serial$state);
-    $Ord$str (*__deserialize__)($Ord$str,$Serial$state);
+    void (*__serialize__)($Ord$str, $Serial$state);
+    $Ord$str (*__deserialize__)($Ord$str, $Serial$state);
     $bool (*__bool__)($Ord$str);
     $str (*__str__)($Ord$str);
     $bool (*__eq__)($Ord$str, $str, $str);
@@ -1503,15 +1608,15 @@ struct $Ord$str$class {
     $bool (*__ge__)($Ord$str, $str, $str);
 };
 
-void $Ord$str$__init__ ($Ord$str);
+void $Ord$str$__init__($Ord$str);
 void $Ord$str$__serialize__($Ord$str, $Serial$state);
 $Ord$str $Ord$str$__deserialize__($Ord$str, $Serial$state);
-$bool $Ord$str$__eq__ ($Ord$str, $str, $str);
-$bool $Ord$str$__ne__ ($Ord$str, $str, $str);
-$bool $Ord$str$__lt__ ($Ord$str, $str, $str);
-$bool $Ord$str$__le__ ($Ord$str, $str, $str);
-$bool $Ord$str$__gt__ ($Ord$str, $str, $str);
-$bool $Ord$str$__ge__ ($Ord$str, $str, $str);
+$bool $Ord$str$__eq__($Ord$str, $str, $str);
+$bool $Ord$str$__ne__($Ord$str, $str, $str);
+$bool $Ord$str$__lt__($Ord$str, $str, $str);
+$bool $Ord$str$__le__($Ord$str, $str, $str);
+$bool $Ord$str$__gt__($Ord$str, $str, $str);
+$bool $Ord$str$__ge__($Ord$str, $str, $str);
 
 // $Container$str ////////////////////////////////////////////////////////////
 
@@ -1525,8 +1630,8 @@ struct $Container$str$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Container$str, $Eq);
-    void (*__serialize__)($Container$str,$Serial$state);
-    $Container$str (*__deserialize__)($Container$str,$Serial$state);
+    void (*__serialize__)($Container$str, $Serial$state);
+    $Container$str (*__deserialize__)($Container$str, $Serial$state);
     $bool (*__bool__)($Container$str);
     $str (*__str__)($Container$str);
     $Iterator (*__iter__)($Container$str, $str);
@@ -1536,13 +1641,13 @@ struct $Container$str$class {
     $bool (*__containsnot__)($Container$str, $str, $str);
 };
 
-void $Container$str$__init__ ($Container$str, $Eq);
+void $Container$str$__init__($Container$str, $Eq);
 void $Container$str$__serialize__($Container$str, $Serial$state);
 $Container$str $Container$str$__deserialize__($Container$str, $Serial$state);
-$Iterator $Container$str$__iter__ ($Container$str, $str);
-$int $Container$str$__len__ ($Container$str, $str);
-$bool $Container$str$__contains__ ($Container$str, $str, $str);
-$bool $Container$str$__containsnot__ ($Container$str, $str, $str);
+$Iterator $Container$str$__iter__($Container$str, $str);
+$int $Container$str$__len__($Container$str, $str);
+$bool $Container$str$__contains__($Container$str, $str, $str);
+$bool $Container$str$__containsnot__($Container$str, $str, $str);
 
 // $Sliceable$str ////////////////////////////////////////////////////////////
 
@@ -1555,8 +1660,8 @@ struct $Sliceable$str$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Sliceable$str);
-    void (*__serialize__)($Sliceable$str,$Serial$state);
-    $Sliceable$str (*__deserialize__)($Sliceable$str,$Serial$state);
+    void (*__serialize__)($Sliceable$str, $Serial$state);
+    $Sliceable$str (*__deserialize__)($Sliceable$str, $Serial$state);
     $bool (*__bool__)($Sliceable$str);
     $str (*__str__)($Sliceable$str);
     $str (*__getitem__)($Sliceable$str, $str, $int);
@@ -1567,15 +1672,15 @@ struct $Sliceable$str$class {
     void (*__delslice__)($Sliceable$str, $str, $slice);
 };
 
-void $Sliceable$str$__init__ ($Sliceable$str);
+void $Sliceable$str$__init__($Sliceable$str);
 void $Sliceable$str$__serialize__($Sliceable$str, $Serial$state);
 $Sliceable$str $Sliceable$str$__deserialize__($Sliceable$str, $Serial$state);
-$str $Sliceable$str$__getitem__ ($Sliceable$str, $str, $int);
-void $Sliceable$str$__setitem__ ($Sliceable$str, $str, $int, $str);
-void $Sliceable$str$__delitem__ ($Sliceable$str, $str, $int);
-$str $Sliceable$str$__getslice__ ($Sliceable$str, $str, $slice);
-void $Sliceable$str$__setslice__ ($Sliceable$str, $str, $Iterable, $slice, $WORD);
-void $Sliceable$str$__delslice__ ($Sliceable$str, $str, $slice);
+$str $Sliceable$str$__getitem__($Sliceable$str, $str, $int);
+void $Sliceable$str$__setitem__($Sliceable$str, $str, $int, $str);
+void $Sliceable$str$__delitem__($Sliceable$str, $str, $int);
+$str $Sliceable$str$__getslice__($Sliceable$str, $str, $slice);
+void $Sliceable$str$__setslice__($Sliceable$str, $str, $Iterable, $slice, $WORD);
+void $Sliceable$str$__delslice__($Sliceable$str, $str, $slice);
 
 // $Times$str ////////////////////////////////////////////////////////////
 
@@ -1588,8 +1693,8 @@ struct $Times$str$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Times$str);
-    void (*__serialize__)($Times$str,$Serial$state);
-    $Times$str (*__deserialize__)($Times$str,$Serial$state);
+    void (*__serialize__)($Times$str, $Serial$state);
+    $Times$str (*__deserialize__)($Times$str, $Serial$state);
     $bool (*__bool__)($Times$str);
     $str (*__str__)($Times$str);
     $str (*__add__)($Times$str, $str, $str);
@@ -1598,12 +1703,12 @@ struct $Times$str$class {
     $str (*__imul__)($Times$str, $str, $int);
 };
 
-void $Times$str$__init__ ($Times$str);
+void $Times$str$__init__($Times$str);
 void $Times$str$__serialize__($Times$str, $Serial$state);
 $Times$str $Times$str$__deserialize__($Times$str, $Serial$state);
 $bool $Times$str$__bool__($Times$str);
 $str $Times$str$__str__($Times$str);
-$str $Times$str$__add__ ($Times$str, $str, $str);
+$str $Times$str$__add__($Times$str, $str, $str);
 $str $Times$str$__mul__($Times$str, $str, $int);
 
 // $Hashable$str ////////////////////////////////////////////////////////////
@@ -1617,8 +1722,8 @@ struct $Hashable$str$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Hashable$str);
-    void (*__serialize__)($Hashable$str,$Serial$state);
-    $Hashable$str (*__deserialize__)($Hashable$str,$Serial$state);
+    void (*__serialize__)($Hashable$str, $Serial$state);
+    $Hashable$str (*__deserialize__)($Hashable$str, $Serial$state);
     $bool (*__bool__)($Hashable$str);
     $str (*__str__)($Hashable$str);
     $bool (*__eq__)($Hashable$str, $str, $str);
@@ -1626,12 +1731,12 @@ struct $Hashable$str$class {
     $int (*__hash__)($Hashable$str, $str);
 };
 
-void $Hashable$str$__init__ ($Hashable$str);
+void $Hashable$str$__init__($Hashable$str);
 void $Hashable$str$__serialize__($Hashable$str, $Serial$state);
 $Hashable$str $Hashable$str$__deserialize__($Hashable$str, $Serial$state);
-$bool $Hashable$str$__eq__ ($Hashable$str, $str, $str);
-$bool $Hashable$str$__ne__ ($Hashable$str, $str, $str);
-$int $Hashable$str$__hash__ ($Hashable$str, $str);
+$bool $Hashable$str$__eq__($Hashable$str, $str, $str);
+$bool $Hashable$str$__ne__($Hashable$str, $str, $str);
+$int $Hashable$str$__hash__($Hashable$str, $str);
 
 // $Integral$int ////////////////////////////////////////////////////////////
 
@@ -1646,33 +1751,41 @@ struct $Integral$int$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Integral$int);
-    void (*__serialize__)($Integral$int,$Serial$state);
-    $Integral$int (*__deserialize__)($Integral$int,$Serial$state);
+    void (*__serialize__)($Integral$int, $Serial$state);
+    $Integral$int (*__deserialize__)($Integral$int, $Serial$state);
     $bool (*__bool__)($Integral$int);
     $str (*__str__)($Integral$int);
     $int (*__add__)($Integral$int, $int, $int);
     $int (*__iadd__)($Integral$int, $int, $int);
     $int (*__mul__)($Integral$int, $int, $int);
     $int (*__imul__)($Integral$int, $int, $int);
-    $int (*__fromatom__)($Integral$int,$atom);
+    $int (*__fromatom__)($Integral$int, $atom);
     $complex (*__complx__)($Integral$int, $int);
-  //    $int (*__truediv__)($Integral$int, $int, $int);
+    //    $int (*__truediv__)($Integral$int, $int, $int);
     $int (*__pow__)($Integral$int, $int, $int);
-  //    $int (*__itruediv__)($Integral$int, $int, $int);
+    //    $int (*__itruediv__)($Integral$int, $int, $int);
     $int (*__ipow__)($Integral$int, $int, $int);
     $int (*__neg__)($Integral$int, $int);
     $int (*__pos__)($Integral$int, $int);
-    $WORD (*real)($Integral$int, $int, $Real);
-    $WORD (*imag)($Integral$int, $int, $Real);
-    $WORD (*__abs__)($Integral$int, $int, $Real);
+    $WORD (*real)
+    ($Integral$int, $int, $Real);
+    $WORD (*imag)
+    ($Integral$int, $int, $Real);
+    $WORD (*__abs__)
+    ($Integral$int, $int, $Real);
     $int (*conjugate)($Integral$int, $int);
     $float (*__float__)($Integral$int, $int);
-    $WORD (*__trunc__)($Integral$int, $int, $Integral);
-    $WORD (*__floor__)($Integral$int, $int, $Integral);
-    $WORD (*__ceil__)($Integral$int, $int, $Integral);
+    $WORD (*__trunc__)
+    ($Integral$int, $int, $Integral);
+    $WORD (*__floor__)
+    ($Integral$int, $int, $Integral);
+    $WORD (*__ceil__)
+    ($Integral$int, $int, $Integral);
     $int (*__round__)($Integral$int, $int, $int);
-    $WORD (*numerator)($Integral$int, $int, $Integral);
-    $WORD (*denominator)($Integral$int, $int, $Integral);
+    $WORD (*numerator)
+    ($Integral$int, $int, $Integral);
+    $WORD (*denominator)
+    ($Integral$int, $int, $Integral);
     $int (*__int__)($Integral$int, $int);
     $int (*__index__)($Integral$int, $int);
     $tuple (*__divmod__)($Integral$int, $int, $int);
@@ -1687,11 +1800,11 @@ struct $Integral$int$class {
     $int (*__invert__)($Integral$int, $int);
 };
 
-void $Integral$int$__init__ ($Integral$int);
+void $Integral$int$__init__($Integral$int);
 void $Integral$int$__serialize__($Integral$int, $Serial$state);
 $Integral$int $Integral$int$__deserialize__($Integral$int, $Serial$state);
 $int $Integral$int$__add__($Integral$int, $int, $int);
-$int $Integral$int$__fromatom__($Integral$int,$atom);
+$int $Integral$int$__fromatom__($Integral$int, $atom);
 $complex $Integral$int$__complx__($Integral$int, $int);
 $int $Integral$int$__mul__($Integral$int, $int, $int);
 //$int $Integral$int$__truediv__($Integral$int, $int, $int);
@@ -1702,21 +1815,21 @@ $WORD $Integral$int$real($Integral$int, $int, $Real);
 $WORD $Integral$int$imag($Integral$int, $int, $Real);
 $WORD $Integral$int$__abs__($Integral$int, $int, $Real);
 $int $Integral$int$conjugate($Integral$int, $int);
-$float $Integral$int$__float__ ($Integral$int, $int);
-$WORD $Integral$int$__trunc__ ($Integral$int, $int, $Integral);
-$WORD $Integral$int$__floor__ ($Integral$int, $int, $Integral);
-$WORD $Integral$int$__ceil__ ($Integral$int, $int, $Integral);
-$int $Integral$int$__round__ ($Integral$int, $int, $int);
-$WORD $Integral$int$numerator ($Integral$int, $int, $Integral);
-$WORD $Integral$int$denominator ($Integral$int, $int, $Integral);
-$int $Integral$int$__int__ ($Integral$int, $int);
-$int $Integral$int$__index__ ($Integral$int, $int);
-$tuple $Integral$int$__divmod__ ($Integral$int, $int, $int);
-$int $Integral$int$__floordiv__ ($Integral$int, $int, $int);
-$int $Integral$int$__mod__ ($Integral$int, $int, $int);
-$int $Integral$int$__lshift__ ($Integral$int, $int, $int);
-$int $Integral$int$__rshift__ ($Integral$int, $int, $int);
-$int $Integral$int$__invert__ ($Integral$int, $int);
+$float $Integral$int$__float__($Integral$int, $int);
+$WORD $Integral$int$__trunc__($Integral$int, $int, $Integral);
+$WORD $Integral$int$__floor__($Integral$int, $int, $Integral);
+$WORD $Integral$int$__ceil__($Integral$int, $int, $Integral);
+$int $Integral$int$__round__($Integral$int, $int, $int);
+$WORD $Integral$int$numerator($Integral$int, $int, $Integral);
+$WORD $Integral$int$denominator($Integral$int, $int, $Integral);
+$int $Integral$int$__int__($Integral$int, $int);
+$int $Integral$int$__index__($Integral$int, $int);
+$tuple $Integral$int$__divmod__($Integral$int, $int, $int);
+$int $Integral$int$__floordiv__($Integral$int, $int, $int);
+$int $Integral$int$__mod__($Integral$int, $int, $int);
+$int $Integral$int$__lshift__($Integral$int, $int, $int);
+$int $Integral$int$__rshift__($Integral$int, $int, $int);
+$int $Integral$int$__invert__($Integral$int, $int);
 
 // $Logical$int ////////////////////////////////////////////////////////////
 
@@ -1730,8 +1843,8 @@ struct $Logical$int$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Logical$int, $Integral);
-    void (*__serialize__)($Logical$int,$Serial$state);
-    $Logical$int (*__deserialize__)($Logical$int,$Serial$state);
+    void (*__serialize__)($Logical$int, $Serial$state);
+    $Logical$int (*__deserialize__)($Logical$int, $Serial$state);
     $bool (*__bool__)($Logical$int);
     $str (*__str__)($Logical$int);
     $int (*__and__)($Logical$int, $int, $int);
@@ -1742,12 +1855,12 @@ struct $Logical$int$class {
     $int (*__ixor__)($Logical$int, $int, $int);
 };
 
-void $Logical$int$__init__ ($Logical$int, $Integral);
+void $Logical$int$__init__($Logical$int, $Integral);
 void $Logical$int$__serialize__($Logical$int, $Serial$state);
 $Logical$int $Logical$int$__deserialize__($Logical$int, $Serial$state);
-$int $Logical$int$__and__ ($Logical$int, $int, $int);
-$int $Logical$int$__or__ ($Logical$int, $int, $int);
-$int $Logical$int$__xor__ ($Logical$int, $int, $int);
+$int $Logical$int$__and__($Logical$int, $int, $int);
+$int $Logical$int$__or__($Logical$int, $int, $int);
+$int $Logical$int$__xor__($Logical$int, $int, $int);
 
 // $Minus$int ////////////////////////////////////////////////////////////
 
@@ -1761,18 +1874,18 @@ struct $Minus$int$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Minus$int, $Integral);
-    void (*__serialize__)($Minus$int,$Serial$state);
-    $Minus$int (*__deserialize__)($Minus$int,$Serial$state);
+    void (*__serialize__)($Minus$int, $Serial$state);
+    $Minus$int (*__deserialize__)($Minus$int, $Serial$state);
     $bool (*__bool__)($Minus$int);
     $str (*__str__)($Minus$int);
     $int (*__sub__)($Minus$int, $int, $int);
     $int (*__isub__)($Minus$int, $int, $int);
 };
 
-void $Minus$int$__init__ ($Minus$int, $Integral);
+void $Minus$int$__init__($Minus$int, $Integral);
 void $Minus$int$__serialize__($Minus$int, $Serial$state);
 $Minus$int $Minus$int$__deserialize__($Minus$int, $Serial$state);
-$int $Minus$int$__sub__ ($Minus$int, $int, $int);
+$int $Minus$int$__sub__($Minus$int, $int, $int);
 
 // $Div$int ////////////////////////////////////////////////////////////
 
@@ -1785,16 +1898,16 @@ struct $Div$int$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Div$int);
-    void (*__serialize__)($Div$int,$Serial$state);
-    $Div$int (*__deserialize__)($Div$int,$Serial$state);
+    void (*__serialize__)($Div$int, $Serial$state);
+    $Div$int (*__deserialize__)($Div$int, $Serial$state);
     $bool (*__bool__)($Div$int);
     $str (*__str__)($Div$int);
     $float (*__truediv__)($Div$int, $int, $int);
     $float (*__itruediv__)($Div$int, $int, $int);
 };
 
-$float $Div$int$__truediv__ ($Div$int, $int, $int);
-$float $Div$int$__itruediv__ ($Div$int, $int, $int);
+$float $Div$int$__truediv__($Div$int, $int, $int);
+$float $Div$int$__itruediv__($Div$int, $int, $int);
 
 // $Ord$int /////////////////////////////////////////////////////////////////
 
@@ -1802,13 +1915,13 @@ struct $Ord$int {
     $Ord$int$class $class;
 };
 
-struct $Ord$int$class {  
+struct $Ord$int$class {
     char *$GCINFO;
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Ord$int);
-    void (*__serialize__)($Ord$int,$Serial$state);
-    $Ord$int (*__deserialize__)($Ord$int,$Serial$state);
+    void (*__serialize__)($Ord$int, $Serial$state);
+    $Ord$int (*__deserialize__)($Ord$int, $Serial$state);
     $bool (*__bool__)($Ord$int);
     $str (*__str__)($Ord$int);
     $bool (*__eq__)($Ord$int, $int, $int);
@@ -1819,16 +1932,15 @@ struct $Ord$int$class {
     $bool (*__ge__)($Ord$int, $int, $int);
 };
 
-void $Ord$int$__init__ ($Ord$int);
+void $Ord$int$__init__($Ord$int);
 void $Ord$int$__serialize__($Ord$int, $Serial$state);
 $Ord$int $Ord$int$__deserialize__($Ord$int, $Serial$state);
-$bool $Ord$int$__eq__ ($Ord$int, $int, $int);
-$bool $Ord$int$__ne__ ($Ord$int, $int, $int);
-$bool $Ord$int$__lt__ ($Ord$int, $int, $int);
-$bool $Ord$int$__le__ ($Ord$int, $int, $int);
-$bool $Ord$int$__gt__ ($Ord$int, $int, $int);
-$bool $Ord$int$__ge__ ($Ord$int, $int, $int);
-  
+$bool $Ord$int$__eq__($Ord$int, $int, $int);
+$bool $Ord$int$__ne__($Ord$int, $int, $int);
+$bool $Ord$int$__lt__($Ord$int, $int, $int);
+$bool $Ord$int$__le__($Ord$int, $int, $int);
+$bool $Ord$int$__gt__($Ord$int, $int, $int);
+$bool $Ord$int$__ge__($Ord$int, $int, $int);
 
 // $Hashable$int ////////////////////////////////////////////////////////////
 
@@ -1841,8 +1953,8 @@ struct $Hashable$int$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Hashable$int);
-    void (*__serialize__)($Hashable$int,$Serial$state);
-    $Hashable$int (*__deserialize__)($Hashable$int,$Serial$state);
+    void (*__serialize__)($Hashable$int, $Serial$state);
+    $Hashable$int (*__deserialize__)($Hashable$int, $Serial$state);
     $bool (*__bool__)($Hashable$int);
     $str (*__str__)($Hashable$int);
     $bool (*__eq__)($Hashable$int, $int, $int);
@@ -1850,12 +1962,12 @@ struct $Hashable$int$class {
     $int (*__hash__)($Hashable$int, $int);
 };
 
-void $Hashable$int$__init__ ($Hashable$int);
+void $Hashable$int$__init__($Hashable$int);
 void $Hashable$int$__serialize__($Hashable$int, $Serial$state);
 $Hashable$int $Hashable$int$__deserialize__($Hashable$int, $Serial$state);
-$bool $Hashable$int$__eq__ ($Hashable$int, $int, $int);
-$bool $Hashable$int$__ne__ ($Hashable$int, $int, $int);
-$int $Hashable$int$__hash__ ($Hashable$int, $int);
+$bool $Hashable$int$__eq__($Hashable$int, $int, $int);
+$bool $Hashable$int$__ne__($Hashable$int, $int, $int);
+$int $Hashable$int$__hash__($Hashable$int, $int);
 
 // $Real$float ////////////////////////////////////////////////////////////
 
@@ -1869,38 +1981,44 @@ struct $Real$float$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Real$float);
-    void (*__serialize__)($Real$float,$Serial$state);
-    $Real$float (*__deserialize__)($Real$float,$Serial$state);
+    void (*__serialize__)($Real$float, $Serial$state);
+    $Real$float (*__deserialize__)($Real$float, $Serial$state);
     $bool (*__bool__)($Real$float);
     $str (*__str__)($Real$float);
     $float (*__add__)($Real$float, $float, $float);
     $float (*__iadd__)($Real$float, $float, $float);
     $float (*__mul__)($Real$float, $float, $float);
     $float (*__imul__)($Real$float, $float, $float);
-    $float (*__fromatom__)($Real$float,$atom);
+    $float (*__fromatom__)($Real$float, $atom);
     $complex (*__complx__)($Real$float, $float);
-  //    $float (*__truediv__)($Real$float, $float, $float);
+    //    $float (*__truediv__)($Real$float, $float, $float);
     $float (*__pow__)($Real$float, $float, $float);
-  //    $float (*__itruediv__)($Real$float, $float, $float);
+    //    $float (*__itruediv__)($Real$float, $float, $float);
     $float (*__ipow__)($Real$float, $float, $float);
     $float (*__neg__)($Real$float, $float);
     $float (*__pos__)($Real$float, $float);
-    $WORD (*real)($Real$float, $float, $Real);
-    $WORD (*imag)($Real$float, $float, $Real);
-    $WORD (*__abs__)($Real$float, $float, $Real);
+    $WORD (*real)
+    ($Real$float, $float, $Real);
+    $WORD (*imag)
+    ($Real$float, $float, $Real);
+    $WORD (*__abs__)
+    ($Real$float, $float, $Real);
     $float (*conjugate)($Real$float, $float);
     $float (*__float__)($Real$float, $float);
-    $WORD (*__trunc__)($Real$float, $float, $Integral);
-    $WORD (*__floor__)($Real$float, $float, $Integral);
-    $WORD (*__ceil__)($Real$float, $float, $Integral);
+    $WORD (*__trunc__)
+    ($Real$float, $float, $Integral);
+    $WORD (*__floor__)
+    ($Real$float, $float, $Integral);
+    $WORD (*__ceil__)
+    ($Real$float, $float, $Integral);
     $float (*__round__)($Real$float, $float, $int);
 };
 
-void $Real$float$__init__ ($Real$float);
+void $Real$float$__init__($Real$float);
 void $Real$float$__serialize__($Real$float, $Serial$state);
 $Real$float $Real$float$__deserialize__($Real$float, $Serial$state);
 $float $Real$float$__add__($Real$float, $float, $float);
-$float $Real$float$__fromatom__($Real$float,$atom);
+$float $Real$float$__fromatom__($Real$float, $atom);
 $complex $Real$float$__complx__($Real$float, $float);
 $float $Real$float$__mul__($Real$float, $float, $float);
 //$float $Real$float$__truediv__($Real$float, $float, $float);
@@ -1911,11 +2029,11 @@ $WORD $Real$float$real($Real$float, $float, $Real);
 $WORD $Real$float$imag($Real$float, $float, $Real);
 $WORD $Real$float$__abs__($Real$float, $float, $Real);
 $float $Real$float$conjugate($Real$float, $float);
-$float $Real$float$__float__ ($Real$float, $float);
-$WORD $Real$float$__trunc__ ($Real$float, $float, $Integral);
-$WORD $Real$float$__floor__ ($Real$float, $float, $Integral);
-$WORD $Real$float$__ceil__ ($Real$float, $float, $Integral);
-$float $Real$float$__round__ ($Real$float, $float, $int);
+$float $Real$float$__float__($Real$float, $float);
+$WORD $Real$float$__trunc__($Real$float, $float, $Integral);
+$WORD $Real$float$__floor__($Real$float, $float, $Integral);
+$WORD $Real$float$__ceil__($Real$float, $float, $Integral);
+$float $Real$float$__round__($Real$float, $float, $int);
 
 // $Div$float ////////////////////////////////////////////////////////////
 
@@ -1928,16 +2046,16 @@ struct $Div$float$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Div$float);
-    void (*__serialize__)($Div$float,$Serial$state);
-    $Div$float (*__deserialize__)($Div$float,$Serial$state);
+    void (*__serialize__)($Div$float, $Serial$state);
+    $Div$float (*__deserialize__)($Div$float, $Serial$state);
     $bool (*__bool__)($Div$float);
     $str (*__str__)($Div$float);
     $float (*__truediv__)($Div$float, $float, $float);
     $float (*__itruediv__)($Div$float, $float, $float);
 };
 
-$float $Div$float$__truediv__ ($Div$float, $float, $float);
-$float $Div$float$__itruediv__ ($Div$float, $float, $float);
+$float $Div$float$__truediv__($Div$float, $float, $float);
+$float $Div$float$__itruediv__($Div$float, $float, $float);
 
 // $Minus$float ////////////////////////////////////////////////////////////
 
@@ -1951,18 +2069,18 @@ struct $Minus$float$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Minus$float, $Real);
-    void (*__serialize__)($Minus$float,$Serial$state);
-    $Minus$float (*__deserialize__)($Minus$float,$Serial$state);
+    void (*__serialize__)($Minus$float, $Serial$state);
+    $Minus$float (*__deserialize__)($Minus$float, $Serial$state);
     $bool (*__bool__)($Minus$float);
     $str (*__str__)($Minus$float);
     $float (*__sub__)($Minus$float, $float, $float);
     $float (*__isub__)($Minus$float, $float, $float);
 };
 
-void $Minus$float$__init__ ($Minus$float, $Real);
+void $Minus$float$__init__($Minus$float, $Real);
 void $Minus$float$__serialize__($Minus$float, $Serial$state);
 $Minus$float $Minus$float$__deserialize__($Minus$float, $Serial$state);
-$float $Minus$float$__sub__ ($Minus$float, $float, $float);
+$float $Minus$float$__sub__($Minus$float, $float, $float);
 
 // $Ord$float /////////////////////////////////////////////////////////////////
 
@@ -1975,8 +2093,8 @@ struct $Ord$float$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Ord$float);
-    void (*__serialize__)($Ord$float,$Serial$state);
-    $Ord$float (*__deserialize__)($Ord$float,$Serial$state);
+    void (*__serialize__)($Ord$float, $Serial$state);
+    $Ord$float (*__deserialize__)($Ord$float, $Serial$state);
     $bool (*__bool__)($Ord$float);
     $str (*__str__)($Ord$float);
     $bool (*__eq__)($Ord$float, $float, $float);
@@ -1987,15 +2105,15 @@ struct $Ord$float$class {
     $bool (*__ge__)($Ord$float, $float, $float);
 };
 
-void $Ord$float$__init__ ($Ord$float);
+void $Ord$float$__init__($Ord$float);
 void $Ord$float$__serialize__($Ord$float, $Serial$state);
 $Ord$float $Ord$float$__deserialize__($Ord$float, $Serial$state);
-$bool $Ord$float$__eq__ ($Ord$float, $float, $float);
-$bool $Ord$float$__ne__ ($Ord$float, $float, $float);
-$bool $Ord$float$__lt__ ($Ord$float, $float, $float);
-$bool $Ord$float$__le__ ($Ord$float, $float, $float);
-$bool $Ord$float$__gt__ ($Ord$float, $float, $float);
-$bool $Ord$float$__ge__ ($Ord$float, $float, $float);
+$bool $Ord$float$__eq__($Ord$float, $float, $float);
+$bool $Ord$float$__ne__($Ord$float, $float, $float);
+$bool $Ord$float$__lt__($Ord$float, $float, $float);
+$bool $Ord$float$__le__($Ord$float, $float, $float);
+$bool $Ord$float$__gt__($Ord$float, $float, $float);
+$bool $Ord$float$__ge__($Ord$float, $float, $float);
 
 // $Hashable$float ////////////////////////////////////////////////////////////
 
@@ -2008,8 +2126,8 @@ struct $Hashable$float$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Hashable$float);
-    void (*__serialize__)($Hashable$float,$Serial$state);
-    $Hashable$float (*__deserialize__)($Hashable$float,$Serial$state);
+    void (*__serialize__)($Hashable$float, $Serial$state);
+    $Hashable$float (*__deserialize__)($Hashable$float, $Serial$state);
     $bool (*__bool__)($Hashable$float);
     $str (*__str__)($Hashable$float);
     $bool (*__eq__)($Hashable$float, $float, $float);
@@ -2017,12 +2135,12 @@ struct $Hashable$float$class {
     $int (*__hash__)($Hashable$float, $float);
 };
 
-void $Hashable$float$__init__ ($Hashable$float);
+void $Hashable$float$__init__($Hashable$float);
 void $Hashable$float$__serialize__($Hashable$float, $Serial$state);
 $Hashable$float $Hashable$float$__deserialize__($Hashable$float, $Serial$state);
-$bool $Hashable$float$__eq__ ($Hashable$float, $float, $float);
-$bool $Hashable$float$__ne__ ($Hashable$float, $float, $float);
-$int $Hashable$float$__hash__ ($Hashable$float, $float);
+$bool $Hashable$float$__eq__($Hashable$float, $float, $float);
+$bool $Hashable$float$__ne__($Hashable$float, $float, $float);
+$int $Hashable$float$__hash__($Hashable$float, $float);
 
 // $Number$complex ////////////////////////////////////////////////////////////
 
@@ -2036,43 +2154,46 @@ struct $Number$complex$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Number$complex);
-    void (*__serialize__)($Number$complex,$Serial$state);
-    $Number$complex (*__deserialize__)($Number$complex,$Serial$state);
+    void (*__serialize__)($Number$complex, $Serial$state);
+    $Number$complex (*__deserialize__)($Number$complex, $Serial$state);
     $bool (*__bool__)($Number$complex);
     $str (*__str__)($Number$complex);
     $complex (*__add__)($Number$complex, $complex, $complex);
     $complex (*__iadd__)($Number$complex, $complex, $complex);
     $complex (*__mul__)($Number$complex, $complex, $complex);
     $complex (*__imul__)($Number$complex, $complex, $complex);
-    $complex (*__fromatom__)($Number$complex,$atom);
+    $complex (*__fromatom__)($Number$complex, $atom);
     $complex (*__complx__)($Number$complex, $complex);
-  //    $complex (*__truediv__)($Number$complex, $complex, $complex);
+    //    $complex (*__truediv__)($Number$complex, $complex, $complex);
     $complex (*__pow__)($Number$complex, $complex, $complex);
-  //    $complex (*__itruediv__)($Number$complex, $complex, $complex);
+    //    $complex (*__itruediv__)($Number$complex, $complex, $complex);
     $complex (*__ipow__)($Number$complex, $complex, $complex);
     $complex (*__neg__)($Number$complex, $complex);
     $complex (*__pos__)($Number$complex, $complex);
-    $WORD (*real)($Number$complex, $complex, $Real);
-    $WORD (*imag)($Number$complex, $complex, $Real);
-    $WORD (*__abs__)($Number$complex, $complex, $Real);
+    $WORD (*real)
+    ($Number$complex, $complex, $Real);
+    $WORD (*imag)
+    ($Number$complex, $complex, $Real);
+    $WORD (*__abs__)
+    ($Number$complex, $complex, $Real);
     $complex (*conjugate)($Number$complex, $complex);
 };
 
-void $Number$complex$__init__ ($Number$complex);
+void $Number$complex$__init__($Number$complex);
 void $Number$complex$__serialize__($Number$complex, $Serial$state);
 $Number$complex $Number$complex$__deserialize__($Number$complex, $Serial$state);
-$complex $Number$complex$__add__ ($Number$complex, $complex, $complex);
-$complex $Number$complex$__fromatom__($Number$complex,$atom);
-$complex $Number$complex$__complx__ ($Number$complex, $complex);
-$complex $Number$complex$__mul__ ($Number$complex, $complex, $complex);
+$complex $Number$complex$__add__($Number$complex, $complex, $complex);
+$complex $Number$complex$__fromatom__($Number$complex, $atom);
+$complex $Number$complex$__complx__($Number$complex, $complex);
+$complex $Number$complex$__mul__($Number$complex, $complex, $complex);
 //$complex $Number$complex$__truediv__ ($Number$complex, $complex, $complex);
-$complex $Number$complex$__pow__ ($Number$complex, $complex, $complex);
-$complex $Number$complex$__neg__ ($Number$complex, $complex);
-$complex $Number$complex$__pos__ ($Number$complex, $complex);
-$WORD $Number$complex$real ($Number$complex, $complex, $Real);
-$WORD $Number$complex$imag ($Number$complex, $complex, $Real);
-$WORD $Number$complex$__abs__ ($Number$complex, $complex, $Real);
-$complex $Number$complex$conjugate ($Number$complex, $complex);
+$complex $Number$complex$__pow__($Number$complex, $complex, $complex);
+$complex $Number$complex$__neg__($Number$complex, $complex);
+$complex $Number$complex$__pos__($Number$complex, $complex);
+$WORD $Number$complex$real($Number$complex, $complex, $Real);
+$WORD $Number$complex$imag($Number$complex, $complex, $Real);
+$WORD $Number$complex$__abs__($Number$complex, $complex, $Real);
+$complex $Number$complex$conjugate($Number$complex, $complex);
 
 // $Div$complex ////////////////////////////////////////////////////////////
 
@@ -2085,16 +2206,16 @@ struct $Div$complex$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Div$complex);
-    void (*__serialize__)($Div$complex,$Serial$state);
-    $Div$complex (*__deserialize__)($Div$complex,$Serial$state);
+    void (*__serialize__)($Div$complex, $Serial$state);
+    $Div$complex (*__deserialize__)($Div$complex, $Serial$state);
     $bool (*__bool__)($Div$complex);
     $str (*__str__)($Div$complex);
     $complex (*__truediv__)($Div$complex, $complex, $complex);
     $complex (*__itruediv__)($Div$complex, $complex, $complex);
 };
 
-$complex $Div$complex$__truediv__ ($Div$complex, $complex, $complex);
-$complex $Div$complex$__itruediv__ ($Div$complex, $complex, $complex);
+$complex $Div$complex$__truediv__($Div$complex, $complex, $complex);
+$complex $Div$complex$__itruediv__($Div$complex, $complex, $complex);
 
 // $Minus$complex ////////////////////////////////////////////////////////////
 
@@ -2108,18 +2229,18 @@ struct $Minus$complex$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Minus$complex, $Number);
-    void (*__serialize__)($Minus$complex,$Serial$state);
-    $Minus$complex (*__deserialize__)($Minus$complex,$Serial$state);
+    void (*__serialize__)($Minus$complex, $Serial$state);
+    $Minus$complex (*__deserialize__)($Minus$complex, $Serial$state);
     $bool (*__bool__)($Minus$complex);
     $str (*__str__)($Minus$complex);
     $complex (*__sub__)($Minus$complex, $complex, $complex);
     $complex (*__isub__)($Minus$complex, $complex, $complex);
 };
 
-void $Minus$complex$__init__ ($Minus$complex, $Number);
+void $Minus$complex$__init__($Minus$complex, $Number);
 void $Minus$complex$__serialize__($Minus$complex, $Serial$state);
 $Minus$complex $Minus$complex$__deserialize__($Minus$complex, $Serial$state);
-$complex $Minus$complex$__sub__ ($Minus$complex, $complex, $complex);
+$complex $Minus$complex$__sub__($Minus$complex, $complex, $complex);
 
 // $Eq$complex ////////////////////////////////////////////////////////////
 
@@ -2132,8 +2253,8 @@ struct $Eq$complex$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Eq$complex);
-    void (*__serialize__)($Eq$complex,$Serial$state);
-    $Eq$complex (*__deserialize__)($Eq$complex,$Serial$state);
+    void (*__serialize__)($Eq$complex, $Serial$state);
+    $Eq$complex (*__deserialize__)($Eq$complex, $Serial$state);
     $bool (*__bool__)($Eq$complex);
     $str (*__str__)($Eq$complex);
     $bool (*__eq__)($Eq$complex, $complex, $complex);
@@ -2143,8 +2264,8 @@ struct $Eq$complex$class {
 void $Eq$complex$__init__($Eq$complex);
 void $Eq$complex$__serialize__($Eq$complex, $Serial$state);
 $Eq$complex $Eq$complex$__deserialize__($Eq$complex, $Serial$state);
-$bool $Eq$complex$__eq__ ($Eq$complex, $complex, $complex);
-$bool $Eq$complex$__ne__ ($Eq$complex, $complex, $complex);
+$bool $Eq$complex$__eq__($Eq$complex, $complex, $complex);
+$bool $Eq$complex$__ne__($Eq$complex, $complex, $complex);
 
 // $Hashable$complex ////////////////////////////////////////////////////////////
 
@@ -2157,8 +2278,8 @@ struct $Hashable$complex$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Hashable$complex);
-    void (*__serialize__)($Hashable$complex,$Serial$state);
-    $Hashable$complex (*__deserialize__)($Hashable$complex,$Serial$state);
+    void (*__serialize__)($Hashable$complex, $Serial$state);
+    $Hashable$complex (*__deserialize__)($Hashable$complex, $Serial$state);
     $bool (*__bool__)($Hashable$complex);
     $str (*__str__)($Hashable$complex);
     $bool (*__eq__)($Hashable$complex, $complex, $complex);
@@ -2166,14 +2287,14 @@ struct $Hashable$complex$class {
     $int (*__hash__)($Hashable$complex, $complex);
 };
 
-void $Hashable$complex$__init__ ($Hashable$complex);
+void $Hashable$complex$__init__($Hashable$complex);
 void $Hashable$complex$__serialize__($Hashable$complex, $Serial$state);
 $Hashable$complex $Hashable$complex$__deserialize__($Hashable$complex, $Serial$state);
 $bool $Hashable$complex$__bool__($Hashable$complex);
 $str $Hashable$complex$__str__($Hashable$complex);
-$bool $Hashable$complex$__eq__ ($Hashable$complex, $complex, $complex);
-$bool $Hashable$complex$__ne__ ($Hashable$complex, $complex, $complex);
-$int $Hashable$complex$__hash__ ($Hashable$complex, $complex);
+$bool $Hashable$complex$__eq__($Hashable$complex, $complex, $complex);
+$bool $Hashable$complex$__ne__($Hashable$complex, $complex, $complex);
+$int $Hashable$complex$__hash__($Hashable$complex, $complex);
 
 // $Iterable$range ////////////////////////////////////////////////////////////
 
@@ -2186,17 +2307,17 @@ struct $Iterable$range$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Iterable$range);
-    void (*__serialize__)($Iterable$range,$Serial$state);
-    $Iterable$range (*__deserialize__)($Iterable$range,$Serial$state);
+    void (*__serialize__)($Iterable$range, $Serial$state);
+    $Iterable$range (*__deserialize__)($Iterable$range, $Serial$state);
     $bool (*__bool__)($Iterable$range);
     $str (*__str__)($Iterable$range);
     $Iterator (*__iter__)($Iterable$range, $range);
 };
 
-void $Iterable$range$__init__ ($Iterable$range);
+void $Iterable$range$__init__($Iterable$range);
 void $Iterable$range$__serialize__($Iterable$range, $Serial$state);
 $Iterable$range $Iterable$range$__deserialize__($Iterable$range, $Serial$state);
-$Iterator $Iterable$range$__iter__ ($Iterable$range, $range);
+$Iterator $Iterable$range$__iter__($Iterable$range, $range);
 
 // $Iterable$tuple ////////////////////////////////////////////////////////////
 
@@ -2209,17 +2330,17 @@ struct $Iterable$tuple$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Iterable$tuple);
-    void (*__serialize__)($Iterable$tuple,$Serial$state);
-    $Iterable$tuple (*__deserialize__)($Iterable$tuple,$Serial$state);
+    void (*__serialize__)($Iterable$tuple, $Serial$state);
+    $Iterable$tuple (*__deserialize__)($Iterable$tuple, $Serial$state);
     $bool (*__bool__)($Iterable$tuple);
     $str (*__str__)($Iterable$tuple);
     $Iterator (*__iter__)($Iterable$tuple, $tuple);
 };
 
-void $Iterable$tuple$__init__ ($Iterable$tuple);
+void $Iterable$tuple$__init__($Iterable$tuple);
 void $Iterable$tuple$__serialize__($Iterable$tuple, $Serial$state);
 $Iterable$tuple $Iterable$tuple$__deserialize__($Iterable$tuple, $Serial$state);
-$Iterator $Iterable$tuple$__iter__ ($Iterable$tuple, $tuple);
+$Iterator $Iterable$tuple$__iter__($Iterable$tuple, $tuple);
 
 // $Sliceable$tuple ////////////////////////////////////////////////////////////
 
@@ -2234,11 +2355,12 @@ struct $Sliceable$tuple$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Sliceable$tuple);
-    void (*__serialize__)($Sliceable$tuple,$Serial$state);
-    $Sliceable$tuple (*__deserialize__)($Sliceable$tuple,$Serial$state);
+    void (*__serialize__)($Sliceable$tuple, $Serial$state);
+    $Sliceable$tuple (*__deserialize__)($Sliceable$tuple, $Serial$state);
     $bool (*__bool__)($Sliceable$tuple);
     $str (*__str__)($Sliceable$tuple);
-    $WORD (*__getitem__)($Sliceable$tuple, $tuple, $int);
+    $WORD (*__getitem__)
+    ($Sliceable$tuple, $tuple, $int);
     void (*__setitem__)($Sliceable$tuple, $tuple, $int, $WORD);
     void (*__delitem__)($Sliceable$tuple, $tuple, $int);
     $tuple (*__getslice__)($Sliceable$tuple, $tuple, $slice);
@@ -2246,44 +2368,44 @@ struct $Sliceable$tuple$class {
     void (*__delslice__)($Sliceable$tuple, $tuple, $slice);
 };
 
-void $Sliceable$tuple$__init__ ($Sliceable$tuple);
+void $Sliceable$tuple$__init__($Sliceable$tuple);
 void $Sliceable$tuple$__serialize__($Sliceable$tuple, $Serial$state);
 $Sliceable$tuple $Sliceable$tuple$__deserialize__($Sliceable$tuple, $Serial$state);
-$WORD $Sliceable$tuple$__getitem__ ($Sliceable$tuple, $tuple, $int);
-void $Sliceable$tuple$__setitem__ ($Sliceable$tuple, $tuple, $int, $WORD);
-void $Sliceable$tuple$__delitem__ ($Sliceable$tuple, $tuple, $int);
-$tuple $Sliceable$tuple$__getslice__ ($Sliceable$tuple, $tuple, $slice);
-void $Sliceable$tuple$__setslice__ ($Sliceable$tuple, $tuple, $Iterable, $slice, $WORD);
-void $Sliceable$tuple$__delslice__ ($Sliceable$tuple, $tuple, $slice);
+$WORD $Sliceable$tuple$__getitem__($Sliceable$tuple, $tuple, $int);
+void $Sliceable$tuple$__setitem__($Sliceable$tuple, $tuple, $int, $WORD);
+void $Sliceable$tuple$__delitem__($Sliceable$tuple, $tuple, $int);
+$tuple $Sliceable$tuple$__getslice__($Sliceable$tuple, $tuple, $slice);
+void $Sliceable$tuple$__setslice__($Sliceable$tuple, $tuple, $Iterable, $slice, $WORD);
+void $Sliceable$tuple$__delslice__($Sliceable$tuple, $tuple, $slice);
 
 // $Hashable$tuple ////////////////////////////////////////////////////////////
 
 struct $Hashable$tuple {
-  $Hashable$tuple$class $class;
-  int w$Hashable$tuple$size;
-  $Hashable *w$Hashable;
+    $Hashable$tuple$class $class;
+    int w$Hashable$tuple$size;
+    $Hashable *w$Hashable;
 };
 
 struct $Hashable$tuple$class {
     char *$GCINFO;
     int $class_id;
     $Super$class $superclass;
-    void (*__init__)($Hashable$tuple,int,$Hashable*);
-    void (*__serialize__)($Hashable$tuple,$Serial$state);
-    $Hashable$tuple (*__deserialize__)($Hashable$tuple,$Serial$state);
+    void (*__init__)($Hashable$tuple, int, $Hashable *);
+    void (*__serialize__)($Hashable$tuple, $Serial$state);
+    $Hashable$tuple (*__deserialize__)($Hashable$tuple, $Serial$state);
     $bool (*__bool__)($Hashable$tuple);
     $str (*__str__)($Hashable$tuple);
     $bool (*__eq__)($Hashable$tuple, $tuple, $tuple);
     $bool (*__ne__)($Hashable$tuple, $tuple, $tuple);
     $int (*__hash__)($Hashable$tuple, $tuple);
 };
-  
-void $Hashable$tuple$__init__ ($Hashable$tuple,int,$Hashable*);
+
+void $Hashable$tuple$__init__($Hashable$tuple, int, $Hashable *);
 void $Hashable$tuple$__serialize__($Hashable$tuple, $Serial$state);
 $Hashable$tuple $Hashable$tuple$__deserialize__($Hashable$tuple, $Serial$state);
-$bool $Hashable$tuple$__eq__ ($Hashable$tuple, $tuple, $tuple);
-$bool $Hashable$tuple$__ne__ ($Hashable$tuple, $tuple, $tuple);
-$int $Hashable$tuple$__hash__ ($Hashable$tuple, $tuple);
+$bool $Hashable$tuple$__eq__($Hashable$tuple, $tuple, $tuple);
+$bool $Hashable$tuple$__ne__($Hashable$tuple, $tuple, $tuple);
+$int $Hashable$tuple$__hash__($Hashable$tuple, $tuple);
 
 // $Ord$bytearray ////////////////////////////////////////////////////////////
 
@@ -2296,8 +2418,8 @@ struct $Ord$bytearray$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Ord$bytearray);
-    void (*__serialize__)($Ord$bytearray,$Serial$state);
-    $Ord$bytearray (*__deserialize__)($Ord$bytearray,$Serial$state);
+    void (*__serialize__)($Ord$bytearray, $Serial$state);
+    $Ord$bytearray (*__deserialize__)($Ord$bytearray, $Serial$state);
     $bool (*__bool__)($Ord$bytearray);
     $str (*__str__)($Ord$bytearray);
     $bool (*__eq__)($Ord$bytearray, $bytearray, $bytearray);
@@ -2308,17 +2430,17 @@ struct $Ord$bytearray$class {
     $bool (*__ge__)($Ord$bytearray, $bytearray, $bytearray);
 };
 
-void $Ord$bytearray$__init__ ($Ord$bytearray);
+void $Ord$bytearray$__init__($Ord$bytearray);
 void $Ord$bytearray$__serialize__($Ord$bytearray, $Serial$state);
 $Ord$bytearray $Ord$bytearray$__deserialize__($Ord$bytearray, $Serial$state);
 $bool $Ord$bytearray$__bool__($Ord$bytearray);
 $str $Ord$bytearray$__str__($Ord$bytearray);
-$bool $Ord$bytearray$__eq__ ($Ord$bytearray, $bytearray, $bytearray);
-$bool $Ord$bytearray$__ne__ ($Ord$bytearray, $bytearray, $bytearray);
-$bool $Ord$bytearray$__lt__ ($Ord$bytearray, $bytearray, $bytearray);
-$bool $Ord$bytearray$__le__ ($Ord$bytearray, $bytearray, $bytearray);
-$bool $Ord$bytearray$__gt__ ($Ord$bytearray, $bytearray, $bytearray);
-$bool $Ord$bytearray$__ge__ ($Ord$bytearray, $bytearray, $bytearray);
+$bool $Ord$bytearray$__eq__($Ord$bytearray, $bytearray, $bytearray);
+$bool $Ord$bytearray$__ne__($Ord$bytearray, $bytearray, $bytearray);
+$bool $Ord$bytearray$__lt__($Ord$bytearray, $bytearray, $bytearray);
+$bool $Ord$bytearray$__le__($Ord$bytearray, $bytearray, $bytearray);
+$bool $Ord$bytearray$__gt__($Ord$bytearray, $bytearray, $bytearray);
+$bool $Ord$bytearray$__ge__($Ord$bytearray, $bytearray, $bytearray);
 
 // $Sequence$bytearray ////////////////////////////////////////////////////////////
 
@@ -2333,8 +2455,8 @@ struct $Sequence$bytearray$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Sequence$bytearray);
-    void (*__serialize__)($Sequence$bytearray,$Serial$state);
-    $Sequence$bytearray (*__deserialize__)($Sequence$bytearray,$Serial$state);
+    void (*__serialize__)($Sequence$bytearray, $Serial$state);
+    $Sequence$bytearray (*__deserialize__)($Sequence$bytearray, $Serial$state);
     $bool (*__bool__)($Sequence$bytearray);
     $str (*__str__)($Sequence$bytearray);
     $int (*__getitem__)($Sequence$bytearray, $bytearray, $int);
@@ -2349,21 +2471,21 @@ struct $Sequence$bytearray$class {
     void (*reverse)($Sequence$bytearray, $bytearray);
 };
 
-void $Sequence$bytearray$__init__ ($Sequence$bytearray);
+void $Sequence$bytearray$__init__($Sequence$bytearray);
 void $Sequence$bytearray$__serialize__($Sequence$bytearray, $Serial$state);
 $Sequence$bytearray $Sequence$bytearray$__deserialize__($Sequence$bytearray, $Serial$state);
 $bool $Sequence$bytearray$__bool__($Sequence$bytearray);
 $str $Sequence$bytearray$__str__($Sequence$bytearray);
-$int $Sequence$bytearray$__getitem__ ($Sequence$bytearray, $bytearray, $int);
-void $Sequence$bytearray$__setitem__ ($Sequence$bytearray, $bytearray, $int, $int);
-void $Sequence$bytearray$__delitem__ ($Sequence$bytearray, $bytearray, $int);
-$bytearray $Sequence$bytearray$__getslice__ ($Sequence$bytearray, $bytearray, $slice);
-void $Sequence$bytearray$__setslice__ ($Sequence$bytearray, $bytearray, $Iterable, $slice, $WORD);
-void $Sequence$bytearray$__delslice__ ($Sequence$bytearray, $bytearray, $slice);
-$Iterator $Sequence$bytearray$__reversed__ ($Sequence$bytearray, $bytearray);
-void $Sequence$bytearray$insert ($Sequence$bytearray, $bytearray, $int, $int);
-void $Sequence$bytearray$append ($Sequence$bytearray, $bytearray, $int);
-void $Sequence$bytearray$reverse ($Sequence$bytearray, $bytearray);
+$int $Sequence$bytearray$__getitem__($Sequence$bytearray, $bytearray, $int);
+void $Sequence$bytearray$__setitem__($Sequence$bytearray, $bytearray, $int, $int);
+void $Sequence$bytearray$__delitem__($Sequence$bytearray, $bytearray, $int);
+$bytearray $Sequence$bytearray$__getslice__($Sequence$bytearray, $bytearray, $slice);
+void $Sequence$bytearray$__setslice__($Sequence$bytearray, $bytearray, $Iterable, $slice, $WORD);
+void $Sequence$bytearray$__delslice__($Sequence$bytearray, $bytearray, $slice);
+$Iterator $Sequence$bytearray$__reversed__($Sequence$bytearray, $bytearray);
+void $Sequence$bytearray$insert($Sequence$bytearray, $bytearray, $int, $int);
+void $Sequence$bytearray$append($Sequence$bytearray, $bytearray, $int);
+void $Sequence$bytearray$reverse($Sequence$bytearray, $bytearray);
 
 // $Collection$bytearray ////////////////////////////////////////////////////////////
 
@@ -2377,8 +2499,8 @@ struct $Collection$bytearray$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Collection$bytearray, $Sequence);
-    void (*__serialize__)($Collection$bytearray,$Serial$state);
-    $Collection$bytearray (*__deserialize__)($Collection$bytearray,$Serial$state);
+    void (*__serialize__)($Collection$bytearray, $Serial$state);
+    $Collection$bytearray (*__deserialize__)($Collection$bytearray, $Serial$state);
     $bool (*__bool__)($Collection$bytearray);
     $str (*__str__)($Collection$bytearray);
     $Iterator (*__iter__)($Collection$bytearray, $bytearray);
@@ -2386,14 +2508,14 @@ struct $Collection$bytearray$class {
     $int (*__len__)($Collection$bytearray, $bytearray);
 };
 
-void $Collection$bytearray$__init__ ($Collection$bytearray, $Sequence);
+void $Collection$bytearray$__init__($Collection$bytearray, $Sequence);
 void $Collection$bytearray$__serialize__($Collection$bytearray, $Serial$state);
 $Collection$bytearray $Collection$bytearray$__deserialize__($Collection$bytearray, $Serial$state);
 $bool $Collection$bytearray$__bool__($Collection$bytearray);
 $str $Collection$bytearray$__str__($Collection$bytearray);
-$Iterator $Collection$bytearray$__iter__ ($Collection$bytearray, $bytearray);
-$bytearray $Collection$bytearray$__fromiter__ ($Collection$bytearray, $Iterable, $WORD);
-$int $Collection$bytearray$__len__ ($Collection$bytearray, $bytearray);
+$Iterator $Collection$bytearray$__iter__($Collection$bytearray, $bytearray);
+$bytearray $Collection$bytearray$__fromiter__($Collection$bytearray, $Iterable, $WORD);
+$int $Collection$bytearray$__len__($Collection$bytearray, $bytearray);
 
 // $Times$bytearray ////////////////////////////////////////////////////////////
 
@@ -2407,8 +2529,8 @@ struct $Times$bytearray$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Times$bytearray, $Sequence);
-    void (*__serialize__)($Times$bytearray,$Serial$state);
-    $Times$bytearray (*__deserialize__)($Times$bytearray,$Serial$state);
+    void (*__serialize__)($Times$bytearray, $Serial$state);
+    $Times$bytearray (*__deserialize__)($Times$bytearray, $Serial$state);
     $bool (*__bool__)($Times$bytearray);
     $str (*__str__)($Times$bytearray);
     $bytearray (*__add__)($Times$bytearray, $bytearray, $bytearray);
@@ -2417,13 +2539,13 @@ struct $Times$bytearray$class {
     $bytearray (*__imul__)($Times$bytearray, $bytearray, $int);
 };
 
-void $Times$bytearray$__init__ ($Times$bytearray, $Sequence);
+void $Times$bytearray$__init__($Times$bytearray, $Sequence);
 void $Times$bytearray$__serialize__($Times$bytearray, $Serial$state);
 $Times$bytearray $Times$bytearray$__deserialize__($Times$bytearray, $Serial$state);
 $bool $Times$bytearray$__bool__($Times$bytearray);
 $str $Times$bytearray$__str__($Times$bytearray);
-$bytearray $Times$bytearray$__add__ ($Times$bytearray, $bytearray, $bytearray);
-$bytearray $Times$bytearray$__mul__ ($Times$bytearray, $bytearray, $int);
+$bytearray $Times$bytearray$__add__($Times$bytearray, $bytearray, $bytearray);
+$bytearray $Times$bytearray$__mul__($Times$bytearray, $bytearray, $int);
 
 // $Container$bytearray ////////////////////////////////////////////////////////////
 
@@ -2437,8 +2559,8 @@ struct $Container$bytearray$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)($Container$bytearray, $Eq);
-    void (*__serialize__)($Container$bytearray,$Serial$state);
-    $Container$bytearray (*__deserialize__)($Container$bytearray,$Serial$state);
+    void (*__serialize__)($Container$bytearray, $Serial$state);
+    $Container$bytearray (*__deserialize__)($Container$bytearray, $Serial$state);
     $bool (*__bool__)($Container$bytearray);
     $str (*__str__)($Container$bytearray);
     $Iterator (*__iter__)($Container$bytearray, $bytearray);
@@ -2447,14 +2569,14 @@ struct $Container$bytearray$class {
     $bool (*__containsnot__)($Container$bytearray, $bytearray, $int);
 };
 
-void $Container$bytearray$__init__ ($Container$bytearray, $Eq);
+void $Container$bytearray$__init__($Container$bytearray, $Eq);
 void $Container$bytearray$__serialize__($Container$bytearray, $Serial$state);
 $Container$bytearray $Container$bytearray$__deserialize__($Container$bytearray, $Serial$state);
 $bool $Container$bytearray$__bool__($Container$bytearray);
 $str $Container$bytearray$__str__($Container$bytearray);
-$Iterator $Container$bytearray$__iter__ ($Container$bytearray, $bytearray);
-$int $Container$bytearray$__len__ ($Container$bytearray, $bytearray);
-$bool $Container$bytearray$__contains__ ($Container$bytearray, $bytearray, $int);
-$bool $Container$bytearray$__containsnot__ ($Container$bytearray, $bytearray, $int);
+$Iterator $Container$bytearray$__iter__($Container$bytearray, $bytearray);
+$int $Container$bytearray$__len__($Container$bytearray, $bytearray);
+$bool $Container$bytearray$__contains__($Container$bytearray, $bytearray, $int);
+$bool $Container$bytearray$__containsnot__($Container$bytearray, $bytearray, $int);
 
 void $register_builtin_protocols();

--- a/builtin/atom.c
+++ b/builtin/atom.c
@@ -15,5 +15,4 @@
 struct $atom$class $atom$methods = {
     "$atom",
     UNASSIGNED,
-    ($Super$class)&$value$methods
-};
+    ($Super$class)&$value$methods};

--- a/builtin/atom.h
+++ b/builtin/atom.h
@@ -1,18 +1,16 @@
 struct $atom$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)($atom, $WORD);
-  void (*__serialize__)($atom,$Serial$state);
-  $atom (*__deserialize__)($atom,$Serial$state);
-  $bool (*__bool__)($atom);
-  $str (*__str__)($atom);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)($atom, $WORD);
+    void (*__serialize__)($atom, $Serial$state);
+    $atom (*__deserialize__)($atom, $Serial$state);
+    $bool (*__bool__)($atom);
+    $str (*__str__)($atom);
 };
 
 struct $atom {
-  struct $atom$class *$class;
+    struct $atom$class *$class;
 };
 
 extern struct $atom$class $atom$methods;
-
-

--- a/builtin/bool.c
+++ b/builtin/bool.c
@@ -12,31 +12,29 @@
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-
-
 // Serialization ///////////////////////////////////////////////////////////////////////
 
-void $bool_init($bool self, $value s){
-  self->val = (s->$class->__bool__(s))->val;
+void $bool_init($bool self, $value s) {
+    self->val = (s->$class->__bool__(s))->val;
 }
 
 $bool $bool_bool($bool self) {
-  return self;
+    return self;
 }
 
 $str $bool_str($bool self) {
-  if (self->val)
-    return to$str("True");
-  else
-    return to$str("False");
+    if (self->val)
+        return to$str("True");
+    else
+        return to$str("False");
 }
 
 void $bool_serialize($bool self, $Serial$state state) {
-  $val_serialize(BOOL_ID,&self->val,state);
+    $val_serialize(BOOL_ID, &self->val, state);
 }
 
 $bool $bool_deserialize($bool self, $Serial$state state) {
-  return to$bool((long)$val_deserialize(state));
+    return to$bool((long)$val_deserialize(state));
 }
 
 struct $bool$class $bool$methods = {
@@ -47,31 +45,29 @@ struct $bool$class $bool$methods = {
     $bool_serialize,
     $bool_deserialize,
     $bool_bool,
-    $bool_str
-};
+    $bool_str};
 
 $bool $bool$new($value s) {
     return $NEW($bool, s);
 }
 
 $bool to$bool(long b) {
-  $bool res = malloc(sizeof(struct $bool));
-  res->$class = &$bool$methods;
-  res->val = b;
-  return res;
-}
-    
-long from$bool($bool b) {
-  return b->val;
+    $bool res = malloc(sizeof(struct $bool));
+    res->$class = &$bool$methods;
+    res->val = b;
+    return res;
 }
 
-struct $bool $t = {&$bool$methods,1L};
-struct $bool $f = {&$bool$methods,0L};
+long from$bool($bool b) {
+    return b->val;
+}
+
+struct $bool $t = {&$bool$methods, 1L};
+struct $bool $f = {&$bool$methods, 0L};
 
 $bool $True = &$t;
 $bool $False = &$f;
 
-
 $bool $default__bool__($value self) {
-  return $True;
+    return $True;
 }

--- a/builtin/bool.h
+++ b/builtin/bool.h
@@ -1,17 +1,17 @@
 struct $bool$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)($bool, $value);
-  void (*__serialize__)($bool, $Serial$state);
-  $bool (*__deserialize__)($bool, $Serial$state);
-  $bool (*__bool__)($bool);
-  $str (*__str__)($bool);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)($bool, $value);
+    void (*__serialize__)($bool, $Serial$state);
+    $bool (*__deserialize__)($bool, $Serial$state);
+    $bool (*__bool__)($bool);
+    $str (*__str__)($bool);
 };
 
 struct $bool {
-  struct $bool$class *$class;
-  long val;
+    struct $bool$class *$class;
+    long val;
 };
 
 extern struct $bool$class $bool$methods;

--- a/builtin/builtin.c
+++ b/builtin/builtin.c
@@ -46,4 +46,3 @@
 #include "registration.c"
 #include "function.c"
 #include "builtin_functions.c"
-

--- a/builtin/builtin.h
+++ b/builtin/builtin.h
@@ -37,4 +37,3 @@
 #include "exceptions.h"
 #include "function.h"
 #include "builtin_functions.h"
-

--- a/builtin/builtin_functions.c
+++ b/builtin/builtin_functions.c
@@ -18,21 +18,21 @@
 // print //////////////////////////////////////////////////////////////////////////////
 
 static $WORD mkstr($WORD w) {
-  $value w1 = ($value)w;
-  return w1->$class->__str__(w);
+    $value w1 = ($value)w;
+    return w1->$class->__str__(w);
 }
 
 void $print(int size, ...) {
     va_list args;
-    va_start(args,size);
+    va_start(args, size);
     if (size > 0) {
-        $value elem = va_arg(args,$value);
-        fputs((const char*)elem->$class->__str__(elem)->str,stdout);
+        $value elem = va_arg(args, $value);
+        fputs((const char *)elem->$class->__str__(elem)->str, stdout);
     }
-    for (int i=1; i<size; i++) {
+    for (int i = 1; i < size; i++) {
         putchar(' ');
-        $value elem = va_arg(args,$value);
-        fputs((const char*)elem->$class->__str__(elem)->str,stdout);
+        $value elem = va_arg(args, $value);
+        fputs((const char *)elem->$class->__str__(elem)->str, stdout);
     }
     putchar('\n');
     va_end(args);
@@ -41,252 +41,250 @@ void $print(int size, ...) {
 // enumerate //////////////////////////////////////////////////////////////////////////
 
 void $Iterator$enumerate_init($Iterator$enumerate self, $Iterator it, $int n) {
-  self->it = it;
-  self->nxt = n->val;
+    self->it = it;
+    self->nxt = n->val;
 }
 
 $bool $Iterator$enumerate_bool($Iterator$enumerate self) {
-  return $True;
+    return $True;
 }
 
 $str $Iterator$enumerate_str($Iterator$enumerate self) {
-  char *s;
-  asprintf(&s,"<enumerate iterator object at %p>",self);
-  return to$str(s);
+    char *s;
+    asprintf(&s, "<enumerate iterator object at %p>", self);
+    return to$str(s);
 }
 
-void $Iterator$enumerate_serialize($Iterator$enumerate self,$Serial$state state) {
-  $step_serialize(self->it,state);
-  $step_serialize(to$int(self->nxt),state);
+void $Iterator$enumerate_serialize($Iterator$enumerate self, $Serial$state state) {
+    $step_serialize(self->it, state);
+    $step_serialize(to$int(self->nxt), state);
 }
 
-$Iterator$enumerate $Iterator$enumerate$_deserialize($Iterator$enumerate res,$Serial$state state) {
+$Iterator$enumerate $Iterator$enumerate$_deserialize($Iterator$enumerate res, $Serial$state state) {
     if (!res)
-       res = $DNEW($Iterator$enumerate,state);
-   res->it = $step_deserialize(state);
-   res->nxt = from$int(($int)$step_deserialize(state));
-   return res;
+        res = $DNEW($Iterator$enumerate, state);
+    res->it = $step_deserialize(state);
+    res->nxt = from$int(($int)$step_deserialize(state));
+    return res;
 }
 
 $WORD $Iterator$enumerate_next($Iterator$enumerate it) {
-  $WORD w = it->it->$class->__next__(it->it);
-  if (w)
-    return $NEWTUPLE(2,to$int(it->nxt++),w);
-  else
-    return NULL;
+    $WORD w = it->it->$class->__next__(it->it);
+    if (w)
+        return $NEWTUPLE(2, to$int(it->nxt++), w);
+    else
+        return NULL;
 }
 
-struct $Iterator$enumerate$class $Iterator$enumerate$methods = {"$Iterator$enumerate",UNASSIGNED,($Super$class)&$Iterator$methods,$Iterator$enumerate_init,
-                                                                $Iterator$enumerate_serialize, $Iterator$enumerate$_deserialize, 
-                                                                $Iterator$enumerate_bool,$Iterator$enumerate_str, $Iterator$enumerate_next};
-
+struct $Iterator$enumerate$class $Iterator$enumerate$methods = {"$Iterator$enumerate", UNASSIGNED, ($Super$class)&$Iterator$methods, $Iterator$enumerate_init,
+                                                                $Iterator$enumerate_serialize, $Iterator$enumerate$_deserialize,
+                                                                $Iterator$enumerate_bool, $Iterator$enumerate_str, $Iterator$enumerate_next};
 
 $Iterator$enumerate $Iterator$enumerate$new($Iterator it, $int n) {
     return $NEW($Iterator$enumerate, it, n);
 }
 
 $Iterator $enumerate($Iterable wit, $WORD iter, $int start) {
-  $Iterator it = wit->$class->__iter__(wit,iter);
-  if (!start)
-    start = to$int(0);
-  return ($Iterator)$Iterator$enumerate$new(it,start); 
+    $Iterator it = wit->$class->__iter__(wit, iter);
+    if (!start)
+        start = to$int(0);
+    return ($Iterator)$Iterator$enumerate$new(it, start);
 }
 
 // filter ////////////////////////////////////////////////////////////////////////////////
 
-void $Iterator$filter_init($Iterator$filter self, $Iterator it,  $function f) {
-  self->it = it;
-  self->f = f;
+void $Iterator$filter_init($Iterator$filter self, $Iterator it, $function f) {
+    self->it = it;
+    self->f = f;
 }
 
 $bool $Iterator$filter_bool($Iterator$filter self) {
-  return $True;
+    return $True;
 }
 
 $str $Iterator$filter_str($Iterator$filter self) {
-  char *s;
-  asprintf(&s,"<filter iterator object at %p>",self);
-  return to$str(s);
+    char *s;
+    asprintf(&s, "<filter iterator object at %p>", self);
+    return to$str(s);
 }
 
-void $Iterator$filter_serialize($Iterator$filter self,$Serial$state state) {
-  $step_serialize(self->it,state);
+void $Iterator$filter_serialize($Iterator$filter self, $Serial$state state) {
+    $step_serialize(self->it, state);
 }
 
 $Iterator$filter $Iterator$filter$_deserialize($Iterator$filter res, $Serial$state state) {
-   if (!res)
-      res = $DNEW($Iterator$filter,state);
-   res->it = $step_deserialize(state);
-   return res;
+    if (!res)
+        res = $DNEW($Iterator$filter, state);
+    res->it = $step_deserialize(state);
+    return res;
 }
 
 $WORD $Iterator$filter_next($Iterator$filter it) {
-  $WORD w;
-  do
-    w = it->it->$class->__next__(it->it);
-  while (w && !from$bool(it->f->$class->__call__(it->f, w)));
-  return w;
+    $WORD w;
+    do
+        w = it->it->$class->__next__(it->it);
+    while (w && !from$bool(it->f->$class->__call__(it->f, w)));
+    return w;
 }
 
-struct $Iterator$filter$class $Iterator$filter$methods = {"$Iterator$filter",UNASSIGNED,($Super$class)&$Iterator$methods,$Iterator$filter_init,
-                                                          $Iterator$filter_serialize, $Iterator$filter$_deserialize, 
-                                                          $Iterator$filter_bool,$Iterator$filter_str, $Iterator$filter_next};
+struct $Iterator$filter$class $Iterator$filter$methods = {"$Iterator$filter", UNASSIGNED, ($Super$class)&$Iterator$methods, $Iterator$filter_init,
+                                                          $Iterator$filter_serialize, $Iterator$filter$_deserialize,
+                                                          $Iterator$filter_bool, $Iterator$filter_str, $Iterator$filter_next};
 
 $Iterator$filter $Iterator$filter$new($Iterator it, $function f) {
     return $NEW($Iterator$filter, it, f);
 }
 
 $Iterator $filter($Iterable wit, $function f, $WORD iter) {
-  $Iterator it = wit->$class->__iter__(wit,iter);
-  return ($Iterator)$Iterator$filter$new(it,f);
+    $Iterator it = wit->$class->__iter__(wit, iter);
+    return ($Iterator)$Iterator$filter$new(it, f);
 }
 
 // map ////////////////////////////////////////////////////////////////////////////////
 
 void $Iterator$map_init($Iterator$map self, $Iterator it, $function f) {
-  self->it = it;
-  self->f = f;
+    self->it = it;
+    self->f = f;
 }
 
 $bool $Iterator$map_bool($Iterator$map self) {
-  return $True;
+    return $True;
 }
 
 $str $Iterator$map_str($Iterator$map self) {
-  char *s;
-  asprintf(&s,"<map iterator object at %p>",self);
-  return to$str(s);
+    char *s;
+    asprintf(&s, "<map iterator object at %p>", self);
+    return to$str(s);
 }
 
-void $Iterator$map_serialize($Iterator$map self,$Serial$state state) {
-  $step_serialize(self->it,state);
+void $Iterator$map_serialize($Iterator$map self, $Serial$state state) {
+    $step_serialize(self->it, state);
 }
 
 $Iterator$map $Iterator$map$_deserialize($Iterator$map res, $Serial$state state) {
-   if (!res)
-      res = $DNEW($Iterator$map,state);
-   res->it = $step_deserialize(state);
-   return res;
+    if (!res)
+        res = $DNEW($Iterator$map, state);
+    res->it = $step_deserialize(state);
+    return res;
 }
 
 $WORD $Iterator$map_next($Iterator$map it) {
-  $WORD w = it->it->$class->__next__(it->it);
-  if (w)
-    return it->f->$class->__call__(it->f, w);
-  else
-    return NULL;
+    $WORD w = it->it->$class->__next__(it->it);
+    if (w)
+        return it->f->$class->__call__(it->f, w);
+    else
+        return NULL;
 }
 
-struct $Iterator$map$class $Iterator$map$methods = {"$Iterator$map",UNASSIGNED,($Super$class)&$Iterator$methods,$Iterator$map_init,
-                                                                $Iterator$map_serialize, $Iterator$map$_deserialize,  
-                                                                $Iterator$map_bool,$Iterator$map_str, $Iterator$map_next};
+struct $Iterator$map$class $Iterator$map$methods = {"$Iterator$map", UNASSIGNED, ($Super$class)&$Iterator$methods, $Iterator$map_init,
+                                                    $Iterator$map_serialize, $Iterator$map$_deserialize,
+                                                    $Iterator$map_bool, $Iterator$map_str, $Iterator$map_next};
 
 $Iterator$map $Iterator$map$new($Iterator it, $function f) {
     return $NEW($Iterator$map, it, f);
 }
 
 $Iterator $map($Iterable wit, $function f, $WORD iter) {
-  $Iterator it = wit->$class->__iter__(wit,iter);
-  return ($Iterator)$Iterator$map$new(it,f);
+    $Iterator it = wit->$class->__iter__(wit, iter);
+    return ($Iterator)$Iterator$map$new(it, f);
 }
-
 
 // max, min ///////////////////////////////////////////////////////////////////////////////////
 
 $WORD $max($Ord wit, $Iterable wit2, $WORD iter, $WORD deflt) {
-  $Iterator it = wit2->$class->__iter__(wit2,iter);  
-  $WORD res, nxt;
-  res = it->$class->__next__(it);
-  if (res) {
-    while ((nxt = it->$class->__next__(it))) {
-      if (wit->$class->__lt__(wit,res,nxt))
-        res = nxt;
-    }
-    return res;
-  } else
-    return deflt;
+    $Iterator it = wit2->$class->__iter__(wit2, iter);
+    $WORD res, nxt;
+    res = it->$class->__next__(it);
+    if (res) {
+        while ((nxt = it->$class->__next__(it))) {
+            if (wit->$class->__lt__(wit, res, nxt))
+                res = nxt;
+        }
+        return res;
+    } else
+        return deflt;
 }
 
 $WORD $min($Ord wit, $Iterable wit2, $WORD iter, $WORD deflt) {
-  $Iterator it = wit2->$class->__iter__(wit2,iter);  
-  $WORD res, nxt;
-  res = it->$class->__next__(it);
-  if (res) {
-    while ((nxt = it->$class->__next__(it))) {
-      if (wit->$class->__gt__(wit,res,nxt))
-        res = nxt;
-    }
-    return res;
-  } else
-    return deflt;
+    $Iterator it = wit2->$class->__iter__(wit2, iter);
+    $WORD res, nxt;
+    res = it->$class->__next__(it);
+    if (res) {
+        while ((nxt = it->$class->__next__(it))) {
+            if (wit->$class->__gt__(wit, res, nxt))
+                res = nxt;
+        }
+        return res;
+    } else
+        return deflt;
 }
- 
+
 $list $sorted($Ord wit, $Iterable wit2, $WORD iter) {
-  return NULL;
+    return NULL;
 }
 
 // sum /////////////////////////////////////////////////////////////////////////////////
 
 $WORD $sum($Plus wit, $Iterable wit2, $WORD iter, $WORD start) {
-  $Iterator it = wit2->$class->__iter__(wit2,iter);  
-  $WORD res = start;
-  $WORD nxt;
-  while ((nxt = it->$class->__next__(it))) 
-    res = wit->$class->__add__(wit,res,nxt);
-  return res;
+    $Iterator it = wit2->$class->__iter__(wit2, iter);
+    $WORD res = start;
+    $WORD nxt;
+    while ((nxt = it->$class->__next__(it)))
+        res = wit->$class->__add__(wit, res, nxt);
+    return res;
 }
 
 // zip ////////////////////////////////////////////////////////////////////////////////
 
 void $Iterator$zip_init($Iterator$zip self, $Iterator it1, $Iterator it2) {
-  self->it1 = it1;
-  self->it2 = it2;
+    self->it1 = it1;
+    self->it2 = it2;
 }
 
 $bool $Iterator$zip_bool($Iterator$zip self) {
-  return $True;
+    return $True;
 }
 
 $str $Iterator$zip_str($Iterator$zip self) {
-  char *s;
-  asprintf(&s,"<zip iterator object at %p>",self);
-  return to$str(s);
+    char *s;
+    asprintf(&s, "<zip iterator object at %p>", self);
+    return to$str(s);
 }
 
-void $Iterator$zip_serialize($Iterator$zip self,$Serial$state state) {
-  $step_serialize(self->it1,state);
-  $step_serialize(self->it2,state);
+void $Iterator$zip_serialize($Iterator$zip self, $Serial$state state) {
+    $step_serialize(self->it1, state);
+    $step_serialize(self->it2, state);
 }
 
 $Iterator$zip $Iterator$zip$_deserialize($Iterator$zip res, $Serial$state state) {
-   if (!res)
-      res = $DNEW($Iterator$zip,state);
-   res->it1 = $step_deserialize(state);
-   res->it2 = $step_deserialize(state);
-   return res;
+    if (!res)
+        res = $DNEW($Iterator$zip, state);
+    res->it1 = $step_deserialize(state);
+    res->it2 = $step_deserialize(state);
+    return res;
 }
 
 $WORD $Iterator$zip_next($Iterator$zip it) {
-  $WORD w1 = it->it1->$class->__next__(it->it1);
-  $WORD w2 = it->it2->$class->__next__(it->it2);
-  if (w1 && w2)
-    return $NEWTUPLE(2,w1,w2);
-  else
-    return NULL;
+    $WORD w1 = it->it1->$class->__next__(it->it1);
+    $WORD w2 = it->it2->$class->__next__(it->it2);
+    if (w1 && w2)
+        return $NEWTUPLE(2, w1, w2);
+    else
+        return NULL;
 }
 
-struct $Iterator$zip$class $Iterator$zip$methods = {" $Iterator$zip",UNASSIGNED,($Super$class)&$Iterator$methods,$Iterator$zip_init,
-                                                    $Iterator$zip_serialize, $Iterator$zip$_deserialize, 
-                                                    $Iterator$zip_bool,$Iterator$zip_str, $Iterator$zip_next};
+struct $Iterator$zip$class $Iterator$zip$methods = {" $Iterator$zip", UNASSIGNED, ($Super$class)&$Iterator$methods, $Iterator$zip_init,
+                                                    $Iterator$zip_serialize, $Iterator$zip$_deserialize,
+                                                    $Iterator$zip_bool, $Iterator$zip_str, $Iterator$zip_next};
 
 $Iterator$zip $Iterator$zip$new($Iterator iter1, $Iterator iter2) {
     return $NEW($Iterator$zip, iter1, iter2);
 }
 
-$Iterator $zip ($Iterable wit1, $Iterable wit2, $WORD iter1, $WORD iter2) {
-  $Iterator it1 = wit1->$class->__iter__(wit1,iter1);
-  $Iterator it2 = wit2->$class->__iter__(wit2,iter2);
-  return ($Iterator)$Iterator$zip$new(it1,it2);
+$Iterator $zip($Iterable wit1, $Iterable wit2, $WORD iter1, $WORD iter2) {
+    $Iterator it1 = wit1->$class->__iter__(wit1, iter1);
+    $Iterator it2 = wit2->$class->__iter__(wit2, iter2);
+    return ($Iterator)$Iterator$zip$new(it1, it2);
 }
 
 // EqOpt //////////////////////////////////////////////////////
@@ -309,20 +307,18 @@ $bool $EqOpt$__ne__($EqOpt wit, $WORD a, $WORD b) {
 
 struct $EqOpt$class $EqOpt$methods = {"$EqOpt", UNASSIGNED, NULL, $EqOpt$__init__, $EqOpt$__eq__, $EqOpt$__ne__};
 
-
 $EqOpt $EqOpt$new($Eq w$Eq$A) {
     return $NEW($EqOpt, w$Eq$A);
 }
-
 
 // Various small functions //////////////////////////////////////////////////////////////
 
 // Code generated by actonc
 
-$WORD $abs ($Number w$149, $Real w$148, $WORD x) {
+$WORD $abs($Number w$149, $Real w$148, $WORD x) {
     return w$149->$class->__abs__(w$149, x, w$148);
 }
-$bool $all ($Iterable w$164, $WORD it) {
+$bool $all($Iterable w$164, $WORD it) {
     $Iterator n$iter = w$164->$class->__iter__(w$164, it);
     $WORD n$1val = n$iter->$class->__next__(n$iter);
     while ($ISNOTNONE(n$1val)) {
@@ -334,7 +330,7 @@ $bool $all ($Iterable w$164, $WORD it) {
     }
     return ($bool)$True;
 }
-$bool $any ($Iterable w$179, $WORD it) {
+$bool $any($Iterable w$179, $WORD it) {
     $Iterator n$2iter = w$179->$class->__iter__(w$179, it);
     $WORD n$3val = n$2iter->$class->__next__(n$2iter);
     while ($ISNOTNONE(n$3val)) {
@@ -346,24 +342,24 @@ $bool $any ($Iterable w$179, $WORD it) {
     }
     return ($bool)$False;
 }
-$tuple $divmod ($Integral w$225, $WORD a, $WORD b) {
+$tuple $divmod($Integral w$225, $WORD a, $WORD b) {
     return w$225->$class->__divmod__(w$225, a, b);
 }
-$int $hash ($Hashable w$255, $WORD x) {
+$int $hash($Hashable w$255, $WORD x) {
     return w$255->$class->__hash__(w$255, x);
 }
-$Iterator $iter ($Iterable w$278, $WORD x) {
+$Iterator $iter($Iterable w$278, $WORD x) {
     return w$278->$class->__iter__(w$278, x);
 }
-$int $len ($Collection w$301, $WORD x) {
+$int $len($Collection w$301, $WORD x) {
     return w$301->$class->__len__(w$301, x);
 }
-$WORD $pow ($Number w$344, $WORD a, $WORD b) {
+$WORD $pow($Number w$344, $WORD a, $WORD b) {
     return w$344->$class->__pow__(w$344, a, b);
 }
-$Iterator $reversed ($Sequence w$369, $WORD seq) {
+$Iterator $reversed($Sequence w$369, $WORD seq) {
     return w$369->$class->__reversed__(w$369, seq);
 }
-$WORD $round ($Real w$395, $WORD x, $int n) {
+$WORD $round($Real w$395, $WORD x, $int n) {
     return w$395->$class->__round__(w$395, x, n);
 }

--- a/builtin/builtin_functions.h
+++ b/builtin/builtin_functions.h
@@ -8,25 +8,26 @@ struct $Iterator$enumerate;
 typedef struct $Iterator$enumerate *$Iterator$enumerate;
 
 struct $Iterator$enumerate$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)($Iterator$enumerate, $Iterator,$int);
-  void (*__serialize__)($Iterator$enumerate,$Serial$state);
-  $Iterator$enumerate (*__deserialize__)($Iterator$enumerate,$Serial$state);
-  $bool (*__bool__)($Iterator$enumerate);
-  $str (*__str__)($Iterator$enumerate);
-  $WORD(*__next__)($Iterator$enumerate);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)($Iterator$enumerate, $Iterator, $int);
+    void (*__serialize__)($Iterator$enumerate, $Serial$state);
+    $Iterator$enumerate (*__deserialize__)($Iterator$enumerate, $Serial$state);
+    $bool (*__bool__)($Iterator$enumerate);
+    $str (*__str__)($Iterator$enumerate);
+    $WORD (*__next__)
+    ($Iterator$enumerate);
 };
 
 struct $Iterator$enumerate {
-  struct $Iterator$enumerate$class *$class;
-  $Iterator it;
-  int nxt;
+    struct $Iterator$enumerate$class *$class;
+    $Iterator it;
+    int nxt;
 };
 
 extern struct $Iterator$enumerate$class $Iterator$enumerate$methods;
-$Iterator$enumerate $Iterator$enumerate$new($Iterator,$int);
+$Iterator$enumerate $Iterator$enumerate$new($Iterator, $int);
 
 $Iterator $enumerate($Iterable wit, $WORD iter, $int start);
 
@@ -36,21 +37,22 @@ struct $Iterator$filter;
 typedef struct $Iterator$filter *$Iterator$filter;
 
 struct $Iterator$filter$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)($Iterator$filter, $Iterator, $function);
-  void (*__serialize__)($Iterator$filter,$Serial$state);
-  $Iterator$filter (*__deserialize__)($Iterator$filter,$Serial$state);
-  $bool (*__bool__)($Iterator$filter);
-  $str (*__str__)($Iterator$filter);
-  $WORD(*__next__)($Iterator$filter);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)($Iterator$filter, $Iterator, $function);
+    void (*__serialize__)($Iterator$filter, $Serial$state);
+    $Iterator$filter (*__deserialize__)($Iterator$filter, $Serial$state);
+    $bool (*__bool__)($Iterator$filter);
+    $str (*__str__)($Iterator$filter);
+    $WORD (*__next__)
+    ($Iterator$filter);
 };
 
 struct $Iterator$filter {
-  struct $Iterator$filter$class *$class;
-  $Iterator it;
-  $function f;
+    struct $Iterator$filter$class *$class;
+    $Iterator it;
+    $function f;
 };
 
 extern struct $Iterator$filter$class $Iterator$filter$methods;
@@ -64,21 +66,22 @@ struct $Iterator$map;
 typedef struct $Iterator$map *$Iterator$map;
 
 struct $Iterator$map$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)($Iterator$map, $Iterator, $function);
-  void (*__serialize__)($Iterator$map,$Serial$state);
-  $Iterator$map (*__deserialize__)($Iterator$map,$Serial$state);
-  $bool (*__bool__)($Iterator$map);
-  $str (*__str__)($Iterator$map);
-  $WORD(*__next__)($Iterator$map);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)($Iterator$map, $Iterator, $function);
+    void (*__serialize__)($Iterator$map, $Serial$state);
+    $Iterator$map (*__deserialize__)($Iterator$map, $Serial$state);
+    $bool (*__bool__)($Iterator$map);
+    $str (*__str__)($Iterator$map);
+    $WORD (*__next__)
+    ($Iterator$map);
 };
 
 struct $Iterator$map {
-  struct $Iterator$map$class *$class;
-  $Iterator it;
-  $function f;
+    struct $Iterator$map$class *$class;
+    $Iterator it;
+    $function f;
 };
 
 extern struct $Iterator$map$class $Iterator$map$methods;
@@ -86,35 +89,34 @@ $Iterator$map $Iterator$map$new($Iterator, $function);
 
 $Iterator $map($Iterable wit, $function, $WORD iter);
 
-
 // zip ////////////////////////////////////////////////////////////
 
 struct $Iterator$zip;
 typedef struct $Iterator$zip *$Iterator$zip;
 
 struct $Iterator$zip$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)($Iterator$zip, $Iterator, $Iterator);
-  void (*__serialize__)($Iterator$zip,$Serial$state);
-  $Iterator$zip (*__deserialize__)($Iterator$zip,$Serial$state);
-  $bool (*__bool__)($Iterator$zip);
-  $str (*__str__)($Iterator$zip);
-  $WORD(*__next__)($Iterator$zip);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)($Iterator$zip, $Iterator, $Iterator);
+    void (*__serialize__)($Iterator$zip, $Serial$state);
+    $Iterator$zip (*__deserialize__)($Iterator$zip, $Serial$state);
+    $bool (*__bool__)($Iterator$zip);
+    $str (*__str__)($Iterator$zip);
+    $WORD (*__next__)
+    ($Iterator$zip);
 };
 
 struct $Iterator$zip {
-  struct $Iterator$zip$class *$class;
-  $Iterator it1;
-  $Iterator it2;
+    struct $Iterator$zip$class *$class;
+    $Iterator it1;
+    $Iterator it2;
 };
 
 extern struct $Iterator$zip$class $Iterator$zip$methods;
 $Iterator$zip $Iterator$zip$new($Iterator, $Iterator);
 
 $Iterator $zip($Iterable wit1, $Iterable wit2, $WORD iter1, $WORD iter2);
-
 
 // EqOpt //////////////////////////////////////////////////////
 
@@ -137,23 +139,22 @@ struct $EqOpt {
 
 $EqOpt $EqOpt$new($Eq);
 
-
 // Various small functions //////////////////////////////////////////////////////////
 
 $WORD $min($Ord wit, $Iterable wit2, $WORD iter, $WORD deflt);
 $WORD $max($Ord wit, $Iterable wit2, $WORD iter, $WORD deflt);
 
-// Signatures generated by actonc 
+// Signatures generated by actonc
 
-$WORD $abs ($Number, $Real, $WORD);
-$bool $all ($Iterable, $WORD);
-$bool $any ($Iterable, $WORD);
-$tuple $divmod ($Integral, $WORD, $WORD);
-$int $hash ($Hashable, $WORD);
-$Iterator $iter ($Iterable, $WORD);
-$int $len ($Collection, $WORD);
-$WORD $next ($Iterator);
-$WORD $pow ($Number, $WORD, $WORD);
-$Iterator $reversed ($Sequence, $WORD);
-$WORD $round ($Real, $WORD, $int);
+$WORD $abs($Number, $Real, $WORD);
+$bool $all($Iterable, $WORD);
+$bool $any($Iterable, $WORD);
+$tuple $divmod($Integral, $WORD, $WORD);
+$int $hash($Hashable, $WORD);
+$Iterator $iter($Iterable, $WORD);
+$int $len($Collection, $WORD);
+$WORD $next($Iterator);
+$WORD $pow($Number, $WORD, $WORD);
+$Iterator $reversed($Sequence, $WORD);
+$WORD $round($Real, $WORD, $int);
 $WORD $sum($Plus, $Iterable, $WORD, $WORD);

--- a/builtin/class_hierarchy.c
+++ b/builtin/class_hierarchy.c
@@ -13,35 +13,33 @@
  */
 
 $Serializable $Serializable$new() {
-  return $NEW($Serializable);
+    return $NEW($Serializable);
 }
 
-void $Serializable$__init__ ($Serializable self) {
-  return;
+void $Serializable$__init__($Serializable self) {
+    return;
 }
 
 $value $value$new() {
-  return $NEW($value);
+    return $NEW($value);
 }
 
-void $value$__init__ ($value self) {
-  return;
+void $value$__init__($value self) {
+    return;
 }
 
 $object $object$new() {
-  return $NEW($object);
+    return $NEW($object);
 }
 
-void $object$__init__ ($object self) {
-  return;
+void $object$__init__($object self) {
+    return;
 }
 
+struct $Initializable$class $Initializable$methods = {"$Initializable", UNASSIGNED, NULL, NULL};
 
+struct $Serializable$class $Serializable$methods = {"$Serializable", UNASSIGNED, ($Super$class)&$Initializable$methods, $Serializable$__init__, NULL, NULL};
 
-struct $Initializable$class $Initializable$methods = {"$Initializable",UNASSIGNED,NULL,NULL};
+struct $value$class $value$methods = {"$value", UNASSIGNED, ($Super$class)&$Serializable$methods, $value$__init__, NULL, NULL, NULL, NULL};
 
-struct $Serializable$class $Serializable$methods = {"$Serializable",UNASSIGNED,($Super$class)&$Initializable$methods, $Serializable$__init__,NULL,NULL};
-
-struct $value$class $value$methods = {"$value",UNASSIGNED,($Super$class)&$Serializable$methods,$value$__init__,NULL,NULL,NULL,NULL};
-
-struct $object$class $object$methods = {"$value",UNASSIGNED,($Super$class)&$value$methods,$object$__init__,NULL,NULL,NULL,NULL};
+struct $object$class $object$methods = {"$value", UNASSIGNED, ($Super$class)&$value$methods, $object$__init__, NULL, NULL, NULL, NULL};

--- a/builtin/class_hierarchy.h
+++ b/builtin/class_hierarchy.h
@@ -9,15 +9,14 @@ struct $Super;
 typedef struct $Super *$Super;
 
 struct $Super$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
 };
 
 struct $Super {
-  $Super$class $class;
+    $Super$class $class;
 };
-
 
 // Initializable //////////////////////////////////////////////////////
 
@@ -25,17 +24,17 @@ struct $Super {
 
 typedef struct $Initializable$class *$Initializable$class;
 
-typedef struct $Initializable  *$Initializable;
+typedef struct $Initializable *$Initializable;
 
 struct $Initializable$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;                   // = NULL
-  void (*__init__)($Initializable);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass; // = NULL
+    void (*__init__)($Initializable);
 };
 
 struct $Initializable {
-  struct $Initializable$class *$class;
+    struct $Initializable$class *$class;
 };
 
 extern struct $Initializable$class $Initializable$methods;
@@ -45,19 +44,19 @@ $Initializable $Initializable$new();
 
 typedef struct $Serializable$class *$Serializable$class;
 
-typedef struct $Serializable  *$Serializable;
+typedef struct $Serializable *$Serializable;
 
 struct $Serializable$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;                   // = Initializable$methods
-  void (*__init__)($Serializable);
-  void (*__serialize__)($Serializable, $Serial$state);
-  $Serializable (*__deserialize__)($Serializable, $Serial$state);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass; // = Initializable$methods
+    void (*__init__)($Serializable);
+    void (*__serialize__)($Serializable, $Serial$state);
+    $Serializable (*__deserialize__)($Serializable, $Serial$state);
 };
 
 struct $Serializable {
-  struct $Serializable$class *$class;
+    struct $Serializable$class *$class;
 };
 
 extern struct $Serializable$class $Serializable$methods;
@@ -69,24 +68,23 @@ $Serializable $Serializable$new();
 // int, float, complex, str, bytes, tuple, range, NoneType (and immutable versions of list, set and dict)
 // For the moment, closures, iterators and exceptions also inherit from struct
 
-
 typedef struct $value$class *$value$class;
 
-typedef struct $value  *$value;
+typedef struct $value *$value;
 
 struct $value$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;                      // = Serializable$methods
-  void (*__init__)($value);
-  void (*__serialize__)($value, $Serial$state);
-  $value (*__deserialize__)($value, $Serial$state);
-  $bool (*__bool__)($value);
-  $str (*__str__)($value);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass; // = Serializable$methods
+    void (*__init__)($value);
+    void (*__serialize__)($value, $Serial$state);
+    $value (*__deserialize__)($value, $Serial$state);
+    $bool (*__bool__)($value);
+    $str (*__str__)($value);
 };
 
 struct $value {
-  struct $value$class *$class;
+    struct $value$class *$class;
 };
 
 extern struct $value$class $value$methods;
@@ -94,29 +92,27 @@ $value $value$new();
 
 // object //////////////////////////////////////////////////////
 
-// All mutable user defined classes inherit from object, 
+// All mutable user defined classes inherit from object,
 // as well as list, dict, set, bytearray
 
 typedef struct $object$class *$object$class;
 
-typedef struct $object  *$object;
+typedef struct $object *$object;
 
 struct $object$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;                      // = $value$methods
-  void (*__init__)($object);
-  void (*__serialize__)($object, $Serial$state);
-  $object (*__deserialize__)($object, $Serial$state);
-  $bool (*__bool__)($object);
-  $str (*__str__)($object);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass; // = $value$methods
+    void (*__init__)($object);
+    void (*__serialize__)($object, $Serial$state);
+    $object (*__deserialize__)($object, $Serial$state);
+    $bool (*__bool__)($object);
+    $str (*__str__)($object);
 };
 
 struct $object {
-  struct $object$class *$class;
+    struct $object$class *$class;
 };
 
 extern struct $object$class $object$methods;
 $object $object$new();
-
-  

--- a/builtin/common.c
+++ b/builtin/common.c
@@ -13,11 +13,10 @@
  */
 
 void $default__init__($WORD s) {
-  return;
+    return;
 }
 
-void $printobj(char *mess,$WORD obj) {
-  $value obj1 = ($value)obj;
-  printf("%s %s\n",mess,obj1->$class->__str__(obj1)->str);
+void $printobj(char *mess, $WORD obj) {
+    $value obj1 = ($value)obj;
+    printf("%s %s\n", mess, obj1->$class->__str__(obj1)->str);
 }
-

--- a/builtin/common.h
+++ b/builtin/common.h
@@ -2,16 +2,14 @@
 typedef void *$WORD;
 #define $None ($WORD)0
 
-#define $long long
+#define $long  long
 #define $int64 int64_t
 
 void $default__init__($WORD);
 
+void $printobj(char *mess, $WORD obj);
 
-void $printobj(char *mess,$WORD obj);
-
-
-#define $NEW($T, ...)       ({ $T $t = malloc(sizeof(struct $T)); \
+#define $NEW($T, ...) ({ $T $t = malloc(sizeof(struct $T)); \
                                $t->$class = &$T ## $methods; \
                                $t->$class->__init__($t, ##__VA_ARGS__); \
                                $t; })
@@ -20,25 +18,25 @@ void $printobj(char *mess,$WORD obj);
                                $x->$class = &$X ## $methods; \
                                $x->$class->__init__($x, ##__VA_ARGS__, $CONSTCONT($x,$c)); })
 
-#define $DNEW($T, $state)   ({ $T $t = malloc(sizeof(struct $T)); \
+#define $DNEW($T, $state) ({ $T $t = malloc(sizeof(struct $T)); \
                                $t->$class = &$T ## $methods;                                     \
                                $dict_setitem($state->done,($Hashable)$Hashable$int$witness,to$int($state->row_no-1),$t); \
                                $t; })
 
-#define $AND(T, a, b)       ({ T $a = (a); ($a && (($value)$a)->$class->__bool__(($value)$a)->val) ? (b) : $a; })
+#define $AND(T, a, b) ({ T $a = (a); ($a && (($value)$a)->$class->__bool__(($value)$a)->val) ? (b) : $a; })
 
-#define $OR(T, a, b)        ({ T $a = (a); ($a && (($value)$a)->$class->__bool__(($value)$a)->val) ? $a : (b); })
+#define $OR(T, a, b) ({ T $a = (a); ($a && (($value)$a)->$class->__bool__(($value)$a)->val) ? $a : (b); })
 
-#define $NOT(T, a)          ({ T $a = (a); ($a && (($value)$a)->$class->__bool__(($value)$a)->val) ? $False : $True; })
+#define $NOT(T, a) ({ T $a = (a); ($a && (($value)$a)->$class->__bool__(($value)$a)->val) ? $False : $True; })
 
-#define $ISINSTANCE($x,$T)  ({ $Super$class $c = (($Super)$x)->$class; \
+#define $ISINSTANCE($x, $T) ({ $Super$class $c = (($Super)$x)->$class; \
                                while($c && $c != ($Super$class)&$T ## $methods) $c = $c->$superclass; \
                                to$bool($c != 0); })
 
-#define $ISNOTNONE(x)       ((x) != $None ? $True : $False)
+#define $ISNOTNONE(x) ((x) != $None ? $True : $False)
 
-#define $ISNONE(x)          ((x) != $None ? $False : $True)
+#define $ISNONE(x) ((x) != $None ? $False : $True)
 
-#define $SKIPRES(cont)      (cont)
+#define $SKIPRES(cont) (cont)
 
-#define $FORMAT($s, ...)    ({ char * $b; asprintf(&$b, $s, ##__VA_ARGS__); to$str($b); })
+#define $FORMAT($s, ...) ({ char * $b; asprintf(&$b, $s, ##__VA_ARGS__); to$str($b); })

--- a/builtin/complex.c
+++ b/builtin/complex.c
@@ -13,101 +13,101 @@
  */
 
 $complex to$complex(complex double c) {
-  $complex res = malloc(sizeof(struct $complex));
-  res->$class = &$complex$methods;
-  res->val = c;
-  return res;
+    $complex res = malloc(sizeof(struct $complex));
+    res->$class = &$complex$methods;
+    res->val = c;
+    return res;
 }
 
 $complex $complex$new($Number wit, $WORD c) {
-  return $NEW($complex,wit,c);
+    return $NEW($complex, wit, c);
 }
 
-void $complex_init($complex self, $Number wit, $WORD c){
-  self->val = wit->$class->__complx__(wit,c)->val;
+void $complex_init($complex self, $Number wit, $WORD c) {
+    self->val = wit->$class->__complx__(wit, c)->val;
 }
 
-void $complex_serialize($complex c,$Serial$state state) {
-  $ROW row = $add_header(COMPLEX_ID,2,state);
-  double re = creal(c->val);
-  double im = cimag(c->val);
-  memcpy(row->blob,&re,sizeof(double));
-  memcpy(row->blob+1,&im,sizeof(double));
+void $complex_serialize($complex c, $Serial$state state) {
+    $ROW row = $add_header(COMPLEX_ID, 2, state);
+    double re = creal(c->val);
+    double im = cimag(c->val);
+    memcpy(row->blob, &re, sizeof(double));
+    memcpy(row->blob + 1, &im, sizeof(double));
 }
 
 $complex $complex_deserialize($complex self, $Serial$state state) {
-  $ROW this = state->row;
-  state->row =this->next;
-  state->row_no++;
-  double re, im;
-  memcpy(&re,this->blob,sizeof(double));
-  memcpy(&im,this->blob+1,sizeof(double));
-  return to$complex(re + im * _Complex_I);
+    $ROW this = state->row;
+    state->row = this->next;
+    state->row_no++;
+    double re, im;
+    memcpy(&re, this->blob, sizeof(double));
+    memcpy(&im, this->blob + 1, sizeof(double));
+    return to$complex(re + im * _Complex_I);
 }
 
 $bool $complex_bool($complex n) {
-  return to$bool(n->val != 0.0);
+    return to$bool(n->val != 0.0);
 }
 
 $str $complex_str($complex c) {
-  char *s;
-  asprintf(&s,"%f + %f*I",creal(c->val),cimag(c->val));
-  return to$str(s);
+    char *s;
+    asprintf(&s, "%f + %f*I", creal(c->val), cimag(c->val));
+    return to$str(s);
 }
-  
-struct $complex$class $complex$methods = {"$complex",UNASSIGNED,($Super$class)&$value$methods,$complex_init,$complex_serialize,$complex_deserialize,$complex_bool,$complex_str};
+
+struct $complex$class $complex$methods = {"$complex", UNASSIGNED, ($Super$class)&$value$methods, $complex_init, $complex_serialize, $complex_deserialize, $complex_bool, $complex_str};
 
 // $Number$complex  ////////////////////////////////////////////////////////////////////////////////////////
 
 void $Number$complex$__serialize__($Number$complex self, $Serial$state state) {
-  $step_serialize(self->w$Minus, state);
+    $step_serialize(self->w$Minus, state);
 }
 
 $Number$complex $Number$complex$__deserialize__($Number$complex res, $Serial$state state) {
-   if (!res)
-      res = $DNEW($Number$complex,state);
-   res->w$Minus = ($Minus)$step_deserialize(state);
-   return res;
+    if (!res)
+        res = $DNEW($Number$complex, state);
+    res->w$Minus = ($Minus)$step_deserialize(state);
+    return res;
 }
 
 $complex $Number$complex$__add__($Number$complex wit, $complex a, $complex b) {
-  return to$complex(a->val + b->val);
-}  
-
-$complex $Number$complex$__complx__ ($Number$complex wit, $complex c) {
-  return c;
+    return to$complex(a->val + b->val);
 }
 
-$complex $Number$complex$__mul__ ($Number$complex wit, $complex a, $complex b){
-  return to$complex(a->val * b->val);
+$complex $Number$complex$__complx__($Number$complex wit, $complex c) {
+    return c;
 }
 
-$complex $Number$complex$__pow__ ($Number$complex wit, $complex a, $complex b) {
-  return to$complex(cpow(a->val,b->val));
+$complex $Number$complex$__mul__($Number$complex wit, $complex a, $complex b) {
+    return to$complex(a->val * b->val);
 }
 
-$complex $Number$complex$__neg__ ($Number$complex wit, $complex c){
-  return to$complex(-c->val);
+$complex $Number$complex$__pow__($Number$complex wit, $complex a, $complex b) {
+    return to$complex(cpow(a->val, b->val));
 }
 
-$complex $Number$complex$__pos__ ($Number$complex wit, $complex c) {
-  return c;
+$complex $Number$complex$__neg__($Number$complex wit, $complex c) {
+    return to$complex(-c->val);
 }
 
-$WORD $Number$complex$real ($Number$complex wit, $complex c, $Real wit2) {
-  return wit2->$class->__fromatom__(wit2,($atom)to$float(creal(c->val)));
+$complex $Number$complex$__pos__($Number$complex wit, $complex c) {
+    return c;
 }
 
-$WORD $Number$complex$imag ($Number$complex wit, $complex c, $Real wit2) {
-  return wit2->$class->__fromatom__(wit2,($atom)to$float(cimag(c->val)));
+$WORD $Number$complex$real($Number$complex wit, $complex c, $Real wit2) {
+    return wit2->$class->__fromatom__(wit2, ($atom)to$float(creal(c->val)));
 }
 
-$WORD $Number$complex$__abs__ ($Number$complex wit, $complex c, $Real wit2) {
-  return wit2->$class->__fromatom__(wit2,($atom)to$float(cabs(c->val)));
+$WORD $Number$complex$imag($Number$complex wit, $complex c, $Real wit2) {
+    return wit2->$class->__fromatom__(wit2, ($atom)to$float(cimag(c->val)));
 }
 
-$complex $Number$complex$conjugate ($Number$complex wit, $complex c) {
-  return to$complex(conj(c->val));
+$WORD $Number$complex$__abs__($Number$complex wit, $complex c, $Real wit2) {
+    return wit2->$class->__fromatom__(wit2, ($atom)to$float(cabs(c->val)));
+}
+
+$complex $Number$complex$conjugate($Number$complex wit, $complex c) {
+    return to$complex(conj(c->val));
 }
 
 // $Div$complex /////////////////////////////////////////////////////////////////////////////////////////
@@ -116,47 +116,46 @@ void $Div$complex$__serialize__($Div$complex self, $Serial$state state) {
 }
 
 $Div$complex $Div$complex$__deserialize__($Div$complex self, $Serial$state state) {
-   $Div$complex res = $DNEW($Div$complex,state);
-   return res;
+    $Div$complex res = $DNEW($Div$complex, state);
+    return res;
 }
 
-$complex $Div$complex$__truediv__ ($Div$complex wit, $complex a, $complex b) {
-  return to$complex(a->val/b->val);
+$complex $Div$complex$__truediv__($Div$complex wit, $complex a, $complex b) {
+    return to$complex(a->val / b->val);
 }
 
 // $Minus$complex  ////////////////////////////////////////////////////////////////////////////////////////
 
 void $Minus$complex$__serialize__($Minus$complex self, $Serial$state state) {
-  $step_serialize(self->w$Number, state);
+    $step_serialize(self->w$Number, state);
 }
 
 $Minus$complex $Minus$complex$__deserialize__($Minus$complex self, $Serial$state state) {
-   $Minus$complex res = $DNEW($Minus$complex,state);
-   res->w$Number = ($Number)$step_deserialize(state);
-   return res;
+    $Minus$complex res = $DNEW($Minus$complex, state);
+    res->w$Number = ($Number)$step_deserialize(state);
+    return res;
 }
 
 $complex $Minus$complex$__sub__($Minus$complex wit, $complex a, $complex b) {
-  return to$complex(a->val - b->val);
-}  
+    return to$complex(a->val - b->val);
+}
 // $Eq$complex  ////////////////////////////////////////////////////////////////////////////////////////
 
 void $Eq$complex$__serialize__($Eq$complex self, $Serial$state state) {
 }
 
 $Eq$complex $Eq$complex$__deserialize__($Eq$complex self, $Serial$state state) {
-   $Eq$complex res = $DNEW($Eq$complex,state);
-   return res;
+    $Eq$complex res = $DNEW($Eq$complex, state);
+    return res;
 }
 
-$bool $Eq$complex$__eq__ ($Eq$complex wit, $complex a, $complex b) {
-  return to$bool(creal(a->val) == creal(b->val) && cimag(a->val) == cimag(b->val));
+$bool $Eq$complex$__eq__($Eq$complex wit, $complex a, $complex b) {
+    return to$bool(creal(a->val) == creal(b->val) && cimag(a->val) == cimag(b->val));
 }
 
-$bool $Eq$complex$__ne__ ($Eq$complex wit, $complex a, $complex b) {
-  return to$bool(!from$bool($Eq$complex$__eq__(wit,a,b)));
+$bool $Eq$complex$__ne__($Eq$complex wit, $complex a, $complex b) {
+    return to$bool(!from$bool($Eq$complex$__eq__(wit, a, b)));
 }
-
 
 // $Hashable$complex  ////////////////////////////////////////////////////////////////////////////////////////
 
@@ -164,60 +163,59 @@ void $Hashable$complex$__serialize__($Hashable$complex self, $Serial$state state
 }
 
 $Hashable$complex $Hashable$complex$__deserialize__($Hashable$complex self, $Serial$state state) {
-   $Hashable$complex res = $DNEW($Hashable$complex,state);
-   return res;
+    $Hashable$complex res = $DNEW($Hashable$complex, state);
+    return res;
 }
 
 $bool $Hashable$complex$__eq__($Hashable$complex wit, $complex a, $complex b) {
-  return to$bool(creal(a->val) == creal(b->val) && cimag(a->val) == cimag(b->val));
+    return to$bool(creal(a->val) == creal(b->val) && cimag(a->val) == cimag(b->val));
 }
 
 $bool $Hashable$complex$__ne__($Hashable$complex wit, $complex a, $complex b) {
-  return to$bool(!from$bool($Hashable$complex$__eq__(wit,a,b)));
+    return to$bool(!from$bool($Hashable$complex$__eq__(wit, a, b)));
 }
 
 $int $Hashable$complex$__hash__($Hashable$complex wit, $complex a) {
-  return to$int($complex_hash(a));
+    return to$int($complex_hash(a));
 }
 
 // init methods ////////////////////////////////////////////////////////////////////////////////////////////////
 
-void $Number$complex_init ($Number$complex wit) {
-  wit-> w$Minus = ($Minus)$NEW($Minus$complex,($Number)wit);
+void $Number$complex_init($Number$complex wit) {
+    wit->w$Minus = ($Minus)$NEW($Minus$complex, ($Number)wit);
 }
 
 void $Minus$complex_init($Minus$complex wit, $Number w$Number) {
-  wit->w$Number =  w$Number;
+    wit->w$Number = w$Number;
 }
 
 void $Eq$complex_init($Eq$complex wit) {
-  return;
+    return;
 }
 
 void $Div$complex_init($Div$complex wit) {
-  return;
+    return;
 }
 
 void $Hashable$complex_init($Hashable$complex wit) {
-  return;
+    return;
 }
 
 $Number$complex $Number$complex$new() {
-  return $NEW($Number$complex);
+    return $NEW($Number$complex);
 }
 
 $Minus$complex $Minus$complex$new($Number wit) {
-  return $NEW($Minus$complex,wit);
+    return $NEW($Minus$complex, wit);
 }
-  
+
 $Eq$complex $Eq$complex$new() {
-  return $NEW($Eq$complex);
+    return $NEW($Eq$complex);
 }
 
 $Hashable$complex $Hashable$complex$new() {
-  return $NEW($Hashable$complex);
+    return $NEW($Hashable$complex);
 }
-
 
 struct $Number$complex $Number$complex_instance;
 struct $Minus$complex $Minus$complex_instance;
@@ -231,23 +229,22 @@ struct $Number$complex$class $Number$complex$methods = {
     $Number$complex_init,
     $Number$complex$__serialize__,
     $Number$complex$__deserialize__,
-    ($bool (*)($Number$complex))$default__bool__,
-    ($str (*)($Number$complex))$default__str__,
+    ($bool(*)($Number$complex))$default__bool__,
+    ($str(*)($Number$complex))$default__str__,
     $Number$complex$__add__,
-    ($complex (*)($Number$complex, $complex, $complex))$Plus$__iadd__,
+    ($complex(*)($Number$complex, $complex, $complex))$Plus$__iadd__,
     $Number$complex$__mul__,
-    ($complex (*)($Number$complex, $complex, $complex))$Times$__imul__,
-    NULL,        // fromatom
+    ($complex(*)($Number$complex, $complex, $complex))$Times$__imul__,
+    NULL, // fromatom
     $Number$complex$__complx__,
     $Number$complex$__pow__,
-    ($complex (*)($Number$complex, $complex, $complex))$Number$__ipow__,
+    ($complex(*)($Number$complex, $complex, $complex))$Number$__ipow__,
     $Number$complex$__neg__,
     $Number$complex$__pos__,
     $Number$complex$real,
     $Number$complex$imag,
     $Number$complex$__abs__,
-    $Number$complex$conjugate
-};
+    $Number$complex$conjugate};
 struct $Number$complex $Number$complex_instance = {&$Number$complex$methods, ($Minus)&$Minus$complex_instance};
 $Number$complex $Number$complex$witness = &$Number$complex_instance;
 
@@ -258,10 +255,10 @@ struct $Div$complex$class $Div$complex$methods = {
     $Div$complex_init,
     $Div$complex$__serialize__,
     $Div$complex$__deserialize__,
-    ($bool (*)($Div$complex))$default__bool__,
-    ($str (*)($Div$complex))$default__str__,
+    ($bool(*)($Div$complex))$default__bool__,
+    ($str(*)($Div$complex))$default__str__,
     $Div$complex$__truediv__,
-    ($complex (*)($Div$complex, $complex, $complex))$Div$__itruediv__,
+    ($complex(*)($Div$complex, $complex, $complex))$Div$__itruediv__,
 };
 
 struct $Div$complex $Div$complex_instance = {&$Div$complex$methods};
@@ -274,11 +271,10 @@ struct $Minus$complex$class $Minus$complex$methods = {
     $Minus$complex_init,
     $Minus$complex$__serialize__,
     $Minus$complex$__deserialize__,
-    ($bool (*)($Minus$complex))$default__bool__,
-    ($str (*)($Minus$complex))$default__str__,
+    ($bool(*)($Minus$complex))$default__bool__,
+    ($str(*)($Minus$complex))$default__str__,
     $Minus$complex$__sub__,
-    ($complex (*)($Minus$complex, $complex, $complex))$Minus$__isub__
-};
+    ($complex(*)($Minus$complex, $complex, $complex))$Minus$__isub__};
 struct $Minus$complex $Minus$complex_instance = {&$Minus$complex$methods, ($Number)&$Number$complex_instance};
 $Minus$complex $Minus$complex$witness = &$Minus$complex_instance;
 
@@ -289,11 +285,10 @@ struct $Eq$complex$class $Eq$complex$methods = {
     $Eq$complex_init,
     $Eq$complex$__serialize__,
     $Eq$complex$__deserialize__,
-    ($bool (*)($Eq$complex))$default__bool__,
-    ($str (*)($Eq$complex))$default__str__,
+    ($bool(*)($Eq$complex))$default__bool__,
+    ($str(*)($Eq$complex))$default__str__,
     $Eq$complex$__eq__,
-    $Eq$complex$__ne__
-};
+    $Eq$complex$__ne__};
 struct $Eq$complex $Eq$complex_instance = {&$Eq$complex$methods};
 $Eq$complex $Eq$complex$witness = &$Eq$complex_instance;
 
@@ -304,11 +299,10 @@ struct $Hashable$complex$class $Hashable$complex$methods = {
     $Hashable$complex_init,
     $Hashable$complex$__serialize__,
     $Hashable$complex$__deserialize__,
-    ($bool (*)($Hashable$complex))$default__bool__,
-    ($str (*)($Hashable$complex))$default__str__,
+    ($bool(*)($Hashable$complex))$default__bool__,
+    ($str(*)($Hashable$complex))$default__str__,
     $Hashable$complex$__eq__,
     $Hashable$complex$__ne__,
-    $Hashable$complex$__hash__
-};
- struct $Hashable$complex $Hashable$complex_instance = {&$Hashable$complex$methods};
- $Hashable$complex $Hashable$complex$witness = &$Hashable$complex_instance;
+    $Hashable$complex$__hash__};
+struct $Hashable$complex $Hashable$complex_instance = {&$Hashable$complex$methods};
+$Hashable$complex $Hashable$complex$witness = &$Hashable$complex_instance;

--- a/builtin/complx.h
+++ b/builtin/complx.h
@@ -6,19 +6,19 @@
 #include <complex.h>
 
 struct $complex$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)($complex, $Number, $WORD);
-  void (*__serialize__)($complex,$Serial$state);
-  $complex (*__deserialize__)($complex,$Serial$state);
-  $bool (*__bool__)($complex);
-  $str (*__str__)($complex);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)($complex, $Number, $WORD);
+    void (*__serialize__)($complex, $Serial$state);
+    $complex (*__deserialize__)($complex, $Serial$state);
+    $bool (*__bool__)($complex);
+    $str (*__str__)($complex);
 };
 
 struct $complex {
-  struct $complex$class *$class;
-  complex double val;
+    struct $complex$class *$class;
+    complex double val;
 };
 
 extern struct $complex$class $complex$methods;

--- a/builtin/csiphash.c
+++ b/builtin/csiphash.c
@@ -43,46 +43,45 @@
  * the hash values' least significant bits.
  */
 #if PY_LITTLE_ENDIAN
-#  define _le64toh(x) ((uint64_t)(x))
+#define _le64toh(x) ((uint64_t)(x))
 #elif defined(__APPLE__)
-#  define _le64toh(x) OSSwapLittleToHostInt64(x)
+#define _le64toh(x) OSSwapLittleToHostInt64(x)
 #elif defined(HAVE_LETOH64)
-#  define _le64toh(x) le64toh(x)
+#define _le64toh(x) le64toh(x)
 #else
-#  define _le64toh(x) (((uint64_t)(x) << 56) | \
-                      (((uint64_t)(x) << 40) & 0xff000000000000ULL) | \
-                      (((uint64_t)(x) << 24) & 0xff0000000000ULL) | \
-                      (((uint64_t)(x) << 8)  & 0xff00000000ULL) | \
-                      (((uint64_t)(x) >> 8)  & 0xff000000ULL) | \
-                      (((uint64_t)(x) >> 24) & 0xff0000ULL) | \
-                      (((uint64_t)(x) >> 40) & 0xff00ULL) | \
-                      ((uint64_t)(x)  >> 56))
+#define _le64toh(x) (((uint64_t)(x) << 56) |                         \
+                     (((uint64_t)(x) << 40) & 0xff000000000000ULL) | \
+                     (((uint64_t)(x) << 24) & 0xff0000000000ULL) |   \
+                     (((uint64_t)(x) << 8) & 0xff00000000ULL) |      \
+                     (((uint64_t)(x) >> 8) & 0xff000000ULL) |        \
+                     (((uint64_t)(x) >> 24) & 0xff0000ULL) |         \
+                     (((uint64_t)(x) >> 40) & 0xff00ULL) |           \
+                     ((uint64_t)(x) >> 56))
 #endif
-
 
 #ifdef _MSC_VER
-#  define ROTATE(x, b)  _rotl64(x, b)
+#define ROTATE(x, b) _rotl64(x, b)
 #else
-#  define ROTATE(x, b) (uint64_t)( ((x) << (b)) | ( (x) >> (64 - (b))) )
+#define ROTATE(x, b) (uint64_t)(((x) << (b)) | ((x) >> (64 - (b))))
 #endif
 
-#define HALF_ROUND(a,b,c,d,s,t)         \
-    a += b; c += d;             \
-    b = ROTATE(b, s) ^ a;           \
-    d = ROTATE(d, t) ^ c;           \
+#define HALF_ROUND(a, b, c, d, s, t) \
+    a += b;                          \
+    c += d;                          \
+    b = ROTATE(b, s) ^ a;            \
+    d = ROTATE(d, t) ^ c;            \
     a = ROTATE(a, 32);
 
-#define DOUBLE_ROUND(v0,v1,v2,v3)       \
-    HALF_ROUND(v0,v1,v2,v3,13,16);      \
-    HALF_ROUND(v2,v1,v0,v3,17,21);      \
-    HALF_ROUND(v0,v1,v2,v3,13,16);      \
-    HALF_ROUND(v2,v1,v0,v3,17,21);
-
+#define DOUBLE_ROUND(v0, v1, v2, v3)    \
+    HALF_ROUND(v0, v1, v2, v3, 13, 16); \
+    HALF_ROUND(v2, v1, v0, v3, 17, 21); \
+    HALF_ROUND(v0, v1, v2, v3, 13, 16); \
+    HALF_ROUND(v2, v1, v0, v3, 17, 21);
 
 static uint64_t
 siphash24(uint64_t k0, uint64_t k1, const void *src, ssize_t src_sz) {
     uint64_t b = (uint64_t)src_sz << 56;
-    const uint8_t *in = (uint8_t*)src;
+    const uint8_t *in = (uint8_t *)src;
 
     uint64_t v0 = k0 ^ 0x736f6d6570736575ULL;
     uint64_t v1 = k1 ^ 0x646f72616e646f6dULL;
@@ -99,29 +98,37 @@ siphash24(uint64_t k0, uint64_t k1, const void *src, ssize_t src_sz) {
         in += sizeof(mi);
         src_sz -= sizeof(mi);
         v3 ^= mi;
-        DOUBLE_ROUND(v0,v1,v2,v3);
+        DOUBLE_ROUND(v0, v1, v2, v3);
         v0 ^= mi;
     }
 
     t = 0;
     pt = (uint8_t *)&t;
     switch (src_sz) {
-        case 7: pt[6] = in[6]; /* fall through */
-        case 6: pt[5] = in[5]; /* fall through */
-        case 5: pt[4] = in[4]; /* fall through */
-        case 4: memcpy(pt, in, sizeof(uint32_t)); break;
-        case 3: pt[2] = in[2]; /* fall through */
-        case 2: pt[1] = in[1]; /* fall through */
-        case 1: pt[0] = in[0]; /* fall through */
+        case 7:
+            pt[6] = in[6]; /* fall through */
+        case 6:
+            pt[5] = in[5]; /* fall through */
+        case 5:
+            pt[4] = in[4]; /* fall through */
+        case 4:
+            memcpy(pt, in, sizeof(uint32_t));
+            break;
+        case 3:
+            pt[2] = in[2]; /* fall through */
+        case 2:
+            pt[1] = in[1]; /* fall through */
+        case 1:
+            pt[0] = in[0]; /* fall through */
     }
     b |= _le64toh(t);
 
     v3 ^= b;
-    DOUBLE_ROUND(v0,v1,v2,v3);
+    DOUBLE_ROUND(v0, v1, v2, v3);
     v0 ^= b;
     v2 ^= 0xff;
-    DOUBLE_ROUND(v0,v1,v2,v3);
-    DOUBLE_ROUND(v0,v1,v2,v3);
+    DOUBLE_ROUND(v0, v1, v2, v3);
+    DOUBLE_ROUND(v0, v1, v2, v3);
 
     /* modified */
     t = (v0 ^ v1) ^ (v2 ^ v3);

--- a/builtin/dict.c
+++ b/builtin/dict.c
@@ -12,16 +12,15 @@
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-
-struct  $Mapping$dict$class $Mapping$dict$methods = {
+struct $Mapping$dict$class $Mapping$dict$methods = {
     "$Mapping$dict",
     UNASSIGNED,
     ($Super$class)&$Mapping$methods,
     $Mapping$dict$__init__,
     $Mapping$dict$__serialize__,
     $Mapping$dict$__deserialize__,
-    ($bool (*)($Mapping$dict))$default__bool__,
-    ($str (*)($Mapping$dict))$default__str__,
+    ($bool(*)($Mapping$dict))$default__bool__,
+    ($str(*)($Mapping$dict))$default__str__,
     $Mapping$dict$__iter__,
     $Mapping$dict$__fromiter__,
     $Mapping$dict$__len__,
@@ -33,8 +32,7 @@ struct  $Mapping$dict$class $Mapping$dict$methods = {
     $Mapping$dict$items,
     $Mapping$dict$update,
     $Mapping$dict$popitem,
-    $Mapping$dict$setdefault
-};
+    $Mapping$dict$setdefault};
 
 struct $Indexed$dict$class $Indexed$dict$methods = {
     "$Indexed$dict",
@@ -43,118 +41,114 @@ struct $Indexed$dict$class $Indexed$dict$methods = {
     $Indexed$dict$__init__,
     $Indexed$dict$__serialize__,
     $Indexed$dict$__deserialize__,
-    ($bool (*)($Indexed$dict))$default__bool__,
-    ($str (*)($Indexed$dict))$default__str__,
+    ($bool(*)($Indexed$dict))$default__bool__,
+    ($str(*)($Indexed$dict))$default__str__,
     $Indexed$dict$__getitem__,
     $Indexed$dict$__setitem__,
-    $Indexed$dict$__delitem__
-};
+    $Indexed$dict$__delitem__};
 
 void $Mapping$dict$__serialize__($Mapping$dict self, $Serial$state state) {
-  $step_serialize(self->w$Indexed, state);
-  $step_serialize(self->w$Eq$A$Mapping$dict, state);
-  $step_serialize(self->w$Hashable$A$Mapping$dict, state);
+    $step_serialize(self->w$Indexed, state);
+    $step_serialize(self->w$Eq$A$Mapping$dict, state);
+    $step_serialize(self->w$Hashable$A$Mapping$dict, state);
 }
 
 $Mapping$dict $Mapping$dict$__deserialize__($Mapping$dict self, $Serial$state state) {
-   $Mapping$dict res = $DNEW($Mapping$dict,state);
-   res->w$Indexed = ($Indexed)$step_deserialize(state);
-   res->w$Eq$A$Mapping$dict = ($Eq)$step_deserialize(state);
-   res->w$Hashable$A$Mapping$dict = ($Hashable)$step_deserialize(state);
-   return res;
+    $Mapping$dict res = $DNEW($Mapping$dict, state);
+    res->w$Indexed = ($Indexed)$step_deserialize(state);
+    res->w$Eq$A$Mapping$dict = ($Eq)$step_deserialize(state);
+    res->w$Hashable$A$Mapping$dict = ($Hashable)$step_deserialize(state);
+    return res;
 }
 
-$Iterator $Mapping$dict$__iter__ ($Mapping$dict wit, $dict dict) {
-  return $dict_iter(dict);
+$Iterator $Mapping$dict$__iter__($Mapping$dict wit, $dict dict) {
+    return $dict_iter(dict);
 }
 
-$dict $Mapping$dict$__fromiter__ ($Mapping$dict wit, $Iterable wit2, $WORD iter) {
-  return $dict_fromiter(wit->w$Hashable$A$Mapping$dict,wit2->$class->__iter__(wit2,iter));
+$dict $Mapping$dict$__fromiter__($Mapping$dict wit, $Iterable wit2, $WORD iter) {
+    return $dict_fromiter(wit->w$Hashable$A$Mapping$dict, wit2->$class->__iter__(wit2, iter));
 }
 
-$int $Mapping$dict$__len__ ($Mapping$dict wit, $dict dict) {
-  return to$int($dict_len(dict));
-}
-  
-$bool $Mapping$dict$__contains__ ($Mapping$dict wit, $dict dict, $WORD key) {
-  return to$bool($dict_contains(dict,wit->w$Hashable$A$Mapping$dict,key));
+$int $Mapping$dict$__len__($Mapping$dict wit, $dict dict) {
+    return to$int($dict_len(dict));
 }
 
-$bool $Mapping$dict$__containsnot__ ($Mapping$dict wit, $dict dict, $WORD key) {
-  return to$bool(!$dict_contains(dict,wit->w$Hashable$A$Mapping$dict,key));
+$bool $Mapping$dict$__contains__($Mapping$dict wit, $dict dict, $WORD key) {
+    return to$bool($dict_contains(dict, wit->w$Hashable$A$Mapping$dict, key));
 }
 
-$WORD $Mapping$dict$get ($Mapping$dict wit, $dict dict, $WORD key, $WORD deflt) {
-  return $dict_get(dict,wit->w$Hashable$A$Mapping$dict,key,deflt);
+$bool $Mapping$dict$__containsnot__($Mapping$dict wit, $dict dict, $WORD key) {
+    return to$bool(!$dict_contains(dict, wit->w$Hashable$A$Mapping$dict, key));
 }
 
-$Iterator $Mapping$dict$keys ($Mapping$dict wit, $dict dict) {
-  return $dict_keys(dict);
+$WORD $Mapping$dict$get($Mapping$dict wit, $dict dict, $WORD key, $WORD deflt) {
+    return $dict_get(dict, wit->w$Hashable$A$Mapping$dict, key, deflt);
 }
 
-$Iterator $Mapping$dict$values ($Mapping$dict wit, $dict dict) {
-  return $dict_values(dict);
+$Iterator $Mapping$dict$keys($Mapping$dict wit, $dict dict) {
+    return $dict_keys(dict);
 }
 
-$Iterator $Mapping$dict$items ($Mapping$dict wit, $dict dict) {
-  return $dict_items(dict);
+$Iterator $Mapping$dict$values($Mapping$dict wit, $dict dict) {
+    return $dict_values(dict);
 }
 
-void $Mapping$dict$update ($Mapping$dict wit, $dict dict, $Iterable wit2, $WORD other) {
-  $dict_update(dict,wit->w$Hashable$A$Mapping$dict,wit2->$class->__iter__(wit2,other));
+$Iterator $Mapping$dict$items($Mapping$dict wit, $dict dict) {
+    return $dict_items(dict);
 }
 
-$tuple $Mapping$dict$popitem ($Mapping$dict wit, $dict dict) {
-  return $dict_popitem(dict, wit->w$Hashable$A$Mapping$dict);
+void $Mapping$dict$update($Mapping$dict wit, $dict dict, $Iterable wit2, $WORD other) {
+    $dict_update(dict, wit->w$Hashable$A$Mapping$dict, wit2->$class->__iter__(wit2, other));
 }
 
-void $Mapping$dict$setdefault ($Mapping$dict wit, $dict dict, $WORD key, $WORD deflt) {
-  $dict_setdefault(dict,wit->w$Hashable$A$Mapping$dict,key,deflt);
+$tuple $Mapping$dict$popitem($Mapping$dict wit, $dict dict) {
+    return $dict_popitem(dict, wit->w$Hashable$A$Mapping$dict);
+}
+
+void $Mapping$dict$setdefault($Mapping$dict wit, $dict dict, $WORD key, $WORD deflt) {
+    $dict_setdefault(dict, wit->w$Hashable$A$Mapping$dict, key, deflt);
 }
 
 void $Indexed$dict$__serialize__($Indexed$dict self, $Serial$state state) {
-  $step_serialize(self->w$Mapping, state);
-  $step_serialize(self->w$Eq$A$Mapping$dict, state);
-  $step_serialize(self->w$Hashable$A$Mapping$dict, state);
+    $step_serialize(self->w$Mapping, state);
+    $step_serialize(self->w$Eq$A$Mapping$dict, state);
+    $step_serialize(self->w$Hashable$A$Mapping$dict, state);
 }
 
 $Indexed$dict $Indexed$dict$__deserialize__($Indexed$dict self, $Serial$state state) {
-   $Indexed$dict res = $DNEW($Indexed$dict,state);
-   res->w$Mapping = ($Mapping)$step_deserialize(state);
-   res->w$Eq$A$Mapping$dict = ($Eq)$step_deserialize(state);
-   res->w$Hashable$A$Mapping$dict = ($Hashable)$step_deserialize(state);
-   return res;
+    $Indexed$dict res = $DNEW($Indexed$dict, state);
+    res->w$Mapping = ($Mapping)$step_deserialize(state);
+    res->w$Eq$A$Mapping$dict = ($Eq)$step_deserialize(state);
+    res->w$Hashable$A$Mapping$dict = ($Hashable)$step_deserialize(state);
+    return res;
 }
 
-$WORD $Indexed$dict$__getitem__ ($Indexed$dict wit, $dict dict, $WORD key) {
-  return $dict_getitem(dict, (($Mapping$dict)wit->w$Mapping)->w$Hashable$A$Mapping$dict,key);
+$WORD $Indexed$dict$__getitem__($Indexed$dict wit, $dict dict, $WORD key) {
+    return $dict_getitem(dict, (($Mapping$dict)wit->w$Mapping)->w$Hashable$A$Mapping$dict, key);
 }
-void $Indexed$dict$__setitem__ ($Indexed$dict wit, $dict dict, $WORD key, $WORD value) {
-  $dict_setitem(dict,  (($Mapping$dict)wit->w$Mapping)->w$Hashable$A$Mapping$dict,key,value);
+void $Indexed$dict$__setitem__($Indexed$dict wit, $dict dict, $WORD key, $WORD value) {
+    $dict_setitem(dict, (($Mapping$dict)wit->w$Mapping)->w$Hashable$A$Mapping$dict, key, value);
 }
-void $Indexed$dict$__delitem__ ($Indexed$dict wit, $dict dict, $WORD key) {
-  $dict_delitem(dict,  (($Mapping$dict)wit->w$Mapping)->w$Hashable$A$Mapping$dict,key);
+void $Indexed$dict$__delitem__($Indexed$dict wit, $dict dict, $WORD key) {
+    $dict_delitem(dict, (($Mapping$dict)wit->w$Mapping)->w$Hashable$A$Mapping$dict, key);
 }
 
 $Mapping$dict $Mapping$dict$new($Hashable h) {
-  return $NEW($Mapping$dict, h);
+    return $NEW($Mapping$dict, h);
 }
 
 void $Mapping$dict$__init__($Mapping$dict self, $Hashable h) {
-  self->w$Indexed = ($Indexed)$NEW($Indexed$dict,($Mapping)self,($Eq)h);
-  self->w$Eq$A$Mapping$dict = ($Eq)h;
-  self->w$Hashable$A$Mapping$dict = h;
+    self->w$Indexed = ($Indexed)$NEW($Indexed$dict, ($Mapping)self, ($Eq)h);
+    self->w$Eq$A$Mapping$dict = ($Eq)h;
+    self->w$Hashable$A$Mapping$dict = h;
 }
 
 $Indexed$dict $Indexed$dict$new($Mapping master, $Eq e) {
-  return $NEW($Indexed$dict, master, e);
+    return $NEW($Indexed$dict, master, e);
 }
-
 
 void $Indexed$dict$__init__($Indexed$dict self, $Mapping master, $Eq e) {
-  self->w$Mapping = master;
-  self->w$Eq$A$Mapping$dict = e;
-  self->w$Hashable$A$Mapping$dict = ($Hashable)e;
+    self->w$Mapping = master;
+    self->w$Eq$A$Mapping$dict = e;
+    self->w$Hashable$A$Mapping$dict = ($Hashable)e;
 }
-
-

--- a/builtin/dict.h
+++ b/builtin/dict.h
@@ -1,28 +1,28 @@
 struct $dict$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void(*__init__)($dict, $Hashable, $Iterable, $WORD);
-  void (*__serialize__)($dict,$Serial$state);
-  $dict (*__deserialize__)($dict,$Serial$state);
-  $bool (*__bool__)($dict);
-  $str (*__str__)($dict);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)($dict, $Hashable, $Iterable, $WORD);
+    void (*__serialize__)($dict, $Serial$state);
+    $dict (*__deserialize__)($dict, $Serial$state);
+    $bool (*__bool__)($dict);
+    $str (*__str__)($dict);
 };
 
 typedef struct $table_struct *$table;
 
 struct $dict {
-  struct $dict$class *$class;
-  long numelements;               // nr of elements in dictionary
-  $table table;                   // the hashtable
+    struct $dict$class *$class;
+    long numelements; // nr of elements in dictionary
+    $table table;     // the hashtable
 };
 
 extern struct $dict$class $dict$methods;
 $dict $dict$new($Hashable, $Iterable, $WORD);
 
-extern struct  $Mapping$dict$class $Mapping$dict$methods;
+extern struct $Mapping$dict$class $Mapping$dict$methods;
 $Mapping$dict $Mapping$dict$new($Hashable);
-extern struct  $Indexed$dict$class $Indexed$dict$methods;
+extern struct $Indexed$dict$class $Indexed$dict$methods;
 $Indexed$dict $Indexed$dict$new($Mapping, $Eq);
 
 // Iterators over dicts ///////////////////////////////////////////////////////
@@ -32,24 +32,25 @@ $Indexed$dict $Indexed$dict$new($Mapping, $Eq);
 typedef struct $Iterator$dict *$Iterator$dict;
 
 struct $Iterator$dict$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)($Iterator$dict, $dict);
-  void (*__serialize__)($Iterator$dict,$Serial$state);
-  $Iterator$dict (*__deserialize__)($Iterator$dict,$Serial$state);
-  $bool (*__bool__)($Iterator$dict);
-  $str (*__str__)($Iterator$dict);
-  $WORD(*__next__)($Iterator$dict);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)($Iterator$dict, $dict);
+    void (*__serialize__)($Iterator$dict, $Serial$state);
+    $Iterator$dict (*__deserialize__)($Iterator$dict, $Serial$state);
+    $bool (*__bool__)($Iterator$dict);
+    $str (*__str__)($Iterator$dict);
+    $WORD (*__next__)
+    ($Iterator$dict);
 };
 
 struct $Iterator$dict {
-  struct $Iterator$dict$class *$class;
-  $dict src;
-  int nxt;
+    struct $Iterator$dict$class *$class;
+    $dict src;
+    int nxt;
 };
 
-extern struct $Iterator$dict$class  $Iterator$dict$methods;
+extern struct $Iterator$dict$class $Iterator$dict$methods;
 $Iterator$dict $Iterator$dict$new($dict);
 
 // values iterator
@@ -57,24 +58,25 @@ $Iterator$dict $Iterator$dict$new($dict);
 typedef struct $Iterator$dict$values *$Iterator$dict$values;
 
 struct $Iterator$dict$values$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)($Iterator$dict$values, $dict);
-  void (*__serialize__)($Iterator$dict$values,$Serial$state);
-  $Iterator$dict$values (*__deserialize__)($Iterator$dict$values,$Serial$state);
-  $bool (*__bool__)($Iterator$dict$values);
-  $str (*__str__)($Iterator$dict$values);
-  $WORD(*__next__)($Iterator$dict$values);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)($Iterator$dict$values, $dict);
+    void (*__serialize__)($Iterator$dict$values, $Serial$state);
+    $Iterator$dict$values (*__deserialize__)($Iterator$dict$values, $Serial$state);
+    $bool (*__bool__)($Iterator$dict$values);
+    $str (*__str__)($Iterator$dict$values);
+    $WORD (*__next__)
+    ($Iterator$dict$values);
 };
 
 struct $Iterator$dict$values {
-  struct $Iterator$dict$values$class *$class;
-  $dict src;
-  int nxt;
+    struct $Iterator$dict$values$class *$class;
+    $dict src;
+    int nxt;
 };
 
-extern struct $Iterator$dict$values$class  $Iterator$dict$values$methods;
+extern struct $Iterator$dict$values$class $Iterator$dict$values$methods;
 $Iterator$dict$values $Iterator$dict$values$new($dict);
 
 // items iterator
@@ -82,22 +84,23 @@ $Iterator$dict$values $Iterator$dict$values$new($dict);
 typedef struct $Iterator$dict$items *$Iterator$dict$items;
 
 struct $Iterator$dict$items$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)($Iterator$dict$items, $dict);
-  void (*__serialize__)($Iterator$dict$items,$Serial$state);
-  $Iterator$dict$items (*__deserialize__)($Iterator$dict$items,$Serial$state);
-  $bool (*__bool__)($Iterator$dict$items);
-  $str (*__str__)($Iterator$dict$items);
-  $WORD(*__next__)($Iterator$dict$items);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)($Iterator$dict$items, $dict);
+    void (*__serialize__)($Iterator$dict$items, $Serial$state);
+    $Iterator$dict$items (*__deserialize__)($Iterator$dict$items, $Serial$state);
+    $bool (*__bool__)($Iterator$dict$items);
+    $str (*__str__)($Iterator$dict$items);
+    $WORD (*__next__)
+    ($Iterator$dict$items);
 };
 
 struct $Iterator$dict$items {
-  struct $Iterator$dict$items$class *$class;
-  $dict src;
-  int nxt;
+    struct $Iterator$dict$items$class *$class;
+    $dict src;
+    int nxt;
 };
 
-extern struct $Iterator$dict$items$class  $Iterator$dict$items$methods;
+extern struct $Iterator$dict$items$class $Iterator$dict$items$methods;
 $Iterator$dict$items $Iterator$dict$items$new($dict);

--- a/builtin/dict_impl.c
+++ b/builtin/dict_impl.c
@@ -23,130 +23,128 @@
 // types //////////////////////////////////////////////////////////////////////////////////////
 
 typedef struct $entry_struct {
-  long hash;
-  $WORD key;
-  $WORD value;  // deleted entry has value NULL
-} *$entry_t;
+    long hash;
+    $WORD key;
+    $WORD value; // deleted entry has value NULL
+} * $entry_t;
 
 struct $table_struct {
-  char *$GCINFO;
-  long tb_size;        // size of dk_indices array; must be power of 2
-  long tb_usable;      // nr of unused entries in tb_entries (deleted entries are counted as used)
-  long tb_nentries;    // nr of used entries in tb_entries
-  int  tb_indices[];   // array of indices
-                       // after this follows tb_entries array;
+    char *$GCINFO;
+    long tb_size;     // size of dk_indices array; must be power of 2
+    long tb_usable;   // nr of unused entries in tb_entries (deleted entries are counted as used)
+    long tb_nentries; // nr of used entries in tb_entries
+    int tb_indices[]; // array of indices
+                      // after this follows tb_entries array;
 };
 
-
-
 #define DKIX_EMPTY (-1)
-#define DKIX_DUMMY (-2)  /* Used internally */
+#define DKIX_DUMMY (-2) /* Used internally */
 #define TB_ENTRIES(tb) \
-  (($entry_t)(&((int*)((tb)->tb_indices))[(tb)->tb_size]))
+    (($entry_t)(&((int *)((tb)->tb_indices))[(tb)->tb_size]))
 
 #define PERTURB_SHIFT 5
 
 // General methods /////////////////////////////////////////////////////////////////////////
 
 $dict $dict$new($Hashable hashwit, $Iterable wit, $WORD iterable) {
-  return $NEW($dict,hashwit, wit, iterable);
+    return $NEW($dict, hashwit, wit, iterable);
 }
 
 void $dict_init($dict dict, $Hashable hashwit, $Iterable wit, $WORD iterable) {
-  dict->numelements = 0;
-  dict->table = malloc(sizeof(char*)+3*sizeof(long) + 8*sizeof(int) + 5*sizeof(struct $entry_struct));
-  dict->table->tb_size = 8;
-  dict->table->tb_usable = 5;
-  dict->table->tb_nentries = 0;
-  memset(&(dict->table->tb_indices[0]), 0xff, 8*sizeof(int));
-  if (wit && iterable) {
-    $Iterator it = wit->$class->__iter__(wit,iterable);
-    $tuple nxt;
-    while((nxt = ($tuple)it->$class->__next__(it))) {
-      $dict_setitem(dict,hashwit,nxt->components[0],nxt->components[1]);
+    dict->numelements = 0;
+    dict->table = malloc(sizeof(char *) + 3 * sizeof(long) + 8 * sizeof(int) + 5 * sizeof(struct $entry_struct));
+    dict->table->tb_size = 8;
+    dict->table->tb_usable = 5;
+    dict->table->tb_nentries = 0;
+    memset(&(dict->table->tb_indices[0]), 0xff, 8 * sizeof(int));
+    if (wit && iterable) {
+        $Iterator it = wit->$class->__iter__(wit, iterable);
+        $tuple nxt;
+        while ((nxt = ($tuple)it->$class->__next__(it))) {
+            $dict_setitem(dict, hashwit, nxt->components[0], nxt->components[1]);
+        }
     }
-  }
 }
 
 $bool $dict_bool($dict self) {
-  return to$bool(self->numelements>0);
+    return to$bool(self->numelements > 0);
 }
 
 $str $dict_str($dict self) {
-  $list s2 = $list_new(self->numelements);
-  $Iterator$dict$items iter = $NEW($Iterator$dict$items,self);
-  $tuple item;
-  for (int i=0; i<self->numelements; i++) {
-    item = ($tuple)iter->$class->__next__(iter);
-    $value key = (($value)item->components[0]);
-    $value value = (($value)item->components[1]);
-    $str keystr = key->$class->__str__(key);
-    $str valuestr = value->$class->__str__(value);
-    $str elem = malloc(sizeof(struct $str));
-    elem->$class = &$str$methods;
-    elem->nbytes = keystr->nbytes+valuestr->nbytes+1;
-    elem->nchars = keystr->nchars+valuestr->nchars+1;
-    elem->str = malloc(elem->nbytes+1);
-    memcpy(elem->str,keystr->str,keystr->nbytes);
-    elem->str[keystr->nbytes] = ':';
-    memcpy(&elem->str[keystr->nbytes+1],valuestr->str,valuestr->nbytes);
-    elem->str[elem->nbytes] = '\0';    
-    $list_append(s2,elem);
-  }
-  return $str_join_par('{',s2,'}');
+    $list s2 = $list_new(self->numelements);
+    $Iterator$dict$items iter = $NEW($Iterator$dict$items, self);
+    $tuple item;
+    for (int i = 0; i < self->numelements; i++) {
+        item = ($tuple)iter->$class->__next__(iter);
+        $value key = (($value)item->components[0]);
+        $value value = (($value)item->components[1]);
+        $str keystr = key->$class->__str__(key);
+        $str valuestr = value->$class->__str__(value);
+        $str elem = malloc(sizeof(struct $str));
+        elem->$class = &$str$methods;
+        elem->nbytes = keystr->nbytes + valuestr->nbytes + 1;
+        elem->nchars = keystr->nchars + valuestr->nchars + 1;
+        elem->str = malloc(elem->nbytes + 1);
+        memcpy(elem->str, keystr->str, keystr->nbytes);
+        elem->str[keystr->nbytes] = ':';
+        memcpy(&elem->str[keystr->nbytes + 1], valuestr->str, valuestr->nbytes);
+        elem->str[elem->nbytes] = '\0';
+        $list_append(s2, elem);
+    }
+    return $str_join_par('{', s2, '}');
 }
 
-void $dict_serialize($dict self,$Serial$state state) {
-  $int prevkey = ($int)$dict_get(state->done,($Hashable)$Hashable$WORD$witness,self,NULL);
-  if (prevkey) {
-    $val_serialize(-DICT_ID,&prevkey->val,state);
-    return;
-  }
-  $dict_setitem(state->done,($Hashable)$Hashable$WORD$witness,self,to$int(state->row_no));
-  int blobsize = 4 + (self->table->tb_size + 1) * sizeof(int)/sizeof($WORD);
-  $ROW row = $add_header(DICT_ID,blobsize,state);
-  row->blob[0] = ($WORD)self->numelements;
-  row->blob[1] = ($WORD)self->table->tb_size;
-  row->blob[2] = ($WORD)self->table->tb_usable;
-  row->blob[3] = ($WORD)self->table->tb_nentries;
-  memcpy(&row->blob[4],self->table->tb_indices,self->table->tb_size*sizeof(int));
-  for (int i=0; i<self->table->tb_nentries; i++) {
-    $entry_t entry = &TB_ENTRIES(self->table)[i];
-    $step_serialize(to$int(entry->hash),state);
-    $step_serialize(entry->key,state);
-    $step_serialize(entry->value,state);
-  }
+void $dict_serialize($dict self, $Serial$state state) {
+    $int prevkey = ($int)$dict_get(state->done, ($Hashable)$Hashable$WORD$witness, self, NULL);
+    if (prevkey) {
+        $val_serialize(-DICT_ID, &prevkey->val, state);
+        return;
+    }
+    $dict_setitem(state->done, ($Hashable)$Hashable$WORD$witness, self, to$int(state->row_no));
+    int blobsize = 4 + (self->table->tb_size + 1) * sizeof(int) / sizeof($WORD);
+    $ROW row = $add_header(DICT_ID, blobsize, state);
+    row->blob[0] = ($WORD)self->numelements;
+    row->blob[1] = ($WORD)self->table->tb_size;
+    row->blob[2] = ($WORD)self->table->tb_usable;
+    row->blob[3] = ($WORD)self->table->tb_nentries;
+    memcpy(&row->blob[4], self->table->tb_indices, self->table->tb_size * sizeof(int));
+    for (int i = 0; i < self->table->tb_nentries; i++) {
+        $entry_t entry = &TB_ENTRIES(self->table)[i];
+        $step_serialize(to$int(entry->hash), state);
+        $step_serialize(entry->key, state);
+        $step_serialize(entry->value, state);
+    }
 }
 
 $dict $dict_deserialize($dict res, $Serial$state state) {
-  $ROW this = state->row;
-  state->row = this->next;
-  state->row_no++;
-  if (this->class_id < 0) {
-    return $dict_get(state->done,($Hashable)$Hashable$int$witness,to$int((long)this->blob[0]),NULL);
-  } else {
-    if (!res)
-       res = malloc(sizeof(struct $dict));
-    $dict_setitem(state->done,($Hashable)$Hashable$int$witness,to$int(state->row_no-1),res);
-    res->$class = &$dict$methods;
-    res->numelements = (long)this->blob[0];
-    long tb_size = (long)this->blob[1];
-    res->table = malloc(sizeof(char*) + 3*sizeof(long) + tb_size*sizeof(int) + (2*tb_size/3)*sizeof(struct $entry_struct));
-    res->table->tb_size = tb_size;
-    res->table->tb_usable = (long)this->blob[2];
-    res->table->tb_nentries = (long)this->blob[3];
-    memcpy(res->table->tb_indices,&this->blob[4],tb_size*sizeof(int));
-    for (int i=0; i<res->table->tb_nentries; i++) {
-      $entry_t entry = &TB_ENTRIES(res->table)[i];
-      entry->hash = from$int(($int)$step_deserialize(state));
-      entry->key =  $step_deserialize(state);
-      entry->value = $step_deserialize(state);
+    $ROW this = state->row;
+    state->row = this->next;
+    state->row_no++;
+    if (this->class_id < 0) {
+        return $dict_get(state->done, ($Hashable)$Hashable$int$witness, to$int((long)this->blob[0]), NULL);
+    } else {
+        if (!res)
+            res = malloc(sizeof(struct $dict));
+        $dict_setitem(state->done, ($Hashable)$Hashable$int$witness, to$int(state->row_no - 1), res);
+        res->$class = &$dict$methods;
+        res->numelements = (long)this->blob[0];
+        long tb_size = (long)this->blob[1];
+        res->table = malloc(sizeof(char *) + 3 * sizeof(long) + tb_size * sizeof(int) + (2 * tb_size / 3) * sizeof(struct $entry_struct));
+        res->table->tb_size = tb_size;
+        res->table->tb_usable = (long)this->blob[2];
+        res->table->tb_nentries = (long)this->blob[3];
+        memcpy(res->table->tb_indices, &this->blob[4], tb_size * sizeof(int));
+        for (int i = 0; i < res->table->tb_nentries; i++) {
+            $entry_t entry = &TB_ENTRIES(res->table)[i];
+            entry->hash = from$int(($int)$step_deserialize(state));
+            entry->key = $step_deserialize(state);
+            entry->value = $step_deserialize(state);
+        }
+        return res;
     }
-    return res;
-  }
 }
 
-struct $dict$class $dict$methods = {"$dict", UNASSIGNED,($Super$class)&$object$methods, $dict_init, $dict_serialize,$dict_deserialize, $dict_bool, $dict_str}; 
+struct $dict$class $dict$methods = {"$dict", UNASSIGNED, ($Super$class)&$object$methods, $dict_init, $dict_serialize, $dict_deserialize, $dict_bool, $dict_str};
 
 // Internal routines //////////////////////////////////////////////////////////////////
 
@@ -154,17 +152,17 @@ struct $dict$class $dict$methods = {"$dict", UNASSIGNED,($Super$class)&$object$m
 Internal routine used by dictresize() to build a hashtable of entries.
 */
 static void build_indices($table tbl, $entry_t ep, long n) {
-  long mask = tbl->tb_size - 1;
-  for (int ix = 0; ix != n; ix++, ep++) {
-    long hash = ep->hash;
+    long mask = tbl->tb_size - 1;
+    for (int ix = 0; ix != n; ix++, ep++) {
+        long hash = ep->hash;
 
-    unsigned long i = (unsigned long)hash & mask;
-    for (unsigned long perturb = hash; tbl->tb_indices[i] != DKIX_EMPTY;) {
-      perturb >>= PERTURB_SHIFT;
-      i = mask & (i*5 + perturb + 1);
+        unsigned long i = (unsigned long)hash & mask;
+        for (unsigned long perturb = hash; tbl->tb_indices[i] != DKIX_EMPTY;) {
+            perturb >>= PERTURB_SHIFT;
+            i = mask & (i * 5 + perturb + 1);
+        }
+        tbl->tb_indices[i] = ix;
     }
-    tbl->tb_indices[i] = ix;
-  }
 }
 
 /*
@@ -174,49 +172,48 @@ actually be smaller than the old one.
 */
 
 static int dictresize($dict d) {
-  $table oldtable = d->table;
-  long numelements = d->numelements;
-  long newsize, minsize = 3*numelements;
-  $entry_t oldentries, newentries;
+    $table oldtable = d->table;
+    long numelements = d->numelements;
+    long newsize, minsize = 3 * numelements;
+    $entry_t oldentries, newentries;
 
-  for (newsize = 8; newsize < minsize; //&& newsize > 0; // ignore case when minsize is so large that newsize overflows
-       newsize <<= 1)
-    ;
-  /*
+    for (newsize = 8; newsize < minsize; //&& newsize > 0; // ignore case when minsize is so large that newsize overflows
+         newsize <<= 1)
+        ;
+    /*
   Again, for the moment, ignore enormous dictionary size request.
   if (newsize <= 0) {
         PyErr_NoMemory();
         return -1;
     }
   */
-  /* Allocate a new table. */
-  $table newtable =  malloc(sizeof(char*) + 3*sizeof(long) + newsize*sizeof(int) + (2*newsize/3)*sizeof(struct $entry_struct));
-  newtable->tb_size = newsize;
-  newtable->tb_usable = 2*newsize/3-numelements;
-  newtable->tb_nentries = numelements;
-  memset(&(newtable->tb_indices[0]), 0xff, newsize*sizeof(int));
-  oldentries = TB_ENTRIES(oldtable);
-  newentries = TB_ENTRIES(newtable);
-  if (oldtable->tb_nentries == numelements) {
-    memcpy(newentries, oldentries, numelements*sizeof(struct $entry_struct));
-  }
-  else {
-    $entry_t ep = oldentries;
-    for (int i = 0; i < numelements; i++) {
-      while (ep->value == NULL) ep++;
-      newentries[i] = *ep++;
+    /* Allocate a new table. */
+    $table newtable = malloc(sizeof(char *) + 3 * sizeof(long) + newsize * sizeof(int) + (2 * newsize / 3) * sizeof(struct $entry_struct));
+    newtable->tb_size = newsize;
+    newtable->tb_usable = 2 * newsize / 3 - numelements;
+    newtable->tb_nentries = numelements;
+    memset(&(newtable->tb_indices[0]), 0xff, newsize * sizeof(int));
+    oldentries = TB_ENTRIES(oldtable);
+    newentries = TB_ENTRIES(newtable);
+    if (oldtable->tb_nentries == numelements) {
+        memcpy(newentries, oldentries, numelements * sizeof(struct $entry_struct));
+    } else {
+        $entry_t ep = oldentries;
+        for (int i = 0; i < numelements; i++) {
+            while (ep->value == NULL)
+                ep++;
+            newentries[i] = *ep++;
+        }
     }
-  }
-  d->table = newtable;
-  free(oldtable);
-  build_indices(newtable, newentries, numelements);
-  return 0;
+    d->table = newtable;
+    free(oldtable);
+    build_indices(newtable, newentries, numelements);
+    return 0;
 }
 
-
-// Search index of hash table from offset of entry table 
+// Search index of hash table from offset of entry table
 static int lookdict_index($table table, long hash, int index) {
-    unsigned long mask =  (table->tb_size)-1;
+    unsigned long mask = (table->tb_size) - 1;
     unsigned long perturb = hash;
     unsigned long i = (unsigned long)hash & mask;
 
@@ -229,7 +226,7 @@ static int lookdict_index($table table, long hash, int index) {
             return DKIX_EMPTY;
         }
         perturb >>= PERTURB_SHIFT;
-        i = mask & (i*5 + perturb + 1);
+        i = mask & (i * 5 + perturb + 1);
     }
     // unreachable
 }
@@ -238,197 +235,194 @@ static int lookdict_index($table table, long hash, int index) {
 // (and returns corresponding value in *res)
 // or DKIX_EMPTY if no such entry exists
 static int lookdict($dict dict, $Hashable hashwit, long hash, $WORD key, $WORD *res) {
-  $table table = dict->table;
-  unsigned long mask = (table->tb_size)-1, i = ( unsigned long)hash & mask, perturb = hash;
-  int ix;
-  for(;;) {
-    ix = table->tb_indices[i];
-    if (ix == DKIX_EMPTY) {
-      // Unused slot
-      *res = NULL;
-      return ix;
+    $table table = dict->table;
+    unsigned long mask = (table->tb_size) - 1, i = (unsigned long)hash & mask, perturb = hash;
+    int ix;
+    for (;;) {
+        ix = table->tb_indices[i];
+        if (ix == DKIX_EMPTY) {
+            // Unused slot
+            *res = NULL;
+            return ix;
+        }
+        if (ix >= 0) {
+            $entry_t entry = &TB_ENTRIES(table)[ix];
+            if (entry->value != NULL && (entry->key == key || (entry->hash == hash && hashwit->$class->__eq__(hashwit, key, entry->key)->val))) {
+                // found an entry with the same or equal key
+                *res = entry->value;
+                return ix;
+            }
+            // collision; probe another location
+        }
+        perturb >>= PERTURB_SHIFT;
+        i = (i * 5 + perturb + 1) & mask;
+        //printf("collision; perturb is %ld, hash is %ld, mask is %ld, next probe is %ld\n", perturb,  hash, mask, i);
     }
-    if (ix >= 0) {
-      $entry_t entry = &TB_ENTRIES(table)[ix];
-      if (entry->value != NULL && (entry->key == key || (entry->hash == hash && hashwit->$class->__eq__(hashwit,key,entry->key)->val))) {
-        // found an entry with the same or equal key
-        *res = entry->value;
-        return ix;
-      }
-      // collision; probe another location
-    }
-    perturb >>= PERTURB_SHIFT;
-    i = (i*5 + perturb + 1) & mask;
-    //printf("collision; perturb is %ld, hash is %ld, mask is %ld, next probe is %ld\n", perturb,  hash, mask, i);
-  }
-  // this should be unreachable
+    // this should be unreachable
 }
 
- //  Internal function to find slot in index array for an item from its hash
- //  when it is known that the key is not present in the dict.
-  
-static long find_empty_slot($table table, long hash) {
-  const unsigned long mask = (table->tb_size)-1;
+//  Internal function to find slot in index array for an item from its hash
+//  when it is known that the key is not present in the dict.
 
-  unsigned long i = (unsigned long)hash & mask;
-  int ix = table->tb_indices[i];
+static long find_empty_slot($table table, long hash) {
+    const unsigned long mask = (table->tb_size) - 1;
+
+    unsigned long i = (unsigned long)hash & mask;
+    int ix = table->tb_indices[i];
     for (unsigned long perturb = hash; ix >= 0;) {
         perturb >>= PERTURB_SHIFT;
-        i = (i*5 + perturb + 1) & mask;
+        i = (i * 5 + perturb + 1) & mask;
         ix = table->tb_indices[i];
     }
     return i;
 }
 
 static int insertdict($dict dict, $Hashable hashwit, long hash, $WORD key, $WORD value) {
-  $WORD old_value;
-  $table table;
-  $entry_t ep;
-  int ix = lookdict(dict,hashwit,hash,key,&old_value);
-  if (ix == DKIX_EMPTY) {
-    if (dict->table->tb_usable <= 0 && dictresize(dict) < 0)
-        return -1;
-    table = dict->table;
-    long hashpos = find_empty_slot(table,hash);
-    ep = &TB_ENTRIES(table)[table->tb_nentries];
-    table->tb_indices[hashpos] = table->tb_nentries;
-    ep->key = key;
-    ep->hash = hash;
-    ep->value = value;
-    table->tb_usable--;
-    table->tb_nentries++;
-    dict->numelements++;
+    $WORD old_value;
+    $table table;
+    $entry_t ep;
+    int ix = lookdict(dict, hashwit, hash, key, &old_value);
+    if (ix == DKIX_EMPTY) {
+        if (dict->table->tb_usable <= 0 && dictresize(dict) < 0)
+            return -1;
+        table = dict->table;
+        long hashpos = find_empty_slot(table, hash);
+        ep = &TB_ENTRIES(table)[table->tb_nentries];
+        table->tb_indices[hashpos] = table->tb_nentries;
+        ep->key = key;
+        ep->hash = hash;
+        ep->value = value;
+        table->tb_usable--;
+        table->tb_nentries++;
+        dict->numelements++;
+        return 0;
+    }
+    if (old_value != value) //eq ??
+        TB_ENTRIES(dict->table)
+        [ix].value = value;
     return 0;
-  }
-  if (old_value != value)  //eq ??
-    TB_ENTRIES(dict->table)[ix].value = value;
-  return 0;
 }
 // Iterable //////////////////////////////////////////////////////////////////////////////
- 
+
 static $WORD $Iterator$dict_next($Iterator$dict self) {
-  int i = self->nxt;
-  $table table = self->src->table;
-  int n = table->tb_nentries;
-  while (i < n) {
-    $entry_t entry =  &TB_ENTRIES(table)[i];
-    if (entry->value != NULL) {
-      self->nxt = i+1;
-      return entry->key;
+    int i = self->nxt;
+    $table table = self->src->table;
+    int n = table->tb_nentries;
+    while (i < n) {
+        $entry_t entry = &TB_ENTRIES(table)[i];
+        if (entry->value != NULL) {
+            self->nxt = i + 1;
+            return entry->key;
+        }
+        i++;
     }
-    i++;
-  }
-  return NULL;
+    return NULL;
 }
 
 $Iterator$dict $Iterator$dict$new($dict dict) {
-  return $NEW($Iterator$dict, dict);
-}
- 
-void $Iterator$dict_init($Iterator$dict self, $dict dict) {
-  self->src = dict;
-  self->nxt = 0;
+    return $NEW($Iterator$dict, dict);
 }
 
+void $Iterator$dict_init($Iterator$dict self, $dict dict) {
+    self->src = dict;
+    self->nxt = 0;
+}
 
 $bool $Iterator$dict_bool($Iterator$dict self) {
-  return $True;
+    return $True;
 }
 
 $str $Iterator$dict_str($Iterator$dict self) {
-  char *s;
-  asprintf(&s,"<dict keys iterator object at %p>",self);
-  return to$str(s);
+    char *s;
+    asprintf(&s, "<dict keys iterator object at %p>", self);
+    return to$str(s);
 }
 
 void $Iterator$dict_serialize($Iterator$dict self, $Serial$state state) {
-  $step_serialize(self->src,state);
-  $step_serialize(to$int(self->nxt),state);
+    $step_serialize(self->src, state);
+    $step_serialize(to$int(self->nxt), state);
 }
-
 
 $Iterator$dict $Iterator$dict$_deserialize($Iterator$dict res, $Serial$state state) {
-   if (!res)
-      res = $DNEW( $Iterator$dict,state);
-   res->src = ($dict)$step_deserialize(state);
-   res->nxt = from$int(($int)$step_deserialize(state));
-   return res;
+    if (!res)
+        res = $DNEW($Iterator$dict, state);
+    res->src = ($dict)$step_deserialize(state);
+    res->nxt = from$int(($int)$step_deserialize(state));
+    return res;
 }
 
-
-struct $Iterator$dict$class $Iterator$dict$methods = {"$Iterator$dict",UNASSIGNED,($Super$class)&$Iterator$methods, $Iterator$dict_init,
-                                                      $Iterator$dict_serialize, $Iterator$dict$_deserialize, $Iterator$dict_bool,$Iterator$dict_str, $Iterator$dict_next};
+struct $Iterator$dict$class $Iterator$dict$methods = {"$Iterator$dict", UNASSIGNED, ($Super$class)&$Iterator$methods, $Iterator$dict_init,
+                                                      $Iterator$dict_serialize, $Iterator$dict$_deserialize, $Iterator$dict_bool, $Iterator$dict_str, $Iterator$dict_next};
 
 $Iterator $dict_iter($dict dict) {
-  return ($Iterator)$NEW($Iterator$dict,dict);
+    return ($Iterator)$NEW($Iterator$dict, dict);
 }
 
 // Indexed ///////////////////////////////////////////////////////////////////////////////
 
 void $dict_setitem($dict dict, $Hashable hashwit, $WORD key, $WORD value) {
-  long hash = from$int(hashwit->$class->__hash__(hashwit,key));
-  if (insertdict(dict, hashwit, hash, key, value)<0) {
-    $RAISE(($BaseException)$NEW($IndexError,to$str("getitem: key not in dictionary")));
-  }      
+    long hash = from$int(hashwit->$class->__hash__(hashwit, key));
+    if (insertdict(dict, hashwit, hash, key, value) < 0) {
+        $RAISE(($BaseException)$NEW($IndexError, to$str("getitem: key not in dictionary")));
+    }
 }
 
 $WORD $dict_getitem($dict dict, $Hashable hashwit, $WORD key) {
-  long hash = from$int(hashwit->$class->__hash__(hashwit,key));
-  $WORD res;
-  int ix = lookdict(dict,hashwit,hash,key,&res);
-  if (ix < 0)  {
-    $RAISE(($BaseException)$NEW($IndexError,to$str("setitem: key not in dictionary")));
-  }      
-  return res;
+    long hash = from$int(hashwit->$class->__hash__(hashwit, key));
+    $WORD res;
+    int ix = lookdict(dict, hashwit, hash, key, &res);
+    if (ix < 0) {
+        $RAISE(($BaseException)$NEW($IndexError, to$str("setitem: key not in dictionary")));
+    }
+    return res;
 }
 
-
 void $dict_delitem($dict dict, $Hashable hashwit, $WORD key) {
-  long hash = from$int(hashwit->$class->__hash__(hashwit,key));
-  $WORD res;
-  int ix = lookdict(dict,hashwit,hash,key,&res);
-  $table table = dict->table;
-  if (ix >= 0) {
-    $entry_t entry = &TB_ENTRIES(table)[ix];
-    int i = lookdict_index(table,hash,ix);
-    table->tb_indices[i] = DKIX_DUMMY;
-    res = entry->value;
-    if (res == NULL) {
-      $RAISE(($BaseException)$NEW($IndexError,to$str("setitem: key not in dictionary")));
-    }
-    entry->value = NULL;
-    dict->numelements--;
-    if (10*dict->numelements < dict->table->tb_size) 
-      dictresize(dict);
+    long hash = from$int(hashwit->$class->__hash__(hashwit, key));
+    $WORD res;
+    int ix = lookdict(dict, hashwit, hash, key, &res);
+    $table table = dict->table;
+    if (ix >= 0) {
+        $entry_t entry = &TB_ENTRIES(table)[ix];
+        int i = lookdict_index(table, hash, ix);
+        table->tb_indices[i] = DKIX_DUMMY;
+        res = entry->value;
+        if (res == NULL) {
+            $RAISE(($BaseException)$NEW($IndexError, to$str("setitem: key not in dictionary")));
+        }
+        entry->value = NULL;
+        dict->numelements--;
+        if (10 * dict->numelements < dict->table->tb_size)
+            dictresize(dict);
     }
 }
 
 // Collection ///////////////////////////////////////////////////////////////////////////////
 
 $dict $dict_fromiter($Hashable hashwit, $Iterator it) {
-  $dict dict = $NEW($dict,hashwit,NULL,NULL);
-  dict->numelements = 0;
-  dict->table = malloc(sizeof(char*)+3*sizeof(long) + 8*sizeof(int) + 5*sizeof(struct $entry_struct));
-  dict->table->tb_size = 8;
-  dict->table->tb_usable = 5;
-  dict->table->tb_nentries = 0;
-  memset(&(dict->table->tb_indices[0]), 0xff, 8*sizeof(int));
-  $tuple nxt;
-  while((nxt = ($tuple)it->$class->__next__(it))) {
-    $dict_setitem(dict,hashwit,nxt->components[0],nxt->components[1]);
-  }
-  return dict;
+    $dict dict = $NEW($dict, hashwit, NULL, NULL);
+    dict->numelements = 0;
+    dict->table = malloc(sizeof(char *) + 3 * sizeof(long) + 8 * sizeof(int) + 5 * sizeof(struct $entry_struct));
+    dict->table->tb_size = 8;
+    dict->table->tb_usable = 5;
+    dict->table->tb_nentries = 0;
+    memset(&(dict->table->tb_indices[0]), 0xff, 8 * sizeof(int));
+    $tuple nxt;
+    while ((nxt = ($tuple)it->$class->__next__(it))) {
+        $dict_setitem(dict, hashwit, nxt->components[0], nxt->components[1]);
+    }
+    return dict;
 }
 
 long $dict_len($dict dict) {
-  return dict->numelements;
+    return dict->numelements;
 }
 
 // Container_Eq /////////////////////////////////////////////////////////////////////////////
 
 int $dict_contains($dict dict, $Hashable hashwit, $WORD key) {
-  $WORD res;
-  return lookdict(dict,hashwit,from$int(hashwit->$class->__hash__(hashwit,key)),key,&res) >= 0;
+    $WORD res;
+    return lookdict(dict, hashwit, from$int(hashwit->$class->__hash__(hashwit, key)), key, &res) >= 0;
 }
 
 // Mapping /////////////////////////////////////////////////////////////////////////////
@@ -436,166 +430,162 @@ int $dict_contains($dict dict, $Hashable hashwit, $WORD key) {
 // values iterator
 
 static $WORD $Iterator$dict$values_next($Iterator$dict$values self) {
-  int i = self->nxt;
-  $table table = self->src->table;
-  int n = table->tb_nentries;
-  while (i < n) {
-    $entry_t entry =  &TB_ENTRIES(table)[i];
-    if (entry->value != NULL) {
-      self->nxt = i+1;
-      return entry->value;
+    int i = self->nxt;
+    $table table = self->src->table;
+    int n = table->tb_nentries;
+    while (i < n) {
+        $entry_t entry = &TB_ENTRIES(table)[i];
+        if (entry->value != NULL) {
+            self->nxt = i + 1;
+            return entry->value;
+        }
+        i++;
     }
-    i++;
-  }
-  return NULL;
-}
- 
-$Iterator$dict$values $Iterator$dict$values$new($dict dict) {
-  return $NEW($Iterator$dict$values, dict);
-}
- 
-void $Iterator$dict$values_init($Iterator$dict$values self, $dict dict) {
-  self->src = dict;
-  self->nxt = 0;
+    return NULL;
 }
 
+$Iterator$dict$values $Iterator$dict$values$new($dict dict) {
+    return $NEW($Iterator$dict$values, dict);
+}
+
+void $Iterator$dict$values_init($Iterator$dict$values self, $dict dict) {
+    self->src = dict;
+    self->nxt = 0;
+}
 
 $bool $Iterator$dict$values_bool($Iterator$dict$values self) {
-  return $True;
+    return $True;
 }
 
 $str $Iterator$dict$values_str($Iterator$dict$values self) {
-  char *s;
-  asprintf(&s,"<dict values iterator object at %p>",self);
-  return to$str(s);
+    char *s;
+    asprintf(&s, "<dict values iterator object at %p>", self);
+    return to$str(s);
 }
 
 void $Iterator$dict$values_serialize($Iterator$dict$values self, $Serial$state state) {
-  $step_serialize(self->src,state);
-  $step_serialize(to$int(self->nxt),state);
+    $step_serialize(self->src, state);
+    $step_serialize(to$int(self->nxt), state);
 }
 
 $Iterator$dict$values $Iterator$dict$values_deserialize($Iterator$dict$values res, $Serial$state state) {
-   if (!res)
-      res = $DNEW($Iterator$dict$values,state);
-   res->src = ($dict)$step_deserialize(state);
-   res->nxt = from$int(($int)$step_deserialize(state));
-   return res;
+    if (!res)
+        res = $DNEW($Iterator$dict$values, state);
+    res->src = ($dict)$step_deserialize(state);
+    res->nxt = from$int(($int)$step_deserialize(state));
+    return res;
 }
 
-struct $Iterator$dict$values$class $Iterator$dict$values$methods = {"$Iterator$dict$values",UNASSIGNED,($Super$class)&$Iterator$methods, $Iterator$dict$values_init,
+struct $Iterator$dict$values$class $Iterator$dict$values$methods = {"$Iterator$dict$values", UNASSIGNED, ($Super$class)&$Iterator$methods, $Iterator$dict$values_init,
                                                                     $Iterator$dict$values_serialize, $Iterator$dict$values_deserialize, $Iterator$dict$values_bool, $Iterator$dict$values_str,
                                                                     $Iterator$dict$values_next};
 
 // items iterator
 
 static $WORD $Iterator$dict$items_next($Iterator$dict$items self) {
-  int i = self->nxt;
-  $table table = self->src->table;
-  int n = table->tb_nentries;
-  while (i < n) {
-    $entry_t entry =  &TB_ENTRIES(table)[i];
-    if (entry->value != NULL) {
-      self->nxt = i+1;
-      return $NEWTUPLE(2,entry->key,entry->value);
+    int i = self->nxt;
+    $table table = self->src->table;
+    int n = table->tb_nentries;
+    while (i < n) {
+        $entry_t entry = &TB_ENTRIES(table)[i];
+        if (entry->value != NULL) {
+            self->nxt = i + 1;
+            return $NEWTUPLE(2, entry->key, entry->value);
+        }
+        i++;
     }
-    i++;
-  }
-  return NULL;
-}
- 
-$Iterator$dict$items $Iterator$dict$items$new($dict dict) {
-  return $NEW($Iterator$dict$items, dict);
-}
- 
-void $Iterator$dict$items_init($Iterator$dict$items self, $dict dict) {
-  self->src = dict;
-  self->nxt = 0;
+    return NULL;
 }
 
+$Iterator$dict$items $Iterator$dict$items$new($dict dict) {
+    return $NEW($Iterator$dict$items, dict);
+}
+
+void $Iterator$dict$items_init($Iterator$dict$items self, $dict dict) {
+    self->src = dict;
+    self->nxt = 0;
+}
 
 $bool $Iterator$dict$items_bool($Iterator$dict$items self) {
-  return $True;
+    return $True;
 }
 
 $str $Iterator$dict$items_str($Iterator$dict$items self) {
-  char *s;
-  asprintf(&s,"<dict items iterator object at %p>",self);
-  return to$str(s);
+    char *s;
+    asprintf(&s, "<dict items iterator object at %p>", self);
+    return to$str(s);
 }
 
 void $Iterator$dict$items_serialize($Iterator$dict$items self, $Serial$state state) {
-  $step_serialize(self->src,state);
-  $step_serialize(to$int(self->nxt),state);
+    $step_serialize(self->src, state);
+    $step_serialize(to$int(self->nxt), state);
 }
 
 $Iterator$dict$items $Iterator$dict$items_deserialize($Iterator$dict$items res, $Serial$state state) {
-   if (!res)
-      res = $DNEW($Iterator$dict$items,state);
-   res->src = ($dict)$step_deserialize(state);
-   res->nxt = from$int(($int)$step_deserialize(state));
-   return res;
-}
-
-
-
-struct $Iterator$dict$items$class $Iterator$dict$items$methods = {"$Iterator$dict$items",UNASSIGNED,($Super$class)&$Iterator$methods, $Iterator$dict$items_init,
-                                                                  $Iterator$dict$items_serialize, $Iterator$dict$items_deserialize,$Iterator$dict$items_bool, $Iterator$dict$items_str, $Iterator$dict$items_next};
-
-
-$Iterator $dict_keys($dict dict) {
-  return ($Iterator)$NEW($Iterator$dict,dict);
-}
-
-$Iterator $dict_values($dict dict) {
-  return ($Iterator)$NEW($Iterator$dict$values, dict);
-}
-
-$Iterator $dict_items($dict dict) {
-  return  ($Iterator)$NEW($Iterator$dict$items, dict);
-}
- 
-$WORD $dict_get($dict dict, $Hashable hashwit, $WORD key, $WORD deflt) {
-  long hash = from$int(hashwit->$class->__hash__(hashwit,key));
-  $WORD res;
-  int ix = lookdict(dict,hashwit,hash,key,&res);
-  if (ix < 0) 
-    return deflt;
-  else
+    if (!res)
+        res = $DNEW($Iterator$dict$items, state);
+    res->src = ($dict)$step_deserialize(state);
+    res->nxt = from$int(($int)$step_deserialize(state));
     return res;
 }
 
-$tuple $dict_popitem($dict dict, $Hashable hashwit) {
-  $table table = dict->table;
-  int ix = table->tb_nentries-1;
-  while (ix >= 0) {
-    $entry_t entry =  &TB_ENTRIES(table)[ix];
-    if (entry->value != NULL) {
-      long hash = from$int(hashwit->$class->__hash__(hashwit,entry->key));
-      int i = lookdict_index(table,hash,ix);
-      table->tb_indices[i] = DKIX_DUMMY;
-      dict->numelements--;
-      table->tb_nentries = ix;
-      return $NEWTUPLE(2,entry->key,entry->value);
-    }
-    ix--;
-  }
-  return NULL;
+struct $Iterator$dict$items$class $Iterator$dict$items$methods = {"$Iterator$dict$items", UNASSIGNED, ($Super$class)&$Iterator$methods, $Iterator$dict$items_init,
+                                                                  $Iterator$dict$items_serialize, $Iterator$dict$items_deserialize, $Iterator$dict$items_bool, $Iterator$dict$items_str, $Iterator$dict$items_next};
+
+$Iterator $dict_keys($dict dict) {
+    return ($Iterator)$NEW($Iterator$dict, dict);
 }
 
-void $dict_update($dict dict,  $Hashable hashwit, $Iterator it) {
-  $tuple item;
-  while((item = ($tuple)it->$class->__next__(it)))
-    $dict_setitem(dict,hashwit,item->components[0],item->components[1]);
+$Iterator $dict_values($dict dict) {
+    return ($Iterator)$NEW($Iterator$dict$values, dict);
+}
+
+$Iterator $dict_items($dict dict) {
+    return ($Iterator)$NEW($Iterator$dict$items, dict);
+}
+
+$WORD $dict_get($dict dict, $Hashable hashwit, $WORD key, $WORD deflt) {
+    long hash = from$int(hashwit->$class->__hash__(hashwit, key));
+    $WORD res;
+    int ix = lookdict(dict, hashwit, hash, key, &res);
+    if (ix < 0)
+        return deflt;
+    else
+        return res;
+}
+
+$tuple $dict_popitem($dict dict, $Hashable hashwit) {
+    $table table = dict->table;
+    int ix = table->tb_nentries - 1;
+    while (ix >= 0) {
+        $entry_t entry = &TB_ENTRIES(table)[ix];
+        if (entry->value != NULL) {
+            long hash = from$int(hashwit->$class->__hash__(hashwit, entry->key));
+            int i = lookdict_index(table, hash, ix);
+            table->tb_indices[i] = DKIX_DUMMY;
+            dict->numelements--;
+            table->tb_nentries = ix;
+            return $NEWTUPLE(2, entry->key, entry->value);
+        }
+        ix--;
+    }
+    return NULL;
+}
+
+void $dict_update($dict dict, $Hashable hashwit, $Iterator it) {
+    $tuple item;
+    while ((item = ($tuple)it->$class->__next__(it)))
+        $dict_setitem(dict, hashwit, item->components[0], item->components[1]);
 }
 
 $WORD $dict_setdefault($dict dict, $Hashable hashwit, $WORD key, $WORD deflt) {
-  // if (!deflt) deflt = void; what is the name of void here?...
-  long hash = from$int(hashwit->$class->__hash__(hashwit,key));
-  $WORD value;
-  int ix = lookdict(dict,hashwit,hash,key,&value);
-  if (ix >= 0)
-    return value;
-  TB_ENTRIES(dict->table)[ix].value = deflt;
-  return deflt;
+    // if (!deflt) deflt = void; what is the name of void here?...
+    long hash = from$int(hashwit->$class->__hash__(hashwit, key));
+    $WORD value;
+    int ix = lookdict(dict, hashwit, hash, key, &value);
+    if (ix >= 0)
+        return value;
+    TB_ENTRIES(dict->table)
+    [ix].value = deflt;
+    return deflt;
 }

--- a/builtin/exceptions.c
+++ b/builtin/exceptions.c
@@ -13,416 +13,415 @@
  */
 
 $BaseException $BaseException$new($str error_message) {
-  return $NEW($BaseException, error_message);
+    return $NEW($BaseException, error_message);
 }
 
 void $BaseException$__init__($BaseException self, $str error_message) {
-  self->error_message = error_message;
+    self->error_message = error_message;
 };
 
 $bool $BaseException$__bool__($BaseException self) {
-  return $True;
+    return $True;
 }
 
 $str $BaseException$__str__($BaseException self) {
-  char *s;
-  asprintf(&s,"BaseException:  %s>",from$str(self->error_message));
-  return to$str(s);
+    char *s;
+    asprintf(&s, "BaseException:  %s>", from$str(self->error_message));
+    return to$str(s);
 }
 
 void $BaseException$__serialize__($BaseException self, $Serial$state state) {
-    $step_serialize(self->error_message,state);
+    $step_serialize(self->error_message, state);
 };
 
 $BaseException $BaseException$__deserialize__($BaseException self, $Serial$state state) {
-  $BaseException res = $DNEW($BaseException,state);
-  res->error_message = $step_deserialize(state);
-  return res;
+    $BaseException res = $DNEW($BaseException, state);
+    res->error_message = $step_deserialize(state);
+    return res;
 };
 
-struct $BaseException$class $BaseException$methods = {"$BaseException",UNASSIGNED,NULL,$BaseException$__init__,
-                                                      $BaseException$__serialize__,$BaseException$__deserialize__,$BaseException$__bool__,$BaseException$__str__};
+struct $BaseException$class $BaseException$methods = {"$BaseException", UNASSIGNED, NULL, $BaseException$__init__,
+                                                      $BaseException$__serialize__, $BaseException$__deserialize__, $BaseException$__bool__, $BaseException$__str__};
 //////////////////////////////////////////////////////////////////////////////////////////////
 
 $SystemExit $SystemExit$new($str error_message) {
-  return $NEW($SystemExit, error_message);
+    return $NEW($SystemExit, error_message);
 }
 
-
 void $SystemExit$__init__($SystemExit self, $str error_message) {
-  self->error_message = error_message;
+    self->error_message = error_message;
 };
 
 $bool $SystemExit$__bool__($SystemExit self) {
-  return $True;
+    return $True;
 }
 
 $str $SystemExit$__str__($SystemExit self) {
-  char *s;
-  asprintf(&s,"SystemExit:  %s>",from$str(self->error_message));
-  return to$str(s);
+    char *s;
+    asprintf(&s, "SystemExit:  %s>", from$str(self->error_message));
+    return to$str(s);
 }
 
 void $SystemExit$__serialize__($SystemExit self, $Serial$state state) {
-    $step_serialize(self->error_message,state);
+    $step_serialize(self->error_message, state);
 };
 
 $SystemExit $SystemExit$__deserialize__($SystemExit self, $Serial$state state) {
-  $SystemExit res = $DNEW($SystemExit,state);
-  res->error_message = $step_deserialize(state);
-  return res;
+    $SystemExit res = $DNEW($SystemExit, state);
+    res->error_message = $step_deserialize(state);
+    return res;
 };
 
-struct $SystemExit$class $SystemExit$methods = {"$SystemExit",UNASSIGNED,($Super$class)&$BaseException$methods,$SystemExit$__init__,
-                                               $SystemExit$__serialize__,$SystemExit$__deserialize__,$SystemExit$__bool__,$SystemExit$__str__};
+struct $SystemExit$class $SystemExit$methods = {"$SystemExit", UNASSIGNED, ($Super$class)&$BaseException$methods, $SystemExit$__init__,
+                                                $SystemExit$__serialize__, $SystemExit$__deserialize__, $SystemExit$__bool__, $SystemExit$__str__};
 //////////////////////////////////////////////////////////////////////////////////////////////
 
 $KeyboardInterrupt $KeyboardInterrupt$new($str error_message) {
-  return $NEW($KeyboardInterrupt, error_message);
+    return $NEW($KeyboardInterrupt, error_message);
 }
 
 void $KeyboardInterrupt$__init__($KeyboardInterrupt self, $str error_message) {
-  self->error_message = error_message;
+    self->error_message = error_message;
 };
 
 $bool $KeyboardInterrupt$__bool__($KeyboardInterrupt self) {
-  return $True;
+    return $True;
 }
 
 $str $KeyboardInterrupt$__str__($KeyboardInterrupt self) {
-  char *s;
-  asprintf(&s,"KeyboardInterrupt:  %s>",from$str(self->error_message));
-  return to$str(s);
+    char *s;
+    asprintf(&s, "KeyboardInterrupt:  %s>", from$str(self->error_message));
+    return to$str(s);
 }
 
-void $KeyboardInterrupt$__serialize__($KeyboardInterrupt self,$Serial$state state) {
-    $step_serialize(self->error_message,state);
+void $KeyboardInterrupt$__serialize__($KeyboardInterrupt self, $Serial$state state) {
+    $step_serialize(self->error_message, state);
 };
 
 $KeyboardInterrupt $KeyboardInterrupt$__deserialize__($KeyboardInterrupt self, $Serial$state state) {
-  $KeyboardInterrupt res = $DNEW($KeyboardInterrupt,state);
-  res->error_message = $step_deserialize(state);
-  return res;
+    $KeyboardInterrupt res = $DNEW($KeyboardInterrupt, state);
+    res->error_message = $step_deserialize(state);
+    return res;
 };
 
-struct $KeyboardInterrupt$class $KeyboardInterrupt$methods = {"$KeyboardInterrupt",UNASSIGNED,($Super$class)&$BaseException$methods,$KeyboardInterrupt$__init__,
-                                                              $KeyboardInterrupt$__serialize__,$KeyboardInterrupt$__deserialize__,$KeyboardInterrupt$__bool__,$KeyboardInterrupt$__str__};
+struct $KeyboardInterrupt$class $KeyboardInterrupt$methods = {"$KeyboardInterrupt", UNASSIGNED, ($Super$class)&$BaseException$methods, $KeyboardInterrupt$__init__,
+                                                              $KeyboardInterrupt$__serialize__, $KeyboardInterrupt$__deserialize__, $KeyboardInterrupt$__bool__, $KeyboardInterrupt$__str__};
 //////////////////////////////////////////////////////////////////////////////////////////////
 
 $Exception $Exception$new($str error_message) {
-  return $NEW($Exception, error_message);
+    return $NEW($Exception, error_message);
 }
 
 void $Exception$__init__($Exception self, $str error_message) {
-  self->error_message = error_message;
+    self->error_message = error_message;
 };
 
 $bool $Exception$__bool__($Exception self) {
-  return $True;
+    return $True;
 }
 
 $str $Exception$__str__($Exception self) {
-  char *s;
-  asprintf(&s,"Exception:  %s>",from$str(self->error_message));
-  return to$str(s);
+    char *s;
+    asprintf(&s, "Exception:  %s>", from$str(self->error_message));
+    return to$str(s);
 }
 
-void $Exception$__serialize__($Exception self,$Serial$state state) {
-    $step_serialize(self->error_message,state);
+void $Exception$__serialize__($Exception self, $Serial$state state) {
+    $step_serialize(self->error_message, state);
 };
 
 $Exception $Exception$__deserialize__($Exception self, $Serial$state state) {
-  $Exception res = $DNEW($Exception,state);
-  res->error_message = $step_deserialize(state);
-  return res;
+    $Exception res = $DNEW($Exception, state);
+    res->error_message = $step_deserialize(state);
+    return res;
 };
 
-struct $Exception$class $Exception$methods = {"$Exception",UNASSIGNED,($Super$class)&$BaseException$methods,$Exception$__init__,
-                                              $Exception$__serialize__,$Exception$__deserialize__,$Exception$__bool__, $Exception$__str__};
+struct $Exception$class $Exception$methods = {"$Exception", UNASSIGNED, ($Super$class)&$BaseException$methods, $Exception$__init__,
+                                              $Exception$__serialize__, $Exception$__deserialize__, $Exception$__bool__, $Exception$__str__};
 //////////////////////////////////////////////////////////////////////////////////////////////
 
 $AssertionError $AssertionError$new($str error_message) {
-  return $NEW($AssertionError, error_message);
+    return $NEW($AssertionError, error_message);
 }
 
 void $AssertionError$__init__($AssertionError self, $str error_message) {
-  self->error_message = error_message;
+    self->error_message = error_message;
 };
 
 $bool $AssertionError$__bool__($AssertionError self) {
-  return $True;
+    return $True;
 }
 
 $str $AssertionError$__str__($AssertionError self) {
-  char *s;
-  asprintf(&s,"AssertionError:  %s>",from$str(self->error_message));
-  return to$str(s);
+    char *s;
+    asprintf(&s, "AssertionError:  %s>", from$str(self->error_message));
+    return to$str(s);
 }
 
 void $AssertionError$__serialize__($AssertionError self, $Serial$state state) {
-    $step_serialize(self->error_message,state);
+    $step_serialize(self->error_message, state);
 };
 
 $AssertionError $AssertionError$__deserialize__($AssertionError self, $Serial$state state) {
-  $AssertionError res = $DNEW($AssertionError,state);
-  res->error_message = $step_deserialize(state);
-  return res;
+    $AssertionError res = $DNEW($AssertionError, state);
+    res->error_message = $step_deserialize(state);
+    return res;
 };
 
-struct $AssertionError$class $AssertionError$methods = {"$AssertionError",UNASSIGNED,($Super$class)&$Exception$methods,$AssertionError$__init__,
-                                                        $AssertionError$__serialize__,$AssertionError$__deserialize__,$AssertionError$__bool__,$AssertionError$__str__};
+struct $AssertionError$class $AssertionError$methods = {"$AssertionError", UNASSIGNED, ($Super$class)&$Exception$methods, $AssertionError$__init__,
+                                                        $AssertionError$__serialize__, $AssertionError$__deserialize__, $AssertionError$__bool__, $AssertionError$__str__};
 //////////////////////////////////////////////////////////////////////////////////////////////
 
 $LookupError $LookupError$new($str error_message) {
-  return $NEW($LookupError, error_message);
+    return $NEW($LookupError, error_message);
 }
 
 void $LookupError$__init__($LookupError self, $str error_message) {
-  self->error_message = error_message;
+    self->error_message = error_message;
 };
 
 $bool $LookupError$__bool__($LookupError self) {
-  return $True;
+    return $True;
 }
 
 $str $LookupError$__str__($LookupError self) {
-  char *s;
-  asprintf(&s,"LookupError:  %s>",from$str(self->error_message));
-  return to$str(s);
+    char *s;
+    asprintf(&s, "LookupError:  %s>", from$str(self->error_message));
+    return to$str(s);
 }
 
-void $LookupError$__serialize__($LookupError self,$Serial$state state) {
-    $step_serialize(self->error_message,state);
+void $LookupError$__serialize__($LookupError self, $Serial$state state) {
+    $step_serialize(self->error_message, state);
 };
 
-$LookupError $LookupError$__deserialize__($LookupError self,$Serial$state state) {
-  $LookupError res = $DNEW($LookupError,state);
-  res->error_message = $step_deserialize(state);
-  return res;
+$LookupError $LookupError$__deserialize__($LookupError self, $Serial$state state) {
+    $LookupError res = $DNEW($LookupError, state);
+    res->error_message = $step_deserialize(state);
+    return res;
 };
 
-struct $LookupError$class $LookupError$methods = {"$LookupError",UNASSIGNED,($Super$class)&$Exception$methods,$LookupError$__init__,
-                                                  $LookupError$__serialize__,$LookupError$__deserialize__,$LookupError$__bool__,$LookupError$__str__};
+struct $LookupError$class $LookupError$methods = {"$LookupError", UNASSIGNED, ($Super$class)&$Exception$methods, $LookupError$__init__,
+                                                  $LookupError$__serialize__, $LookupError$__deserialize__, $LookupError$__bool__, $LookupError$__str__};
 //////////////////////////////////////////////////////////////////////////////////////////////
 
 $IndexError $IndexError$new($str error_message) {
-  return $NEW($IndexError, error_message);
+    return $NEW($IndexError, error_message);
 }
 
 void $IndexError$__init__($IndexError self, $str error_message) {
-  self->error_message = error_message;
+    self->error_message = error_message;
 };
 
 $bool $IndexError$__bool__($IndexError self) {
-  return $True;
+    return $True;
 }
 
 $str $IndexError$__str__($IndexError self) {
-  char *s;
-  asprintf(&s,"IndexError:  %s>",from$str(self->error_message));
-  return to$str(s);
+    char *s;
+    asprintf(&s, "IndexError:  %s>", from$str(self->error_message));
+    return to$str(s);
 }
 
 void $IndexError$__serialize__($IndexError self, $Serial$state state) {
-    $step_serialize(self->error_message,state);
+    $step_serialize(self->error_message, state);
 };
 
 $IndexError $IndexError$__deserialize__($IndexError self, $Serial$state state) {
-  $IndexError res = $DNEW($IndexError,state);
-  res->error_message = $step_deserialize(state);
-  return res;
+    $IndexError res = $DNEW($IndexError, state);
+    res->error_message = $step_deserialize(state);
+    return res;
 };
 
-struct $IndexError$class $IndexError$methods = {"$IndexError",UNASSIGNED,($Super$class)&$LookupError$methods,$IndexError$__init__,$IndexError$__serialize__,$IndexError$__deserialize__,$IndexError$__bool__,$IndexError$__str__};
+struct $IndexError$class $IndexError$methods = {"$IndexError", UNASSIGNED, ($Super$class)&$LookupError$methods, $IndexError$__init__, $IndexError$__serialize__, $IndexError$__deserialize__, $IndexError$__bool__, $IndexError$__str__};
 //////////////////////////////////////////////////////////////////////////////////////////////
 
 $KeyError $KeyError$new($str error_message) {
-  return $NEW($KeyError, error_message);
+    return $NEW($KeyError, error_message);
 }
 
 void $KeyError$__init__($KeyError self, $str error_message) {
-  self->error_message = error_message;
+    self->error_message = error_message;
 };
 
 $bool $KeyError$__bool__($KeyError self) {
-  return $True;
+    return $True;
 }
 
 $str $KeyError$__str__($KeyError self) {
-  char *s;
-  asprintf(&s,"KeyError:  %s>",from$str(self->error_message));
-  return to$str(s);
+    char *s;
+    asprintf(&s, "KeyError:  %s>", from$str(self->error_message));
+    return to$str(s);
 }
 
 void $KeyError$__serialize__($KeyError self, $Serial$state state) {
-    $step_serialize(self->error_message,state);
+    $step_serialize(self->error_message, state);
 };
 
 $KeyError $KeyError$__deserialize__($KeyError self, $Serial$state state) {
-  $KeyError res = $DNEW($KeyError,state);
-  res->error_message = $step_deserialize(state);
-  return res;
+    $KeyError res = $DNEW($KeyError, state);
+    res->error_message = $step_deserialize(state);
+    return res;
 };
 
-struct $KeyError$class $KeyError$methods = {"$KeyError",UNASSIGNED,($Super$class)&$LookupError$methods,$KeyError$__init__,
-                                            $KeyError$__serialize__,$KeyError$__deserialize__,$KeyError$__bool__,$KeyError$__str__};
+struct $KeyError$class $KeyError$methods = {"$KeyError", UNASSIGNED, ($Super$class)&$LookupError$methods, $KeyError$__init__,
+                                            $KeyError$__serialize__, $KeyError$__deserialize__, $KeyError$__bool__, $KeyError$__str__};
 //////////////////////////////////////////////////////////////////////////////////////////////
 
 $MemoryError $MemoryError$new($str error_message) {
-  return $NEW($MemoryError, error_message);
+    return $NEW($MemoryError, error_message);
 }
 
 void $MemoryError$__init__($MemoryError self, $str error_message) {
-  self->error_message = error_message;
+    self->error_message = error_message;
 };
 
 $bool $MemoryError$__bool__($MemoryError self) {
-  return $True;
+    return $True;
 }
 
 $str $MemoryError$__str__($MemoryError self) {
-  char *s;
-  asprintf(&s,"MemoryError:  %s>",from$str(self->error_message));
-  return to$str(s);
+    char *s;
+    asprintf(&s, "MemoryError:  %s>", from$str(self->error_message));
+    return to$str(s);
 }
 
 void $MemoryError$__serialize__($MemoryError self, $Serial$state state) {
-    $add_header(MEMORYERROR_ID,0,state);
-    $step_serialize(self->error_message,state);
+    $add_header(MEMORYERROR_ID, 0, state);
+    $step_serialize(self->error_message, state);
 };
 
 $MemoryError $MemoryError$__deserialize__($MemoryError self, $Serial$state state) {
-  $MemoryError res = $DNEW($MemoryError,state);
-  res->error_message = $step_deserialize(state);
-  return res;
+    $MemoryError res = $DNEW($MemoryError, state);
+    res->error_message = $step_deserialize(state);
+    return res;
 };
 
-struct $MemoryError$class $MemoryError$methods = {"$MemoryError",UNASSIGNED,($Super$class)&$Exception$methods,$MemoryError$__init__,$MemoryError$__serialize__,$MemoryError$__deserialize__,$MemoryError$__bool__,$MemoryError$__str__};
+struct $MemoryError$class $MemoryError$methods = {"$MemoryError", UNASSIGNED, ($Super$class)&$Exception$methods, $MemoryError$__init__, $MemoryError$__serialize__, $MemoryError$__deserialize__, $MemoryError$__bool__, $MemoryError$__str__};
 //////////////////////////////////////////////////////////////////////////////////////////////
 
 $OSError $OSError$new($str error_message) {
-  return $NEW($OSError, error_message);
+    return $NEW($OSError, error_message);
 }
 
 void $OSError$__init__($OSError self, $str error_message) {
-  self->error_message = error_message;
+    self->error_message = error_message;
 };
 
 $bool $OSError$__bool__($OSError self) {
-  return $True;
+    return $True;
 }
 
 $str $OSError$__str__($OSError self) {
-  char *s;
-  asprintf(&s,"OSError:  %s>",from$str(self->error_message));
-  return to$str(s);
+    char *s;
+    asprintf(&s, "OSError:  %s>", from$str(self->error_message));
+    return to$str(s);
 }
 
 void $OSError$__serialize__($OSError self, $Serial$state state) {
-    $step_serialize(self->error_message,state);
+    $step_serialize(self->error_message, state);
 };
 
 $OSError $OSError$__deserialize__($OSError self, $Serial$state state) {
-  $OSError res = $DNEW($OSError,state);
-  res->error_message = $step_deserialize(state);
-  return res;
+    $OSError res = $DNEW($OSError, state);
+    res->error_message = $step_deserialize(state);
+    return res;
 };
 
-struct $OSError$class $OSError$methods = {"$OSError",UNASSIGNED,($Super$class)&$Exception$methods,$OSError$__init__,
-                                          $OSError$__serialize__,$OSError$__deserialize__,$OSError$__bool__,$OSError$__str__};
+struct $OSError$class $OSError$methods = {"$OSError", UNASSIGNED, ($Super$class)&$Exception$methods, $OSError$__init__,
+                                          $OSError$__serialize__, $OSError$__deserialize__, $OSError$__bool__, $OSError$__str__};
 //////////////////////////////////////////////////////////////////////////////////////////////
 $RuntimeError $RuntimeError$new($str error_message) {
     return $NEW($RuntimeError, error_message);
 }
 
 void $RuntimeError$__init__($RuntimeError self, $str error_message) {
-  self->error_message = error_message;
+    self->error_message = error_message;
 };
 
 $bool $RuntimeError$__bool__($RuntimeError self) {
-  return $True;
+    return $True;
 }
 
 $str $RuntimeError$__str__($RuntimeError self) {
-  char *s;
-  asprintf(&s,"RuntimeError:  %s>",from$str(self->error_message));
-  return to$str(s);
+    char *s;
+    asprintf(&s, "RuntimeError:  %s>", from$str(self->error_message));
+    return to$str(s);
 }
 
 void $RuntimeError$__serialize__($RuntimeError self, $Serial$state state) {
-    $step_serialize(self->error_message,state);
+    $step_serialize(self->error_message, state);
 };
 
 $RuntimeError $RuntimeError$__deserialize__($RuntimeError self, $Serial$state state) {
-  $RuntimeError res = $DNEW($RuntimeError,state);
-  res->error_message = $step_deserialize(state);
-  return res;
+    $RuntimeError res = $DNEW($RuntimeError, state);
+    res->error_message = $step_deserialize(state);
+    return res;
 };
 
-struct $RuntimeError$class $RuntimeError$methods = {"$RuntimeError",UNASSIGNED,($Super$class)&$Exception$methods,$RuntimeError$__init__,$RuntimeError$__serialize__,$RuntimeError$__deserialize__,$RuntimeError$__bool__,$RuntimeError$__str__};
+struct $RuntimeError$class $RuntimeError$methods = {"$RuntimeError", UNASSIGNED, ($Super$class)&$Exception$methods, $RuntimeError$__init__, $RuntimeError$__serialize__, $RuntimeError$__deserialize__, $RuntimeError$__bool__, $RuntimeError$__str__};
 //////////////////////////////////////////////////////////////////////////////////////////////
 void $NotImplementedError$__init__($NotImplementedError self, $str error_message) {
-  self->error_message = error_message;
+    self->error_message = error_message;
 };
 
 $bool $NotImplementedError$__bool__($NotImplementedError self) {
-  return $True;
+    return $True;
 }
 
 $str $NotImplementedError$__str__($NotImplementedError self) {
-  char *s;
-  asprintf(&s,"NotImplementedError:  %s>",from$str(self->error_message));
-  return to$str(s);
+    char *s;
+    asprintf(&s, "NotImplementedError:  %s>", from$str(self->error_message));
+    return to$str(s);
 }
 
 void $NotImplementedError$__serialize__($NotImplementedError self, $Serial$state state) {
-    $add_header(NOTIMPLEMENTEDERROR_ID,0,state);
-    $step_serialize(self->error_message,state);
+    $add_header(NOTIMPLEMENTEDERROR_ID, 0, state);
+    $step_serialize(self->error_message, state);
 };
 
 $NotImplementedError $NotImplementedError$__deserialize__($NotImplementedError self, $Serial$state state) {
-  $NotImplementedError res = $DNEW($NotImplementedError,state);
-  res->error_message = $step_deserialize(state);
-  return res;
+    $NotImplementedError res = $DNEW($NotImplementedError, state);
+    res->error_message = $step_deserialize(state);
+    return res;
 };
 
-struct $NotImplementedError$class $NotImplementedError$methods = {"$NotImplementedError",UNASSIGNED,($Super$class)&$RuntimeError$methods,$NotImplementedError$__init__,$NotImplementedError$__serialize__,
-                                                                 $NotImplementedError$__deserialize__,$NotImplementedError$__bool__,$NotImplementedError$__str__};
+struct $NotImplementedError$class $NotImplementedError$methods = {"$NotImplementedError", UNASSIGNED, ($Super$class)&$RuntimeError$methods, $NotImplementedError$__init__, $NotImplementedError$__serialize__,
+                                                                  $NotImplementedError$__deserialize__, $NotImplementedError$__bool__, $NotImplementedError$__str__};
 //////////////////////////////////////////////////////////////////////////////////////////////
 
 $ValueError $ValueError$new($str error_message) {
-  return $NEW($ValueError, error_message);
+    return $NEW($ValueError, error_message);
 }
 
 void $ValueError$__init__($ValueError self, $str error_message) {
-  self->error_message = error_message;
+    self->error_message = error_message;
 };
 
 $bool $ValueError$__bool__($ValueError self) {
-  return $True;
+    return $True;
 }
 
 $str $ValueError$__str__($ValueError self) {
-  char *s;
-  asprintf(&s,"ValueError:  %s>",from$str(self->error_message));
-  return to$str(s);
+    char *s;
+    asprintf(&s, "ValueError:  %s>", from$str(self->error_message));
+    return to$str(s);
 }
 
-void $ValueError$__serialize__($ValueError self,$Serial$state state) {
-    $add_header(VALUEERROR_ID,0,state);
-    $step_serialize(self->error_message,state);
+void $ValueError$__serialize__($ValueError self, $Serial$state state) {
+    $add_header(VALUEERROR_ID, 0, state);
+    $step_serialize(self->error_message, state);
 };
 
-$ValueError $ValueError$__deserialize__($ValueError self,$Serial$state state) {
-  $ValueError res = $DNEW($ValueError,state);
-  res->error_message = $step_deserialize(state);
-  return res;
+$ValueError $ValueError$__deserialize__($ValueError self, $Serial$state state) {
+    $ValueError res = $DNEW($ValueError, state);
+    res->error_message = $step_deserialize(state);
+    return res;
 };
 
-struct $ValueError$class $ValueError$methods = {"$ValueError",UNASSIGNED,($Super$class)&$Exception$methods,$ValueError$__init__,$ValueError$__serialize__,$ValueError$__deserialize__,$ValueError$__bool__,$ValueError$__str__};
+struct $ValueError$class $ValueError$methods = {"$ValueError", UNASSIGNED, ($Super$class)&$Exception$methods, $ValueError$__init__, $ValueError$__serialize__, $ValueError$__deserialize__, $ValueError$__bool__, $ValueError$__str__};
 //////////////////////////////////////////////////////////////////////////////////////////////
 
 void $RAISE($BaseException e) {
-  fprintf(stderr,"%s\n",(char*)from$str(e->error_message));
-  exit(1);
+    fprintf(stderr, "%s\n", (char *)from$str(e->error_message));
+    exit(1);
 }

--- a/builtin/exceptions.h
+++ b/builtin/exceptions.h
@@ -1,271 +1,271 @@
 struct $BaseException$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)($BaseException,$str);
-  void (*__serialize__)($BaseException, $Serial$state);
-  $BaseException (*__deserialize__)($BaseException, $Serial$state);
-  $bool (*__bool__)($BaseException);
-  $str (*__str__)($BaseException);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)($BaseException, $str);
+    void (*__serialize__)($BaseException, $Serial$state);
+    $BaseException (*__deserialize__)($BaseException, $Serial$state);
+    $bool (*__bool__)($BaseException);
+    $str (*__str__)($BaseException);
 };
 
 typedef struct $BaseException *$BaseException;
 
 struct $BaseException {
-  struct $BaseException$class *$class;
-  $str error_message;
+    struct $BaseException$class *$class;
+    $str error_message;
 };
 
 extern struct $BaseException$class $BaseException$methods;
 $BaseException $BaseException$new($str);
 ////////////////////////////////////////////////////////////////////////////////////////
 struct $SystemExit$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)($SystemExit,$str);
-  void (*__serialize__)($SystemExit,$Serial$state);
-  $SystemExit (*__deserialize__)($SystemExit,$Serial$state);
-  $bool (*__bool__)($SystemExit);
-  $str (*__str__)($SystemExit);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)($SystemExit, $str);
+    void (*__serialize__)($SystemExit, $Serial$state);
+    $SystemExit (*__deserialize__)($SystemExit, $Serial$state);
+    $bool (*__bool__)($SystemExit);
+    $str (*__str__)($SystemExit);
 };
 
 typedef struct $SystemExit *$SystemExit;
 
 struct $SystemExit {
-  struct $SystemExit$class *$class;
-  $str error_message;
+    struct $SystemExit$class *$class;
+    $str error_message;
 };
 
 extern struct $SystemExit$class $SystemExit$methods;
 $SystemExit $SystemExit$new($str);
 ////////////////////////////////////////////////////////////////////////////////////////
 struct $KeyboardInterrupt$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)($KeyboardInterrupt,$str);
-  void (*__serialize__)($KeyboardInterrupt,$Serial$state);
-  $KeyboardInterrupt (*__deserialize__)($KeyboardInterrupt,$Serial$state);
-  $bool (*__bool__)($KeyboardInterrupt);
-  $str (*__str__)($KeyboardInterrupt);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)($KeyboardInterrupt, $str);
+    void (*__serialize__)($KeyboardInterrupt, $Serial$state);
+    $KeyboardInterrupt (*__deserialize__)($KeyboardInterrupt, $Serial$state);
+    $bool (*__bool__)($KeyboardInterrupt);
+    $str (*__str__)($KeyboardInterrupt);
 };
 
 typedef struct $KeyboardInterrupt *$KeyboardInterrupt;
 
 struct $KeyboardInterrupt {
-  struct $KeyboardInterrupt$class *$class;
-  $str error_message;
+    struct $KeyboardInterrupt$class *$class;
+    $str error_message;
 };
 
 extern struct $KeyboardInterrupt$class $KeyboardInterrupt$methods;
 $KeyboardInterrupt $KeyboardInterrupt$new($str);
 ////////////////////////////////////////////////////////////////////////////////////////
 struct $Exception$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)($Exception,$str);
-  void (*__serialize__)($Exception,$Serial$state);
-  $Exception (*__deserialize__)($Exception,$Serial$state);
-  $bool (*__bool__)($Exception);
-  $str (*__str__)($Exception);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)($Exception, $str);
+    void (*__serialize__)($Exception, $Serial$state);
+    $Exception (*__deserialize__)($Exception, $Serial$state);
+    $bool (*__bool__)($Exception);
+    $str (*__str__)($Exception);
 };
 
 typedef struct $Exception *$Exception;
 
 struct $Exception {
-  struct $Exception$class *$class;
-  $str error_message;
+    struct $Exception$class *$class;
+    $str error_message;
 };
 
 extern struct $Exception$class $Exception$methods;
 $Exception $Exception$new($str);
 ////////////////////////////////////////////////////////////////////////////////////////
 struct $AssertionError$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)($AssertionError,$str);
-  void (*__serialize__)($AssertionError,$Serial$state);
-  $AssertionError (*__deserialize__)($AssertionError,$Serial$state);
-  $bool (*__bool__)($AssertionError);
-  $str (*__str__)($AssertionError);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)($AssertionError, $str);
+    void (*__serialize__)($AssertionError, $Serial$state);
+    $AssertionError (*__deserialize__)($AssertionError, $Serial$state);
+    $bool (*__bool__)($AssertionError);
+    $str (*__str__)($AssertionError);
 };
 
 typedef struct $AssertionError *$AssertionError;
 
 struct $AssertionError {
-  struct $AssertionError$class *$class;
-  $str error_message;
+    struct $AssertionError$class *$class;
+    $str error_message;
 };
 
 extern struct $AssertionError$class $AssertionError$methods;
 $AssertionError $AssertionError$new($str);
 ////////////////////////////////////////////////////////////////////////////////////////
 struct $LookupError$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)($LookupError,$str);
-  void (*__serialize__)($LookupError,$Serial$state);
-  $LookupError (*__deserialize__)($LookupError,$Serial$state);
-  $bool (*__bool__)($LookupError);
-  $str (*__str__)($LookupError);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)($LookupError, $str);
+    void (*__serialize__)($LookupError, $Serial$state);
+    $LookupError (*__deserialize__)($LookupError, $Serial$state);
+    $bool (*__bool__)($LookupError);
+    $str (*__str__)($LookupError);
 };
 
 typedef struct $LookupError *$LookupError;
 
 struct $LookupError {
-  struct $LookupError$class *$class;
-  $str error_message;
+    struct $LookupError$class *$class;
+    $str error_message;
 };
 
 extern struct $LookupError$class $LookupError$methods;
 $LookupError $LookupError$new($str);
 ////////////////////////////////////////////////////////////////////////////////////////
 struct $IndexError$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)($IndexError,$str);
-  void (*__serialize__)($IndexError, $Serial$state);
-  $IndexError (*__deserialize__)($IndexError, $Serial$state);
-  $bool (*__bool__)($IndexError);
-  $str (*__str__)($IndexError);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)($IndexError, $str);
+    void (*__serialize__)($IndexError, $Serial$state);
+    $IndexError (*__deserialize__)($IndexError, $Serial$state);
+    $bool (*__bool__)($IndexError);
+    $str (*__str__)($IndexError);
 };
 
 typedef struct $IndexError *$IndexError;
 
 struct $IndexError {
-  struct $IndexError$class *$class;
-  $str error_message;
+    struct $IndexError$class *$class;
+    $str error_message;
 };
 
 extern struct $IndexError$class $IndexError$methods;
 $IndexError $IndexError$new($str);
 ////////////////////////////////////////////////////////////////////////////////////////
 struct $KeyError$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)($KeyError,$str);
-  void (*__serialize__)($KeyError,$Serial$state);
-  $KeyError (*__deserialize__)($KeyError,$Serial$state);
-  $bool (*__bool__)($KeyError);
-  $str (*__str__)($KeyError);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)($KeyError, $str);
+    void (*__serialize__)($KeyError, $Serial$state);
+    $KeyError (*__deserialize__)($KeyError, $Serial$state);
+    $bool (*__bool__)($KeyError);
+    $str (*__str__)($KeyError);
 };
 
 typedef struct $KeyError *$KeyError;
 
 struct $KeyError {
-  struct $KeyError$class *$class;
-  $str error_message;
+    struct $KeyError$class *$class;
+    $str error_message;
 };
 
 extern struct $KeyError$class $KeyError$methods;
 $KeyError $KeyError$new($str);
 ////////////////////////////////////////////////////////////////////////////////////////
 struct $MemoryError$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)($MemoryError,$str);
-  void (*__serialize__)($MemoryError, $Serial$state);
-  $MemoryError (*__deserialize__)($MemoryError, $Serial$state);
-  $bool (*__bool__)($MemoryError);
-  $str (*__str__)($MemoryError);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)($MemoryError, $str);
+    void (*__serialize__)($MemoryError, $Serial$state);
+    $MemoryError (*__deserialize__)($MemoryError, $Serial$state);
+    $bool (*__bool__)($MemoryError);
+    $str (*__str__)($MemoryError);
 };
 
 typedef struct $$MemoryError *$$MemoryError;
 
 struct $MemoryError {
-  struct $MemoryError$class *$class;
-  $str error_message;
+    struct $MemoryError$class *$class;
+    $str error_message;
 };
 
 extern struct $MemoryError$class $MemoryError$methods;
 $MemoryError $MemoryError$new($str);
 ////////////////////////////////////////////////////////////////////////////////////////
 struct $OSError$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)($OSError,$str);
-  void (*__serialize__)($OSError, $Serial$state);
-  $OSError (*__deserialize__)($OSError, $Serial$state);
-  $bool (*__bool__)($OSError);
-  $str (*__str__)($OSError);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)($OSError, $str);
+    void (*__serialize__)($OSError, $Serial$state);
+    $OSError (*__deserialize__)($OSError, $Serial$state);
+    $bool (*__bool__)($OSError);
+    $str (*__str__)($OSError);
 };
 
 typedef struct $OSError *$OSError;
 
 struct $OSError {
-  struct $OSError$class *$class;
-  $str error_message;
+    struct $OSError$class *$class;
+    $str error_message;
 };
 
 extern struct $OSError$class $OSError$methods;
 $OSError $OSError$new($str);
 ////////////////////////////////////////////////////////////////////////////////////////
 struct $RuntimeError$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)($RuntimeError,$str);
-  void (*__serialize__)($RuntimeError, $Serial$state);
-  $RuntimeError (*__deserialize__)($RuntimeError, $Serial$state);
-  $bool (*__bool__)($RuntimeError);
-  $str (*__str__)($RuntimeError);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)($RuntimeError, $str);
+    void (*__serialize__)($RuntimeError, $Serial$state);
+    $RuntimeError (*__deserialize__)($RuntimeError, $Serial$state);
+    $bool (*__bool__)($RuntimeError);
+    $str (*__str__)($RuntimeError);
 };
 
 typedef struct $RuntimeError *$RuntimeError;
 
 struct $RuntimeError {
-  struct $RuntimeError$class *$class;
-  $str error_message;
+    struct $RuntimeError$class *$class;
+    $str error_message;
 };
 
 extern struct $RuntimeError$class $RuntimeError$methods;
 $RuntimeError $RuntimeError$new($str);
 ////////////////////////////////////////////////////////////////////////////////////////
 struct $NotImplementedError$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)($NotImplementedError,$str);
-  void (*__serialize__)($NotImplementedError,$Serial$state);
-  $NotImplementedError (*__deserialize__)($NotImplementedError,$Serial$state);
-  $bool (*__bool__)($NotImplementedError);
-  $str (*__str__)($NotImplementedError);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)($NotImplementedError, $str);
+    void (*__serialize__)($NotImplementedError, $Serial$state);
+    $NotImplementedError (*__deserialize__)($NotImplementedError, $Serial$state);
+    $bool (*__bool__)($NotImplementedError);
+    $str (*__str__)($NotImplementedError);
 };
 
 typedef struct $NotImplementedError *$NotImplementedError;
 
 struct $NotImplementedError {
-  struct $NotImplementedError$class *$class;
-  $str error_message;
+    struct $NotImplementedError$class *$class;
+    $str error_message;
 };
 
 extern struct $NotImplementedError$class $NotImplementedError$methods;
 $NotImplementedError $NotImplementedError$new($str);
 ////////////////////////////////////////////////////////////////////////////////////////
 struct $ValueError$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)($ValueError,$str);
-  void (*__serialize__)($ValueError, $Serial$state);
-  $ValueError (*__deserialize__)($ValueError, $Serial$state);
-  $bool (*__bool__)($ValueError);
-  $str (*__str__)($ValueError);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)($ValueError, $str);
+    void (*__serialize__)($ValueError, $Serial$state);
+    $ValueError (*__deserialize__)($ValueError, $Serial$state);
+    $bool (*__bool__)($ValueError);
+    $str (*__str__)($ValueError);
 };
 
 typedef struct $ValueError *$ValueError;
 
 struct $ValueError {
-  struct $ValueError$class *$class;
-  $str error_message;
+    struct $ValueError$class *$class;
+    $str error_message;
 };
 
 extern struct $ValueError$class $ValueError$methods;
@@ -273,7 +273,6 @@ $ValueError $ValueError$new($str);
 
 void $RAISE($BaseException e);
 
- 
 /*
 Exceptions hierarchy in Python 3.8 according to
 

--- a/builtin/float.c
+++ b/builtin/float.c
@@ -17,46 +17,48 @@
 // General methods ///////////////////////////////////////////////////////////////////////
 
 $float $float$new($atom a) {
-  if ($ISINSTANCE(a,$int)->val) return to$float((double)(($int)a)->val);
-  if ($ISINSTANCE(a,$float)->val) return ($float)a;
-  if ($ISINSTANCE(a,$bool)->val) return to$float((double)(($bool)a)->val);
-  if ($ISINSTANCE(a,$str)->val) {
-    double x;
-    int c;
-    sscanf((char *)(($str)a)->str,"%lf%n",&x,&c);
-    if (c==(($str)a)->nbytes)
-      return to$float(x);
-    else
-      $RAISE(($BaseException)$NEW($ValueError,to$str("float_fromatom(): invalid str literal for type float")));
-  }
-  fprintf(stderr,"internal error: float_fromatom: argument not of atomic type");
-  exit(-1);
-
+    if ($ISINSTANCE(a, $int)->val)
+        return to$float((double)(($int)a)->val);
+    if ($ISINSTANCE(a, $float)->val)
+        return ($float)a;
+    if ($ISINSTANCE(a, $bool)->val)
+        return to$float((double)(($bool)a)->val);
+    if ($ISINSTANCE(a, $str)->val) {
+        double x;
+        int c;
+        sscanf((char *)(($str)a)->str, "%lf%n", &x, &c);
+        if (c == (($str)a)->nbytes)
+            return to$float(x);
+        else
+            $RAISE(($BaseException)$NEW($ValueError, to$str("float_fromatom(): invalid str literal for type float")));
+    }
+    fprintf(stderr, "internal error: float_fromatom: argument not of atomic type");
+    exit(-1);
 }
 
-void $float_init($float self, $atom a){
-  self->val = $float$new(a)->val;
+void $float_init($float self, $atom a) {
+    self->val = $float$new(a)->val;
 }
 
 void $float_serialize($float self, $Serial$state state) {
-  $val_serialize(FLOAT_ID,&self->val,state);
+    $val_serialize(FLOAT_ID, &self->val, state);
 }
 
 $float $float_deserialize($float self, $Serial$state state) {
- $WORD w = $val_deserialize(state);
- double x;
- memcpy(&x,&w,sizeof($WORD));
- return to$float(x);
+    $WORD w = $val_deserialize(state);
+    double x;
+    memcpy(&x, &w, sizeof($WORD));
+    return to$float(x);
 }
 
 $bool $float_bool($float x) {
-  return to$bool(x->val != 0.0);
+    return to$bool(x->val != 0.0);
 }
 
 $str $float_str($float x) {
-  char *s;
-  asprintf(&s,"%g",x->val);
-  return to$str(s);
+    char *s;
+    asprintf(&s, "%g", x->val);
+    return to$str(s);
 }
 
 struct $float$class $float$methods = {
@@ -67,114 +69,111 @@ struct $float$class $float$methods = {
     $float_serialize,
     $float_deserialize,
     $float_bool,
-    $float_str
-};
-  
+    $float_str};
+
 $float to$float(double x) {
-  $float res = malloc(sizeof(struct $float));
-  res->$class = &$float$methods;
-  res->val = x;
-  return res;
+    $float res = malloc(sizeof(struct $float));
+    res->$class = &$float$methods;
+    res->val = x;
+    return res;
 }
 
 double from$float($float x) {
-  return x->val;
+    return x->val;
 }
-
 
 // $Real$float /////////////////////////////////////////////////////////////////////////
 
 void $Real$float$__serialize__($Real$float self, $Serial$state state) {
-  $step_serialize(self->w$Minus, state);
+    $step_serialize(self->w$Minus, state);
 }
 
 $Real$float $Real$float$__deserialize__($Real$float self, $Serial$state state) {
-   $Real$float res = $DNEW($Real$float,state);
-   res->w$Minus = ($Minus)$step_deserialize(state);
-   return res;
+    $Real$float res = $DNEW($Real$float, state);
+    res->w$Minus = ($Minus)$step_deserialize(state);
+    return res;
 }
 
-
-$float $Real$float$__add__($Real$float wit,  $float a, $float b) {
-  return to$float(from$float(a) + from$float(b));
-}  
+$float $Real$float$__add__($Real$float wit, $float a, $float b) {
+    return to$float(from$float(a) + from$float(b));
+}
 
 $float $Real$float$__fromatom__($Real$float wit, $atom a) {
-  return $float$new(a);
+    return $float$new(a);
 }
 
 $complex $Real$float$__complx__($Real$float wit, $float a) {
-  return to$complex(a->val);
+    return to$complex(a->val);
 }
 
-$float $Real$float$__mul__($Real$float wit,  $float a, $float b) {
-  return to$float(from$float(a) * from$float(b));
-}  
+$float $Real$float$__mul__($Real$float wit, $float a, $float b) {
+    return to$float(from$float(a) * from$float(b));
+}
 
-$float $Real$float$__pow__($Real$float wit,  $float a, $float b) {
-  return to$float(exp(from$float(b) * log(from$float(a))));
-  }
+$float $Real$float$__pow__($Real$float wit, $float a, $float b) {
+    return to$float(exp(from$float(b) * log(from$float(a))));
+}
 
 $float $Real$float$__neg__($Real$float wit, $float a) {
-  return to$float(-from$float(a));
+    return to$float(-from$float(a));
 }
 
 $float $Real$float$__pos__($Real$float wit, $float a) {
-  return a;
+    return a;
 }
 
 $WORD $Real$float$real($Real$float wit, $float a, $Real wit2) {
-  return wit2->$class->__fromatom__(wit2,($atom)a);
+    return wit2->$class->__fromatom__(wit2, ($atom)a);
 }
 
 $WORD $Real$float$imag($Real$float wit, $float a, $Real wit2) {
-  return wit2->$class->__fromatom__(wit2,($atom)to$float(0.0));
+    return wit2->$class->__fromatom__(wit2, ($atom)to$float(0.0));
 }
 
 $WORD $Real$float$__abs__($Real$float wit, $float a, $Real wit2) {
-  return wit2->$class->__fromatom__(wit2,($atom)to$float(fabs(from$float(a))));
+    return wit2->$class->__fromatom__(wit2, ($atom)to$float(fabs(from$float(a))));
 }
 
 $float $Real$float$conjugate($Real$float wit, $float a) {
-  return a;
+    return a;
 }
-$float $Real$float$__float__ ($Real$float wit, $float x) {
-  return x;
+$float $Real$float$__float__($Real$float wit, $float x) {
+    return x;
 }
 
-$WORD $Real$float$__trunc__ ($Real$float wit, $float x, $Integral wit2) {
-  return wit2->$class->__fromatom__(wit2,($atom)to$int((long)trunc(from$float(x))));
+$WORD $Real$float$__trunc__($Real$float wit, $float x, $Integral wit2) {
+    return wit2->$class->__fromatom__(wit2, ($atom)to$int((long)trunc(from$float(x))));
 }
-  
-$WORD $Real$float$__floor__ ($Real$float wit, $float x, $Integral wit2) {
-  return wit2->$class->__fromatom__(wit2,($atom)to$int((long)floor(from$float(x))));
+
+$WORD $Real$float$__floor__($Real$float wit, $float x, $Integral wit2) {
+    return wit2->$class->__fromatom__(wit2, ($atom)to$int((long)floor(from$float(x))));
 }
-  
-$WORD $Real$float$__ceil__ ($Real$float wit, $float x, $Integral wit2) {
-  return wit2->$class->__fromatom__(wit2,($atom)to$int((long)ceil(from$float(x))));
+
+$WORD $Real$float$__ceil__($Real$float wit, $float x, $Integral wit2) {
+    return wit2->$class->__fromatom__(wit2, ($atom)to$int((long)ceil(from$float(x))));
 }
-  
-$float $Real$float$__round__ ($Real$float wit, $float x, $int p) {
-  double pval = p==NULL ? 0.0 : (double)p->val;
-  double p10 = pow(10.0,pval);
-  return to$float(round(x->val * p10)/p10);
+
+$float $Real$float$__round__($Real$float wit, $float x, $int p) {
+    double pval = p == NULL ? 0.0 : (double)p->val;
+    double p10 = pow(10.0, pval);
+    return to$float(round(x->val * p10) / p10);
 }
-     
+
 // $Minus$float  ////////////////////////////////////////////////////////////////////////////////////////
 
 void $Minus$float$__serialize__($Minus$float self, $Serial$state state) {
-  $step_serialize(self->w$Real, state);
+    $step_serialize(self->w$Real, state);
 }
 
 $Minus$float $Minus$float$__deserialize__($Minus$float self, $Serial$state state) {
-   $Minus$float res = $DNEW($Minus$float,state);
-   res->w$Real = ($Real)$step_deserialize(state);
-   return res;
+    $Minus$float res = $DNEW($Minus$float, state);
+    res->w$Real = ($Real)$step_deserialize(state);
+    return res;
 }
 
-$float $Minus$float$__sub__($Minus$float wit,  $float a, $float b) {
-  return to$float(from$float(a) - from$float(b));
-}  
+$float $Minus$float$__sub__($Minus$float wit, $float a, $float b) {
+    return to$float(from$float(a) - from$float(b));
+}
 
 // $Div$float  ////////////////////////////////////////////////////////////////////////////////////////
 
@@ -182,13 +181,13 @@ void $Div$float$__serialize__($Div$float self, $Serial$state state) {
 }
 
 $Div$float $Div$float$__deserialize__($Div$float self, $Serial$state state) {
-   $Div$float res = $DNEW($Div$float,state);
-   return res;
+    $Div$float res = $DNEW($Div$float, state);
+    return res;
 }
 
 $float $Div$float$__truediv__($Div$float wit, $float a, $float b) {
-  return to$float(from$float(a) / from$float(b));
-}  
+    return to$float(from$float(a) / from$float(b));
+}
 
 // $Ord$float  ////////////////////////////////////////////////////////////////////////////////////////
 
@@ -196,34 +195,33 @@ void $Ord$float$__serialize__($Ord$float self, $Serial$state state) {
 }
 
 $Ord$float $Ord$float$__deserialize__($Ord$float self, $Serial$state state) {
-   $Ord$float res = $DNEW($Ord$float,state);
-   return res;
+    $Ord$float res = $DNEW($Ord$float, state);
+    return res;
 }
 
-$bool $Ord$float$__eq__ ($Ord$float wit, $float a, $float b) {
-  return to$bool(a->val == b->val);
+$bool $Ord$float$__eq__($Ord$float wit, $float a, $float b) {
+    return to$bool(a->val == b->val);
 }
 
-$bool $Ord$float$__ne__ ($Ord$float wit, $float a, $float b) {
-  return to$bool(a->val != b->val);
+$bool $Ord$float$__ne__($Ord$float wit, $float a, $float b) {
+    return to$bool(a->val != b->val);
 }
 
-$bool $Ord$float$__lt__ ($Ord$float wit, $float a, $float b) {
-  return to$bool(a->val < b->val);
+$bool $Ord$float$__lt__($Ord$float wit, $float a, $float b) {
+    return to$bool(a->val < b->val);
 }
 
-$bool $Ord$float$__le__ ($Ord$float wit, $float a, $float b) {
-  return to$bool(a->val <= b->val);
+$bool $Ord$float$__le__($Ord$float wit, $float a, $float b) {
+    return to$bool(a->val <= b->val);
 }
 
-$bool $Ord$float$__gt__ ($Ord$float wit, $float a, $float b) {
-  return to$bool(a->val > b->val);
+$bool $Ord$float$__gt__($Ord$float wit, $float a, $float b) {
+    return to$bool(a->val > b->val);
 }
 
-$bool $Ord$float$__ge__ ($Ord$float wit, $float a, $float b) {
-  return to$bool(a->val == b->val);
+$bool $Ord$float$__ge__($Ord$float wit, $float a, $float b) {
+    return to$bool(a->val == b->val);
 }
-
 
 // $Hashable$float ///////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -231,68 +229,67 @@ void $Hashable$float$__serialize__($Hashable$float self, $Serial$state state) {
 }
 
 $Hashable$float $Hashable$float$__deserialize__($Hashable$float self, $Serial$state state) {
-   $Hashable$float res = $DNEW($Hashable$float,state);
-   return res;
+    $Hashable$float res = $DNEW($Hashable$float, state);
+    return res;
 }
 
 $bool $Hashable$float$__eq__($Hashable$float wit, $float a, $float b) {
-  return to$bool(a->val == b->val);
+    return to$bool(a->val == b->val);
 }
 
 $bool $Hashable$float$__neq__($Hashable$float wit, $float a, $float b) {
-  return to$bool(a->val != b->val);
+    return to$bool(a->val != b->val);
 }
 
 $int $Hashable$float$__hash__($Hashable$float wit, $float a) {
-  return to$int($float_hash(a));
+    return to$int($float_hash(a));
 }
 
 // init methods ////////////////////////////////////////////////////////////////////////////////////////////////
 
 void $Real$float_init($Real$float wit) {
-  wit-> w$Minus = ($Minus)$NEW($Minus$float,($Real)wit);
+    wit->w$Minus = ($Minus)$NEW($Minus$float, ($Real)wit);
 };
 
 void $Minus$float_init($Minus$float wit, $Real w$Real) {
-  wit->w$Real =  w$Real;
+    wit->w$Real = w$Real;
 }
 
 void $Ord$float_init($Ord$float wit) {
-  return;
+    return;
 }
 void $Div$float_init($Div$float wit) {
-  return;
+    return;
 }
 
 void $Hashable$float_init($Hashable$float wit) {
-  return;
+    return;
 }
 
 $Real$float $Real$float$new() {
-  return $NEW($Real$float);
+    return $NEW($Real$float);
 }
 
 $Div$float $Div$float$new() {
-  return $NEW($Div$float);
+    return $NEW($Div$float);
 }
 
 $Minus$float $Minus$float$new($Real wit) {
-  return $NEW($Minus$float,wit);
+    return $NEW($Minus$float, wit);
 }
-  
+
 $Ord$float $Ord$float$new() {
-  return $NEW($Ord$float);
+    return $NEW($Ord$float);
 }
 
 $Hashable$float $Hashable$float$new() {
-  return $NEW($Hashable$float);
+    return $NEW($Hashable$float);
 }
 
-
- struct $Real$float $Real$float_instance;
- struct $Minus$float $Minus$float_instance;
- struct $Ord$float $Ord$float_instance;
- struct $Hashable$float $Hashable$float_instance;
+struct $Real$float $Real$float_instance;
+struct $Minus$float $Minus$float_instance;
+struct $Ord$float $Ord$float_instance;
+struct $Hashable$float $Hashable$float_instance;
 
 struct $Real$float$class $Real$float$methods = {
     "$Real$float",
@@ -301,16 +298,16 @@ struct $Real$float$class $Real$float$methods = {
     $Real$float_init,
     $Real$float$__serialize__,
     $Real$float$__deserialize__,
-    ($bool (*)($Real$float))$default__bool__,
-    ($str (*)($Real$float))$default__str__,
+    ($bool(*)($Real$float))$default__bool__,
+    ($str(*)($Real$float))$default__str__,
     $Real$float$__add__,
-    ($float (*)($Real$float, $float, $float))$Plus$__iadd__,
+    ($float(*)($Real$float, $float, $float))$Plus$__iadd__,
     $Real$float$__mul__,
-    ($float (*)($Real$float, $float, $float))$Times$__imul__,
+    ($float(*)($Real$float, $float, $float))$Times$__imul__,
     $Real$float$__fromatom__,
     $Real$float$__complx__,
     $Real$float$__pow__,
-    ($float (*)($Real$float, $float, $float))$Number$__ipow__,
+    ($float(*)($Real$float, $float, $float))$Number$__ipow__,
     $Real$float$__neg__,
     $Real$float$__pos__,
     $Real$float$real,
@@ -318,11 +315,10 @@ struct $Real$float$class $Real$float$methods = {
     $Real$float$__abs__,
     $Real$float$conjugate,
     $Real$float$__float__,
-    $Real$float$__trunc__ ,
-    $Real$float$__floor__ ,
-    $Real$float$__ceil__ ,
-    $Real$float$__round__
-};
+    $Real$float$__trunc__,
+    $Real$float$__floor__,
+    $Real$float$__ceil__,
+    $Real$float$__round__};
 struct $Real$float $Real$float_instance = {&$Real$float$methods, ($Minus)&$Minus$float_instance};
 $Real$float $Real$float$witness = &$Real$float_instance;
 
@@ -333,10 +329,10 @@ struct $Minus$float$class $Minus$float$methods = {
     $Minus$float_init,
     $Minus$float$__serialize__,
     $Minus$float$__deserialize__,
-    ($bool (*)($Minus$float))$default__bool__,
-    ($str (*)($Minus$float))$default__str__,
+    ($bool(*)($Minus$float))$default__bool__,
+    ($str(*)($Minus$float))$default__str__,
     $Minus$float$__sub__,
-    ($float (*)($Minus$float, $float, $float))$Minus$__isub__,
+    ($float(*)($Minus$float, $float, $float))$Minus$__isub__,
 
 };
 struct $Minus$float $Minus$float_instance = {&$Minus$float$methods, ($Real)&$Real$float_instance};
@@ -349,15 +345,14 @@ struct $Div$float$class $Div$float$methods = {
     $Div$float_init,
     $Div$float$__serialize__,
     $Div$float$__deserialize__,
-    ($bool (*)($Div$float))$default__bool__,
-    ($str (*)($Div$float))$default__str__,
+    ($bool(*)($Div$float))$default__bool__,
+    ($str(*)($Div$float))$default__str__,
     $Div$float$__truediv__,
-    ($float (*)($Div$float, $float, $float))$Div$__itruediv__,
+    ($float(*)($Div$float, $float, $float))$Div$__itruediv__,
 };
 
 struct $Div$float $Div$float_instance = {&$Div$float$methods};
 $Div$float $Div$float$witness = &$Div$float_instance;
-
 
 struct $Ord$float$class $Ord$float$methods = {
     "$Ord$float",
@@ -366,15 +361,14 @@ struct $Ord$float$class $Ord$float$methods = {
     $Ord$float_init,
     $Ord$float$__serialize__,
     $Ord$float$__deserialize__,
-    ($bool (*)($Ord$float))$default__bool__,
-    ($str (*)($Ord$float))$default__str__,
-    $Ord$float$__eq__ ,
-    $Ord$float$__ne__ ,
-    $Ord$float$__lt__ ,
-    $Ord$float$__le__ ,
-    $Ord$float$__gt__ ,
-    $Ord$float$__ge__
-};
+    ($bool(*)($Ord$float))$default__bool__,
+    ($str(*)($Ord$float))$default__str__,
+    $Ord$float$__eq__,
+    $Ord$float$__ne__,
+    $Ord$float$__lt__,
+    $Ord$float$__le__,
+    $Ord$float$__gt__,
+    $Ord$float$__ge__};
 struct $Ord$float $Ord$float_instance = {&$Ord$float$methods};
 $Ord$float $Ord$float$witness = &$Ord$float_instance;
 
@@ -385,12 +379,10 @@ struct $Hashable$float$class $Hashable$float$methods = {
     $Hashable$float_init,
     $Hashable$float$__serialize__,
     $Hashable$float$__deserialize__,
-    ($bool (*)($Hashable$float))$default__bool__,
-    ($str (*)($Hashable$float))$default__str__,
+    ($bool(*)($Hashable$float))$default__bool__,
+    ($str(*)($Hashable$float))$default__str__,
     $Hashable$float$__eq__,
     $Hashable$float$__neq__,
-    $Hashable$float$__hash__
-};
+    $Hashable$float$__hash__};
 struct $Hashable$float $Hashable$float_instance = {&$Hashable$float$methods};
 $Hashable$float $Hashable$float$witness = &$Hashable$float_instance;
- 

--- a/builtin/float.h
+++ b/builtin/float.h
@@ -1,18 +1,17 @@
 struct $float$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)($float, $atom);
-  void (*__serialize__)($float,$Serial$state);
-  $float (*__deserialize__)($float,$Serial$state);
-  $bool (*__bool__)($float);
-  $str (*__str__)($float);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)($float, $atom);
+    void (*__serialize__)($float, $Serial$state);
+    $float (*__deserialize__)($float, $Serial$state);
+    $bool (*__bool__)($float);
+    $str (*__str__)($float);
 };
 
-
 struct $float {
-  struct $float$class *$class;
-  double val;
+    struct $float$class *$class;
+    double val;
 };
 
 extern struct $float$class $float$methods;
@@ -22,7 +21,7 @@ extern struct $Real$float$class $Real$float$methods;
 $Real$float $Real$float$new();
 
 #define $RealFloat$float$new(...) $Real$float$new(__VA_ARGS__)
-#define $RealFloat$float $Real$float
+#define $RealFloat$float          $Real$float
 
 extern struct $Div$float$class $Div$float$methods;
 $Div$float $Div$float$new();

--- a/builtin/function.c
+++ b/builtin/function.c
@@ -14,16 +14,16 @@
 
 ////////////////////////////////////////////////////////////////////////////////////////
 
-void $function$__init__($function $this) { }
+void $function$__init__($function $this) {}
 
 $bool $function$__bool__($function self) {
-  return $True;
+    return $True;
 }
 
 $str $function$__str__($function self) {
-  char *s;
-  asprintf(&s,"<function object at %p>",self);
-  return to$str(s);
+    char *s;
+    asprintf(&s, "<function object at %p>", self);
+    return to$str(s);
 }
 
 void $function$__serialize__($function self, $Serial$state state) {
@@ -44,5 +44,4 @@ struct $function$class $function$methods = {
     $function$__deserialize__,
     $function$__bool__,
     $function$__str__,
-    NULL
-};
+    NULL};

--- a/builtin/function.h
+++ b/builtin/function.h
@@ -10,7 +10,8 @@ struct $function$class {
     $function (*__deserialize__)($function, $Serial$state);
     $bool (*__bool__)($function);
     $str (*__str__)($function);
-    $WORD (*__call__)($function, ...);
+    $WORD (*__call__)
+    ($function, ...);
 };
 struct $function {
     struct $function$class *$class;

--- a/builtin/hash.c
+++ b/builtin/hash.c
@@ -35,56 +35,56 @@ However, CPython uses unsigned type size_t for hash values.
 */
 
 #ifdef __APPLE__
-#  include <libkern/OSByteOrder.h>
+#include <libkern/OSByteOrder.h>
 #elif defined(HAVE_LE64TOH) && defined(HAVE_ENDIAN_H)
-#  include <endian.h>
+#include <endian.h>
 #elif defined(HAVE_LE64TOH) && defined(HAVE_SYS_ENDIAN_H)
-#  include <sys/endian.h>
+#include <sys/endian.h>
 #endif
 
-#define _PyHASH_BITS 61
-#define _PyHASH_MODULUS (((long)1 << _PyHASH_BITS) - 1)
-#define _PyHASH_INF 314159
-#define _PyHASH_NAN 0
-#define _PyHASH_MULTIPLIER 1000003UL  /* 0xf4243 */
-#define SIZEOF_PY_UHASH_T 8
+#define _PyHASH_BITS       61
+#define _PyHASH_MODULUS    (((long)1 << _PyHASH_BITS) - 1)
+#define _PyHASH_INF        314159
+#define _PyHASH_NAN        0
+#define _PyHASH_MULTIPLIER 1000003UL /* 0xf4243 */
+#define SIZEOF_PY_UHASH_T  8
 
 /* 
 BvS 191002: For the moment, stick to little endian. In CPython, this is set in pyport.h based on info from the configure script.
 */
 
-#define PY_BIG_ENDIAN 0
+#define PY_BIG_ENDIAN    0
 #define PY_LITTLE_ENDIAN 1
 
-static long long_hash (long u) {
-  long sign=1;
-  if (u<0)  {
+static long long_hash(long u) {
+    long sign = 1;
+    if (u < 0) {
 
-    sign=-1;
-    u = -u;
-  }
-  long h = u % _PyHASH_MODULUS * sign;
-  if (h == (long)-1)
-    h = (long)-2;
-  return h;
+        sign = -1;
+        u = -u;
+    }
+    long h = u % _PyHASH_MODULUS * sign;
+    if (h == (long)-1)
+        h = (long)-2;
+    return h;
 }
 
-long $int_hash ($int n) {
-  return long_hash(from$int(n));
+long $int_hash($int n) {
+    return long_hash(from$int(n));
 }
 
 static long double_hash(double d) {
     int e, sign;
     double m;
     long x, y;
-    
+
     if (!isfinite(d)) {
         if (isinf(d))
             return d > 0 ? _PyHASH_INF : -_PyHASH_INF;
         else
             return _PyHASH_NAN;
     }
-    
+
     m = frexp(d, &e);
 
     sign = 1;
@@ -98,9 +98,9 @@ static long double_hash(double d) {
     x = 0;
     while (m) {
         x = ((x << 28) & _PyHASH_MODULUS) | x >> (_PyHASH_BITS - 28);
-        m *= 268435456.0;  /* 2**28 */
+        m *= 268435456.0; /* 2**28 */
         e -= 28;
-        y = (long)m;  /* pull out integer part */
+        y = (long)m; /* pull out integer part */
         m -= y;
         x += y;
         if (x >= _PyHASH_MODULUS)
@@ -108,7 +108,7 @@ static long double_hash(double d) {
     }
 
     /* adjust for the exponent;  first reduce it modulo _PyHASH_BITS */
-    e = e >= 0 ? e % _PyHASH_BITS : _PyHASH_BITS-1-((-1-e) % _PyHASH_BITS);
+    e = e >= 0 ? e % _PyHASH_BITS : _PyHASH_BITS - 1 - ((-1 - e) % _PyHASH_BITS);
     x = ((x << e) & _PyHASH_MODULUS) | x >> (_PyHASH_BITS - e);
 
     x = x * sign;
@@ -118,29 +118,29 @@ static long double_hash(double d) {
 }
 
 long $float_hash($float v) {
-  return double_hash(from$float(v));
+    return double_hash(from$float(v));
 }
 
 long $complex_hash($complex c) {
-  // we use the tuple_hash algorithm (see below)
-  long h1 = double_hash(creal(c->val));
-  long h2 = double_hash(cimag(c->val));
-  long x = 0x345678UL;
-  long mult = _PyHASH_MULTIPLIER;
-  x = (x ^ h1) * mult;
-  mult +=  (long)82522UL;
-  x = (x ^ h2) * mult;
-  x += 97531UL;
-  if (x == (long)-1) 
-    x = -2;
-  return x;
-}  
- 
+    // we use the tuple_hash algorithm (see below)
+    long h1 = double_hash(creal(c->val));
+    long h2 = double_hash(cimag(c->val));
+    long x = 0x345678UL;
+    long mult = _PyHASH_MULTIPLIER;
+    x = (x ^ h1) * mult;
+    mult += (long)82522UL;
+    x = (x ^ h2) * mult;
+    x += 97531UL;
+    if (x == (long)-1)
+        x = -2;
+    return x;
+}
+
 long $pointer_hash($WORD p) {
     long x;
     long y = (long)p;
     // bottom 3 or 4 bits are likely to be 0; rotate y by 4 to avoid
-    //  excessive hash collisions for dicts and sets 
+    //  excessive hash collisions for dicts and sets
     y = (y >> 4) | (y << 60);
     x = (long)y;
     if (x == -1)
@@ -158,11 +158,10 @@ long $pointer_hash($WORD p) {
  *   ........ ........ eeeeeeee  pyexpat XML hash salt
  */
 
-
 typedef union {
-    // ensure 24 bytes 
+    // ensure 24 bytes
     unsigned char uc[24];
-    // two uint64 for SipHash24 
+    // two uint64 for SipHash24
     struct {
         uint64_t k0;
         uint64_t k1;
@@ -172,7 +171,6 @@ typedef union {
         long hashsalt;
     } expat;
 } _Py_HashSecret_t;
-
 
 _Py_HashSecret_t _Py_HashSecret = {{0}};
 
@@ -185,7 +183,7 @@ static long pysiphash(void *src, long src_sz) {
 }
 
 long $string_hash($str s) {
-  int len = s->nbytes;
+    int len = s->nbytes;
     long x;
     /*
       We make the hash of the empty string be 0, rather than using
@@ -194,31 +192,30 @@ long $string_hash($str s) {
     if (len == 0) {
         return 0;
     }
-         x = pysiphash(s->str, len);
+    x = pysiphash(s->str, len);
 
     if (x == -1)
         return -2;
     return x;
 }
 
-   
 /*
  "Old" hash algorithm for tuples; used in Python versions <= 3.7. 
     From 3.8 the xxHash-based algorithm above is used.
 */
-long $tuple_hash($Hashable$tuple wit,$tuple tup) {
-  int size = tup->size;
-  long x = 0x345678UL;
-  long y;
-  long mult = _PyHASH_MULTIPLIER;
-  for (int i=0; i < size; i++) {
-    $Hashable h = wit->w$Hashable[i];
-    y = from$int(h->$class->__hash__(h,tup->components[i]));
-    x = (x ^ y) * mult;
-    mult += (long)(82520UL + 2*(size-i-1));
-  }
-  x += 97531UL;
-  if (x == (long)-1) 
-    x = -2;
-  return x;
+long $tuple_hash($Hashable$tuple wit, $tuple tup) {
+    int size = tup->size;
+    long x = 0x345678UL;
+    long y;
+    long mult = _PyHASH_MULTIPLIER;
+    for (int i = 0; i < size; i++) {
+        $Hashable h = wit->w$Hashable[i];
+        y = from$int(h->$class->__hash__(h, tup->components[i]));
+        x = (x ^ y) * mult;
+        mult += (long)(82520UL + 2 * (size - i - 1));
+    }
+    x += 97531UL;
+    if (x == (long)-1)
+        x = -2;
+    return x;
 }

--- a/builtin/hash.h
+++ b/builtin/hash.h
@@ -6,4 +6,4 @@ long $complex_hash($complex c);
 long $string_hash($str s);
 
 long $pointer_hash($WORD w);
-long $tuple_hash($Hashable$tuple wit,$tuple tup);
+long $tuple_hash($Hashable$tuple wit, $tuple tup);

--- a/builtin/int.c
+++ b/builtin/int.c
@@ -16,53 +16,59 @@
 
 // only called with e>=0.
 long longpow(long a, long e) {
-  if (e == 0) return 1;
-  if (e == 1) return a;
-  if (e%2 == 0) return longpow(a*a,e/2);
-  return a * longpow(a*a,e/2);
+    if (e == 0)
+        return 1;
+    if (e == 1)
+        return a;
+    if (e % 2 == 0)
+        return longpow(a * a, e / 2);
+    return a * longpow(a * a, e / 2);
 }
 
 // General methods ///////////////////////////////////////////////////////////////////////
 
 $int $int$new($atom a) {
-  if ($ISINSTANCE(a,$int)->val) return ($int)a;
-  if ($ISINSTANCE(a,$float)->val) return to$int(round((($float)a)->val));
-  if ($ISINSTANCE(a,$bool)->val) return to$int((($bool)a)->val);
-  if ($ISINSTANCE(a,$str)->val) {
-    long x;
-    int c;
-    sscanf((char *)(($str)a)->str,"%ld%n",&x,&c);
-    if (c==(($str)a)->nbytes)
-      return to$int(x);
-    else 
-      $RAISE(($BaseException)$NEW($ValueError,to$str("int(): invalid str value for type int")));
-  }
-  fprintf(stderr,"internal error: $int$new: argument not of atomic type");
-  exit(-1);
+    if ($ISINSTANCE(a, $int)->val)
+        return ($int)a;
+    if ($ISINSTANCE(a, $float)->val)
+        return to$int(round((($float)a)->val));
+    if ($ISINSTANCE(a, $bool)->val)
+        return to$int((($bool)a)->val);
+    if ($ISINSTANCE(a, $str)->val) {
+        long x;
+        int c;
+        sscanf((char *)(($str)a)->str, "%ld%n", &x, &c);
+        if (c == (($str)a)->nbytes)
+            return to$int(x);
+        else
+            $RAISE(($BaseException)$NEW($ValueError, to$str("int(): invalid str value for type int")));
+    }
+    fprintf(stderr, "internal error: $int$new: argument not of atomic type");
+    exit(-1);
 }
 
-void $int_init($int self, $atom a){
-  self->val = $int$new(a)->val;
+void $int_init($int self, $atom a) {
+    self->val = $int$new(a)->val;
 }
 
-void $int_serialize($int n,$Serial$state state) {
-  $val_serialize(INT_ID,&n->val,state);
+void $int_serialize($int n, $Serial$state state) {
+    $val_serialize(INT_ID, &n->val, state);
 }
 
-$int $int_deserialize($int n,$Serial$state state) {
-  return to$int((long)$val_deserialize(state));
+$int $int_deserialize($int n, $Serial$state state) {
+    return to$int((long)$val_deserialize(state));
 }
 
 $bool $int_bool($int n) {
-  return to$bool(n->val != 0);
+    return to$bool(n->val != 0);
 }
 
 $str $int_str($int n) {
-  char *s;
-  asprintf(&s,"%ld",n->val);
-  return to$str(s);
+    char *s;
+    asprintf(&s, "%ld", n->val);
+    return to$str(s);
 }
-  
+
 struct $int$class $int$methods = {
     "$int",
     UNASSIGNED,
@@ -71,196 +77,192 @@ struct $int$class $int$methods = {
     $int_serialize,
     $int_deserialize,
     $int_bool,
-    $int_str
-};
+    $int_str};
 
 $int to$int(long i) {
-  $int res = malloc(sizeof(struct $int));
-  res->$class = &$int$methods;
-  res->val = i;
-  return res;
+    $int res = malloc(sizeof(struct $int));
+    res->$class = &$int$methods;
+    res->val = i;
+    return res;
 }
 
 long from$int($int w) {
-  return w->val;
+    return w->val;
 }
-
-                  
 
 // $Integral$int /////////////////////////////////////////////////////////////////////////
 
 void $Integral$int$__serialize__($Integral$int self, $Serial$state state) {
-  $step_serialize(self->w$Logical, state);
-  $step_serialize(self->w$Minus, state);
+    $step_serialize(self->w$Logical, state);
+    $step_serialize(self->w$Minus, state);
 }
 
 $Integral$int $Integral$int$__deserialize__($Integral$int self, $Serial$state state) {
-   $Integral$int res = $DNEW($Integral$int,state);
-   res->w$Logical = ($Logical)$step_deserialize(state);
-   res->w$Minus = ($Minus)$step_deserialize(state);
-   return res;
+    $Integral$int res = $DNEW($Integral$int, state);
+    res->w$Logical = ($Logical)$step_deserialize(state);
+    res->w$Minus = ($Minus)$step_deserialize(state);
+    return res;
 }
 
-$int $Integral$int$__add__($Integral$int wit,  $int a, $int b) {
-  return to$int(a->val + b->val);
-}  
+$int $Integral$int$__add__($Integral$int wit, $int a, $int b) {
+    return to$int(a->val + b->val);
+}
 
 $complex $Integral$int$__complx__($Integral$int wit, $int a) {
-  return to$complex((double)a->val);
+    return to$complex((double)a->val);
 }
 
 $int $Integral$int$__fromatom__($Integral$int wit, $atom a) {
-  return $int$new(a);
+    return $int$new(a);
 }
 
-$int $Integral$int$__mul__($Integral$int wit,  $int a, $int b) {
-  return to$int(a->val * b->val);
-}  
-  
-$int $Integral$int$__pow__($Integral$int wit,  $int a, $int b) {
-  if ( b->val < 0) {
-    // raise VALUEERROR;
-    return NULL;
-  }
-  return to$int(longpow(a->val,b->val));
+$int $Integral$int$__mul__($Integral$int wit, $int a, $int b) {
+    return to$int(a->val * b->val);
 }
 
-$int $Integral$int$__neg__($Integral$int wit,  $int a) {
-  return to$int(-a->val);
+$int $Integral$int$__pow__($Integral$int wit, $int a, $int b) {
+    if (b->val < 0) {
+        // raise VALUEERROR;
+        return NULL;
+    }
+    return to$int(longpow(a->val, b->val));
 }
 
-$int $Integral$int$__pos__($Integral$int wit,  $int a) {
-  return a;
+$int $Integral$int$__neg__($Integral$int wit, $int a) {
+    return to$int(-a->val);
+}
+
+$int $Integral$int$__pos__($Integral$int wit, $int a) {
+    return a;
 }
 
 $WORD $Integral$int$real($Integral$int wit, $int a, $Real wit2) {
-  return wit2->$class->__fromatom__(wit2,($atom)a);
+    return wit2->$class->__fromatom__(wit2, ($atom)a);
 }
 
 $WORD $Integral$int$imag($Integral$int wit, $int a, $Real wit2) {
-  return wit2->$class->__fromatom__(wit2,($atom)to$int(0L));
+    return wit2->$class->__fromatom__(wit2, ($atom)to$int(0L));
 }
 
 $WORD $Integral$int$__abs__($Integral$int wit, $int a, $Real wit2) {
-  return wit2->$class->__fromatom__(wit2,($atom)to$int(labs(a->val)));
+    return wit2->$class->__fromatom__(wit2, ($atom)to$int(labs(a->val)));
 }
 
-$int $Integral$int$__conjugate__($Integral$int wit,  $int a) {
-  return a;
+$int $Integral$int$__conjugate__($Integral$int wit, $int a) {
+    return a;
 }
 
-$float $Integral$int$__float__ ($Integral$int wit, $int n) {
-  return to$float((double)n->val);
+$float $Integral$int$__float__($Integral$int wit, $int n) {
+    return to$float((double)n->val);
 }
 
-$WORD $Integral$int$__trunc__ ($Integral$int wit, $int n, $Integral wit2) {
-  return wit2->$class->__fromatom__(wit2,($atom)n);
+$WORD $Integral$int$__trunc__($Integral$int wit, $int n, $Integral wit2) {
+    return wit2->$class->__fromatom__(wit2, ($atom)n);
 }
-  
-$WORD $Integral$int$__floor__ ($Integral$int wit, $int n, $Integral wit2) {
-  return wit2->$class->__fromatom__(wit2,($atom)n);
+
+$WORD $Integral$int$__floor__($Integral$int wit, $int n, $Integral wit2) {
+    return wit2->$class->__fromatom__(wit2, ($atom)n);
 }
-  
-$WORD $Integral$int$__ceil__ ($Integral$int wit, $int n, $Integral wit2) {
-  return wit2->$class->__fromatom__(wit2,($atom)n);
+
+$WORD $Integral$int$__ceil__($Integral$int wit, $int n, $Integral wit2) {
+    return wit2->$class->__fromatom__(wit2, ($atom)n);
 }
-  
-$int $Integral$int$__round__ ($Integral$int wit, $int n, $int p) {
-  long nval = n->val;
-  if (nval<0)
-    return to$int(-$Integral$int$__round__(wit,to$int(-nval),p)->val);
-  long pval = p==NULL ? 0 : p->val;
-  if (pval>=0)
+
+$int $Integral$int$__round__($Integral$int wit, $int n, $int p) {
+    long nval = n->val;
+    if (nval < 0)
+        return to$int(-$Integral$int$__round__(wit, to$int(-nval), p)->val);
+    long pval = p == NULL ? 0 : p->val;
+    if (pval >= 0)
+        return n;
+    long p10 = longpow(10, -pval);
+    long res = nval / p10;
+    if (nval % p10 * 2 > p10)
+        res++;
+    return to$int(res * p10);
+}
+
+$WORD $Integral$int$numerator($Integral$int wit, $int n, $Integral wit2) {
+    return wit2->$class->__fromatom__(wit2, ($atom)n);
+}
+
+$WORD $Integral$int$denominator($Integral$int wit, $int n, $Integral wit2) {
+    return wit2->$class->__fromatom__(wit2, ($atom)to$int(1L));
+}
+
+$int $Integral$int$__int__($Integral$int wit, $int n) {
     return n;
-  long p10 = longpow(10,-pval);
-  long res = nval/p10;
-  if (nval%p10 * 2 > p10)
-    res++; 
-  return to$int (res * p10);
-}
-  
-$WORD $Integral$int$numerator ($Integral$int wit, $int n, $Integral wit2) {
-  return wit2->$class->__fromatom__(wit2,($atom)n);
-}
-  
-$WORD $Integral$int$denominator ($Integral$int wit, $int n, $Integral wit2) {
-  return wit2->$class->__fromatom__(wit2,($atom)to$int(1L));
-}
-  
-$int $Integral$int$__int__ ($Integral$int wit, $int n) {
-  return n;
 }
 
 $int $Integral$int$__index__($Integral$int wit, $int n) {
-  return n;
+    return n;
 }
 
 $tuple $Integral$int$__divmod__($Integral$int wit, $int a, $int b) {
-  int n = a->val;
-  int d = b->val;
-  return $NEWTUPLE(2, to$int(n/d), to$int(n%d));
+    int n = a->val;
+    int d = b->val;
+    return $NEWTUPLE(2, to$int(n / d), to$int(n % d));
 }
 
 $int $Integral$int$__floordiv__($Integral$int wit, $int a, $int b) {
-  return to$int(a->val / b->val);
+    return to$int(a->val / b->val);
 }
 
 $int $Integral$int$__mod__($Integral$int wit, $int a, $int b) {
-  return to$int(a->val % b->val);
+    return to$int(a->val % b->val);
 }
 
-$int $Integral$int$__lshift__($Integral$int wit,  $int a, $int b) {
-  return to$int(a->val << b->val);
+$int $Integral$int$__lshift__($Integral$int wit, $int a, $int b) {
+    return to$int(a->val << b->val);
 }
 
-$int $Integral$int$__rshift__($Integral$int wit,  $int a, $int b) {
-  return to$int(a->val >> b->val);
-}
- 
-$int $Integral$int$__invert__($Integral$int wit,  $int a) {
-  return to$int(~a->val);
+$int $Integral$int$__rshift__($Integral$int wit, $int a, $int b) {
+    return to$int(a->val >> b->val);
 }
 
+$int $Integral$int$__invert__($Integral$int wit, $int a) {
+    return to$int(~a->val);
+}
 
 // Logical$int  ////////////////////////////////////////////////////////////////////////////////////////
 
 void $Logical$int$__serialize__($Logical$int self, $Serial$state state) {
-  $step_serialize(self->w$Integral, state);
+    $step_serialize(self->w$Integral, state);
 }
 
 $Logical$int $Logical$int$__deserialize__($Logical$int self, $Serial$state state) {
-   $Logical$int res = $DNEW($Logical$int,state);
-   res->w$Integral = ($Integral)$step_deserialize(state);
-   return res;
+    $Logical$int res = $DNEW($Logical$int, state);
+    res->w$Integral = ($Integral)$step_deserialize(state);
+    return res;
 }
 
-$int $Logical$int$__and__($Logical$int wit,  $int a, $int b) {
-  return to$int(a->val & b->val);
+$int $Logical$int$__and__($Logical$int wit, $int a, $int b) {
+    return to$int(a->val & b->val);
 }
-                                                 
-$int $Logical$int$__or__($Logical$int wit,  $int a, $int b) {
-  return to$int(a->val | b->val);
+
+$int $Logical$int$__or__($Logical$int wit, $int a, $int b) {
+    return to$int(a->val | b->val);
 }
-                                                 
-$int $Logical$int$__xor__($Logical$int wit,  $int a, $int b) {
-  return to$int(a->val ^ b->val);
-}  
- 
+
+$int $Logical$int$__xor__($Logical$int wit, $int a, $int b) {
+    return to$int(a->val ^ b->val);
+}
+
 // $Minus$int  ////////////////////////////////////////////////////////////////////////////////////////
 
 void $Minus$int$__serialize__($Minus$int self, $Serial$state state) {
-  $step_serialize(self->w$Integral, state);
+    $step_serialize(self->w$Integral, state);
 }
 
 $Minus$int $Minus$int$__deserialize__($Minus$int self, $Serial$state state) {
-   $Minus$int res = $DNEW($Minus$int,state);
-   res->w$Integral = ($Integral)$step_deserialize(state);
-   return res;
+    $Minus$int res = $DNEW($Minus$int, state);
+    res->w$Integral = ($Integral)$step_deserialize(state);
+    return res;
 }
 
-$int $Minus$int$__sub__($Minus$int wit,  $int a, $int b) {
-  return to$int(a->val - b->val);
-}  
+$int $Minus$int$__sub__($Minus$int wit, $int a, $int b) {
+    return to$int(a->val - b->val);
+}
 
 // $Div$int  ////////////////////////////////////////////////////////////////////////////////////////
 
@@ -268,12 +270,12 @@ void $Div$int$__serialize__($Div$int self, $Serial$state state) {
 }
 
 $Div$int $Div$int$__deserialize__($Div$int self, $Serial$state state) {
-   $Div$int res = $DNEW($Div$int,state);
-   return res;
+    $Div$int res = $DNEW($Div$int, state);
+    return res;
 }
 
-$float $Div$int$__truediv__ ($Div$int wit, $int a, $int b) {
-  return to$float((double)a->val/(double)b->val);
+$float $Div$int$__truediv__($Div$int wit, $int a, $int b) {
+    return to$float((double)a->val / (double)b->val);
 }
 
 // $Ord$int  ////////////////////////////////////////////////////////////////////////////////////////
@@ -282,32 +284,32 @@ void $Ord$int$__serialize__($Ord$int self, $Serial$state state) {
 }
 
 $Ord$int $Ord$int$__deserialize__($Ord$int self, $Serial$state state) {
-   $Ord$int res = $DNEW($Ord$int,state);
-   return res;
+    $Ord$int res = $DNEW($Ord$int, state);
+    return res;
 }
 
-$bool $Ord$int$__eq__ ($Ord$int wit, $int a, $int b) {
-  return to$bool(a->val == b->val);
+$bool $Ord$int$__eq__($Ord$int wit, $int a, $int b) {
+    return to$bool(a->val == b->val);
 }
 
-$bool $Ord$int$__ne__ ($Ord$int wit, $int a, $int b) {
-  return to$bool(a->val != b->val);
+$bool $Ord$int$__ne__($Ord$int wit, $int a, $int b) {
+    return to$bool(a->val != b->val);
 }
 
-$bool $Ord$int$__lt__ ($Ord$int wit, $int a, $int b) {
-  return to$bool(a->val < b->val);
+$bool $Ord$int$__lt__($Ord$int wit, $int a, $int b) {
+    return to$bool(a->val < b->val);
 }
 
-$bool $Ord$int$__le__ ($Ord$int wit, $int a, $int b) {
-  return to$bool(a->val <= b->val);
+$bool $Ord$int$__le__($Ord$int wit, $int a, $int b) {
+    return to$bool(a->val <= b->val);
 }
 
-$bool $Ord$int$__gt__ ($Ord$int wit, $int a, $int b) {
-  return to$bool(a->val > b->val);
+$bool $Ord$int$__gt__($Ord$int wit, $int a, $int b) {
+    return to$bool(a->val > b->val);
 }
 
-$bool $Ord$int$__ge__ ($Ord$int wit, $int a, $int b) {
-  return to$bool(a->val >= b->val);
+$bool $Ord$int$__ge__($Ord$int wit, $int a, $int b) {
+    return to$bool(a->val >= b->val);
 }
 
 // $Hashable$int ///////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -316,73 +318,72 @@ void $Hashable$int$__serialize__($Hashable$int self, $Serial$state state) {
 }
 
 $Hashable$int $Hashable$int$__deserialize__($Hashable$int self, $Serial$state state) {
-   $Hashable$int res = $DNEW($Hashable$int,state);
-   return res;
+    $Hashable$int res = $DNEW($Hashable$int, state);
+    return res;
 }
 
 $bool $Hashable$int$__eq__($Hashable$int wit, $int a, $int b) {
-  return to$bool(a->val == b->val);
+    return to$bool(a->val == b->val);
 }
 
 $bool $Hashable$int$__neq__($Hashable$int wit, $int a, $int b) {
-  return to$bool(a->val != b->val);
+    return to$bool(a->val != b->val);
 }
 
 $int $Hashable$int$__hash__($Hashable$int wit, $int a) {
-  return to$int($int_hash(a));
+    return to$int($int_hash(a));
 }
 
 // Initialization ////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 void $Integral$int_init($Integral$int wit) {
-  wit-> w$Logical = ($Logical)$NEW($Logical$int,($Integral)wit);
-  wit-> w$Minus = ($Minus)$NEW($Minus$int,($Integral)wit);
+    wit->w$Logical = ($Logical)$NEW($Logical$int, ($Integral)wit);
+    wit->w$Minus = ($Minus)$NEW($Minus$int, ($Integral)wit);
 };
 
 void $Logical$int_init($Logical$int wit, $Integral w$Integral) {
-  wit->w$Integral =  w$Integral;
+    wit->w$Integral = w$Integral;
 }
 
 void $Minus$int_init($Minus$int wit, $Integral w$Integral) {
-  wit->w$Integral =  w$Integral;
+    wit->w$Integral = w$Integral;
 }
 
 void $Div$int_init($Div$int wit) {
-  return;
+    return;
 }
 
 void $Ord$int_init($Ord$int wit) {
-  return;
+    return;
 }
 
 void $Hashable$int_init($Hashable$int wit) {
-  return;
+    return;
 }
 
 $Integral$int $Integral$int$new() {
-  return $NEW($Integral$int);
+    return $NEW($Integral$int);
 }
 
 $Logical$int $Logical$int$new($Integral wit) {
-  return $NEW($Logical$int,wit);
+    return $NEW($Logical$int, wit);
 }
-  
+
 $Minus$int $Minus$int$new($Integral wit) {
-  return $NEW($Minus$int,wit);
+    return $NEW($Minus$int, wit);
 }
-  
+
 $Ord$int $Ord$int$new() {
-  return $NEW($Ord$int);
+    return $NEW($Ord$int);
 }
 
 $Div$int $Div$int$new() {
-  return $NEW($Div$int);
+    return $NEW($Div$int);
 }
 
 $Hashable$int $Hashable$int$new() {
-  return $NEW($Hashable$int);
+    return $NEW($Hashable$int);
 }
-
 
 struct $Integral$int $Integral$int_instance;
 struct $Logical$int $Logical$int_instance;
@@ -398,16 +399,16 @@ struct $Integral$int$class $Integral$int$methods = {
     $Integral$int_init,
     $Integral$int$__serialize__,
     $Integral$int$__deserialize__,
-    ($bool (*)($Integral$int))$default__bool__,
-    ($str (*)($Integral$int))$default__str__,
+    ($bool(*)($Integral$int))$default__bool__,
+    ($str(*)($Integral$int))$default__str__,
     $Integral$int$__add__,
-    ($int (*)($Integral$int, $int, $int))$Plus$__iadd__,
+    ($int(*)($Integral$int, $int, $int))$Plus$__iadd__,
     $Integral$int$__mul__,
-    ($int (*)($Integral$int, $int, $int))$Times$__imul__,
+    ($int(*)($Integral$int, $int, $int))$Times$__imul__,
     $Integral$int$__fromatom__,
     $Integral$int$__complx__,
     $Integral$int$__pow__,
-    ($int (*)($Integral$int, $int, $int))$Number$__ipow__,
+    ($int(*)($Integral$int, $int, $int))$Number$__ipow__,
     $Integral$int$__neg__,
     $Integral$int$__pos__,
     $Integral$int$real,
@@ -428,32 +429,30 @@ struct $Integral$int$class $Integral$int$methods = {
     $Integral$int$__mod__,
     $Integral$int$__lshift__,
     $Integral$int$__rshift__,
-    ($int (*)($Integral$int, $int, $int))$Integral$__ifloordiv__,
-    ($int (*)($Integral$int, $int, $int))$Integral$__imod__,
-    ($int (*)($Integral$int, $int, $int))$Integral$__ilshift__,
-    ($int (*)($Integral$int, $int, $int))$Integral$__irshift__,
-    $Integral$int$__invert__
-};
+    ($int(*)($Integral$int, $int, $int))$Integral$__ifloordiv__,
+    ($int(*)($Integral$int, $int, $int))$Integral$__imod__,
+    ($int(*)($Integral$int, $int, $int))$Integral$__ilshift__,
+    ($int(*)($Integral$int, $int, $int))$Integral$__irshift__,
+    $Integral$int$__invert__};
 
 struct $Integral$int $Integral$int_instance = {&$Integral$int$methods, ($Minus)&$Minus$int_instance, ($Logical)&$Logical$int_instance};
 $Integral$int $Integral$int$witness = &$Integral$int_instance;
 
-struct $Logical$int$class $Logical$int$methods =  {
+struct $Logical$int$class $Logical$int$methods = {
     "$Logical$int",
     UNASSIGNED,
     ($Super$class)&$Logical$methods,
     $Logical$int_init,
     $Logical$int$__serialize__,
     $Logical$int$__deserialize__,
-    ($bool (*)($Logical$int))$default__bool__,
-    ($str (*)($Logical$int))$default__str__,
+    ($bool(*)($Logical$int))$default__bool__,
+    ($str(*)($Logical$int))$default__str__,
     $Logical$int$__and__,
     $Logical$int$__or__,
     $Logical$int$__xor__,
-    ($int (*)($Logical$int, $int, $int))$Logical$__iand__,
-    ($int (*)($Logical$int, $int, $int))$Logical$__ior__,
-    ($int (*)($Logical$int, $int, $int))$Logical$__ixor__
-};
+    ($int(*)($Logical$int, $int, $int))$Logical$__iand__,
+    ($int(*)($Logical$int, $int, $int))$Logical$__ior__,
+    ($int(*)($Logical$int, $int, $int))$Logical$__ixor__};
 
 struct $Logical$int $Logical$int_instance = {&$Logical$int$methods, ($Integral)&$Integral$int_instance};
 $Logical$int $Logical$int$witness = &$Logical$int_instance;
@@ -465,10 +464,10 @@ struct $Minus$int$class $Minus$int$methods = {
     $Minus$int_init,
     $Minus$int$__serialize__,
     $Minus$int$__deserialize__,
-    ($bool (*)($Minus$int))$default__bool__,
-    ($str (*)($Minus$int))$default__str__,
+    ($bool(*)($Minus$int))$default__bool__,
+    ($str(*)($Minus$int))$default__str__,
     $Minus$int$__sub__,
-    ($int (*)($Minus$int, $int, $int))$Minus$__isub__,
+    ($int(*)($Minus$int, $int, $int))$Minus$__isub__,
 
 };
 struct $Minus$int $Minus$int_instance = {&$Minus$int$methods, ($Integral)&$Integral$int_instance};
@@ -481,15 +480,14 @@ struct $Ord$int$class $Ord$int$methods = {
     $Ord$int_init,
     $Ord$int$__serialize__,
     $Ord$int$__deserialize__,
-    ($bool (*)($Ord$int))$default__bool__,
-    ($str (*)($Ord$int))$default__str__,
+    ($bool(*)($Ord$int))$default__bool__,
+    ($str(*)($Ord$int))$default__str__,
     $Ord$int$__eq__,
     $Ord$int$__ne__,
     $Ord$int$__lt__,
     $Ord$int$__le__,
     $Ord$int$__gt__,
-    $Ord$int$__ge__
-};
+    $Ord$int$__ge__};
 
 struct $Ord$int $Ord$int_instance = {&$Ord$int$methods};
 $Ord$int $Ord$int$witness = &$Ord$int_instance;
@@ -501,10 +499,10 @@ struct $Div$int$class $Div$int$methods = {
     $Div$int_init,
     $Div$int$__serialize__,
     $Div$int$__deserialize__,
-    ($bool (*)($Div$int))$default__bool__,
-    ($str (*)($Div$int))$default__str__,
+    ($bool(*)($Div$int))$default__bool__,
+    ($str(*)($Div$int))$default__str__,
     $Div$int$__truediv__,
-    ($float (*)($Div$int, $int, $int))$Div$__itruediv__,
+    ($float(*)($Div$int, $int, $int))$Div$__itruediv__,
 };
 
 struct $Div$int $Div$int_instance = {&$Div$int$methods};
@@ -517,12 +515,11 @@ struct $Hashable$int$class $Hashable$int$methods = {
     $Hashable$int_init,
     $Hashable$int$__serialize__,
     $Hashable$int$__deserialize__,
-    ($bool (*)($Hashable$int))$default__bool__,
-    ($str (*)($Hashable$int))$default__str__,
+    ($bool(*)($Hashable$int))$default__bool__,
+    ($str(*)($Hashable$int))$default__str__,
     $Hashable$int$__eq__,
     $Hashable$int$__neq__,
-    $Hashable$int$__hash__
-};
+    $Hashable$int$__hash__};
 
 struct $Hashable$int $Hashable$int_instance = {&$Hashable$int$methods};
 $Hashable$int $Hashable$int$witness = &$Hashable$int_instance;

--- a/builtin/int.h
+++ b/builtin/int.h
@@ -1,17 +1,17 @@
 struct $int$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)($int, $atom);
-  void (*__serialize__)($int,$Serial$state);
-  $int (*__deserialize__)($int,$Serial$state);
-  $bool (*__bool__)($int);
-  $str (*__str__)($int);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)($int, $atom);
+    void (*__serialize__)($int, $Serial$state);
+    $int (*__deserialize__)($int, $Serial$state);
+    $bool (*__bool__)($int);
+    $str (*__str__)($int);
 };
 
 struct $int {
-  struct $int$class *$class;
-  long val;
+    struct $int$class *$class;
+    long val;
 };
 
 extern struct $int$class $int$methods;
@@ -37,7 +37,6 @@ extern struct $Div$int *$Div$int$witness;
 extern struct $Ord$int *$Ord$int$witness;
 extern struct $Hashable$int *$Hashable$int$witness;
 
-
 $int to$int(long n);
 long from$int($int n);
 
@@ -54,4 +53,3 @@ $int $int$new($atom a);
 
 // only called with e>=0.
 long longpow(long a, long e); // used also for ndarrays
-

--- a/builtin/list.c
+++ b/builtin/list.c
@@ -12,20 +12,19 @@
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-
 struct $Sequence$list $Sequence$list_instance;
 struct $Collection$list $Collection$list_instance;
 struct $Times$list $Times$list_instance;
 
 struct $Sequence$list$class $Sequence$list$methods = {
-    "$Sequence$list", 
+    "$Sequence$list",
     UNASSIGNED,
     ($Super$class)&$Sequence$methods,
     $Sequence$list$__init__,
     $Sequence$list$__serialize__,
     $Sequence$list$__deserialize__,
-    ($bool (*)($Sequence$list))$default__bool__,
-    ($str (*)($Sequence$list))$default__str__,
+    ($bool(*)($Sequence$list))$default__bool__,
+    ($str(*)($Sequence$list))$default__str__,
     $Sequence$list$__getitem__,
     $Sequence$list$__setitem__,
     $Sequence$list$__delitem__,
@@ -35,13 +34,11 @@ struct $Sequence$list$class $Sequence$list$methods = {
     $Sequence$list$__reversed__,
     $Sequence$list$insert,
     $Sequence$list$append,
-    $Sequence$list$reverse
-};
+    $Sequence$list$reverse};
 struct $Sequence$list $Sequence$list_instance = {
     &$Sequence$list$methods,
-    ($Collection)&$Collection$list_instance, 
-    ($Times)&$Times$list_instance
-};
+    ($Collection)&$Collection$list_instance,
+    ($Times)&$Times$list_instance};
 $Sequence$list $Sequence$list$witness = &$Sequence$list_instance;
 
 struct $Collection$list$class $Collection$list$methods = {
@@ -51,18 +48,15 @@ struct $Collection$list$class $Collection$list$methods = {
     $Collection$list$__init__,
     $Collection$list$__serialize__,
     $Collection$list$__deserialize__,
-    ($bool (*)($Collection$list))$default__bool__,
-    ($str (*)($Collection$list))$default__str__,
+    ($bool(*)($Collection$list))$default__bool__,
+    ($str(*)($Collection$list))$default__str__,
     $Collection$list$__iter__,
     $Collection$list$__fromiter__,
-    $Collection$list$__len__
-};
+    $Collection$list$__len__};
 struct $Collection$list $Collection$list_instance = {
     &$Collection$list$methods,
-    ($Sequence)&$Sequence$list_instance
-};
+    ($Sequence)&$Sequence$list_instance};
 $Collection$list $Collection$list$witness = &$Collection$list_instance;
-
 
 struct $Times$list$class $Times$list$methods = {
     "$Times$list",
@@ -71,17 +65,16 @@ struct $Times$list$class $Times$list$methods = {
     $Times$list$__init__,
     $Times$list$__serialize__,
     $Times$list$__deserialize__,
-    ($bool (*)($Times$list))$default__bool__,
-    ($str (*)($Times$list))$default__str__,
+    ($bool(*)($Times$list))$default__bool__,
+    ($str(*)($Times$list))$default__str__,
     $Times$list$__add__,
-    ($list (*)($Times$list, $list, $list))$Plus$__iadd__,
+    ($list(*)($Times$list, $list, $list))$Plus$__iadd__,
     $Times$list$__mul__,
-    ($list (*)($Times$list, $list, $int))$Times$__imul__,
+    ($list(*)($Times$list, $list, $int))$Times$__imul__,
 };
 struct $Times$list $Times$list_instance = {
     &$Times$list$methods,
-    ($Sequence)&$Sequence$list_instance
-};
+    ($Sequence)&$Sequence$list_instance};
 $Times$list $Times$list$witness = &$Times$list_instance;
 
 struct $Container$list$class $Container$list$methods = {
@@ -91,159 +84,156 @@ struct $Container$list$class $Container$list$methods = {
     $Container$list$__init__,
     $Container$list$__serialize__,
     $Container$list$__deserialize__,
-    ($bool (*)($Container$list))$default__bool__,
-    ($str (*)($Container$list))$default__str__,
-    ($Iterator (*)($Container$list, $list))$Collection$list$__iter__,
-    ($list (*)($Container$list,$Iterable,$WORD))$Collection$list$__fromiter__,
-    ($int (*)($Container$list, $list))$Collection$list$__len__,
+    ($bool(*)($Container$list))$default__bool__,
+    ($str(*)($Container$list))$default__str__,
+    ($Iterator(*)($Container$list, $list))$Collection$list$__iter__,
+    ($list(*)($Container$list, $Iterable, $WORD))$Collection$list$__fromiter__,
+    ($int(*)($Container$list, $list))$Collection$list$__len__,
     $Container$list$__contains__,
-    $Container$list$__containsnot__
-};
+    $Container$list$__containsnot__};
 
 void $Times$list$__serialize__($Times$list self, $Serial$state state) {
-  $step_serialize(self->w$Sequence, state);
+    $step_serialize(self->w$Sequence, state);
 }
 
 $Times$list $Times$list$__deserialize__($Times$list self, $Serial$state state) {
-   $Times$list res = $DNEW($Times$list,state);
-   res->w$Sequence = ($Sequence)$step_deserialize(state);
-   return res;
+    $Times$list res = $DNEW($Times$list, state);
+    res->w$Sequence = ($Sequence)$step_deserialize(state);
+    return res;
 }
 
-$list $Times$list$__add__ ($Times$list wit, $list a, $list b) {
-  return $list_add(a,b);
+$list $Times$list$__add__($Times$list wit, $list a, $list b) {
+    return $list_add(a, b);
 }
 
-$list $Times$list$__mul__ ($Times$list wit, $list a, $int n) {
-  return $list_mul(a,n);
+$list $Times$list$__mul__($Times$list wit, $list a, $int n) {
+    return $list_mul(a, n);
 }
 
 void $Collection$list$__serialize__($Collection$list self, $Serial$state state) {
-  $step_serialize(self->w$Sequence, state);
+    $step_serialize(self->w$Sequence, state);
 }
 
 $Collection$list $Collection$list$__deserialize__($Collection$list self, $Serial$state state) {
-   $Collection$list res = $DNEW($Collection$list,state);
-   res->w$Sequence = ($Sequence)$step_deserialize(state);
-   return res;
+    $Collection$list res = $DNEW($Collection$list, state);
+    res->w$Sequence = ($Sequence)$step_deserialize(state);
+    return res;
 }
 
 $Iterator $Collection$list$__iter__($Collection$list wit, $list self) {
-  return $list_iter(self);
+    return $list_iter(self);
 }
- 
-$list $Collection$list$__fromiter__ ($Collection$list wit, $Iterable wit2, $WORD iter) {
-  return $list_fromiter(wit2->$class->__iter__(wit2,iter));
+
+$list $Collection$list$__fromiter__($Collection$list wit, $Iterable wit2, $WORD iter) {
+    return $list_fromiter(wit2->$class->__iter__(wit2, iter));
 }
 
 $int $Collection$list$__len__($Collection$list wit, $list self) {
-  return to$int($list_len(self));
+    return to$int($list_len(self));
 }
 
 void $Sequence$list$__serialize__($Sequence$list self, $Serial$state state) {
-  $step_serialize(self->w$Collection, state);
-  $step_serialize(self->w$Times, state);
+    $step_serialize(self->w$Collection, state);
+    $step_serialize(self->w$Times, state);
 }
 
 $Sequence$list $Sequence$list$__deserialize__($Sequence$list self, $Serial$state state) {
-   $Sequence$list res = $DNEW($Sequence$list,state);
-   res->w$Collection = ($Collection)$step_deserialize(state);
-   res->w$Times = ($Times)$step_deserialize(state);
-   return res;
+    $Sequence$list res = $DNEW($Sequence$list, state);
+    res->w$Collection = ($Collection)$step_deserialize(state);
+    res->w$Times = ($Times)$step_deserialize(state);
+    return res;
 }
-  
-  
+
 $WORD $Sequence$list$__getitem__($Sequence$list wit, $list self, $int ix) {
-  return $list_getitem(self,from$int(ix));
+    return $list_getitem(self, from$int(ix));
 }
 
 void $Sequence$list$__setitem__($Sequence$list wit, $list self, $int ix, $WORD val) {
-  $list_setitem(self,from$int(ix),val);
+    $list_setitem(self, from$int(ix), val);
 }
 
 void $Sequence$list$__delitem__($Sequence$list wit, $list self, $int ix) {
-  $list_delitem(self,from$int(ix));
+    $list_delitem(self, from$int(ix));
 }
 
 $list $Sequence$list$__getslice__($Sequence$list wit, $list self, $slice slice) {
-  return $list_getslice(self,slice);
+    return $list_getslice(self, slice);
 }
 
 void $Sequence$list$__setslice__($Sequence$list wit, $list self, $Iterable wit2, $slice slice, $WORD iter) {
-  $list_setslice(self,slice,wit2->$class->__iter__(wit2,iter));
+    $list_setslice(self, slice, wit2->$class->__iter__(wit2, iter));
 }
 
 void $Sequence$list$__delslice__($Sequence$list wit, $list self, $slice slice) {
-  $list_delslice(($list)self,slice);
-}  
+    $list_delslice(($list)self, slice);
+}
 
 void $Container$list$__serialize__($Container$list self, $Serial$state state) {
-  $step_serialize(self->w$Eq$A$Container$list, state);
+    $step_serialize(self->w$Eq$A$Container$list, state);
 }
 
 $Container$list $Container$list$__deserialize__($Container$list self, $Serial$state state) {
-   $Container$list res = $DNEW($Container$list,state);
-   res->w$Eq$A$Container$list = ($Eq)$step_deserialize(state);
-   return res;
+    $Container$list res = $DNEW($Container$list, state);
+    res->w$Eq$A$Container$list = ($Eq)$step_deserialize(state);
+    return res;
 }
 
 $bool $Container$list$__contains__($Container$list wit, $list self, $WORD elem) {
-  return to$bool($list_contains(wit->w$Eq$A$Container$list,self,elem));
+    return to$bool($list_contains(wit->w$Eq$A$Container$list, self, elem));
 }
-                 
+
 $bool $Container$list$__containsnot__($Container$list wit, $list self, $WORD elem) {
-  return to$bool($list_containsnot(wit->w$Eq$A$Container$list,self,elem));
+    return to$bool($list_containsnot(wit->w$Eq$A$Container$list, self, elem));
 }
 
 $Iterator $Iterable$list$reversed__iter__($Iterable wit, $WORD lst) {
-  return $list_reversed(lst);
+    return $list_reversed(lst);
 }
 
 $Iterator $Sequence$list$__reversed__($Sequence$list wit, $list self) {
-  return $list_reversed(self);
+    return $list_reversed(self);
 }
 
 void $Sequence$list$insert($Sequence$list wit, $list self, $int ix, $WORD elem) {
-  $list_insert(self,from$int(ix),elem);
+    $list_insert(self, from$int(ix), elem);
 }
 
 void $Sequence$list$append($Sequence$list wit, $list self, $WORD elem) {
-  $list_append(self,elem);
+    $list_append(self, elem);
 }
 
 void $Sequence$list$reverse($Sequence$list wit, $list self) {
-  $list_reverse(self);
+    $list_reverse(self);
 }
 
 $Container$list $Container$list$new($Eq e) {
-  return $NEW($Container$list,e);
+    return $NEW($Container$list, e);
 }
 
-
 void $Container$list$__init__($Container$list self, $Eq w$Eq$A$Container$list) {
-  self->w$Eq$A$Container$list = w$Eq$A$Container$list;
+    self->w$Eq$A$Container$list = w$Eq$A$Container$list;
 }
 
 void $Collection$list$__init__($Collection$list self, $Sequence master) {
-  self->w$Sequence = master;
+    self->w$Sequence = master;
 }
 
 void $Times$list$__init__($Times$list self, $Sequence master) {
-  self->w$Sequence = master;
+    self->w$Sequence = master;
 }
 
 $Sequence$list $Sequence$list$new() {
-  return $NEW($Sequence$list);
+    return $NEW($Sequence$list);
 }
 
-$Collection$list $Collection$list$new($Sequence master){
-  return $NEW($Collection$list, master);
+$Collection$list $Collection$list$new($Sequence master) {
+    return $NEW($Collection$list, master);
 }
 $Times$list $Times$list$new($Sequence master) {
-  return $NEW($Times$list, master);
+    return $NEW($Times$list, master);
 }
 
 void $Sequence$list$__init__($Sequence$list self) {
-  self->w$Collection = ($Collection)$Collection$list$new(($Sequence)self);
-  self->w$Times = ($Times)$Times$list$new(($Sequence)self);
+    self->w$Collection = ($Collection)$Collection$list$new(($Sequence)self);
+    self->w$Times = ($Times)$Times$list$new(($Sequence)self);
 }

--- a/builtin/list.h
+++ b/builtin/list.h
@@ -1,21 +1,21 @@
 struct $list$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)($list, $Iterable, $WORD);
-  void (*__serialize__)($list,$Serial$state);
-  $list (*__deserialize__)($list,$Serial$state);
-  $bool (*__bool__)($list);
-  $str (*__str__)($list);
-  $list(*copy)($list);
-  //  $int (*sort)($list self, int (*cmp)($WORD,$WORD));
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)($list, $Iterable, $WORD);
+    void (*__serialize__)($list, $Serial$state);
+    $list (*__deserialize__)($list, $Serial$state);
+    $bool (*__bool__)($list);
+    $str (*__str__)($list);
+    $list (*copy)($list);
+    //  $int (*sort)($list self, int (*cmp)($WORD,$WORD));
 };
 
 struct $list {
-  struct $list$class *$class;
-  $WORD *data;
-  int length;
-  int capacity;
+    struct $list$class *$class;
+    $WORD *data;
+    int length;
+    int capacity;
 };
 
 extern struct $list$class $list$methods;
@@ -38,26 +38,27 @@ extern struct $Container$list *$Container$list_new($Eq); // equality is for elem
 
 // Iterators over lists ///////////////////////////////////////////////////////
 
-typedef struct $Iterator$list *$Iterator$list; ;
+typedef struct $Iterator$list *$Iterator$list;
+;
 
 struct $Iterator$list$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)($Iterator$list, $list);
-  void (*__serialize__)($Iterator$list,$Serial$state);
-  $Iterator$list (*__deserialize__)($Iterator$list,$Serial$state);
-  $bool (*__bool__)($Iterator$list);
-  $str (*__str__)($Iterator$list);
-  $WORD(*__next__)($Iterator$list);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)($Iterator$list, $list);
+    void (*__serialize__)($Iterator$list, $Serial$state);
+    $Iterator$list (*__deserialize__)($Iterator$list, $Serial$state);
+    $bool (*__bool__)($Iterator$list);
+    $str (*__str__)($Iterator$list);
+    $WORD (*__next__)
+    ($Iterator$list);
 };
 
 struct $Iterator$list {
-  struct $Iterator$list$class *$class;
-  $list src;
-  int nxt;
+    struct $Iterator$list$class *$class;
+    $list src;
+    int nxt;
 };
 
-extern struct  $Iterator$list$class  $Iterator$list$methods;
+extern struct $Iterator$list$class $Iterator$list$methods;
 $Iterator$list $Iterator$list$new($list);
-

--- a/builtin/list_impl.c
+++ b/builtin/list_impl.c
@@ -15,7 +15,7 @@
 // General methods //////////////////////////////////////////////////////////////////////////
 
 $list $list$new($Iterable wit, $WORD iterable) {
-  return $NEW($list, wit, iterable);
+    return $NEW($list, wit, iterable);
 }
 
 void $list_init($list lst, $Iterable wit, $WORD iterable) {
@@ -26,357 +26,354 @@ void $list_init($list lst, $Iterable wit, $WORD iterable) {
         return;
     }
     $WORD w;
-    $Iterator it = wit->$class->__iter__(wit,iterable);
-    while((w = it->$class->__next__(it)))
-        $list_append(lst,w);
+    $Iterator it = wit->$class->__iter__(wit, iterable);
+    while ((w = it->$class->__next__(it)))
+        $list_append(lst, w);
 }
-  
+
 $bool $list_bool($list self) {
-  return to$bool(self->length>0);
+    return to$bool(self->length > 0);
 }
 
 $str $list_str($list self) {
-  $list s2 = $list_new(self->length);
-  for (int i=0; i< self->length; i++) {
-    $value elem = ($value)self->data[i];
-    $list_append(s2,elem->$class->__str__(elem));
-  }
-  return $str_join_par('[',s2,']');
+    $list s2 = $list_new(self->length);
+    for (int i = 0; i < self->length; i++) {
+        $value elem = ($value)self->data[i];
+        $list_append(s2, elem->$class->__str__(elem));
+    }
+    return $str_join_par('[', s2, ']');
 }
 
-void $list_serialize($list self,$Serial$state state) {
-  $int prevkey = ($int)$dict_get(state->done,($Hashable)$Hashable$WORD$witness,self,NULL);
-  if (prevkey) {
-    $val_serialize(-LIST_ID,&prevkey->val,state);
-    return;
-  }
-  $dict_setitem(state->done,($Hashable)$Hashable$WORD$witness,self,to$int(state->row_no));
-  long len = (long)self->length;
-  $val_serialize(LIST_ID,&len,state);
-  for (int i=0; i<self->length; i++) {
-    $step_serialize(self->data[i],state);
-  }
+void $list_serialize($list self, $Serial$state state) {
+    $int prevkey = ($int)$dict_get(state->done, ($Hashable)$Hashable$WORD$witness, self, NULL);
+    if (prevkey) {
+        $val_serialize(-LIST_ID, &prevkey->val, state);
+        return;
+    }
+    $dict_setitem(state->done, ($Hashable)$Hashable$WORD$witness, self, to$int(state->row_no));
+    long len = (long)self->length;
+    $val_serialize(LIST_ID, &len, state);
+    for (int i = 0; i < self->length; i++) {
+        $step_serialize(self->data[i], state);
+    }
 }
- 
+
 $list $list_deserialize($list res, $Serial$state state) {
-  $ROW this = state->row;
-  state->row = this->next;
-  state->row_no++;
-  if (this->class_id < 0) {
-    return ($list)$dict_get(state->done,($Hashable)$Hashable$int$witness,to$int((long)this->blob[0]),NULL);
-  } else {
-    if (!res)
-       res = $list_new((int)(long)this->blob[0]);
-    $dict_setitem(state->done,($Hashable)$Hashable$int$witness,to$int(state->row_no-1),res);
-    res->length = res->capacity;
-    for (int i = 0; i < res->length; i++) 
-      res->data[i] = $step_deserialize(state);
-    return res;
-  }
+    $ROW this = state->row;
+    state->row = this->next;
+    state->row_no++;
+    if (this->class_id < 0) {
+        return ($list)$dict_get(state->done, ($Hashable)$Hashable$int$witness, to$int((long)this->blob[0]), NULL);
+    } else {
+        if (!res)
+            res = $list_new((int)(long)this->blob[0]);
+        $dict_setitem(state->done, ($Hashable)$Hashable$int$witness, to$int(state->row_no - 1), res);
+        res->length = res->capacity;
+        for (int i = 0; i < res->length; i++)
+            res->data[i] = $step_deserialize(state);
+        return res;
+    }
 }
 
-struct $list$class $list$methods = {"$list",UNASSIGNED,($Super$class)&$object$methods, $list_init, $list_serialize,$list_deserialize, $list_bool, $list_str, $list_copy};
+struct $list$class $list$methods = {"$list", UNASSIGNED, ($Super$class)&$object$methods, $list_init, $list_serialize, $list_deserialize, $list_bool, $list_str, $list_copy};
 
 // Auxiliary functions /////////////////////////////////////////////////////////////////////////////////////////////////////
- 
-// For now, expansion doubles capacity. 
-static void expand($list lst,int n) {
-   if (lst->capacity >= lst->length + n)
-     return;
-   int newcapacity = lst->capacity==0 ? 1 : lst->capacity;
-   while (newcapacity < lst->length+n)
-     newcapacity <<= 1;
-   $WORD* newptr = lst->data==NULL
-     ? malloc(newcapacity*sizeof($WORD))
-     : realloc(lst->data,newcapacity*sizeof($WORD));
-   if (newptr == NULL) {
-    $RAISE(($BaseException)$NEW($MemoryError,to$str("memory allocation failed")));
-   }
-   lst->data = newptr;
-   lst->capacity = newcapacity;
-}  
+
+// For now, expansion doubles capacity.
+static void expand($list lst, int n) {
+    if (lst->capacity >= lst->length + n)
+        return;
+    int newcapacity = lst->capacity == 0 ? 1 : lst->capacity;
+    while (newcapacity < lst->length + n)
+        newcapacity <<= 1;
+    $WORD *newptr = lst->data == NULL
+                        ? malloc(newcapacity * sizeof($WORD))
+                        : realloc(lst->data, newcapacity * sizeof($WORD));
+    if (newptr == NULL) {
+        $RAISE(($BaseException)$NEW($MemoryError, to$str("memory allocation failed")));
+    }
+    lst->data = newptr;
+    lst->capacity = newcapacity;
+}
 
 $list $list_new(int capacity) {
-  if (capacity < 0) {
-    fprintf(stderr,"Internal error list_new: negative capacity");
-    exit(-1);
-  } 
-  $list lst = malloc(sizeof(struct $list));
-  if (lst == NULL) {
-     $RAISE(($BaseException)$NEW($MemoryError,to$str("memory allocation failed")));
-  }
-  if (capacity>0) {
-    lst->data = malloc(capacity*sizeof($WORD));
-    if (lst->data == NULL) {
-       $RAISE(($BaseException)$NEW($MemoryError,to$str("memory allocation failed")));
+    if (capacity < 0) {
+        fprintf(stderr, "Internal error list_new: negative capacity");
+        exit(-1);
     }
-  } else {
-    lst->data = NULL;
-  }
-  lst->length = 0;
-  lst->capacity = capacity;
-  lst->$class = &$list$methods; 
-  return lst;
+    $list lst = malloc(sizeof(struct $list));
+    if (lst == NULL) {
+        $RAISE(($BaseException)$NEW($MemoryError, to$str("memory allocation failed")));
+    }
+    if (capacity > 0) {
+        lst->data = malloc(capacity * sizeof($WORD));
+        if (lst->data == NULL) {
+            $RAISE(($BaseException)$NEW($MemoryError, to$str("memory allocation failed")));
+        }
+    } else {
+        lst->data = NULL;
+    }
+    lst->length = 0;
+    lst->capacity = capacity;
+    lst->$class = &$list$methods;
+    return lst;
 }
 
 // Times /////////////////////////////////////////////////////////////////////////////////////////////
 
 $list $list_add($list lst, $list other) {
-  int lstlen = lst->length;
-  int otherlen = other->length;
-  int reslen = lstlen + otherlen;
-  $list res = $list_new(reslen);
-  memcpy(res->data,lst->data,lstlen*sizeof($WORD));
-  memcpy(res->data+lstlen,other->data,otherlen*sizeof($WORD));
-  res->length = reslen;
-  return res;
+    int lstlen = lst->length;
+    int otherlen = other->length;
+    int reslen = lstlen + otherlen;
+    $list res = $list_new(reslen);
+    memcpy(res->data, lst->data, lstlen * sizeof($WORD));
+    memcpy(res->data + lstlen, other->data, otherlen * sizeof($WORD));
+    res->length = reslen;
+    return res;
 }
 
 $list $list_mul($list lst, $int n) {
-  int lstlen = lst->length;
-  if (n->val <= 0)
-    return $list_new(0);
-  else {
-    $list res = $list_new(lstlen * n->val);
-    for (int i=0; i<n->val; i++)
-      memcpy(res->data + i*lstlen, lst->data, lstlen * sizeof($WORD));
-    res->length = lstlen * n->val;
-    return res;
-  }
+    int lstlen = lst->length;
+    if (n->val <= 0)
+        return $list_new(0);
+    else {
+        $list res = $list_new(lstlen * n->val);
+        for (int i = 0; i < n->val; i++)
+            memcpy(res->data + i * lstlen, lst->data, lstlen * sizeof($WORD));
+        res->length = lstlen * n->val;
+        return res;
+    }
 }
-      
-    
+
 // Collection ///////////////////////////////////////////////////////////////////////////////////////
 
 $list $list_fromiter($Iterator it) {
-  $list res = $list_new(4);
-  $WORD nxt;
-  while ((nxt = it->$class->__next__(it))) {
-    $list_append(res,nxt);
-  }
-  return res;
+    $list res = $list_new(4);
+    $WORD nxt;
+    while ((nxt = it->$class->__next__(it))) {
+        $list_append(res, nxt);
+    }
+    return res;
 }
 
 long $list_len($list lst) {
-  return (long)lst->length;
+    return (long)lst->length;
 }
 
 // Container ///////////////////////////////////////////////////////////////////////////
 
 int $list_contains($Eq w, $list lst, $WORD elem) {
-  for (int i=0; i < lst->length; i++) {
-    if (from$bool(w->$class->__eq__(w,elem,lst->data[i])))
-      return 1;
-  }
-  return 0;
+    for (int i = 0; i < lst->length; i++) {
+        if (from$bool(w->$class->__eq__(w, elem, lst->data[i])))
+            return 1;
+    }
+    return 0;
 }
 
 int $list_containsnot($Eq w, $list lst, $WORD elem) {
-  return !$list_contains(w,lst,elem);
+    return !$list_contains(w, lst, elem);
 }
 
 // Iterable ///////////////////////////////////////////////////////////////////////////
 
-
 static $WORD $Iterator$list_next($Iterator$list self) {
-  return self->nxt >= self->src->length ? NULL : self->src->data[self->nxt++];
+    return self->nxt >= self->src->length ? NULL : self->src->data[self->nxt++];
 }
 
 $Iterator$list $Iterator$list$new($list lst) {
-  return $NEW($Iterator$list, lst);
+    return $NEW($Iterator$list, lst);
 }
 
 void $Iterator$list_init($Iterator$list self, $list lst) {
-  self->src = lst;
-  self->nxt = 0;
+    self->src = lst;
+    self->nxt = 0;
 }
 
 $bool $Iterator$list_bool($Iterator$list self) {
-  return $True;
+    return $True;
 }
 
 $str $Iterator$list_str($Iterator$list self) {
-  char *s;
-  asprintf(&s,"<list iterator object at %p>",self);
-  return to$str(s);
+    char *s;
+    asprintf(&s, "<list iterator object at %p>", self);
+    return to$str(s);
 }
 
-void $Iterator$list_serialize($Iterator$list self,$Serial$state state) {
-  $step_serialize(self->src,state);
-  $step_serialize(to$int(self->nxt),state);
+void $Iterator$list_serialize($Iterator$list self, $Serial$state state) {
+    $step_serialize(self->src, state);
+    $step_serialize(to$int(self->nxt), state);
 }
 
 $Iterator$list $Iterator$list$_deserialize($Iterator$list res, $Serial$state state) {
-   if(!res)
-      res = $DNEW($Iterator$list,state);
-   res->src = ($list)$step_deserialize(state);
-   res->nxt = from$int(($int)$step_deserialize(state));
-   return res;
+    if (!res)
+        res = $DNEW($Iterator$list, state);
+    res->src = ($list)$step_deserialize(state);
+    res->nxt = from$int(($int)$step_deserialize(state));
+    return res;
 }
 
-struct $Iterator$list$class $Iterator$list$methods = {"$Iterator$list",UNASSIGNED,($Super$class)&$Iterator$methods, $Iterator$list_init,
-                                                      $Iterator$list_serialize, $Iterator$list$_deserialize,$Iterator$list_bool,$Iterator$list_str,$Iterator$list_next};
+struct $Iterator$list$class $Iterator$list$methods = {"$Iterator$list", UNASSIGNED, ($Super$class)&$Iterator$methods, $Iterator$list_init,
+                                                      $Iterator$list_serialize, $Iterator$list$_deserialize, $Iterator$list_bool, $Iterator$list_str, $Iterator$list_next};
 
 $Iterator $list_iter($list lst) {
-  return ($Iterator)$NEW($Iterator$list,lst);
+    return ($Iterator)$NEW($Iterator$list, lst);
 }
 
 // Indexed ///////////////////////////////////////////////////////////////////////////
 
 $WORD $list_getitem($list lst, int ix) {
-  int len = lst->length;
-  int ix0 = ix < 0 ? len + ix : ix;
-  if (ix0 < 0 || ix0 >= len) {
-    $RAISE(($BaseException)$NEW($IndexError,to$str("getitem: indexing outside list")));
-  }
-  return lst->data[ix0];
+    int len = lst->length;
+    int ix0 = ix < 0 ? len + ix : ix;
+    if (ix0 < 0 || ix0 >= len) {
+        $RAISE(($BaseException)$NEW($IndexError, to$str("getitem: indexing outside list")));
+    }
+    return lst->data[ix0];
 }
 
 void $list_setitem($list lst, int ix, $WORD val) {
-  int len = lst->length;
-  int ix0 = ix < 0 ? len + ix : ix;
-  if (ix0 < 0 || ix0 >= len) {
-    $RAISE(($BaseException)$NEW($IndexError,to$str("setitem: indexing outside list")));
-  }
-  lst->data[ix0] = val;
+    int len = lst->length;
+    int ix0 = ix < 0 ? len + ix : ix;
+    if (ix0 < 0 || ix0 >= len) {
+        $RAISE(($BaseException)$NEW($IndexError, to$str("setitem: indexing outside list")));
+    }
+    lst->data[ix0] = val;
 }
 
-void $list_delitem($list lst,int ix) {
-  int len = lst->length;
-  int ix0 = ix < 0 ? len + ix : ix;
-  if(ix0 < 0 || ix0 >= len) {
-    $RAISE(($BaseException)$NEW($IndexError,to$str("delitem: indexing outside list")));
-  }
-  memmove(lst->data + ix0,
-          lst->data + (ix0 + 1),
-          (len-(ix0+1))*sizeof($WORD));
-  lst->length--;
+void $list_delitem($list lst, int ix) {
+    int len = lst->length;
+    int ix0 = ix < 0 ? len + ix : ix;
+    if (ix0 < 0 || ix0 >= len) {
+        $RAISE(($BaseException)$NEW($IndexError, to$str("delitem: indexing outside list")));
+    }
+    memmove(lst->data + ix0,
+            lst->data + (ix0 + 1),
+            (len - (ix0 + 1)) * sizeof($WORD));
+    lst->length--;
 }
- 
 
 // Sliceable //////////////////////////////////////////////////////////////////////////////////////
 
 $list $list_getslice($list lst, $slice slc) {
-  int len = lst->length;
-  int start, stop, step, slen;
-  normalize_slice(slc, len, &slen, &start, &stop, &step);
-  // slice notation has been eliminated and default values applied.
-  // slen is now the length of the slice
-  $list rlst = $list_new(slen);
-  int t = start;
-  for (int i=0; i<slen; i++) {
-    $WORD w;
-    w = $list_getitem(lst,t);
-    $list_append(rlst,w);
-    t += step;
-  }
-  return rlst;
+    int len = lst->length;
+    int start, stop, step, slen;
+    normalize_slice(slc, len, &slen, &start, &stop, &step);
+    // slice notation has been eliminated and default values applied.
+    // slen is now the length of the slice
+    $list rlst = $list_new(slen);
+    int t = start;
+    for (int i = 0; i < slen; i++) {
+        $WORD w;
+        w = $list_getitem(lst, t);
+        $list_append(rlst, w);
+        t += step;
+    }
+    return rlst;
 }
 
 void $list_setslice($list lst, $slice slc, $Iterator it) {
-  int len = lst->length;
-  $list other = $list_new(0);
-  $WORD w;
-  while((w=it->$class->__next__(it)))
-    $list_append(other,w);
-  int olen = other->length; 
-  int start, stop, step, slen;
-  normalize_slice(slc, len, &slen, &start, &stop, &step);
-  if (step != 1 && olen != slen) {
-    $RAISE(($BaseException)$NEW($ValueError,to$str("setslice: illegal slice")));
-  }
-  int copy = olen <= slen ? olen : slen;
-  int t = start;
-  for (int i= 0; i<copy; i++) {
-    lst->data[t] = other->data[i];
-    t += step;
-  }
-  if (olen == slen)
-    return;
-  // now we know that step=1
-  if (olen < slen) {
-    memmove(lst->data + start + copy,
-            lst->data + start + slen,
-            (len-(start+slen))*sizeof($WORD));
-     lst->length-=slen-olen;
-     return;
-  } else {
-    expand(lst,olen-slen);
-    int rest = len - (start+copy);
-    int incr = olen - slen;
-    memmove(lst->data + start + copy + incr,
-            lst->data + start + copy,
-            rest*sizeof($WORD));
-    for (int i = copy; i < olen; i++)
-      lst->data[start+i] = other->data[i];
-    lst->length += incr;
-  }
+    int len = lst->length;
+    $list other = $list_new(0);
+    $WORD w;
+    while ((w = it->$class->__next__(it)))
+        $list_append(other, w);
+    int olen = other->length;
+    int start, stop, step, slen;
+    normalize_slice(slc, len, &slen, &start, &stop, &step);
+    if (step != 1 && olen != slen) {
+        $RAISE(($BaseException)$NEW($ValueError, to$str("setslice: illegal slice")));
+    }
+    int copy = olen <= slen ? olen : slen;
+    int t = start;
+    for (int i = 0; i < copy; i++) {
+        lst->data[t] = other->data[i];
+        t += step;
+    }
+    if (olen == slen)
+        return;
+    // now we know that step=1
+    if (olen < slen) {
+        memmove(lst->data + start + copy,
+                lst->data + start + slen,
+                (len - (start + slen)) * sizeof($WORD));
+        lst->length -= slen - olen;
+        return;
+    } else {
+        expand(lst, olen - slen);
+        int rest = len - (start + copy);
+        int incr = olen - slen;
+        memmove(lst->data + start + copy + incr,
+                lst->data + start + copy,
+                rest * sizeof($WORD));
+        for (int i = copy; i < olen; i++)
+            lst->data[start + i] = other->data[i];
+        lst->length += incr;
+    }
 }
 
 void $list_delslice($list lst, $slice slc) {
-  int len = lst->length;
-  int start, stop, step, slen;
-  normalize_slice(slc, len, &slen, &start, &stop, &step);
-  if (slen==0) return;
-  $WORD *p = lst->data + start;
-  for (int i=0; i<slen-1; i++) {
-    memmove(p,p+i+1,(step-1)*sizeof($WORD));
-    p+=step-1;
-  }
-  memmove(p,p+slen,(len-1-(start+step*(slen-1)))*sizeof($WORD));
-  lst->length-=slen;
+    int len = lst->length;
+    int start, stop, step, slen;
+    normalize_slice(slc, len, &slen, &start, &stop, &step);
+    if (slen == 0)
+        return;
+    $WORD *p = lst->data + start;
+    for (int i = 0; i < slen - 1; i++) {
+        memmove(p, p + i + 1, (step - 1) * sizeof($WORD));
+        p += step - 1;
+    }
+    memmove(p, p + slen, (len - 1 - (start + step * (slen - 1))) * sizeof($WORD));
+    lst->length -= slen;
 }
 
 // Sequence /////////////////////////////////////////////////////////////////////////////
 
 void $list_append($list lst, $WORD val) {
-  expand(lst,1);
-  lst->data[lst->length++] = val;
+    expand(lst, 1);
+    lst->data[lst->length++] = val;
 }
 
 static $WORD $Iterator$list_reversed_next($Iterator$list self) {
-  return self->nxt < 0 ? NULL : self->src->data[self->nxt--];
+    return self->nxt < 0 ? NULL : self->src->data[self->nxt--];
 }
 
-$Iterator $list_reversed($list lst){
-  $list copy = $list_copy(lst);
-  $list_reverse(copy);
-  return $list_iter(copy);
+$Iterator $list_reversed($list lst) {
+    $list copy = $list_copy(lst);
+    $list_reverse(copy);
+    return $list_iter(copy);
 }
 
 void $list_insert($list lst, int ix, $WORD val) {
-  int len = lst->length;
-  expand(lst,1);
-  int ix0 = ix < 0 ? (len+ix < 0 ? 0 : len+ix) : (ix < len ? ix : len);
-  memmove(lst->data + (ix0 + 1),
-          lst->data + ix0 ,
-          (len - ix0) * sizeof($WORD));
-  lst->data[ix0] = val;
-  lst->length++;
+    int len = lst->length;
+    expand(lst, 1);
+    int ix0 = ix < 0 ? (len + ix < 0 ? 0 : len + ix) : (ix < len ? ix : len);
+    memmove(lst->data + (ix0 + 1),
+            lst->data + ix0,
+            (len - ix0) * sizeof($WORD));
+    lst->data[ix0] = val;
+    lst->length++;
 }
 
 // In place reversal
 void $list_reverse($list lst) {
-  int len = lst->length;
-  for (int i = 0; i < len/2; i++) {
-    $WORD tmp = lst->data[i];
-    lst->data[i] = lst->data[len-1-i];
-    lst->data[len-1-i] = tmp;
-  }
+    int len = lst->length;
+    for (int i = 0; i < len / 2; i++) {
+        $WORD tmp = lst->data[i];
+        lst->data[i] = lst->data[len - 1 - i];
+        lst->data[len - 1 - i] = tmp;
+    }
 }
- 
+
 // List-specific methods /////////////////////////////////////////////////////////////////////
 
 $list $list_copy($list lst) {
-  int len = lst->length;
-  $list res = $list_new(len);
-  res->length = len;
-  memcpy(res->data,lst->data,len*sizeof($WORD));
-  return res;
+    int len = lst->length;
+    $list res = $list_new(len);
+    res->length = len;
+    memcpy(res->data, lst->data, len * sizeof($WORD));
+    return res;
 }
 /*                   
 int list_sort(list_t lst, int (*cmp)(WORD,WORD)) {
   return heapsort(lst->data, lst->length, sizeof(WORD), cmp);
 }
 */
- 

--- a/builtin/list_impl.h
+++ b/builtin/list_impl.h
@@ -11,12 +11,12 @@ $Iterator $list_iter($list lst);
 $list $list_fromiter($Iterator it);
 long $list_len($list lst);
 
-int $list_contains($Eq w,$list lst, $WORD elem);
+int $list_contains($Eq w, $list lst, $WORD elem);
 int $list_containsnot($Eq w, $list lst, $WORD elem);
 
 $WORD $list_getitem($list lst, int ix);
 void $list_setitem($list lst, int ix, $WORD val);
-void $list_delitem($list lst,int ix);
+void $list_delitem($list lst, int ix);
 
 $list $list_getslice($list lst, $slice slc);
 void $list_setslice($list lst, $slice slc, $Iterator it);

--- a/builtin/none.c
+++ b/builtin/none.c
@@ -13,27 +13,26 @@
  */
 
 $NoneType $NoneType$new() {
-  return $NEW($NoneType);
+    return $NEW($NoneType);
 }
 
-
 void $NoneType__serialize__($NoneType self, $Serial$state state) {
-  $add_header(NONE_ID,0,state);
+    $add_header(NONE_ID, 0, state);
 }
 
 $NoneType $NoneType__deserialize__($NoneType self, $Serial$state state) {
-  state->row = state->row->next;
-  state->row_no++;
-  return NULL;
+    state->row = state->row->next;
+    state->row_no++;
+    return NULL;
 }
 
 $bool $NoneType__bool__($NoneType self) {
-  return $False;
+    return $False;
 }
 
 $str $NoneType__str__($NoneType self) {
-  return to$str("None");
+    return to$str("None");
 }
 
-struct $NoneType$class $NoneType$methods = {"$NoneType",UNASSIGNED,($Super$class)&$value$methods,(void (*)($NoneType))$default__init__,
-                                            $NoneType__serialize__,  $NoneType__deserialize__, $NoneType__bool__, $NoneType__str__};
+struct $NoneType$class $NoneType$methods = {"$NoneType", UNASSIGNED, ($Super$class)&$value$methods, (void (*)($NoneType))$default__init__,
+                                            $NoneType__serialize__, $NoneType__deserialize__, $NoneType__bool__, $NoneType__str__};

--- a/builtin/none.h
+++ b/builtin/none.h
@@ -1,16 +1,16 @@
 struct $NoneType$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)($NoneType);
-  void (*__serialize__)($NoneType,$Serial$state);
-  $NoneType (*__deserialize__)($NoneType,$Serial$state);
-  $bool (*__bool__)($NoneType);
-  $str (*__str__)($NoneType);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)($NoneType);
+    void (*__serialize__)($NoneType, $Serial$state);
+    $NoneType (*__deserialize__)($NoneType, $Serial$state);
+    $bool (*__bool__)($NoneType);
+    $str (*__str__)($NoneType);
 };
 
 struct $NoneType {
-  struct $NoneType$class *$class;
+    struct $NoneType$class *$class;
 };
 
 extern struct $NoneType$class $NoneType$methods;

--- a/builtin/range.c
+++ b/builtin/range.c
@@ -13,110 +13,105 @@
  */
 
 $range $range$new($int start, $int stop, $int step) {
-  return $NEW($range, start, stop, step);
+    return $NEW($range, start, stop, step);
 }
 
 void $range$__init__($range self, $int start, $int stop, $int step) {
-  if (stop) {
-      self->start = from$int(start);
-      self->stop = from$int(stop);
-  } else {
-      self->start = 0;
-      self->stop = from$int(start);
-  }
-  if (step) {
-    int stp = from$int(step);
-    if (stp==0) {
-      $RAISE(($BaseException)$NEW($ValueError,to$str("step size zero in range")));
+    if (stop) {
+        self->start = from$int(start);
+        self->stop = from$int(stop);
+    } else {
+        self->start = 0;
+        self->stop = from$int(start);
     }
-    else
-      self->step = stp;
-  } else
-    self->step = 1;
+    if (step) {
+        int stp = from$int(step);
+        if (stp == 0) {
+            $RAISE(($BaseException)$NEW($ValueError, to$str("step size zero in range")));
+        } else
+            self->step = stp;
+    } else
+        self->step = 1;
 }
 
-
 $bool $range$__bool__($range self) {
-  return to$bool ((self->step > 0 && self->stop > self->start) ||
-                  (self->start > self->stop));
+    return to$bool((self->step > 0 && self->stop > self->start) ||
+                   (self->start > self->stop));
 }
 
 $str $range$__str__($range self) {
-  char *s;
-  asprintf(&s,"range(%ld,%ld,%ld)",self->start,self->stop,self->step);
-  return to$str(s);
+    char *s;
+    asprintf(&s, "range(%ld,%ld,%ld)", self->start, self->stop, self->step);
+    return to$str(s);
 }
 
 void $range$__serialize__($range self, $Serial$state state) {
-  $ROW row = $add_header(RANGE_ID,3,state);
-  row->blob[0] = ($WORD)self->start;
-  row->blob[1] = ($WORD)self->stop;
-  row->blob[2] = ($WORD)self->step;
+    $ROW row = $add_header(RANGE_ID, 3, state);
+    row->blob[0] = ($WORD)self->start;
+    row->blob[1] = ($WORD)self->stop;
+    row->blob[2] = ($WORD)self->step;
 }
 
 $range $range$__deserialize__($range self, $Serial$state state) {
-  $ROW this = state->row;
-  state->row = this->next;
-  state->row_no++;
-  $range res = malloc(sizeof(struct $range));
-  res->$class = &$range$methods;
-  res->start = (long)this->blob[0];
-  res->stop = (long)this->blob[1];
-  res->step = (long)this->blob[2];
-  return res;
+    $ROW this = state->row;
+    state->row = this->next;
+    state->row_no++;
+    $range res = malloc(sizeof(struct $range));
+    res->$class = &$range$methods;
+    res->start = (long)this->blob[0];
+    res->stop = (long)this->blob[1];
+    res->step = (long)this->blob[2];
+    return res;
 }
 
 static $WORD $Iterator$range_next($Iterator$range self) {
-  int res = self->src->start + self->nxt++*self->src->step;
-  if (self->src->step>0)
-    return res < self->src->stop ? to$int(res) : NULL;
-  else
-    return res > self->src->stop ? to$int(res) : NULL;
+    int res = self->src->start + self->nxt++ * self->src->step;
+    if (self->src->step > 0)
+        return res < self->src->stop ? to$int(res) : NULL;
+    else
+        return res > self->src->stop ? to$int(res) : NULL;
 }
 
 $Iterator$range $Iterator$range$new($range rng) {
-  return $NEW($Iterator$range,rng);
+    return $NEW($Iterator$range, rng);
 }
 
 void $Iterator$range_init($Iterator$range self, $range rng) {
-  self->src = rng;
-  self->nxt = 0;
-}                                    
+    self->src = rng;
+    self->nxt = 0;
+}
 
 $bool $Iterator$range_bool($Iterator$range self) {
-  return $True;
+    return $True;
 }
 
 $str $Iterator$range_str($Iterator$range self) {
-  char *s;
-  asprintf(&s,"<range iterator object at %p>",self);
-  return to$str(s);
+    char *s;
+    asprintf(&s, "<range iterator object at %p>", self);
+    return to$str(s);
 }
 
 void $Iterator$range_serialize($Iterator$range self, $Serial$state state) {
-  $step_serialize(self->src,state);
-  $step_serialize(to$int(self->nxt),state);
+    $step_serialize(self->src, state);
+    $step_serialize(to$int(self->nxt), state);
 }
 
 $Iterator$range $Iterator$range$_deserialize($Iterator$range self, $Serial$state state) {
-   $Iterator$range res = $DNEW($Iterator$range,state);
-   res->src = ($range)$step_deserialize(state);
-   res->nxt = from$int(($int)$step_deserialize(state));
-   return res;
+    $Iterator$range res = $DNEW($Iterator$range, state);
+    res->src = ($range)$step_deserialize(state);
+    res->nxt = from$int(($int)$step_deserialize(state));
+    return res;
 }
 
-
 struct $range$class $range$methods = {
-   "$range",
-   UNASSIGNED,
-   ($Super$class)&$value$methods,
-   $range$__init__,
-   $range$__serialize__,
-   $range$__deserialize__,
-   $range$__bool__,
-   $range$__str__
-};
-
+    "$range",
+    UNASSIGNED,
+    ($Super$class)&$value$methods,
+    $range$__init__,
+    $range$__serialize__,
+    $range$__deserialize__,
+    $range$__bool__,
+    $range$__str__};
 
 struct $Iterator$range$class $Iterator$range$methods = {
     "$Iterator$range",
@@ -127,32 +122,31 @@ struct $Iterator$range$class $Iterator$range$methods = {
     $Iterator$range$_deserialize,
     $Iterator$range_bool,
     $Iterator$range_str,
-    $Iterator$range_next
-};
+    $Iterator$range_next};
 
 //$Iterator $range_iter($range rng) {
 //  return ($Iterator)$NEW($Iterator$range,rng);
 //}
 
 $Iterable$range $Iterable$range$new() {
-  return $NEW($Iterable$range);
+    return $NEW($Iterable$range);
 }
 
-void $Iterable$range$__init__ ($Iterable$range wit){
-  return;
+void $Iterable$range$__init__($Iterable$range wit) {
+    return;
 }
 
 void $Iterable$range$__serialize__($Iterable$range self, $Serial$state state) {
 }
 
 $Iterable$range $Iterable$range$__deserialize__($Iterable$range res, $Serial$state state) {
-   if(!res)
-      res = $DNEW($Iterable$range,state);
-   return res;
+    if (!res)
+        res = $DNEW($Iterable$range, state);
+    return res;
 }
 
-$Iterator $Iterable$range$__iter__ ($Iterable$range wit, $range rng) {
-  return ($Iterator)$NEW($Iterator$range,rng);
+$Iterator $Iterable$range$__iter__($Iterable$range wit, $range rng) {
+    return ($Iterator)$NEW($Iterator$range, rng);
 }
 
 struct $Iterable$range$class $Iterable$range$methods = {
@@ -162,12 +156,9 @@ struct $Iterable$range$class $Iterable$range$methods = {
     $Iterable$range$__init__,
     $Iterable$range$__serialize__,
     $Iterable$range$__deserialize__,
-    ($bool (*)($Iterable$range))$default__bool__,
-    ($str (*)($Iterable$range))$default__str__,
-    $Iterable$range$__iter__
-};
+    ($bool(*)($Iterable$range))$default__bool__,
+    ($str(*)($Iterable$range))$default__str__,
+    $Iterable$range$__iter__};
 
 struct $Iterable$range $Iterable$range_instance = {&$Iterable$range$methods};
 $Iterable$range $Iterable$range$witness = &$Iterable$range_instance;
-
- 

--- a/builtin/range.h
+++ b/builtin/range.h
@@ -1,21 +1,20 @@
 struct $range$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)($range, $int, $int, $int);
-  void (*__serialize__)($range,$Serial$state);
-  $range (*__deserialize__)($range,$Serial$state);
-  $bool (*__bool__)($range);
-  $str (*__str__)($range);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)($range, $int, $int, $int);
+    void (*__serialize__)($range, $Serial$state);
+    $range (*__deserialize__)($range, $Serial$state);
+    $bool (*__bool__)($range);
+    $str (*__str__)($range);
 };
 
 struct $range {
-  struct $range$class *$class;
-  long start;
-  long stop;
-  long step;
+    struct $range$class *$class;
+    long start;
+    long stop;
+    long step;
 };
-
 
 extern struct $range$class $range$methods;
 $range $range$new($int, $int, $int);
@@ -29,23 +28,24 @@ extern $Iterable$range $Iterable$range$witness;
 typedef struct $Iterator$range *$Iterator$range;
 
 struct $Iterator$range$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)($Iterator$range, $range);
-  void (*__serialize__)($Iterator$range,$Serial$state);
-  $Iterator$range (*__deserialize__)($Iterator$range,$Serial$state);
-  $bool (*__bool__)($Iterator$range);
-  $str (*__str__)($Iterator$range);
-  $WORD(*__next__)($Iterator$range);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)($Iterator$range, $range);
+    void (*__serialize__)($Iterator$range, $Serial$state);
+    $Iterator$range (*__deserialize__)($Iterator$range, $Serial$state);
+    $bool (*__bool__)($Iterator$range);
+    $str (*__str__)($Iterator$range);
+    $WORD (*__next__)
+    ($Iterator$range);
 };
 
 struct $Iterator$range {
-  struct $Iterator$range$class *$class;
-  $range src;
-  int nxt;
+    struct $Iterator$range$class *$class;
+    $range src;
+    int nxt;
 };
 
-extern struct $Iterator$range$class  $Iterator$range$methods;
+extern struct $Iterator$range$class $Iterator$range$methods;
 $Iterator$range $Iterator$range$new($range);
 extern $Iterator$range $Iterator$range$witness;

--- a/builtin/registration.c
+++ b/builtin/registration.c
@@ -19,79 +19,76 @@
  * We need to sort out how initialization is to be done.
  */
 
-$list $methods;  //key is classid; values are method tables
-
+$list $methods; //key is classid; values are method tables
 
 void $register_force(int classid, $WORD meths) {
-  // we require that $methods is big enough to index it at classid. See register_builtin below.
-  $list_setitem($methods,classid,meths);
-  (($Serializable$class)meths)->$class_id = classid;
-}
-    
-void $register($WORD meths) {
-    $list_append($methods,meths);
-    (($Serializable$class)meths)->$class_id = $methods->length-1;
-    //printf("$register class %s at index %d\n", (($Serializable$class)meths)->$GCINFO, $methods->length-1);
+    // we require that $methods is big enough to index it at classid. See register_builtin below.
+    $list_setitem($methods, classid, meths);
+    (($Serializable$class)meths)->$class_id = classid;
 }
 
+void $register($WORD meths) {
+    $list_append($methods, meths);
+    (($Serializable$class)meths)->$class_id = $methods->length - 1;
+    //printf("$register class %s at index %d\n", (($Serializable$class)meths)->$GCINFO, $methods->length-1);
+}
 
 /*
  * We do not register rts classid's here, since we want to be able to serialize without including all of rts.o with its  
  * special main and handling of $ROOT. Doing so would complicate testing of builtin types significantly.
  */
 void $register_builtin() {
-  $methods = $list_new(2*PREASSIGNED); //preallocate space for PREASSIGNED user classes before doubling needed
-  memset($methods->data,0,PREASSIGNED*sizeof($WORD)); // initiate PREASSIGNED first slots to NULL;
-  $methods->length = PREASSIGNED;
-  $register_force(NONE_ID,&$NoneType$methods);
-  // $register_force(ATOM_ID,&$atom$methods);
-  $register_force(INT_ID,&$int$methods);
-  $register_force(FLOAT_ID,&$float$methods);
-  //  $register_force(COMPLEX_ID,&$complex$methods);
-  $register_force(BOOL_ID,&$bool$methods);
-  $register_force(STR_ID,&$str$methods);
-  $register_force(LIST_ID,&$list$methods);
-  $register_force(DICT_ID,&$dict$methods);
-  $register_force(SET_ID,&$set$methods);
-  $register_force(RANGE_ID,&$range$methods);
-  $register_force(TUPLE_ID,&$tuple$methods);
-  $register_force(BYTEARRAY_ID,&$bytearray$methods);
-  $register_force(STRITERATOR_ID,&$Iterator$str$methods);
-  $register_force(LISTITERATOR_ID,&$Iterator$list$methods);
-  $register_force(DICTITERATOR_ID,&$Iterator$dict$methods);
-  $register_force(VALUESITERATOR_ID,&$Iterator$dict$values$methods);
-  $register_force(ITEMSITERATOR_ID,&$Iterator$dict$items$methods);
-  $register_force(SETITERATOR_ID,&$Iterator$set$methods);
-  $register_force(RANGEITERATOR_ID,&$Iterator$range$methods);
-  $register_force(ENUMERATEITERATOR_ID,&$Iterator$enumerate$methods);
-  $register_force(FILTERITERATOR_ID,&$Iterator$filter$methods);
-  $register_force(MAPITERATOR_ID,&$Iterator$map$methods);
-  $register_force(ZIPITERATOR_ID,&$Iterator$zip$methods);
-  $register_force(BASEEXCEPTION_ID,&$BaseException$methods);
-  $register_force(SYSTEMEXIT_ID,&$SystemExit$methods);
-  $register_force(KEYBOARDINTERRUPT_ID,&$KeyboardInterrupt$methods);
-  $register_force(EXCEPTION_ID,&$Exception$methods);
-  $register_force(ASSERTIONERROR_ID,&$AssertionError$methods);
-  $register_force(LOOKUPERROR_ID,&$LookupError$methods);
-  $register_force(INDEXERROR_ID,&$IndexError$methods);
-  $register_force(KEYERROR_ID,&$KeyError$methods);
-  $register_force(MEMORYERROR_ID,&$MemoryError$methods);
-  $register_force(OSERROR_ID,&$OSError$methods);
-  $register_force(RUNTIMEERROR_ID,&$RuntimeError$methods);
-  $register_force(NOTIMPLEMENTEDERROR_ID,&$NotImplementedError$methods);
-  $register_force(VALUEERROR_ID,&$ValueError$methods);
-  $register_builtin_protocols();
+    $methods = $list_new(2 * PREASSIGNED);                  //preallocate space for PREASSIGNED user classes before doubling needed
+    memset($methods->data, 0, PREASSIGNED * sizeof($WORD)); // initiate PREASSIGNED first slots to NULL;
+    $methods->length = PREASSIGNED;
+    $register_force(NONE_ID, &$NoneType$methods);
+    // $register_force(ATOM_ID,&$atom$methods);
+    $register_force(INT_ID, &$int$methods);
+    $register_force(FLOAT_ID, &$float$methods);
+    //  $register_force(COMPLEX_ID,&$complex$methods);
+    $register_force(BOOL_ID, &$bool$methods);
+    $register_force(STR_ID, &$str$methods);
+    $register_force(LIST_ID, &$list$methods);
+    $register_force(DICT_ID, &$dict$methods);
+    $register_force(SET_ID, &$set$methods);
+    $register_force(RANGE_ID, &$range$methods);
+    $register_force(TUPLE_ID, &$tuple$methods);
+    $register_force(BYTEARRAY_ID, &$bytearray$methods);
+    $register_force(STRITERATOR_ID, &$Iterator$str$methods);
+    $register_force(LISTITERATOR_ID, &$Iterator$list$methods);
+    $register_force(DICTITERATOR_ID, &$Iterator$dict$methods);
+    $register_force(VALUESITERATOR_ID, &$Iterator$dict$values$methods);
+    $register_force(ITEMSITERATOR_ID, &$Iterator$dict$items$methods);
+    $register_force(SETITERATOR_ID, &$Iterator$set$methods);
+    $register_force(RANGEITERATOR_ID, &$Iterator$range$methods);
+    $register_force(ENUMERATEITERATOR_ID, &$Iterator$enumerate$methods);
+    $register_force(FILTERITERATOR_ID, &$Iterator$filter$methods);
+    $register_force(MAPITERATOR_ID, &$Iterator$map$methods);
+    $register_force(ZIPITERATOR_ID, &$Iterator$zip$methods);
+    $register_force(BASEEXCEPTION_ID, &$BaseException$methods);
+    $register_force(SYSTEMEXIT_ID, &$SystemExit$methods);
+    $register_force(KEYBOARDINTERRUPT_ID, &$KeyboardInterrupt$methods);
+    $register_force(EXCEPTION_ID, &$Exception$methods);
+    $register_force(ASSERTIONERROR_ID, &$AssertionError$methods);
+    $register_force(LOOKUPERROR_ID, &$LookupError$methods);
+    $register_force(INDEXERROR_ID, &$IndexError$methods);
+    $register_force(KEYERROR_ID, &$KeyError$methods);
+    $register_force(MEMORYERROR_ID, &$MemoryError$methods);
+    $register_force(OSERROR_ID, &$OSError$methods);
+    $register_force(RUNTIMEERROR_ID, &$RuntimeError$methods);
+    $register_force(NOTIMPLEMENTEDERROR_ID, &$NotImplementedError$methods);
+    $register_force(VALUEERROR_ID, &$ValueError$methods);
+    $register_builtin_protocols();
 }
 
-
 $bool issubtype(int sub_id, int ancestor_id) {
-  if (sub_id == ancestor_id)
-    return $True;
-  $Super$class c =  ($Super$class)$GET_METHODS(sub_id)->$superclass;
-  while(c)
-    if(c->$class_id == ancestor_id)
-      return $True;
-    else
-      c = c->$superclass;
-  return $False;
+    if (sub_id == ancestor_id)
+        return $True;
+    $Super$class c = ($Super$class)$GET_METHODS(sub_id)->$superclass;
+    while (c)
+        if (c->$class_id == ancestor_id)
+            return $True;
+        else
+            c = c->$superclass;
+    return $False;
 }

--- a/builtin/registration.h
+++ b/builtin/registration.h
@@ -10,56 +10,55 @@
  * by being the same piece of software.
  */
 
-#define UNASSIGNED -1
-#define NONE_ID 0
-#define ATOM_ID 1
-#define INT_ID 2
-#define FLOAT_ID 3
-#define COMPLEX_ID 4
-#define BOOL_ID 5
-#define STR_ID 6
-#define LIST_ID 7
-#define DICT_ID 8
-#define SET_ID 9
-#define RANGE_ID 10
-#define TUPLE_ID 11
-#define BYTEARRAY_ID 12
-#define ITEM_ID 13
-#define MSG_ID 14
-#define ACTOR_ID 15
-#define CATCHER_ID 16
-#define CLOS_ID 17
-#define CONT_ID 18
-#define DONE_ID 19
-#define CONSTCONT_ID 20
-#define STRITERATOR_ID 21
-#define LISTITERATOR_ID 22
-#define DICTITERATOR_ID 23
-#define VALUESITERATOR_ID 24
-#define ITEMSITERATOR_ID 25
-#define SETITERATOR_ID 26
-#define RANGEITERATOR_ID 27
+#define UNASSIGNED           -1
+#define NONE_ID              0
+#define ATOM_ID              1
+#define INT_ID               2
+#define FLOAT_ID             3
+#define COMPLEX_ID           4
+#define BOOL_ID              5
+#define STR_ID               6
+#define LIST_ID              7
+#define DICT_ID              8
+#define SET_ID               9
+#define RANGE_ID             10
+#define TUPLE_ID             11
+#define BYTEARRAY_ID         12
+#define ITEM_ID              13
+#define MSG_ID               14
+#define ACTOR_ID             15
+#define CATCHER_ID           16
+#define CLOS_ID              17
+#define CONT_ID              18
+#define DONE_ID              19
+#define CONSTCONT_ID         20
+#define STRITERATOR_ID       21
+#define LISTITERATOR_ID      22
+#define DICTITERATOR_ID      23
+#define VALUESITERATOR_ID    24
+#define ITEMSITERATOR_ID     25
+#define SETITERATOR_ID       26
+#define RANGEITERATOR_ID     27
 #define ENUMERATEITERATOR_ID 28
-#define FILTERITERATOR_ID 29
-#define MAPITERATOR_ID 30
-#define ZIPITERATOR_ID 31
+#define FILTERITERATOR_ID    29
+#define MAPITERATOR_ID       30
+#define ZIPITERATOR_ID       31
 
-#define BASEEXCEPTION_ID                        32
-#define     SYSTEMEXIT_ID                       33
-#define     KEYBOARDINTERRUPT_ID                34
-#define     EXCEPTION_ID                        35
-#define         ASSERTIONERROR_ID               36
-#define         LOOKUPERROR_ID                  37
-#define             INDEXERROR_ID               38
-#define             KEYERROR_ID                 39
-#define         MEMORYERROR_ID                  40
-#define         OSERROR_ID                      41
-#define         RUNTIMEERROR_ID                 42
-#define             NOTIMPLEMENTEDERROR_ID      43
-#define         VALUEERROR_ID                   44
+#define BASEEXCEPTION_ID       32
+#define SYSTEMEXIT_ID          33
+#define KEYBOARDINTERRUPT_ID   34
+#define EXCEPTION_ID           35
+#define ASSERTIONERROR_ID      36
+#define LOOKUPERROR_ID         37
+#define INDEXERROR_ID          38
+#define KEYERROR_ID            39
+#define MEMORYERROR_ID         40
+#define OSERROR_ID             41
+#define RUNTIMEERROR_ID        42
+#define NOTIMPLEMENTEDERROR_ID 43
+#define VALUEERROR_ID          44
 
 #define PREASSIGNED 45
-
 
 /* 
  * Register the builtin classes (those with the above class id's except MSG_ID  -- CONSTCONT_ID). 
@@ -82,12 +81,12 @@ void $register($WORD meths);
  */
 void $register_force(int classid, $WORD meths);
 
-#define $GET_CLASSID(meths)  ((meths)->$class_id)
+#define $GET_CLASSID(meths) ((meths)->$class_id)
 
-#define $GET_METHODS(classid)  (($Serializable$class)$list_getitem($methods,classid))
+#define $GET_METHODS(classid) (($Serializable$class)$list_getitem($methods, classid))
 
 // list of method tables indexed by class_id. Only accessed via GET_METHODS above
 
 extern $list $methods;
 
-$bool issubtype(int sub_id, int ancestor_id); 
+$bool issubtype(int sub_id, int ancestor_id);

--- a/builtin/serialize.c
+++ b/builtin/serialize.c
@@ -17,40 +17,40 @@
 // Queue implementation //////////////////////////////////////////////////////////////////
 
 void $enqueue($Serial$state state, $ROW elem) {
-  if (state->row)
-    state->row->next = elem;
-  else
-    state->fst = elem;
-  state->row = elem;
+    if (state->row)
+        state->row->next = elem;
+    else
+        state->fst = elem;
+    state->row = elem;
 }
 void $enqueue2(struct $ROWLISTHEADER *header, $ROW elem) {
-  if (header->last)
-    header->last->next = elem;
-  else
-    header->fst = elem;
-  header->last = elem;
+    if (header->last)
+        header->last->next = elem;
+    else
+        header->fst = elem;
+    header->last = elem;
 }
- 
+
 // Hashable$WORD methods //////////////////////////////////////////////////
 
 void $Hashable$WORD$__serialize__($Hashable$WORD self, $Serial$state state) {
 }
 
 $Hashable$WORD $Hashable$WORD$__deserialize__($Hashable$WORD self, $Serial$state state) {
-   $Hashable$WORD res = $DNEW($Hashable$WORD,state);
-   return res;
+    $Hashable$WORD res = $DNEW($Hashable$WORD, state);
+    return res;
 }
 
 $bool $Hashable$WORD_eq($Hashable$WORD wit, $WORD a, $WORD b) {
-  return to$bool(a==b);
+    return to$bool(a == b);
 }
 
 $bool $Hashable$WORD_ne($Hashable$WORD wit, $WORD a, $WORD b) {
-  return  to$bool(a != b);
+    return to$bool(a != b);
 }
 
 $int $Hashable$WORD_hash($Hashable$WORD wit, $WORD a) {
-  return to$int($pointer_hash(a));
+    return to$int($pointer_hash(a));
 }
 
 struct $Hashable$WORD$class $Hashable$WORD$methods = {
@@ -60,219 +60,215 @@ struct $Hashable$WORD$class $Hashable$WORD$methods = {
     (void (*)($Hashable$WORD))$default__init__,
     $Hashable$WORD$__serialize__,
     $Hashable$WORD$__deserialize__,
-    ($bool (*)($Hashable$WORD))$default__bool__,
-    ($str (*)($Hashable$WORD))$default__str__,
+    ($bool(*)($Hashable$WORD))$default__bool__,
+    ($str(*)($Hashable$WORD))$default__str__,
     $Hashable$WORD_eq,
     $Hashable$WORD_ne,
-    $Hashable$WORD_hash
-};
+    $Hashable$WORD_hash};
 struct $Hashable$WORD $Hashable$WORD_instance = {&$Hashable$WORD$methods};
 struct $Hashable$WORD *$Hashable$WORD$witness = &$Hashable$WORD_instance;
-
 
 // small-step functions for (de)serializing the next object /////////////////////////////////////////////////
 
 $ROW $add_header(int class_id, int blob_size, $Serial$state state) {
-  $ROW res = malloc(2 * sizeof(int) + (1+blob_size)*sizeof($WORD));
-  res->class_id = class_id;
-  state->row_no++;
-  res->blob_size = blob_size;
-  res->next = NULL;
-  $enqueue(state,res);
-  return res;
+    $ROW res = malloc(2 * sizeof(int) + (1 + blob_size) * sizeof($WORD));
+    res->class_id = class_id;
+    state->row_no++;
+    res->blob_size = blob_size;
+    res->next = NULL;
+    $enqueue(state, res);
+    return res;
 }
 
 void $step_serialize($WORD self, $Serial$state state) {
-  if (self) {
-    int class_id = $GET_CLASSID((($Serializable)self)->$class);
-    if (class_id > ITEM_ID) { // not one of the Acton builtin datatypes, which have hand-crafted serializations
-      if (state->globmap) {
-          long key = (long)state->globmap(self);
-          if (key < 0) {
-            $val_serialize(-class_id,&key,state);
-            return;
-          }
-      }
-      $int prevkey = ($int)$dict_get(state->done,($Hashable)$Hashable$WORD$witness,self,NULL);
-      if (prevkey) {
-        $val_serialize(-class_id,&prevkey->val,state);
-      } else {
-        $dict_setitem(state->done,($Hashable)$Hashable$WORD$witness,self,to$int(state->row_no));
-        $add_header(class_id,0,state);
-        (($Serializable)self)->$class->__serialize__(self,state);
-      }
-    } else 
-       (($Serializable)self)->$class->__serialize__(self,state);
-  } else
-    $add_header(NONE_ID,0,state);
+    if (self) {
+        int class_id = $GET_CLASSID((($Serializable)self)->$class);
+        if (class_id > ITEM_ID) { // not one of the Acton builtin datatypes, which have hand-crafted serializations
+            if (state->globmap) {
+                long key = (long)state->globmap(self);
+                if (key < 0) {
+                    $val_serialize(-class_id, &key, state);
+                    return;
+                }
+            }
+            $int prevkey = ($int)$dict_get(state->done, ($Hashable)$Hashable$WORD$witness, self, NULL);
+            if (prevkey) {
+                $val_serialize(-class_id, &prevkey->val, state);
+            } else {
+                $dict_setitem(state->done, ($Hashable)$Hashable$WORD$witness, self, to$int(state->row_no));
+                $add_header(class_id, 0, state);
+                (($Serializable)self)->$class->__serialize__(self, state);
+            }
+        } else
+            (($Serializable)self)->$class->__serialize__(self, state);
+    } else
+        $add_header(NONE_ID, 0, state);
 }
 
 $WORD $step_deserialize($Serial$state state) {
-  if (abs(state->row->class_id) > ITEM_ID) {
-    $ROW this = state->row;
-    state->row = this->next;
-    state->row_no++;
-    if (this->class_id < 0) {
-      long key = (long)this->blob[0];
-      if (key < 0)
-          return state->globmap(($WORD)key);
-      else
-          return $dict_get(state->done,($Hashable)$Hashable$int$witness,to$int(key),NULL);
+    if (abs(state->row->class_id) > ITEM_ID) {
+        $ROW this = state->row;
+        state->row = this->next;
+        state->row_no++;
+        if (this->class_id < 0) {
+            long key = (long)this->blob[0];
+            if (key < 0)
+                return state->globmap(($WORD)key);
+            else
+                return $dict_get(state->done, ($Hashable)$Hashable$int$witness, to$int(key), NULL);
+        } else
+            return $GET_METHODS(this->class_id)->__deserialize__(NULL, state);
     } else
-      return $GET_METHODS(this->class_id)->__deserialize__(NULL, state);
-  } else
-    return $GET_METHODS(abs(state->row->class_id))->__deserialize__(NULL, state);
+        return $GET_METHODS(abs(state->row->class_id))->__deserialize__(NULL, state);
 }
 
-
-
-void $val_serialize(int class_id, $WORD val,$Serial$state state) {
-  $ROW row = $add_header(class_id,1,state);
-  memcpy(row->blob,val,sizeof($WORD));
+void $val_serialize(int class_id, $WORD val, $Serial$state state) {
+    $ROW row = $add_header(class_id, 1, state);
+    memcpy(row->blob, val, sizeof($WORD));
 }
 
 $WORD $val_deserialize($Serial$state state) {
-  $WORD res;
-  memcpy(&res,(state->row)->blob,sizeof($WORD));
-  state->row = state->row->next;
-  state->row_no++;
-  return res;
+    $WORD res;
+    memcpy(&res, (state->row)->blob, sizeof($WORD));
+    state->row = state->row->next;
+    state->row_no++;
+    return res;
 }
 
 // Serialization methods ///////////////////////////////////////////////////////////////////////////////
 
 void $write_serialized($ROW row, char *file) {
-  char buf[BUF_SIZE];
-  char *p = buf;
-  char *bufend = buf + BUF_SIZE;
-  FILE *fileptr = fopen(file,"wb");
-  int chunk_size;
-  char *start;
-  while(row) {
-    chunk_size = 2*sizeof(int);
-    start = (char*)row;
-    if (p+chunk_size > bufend) {
-      int fits = bufend - p;
-      memcpy(p,start,fits);
-      fwrite(buf,1,sizeof(buf),fileptr); // TODO:  handle file write error
-      p = buf;
-      chunk_size -= fits;
-      start += fits;
+    char buf[BUF_SIZE];
+    char *p = buf;
+    char *bufend = buf + BUF_SIZE;
+    FILE *fileptr = fopen(file, "wb");
+    int chunk_size;
+    char *start;
+    while (row) {
+        chunk_size = 2 * sizeof(int);
+        start = (char *)row;
+        if (p + chunk_size > bufend) {
+            int fits = bufend - p;
+            memcpy(p, start, fits);
+            fwrite(buf, 1, sizeof(buf), fileptr); // TODO:  handle file write error
+            p = buf;
+            chunk_size -= fits;
+            start += fits;
+        }
+        memcpy(p, start, chunk_size);
+        p += chunk_size;
+
+        chunk_size = (row->blob_size) * sizeof($WORD);
+        start = (char *)row->blob;
+        while (p + chunk_size > bufend) {
+            int fits = bufend - p;
+            memcpy(p, start, fits);
+            fwrite(buf, 1, sizeof(buf), fileptr); // TODO:  handle file write error
+            p = buf;
+            chunk_size -= fits;
+            start += fits;
+        }
+        memcpy(p, start, chunk_size);
+        p += chunk_size;
+
+        row = row->next;
     }
-    memcpy(p,start,chunk_size);
-    p+=chunk_size;
-    
-    chunk_size = (row->blob_size)*sizeof($WORD);
-    start =  (char*)row->blob;
-    while (p+chunk_size > bufend) {
-      int fits = bufend - p;
-      memcpy(p,start,fits);
-      fwrite(buf,1,sizeof(buf),fileptr); // TODO:  handle file write error
-      p = buf;
-      chunk_size -= fits;
-      start += fits;
-    }
-    memcpy(p,start,chunk_size);
-    p+=chunk_size;
-    
-    row = row->next;
-  }
-  fwrite(buf,1,p-buf,fileptr); // TODO:  handle file write error
-  fclose(fileptr);
+    fwrite(buf, 1, p - buf, fileptr); // TODO:  handle file write error
+    fclose(fileptr);
 }
- 
+
 $ROW $serialize($Serializable s, $WORD (*globmap)($WORD)) {
-  $Serial$state state = malloc(sizeof(struct $Serial$state));
-  state->done = $NEW($dict,($Hashable)$Hashable$WORD$witness,NULL,NULL);
-  state->globmap = globmap;
-  state->row_no=0;
-  state->row = NULL;
-  state->fst = NULL;
-  $step_serialize(s,state);
-  return state->fst;
+    $Serial$state state = malloc(sizeof(struct $Serial$state));
+    state->done = $NEW($dict, ($Hashable)$Hashable$WORD$witness, NULL, NULL);
+    state->globmap = globmap;
+    state->row_no = 0;
+    state->row = NULL;
+    state->fst = NULL;
+    $step_serialize(s, state);
+    return state->fst;
 }
 
 $ROW $glob_serialize($Serializable self, $WORD (*globmap)($WORD)) {
-  $Serial$state state = malloc(sizeof(struct $Serial$state));
-  state->done = $NEW($dict,($Hashable)$Hashable$WORD$witness,NULL,NULL);
-  state->globmap = globmap;
-  state->row_no=0;
-  state->row = NULL;
-  state->fst = NULL;
-  $add_header(self->$class->$class_id,0,state);
-  self->$class->__serialize__(self,state);
-  return state->fst;
+    $Serial$state state = malloc(sizeof(struct $Serial$state));
+    state->done = $NEW($dict, ($Hashable)$Hashable$WORD$witness, NULL, NULL);
+    state->globmap = globmap;
+    state->row_no = 0;
+    state->row = NULL;
+    state->fst = NULL;
+    $add_header(self->$class->$class_id, 0, state);
+    self->$class->__serialize__(self, state);
+    return state->fst;
 }
 
 void $serialize_file($Serializable s, char *file) {
-  $write_serialized($serialize(s,NULL),file);
+    $write_serialized($serialize(s, NULL), file);
 }
 
 $Serializable $deserialize($ROW row, $WORD (*globmap)($WORD)) {
-  $Serial$state state = malloc(sizeof(struct $Serial$state));
-  state->done = $NEW($dict,($Hashable)$Hashable$int$witness,NULL,NULL);
-  state->globmap = globmap;
-  state->row_no=0;
-  state->row = row;
-  state->fst = NULL;
-  return $step_deserialize(state);
+    $Serial$state state = malloc(sizeof(struct $Serial$state));
+    state->done = $NEW($dict, ($Hashable)$Hashable$int$witness, NULL, NULL);
+    state->globmap = globmap;
+    state->row_no = 0;
+    state->row = row;
+    state->fst = NULL;
+    return $step_deserialize(state);
 }
 
 $Serializable $glob_deserialize($Serializable self, $ROW row, $WORD (*globmap)($WORD)) {
-  $Serial$state state = malloc(sizeof(struct $Serial$state));
-  state->done = $NEW($dict,($Hashable)$Hashable$int$witness,NULL,NULL);
-  state->globmap = globmap;
-  state->row_no=1;
-  state->row = row->next;
-  state->fst = NULL;
-  return self->$class->__deserialize__(self,state);
+    $Serial$state state = malloc(sizeof(struct $Serial$state));
+    state->done = $NEW($dict, ($Hashable)$Hashable$int$witness, NULL, NULL);
+    state->globmap = globmap;
+    state->row_no = 1;
+    state->row = row->next;
+    state->fst = NULL;
+    return self->$class->__deserialize__(self, state);
 }
 
 $ROW $read_serialized(char *file) {
-  char buf[BUF_SIZE];
-  char *p = buf;
-  char *bufend;
-  FILE *fileptr = fopen(file,"rb");
-  int chunk_size;
-  char *start;
-  struct $ROWLISTHEADER header;
-  header.fst = NULL;
-  header.last = NULL;
-  bufend = buf + fread(buf,1,sizeof(buf),fileptr);
-  while(p < bufend || !feof(fileptr)) {
-    int init[2];//4
-    chunk_size = 2*sizeof(int); 
-    start = (char*)init;
-    if (p + chunk_size > bufend) {
-      int fits = bufend - p;
-      memcpy(start,p,fits);
-      bufend = buf + fread(buf,1,sizeof(buf),fileptr); // TODO:  handle file write error
-      p = buf;
-      chunk_size -= fits;
-      start += fits;
+    char buf[BUF_SIZE];
+    char *p = buf;
+    char *bufend;
+    FILE *fileptr = fopen(file, "rb");
+    int chunk_size;
+    char *start;
+    struct $ROWLISTHEADER header;
+    header.fst = NULL;
+    header.last = NULL;
+    bufend = buf + fread(buf, 1, sizeof(buf), fileptr);
+    while (p < bufend || !feof(fileptr)) {
+        int init[2]; //4
+        chunk_size = 2 * sizeof(int);
+        start = (char *)init;
+        if (p + chunk_size > bufend) {
+            int fits = bufend - p;
+            memcpy(start, p, fits);
+            bufend = buf + fread(buf, 1, sizeof(buf), fileptr); // TODO:  handle file write error
+            p = buf;
+            chunk_size -= fits;
+            start += fits;
+        }
+        memcpy(start, p, chunk_size);
+        p += chunk_size;
+        $ROW row = malloc(2 * sizeof(int) + (init[1] + 1) * sizeof($WORD));
+        memcpy(row, init, 2 * sizeof(int)); //4
+        row->next = NULL;
+        chunk_size = (init[1]) * sizeof($WORD);
+        start = (char *)row->blob;
+        while (p + chunk_size > bufend) {
+            int fits = bufend - p;
+            memcpy(start, p, fits);
+            bufend = buf + fread(buf, 1, sizeof(buf), fileptr); // TODO:  handle file write error
+            p = buf;
+            chunk_size -= fits;
+            start += fits;
+        }
+        memcpy(start, p, chunk_size);
+        p += chunk_size;
+        $enqueue2(&header, row);
     }
-    memcpy(start,p,chunk_size);
-    p+=chunk_size;
-    $ROW row = malloc(2*sizeof(int) + (init[1]+1) * sizeof($WORD));
-    memcpy(row,init,2*sizeof(int));//4
-    row->next = NULL;
-    chunk_size =  (init[1]) * sizeof($WORD);
-    start = (char*)row->blob;
-    while (p + chunk_size > bufend) {
-      int fits = bufend - p;
-      memcpy(start,p,fits);
-      bufend = buf + fread(buf,1,sizeof(buf),fileptr); // TODO:  handle file write error
-      p = buf;
-      chunk_size -= fits;
-      start += fits;
-    }
-    memcpy(start,p,chunk_size);
-    p+=chunk_size;
-    $enqueue2(&header,row);
-  }
-  return header.fst;
+    return header.fst;
 }
-       
+
 $Serializable $deserialize_file(char *file) {
-  return $deserialize($read_serialized(file), NULL);
+    return $deserialize($read_serialized(file), NULL);
 }

--- a/builtin/serialize.h
+++ b/builtin/serialize.h
@@ -2,33 +2,32 @@
 
 // Types for serialization ////////////////////////////////////////////////////////////////////////////
 
-
 // The serialization of an Acton object/value is a linked list of $ROW:s.
-
 
 typedef struct $ROW *$ROW;
 
 struct $ROW {
-  $ROW next;
-  int class_id;
-  int blob_size;
-  $WORD blob[];
+    $ROW next;
+    int class_id;
+    int blob_size;
+    $WORD blob[];
 };
 
 struct $ROWLISTHEADER {
-  $ROW fst;
-  $ROW last;
+    $ROW fst;
+    $ROW last;
 };
 
 //typedef struct $Serial$state *$Serial$state;
 
 struct $Serial$state {
-  char *$GCINFO;
-  $dict done;
-  $WORD (*globmap)($WORD);
-  long row_no;
-  $ROW row;
-  $ROW fst; //not used in deserialization
+    char *$GCINFO;
+    $dict done;
+    $WORD (*globmap)
+    ($WORD);
+    long row_no;
+    $ROW row;
+    $ROW fst; //not used in deserialization
 };
 
 // small-step helpers for defining serializations //////////////////////////////////////////////////
@@ -66,8 +65,8 @@ struct $Hashable$WORD$class {
     int $class_id;
     $Super$class superclass;
     void (*__init__)($Hashable$WORD);
-    void (*__serialize__)($Hashable$WORD,$Serial$state);
-    $Hashable$WORD (*__deserialize__)($Hashable$WORD,$Serial$state);
+    void (*__serialize__)($Hashable$WORD, $Serial$state);
+    $Hashable$WORD (*__deserialize__)($Hashable$WORD, $Serial$state);
     $bool (*__bool__)($Hashable$WORD);
     $str (*__str__)($Hashable$WORD);
     $bool (*__eq__)($Hashable$WORD, $WORD, $WORD);

--- a/builtin/set.c
+++ b/builtin/set.c
@@ -14,7 +14,6 @@
 
 #include "builtin.h"
 #include "set_impl.h"
- 
 
 void $set_serialize($set, $Serial$state);
 $set $set_deserialize($set, $Serial$state);
@@ -30,8 +29,8 @@ struct $Set$set$class $Set$set$methods = {
     $Set$set$__init__,
     $Set$set$__serialize__,
     $Set$set$__deserialize__,
-    ($bool (*)($Set$set))$default__bool__,
-    ($str (*)($Set$set))$default__str__,
+    ($bool(*)($Set$set))$default__bool__,
+    ($str(*)($Set$set))$default__str__,
     $Set$set$__iter__,
     $Set$set$__fromiter__,
     $Set$set$__len__,
@@ -40,8 +39,7 @@ struct $Set$set$class $Set$set$methods = {
     $Set$set$isdisjoint,
     $Set$set$add,
     $Set$set$discard,
-    $Set$set$pop
-};   
+    $Set$set$pop};
 
 struct $Ord$set$class $Ord$set$methods = {
     "$Ord$set",
@@ -50,15 +48,14 @@ struct $Ord$set$class $Ord$set$methods = {
     $Ord$set$__init__,
     $Ord$set$__serialize__,
     $Ord$set$__deserialize__,
-    ($bool (*)($Ord$set))$default__bool__,
-    ($str (*)($Ord$set))$default__str__,
+    ($bool(*)($Ord$set))$default__bool__,
+    ($str(*)($Ord$set))$default__str__,
     $Ord$set$__eq__,
     $Ord$set$__ne__,
     $Ord$set$__lt__,
     $Ord$set$__le__,
     $Ord$set$__gt__,
-    $Ord$set$__ge__
-};
+    $Ord$set$__ge__};
 
 struct $Minus$set$class $Minus$set$methods = {
     "$Minus$set",
@@ -67,10 +64,10 @@ struct $Minus$set$class $Minus$set$methods = {
     $Minus$set$__init__,
     $Minus$set$__serialize__,
     $Minus$set$__deserialize__,
-    ($bool (*)($Minus$set))$default__bool__,
-    ($str (*)($Minus$set))$default__str__,
+    ($bool(*)($Minus$set))$default__bool__,
+    ($str(*)($Minus$set))$default__str__,
     $Minus$set$__sub__,
-    ($set (*)($Minus$set, $set, $set))$Minus$__isub__,
+    ($set(*)($Minus$set, $set, $set))$Minus$__isub__,
 
 };
 
@@ -81,171 +78,168 @@ struct $Logical$set$class $Logical$set$methods = {
     $Logical$set$__init__,
     $Logical$set$__serialize__,
     $Logical$set$__deserialize__,
-    ($bool (*)($Logical$set))$default__bool__,
-    ($str (*)($Logical$set))$default__str__,
+    ($bool(*)($Logical$set))$default__bool__,
+    ($str(*)($Logical$set))$default__str__,
     $Logical$set$__and__,
     $Logical$set$__or__,
     $Logical$set$__xor__,
-    ($set (*)($Logical$set, $set, $set))$Logical$__iand__,
-    ($set (*)($Logical$set, $set, $set))$Logical$__ior__,
-    ($set (*)($Logical$set, $set, $set))$Logical$__ixor__
-};
+    ($set(*)($Logical$set, $set, $set))$Logical$__iand__,
+    ($set(*)($Logical$set, $set, $set))$Logical$__ior__,
+    ($set(*)($Logical$set, $set, $set))$Logical$__ixor__};
 
 // $Set
 
 void $Set$set$__serialize__($Set$set self, $Serial$state state) {
-  $step_serialize(self->w$Ord, state);
-  $step_serialize(self->w$Logical, state);
-  $step_serialize(self->w$Minus, state);
-  $step_serialize(self->w$Eq$A$Set$set, state);
-  $step_serialize(self->w$Hashable$A$Set$set, state);
+    $step_serialize(self->w$Ord, state);
+    $step_serialize(self->w$Logical, state);
+    $step_serialize(self->w$Minus, state);
+    $step_serialize(self->w$Eq$A$Set$set, state);
+    $step_serialize(self->w$Hashable$A$Set$set, state);
 }
 
 $Set$set $Set$set$__deserialize__($Set$set self, $Serial$state state) {
-   $Set$set res = $DNEW($Set$set,state);
-   res->w$Ord = ($Ord)$step_deserialize(state);
-   res->w$Logical = ($Logical)$step_deserialize(state);
-   res->w$Minus = ($Minus)$step_deserialize(state);
-   res->w$Eq$A$Set$set = ($Eq)$step_deserialize(state);
-   res->w$Hashable$A$Set$set = ($Hashable)$step_deserialize(state);
-   return res;
+    $Set$set res = $DNEW($Set$set, state);
+    res->w$Ord = ($Ord)$step_deserialize(state);
+    res->w$Logical = ($Logical)$step_deserialize(state);
+    res->w$Minus = ($Minus)$step_deserialize(state);
+    res->w$Eq$A$Set$set = ($Eq)$step_deserialize(state);
+    res->w$Hashable$A$Set$set = ($Hashable)$step_deserialize(state);
+    return res;
 }
 
-
-$Iterator $Set$set$__iter__ ($Set$set wit, $set set) {
-  return $set_iter(set);
+$Iterator $Set$set$__iter__($Set$set wit, $set set) {
+    return $set_iter(set);
 }
 
 $set $Set$set$__fromiter__($Set$set wit, $Iterable wit2, $WORD iter) {
-  return $set_fromiter(wit->w$Hashable$A$Set$set,wit2->$class->__iter__(wit2,iter));
+    return $set_fromiter(wit->w$Hashable$A$Set$set, wit2->$class->__iter__(wit2, iter));
 }
 
-$int $Set$set$__len__ ($Set$set wit, $set set) {
-  return to$int($set_len(set));
+$int $Set$set$__len__($Set$set wit, $set set) {
+    return to$int($set_len(set));
 }
-$bool $Set$set$__contains__ ($Set$set wit, $set set, $WORD val) {
-  return  to$bool($set_contains(set,wit->w$Hashable$A$Set$set,val));
-}
-
-$bool $Set$set$__containsnot__ ($Set$set wit, $set set, $WORD val) {
-  return  to$bool(!$set_contains(set,wit->w$Hashable$A$Set$set,val));
+$bool $Set$set$__contains__($Set$set wit, $set set, $WORD val) {
+    return to$bool($set_contains(set, wit->w$Hashable$A$Set$set, val));
 }
 
-$bool $Set$set$isdisjoint ($Set$set wit, $set set, $set other) {
-  return to$bool($set_isdisjoint(wit->w$Hashable$A$Set$set,set,other));
+$bool $Set$set$__containsnot__($Set$set wit, $set set, $WORD val) {
+    return to$bool(!$set_contains(set, wit->w$Hashable$A$Set$set, val));
 }
 
-void $Set$set$add ($Set$set wit, $set set, $WORD elem) {
-   $set_add(set,wit->w$Hashable$A$Set$set,elem);
+$bool $Set$set$isdisjoint($Set$set wit, $set set, $set other) {
+    return to$bool($set_isdisjoint(wit->w$Hashable$A$Set$set, set, other));
 }
 
-void $Set$set$discard ($Set$set wit, $set set, $WORD elem) {
-  $set_discard(set,wit->w$Hashable$A$Set$set,elem);
+void $Set$set$add($Set$set wit, $set set, $WORD elem) {
+    $set_add(set, wit->w$Hashable$A$Set$set, elem);
 }
 
-$WORD $Set$set$pop ($Set$set wit, $set set) {
-  return $set_pop(set);
+void $Set$set$discard($Set$set wit, $set set, $WORD elem) {
+    $set_discard(set, wit->w$Hashable$A$Set$set, elem);
+}
+
+$WORD $Set$set$pop($Set$set wit, $set set) {
+    return $set_pop(set);
 }
 
 // $Ord
 
 void $Ord$set$__serialize__($Ord$set self, $Serial$state state) {
-  $step_serialize(self->w$Set, state);
+    $step_serialize(self->w$Set, state);
 }
 
 $Ord$set $Ord$set$__deserialize__($Ord$set self, $Serial$state state) {
-   $Ord$set res = $DNEW($Ord$set,state);
-   res->w$Set = ($Set)$step_deserialize(state);
-   return res;
+    $Ord$set res = $DNEW($Ord$set, state);
+    res->w$Set = ($Set)$step_deserialize(state);
+    return res;
 }
 
-$bool $Ord$set$__eq__ ($Ord$set wit, $set a, $set b) {
-  return to$bool($set_eq((($Set$set)wit->w$Set)->w$Hashable$A$Set$set,a,b));
+$bool $Ord$set$__eq__($Ord$set wit, $set a, $set b) {
+    return to$bool($set_eq((($Set$set)wit->w$Set)->w$Hashable$A$Set$set, a, b));
 }
-  
-$bool $Ord$set$__ne__ ($Ord$set wit, $set a, $set b) {
-  return to$bool(!$set_eq((($Set$set)wit->w$Set)->w$Hashable$A$Set$set,a,b));
+
+$bool $Ord$set$__ne__($Ord$set wit, $set a, $set b) {
+    return to$bool(!$set_eq((($Set$set)wit->w$Set)->w$Hashable$A$Set$set, a, b));
 }
-  
-$bool $Ord$set$__lt__ ($Ord$set wit, $set a, $set b) {
-  return to$bool($set_lt((($Set$set)wit->w$Set)->w$Hashable$A$Set$set,a,b));
+
+$bool $Ord$set$__lt__($Ord$set wit, $set a, $set b) {
+    return to$bool($set_lt((($Set$set)wit->w$Set)->w$Hashable$A$Set$set, a, b));
 }
-  
-$bool $Ord$set$__le__ ($Ord$set wit, $set a, $set b) {
-  return to$bool($set_le((($Set$set)wit->w$Set)->w$Hashable$A$Set$set,a,b));
+
+$bool $Ord$set$__le__($Ord$set wit, $set a, $set b) {
+    return to$bool($set_le((($Set$set)wit->w$Set)->w$Hashable$A$Set$set, a, b));
 }
-  
-$bool $Ord$set$__gt__ ($Ord$set wit, $set a, $set b) {
-  return to$bool($set_gt((($Set$set)wit->w$Set)->w$Hashable$A$Set$set,a,b));
+
+$bool $Ord$set$__gt__($Ord$set wit, $set a, $set b) {
+    return to$bool($set_gt((($Set$set)wit->w$Set)->w$Hashable$A$Set$set, a, b));
 }
-  
-$bool $Ord$set$__ge__ ($Ord$set wit, $set a, $set b) {
-  return to$bool($set_ge((($Set$set)wit->w$Set)->w$Hashable$A$Set$set,a,b));
+
+$bool $Ord$set$__ge__($Ord$set wit, $set a, $set b) {
+    return to$bool($set_ge((($Set$set)wit->w$Set)->w$Hashable$A$Set$set, a, b));
 }
 
 // $Minus
 
 void $Logical$set$__serialize__($Logical$set self, $Serial$state state) {
-  $step_serialize(self->w$Set, state);
+    $step_serialize(self->w$Set, state);
 }
 
 $Logical$set $Logical$set$__deserialize__($Logical$set self, $Serial$state state) {
-   $Logical$set res = $DNEW($Logical$set,state);
-   res->w$Set = ($Set)$step_deserialize(state);
-   return res;
+    $Logical$set res = $DNEW($Logical$set, state);
+    res->w$Set = ($Set)$step_deserialize(state);
+    return res;
 }
 
-$set $Minus$set$__sub__ ($Minus$set wit, $set a, $set b) {
-  return $set_difference((($Set$set)wit->w$Set)->w$Hashable$A$Set$set,a,b);
+$set $Minus$set$__sub__($Minus$set wit, $set a, $set b) {
+    return $set_difference((($Set$set)wit->w$Set)->w$Hashable$A$Set$set, a, b);
 }
 
 // $Logical
 
 void $Minus$set$__serialize__($Minus$set self, $Serial$state state) {
-  $step_serialize(self->w$Set, state);
+    $step_serialize(self->w$Set, state);
 }
 
 $Minus$set $Minus$set$__deserialize__($Minus$set self, $Serial$state state) {
-   $Minus$set res = $DNEW($Minus$set,state);
-   res->w$Set = ($Set)$step_deserialize(state);
-   return res;
+    $Minus$set res = $DNEW($Minus$set, state);
+    res->w$Set = ($Set)$step_deserialize(state);
+    return res;
 }
 
 $set $Logical$set$__and__($Logical$set wit, $set a, $set b) {
-  return $set_intersection((($Set$set)wit->w$Set)->w$Hashable$A$Set$set,a,b);
+    return $set_intersection((($Set$set)wit->w$Set)->w$Hashable$A$Set$set, a, b);
 }
 
-$set $Logical$set$__or__ ($Logical$set wit, $set a, $set b) {
-  return $set_union((($Set$set)wit->w$Set)->w$Hashable$A$Set$set,a,b);
+$set $Logical$set$__or__($Logical$set wit, $set a, $set b) {
+    return $set_union((($Set$set)wit->w$Set)->w$Hashable$A$Set$set, a, b);
 }
 
 $set $Logical$set$__xor__($Logical$set wit, $set a, $set b) {
-  return $set_symmetric_difference((($Set$set)wit->w$Set)->w$Hashable$A$Set$set,a,b);
+    return $set_symmetric_difference((($Set$set)wit->w$Set)->w$Hashable$A$Set$set, a, b);
 }
 
 // init and new
 
 void $Ord$set$__init__($Ord$set self, $Set master) {
-  self->w$Set = master;
+    self->w$Set = master;
 }
 
 void $Logical$set$__init__($Logical$set self, $Set master) {
-  self->w$Set = master;
+    self->w$Set = master;
 }
 
 void $Minus$set$__init__($Minus$set self, $Set master) {
-  self->w$Set = master;
+    self->w$Set = master;
 }
 
 $Set$set $Set$set$new($Hashable h) {
-  return $NEW($Set$set, h);
+    return $NEW($Set$set, h);
 }
 
 void $Set$set$__init__($Set$set self, $Hashable h) {
-  self->w$Ord = ($Ord)$NEW($Ord$set,($Set)self);
-  self->w$Logical = ($Logical)$NEW($Logical$set,($Set)self);
-  self->w$Minus = ($Minus)$NEW($Minus$set,($Set)self);
-  self->w$Eq$A$Set$set = ($Eq)h;
-  self->w$Hashable$A$Set$set = h;
+    self->w$Ord = ($Ord)$NEW($Ord$set, ($Set)self);
+    self->w$Logical = ($Logical)$NEW($Logical$set, ($Set)self);
+    self->w$Minus = ($Minus)$NEW($Minus$set, ($Set)self);
+    self->w$Eq$A$Set$set = ($Eq)h;
+    self->w$Hashable$A$Set$set = h;
 }
-   

--- a/builtin/set.h
+++ b/builtin/set.h
@@ -1,29 +1,28 @@
 struct $set$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)($set, $Hashable, $Iterable, $WORD);
-  void (*__serialize__)($set, $Serial$state);
-  $set (*__deserialize__)($set, $Serial$state);
-  $bool (*__bool__)($set);
-  $str (*__str__)($set);
-  $set(*copy)($set, $Hashable);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)($set, $Hashable, $Iterable, $WORD);
+    void (*__serialize__)($set, $Serial$state);
+    $set (*__deserialize__)($set, $Serial$state);
+    $bool (*__bool__)($set);
+    $str (*__str__)($set);
+    $set (*copy)($set, $Hashable);
 };
 
 typedef struct {
-  $WORD key;
-  long hash;    
+    $WORD key;
+    long hash;
 } $setentry;
 
 typedef struct $set {
-  struct $set$class *$class;
-  long numelements;    // nr of elements in $set
-  long fill;           // numelements + #dummy entries
-  long mask;
-  long finger;                       // Search finger for pop() 
-  $setentry *table;                  // the hashtable
-} *$set;
-
+    struct $set$class *$class;
+    long numelements; // nr of elements in $set
+    long fill;        // numelements + #dummy entries
+    long mask;
+    long finger;      // Search finger for pop()
+    $setentry *table; // the hashtable
+} * $set;
 
 extern struct $set$class $set$methods;
 $set $set$new($Hashable, $Iterable, $WORD);
@@ -41,25 +40,27 @@ extern struct $Set$set *$Set$set_new($Hashable);
 
 // Iterators over sets ///////////////////////////////////////////////////////
 
-typedef struct $Iterator$set *$Iterator$set; ;
+typedef struct $Iterator$set *$Iterator$set;
+;
 
 struct $Iterator$set$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)($Iterator$set, $set);
-  void (*__serialize__)($Iterator$set, $Serial$state);
-  $Iterator$set (*__deserialize__)($Iterator$set, $Serial$state);
-  $bool (*__bool__)($Iterator$set);
-  $str (*__str__)($Iterator$set);
-  $WORD(*__next__)($Iterator$set);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)($Iterator$set, $set);
+    void (*__serialize__)($Iterator$set, $Serial$state);
+    $Iterator$set (*__deserialize__)($Iterator$set, $Serial$state);
+    $bool (*__bool__)($Iterator$set);
+    $str (*__str__)($Iterator$set);
+    $WORD (*__next__)
+    ($Iterator$set);
 };
 
 struct $Iterator$set {
-  struct $Iterator$set$class *$class;
-  $set src;
-  int nxt;
+    struct $Iterator$set$class *$class;
+    $set src;
+    int nxt;
 };
 
-extern struct  $Iterator$set$class  $Iterator$set$methods;
+extern struct $Iterator$set$class $Iterator$set$methods;
 $Iterator$set $Iterator$set$new($set);

--- a/builtin/set_impl.c
+++ b/builtin/set_impl.c
@@ -15,7 +15,7 @@
 #include <string.h> /*memset*/
 
 #define DISCARD_NOTFOUND 0
-#define DISCARD_FOUND 1
+#define DISCARD_FOUND    1
 #include "builtin.h"
 
 /* 
@@ -24,7 +24,7 @@ This implementation of sets is an adaptation of CPython's set implementation.
 */
 
 #define PERTURB_SHIFT 5
-#define MIN_SIZE 8
+#define MIN_SIZE      8
 
 static $WORD _dummy;
 #define dummy (&_dummy)
@@ -34,90 +34,89 @@ static $Iterator $set_iter_entry($set set);
 // General methods ///////////////////////////////////////////////////////////////////////////////////
 
 $set $set$new($Hashable hashwit, $Iterable wit, $WORD iterable) {
-  return $NEW($set, hashwit, wit, iterable);
+    return $NEW($set, hashwit, wit, iterable);
 }
 
 void $set_init($set set, $Hashable hashwit, $Iterable wit, $WORD iterable) {
-  set->numelements = 0;
-  set->fill = 0;
-  set->mask = MIN_SIZE-1;
-  set->finger = 0;
-  set->table = malloc(MIN_SIZE*sizeof($setentry));
-  memset(set->table,0,MIN_SIZE*sizeof($setentry));
-  if (wit && iterable) {
-    $Iterator it = wit->$class->__iter__(wit,iterable);
-    $WORD nxt;
-    while((nxt = it->$class->__next__(it))) {
-      $set_add(set,hashwit,nxt);
+    set->numelements = 0;
+    set->fill = 0;
+    set->mask = MIN_SIZE - 1;
+    set->finger = 0;
+    set->table = malloc(MIN_SIZE * sizeof($setentry));
+    memset(set->table, 0, MIN_SIZE * sizeof($setentry));
+    if (wit && iterable) {
+        $Iterator it = wit->$class->__iter__(wit, iterable);
+        $WORD nxt;
+        while ((nxt = it->$class->__next__(it))) {
+            $set_add(set, hashwit, nxt);
+        }
     }
-  }
 }
 
 $bool $set_bool($set self) {
-  return to$bool(self->numelements>0);
+    return to$bool(self->numelements > 0);
 }
 
 $str $set_str($set self) {
-  $list s2 = $list_new(self->numelements);
-  $Iterator$set iter = $NEW($Iterator$set,self);
-  $value elem;
-  for (int i=0; i<self->numelements; i++) {
-    elem = ($value)iter->$class->__next__(iter);
-    $list_append(s2,elem->$class->__str__(elem));
-  }
-  return $str_join_par('{',s2,'}');
+    $list s2 = $list_new(self->numelements);
+    $Iterator$set iter = $NEW($Iterator$set, self);
+    $value elem;
+    for (int i = 0; i < self->numelements; i++) {
+        elem = ($value)iter->$class->__next__(iter);
+        $list_append(s2, elem->$class->__str__(elem));
+    }
+    return $str_join_par('{', s2, '}');
 }
 
 void $set_serialize($set self, $Serial$state state) {
-  $int prevkey = ($int)$dict_get(state->done,($Hashable)$Hashable$WORD$witness,self,NULL);
-  if (prevkey) {
-      $val_serialize(-SET_ID,&prevkey->val,state);
-    return;
-  }
-  $dict_setitem(state->done,($Hashable)$Hashable$WORD$witness,self,to$int(state->row_no));
-  $ROW row = $add_header(SET_ID,4,state);
-  row->blob[0] = ($WORD)self->numelements;
-  row->blob[1] = ($WORD)self->fill;
-  row->blob[2] = ($WORD)self->mask;
-  row->blob[3] = ($WORD)self->finger;
-  for (long i=0; i<=self->mask; i++) {
-    $setentry *entry = &self->table[i];
-    $step_serialize(to$int(entry->hash),state);
-    $step_serialize(entry->key,state);
-  }
-}
- 
-$set $set_deserialize ($set res, $Serial$state state) {
-  $ROW this = state->row;
-  state->row = this->next;
-  state->row_no++;
-  if (this->class_id < 0) {
-    return $dict_get(state->done,($Hashable)$Hashable$int$witness,to$int((long)this->blob[0]),NULL);
-  } else {
-    if (!res)
-       res = malloc(sizeof(struct $set));
-    $dict_setitem(state->done,($Hashable)$Hashable$int$witness,to$int(state->row_no-1),res);
-    res->$class = &$set$methods;
-    res->numelements = (long)this->blob[0];
-    res->fill = (long)this->blob[1];
-    res->mask = (long)this->blob[2];
-    res->finger = (long)this->blob[3];
-    res->table = malloc((res->mask+1)*sizeof($setentry));
-    memset(res->table,0,(res->mask+1)*sizeof($setentry));
-    for (int i=0; i<=res->mask;i++) {
-      $setentry *entry = &res->table[i];
-      entry->hash = from$int(($int)$step_deserialize(state));
-      entry->key = $step_deserialize(state);
-        if (entry->hash==-1)
-          entry->key = dummy;
+    $int prevkey = ($int)$dict_get(state->done, ($Hashable)$Hashable$WORD$witness, self, NULL);
+    if (prevkey) {
+        $val_serialize(-SET_ID, &prevkey->val, state);
+        return;
     }
-    return res;
-  }
+    $dict_setitem(state->done, ($Hashable)$Hashable$WORD$witness, self, to$int(state->row_no));
+    $ROW row = $add_header(SET_ID, 4, state);
+    row->blob[0] = ($WORD)self->numelements;
+    row->blob[1] = ($WORD)self->fill;
+    row->blob[2] = ($WORD)self->mask;
+    row->blob[3] = ($WORD)self->finger;
+    for (long i = 0; i <= self->mask; i++) {
+        $setentry *entry = &self->table[i];
+        $step_serialize(to$int(entry->hash), state);
+        $step_serialize(entry->key, state);
+    }
+}
+
+$set $set_deserialize($set res, $Serial$state state) {
+    $ROW this = state->row;
+    state->row = this->next;
+    state->row_no++;
+    if (this->class_id < 0) {
+        return $dict_get(state->done, ($Hashable)$Hashable$int$witness, to$int((long)this->blob[0]), NULL);
+    } else {
+        if (!res)
+            res = malloc(sizeof(struct $set));
+        $dict_setitem(state->done, ($Hashable)$Hashable$int$witness, to$int(state->row_no - 1), res);
+        res->$class = &$set$methods;
+        res->numelements = (long)this->blob[0];
+        res->fill = (long)this->blob[1];
+        res->mask = (long)this->blob[2];
+        res->finger = (long)this->blob[3];
+        res->table = malloc((res->mask + 1) * sizeof($setentry));
+        memset(res->table, 0, (res->mask + 1) * sizeof($setentry));
+        for (int i = 0; i <= res->mask; i++) {
+            $setentry *entry = &res->table[i];
+            entry->hash = from$int(($int)$step_deserialize(state));
+            entry->key = $step_deserialize(state);
+            if (entry->hash == -1)
+                entry->key = dummy;
+        }
+        return res;
+    }
 }
 
 // Maybe we should  offer union, intersection and symmetric difference under those names.
-struct $set$class $set$methods = {"$set",UNASSIGNED,($Super$class)&$object$methods,$set_init,$set_serialize,$set_deserialize,$set_bool,$set_str,$set_copy}; 
-
+struct $set$class $set$methods = {"$set", UNASSIGNED, ($Super$class)&$object$methods, $set_init, $set_serialize, $set_deserialize, $set_bool, $set_str, $set_copy};
 
 static void $set_insert_clean($setentry *table, long mask, $WORD *key, long hash) {
     $setentry *entry;
@@ -129,11 +128,11 @@ static void $set_insert_clean($setentry *table, long mask, $WORD *key, long hash
         entry = &table[i];
         if (entry->key == NULL)
             goto found_null;
-        
+
         perturb >>= PERTURB_SHIFT;
         i = (i * 5 + 1 + perturb) & mask;
     }
-  found_null:
+found_null:
     entry->key = key;
     entry->hash = hash;
 }
@@ -153,7 +152,7 @@ static int $set_table_resize($set so, int minsize) {
 
     newtable = malloc(sizeof($setentry) * newsize);
     if (newtable == NULL) {
-      return -1;
+        return -1;
     }
 
     /* Make the $set empty, using the new table. */
@@ -198,10 +197,10 @@ static $setentry *$set_lookkey($set set, $Hashable hashwit, $WORD key, long hash
     while (1) {
         if (entry->hash == hash) {
             $WORD *startkey = entry->key;
-            // startkey cannot be a dummy because the dummy hash field is -1 
+            // startkey cannot be a dummy because the dummy hash field is -1
             // assert(startkey != dummy);
-            if (startkey == key || hashwit->$class->__eq__(hashwit,startkey,key))
-              return entry;
+            if (startkey == key || hashwit->$class->__eq__(hashwit, startkey, key))
+                return entry;
         }
         perturb >>= PERTURB_SHIFT;
         i = (i * 5 + 1 + perturb) & mask;
@@ -212,355 +211,347 @@ static $setentry *$set_lookkey($set set, $Hashable hashwit, $WORD key, long hash
     }
 }
 
-static int $set_contains_entry($set set,  $Hashable hashwit, $WORD elem, long hash) {
-  return $set_lookkey(set, hashwit, elem, hash)->key != NULL;
+static int $set_contains_entry($set set, $Hashable hashwit, $WORD elem, long hash) {
+    return $set_lookkey(set, hashwit, elem, hash)->key != NULL;
 }
 
 static void $set_add_entry($set set, $Hashable hashwit, $WORD key, long hash) {
-  $setentry *freeslot;
-  $setentry *entry;
-  long perturb;
-  long mask;
-  long i;  
-  mask = set->mask;
-  i = hash & mask;
+    $setentry *freeslot;
+    $setentry *entry;
+    long perturb;
+    long mask;
+    long i;
+    mask = set->mask;
+    i = hash & mask;
 
-  entry = &set->table[i];
-  if (entry->key == NULL)
-    goto found_unused;
+    entry = &set->table[i];
+    if (entry->key == NULL)
+        goto found_unused;
 
-  freeslot = NULL;
-  perturb = hash;
+    freeslot = NULL;
+    perturb = hash;
 
-  while (1) {
-    if (entry->hash == hash) {
-      $WORD startkey = entry->key;
-      // startkey cannot be a dummy because the dummy hash field is -1 
-      if (startkey == key || hashwit->$class->__eq__(hashwit,startkey,key))
-          goto found_active;
-          }
-      else if (entry->hash == -1)
-        freeslot = entry;
+    while (1) {
+        if (entry->hash == hash) {
+            $WORD startkey = entry->key;
+            // startkey cannot be a dummy because the dummy hash field is -1
+            if (startkey == key || hashwit->$class->__eq__(hashwit, startkey, key))
+                goto found_active;
+        } else if (entry->hash == -1)
+            freeslot = entry;
 
-      perturb >>= PERTURB_SHIFT;
-      i = (i * 5 + 1 + perturb) & mask;
+        perturb >>= PERTURB_SHIFT;
+        i = (i * 5 + 1 + perturb) & mask;
 
-      entry = &set->table[i];
-      if (entry->key == NULL)
-        goto found_unused_or_dummy;
+        entry = &set->table[i];
+        if (entry->key == NULL)
+            goto found_unused_or_dummy;
     }
 
-  found_unused_or_dummy:
+found_unused_or_dummy:
     if (freeslot == NULL)
-      goto found_unused;
+        goto found_unused;
     set->numelements++;
     freeslot->key = key;
     freeslot->hash = hash;
     return;
 
-  found_unused:
+found_unused:
     set->fill++;
     set->numelements++;
     entry->key = key;
     entry->hash = hash;
-    if ((size_t)set->fill*5 < mask*3)
-      return;
-    $set_table_resize(set, set->numelements>50000 ? set->numelements*2 : set->numelements*4);
+    if ((size_t)set->fill * 5 < mask * 3)
+        return;
+    $set_table_resize(set, set->numelements > 50000 ? set->numelements * 2 : set->numelements * 4);
     return;
-  found_active:
+found_active:
     return;
 }
 
-
 $set $set_copy($set set, $Hashable hashwit) {
-  $set res = malloc(sizeof(struct $set));
-  memcpy(res,set,sizeof(struct $set));
-  res->table = malloc((set->mask+1)*sizeof($setentry));
-  memcpy(res->table,set->table,(set->mask+1)*sizeof($setentry));
-  return res;
+    $set res = malloc(sizeof(struct $set));
+    memcpy(res, set, sizeof(struct $set));
+    res->table = malloc((set->mask + 1) * sizeof($setentry));
+    memcpy(res->table, set->table, (set->mask + 1) * sizeof($setentry));
+    return res;
 }
 
 static int $set_discard_entry($set set, $Hashable hashwit, $WORD elem, long hash) {
-  $setentry *entry = $set_lookkey(set,hashwit,elem, hash);
-  if (entry->key != NULL) {
-    entry->key = dummy;
-    entry->hash = -1;
-    set->numelements--;
-    return DISCARD_FOUND;
-  } else
-    return DISCARD_NOTFOUND;
+    $setentry *entry = $set_lookkey(set, hashwit, elem, hash);
+    if (entry->key != NULL) {
+        entry->key = dummy;
+        entry->hash = -1;
+        set->numelements--;
+        return DISCARD_FOUND;
+    } else
+        return DISCARD_NOTFOUND;
 }
 
 // Eq //////////////////////////////////////////////////////////////////////////////////////////////
 
-
 int $set_eq($Hashable hashwit, $set set, $set other) {
-  if (set == other) 
+    if (set == other)
+        return 1;
+    if (set->numelements != other->numelements)
+        return 0;
+    $Iterator iter = $set_iter_entry(other);
+    $WORD w;
+    while ((w = $next(iter))) {
+        if (!$set_contains_entry(set, hashwit, (($setentry *)w)->key, (($setentry *)w)->hash))
+            return 0;
+    }
     return 1;
-  if (set->numelements != other->numelements)
-    return 0;
-  $Iterator iter = $set_iter_entry(other);
-  $WORD w;
-  while((w = $next(iter))){
-    if(!$set_contains_entry(set, hashwit, (($setentry*)w)->key, (($setentry*)w)->hash))
-      return 0;
-  }
-  return 1;
 }
 
 // Ord /////////////////////////////////////////////////////////////////////////////////////////////
 
 int $set_ge($Hashable hashwit, $set set, $set other) {
-  if (set == other) 
-    return 1;    
-  if (set->numelements < other->numelements)
-    return 0;
-  $Iterator iter = $set_iter_entry(other);
-  $WORD w;
-  while((w = $next(iter))){
-    if(!$set_contains_entry(set, hashwit, (($setentry*)w)->key, (($setentry*)w)->hash))
-      return 0;
-  }
-  return 1;
+    if (set == other)
+        return 1;
+    if (set->numelements < other->numelements)
+        return 0;
+    $Iterator iter = $set_iter_entry(other);
+    $WORD w;
+    while ((w = $next(iter))) {
+        if (!$set_contains_entry(set, hashwit, (($setentry *)w)->key, (($setentry *)w)->hash))
+            return 0;
+    }
+    return 1;
 }
 
 int $set_gt($Hashable hashwit, $set set, $set other) {
-  if (set == other) 
-    return 0;    
-  if (set->numelements <= other->numelements)
-    return 0;
-  $Iterator iter = $set_iter_entry(other);
-  $WORD w;
-  while((w = $next(iter))){
-    if(!$set_contains_entry(set, hashwit, (($setentry*)w)->key, (($setentry*)w)->hash))
-      return 0;
-  }
-  return 1;
+    if (set == other)
+        return 0;
+    if (set->numelements <= other->numelements)
+        return 0;
+    $Iterator iter = $set_iter_entry(other);
+    $WORD w;
+    while ((w = $next(iter))) {
+        if (!$set_contains_entry(set, hashwit, (($setentry *)w)->key, (($setentry *)w)->hash))
+            return 0;
+    }
+    return 1;
 }
 
 int $set_le($Hashable hashwit, $set set, $set other) {
-  return $set_ge(hashwit,other,set);
+    return $set_ge(hashwit, other, set);
 }
 
 int $set_lt($Hashable hashwit, $set set, $set other) {
-  return $set_gt(hashwit,other,set);
+    return $set_gt(hashwit, other, set);
 }
 
 // Logical /////////////////////////////////////////////////////////////////////////////////////////////
 
-
 $set $set_intersection($Hashable hashwit, $set set, $set other) {
-  if ($set_len(other) > $set_len(set))
-    return $set_intersection(hashwit,other,set);
-  $set res = $NEW($set,hashwit,NULL,NULL);
-  $Iterator iter = $set_iter_entry(set);
-  $WORD w;
-  while((w = $next(iter))){
-    $WORD key = (($setentry*)w)->key;
-    long hash = (($setentry*)w)->hash;
-    if ($set_contains_entry(other,hashwit,key,hash))
-      $set_add_entry(res,hashwit,key,hash);
-  }
-  return res;
+    if ($set_len(other) > $set_len(set))
+        return $set_intersection(hashwit, other, set);
+    $set res = $NEW($set, hashwit, NULL, NULL);
+    $Iterator iter = $set_iter_entry(set);
+    $WORD w;
+    while ((w = $next(iter))) {
+        $WORD key = (($setentry *)w)->key;
+        long hash = (($setentry *)w)->hash;
+        if ($set_contains_entry(other, hashwit, key, hash))
+            $set_add_entry(res, hashwit, key, hash);
+    }
+    return res;
 }
 
-
 $set $set_union($Hashable hashwit, $set set, $set other) {
-  if ($set_len(other) > $set_len(set))
-    return $set_union(hashwit,other,set);
-  $set res = $set_copy(set, hashwit);
-  $Iterator iter = $set_iter_entry(other);
-  $WORD w;
-  while((w = $next(iter))){
-    $WORD key = (($setentry*)w)->key;
-    long hash = (($setentry*)w)->hash;
-    $set_add_entry(res,hashwit,key,hash);
-  }
-  return res;
+    if ($set_len(other) > $set_len(set))
+        return $set_union(hashwit, other, set);
+    $set res = $set_copy(set, hashwit);
+    $Iterator iter = $set_iter_entry(other);
+    $WORD w;
+    while ((w = $next(iter))) {
+        $WORD key = (($setentry *)w)->key;
+        long hash = (($setentry *)w)->hash;
+        $set_add_entry(res, hashwit, key, hash);
+    }
+    return res;
 }
 
 $set $set_symmetric_difference($Hashable hashwit, $set set, $set other) {
-  $set res = $set_copy(set, hashwit);
-  $Iterator iter = $set_iter_entry(other);
-  $WORD w;
-  while((w = $next(iter))){
-    $WORD key = (($setentry*)w)->key;
-    long hash = (($setentry*)w)->hash;
-    if(!$set_discard_entry(res,hashwit,key,hash))
-      $set_add_entry(res,hashwit,key,hash);
-  }
-  return res;
+    $set res = $set_copy(set, hashwit);
+    $Iterator iter = $set_iter_entry(other);
+    $WORD w;
+    while ((w = $next(iter))) {
+        $WORD key = (($setentry *)w)->key;
+        long hash = (($setentry *)w)->hash;
+        if (!$set_discard_entry(res, hashwit, key, hash))
+            $set_add_entry(res, hashwit, key, hash);
+    }
+    return res;
 }
 
 // Set /////////////////////////////////////////////////////////////////////////////////////////////
 
-void $set_add($set set, $Hashable hashwit,  $WORD elem) {
-  $set_add_entry(set,hashwit,elem,from$int(hashwit->$class->__hash__(hashwit,elem)));
+void $set_add($set set, $Hashable hashwit, $WORD elem) {
+    $set_add_entry(set, hashwit, elem, from$int(hashwit->$class->__hash__(hashwit, elem)));
 }
 
-
 void $set_discard($set set, $Hashable hashwit, $WORD elem) {
-  $set_discard_entry(set,hashwit,elem,from$int(hashwit->$class->__hash__(hashwit,elem)));
+    $set_discard_entry(set, hashwit, elem, from$int(hashwit->$class->__hash__(hashwit, elem)));
 }
 
 void $set_remove($set set, $Hashable hashwit, $WORD elem) {
-  long hash = from$int(hashwit->$class->__hash__(hashwit,elem));
-  if($set_discard_entry(set,hashwit,elem,hash))
-    return;
-  else {
-    $RAISE(($BaseException)$NEW($KeyError,to$str("remove: element not set member")));
-  }
+    long hash = from$int(hashwit->$class->__hash__(hashwit, elem));
+    if ($set_discard_entry(set, hashwit, elem, hash))
+        return;
+    else {
+        $RAISE(($BaseException)$NEW($KeyError, to$str("remove: element not set member")));
+    }
 }
 
 $WORD $set_pop($set set) {
-  $WORD res;
-  // Make sure the search finger is in bounds 
-  $setentry *entry = set->table + (set->finger & set->mask);
-  $setentry *limit = set->table + set->mask;
+    $WORD res;
+    // Make sure the search finger is in bounds
+    $setentry *entry = set->table + (set->finger & set->mask);
+    $setentry *limit = set->table + set->mask;
 
-  if (set->numelements == 0) {
-    return NULL;
-  }
-  while (entry->key == NULL || entry->key==dummy) {
-    entry++;
-    if (entry > limit)
-      entry = set->table;
-  }
-  res = entry->key;
-  entry->key = dummy;
-  entry->hash = -1;
-  set->numelements--;
-  set->finger = entry - set->table + 1;   // next place to start 
-  return res;
+    if (set->numelements == 0) {
+        return NULL;
+    }
+    while (entry->key == NULL || entry->key == dummy) {
+        entry++;
+        if (entry > limit)
+            entry = set->table;
+    }
+    res = entry->key;
+    entry->key = dummy;
+    entry->hash = -1;
+    set->numelements--;
+    set->finger = entry - set->table + 1; // next place to start
+    return res;
 }
 
 int $set_isdisjoint($Hashable hashwit, $set set, $set other) {
-  if (set == other) 
-    return set->numelements == 0;
-  if (other->numelements > set->numelements)
-    return $set_isdisjoint(hashwit,other,set);
-  $Iterator iter = $set_iter_entry(other);
-  $WORD w;
-  while((w = $next(iter))){
-    if($set_contains_entry(set, hashwit,(($setentry*)w)->key, (($setentry*)w)->hash))
-      return 0;
-  }
-  return 1;
+    if (set == other)
+        return set->numelements == 0;
+    if (other->numelements > set->numelements)
+        return $set_isdisjoint(hashwit, other, set);
+    $Iterator iter = $set_iter_entry(other);
+    $WORD w;
+    while ((w = $next(iter))) {
+        if ($set_contains_entry(set, hashwit, (($setentry *)w)->key, (($setentry *)w)->hash))
+            return 0;
+    }
+    return 1;
 }
 
 // Collection /////////////////////////////////////////////////////////////////////////////////////////////
 
-$set $set_fromiter($Hashable hashwit,$Iterator it) {
-  $set res = $NEW($set,hashwit,NULL,NULL);
-  res->numelements = 0;
-  res->fill = 0;
-  res->mask = MIN_SIZE-1;
-  res->finger = 0;
-  res->table = malloc(MIN_SIZE*sizeof($setentry));
-  memset(res->table,0,MIN_SIZE*sizeof($setentry));
-  $WORD nxt;
-  while((nxt = it->$class->__next__(it))) {
-    $set_add(res,hashwit,nxt);
-  }
-  return res;
+$set $set_fromiter($Hashable hashwit, $Iterator it) {
+    $set res = $NEW($set, hashwit, NULL, NULL);
+    res->numelements = 0;
+    res->fill = 0;
+    res->mask = MIN_SIZE - 1;
+    res->finger = 0;
+    res->table = malloc(MIN_SIZE * sizeof($setentry));
+    memset(res->table, 0, MIN_SIZE * sizeof($setentry));
+    $WORD nxt;
+    while ((nxt = it->$class->__next__(it))) {
+        $set_add(res, hashwit, nxt);
+    }
+    return res;
 }
 
 long $set_len($set set) {
-  return set->numelements;
+    return set->numelements;
 }
 
 // Container_Eq ///////////////////////////////////////////////////////////////////////////////////////
 
 int $set_contains($set set, $Hashable hashwit, $WORD elem) {
-  return $set_contains_entry(set,hashwit,elem,from$int(hashwit->$class->__hash__(hashwit,elem)));
+    return $set_contains_entry(set, hashwit, elem, from$int(hashwit->$class->__hash__(hashwit, elem)));
 }
- 
+
 // Iterable ///////////////////////////////////////////////////////////////////////////////////////
 
 static $WORD $Iterator$set_next_entry($Iterator$set self) {
-  $setentry *table = self->src->table;
-  long n = self->src->mask;
-  long i = self->nxt;
-  while (i <= n) {
-    $setentry *entry = &table[i];
-    if (entry->key != NULL && entry->key != dummy) {
-      self->nxt = i+1;
-      return entry;
+    $setentry *table = self->src->table;
+    long n = self->src->mask;
+    long i = self->nxt;
+    while (i <= n) {
+        $setentry *entry = &table[i];
+        if (entry->key != NULL && entry->key != dummy) {
+            self->nxt = i + 1;
+            return entry;
+        }
+        i++;
     }
-    i++;
-  }
-  return NULL;
+    return NULL;
 }
 
 static $Iterator $set_iter_entry($set set) {
-  $Iterator$set iter =  malloc(sizeof(struct $Iterator$set));
-  struct $Iterator$set$class *methods = malloc(sizeof(struct $Iterator$set$class));
-  iter->$class = methods;
-  methods->__next__ =  $Iterator$set_next_entry;
-  iter->src = set;
-  iter->nxt = 0;
-  return ($Iterator)iter;
+    $Iterator$set iter = malloc(sizeof(struct $Iterator$set));
+    struct $Iterator$set$class *methods = malloc(sizeof(struct $Iterator$set$class));
+    iter->$class = methods;
+    methods->__next__ = $Iterator$set_next_entry;
+    iter->src = set;
+    iter->nxt = 0;
+    return ($Iterator)iter;
 }
-                                            
+
 static $WORD $Iterator$set_next($Iterator$set self) {
-  $WORD res;
-  if((res = $Iterator$set_next_entry(self))) {
-    return (($setentry*)res)->key;
-  } 
-  return NULL;
+    $WORD res;
+    if ((res = $Iterator$set_next_entry(self))) {
+        return (($setentry *)res)->key;
+    }
+    return NULL;
 }
 
 $Iterator$set $Iterator$set$new($set s) {
-  return $NEW($Iterator$set, s);
+    return $NEW($Iterator$set, s);
 }
 
 void $Iterator$set_init($Iterator$set self, $set set) {
-  self->src = set;
-  self->nxt = 0;
+    self->src = set;
+    self->nxt = 0;
 }
 
 $bool $Iterator$set_bool($Iterator$set self) {
-  return $True;
+    return $True;
 }
 
 $str $Iterator$set_str($Iterator$set self) {
-  char *s;
-  asprintf(&s,"<set keys iterator object at %p>",self);
-  return to$str(s);
+    char *s;
+    asprintf(&s, "<set keys iterator object at %p>", self);
+    return to$str(s);
 }
 
 void $Iterator$set_serialize($Iterator$set self, $Serial$state state) {
-  $step_serialize(self->src,state);
-  $step_serialize(to$int(self->nxt),state);
+    $step_serialize(self->src, state);
+    $step_serialize(to$int(self->nxt), state);
 }
 
 $Iterator$set $Iterator$set$_deserialize($Iterator$set res, $Serial$state state) {
-   if (!res)
-      res = $DNEW($Iterator$set,state);
-   res->src = ($set)$step_deserialize(state);
-   res->nxt = from$int(($int)$step_deserialize(state));
-   return res;
+    if (!res)
+        res = $DNEW($Iterator$set, state);
+    res->src = ($set)$step_deserialize(state);
+    res->nxt = from$int(($int)$step_deserialize(state));
+    return res;
 }
 
-struct $Iterator$set$class $Iterator$set$methods = {"$Iterator$set",UNASSIGNED,($Super$class)&$Iterator$methods, $Iterator$set_init,
-                                                      $Iterator$set_serialize, $Iterator$set$_deserialize,$Iterator$set_bool,$Iterator$set_str, $Iterator$set_next};
-
+struct $Iterator$set$class $Iterator$set$methods = {"$Iterator$set", UNASSIGNED, ($Super$class)&$Iterator$methods, $Iterator$set_init,
+                                                    $Iterator$set_serialize, $Iterator$set$_deserialize, $Iterator$set_bool, $Iterator$set_str, $Iterator$set_next};
 
 $Iterator $set_iter($set set) {
-  return ($Iterator)$NEW($Iterator$set,set);
+    return ($Iterator)$NEW($Iterator$set, set);
 }
- 
+
 // Minus ///////////////////////////////////////////////////////////////////////////////////////////
 
 $set $set_difference($Hashable hashwit, $set set, $set other) {
-  $set res = $set_copy(set,hashwit);
-  $Iterator iter = $set_iter_entry(other);
-  $WORD w;
-  while((w = $next(iter))){
-    $WORD key = (($setentry*)w)->key;
-    long hash = (($setentry*)w)->hash;
-    $set_discard_entry(res,hashwit,key,hash);
-  }
-  return res;
+    $set res = $set_copy(set, hashwit);
+    $Iterator iter = $set_iter_entry(other);
+    $WORD w;
+    while ((w = $next(iter))) {
+        $WORD key = (($setentry *)w)->key;
+        long hash = (($setentry *)w)->hash;
+        $set_discard_entry(res, hashwit, key, hash);
+    }
+    return res;
 }
- 

--- a/builtin/set_impl.h
+++ b/builtin/set_impl.h
@@ -12,7 +12,6 @@ void $set_add($set set, $Hashable hashwit, $WORD elem);
 void $set_discard($set set, $Hashable hashwit, $WORD elem);
 $WORD $set_pop($set set);
 
-
 int $set_eq($Hashable hashwit, $set set, $set other);
 
 int $set_lt($Hashable hashwit, $set set, $set other);

--- a/builtin/slice.c
+++ b/builtin/slice.c
@@ -12,7 +12,6 @@
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-
 /* Normalize slice notation, so that
 - if step == 0, VALUEERROR is raised
 
@@ -25,56 +24,55 @@
        - *slen is the # of elements in the slice. 
 */
 
-
 void normalize_slice($slice slc, int len, int *slen, int *start, int *stop, int *step) {
-  if (slc->step == NULL)
-    *step = 1;
-  else
-    *step = *slc->step;
-  if (*step == 0) {
-    $RAISE(($BaseException)$NEW($ValueError,to$str("step size 0 in slice")));
-  }
-  if (slc->start == NULL)
-    *start = *step > 0 ? 0 : len-1;
-  else {
-    *start = *slc->start;
-    *start = *start >=0 ? (*start < len  ? *start : len-1 + (*step > 0))
-                        : (*start > -len ? len+*start : 0);
-  }
-  if (slc->stop == NULL)
-    *stop = *step > 0 ? len : -1;
-  else {
-    *stop = *slc->stop;
-    *stop = *stop >= 0 ? (*stop < len  ? *stop : len-1 + (*step > 0)) 
-                       : (*stop > -len ? len+*stop : 0);
-  }
-  
-  if ((*step > 0 && *start >= *stop) || (*step < 0 && *start <= *stop))
-    *slen = 0;
-  else
-    *slen = (*stop-*start)/ *step + ((*stop-*start)%*step != 0);
+    if (slc->step == NULL)
+        *step = 1;
+    else
+        *step = *slc->step;
+    if (*step == 0) {
+        $RAISE(($BaseException)$NEW($ValueError, to$str("step size 0 in slice")));
+    }
+    if (slc->start == NULL)
+        *start = *step > 0 ? 0 : len - 1;
+    else {
+        *start = *slc->start;
+        *start = *start >= 0 ? (*start < len ? *start : len - 1 + (*step > 0))
+                             : (*start > -len ? len + *start : 0);
+    }
+    if (slc->stop == NULL)
+        *stop = *step > 0 ? len : -1;
+    else {
+        *stop = *slc->stop;
+        *stop = *stop >= 0 ? (*stop < len ? *stop : len - 1 + (*step > 0))
+                           : (*stop > -len ? len + *stop : 0);
+    }
+
+    if ((*step > 0 && *start >= *stop) || (*step < 0 && *start <= *stop))
+        *slen = 0;
+    else
+        *slen = (*stop - *start) / *step + ((*stop - *start) % *step != 0);
 }
 
-$slice $slice$new($int start,$int stop,$int step) {
-  return $NEW($slice,start,stop,step);
+$slice $slice$new($int start, $int stop, $int step) {
+    return $NEW($slice, start, stop, step);
 }
 
 void $slice__init__($slice s, $int start, $int stop, $int step) {
-  if (start) {
-    s->start = malloc(sizeof(int));
-    *s->start = start->val;
-  } else
-    s->start = NULL;
- if (stop) {
-    s->stop = malloc(sizeof(int));
-    *s->stop = stop->val;
-  } else
-   s->stop = NULL;
- if (step) {
-    s->step = malloc(sizeof(int));
-    *s->step = step->val;
-  } else
-   s->step = NULL;
+    if (start) {
+        s->start = malloc(sizeof(int));
+        *s->start = start->val;
+    } else
+        s->start = NULL;
+    if (stop) {
+        s->stop = malloc(sizeof(int));
+        *s->stop = stop->val;
+    } else
+        s->stop = NULL;
+    if (step) {
+        s->step = malloc(sizeof(int));
+        *s->step = step->val;
+    } else
+        s->step = NULL;
 }
 
-struct $slice$class $slice$methods = {"$slice",UNASSIGNED,($Super$class)&$value$methods,$slice__init__,NULL,NULL,NULL,NULL};
+struct $slice$class $slice$methods = {"$slice", UNASSIGNED, ($Super$class)&$value$methods, $slice__init__, NULL, NULL, NULL, NULL};

--- a/builtin/slice.h
+++ b/builtin/slice.h
@@ -1,22 +1,22 @@
 struct $slice$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)($slice,$int,$int,$int);
-  void (*__serialize__)($slice,$Serial$state);
-  $slice (*__deserialize__)($slice,$Serial$state);
-  $bool (*__bool__)($float);
-  $str (*__str__)($float);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)($slice, $int, $int, $int);
+    void (*__serialize__)($slice, $Serial$state);
+    $slice (*__deserialize__)($slice, $Serial$state);
+    $bool (*__bool__)($float);
+    $str (*__str__)($float);
 };
 
 typedef struct $slice {
-  struct $slice$class *$class;
-  int *start;
-  int *stop;
-  int *step;
-} *$slice;
+    struct $slice$class *$class;
+    int *start;
+    int *stop;
+    int *step;
+} * $slice;
 
 extern struct $slice$class $slice$methods;
-$slice $slice$new($int,$int,$int);
+$slice $slice$new($int, $int, $int);
 
 void normalize_slice($slice slc, int len, int *slen, int *start, int *stop, int *step);

--- a/builtin/str.c
+++ b/builtin/str.c
@@ -19,7 +19,6 @@
 #include <ctype.h>
 #include "utf8proc.h"
 
-
 //  Method tables ///////////////////////////////////////////////////////////////
 
 // General methods
@@ -27,8 +26,8 @@
 void $str_init($str, $value);
 $bool $str_bool($str);
 $str $str_str($str);
-void $str_serialize($str,$Serial$state);
-$str $str_deserialize($str,$Serial$state);
+void $str_serialize($str, $Serial$state);
+$str $str_deserialize($str, $Serial$state);
 
 // String-specific methods
 $str $str_capitalize($str s);
@@ -36,7 +35,7 @@ $str $str_center($str s, $int width, $str fill);
 $int $str_count($str s, $str sub, $int start, $int end);
 $bytearray $str_encode($str s);
 $bool $str_endswith($str s, $str suffix, $int start, $int end);
-$str $str_expandtabs($str s, $int tabsize);      
+$str $str_expandtabs($str s, $int tabsize);
 $int $str_find($str s, $str sub, $int start, $int end);
 $int $str_index($str s, $str sub, $int start, $int end);
 $bool $str_isalnum($str s);
@@ -52,54 +51,53 @@ $bool $str_isspace($str s);
 $bool $str_istitle($str s);
 $bool $str_isupper($str s);
 $str $str_join($str sep, $Iterable wit, $WORD iter);
-$str $str_ljust($str s, $int width, $str fill); 
+$str $str_ljust($str s, $int width, $str fill);
 $str $str_lower($str s);
-$str $str_lstrip($str s,$str cs); 
+$str $str_lstrip($str s, $str cs);
 $tuple $str_partition($str s, $str sep);
 $str $str_replace($str s, $str old, $str new, $int count);
 $int $str_rfind($str s, $str sub, $int start, $int end);
 $int $str_rindex($str s, $str sub, $int start, $int end);
-$str $str_rjust($str s, $int width, $str fill);  
-$tuple $str_rpartition($str s, $str sep); 
-$str $str_rstrip($str s,$str cs);
-$list $str_split($str s, $str sep, $int maxsplit);  
-$list $str_splitlines($str s, $bool keepends); 
-$bool $str_startswith($str s, $str prefix, $int start, $int end); 
-$str $str_strip($str s,$str cs);
+$str $str_rjust($str s, $int width, $str fill);
+$tuple $str_rpartition($str s, $str sep);
+$str $str_rstrip($str s, $str cs);
+$list $str_split($str s, $str sep, $int maxsplit);
+$list $str_splitlines($str s, $bool keepends);
+$bool $str_startswith($str s, $str prefix, $int start, $int end);
+$str $str_strip($str s, $str cs);
 $str $str_upper($str s);
 $str $str_zfill($str s, $int width);
 
 struct $str$class $str$methods =
-  {"$str",UNASSIGNED,($Super$class)&$atom$methods, $str_init, $str_serialize, $str_deserialize, $str_bool, $str_str, $str_capitalize, $str_center, $str_count, $str_encode, $str_endswith,
-   $str_expandtabs, $str_find, $str_index, $str_isalnum, $str_isalpha, $str_isascii, $str_isdecimal, $str_islower, $str_isprintable, $str_isspace,
-   $str_istitle, $str_isupper, $str_join, $str_ljust, $str_lower, $str_lstrip, $str_partition, $str_replace, $str_rfind, $str_rindex, $str_rjust,
-   $str_rpartition, $str_rstrip, $str_split, $str_splitlines, $str_startswith, $str_strip, $str_upper, $str_zfill};
-
+    {"$str", UNASSIGNED, ($Super$class)&$atom$methods, $str_init, $str_serialize, $str_deserialize, $str_bool, $str_str, $str_capitalize, $str_center, $str_count, $str_encode, $str_endswith,
+     $str_expandtabs, $str_find, $str_index, $str_isalnum, $str_isalpha, $str_isascii, $str_isdecimal, $str_islower, $str_isprintable, $str_isspace,
+     $str_istitle, $str_isupper, $str_join, $str_ljust, $str_lower, $str_lstrip, $str_partition, $str_replace, $str_rfind, $str_rindex, $str_rjust,
+     $str_rpartition, $str_rstrip, $str_split, $str_splitlines, $str_startswith, $str_strip, $str_upper, $str_zfill};
 
 // protocol methods; string implementation prototypes ///////////////////////////////////////////////////
 
-int $str_eq($str,$str);
-int $str_neq($str,$str);
-int $str_lt($str,$str);
-int $str_le($str,$str);
-int $str_gt($str,$str);
-int $str_ge($str,$str);
+int $str_eq($str, $str);
+int $str_neq($str, $str);
+int $str_lt($str, $str);
+int $str_le($str, $str);
+int $str_gt($str, $str);
+int $str_ge($str, $str);
 
 $Iterator $str_iter($str);
 
 $str $str_fromiter($Iterable, $WORD);
 $int $str_len($str str);
 
-int $str_contains ($str, $str);
-int $str_containsnot ($str, $str);
+int $str_contains($str, $str);
+int $str_containsnot($str, $str);
 
 $str $str_getitem($str, int);
 $str $str_getslice($str, $slice);
- 
+
 $str $str_add($str, $str);
 $str $str_mul($str, $int);
 
-// Protocol instances, using above prototypes 
+// Protocol instances, using above prototypes
 
 // Ord
 
@@ -107,69 +105,69 @@ void $Ord$str$__serialize__($Ord$str self, $Serial$state state) {
 }
 
 $Ord$str $Ord$str$__deserialize__($Ord$str self, $Serial$state state) {
-   $Ord$str res = $DNEW($Ord$str,state);
-   return res;
+    $Ord$str res = $DNEW($Ord$str, state);
+    return res;
 }
 
 $Ord$str $Ord$str$new() {
-  return $NEW($Ord$str);
+    return $NEW($Ord$str);
 }
 
-$bool $Ord$str$__eq__ ($Ord$str wit, $str a, $str b) {
-  return to$bool($str_eq(a,b));
+$bool $Ord$str$__eq__($Ord$str wit, $str a, $str b) {
+    return to$bool($str_eq(a, b));
 }
 
-$bool $Ord$str$__ne__ ($Ord$str wit, $str a, $str b) {
-  return  to$bool($str_neq(a,b));
+$bool $Ord$str$__ne__($Ord$str wit, $str a, $str b) {
+    return to$bool($str_neq(a, b));
 }
 
-$bool $Ord$str$__lt__ ($Ord$str wit, $str a, $str b) {
-  return to$bool($str_lt(a,b));
+$bool $Ord$str$__lt__($Ord$str wit, $str a, $str b) {
+    return to$bool($str_lt(a, b));
 }
 
-$bool $Ord$str$__le__ ($Ord$str wit, $str a, $str b){
-  return to$bool($str_le(a,b));
+$bool $Ord$str$__le__($Ord$str wit, $str a, $str b) {
+    return to$bool($str_le(a, b));
 }
 
-$bool $Ord$str$__gt__ ($Ord$str wit, $str a, $str b){
-  return to$bool($str_gt(a,b));
+$bool $Ord$str$__gt__($Ord$str wit, $str a, $str b) {
+    return to$bool($str_gt(a, b));
 }
 
-$bool $Ord$str$__ge__ ($Ord$str wit, $str a, $str b){
-  return to$bool($str_ge(a,b));
+$bool $Ord$str$__ge__($Ord$str wit, $str a, $str b) {
+    return to$bool($str_ge(a, b));
 }
 
 // Container
 
 void $Container$str$__serialize__($Container$str self, $Serial$state state) {
-  $step_serialize(self-> w$Eq$A$Container$str, state);
+    $step_serialize(self->w$Eq$A$Container$str, state);
 }
 
 $Container$str $Container$str$__deserialize__($Container$str self, $Serial$state state) {
-   $Container$str res = $DNEW($Container$str,state);
-   res->w$Eq$A$Container$str = ($Eq)$step_deserialize(state);
-   return res;
+    $Container$str res = $DNEW($Container$str, state);
+    res->w$Eq$A$Container$str = ($Eq)$step_deserialize(state);
+    return res;
 }
 
-$Iterator $Container$str$__iter__ ($Container$str wit, $str str) {
-  return $str_iter(str);
+$Iterator $Container$str$__iter__($Container$str wit, $str str) {
+    return $str_iter(str);
 }
 
-$str $Container$str$__fromiter__ ($Container$str wit, $Iterable wit2, $WORD iter) {
-  return $str_join(to$str(""),wit2,iter);
+$str $Container$str$__fromiter__($Container$str wit, $Iterable wit2, $WORD iter) {
+    return $str_join(to$str(""), wit2, iter);
 }
 
-$int $Container$str$__len__ ($Container$str wit, $str str) {
-  return $str_len(str);
+$int $Container$str$__len__($Container$str wit, $str str) {
+    return $str_len(str);
 }
 
-$bool $Container$str$__contains__ ($Container$str wit, $str str, $str sub) {
-  return to$bool($str_contains(str, sub));
+$bool $Container$str$__contains__($Container$str wit, $str str, $str sub) {
+    return to$bool($str_contains(str, sub));
 }
 
-$bool $Container$str$__containsnot__ ($Container$str wit, $str str, $str sub) {
-  return to$bool($str_containsnot(str, sub));
-}  
+$bool $Container$str$__containsnot__($Container$str wit, $str str, $str sub) {
+    return to$bool($str_containsnot(str, sub));
+}
 
 // Sliceable
 
@@ -177,39 +175,39 @@ void $Sliceable$str$__serialize__($Sliceable$str self, $Serial$state state) {
 }
 
 $Sliceable$str $Sliceable$str$__deserialize__($Sliceable$str self, $Serial$state state) {
-   $Sliceable$str res = $DNEW($Sliceable$str,state);
-   return res;
+    $Sliceable$str res = $DNEW($Sliceable$str, state);
+    return res;
 }
 
 $Sliceable$str $Sliceable$str$new() {
-  return $NEW($Sliceable$str);
+    return $NEW($Sliceable$str);
 }
-$str $Sliceable$str$__getitem__ ($Sliceable$str wit, $str str, $int i) {
-  return $str_getitem(str,from$int(i));
-}
-
-void $Sliceable$str$__setitem__ ($Sliceable$str wit, $str str, $int i, $str val) {
-  fprintf(stderr,"Internal error: call to mutating method setitem on string");
-  exit(-1);
+$str $Sliceable$str$__getitem__($Sliceable$str wit, $str str, $int i) {
+    return $str_getitem(str, from$int(i));
 }
 
-void $Sliceable$str$__delitem__ ($Sliceable$str wit, $str str, $int i) {
-  fprintf(stderr,"Internal error: call to mutating method delitem on string");
-  exit(-1);
+void $Sliceable$str$__setitem__($Sliceable$str wit, $str str, $int i, $str val) {
+    fprintf(stderr, "Internal error: call to mutating method setitem on string");
+    exit(-1);
 }
 
-$str $Sliceable$str$__getslice__ ($Sliceable$str wit, $str str, $slice slc) {
-  return $str_getslice(str,slc);
+void $Sliceable$str$__delitem__($Sliceable$str wit, $str str, $int i) {
+    fprintf(stderr, "Internal error: call to mutating method delitem on string");
+    exit(-1);
 }
 
-void $Sliceable$str$__setslice__ ($Sliceable$str wit, $str str, $Iterable wit2, $slice slc, $WORD iter) {
-  fprintf(stderr,"Internal error: call to mutating method setslice on string");
-  exit(-1);
+$str $Sliceable$str$__getslice__($Sliceable$str wit, $str str, $slice slc) {
+    return $str_getslice(str, slc);
 }
 
-void $Sliceable$str$__delslice__ ($Sliceable$str wit, $str str, $slice slc) {
-  fprintf(stderr,"Internal error: call to mutating method delslice on string");
-  exit(-1);
+void $Sliceable$str$__setslice__($Sliceable$str wit, $str str, $Iterable wit2, $slice slc, $WORD iter) {
+    fprintf(stderr, "Internal error: call to mutating method setslice on string");
+    exit(-1);
+}
+
+void $Sliceable$str$__delslice__($Sliceable$str wit, $str str, $slice slc) {
+    fprintf(stderr, "Internal error: call to mutating method delslice on string");
+    exit(-1);
 }
 
 // Times
@@ -218,16 +216,16 @@ void $Times$str$__serialize__($Times$str self, $Serial$state state) {
 }
 
 $Times$str $Times$str$__deserialize__($Times$str self, $Serial$state state) {
-   $Times$str res = $DNEW($Times$str,state);
-   return res;
+    $Times$str res = $DNEW($Times$str, state);
+    return res;
 }
 
-$str $Times$str$__add__ ($Times$str wit, $str a, $str b) {
-  return $str_add(a,b);
+$str $Times$str$__add__($Times$str wit, $str a, $str b) {
+    return $str_add(a, b);
 }
 
-$str $Times$str$__mul__ ($Times$str wit, $str a, $int n) {
-  return $str_mul(a,n);
+$str $Times$str$__mul__($Times$str wit, $str a, $int n) {
+    return $str_mul(a, n);
 }
 
 // Hashable
@@ -236,208 +234,201 @@ void $Hashable$str$__serialize__($Hashable$str self, $Serial$state state) {
 }
 
 $Hashable$str $Hashable$str$__deserialize__($Hashable$str self, $Serial$state state) {
-   $Hashable$str res = $DNEW($Hashable$str,state);
-   return res;
+    $Hashable$str res = $DNEW($Hashable$str, state);
+    return res;
 }
 
-$bool $Hashable$str$__eq__ ($Hashable$str wit, $str a, $str b) {
-  return to$bool($str_eq(a,b));
+$bool $Hashable$str$__eq__($Hashable$str wit, $str a, $str b) {
+    return to$bool($str_eq(a, b));
 }
 
 $Hashable$str $Hashable$str$new() {
-  return $NEW($Hashable$str);
+    return $NEW($Hashable$str);
 }
-$bool $Hashable$str$__ne__ ($Hashable$str wit, $str a, $str b) {
-  return to$bool($str_neq(a,b));
+$bool $Hashable$str$__ne__($Hashable$str wit, $str a, $str b) {
+    return to$bool($str_neq(a, b));
 }
 
 $int $Hashable$str$__hash__($Hashable$str wit, $str str) {
-  return to$int($string_hash(str));
+    return to$int($string_hash(str));
 }
-
 
 // Method tables for witness classes
 
-struct $Ord$str$class  $Ord$str$methods = {
+struct $Ord$str$class $Ord$str$methods = {
     "$Ord$str",
     UNASSIGNED,
     ($Super$class)&$Ord$methods,
     (void (*)($Ord$str))$default__init__,
     $Ord$str$__serialize__,
     $Ord$str$__deserialize__,
-    ($bool (*)($Ord$str))$default__bool__,
-    ($str (*)($Ord$str))$default__str__,
+    ($bool(*)($Ord$str))$default__bool__,
+    ($str(*)($Ord$str))$default__str__,
     $Ord$str$__eq__,
     $Ord$str$__ne__,
     $Ord$str$__lt__,
     $Ord$str$__le__,
     $Ord$str$__gt__,
-    $Ord$str$__ge__
-};
+    $Ord$str$__ge__};
 struct $Ord$str $Ord$str_instance = {&$Ord$str$methods};
 $Ord$str $Ord$str$witness = &$Ord$str_instance;
 
-struct $Container$str$class  $Container$str$methods = {
+struct $Container$str$class $Container$str$methods = {
     "$Container$str",
     UNASSIGNED,
     ($Super$class)&$Container$methods,
     $Container$str$__init__,
     $Container$str$__serialize__,
     $Container$str$__deserialize__,
-    ($bool (*)($Container$str))$default__bool__,
-    ($str (*)($Container$str))$default__str__,
+    ($bool(*)($Container$str))$default__bool__,
+    ($str(*)($Container$str))$default__str__,
     $Container$str$__iter__,
     NULL,
     $Container$str$__len__,
     $Container$str$__contains__,
-    $Container$str$__containsnot__
-};
-struct $Container$str $Container$str_instance = {&$Container$str$methods,($Eq)&$Ord$str_instance};
+    $Container$str$__containsnot__};
+struct $Container$str $Container$str_instance = {&$Container$str$methods, ($Eq)&$Ord$str_instance};
 $Container$str $Container$str$witness = &$Container$str_instance;
 
-
-struct $Sliceable$str$class  $Sliceable$str$methods = {
+struct $Sliceable$str$class $Sliceable$str$methods = {
     "$Sliceable$str",
     UNASSIGNED,
     ($Super$class)&$Sliceable$methods,
     (void (*)($Sliceable$str))$default__init__,
     $Sliceable$str$__serialize__,
     $Sliceable$str$__deserialize__,
-    ($bool (*)($Sliceable$str))$default__bool__,
-    ($str (*)($Sliceable$str))$default__str__,
+    ($bool(*)($Sliceable$str))$default__bool__,
+    ($str(*)($Sliceable$str))$default__str__,
     $Sliceable$str$__getitem__,
     $Sliceable$str$__setitem__,
     $Sliceable$str$__delitem__,
     $Sliceable$str$__getslice__,
     $Sliceable$str$__setslice__,
-    $Sliceable$str$__delslice__
-};
+    $Sliceable$str$__delslice__};
 struct $Sliceable$str $Sliceable$str_instance = {&$Sliceable$str$methods};
 $Sliceable$str $Sliceable$str$witness = &$Sliceable$str_instance;
 
-struct $Times$str$class  $Times$str$methods = {
+struct $Times$str$class $Times$str$methods = {
     "$Times$str",
     UNASSIGNED,
     ($Super$class)&$Times$methods,
     (void (*)($Times$str))$default__init__,
     $Times$str$__serialize__,
     $Times$str$__deserialize__,
-    ($bool (*)($Times$str))$default__bool__,
-    ($str (*)($Times$str))$default__str__,
+    ($bool(*)($Times$str))$default__bool__,
+    ($str(*)($Times$str))$default__str__,
     $Times$str$__add__,
-    ($str (*)($Times$str, $str, $str))$Plus$__iadd__,
+    ($str(*)($Times$str, $str, $str))$Plus$__iadd__,
     $Times$str$__mul__,
-    ($str (*)($Times$str, $str, $int))$Times$__imul__,
+    ($str(*)($Times$str, $str, $int))$Times$__imul__,
 
 };
 struct $Times$str $Times$str_instance = {&$Times$str$methods};
 $Times$str $Times$str$witness = &$Times$str_instance;
 
-struct $Hashable$str$class  $Hashable$str$methods = {
+struct $Hashable$str$class $Hashable$str$methods = {
     "$Hashable$str",
     UNASSIGNED,
     ($Super$class)&$Hashable$methods,
     (void (*)($Hashable$str))$default__init__,
     $Hashable$str$__serialize__,
     $Hashable$str$__deserialize__,
-    ($bool (*)($Hashable$str))$default__bool__,
-    ($str (*)($Hashable$str))$default__str__,
+    ($bool(*)($Hashable$str))$default__bool__,
+    ($str(*)($Hashable$str))$default__str__,
     $Hashable$str$__eq__,
     $Hashable$str$__ne__,
-    $Hashable$str$__hash__
-};
+    $Hashable$str$__hash__};
 struct $Hashable$str $Hashable$str_instance = {&$Hashable$str$methods};
 $Hashable$str $Hashable$str$witness = &$Hashable$str_instance;
 
- 
-void $Container$str$__init__ ($Container$str wit, $Eq w$Eq$A$Container$str) {
-  wit->w$Eq$A$Container$str = w$Eq$A$Container$str;
+void $Container$str$__init__($Container$str wit, $Eq w$Eq$A$Container$str) {
+    wit->w$Eq$A$Container$str = w$Eq$A$Container$str;
 }
 
 // Auxiliaries, some used for both str and bytearray implementations ////////////////////////////////////////////////////////
 
 static unsigned char nul = 0;
 
-static struct $str null_struct = {&$str$methods,0,0,&nul};
+static struct $str null_struct = {&$str$methods, 0, 0, &nul};
 
 static $str null_str = &null_struct;
 
-static struct $str space_struct = {&$str$methods,1,1,(unsigned char *)" "};
+static struct $str space_struct = {&$str$methods, 1, 1, (unsigned char *)" "};
 
 static $str space_str = &space_struct;
 
-static struct $str whitespace_struct = {&$str$methods,6,6,(unsigned char *)" \t\n\r\x0b\x0c"};
+static struct $str whitespace_struct = {&$str$methods, 6, 6, (unsigned char *)" \t\n\r\x0b\x0c"};
 
 static $str whitespace_str = &whitespace_struct;
 
-#define NEW_UNFILLED_STR(nm,nchrs,nbtes)         \
-nm = malloc(sizeof(struct $str)); \
-(nm)->$class = &$str$methods; \
-(nm)->nchars = nchrs;            \
-(nm)->nbytes = nbtes;            \
-(nm)->str = malloc((nm)->nbytes + 1);    \
-(nm)->str[(nm)->nbytes] = 0
+#define NEW_UNFILLED_STR(nm, nchrs, nbtes) \
+    nm = malloc(sizeof(struct $str));      \
+    (nm)->$class = &$str$methods;          \
+    (nm)->nchars = nchrs;                  \
+    (nm)->nbytes = nbtes;                  \
+    (nm)->str = malloc((nm)->nbytes + 1);  \
+    (nm)->str[(nm)->nbytes] = 0
 
-#define NEW_UNFILLED_BYTEARRAY(nm,nbtes)         \
-nm = malloc(sizeof(struct $bytearray)); \
-(nm)->$class = &$bytearray$methods; \
-(nm)->nbytes = nbtes;            \
-(nm)->capacity = nbtes;            \
-(nm)->str = malloc((nm)->nbytes + 1);    \
-(nm)->str[(nm)->nbytes] = 0
+#define NEW_UNFILLED_BYTEARRAY(nm, nbtes)   \
+    nm = malloc(sizeof(struct $bytearray)); \
+    (nm)->$class = &$bytearray$methods;     \
+    (nm)->nbytes = nbtes;                   \
+    (nm)->capacity = nbtes;                 \
+    (nm)->str = malloc((nm)->nbytes + 1);   \
+    (nm)->str[(nm)->nbytes] = 0
 
 // Conversion to and from C strings
 
-$str to$str(char *str) { 
-  int nbytes = 0;
-  int nchars = 0;
+$str to$str(char *str) {
+    int nbytes = 0;
+    int nchars = 0;
 
-  unsigned char *p = (unsigned char*)str;
-  int cp, cpnbytes;
-  while(1) {
-    if (*p == '\0') {
-      $str res;
-      NEW_UNFILLED_STR(res,nchars, nbytes);
-      memcpy(res->str,str,nbytes);
-      return res;
+    unsigned char *p = (unsigned char *)str;
+    int cp, cpnbytes;
+    while (1) {
+        if (*p == '\0') {
+            $str res;
+            NEW_UNFILLED_STR(res, nchars, nbytes);
+            memcpy(res->str, str, nbytes);
+            return res;
+        }
+        cpnbytes = utf8proc_iterate(p, -1, &cp);
+        if (cpnbytes < 0) {
+            $RAISE(($BaseException)$NEW($ValueError, to$str("to$str: Unicode decode error")));
+            return NULL;
+        }
+        nbytes += cpnbytes;
+        nchars++;
+        p += cpnbytes;
     }
-    cpnbytes = utf8proc_iterate(p,-1,&cp);
-    if (cpnbytes < 0) {
-      $RAISE(($BaseException)$NEW($ValueError,to$str("to$str: Unicode decode error")));
-      return NULL;
-    }
-    nbytes += cpnbytes;
-    nchars++;
-    p += cpnbytes;
-  }
 }
 
 unsigned char *from$str($str str) {
-  return str->str;
+    return str->str;
 }
 
 // #bytes in UTF-8 to represent codepoint cp
 static int byte_length(unsigned int cp) {
-   if (cp < 0x80) 
-      return 1;
-   else if (cp < 0x800) 
-      return 2;
-   else if (cp < 0x10000) 
-      return 3;
-   else 
-      return 4;
+    if (cp < 0x80)
+        return 1;
+    else if (cp < 0x800)
+        return 2;
+    else if (cp < 0x10000)
+        return 3;
+    else
+        return 4;
 }
 
 // #bytes in UTF-8 for char starting with byte c
 static int byte_length2(unsigned char c) {
-   if (c < 0x7f) 
-      return 1;
-   else if (c < 0xdf) 
-      return 2;
-   else if (c < 0xef) 
-      return 3;
-   else 
-      return 4;
+    if (c < 0x7f)
+        return 1;
+    else if (c < 0xdf)
+        return 2;
+    else if (c < 0xef)
+        return 3;
+    else
+        return 4;
 }
 
 typedef int (*transform)(int codepoint);
@@ -446,118 +437,117 @@ typedef int (*transform)(int codepoint);
 // For the moment only used for str_upper and str_lower;
 // maybe not worthwhile to keep.
 static $str str_transform($str s, transform f) {
-  int cp, cpu, cplen, cpulen;
-  unsigned char *p = s->str;
-  unsigned char buffer[4*s->nchars];
-  unsigned char *up = buffer;
-  for (int i=0; i < s->nchars; i++) {
-    cplen = utf8proc_iterate(p,-1,&cp);
-    cpu = f(cp);
-    cpulen = utf8proc_encode_char(cpu,up);
-    p+=cplen;
-    up += cpulen;
-  }
-  int nbytes = (int)(up-buffer);
-  $str res;
-  NEW_UNFILLED_STR(res,s->nchars,nbytes);
-  memcpy(res->str,buffer,nbytes);
-  return res;
+    int cp, cpu, cplen, cpulen;
+    unsigned char *p = s->str;
+    unsigned char buffer[4 * s->nchars];
+    unsigned char *up = buffer;
+    for (int i = 0; i < s->nchars; i++) {
+        cplen = utf8proc_iterate(p, -1, &cp);
+        cpu = f(cp);
+        cpulen = utf8proc_encode_char(cpu, up);
+        p += cplen;
+        up += cpulen;
+    }
+    int nbytes = (int)(up - buffer);
+    $str res;
+    NEW_UNFILLED_STR(res, s->nchars, nbytes);
+    memcpy(res->str, buffer, nbytes);
+    return res;
 }
 
 // Find char position in text from byte position.
 // Assume that i is first byte of a char in text.
-static int char_no($str text,int i) {
-  if (text->nbytes == text->nchars) // ASCII string
-    return i;
-  int res = 0;
-  int k=0;
-  unsigned char *t = text->str;
-  while (k<i) {
-    k += byte_length2(t[k]);
-    res++;
-  }
-  return res;
-}
-
-static unsigned char *skip_chars(unsigned char* start,int n, int isascii) {
-  unsigned char *res = start;
-  if (isascii)
-    return start+n;
-  if (n >= 0) {
-    for (int i=0; i<n; i++)
-      res += byte_length2(*res);
-  } else {
-    for (int i= 0; i<-n; i++) {
-      res--;
-      while (*res >> 6 == 2) res--;
+static int char_no($str text, int i) {
+    if (text->nbytes == text->nchars) // ASCII string
+        return i;
+    int res = 0;
+    int k = 0;
+    unsigned char *t = text->str;
+    while (k < i) {
+        k += byte_length2(t[k]);
+        res++;
     }
-  }
-  return res;
+    return res;
 }
 
+static unsigned char *skip_chars(unsigned char *start, int n, int isascii) {
+    unsigned char *res = start;
+    if (isascii)
+        return start + n;
+    if (n >= 0) {
+        for (int i = 0; i < n; i++)
+            res += byte_length2(*res);
+    } else {
+        for (int i = 0; i < -n; i++) {
+            res--;
+            while (*res >> 6 == 2)
+                res--;
+        }
+    }
+    return res;
+}
 
 // Find byte position in text from char position.
 // Assume i is a valid char index in text
 static int byte_no($str text, int i) {
-  int res = 0;
-  unsigned char *t = text->str;
-  for (int k=0; k<i; k++)
-    res += byte_length2(t[k]);
-  return res;
+    int res = 0;
+    unsigned char *t = text->str;
+    for (int k = 0; k < i; k++)
+        res += byte_length2(t[k]);
+    return res;
 }
 
-// Handles negative indices in getitem etc (slice notation) 
+// Handles negative indices in getitem etc (slice notation)
 static int get_index(int i, int nchars) {
-  if (i >= 0) {
-    if (i<nchars)
-      return i;
-  } else {
-    if (i >= -nchars)
-      return nchars+i;
-  }
-  $RAISE(($BaseException)$NEW($IndexError,to$str("indexing outside str")));
-  return 0;
+    if (i >= 0) {
+        if (i < nchars)
+            return i;
+    } else {
+        if (i >= -nchars)
+            return nchars + i;
+    }
+    $RAISE(($BaseException)$NEW($IndexError, to$str("indexing outside str")));
+    return 0;
 }
 
- 
 // Eliminates slice notation in find, index, count and other methods
 // with optional start and end and adds defaults for omitted parameters.
 
 static int fix_start_end(int nchars, $int *start, $int *end) {
-  if (*start==NULL) {
-    *start = malloc(sizeof(struct $int));
-    *start = to$int(0);
-  }
-  long st = from$int(*start);
-  if (st > nchars)
-    return -1;
-  if (st < 0) 
-    st += nchars;
-  st = st < 0 ? 0 : st;
-  *start = to$int(st);
+    if (*start == NULL) {
+        *start = malloc(sizeof(struct $int));
+        *start = to$int(0);
+    }
+    long st = from$int(*start);
+    if (st > nchars)
+        return -1;
+    if (st < 0)
+        st += nchars;
+    st = st < 0 ? 0 : st;
+    *start = to$int(st);
 
-  if (*end==NULL) {
-    *end = malloc(sizeof(struct $int));
-    *end = to$int(nchars);
-  }
-  long en = from$int(*end);
-  if (en > nchars)   
-    en = nchars;      
-  else if (en < 0) 
-    en += nchars;     
-  en = en < 0 ? 0 : en;    
+    if (*end == NULL) {
+        *end = malloc(sizeof(struct $int));
+        *end = to$int(nchars);
+    }
+    long en = from$int(*end);
+    if (en > nchars)
+        en = nchars;
+    else if (en < 0)
+        en += nchars;
+    en = en < 0 ? 0 : en;
 
-  *end = to$int(en);
-  return 0;
+    *end = to$int(en);
+    return 0;
 }
 
 // Builds a new one-char string starting at p.
 static $str mk_char(unsigned char *p) {
-  $str res;
-  NEW_UNFILLED_STR(res,1,byte_length2(*p));
-  for (int i=0; i<res->nbytes; i++)
-    res->str[i] = p[i];
-  return res;
+    $str res;
+    NEW_UNFILLED_STR(res, 1, byte_length2(*p));
+    for (int i = 0; i < res->nbytes; i++)
+        res->str[i] = p[i];
+    return res;
 }
 
 static int isspace_codepoint(int codepoint) {
@@ -567,13 +557,12 @@ static int isspace_codepoint(int codepoint) {
 }
 
 static int islinebreak_codepoint(int codepoint) {
-  // category not useful; all the seven codepoints we handle are in category Other, control.
-  return (codepoint <= 0x0a && codepoint <= 0x0d) ||
-    (codepoint >= 0x1c && codepoint <= 0x1e);
+    // category not useful; all the seven codepoints we handle are in category Other, control.
+    return (codepoint <= 0x0a && codepoint <= 0x0d) ||
+           (codepoint >= 0x1c && codepoint <= 0x1e);
     // For now we ignore the three codepoints below which are counted as linebreaks by
     // Python's splitlines for strings.
     //  || codepoint == 0x85 || codepoint == 0x2028 ||codepoint == 0x2029;
-    
 }
 
 // The Boyer-Moore-Horspool algorithm for searching for pattern in text.
@@ -581,45 +570,53 @@ static int islinebreak_codepoint(int codepoint) {
 // Returns byte position in text where first occurrence of pattern starts,
 // or -1 if it does not occur.
 // Start search from the left end of text.
-int bmh( unsigned char *text, unsigned char *pattern, int tbytes, int pbytes) {
-  if (pbytes>tbytes) return -1;
-  int skip[256];
-  for (int i=0; i<256; i++) skip[i] = pbytes;
-  for (int i=0; i<pbytes-1; i++)
-    skip[(int)pattern[i]] = pbytes-i-1;
-  int k = pbytes-1;
-  int i, j;
-  while (k<tbytes) {
-    j = pbytes-1;
-    i = k;
-    while (j >=0 && text[i] == pattern[j]) {
-      j--; i--;
+int bmh(unsigned char *text, unsigned char *pattern, int tbytes, int pbytes) {
+    if (pbytes > tbytes)
+        return -1;
+    int skip[256];
+    for (int i = 0; i < 256; i++)
+        skip[i] = pbytes;
+    for (int i = 0; i < pbytes - 1; i++)
+        skip[(int)pattern[i]] = pbytes - i - 1;
+    int k = pbytes - 1;
+    int i, j;
+    while (k < tbytes) {
+        j = pbytes - 1;
+        i = k;
+        while (j >= 0 && text[i] == pattern[j]) {
+            j--;
+            i--;
+        }
+        if (j == -1)
+            return i + 1;
+        k += skip[(int)text[k]];
     }
-    if (j==-1) return i+1;
-    k += skip[(int)text[k]];
-  }
-  return -1;
+    return -1;
 }
 
 // Start search from the right end of text.
-static int rbmh( unsigned char *text, unsigned char *pattern, int tbytes, int pbytes) {
-  if (pbytes>tbytes) return -1;
-  int skip[256];
-  for (int i=0; i<256; i++) skip[i] = pbytes;
-  for (int i=pbytes-1; i>0; i--)
-    skip[(int)pattern[i]] = i;
-  int k = tbytes - pbytes;
-  int i, j;
-  while (k >= 0) {
-    j = 0;
-    i = k;
-    while (j < pbytes && text[i] == pattern[j]) {
-      j++; i++;
+static int rbmh(unsigned char *text, unsigned char *pattern, int tbytes, int pbytes) {
+    if (pbytes > tbytes)
+        return -1;
+    int skip[256];
+    for (int i = 0; i < 256; i++)
+        skip[i] = pbytes;
+    for (int i = pbytes - 1; i > 0; i--)
+        skip[(int)pattern[i]] = i;
+    int k = tbytes - pbytes;
+    int i, j;
+    while (k >= 0) {
+        j = 0;
+        i = k;
+        while (j < pbytes && text[i] == pattern[j]) {
+            j++;
+            i++;
+        }
+        if (j == pbytes)
+            return i - pbytes;
+        k -= skip[(int)text[k]];
     }
-    if (j==pbytes) return i-pbytes;
-    k -= skip[(int)text[k]];
-  }
-  return -1;
+    return -1;
 }
 
 // Protocol methods; string implementations /////////////////////////////////////////////////////////////////////////////
@@ -630,36 +627,35 @@ include mutating methods.
 
 // $Ord ///////////////////////////////////////////////////////////////////////////////////////////////
 
-
 // TODO: We should consider how to normalize strings before comparisons
 
 int $str_eq($str a, $str b) {
-  return (strcmp((char *)a->str,(char *)b->str)==0);
+    return (strcmp((char *)a->str, (char *)b->str) == 0);
 }
-         
+
 int $str_neq($str a, $str b) {
-  return !$str_eq(a,b);
+    return !$str_eq(a, b);
 }
 
 // The comparisons below do lexicographic byte-wise comparisons.
 // Thus they do not in general reflect locale-dependent order conventions.
- 
+
 int $str_lt($str a, $str b) {
-  return (strcmp((char *)a->str,(char *)b->str) < 0);
+    return (strcmp((char *)a->str, (char *)b->str) < 0);
 }
- 
+
 int $str_le($str a, $str b) {
-  return (strcmp((char *)a->str,(char *)b->str) <= 0);
+    return (strcmp((char *)a->str, (char *)b->str) <= 0);
 }
- 
+
 int $str_gt($str a, $str b) {
-  return (strcmp((char *)a->str,(char *)b->str) > 0);
+    return (strcmp((char *)a->str, (char *)b->str) > 0);
 }
- 
+
 int $str_ge($str a, $str b) {
-  return (strcmp((char *)a->str,(char *)b->str) >= 0);
+    return (strcmp((char *)a->str, (char *)b->str) >= 0);
 }
- 
+
 // $Hashable ///////////////////////////////////////////////////////////////////////////////////
 
 // hash function $string_hash defined in hash.c
@@ -667,901 +663,894 @@ int $str_ge($str a, $str b) {
 // $Times /////////////////////////////////////////////////////////////////////////////////////////////
 
 $Times$str $Times$str$new() {
-  return $NEW($Times$str);
-}
- 
-$str $str_add($str s, $str t) {
-  $str res;
-  NEW_UNFILLED_STR(res,s->nchars + t->nchars,s->nbytes + t->nbytes);
-  memcpy(res->str,s->str,s->nbytes);
-  memcpy(res->str+s->nbytes,t->str,t->nbytes);
-  return res;
+    return $NEW($Times$str);
 }
 
-$str $str_mul ($str a, $int n) {
-  if (n->val <= 0)
-    return to$str("");
-  else {
-      $str res;
-      NEW_UNFILLED_STR(res,a->nchars * n->val, a->nbytes * n->val);
-      for (int i=0; i<n->val; i++)
-        memcpy(res->str + i*a->nbytes,a->str,a->nbytes);
-      return res;
-  }
+$str $str_add($str s, $str t) {
+    $str res;
+    NEW_UNFILLED_STR(res, s->nchars + t->nchars, s->nbytes + t->nbytes);
+    memcpy(res->str, s->str, s->nbytes);
+    memcpy(res->str + s->nbytes, t->str, t->nbytes);
+    return res;
+}
+
+$str $str_mul($str a, $int n) {
+    if (n->val <= 0)
+        return to$str("");
+    else {
+        $str res;
+        NEW_UNFILLED_STR(res, a->nchars * n->val, a->nbytes * n->val);
+        for (int i = 0; i < n->val; i++)
+            memcpy(res->str + i * a->nbytes, a->str, a->nbytes);
+        return res;
+    }
 }
 
 // Collection ///////////////////////////////////////////////////////////////////////////////////////
 
 $int $str_len($str s) {
-  $int res = to$int(s->nchars);
-  return res;
+    $int res = to$int(s->nchars);
+    return res;
 }
 
 // $Container ///////////////////////////////////////////////////////////////////////////
 
- 
 $Container$str $Container$str$new($Eq wit) {
-  return $NEW($Container$str, wit);
+    return $NEW($Container$str, wit);
 }
 
 int $str_contains($str s, $str sub) {
-  return bmh(s->str,sub->str,s->nbytes,sub->nbytes) > 0;
+    return bmh(s->str, sub->str, s->nbytes, sub->nbytes) > 0;
 }
 
 int $str_containsnot($str s, $str sub) {
-  return !$str_contains(s,sub);
+    return !$str_contains(s, sub);
 }
 
 // Iterable ///////////////////////////////////////////////////////////////////////////
 
 $Iterator$str $Iterator$str$new($str str) {
-  return $NEW($Iterator$str, str);
+    return $NEW($Iterator$str, str);
 }
 
 void $Iterator$str_init($Iterator$str self, $str str) {
-  self->src = str;
-  self->nxt = 0;
+    self->src = str;
+    self->nxt = 0;
 }
 
-void $Iterator$str_serialize($Iterator$str self,$Serial$state state) {
-  $step_serialize(self->src,state);
-  $step_serialize(to$int(self->nxt),state);
+void $Iterator$str_serialize($Iterator$str self, $Serial$state state) {
+    $step_serialize(self->src, state);
+    $step_serialize(to$int(self->nxt), state);
 }
-
 
 $Iterator$str $Iterator$str$_deserialize($Iterator$str res, $Serial$state state) {
-   if (!res)
-      res = $DNEW($Iterator$str,state);
-   res->src = ($str)$step_deserialize(state);
-   res->nxt = from$int(($int)$step_deserialize(state));
-   return res;
+    if (!res)
+        res = $DNEW($Iterator$str, state);
+    res->src = ($str)$step_deserialize(state);
+    res->nxt = from$int(($int)$step_deserialize(state));
+    return res;
 }
 
 $bool $Iterator$str_bool($Iterator$str self) {
-  return $True;
+    return $True;
 }
 
 $str $Iterator$str_str($Iterator$str self) {
-  char *s;
-  asprintf(&s,"<str iterator object at %p>",self);
-  return to$str(s);
+    char *s;
+    asprintf(&s, "<str iterator object at %p>", self);
+    return to$str(s);
 }
 
 // this is next function for forward iteration
 static $str $Iterator$str_next($Iterator$str self) {
-  unsigned char *p = &self->src->str[self->nxt];
-  if (*p != 0) {
-    self->nxt +=byte_length2(*p);
-    return mk_char(p);
-  }
-  return NULL;
+    unsigned char *p = &self->src->str[self->nxt];
+    if (*p != 0) {
+        self->nxt += byte_length2(*p);
+        return mk_char(p);
+    }
+    return NULL;
 }
 
 $Iterator $str_iter($str str) {
-  return ($Iterator)$NEW($Iterator$str,str);
+    return ($Iterator)$NEW($Iterator$str, str);
 }
 
-struct $Iterator$str$class $Iterator$str$methods = {"$Iterator$str",UNASSIGNED,($Super$class)&$Iterator$methods, $Iterator$str_init,
+struct $Iterator$str$class $Iterator$str$methods = {"$Iterator$str", UNASSIGNED, ($Super$class)&$Iterator$methods, $Iterator$str_init,
                                                     $Iterator$str_serialize, $Iterator$str$_deserialize,
                                                     $Iterator$str_bool, $Iterator$str_str, $Iterator$str_next};
-
 
 // Indexed ///////////////////////////////////////////////////////////////////////////
 
 $str $str_getitem($str s, int i) {
-  unsigned char *p = s->str;
-  int ix = get_index(i,s->nchars);
-  p = skip_chars(p,ix,s->nchars == s->nbytes);
-  return mk_char(p);
+    unsigned char *p = s->str;
+    int ix = get_index(i, s->nchars);
+    p = skip_chars(p, ix, s->nchars == s->nbytes);
+    return mk_char(p);
 }
- 
+
 // Sliceable //////////////////////////////////////////////////////////////////////////////////////
 
 $str $str_getslice($str s, $slice slc) {
-  int isascii = s->nchars == s->nbytes;
-  int nchars = s->nchars;
-  int nbytes = 0;
-  int start, stop, step, slen;
-  normalize_slice(slc, nchars, &slen, &start, &stop, &step);
- //slice notation have been eliminated and default values applied.
-  unsigned char buffer[4*slen]; // very conservative buffer size.
-  unsigned char *p = buffer;
-  unsigned char *t = skip_chars(s->str,start,isascii);
-  for (int i=0; i<slen; i++) {
-    int bytes = byte_length2(*t);
-    for (int k=0; k<bytes;k++) {
-      p[nbytes] = *t;
-      t++; nbytes++;
+    int isascii = s->nchars == s->nbytes;
+    int nchars = s->nchars;
+    int nbytes = 0;
+    int start, stop, step, slen;
+    normalize_slice(slc, nchars, &slen, &start, &stop, &step);
+    //slice notation have been eliminated and default values applied.
+    unsigned char buffer[4 * slen]; // very conservative buffer size.
+    unsigned char *p = buffer;
+    unsigned char *t = skip_chars(s->str, start, isascii);
+    for (int i = 0; i < slen; i++) {
+        int bytes = byte_length2(*t);
+        for (int k = 0; k < bytes; k++) {
+            p[nbytes] = *t;
+            t++;
+            nbytes++;
+        }
+        t = skip_chars(t, step - 1, isascii);
     }
-    t = skip_chars(t,step-1,isascii);
-  }
-  $str res;
-  NEW_UNFILLED_STR(res,slen,nbytes);
-  if (nbytes > 0)
-    memcpy(res->str,buffer,nbytes);
- return res;
+    $str res;
+    NEW_UNFILLED_STR(res, slen, nbytes);
+    if (nbytes > 0)
+        memcpy(res->str, buffer, nbytes);
+    return res;
 }
 
-
-
-// General methods ////////////////////////////////////////////////////////////// 
+// General methods //////////////////////////////////////////////////////////////
 
 $str $str$new($value s) {
-  return $NEW($str, s);
+    return $NEW($str, s);
 }
 
 void $str_init($str self, $value s) {
-  $str res = s->$class->__str__(s);
-  self->nchars = res->nchars;
-  self->nbytes = res->nbytes;
-  self->str = res->str;
+    $str res = s->$class->__str__(s);
+    self->nchars = res->nchars;
+    self->nbytes = res->nbytes;
+    self->str = res->str;
 }
 
 $bool $str_bool($str s) {
-  return to$bool(s->nchars > 0);
+    return to$bool(s->nchars > 0);
 };
 
 $str $str_str($str s) {
-  return s;
+    return s;
 }
 
-
-void $str_serialize($str str,$Serial$state state) {
-  int nWords = str->nbytes/sizeof($WORD) + 1;         // # $WORDS needed to store str->str, including terminating 0.
-  $ROW row = $add_header(STR_ID,2+nWords,state);
-  long nbytes = (long)str->nbytes;                    // We could pack nbytes and nchars in one $WORD, 
-  memcpy(row->blob,&nbytes,sizeof($WORD));            // but we should think of a better, general approach.
-  long nchars = (long)str->nchars;
-  memcpy(row->blob+1,&nchars,sizeof($WORD));
-  memcpy(row->blob+2,str->str,nbytes+1);
+void $str_serialize($str str, $Serial$state state) {
+    int nWords = str->nbytes / sizeof($WORD) + 1; // # $WORDS needed to store str->str, including terminating 0.
+    $ROW row = $add_header(STR_ID, 2 + nWords, state);
+    long nbytes = (long)str->nbytes;           // We could pack nbytes and nchars in one $WORD,
+    memcpy(row->blob, &nbytes, sizeof($WORD)); // but we should think of a better, general approach.
+    long nchars = (long)str->nchars;
+    memcpy(row->blob + 1, &nchars, sizeof($WORD));
+    memcpy(row->blob + 2, str->str, nbytes + 1);
 }
 
 $str $str_deserialize($str self, $Serial$state state) {
-  $ROW this = state->row;
-  state->row =this->next;
-  state->row_no++;
-  $str res = malloc(sizeof(struct $str));
-  long nbytes;
-  memcpy(&nbytes,this->blob,sizeof($WORD));
-  res->$class = &$str$methods;
-  res->nbytes = (int)nbytes;
-  long nchars;
-  memcpy(&nchars,this->blob+1,sizeof($WORD));
-  res->nchars = (int)nchars;
-  res->str = malloc(nbytes+1);
-  memcpy(res->str,this->blob+2,nbytes+1);
-  return res;
+    $ROW this = state->row;
+    state->row = this->next;
+    state->row_no++;
+    $str res = malloc(sizeof(struct $str));
+    long nbytes;
+    memcpy(&nbytes, this->blob, sizeof($WORD));
+    res->$class = &$str$methods;
+    res->nbytes = (int)nbytes;
+    long nchars;
+    memcpy(&nchars, this->blob + 1, sizeof($WORD));
+    res->nchars = (int)nchars;
+    res->str = malloc(nbytes + 1);
+    memcpy(res->str, this->blob + 2, nbytes + 1);
+    return res;
 }
 
- 
 // str-specific methods ////////////////////////////////////////////////////////
 
 $str $str_capitalize($str s) {
-  if (s->nchars==0) {
-    return null_str;
-  }
-  int cp, cpu, cplen, cpulen;
-  unsigned char *p = s->str;
-  unsigned char buffer[4*s->nchars];
-  unsigned char *up = buffer;
-  for (int i=0; i < s->nchars; i++) {
-    cplen = utf8proc_iterate(p,-1,&cp);
-    cpu = i==0? utf8proc_totitle(cp) : utf8proc_tolower(cp);
-    cpulen = utf8proc_encode_char(cpu,up);
-    p+=cplen;
-    up += cpulen;
-  }
-  int nbytes = (int)(up-buffer);
-  $str res;
-  NEW_UNFILLED_STR(res,s->nchars,nbytes);
-  memcpy(res->str,buffer,nbytes);
-  return res;
+    if (s->nchars == 0) {
+        return null_str;
+    }
+    int cp, cpu, cplen, cpulen;
+    unsigned char *p = s->str;
+    unsigned char buffer[4 * s->nchars];
+    unsigned char *up = buffer;
+    for (int i = 0; i < s->nchars; i++) {
+        cplen = utf8proc_iterate(p, -1, &cp);
+        cpu = i == 0 ? utf8proc_totitle(cp) : utf8proc_tolower(cp);
+        cpulen = utf8proc_encode_char(cpu, up);
+        p += cplen;
+        up += cpulen;
+    }
+    int nbytes = (int)(up - buffer);
+    $str res;
+    NEW_UNFILLED_STR(res, s->nchars, nbytes);
+    memcpy(res->str, buffer, nbytes);
+    return res;
 }
 
 $str $str_center($str s, $int width, $str fill) {
-  if (!fill)
-    fill = space_str;
-  if (fill->nchars != 1) {
-    $RAISE(($BaseException)$NEW($ValueError,to$str("center: fill string not single char")));
-  }
-  if (width->val <= s->nchars) {
-    return s;
-  }
-  int pad = (width->val-s->nchars);
-  int padleft = pad/2; // Below we make use of the fact padright >= padleft.
-  int padright = pad-padleft;
-  int fillbytes = fill->nbytes;
-  int sbytes = s->nbytes;
-  $str res;
-  NEW_UNFILLED_STR(res, width->val,sbytes+pad*fillbytes);
-  unsigned char *c = fill->str;
-  unsigned char *p = res->str;
-  p += padleft*fillbytes+sbytes;
-  for (int i = 0; i<padright; i++) {
-    for (int j = 0; j < fillbytes; j++) 
-      p[j] = c[j];
-    p += fillbytes;
-  }
-  p -= padright*fillbytes;
-  memcpy(res->str,p,padleft*fillbytes);
-  p -= sbytes;
-  memcpy(p,s->str,sbytes);
-  return res;
+    if (!fill)
+        fill = space_str;
+    if (fill->nchars != 1) {
+        $RAISE(($BaseException)$NEW($ValueError, to$str("center: fill string not single char")));
+    }
+    if (width->val <= s->nchars) {
+        return s;
+    }
+    int pad = (width->val - s->nchars);
+    int padleft = pad / 2; // Below we make use of the fact padright >= padleft.
+    int padright = pad - padleft;
+    int fillbytes = fill->nbytes;
+    int sbytes = s->nbytes;
+    $str res;
+    NEW_UNFILLED_STR(res, width->val, sbytes + pad * fillbytes);
+    unsigned char *c = fill->str;
+    unsigned char *p = res->str;
+    p += padleft * fillbytes + sbytes;
+    for (int i = 0; i < padright; i++) {
+        for (int j = 0; j < fillbytes; j++)
+            p[j] = c[j];
+        p += fillbytes;
+    }
+    p -= padright * fillbytes;
+    memcpy(res->str, p, padleft * fillbytes);
+    p -= sbytes;
+    memcpy(p, s->str, sbytes);
+    return res;
 }
 
-
 $int $str_count($str s, $str sub, $int start, $int end) {
-  int isascii = s->nchars == s->nbytes;
-  $int st = start;
-  $int en = end;
-  if (fix_start_end(s->nchars,&st,&en) < 0) return to$int(0);
-  unsigned char *p = skip_chars(s->str,from$int(st),isascii);
-  unsigned char *q = skip_chars(p,from$int(en)-from$int(st),isascii);
-  int res = 0;
-  int n = bmh(p,sub->str,q-p,sub->nbytes);
-  while (n>=0) {
-    res++;
-    p += n + (sub->nbytes>0 ? sub->nbytes : 1);
-    n = bmh(p,sub->str,q-p,sub->nbytes);
-  }
-  return to$int(res);
+    int isascii = s->nchars == s->nbytes;
+    $int st = start;
+    $int en = end;
+    if (fix_start_end(s->nchars, &st, &en) < 0)
+        return to$int(0);
+    unsigned char *p = skip_chars(s->str, from$int(st), isascii);
+    unsigned char *q = skip_chars(p, from$int(en) - from$int(st), isascii);
+    int res = 0;
+    int n = bmh(p, sub->str, q - p, sub->nbytes);
+    while (n >= 0) {
+        res++;
+        p += n + (sub->nbytes > 0 ? sub->nbytes : 1);
+        n = bmh(p, sub->str, q - p, sub->nbytes);
+    }
+    return to$int(res);
 }
 
 $bytearray $str_encode($str s) {
-  $bytearray res;
-  NEW_UNFILLED_BYTEARRAY(res,s->nbytes);
-  memcpy(res->str,s->str,s->nbytes);
-  return res;
+    $bytearray res;
+    NEW_UNFILLED_BYTEARRAY(res, s->nbytes);
+    memcpy(res->str, s->str, s->nbytes);
+    return res;
 }
 
 $bool $str_endswith($str s, $str sub, $int start, $int end) {
-  $int st = start;
-  $int en = end;
-  if (fix_start_end(s->nchars,&st,&en) < 0) return $False;
-  int isascii = s->nchars==s->nbytes;
-  unsigned char *p = skip_chars(s->str + s->nbytes,from$int(en) - s->nchars,isascii) - sub->nbytes;
-  unsigned char *q = sub->str;
-  for (int i=0; i<sub->nbytes; i++) {
-    if (*p == 0 || *p++ != *q++) {
-      return $False;
+    $int st = start;
+    $int en = end;
+    if (fix_start_end(s->nchars, &st, &en) < 0)
+        return $False;
+    int isascii = s->nchars == s->nbytes;
+    unsigned char *p = skip_chars(s->str + s->nbytes, from$int(en) - s->nchars, isascii) - sub->nbytes;
+    unsigned char *q = sub->str;
+    for (int i = 0; i < sub->nbytes; i++) {
+        if (*p == 0 || *p++ != *q++) {
+            return $False;
+        }
     }
-  }
-  return $True;
+    return $True;
 }
 
-$str $str_expandtabs($str s, $int tabsize){
-  int tabsz = tabsize?(long)tabsize->val:8;
-  int pos = 0;
-  int expanded = 0;
-  tabsz = tabsz <= 0 ? 1 : tabsz;
-  unsigned char buffer[tabsz * s->nchars];
-  unsigned char *p = s->str;
-  unsigned char *q = buffer;
-  for (int i=0; i<s->nchars; i++) {
-    if (*p == '\t') {
-      int n = tabsz - pos % tabsz;
-      for (int j=0; j < n; j++) {
-        *q++ = ' ';
-      }
-      p++;
-      expanded += n-1;
-      pos+=n;
-    } else if (*p=='\n' || *p == '\r') {
-      *q++ = *p++;
-      pos = 0;
-    } else {
-      for (int j=0; j< byte_length2(*p); j++) {
-        *q++ = *p++;
-        pos++;
-      }
+$str $str_expandtabs($str s, $int tabsize) {
+    int tabsz = tabsize ? (long)tabsize->val : 8;
+    int pos = 0;
+    int expanded = 0;
+    tabsz = tabsz <= 0 ? 1 : tabsz;
+    unsigned char buffer[tabsz * s->nchars];
+    unsigned char *p = s->str;
+    unsigned char *q = buffer;
+    for (int i = 0; i < s->nchars; i++) {
+        if (*p == '\t') {
+            int n = tabsz - pos % tabsz;
+            for (int j = 0; j < n; j++) {
+                *q++ = ' ';
+            }
+            p++;
+            expanded += n - 1;
+            pos += n;
+        } else if (*p == '\n' || *p == '\r') {
+            *q++ = *p++;
+            pos = 0;
+        } else {
+            for (int j = 0; j < byte_length2(*p); j++) {
+                *q++ = *p++;
+                pos++;
+            }
+        }
     }
-  }
-  $str res;
-  NEW_UNFILLED_STR(res,s->nchars+expanded,s->nbytes+expanded);
-  memcpy(res->str,buffer,s->nbytes+expanded);
-  return res;
+    $str res;
+    NEW_UNFILLED_STR(res, s->nchars + expanded, s->nbytes + expanded);
+    memcpy(res->str, buffer, s->nbytes + expanded);
+    return res;
 }
 
 $int $str_find($str s, $str sub, $int start, $int end) {
-  int isascii = s->nchars == s->nbytes;
-  $int st = start;
-  $int en = end;
-  if (fix_start_end(s->nchars,&st,&en) < 0) return to$int(-1);
-  unsigned char *p = skip_chars(s->str,from$int(st),isascii);
-  unsigned char *q = skip_chars(p,from$int(en)-from$int(st),isascii);
-  int n = bmh(p,sub->str,q-p,sub->nbytes);
-  if (n<0) return to$int(-1);
-  return to$int(char_no(s,n+p-s->str));
+    int isascii = s->nchars == s->nbytes;
+    $int st = start;
+    $int en = end;
+    if (fix_start_end(s->nchars, &st, &en) < 0)
+        return to$int(-1);
+    unsigned char *p = skip_chars(s->str, from$int(st), isascii);
+    unsigned char *q = skip_chars(p, from$int(en) - from$int(st), isascii);
+    int n = bmh(p, sub->str, q - p, sub->nbytes);
+    if (n < 0)
+        return to$int(-1);
+    return to$int(char_no(s, n + p - s->str));
 }
 
 $int $str_index($str s, $str sub, $int start, $int end) {
-  $int n = $str_find(s,sub,start,end);
-  if (from$int(n)<0) {
-    $RAISE(($BaseException)$NEW($ValueError,to$str("index: substring not found")));
-  }
-  return n;
+    $int n = $str_find(s, sub, start, end);
+    if (from$int(n) < 0) {
+        $RAISE(($BaseException)$NEW($ValueError, to$str("index: substring not found")));
+    }
+    return n;
 }
 
 $bool $str_isalnum($str s) {
-  unsigned char *p = s->str;
-  int codepoint;
-  int nbytes;
-  if (s->nchars == 0)
-    return $False;
-  for (int i=0; i < s->nchars; i++) {
-    nbytes = utf8proc_iterate(p,-1,&codepoint);
-    utf8proc_category_t cat = utf8proc_category(codepoint);
-    if ((cat <  UTF8PROC_CATEGORY_LU || cat >  UTF8PROC_CATEGORY_LO) && cat != UTF8PROC_CATEGORY_ND)
-      return $False;
-    p += nbytes;
-  }
-  return $True;
+    unsigned char *p = s->str;
+    int codepoint;
+    int nbytes;
+    if (s->nchars == 0)
+        return $False;
+    for (int i = 0; i < s->nchars; i++) {
+        nbytes = utf8proc_iterate(p, -1, &codepoint);
+        utf8proc_category_t cat = utf8proc_category(codepoint);
+        if ((cat < UTF8PROC_CATEGORY_LU || cat > UTF8PROC_CATEGORY_LO) && cat != UTF8PROC_CATEGORY_ND)
+            return $False;
+        p += nbytes;
+    }
+    return $True;
 }
 
 $bool $str_isalpha($str s) {
-  unsigned char *p = s->str;
-  int codepoint;
-  int nbytes;
-  if (s->nchars == 0)
-    return $False;
-  for (int i=0; i < s->nchars; i++) {
-    nbytes = utf8proc_iterate(p,-1,&codepoint);
-    utf8proc_category_t cat = utf8proc_category(codepoint);
-    if (cat <  UTF8PROC_CATEGORY_LU || cat >  UTF8PROC_CATEGORY_LO)
-      return $False;
-    p += nbytes;
-  }
-  return $True;
+    unsigned char *p = s->str;
+    int codepoint;
+    int nbytes;
+    if (s->nchars == 0)
+        return $False;
+    for (int i = 0; i < s->nchars; i++) {
+        nbytes = utf8proc_iterate(p, -1, &codepoint);
+        utf8proc_category_t cat = utf8proc_category(codepoint);
+        if (cat < UTF8PROC_CATEGORY_LU || cat > UTF8PROC_CATEGORY_LO)
+            return $False;
+        p += nbytes;
+    }
+    return $True;
 }
 
 $bool $str_isascii($str s) {
-  unsigned char *p = s->str;
-  for (int i=0; i < s->nbytes; i++) {
-    if (*p > 127)
-      return $False;
-    p++;
-  }
-  return $True;
+    unsigned char *p = s->str;
+    for (int i = 0; i < s->nbytes; i++) {
+        if (*p > 127)
+            return $False;
+        p++;
+    }
+    return $True;
 }
 
 $bool $str_isdecimal($str s) {
-  unsigned char *p = s->str;
-  int codepoint;
-  int nbytes;
-  if (s->nchars == 0)
-    return $False;
-  for (int i=0; i < s->nchars; i++) {
-    nbytes = utf8proc_iterate(p,-1,&codepoint);
-    utf8proc_category_t cat = utf8proc_category(codepoint);
-    if (cat != UTF8PROC_CATEGORY_ND)
-      return $False;
-    p += nbytes;
-  }
-  return $True;
+    unsigned char *p = s->str;
+    int codepoint;
+    int nbytes;
+    if (s->nchars == 0)
+        return $False;
+    for (int i = 0; i < s->nchars; i++) {
+        nbytes = utf8proc_iterate(p, -1, &codepoint);
+        utf8proc_category_t cat = utf8proc_category(codepoint);
+        if (cat != UTF8PROC_CATEGORY_ND)
+            return $False;
+        p += nbytes;
+    }
+    return $True;
 }
 
 $bool $str_islower($str s) {
-  unsigned char *p = s->str;
-  int codepoint;
-  int nbytes;
-  int has_cased = 0;
-  if (s->nchars == 0)
-    return $False;
-  for (int i=0; i < s->nchars; i++) {
-    nbytes = utf8proc_iterate(p,-1,&codepoint);
-    utf8proc_category_t cat = utf8proc_category(codepoint);
-    if (cat == UTF8PROC_CATEGORY_LT|| cat == UTF8PROC_CATEGORY_LU)
-      return $False;
-    if (cat == UTF8PROC_CATEGORY_LL)
-      has_cased = 1;
-    p += nbytes;
-  }
-  return to$bool(has_cased);
+    unsigned char *p = s->str;
+    int codepoint;
+    int nbytes;
+    int has_cased = 0;
+    if (s->nchars == 0)
+        return $False;
+    for (int i = 0; i < s->nchars; i++) {
+        nbytes = utf8proc_iterate(p, -1, &codepoint);
+        utf8proc_category_t cat = utf8proc_category(codepoint);
+        if (cat == UTF8PROC_CATEGORY_LT || cat == UTF8PROC_CATEGORY_LU)
+            return $False;
+        if (cat == UTF8PROC_CATEGORY_LL)
+            has_cased = 1;
+        p += nbytes;
+    }
+    return to$bool(has_cased);
 }
 
 $bool $str_isprintable($str s) {
-  unsigned char *p = s->str;
-  int codepoint;
-  int nbytes;
-  if (s->nchars == 0)
-    return $False;
-  for (int i=0; i < s->nchars; i++) {
-    nbytes = utf8proc_iterate(p,-1,&codepoint);
-    utf8proc_category_t cat = utf8proc_category(codepoint);
-    if (cat >= UTF8PROC_CATEGORY_ZS && codepoint != 0x20)
-      return $False;
-    p += nbytes;
-  }
-  return $True;
+    unsigned char *p = s->str;
+    int codepoint;
+    int nbytes;
+    if (s->nchars == 0)
+        return $False;
+    for (int i = 0; i < s->nchars; i++) {
+        nbytes = utf8proc_iterate(p, -1, &codepoint);
+        utf8proc_category_t cat = utf8proc_category(codepoint);
+        if (cat >= UTF8PROC_CATEGORY_ZS && codepoint != 0x20)
+            return $False;
+        p += nbytes;
+    }
+    return $True;
 }
 
 $bool $str_isspace($str s) {
-  unsigned char *p = s->str;
-  int codepoint;
-  int nbytes;
-  if (s->nchars == 0)
-    return $False;
-  for (int i=0; i < s->nchars; i++) {
-    nbytes = utf8proc_iterate(p,-1,&codepoint);
-    if (!isspace_codepoint(codepoint))
-      return $False;
-    p += nbytes;
-  }
-  return $True;
+    unsigned char *p = s->str;
+    int codepoint;
+    int nbytes;
+    if (s->nchars == 0)
+        return $False;
+    for (int i = 0; i < s->nchars; i++) {
+        nbytes = utf8proc_iterate(p, -1, &codepoint);
+        if (!isspace_codepoint(codepoint))
+            return $False;
+        p += nbytes;
+    }
+    return $True;
 }
 
 $bool $str_istitle($str s) {
-  unsigned char *p = s->str;
-  int codepoint;
-  int nbytes;
-  int hascased = 0;
-  int incasedrun = 0;
-  if (s->nchars == 0)
-    return $False;
-  for (int i=0; i < s->nchars; i++) {
-    nbytes = utf8proc_iterate(p,-1,&codepoint);
-    utf8proc_category_t cat = utf8proc_category(codepoint);
-    if (cat == UTF8PROC_CATEGORY_LU || cat == UTF8PROC_CATEGORY_LT ) {
-      hascased = 1;
-      if (incasedrun)
+    unsigned char *p = s->str;
+    int codepoint;
+    int nbytes;
+    int hascased = 0;
+    int incasedrun = 0;
+    if (s->nchars == 0)
         return $False;
-      incasedrun = 1;
-    } else if (cat == UTF8PROC_CATEGORY_LL) {
-      hascased = 1;
-      if (!incasedrun)
-        return $False;
-    } else
-        incasedrun = 0;
-    p += nbytes;
-  }
-  return to$bool(hascased);
+    for (int i = 0; i < s->nchars; i++) {
+        nbytes = utf8proc_iterate(p, -1, &codepoint);
+        utf8proc_category_t cat = utf8proc_category(codepoint);
+        if (cat == UTF8PROC_CATEGORY_LU || cat == UTF8PROC_CATEGORY_LT) {
+            hascased = 1;
+            if (incasedrun)
+                return $False;
+            incasedrun = 1;
+        } else if (cat == UTF8PROC_CATEGORY_LL) {
+            hascased = 1;
+            if (!incasedrun)
+                return $False;
+        } else
+            incasedrun = 0;
+        p += nbytes;
+    }
+    return to$bool(hascased);
 }
 
 $bool $str_isupper($str s) {
-  unsigned char *p = s->str;
-  int codepoint;
-  int nbytes;
-  int hascased = 0;
-  if (s->nchars == 0)
-    return $False;
-  for (int i=0; i < s->nchars; i++) {
-    nbytes = utf8proc_iterate(p,-1,&codepoint);
-    utf8proc_category_t cat = utf8proc_category(codepoint);
-    if (cat == UTF8PROC_CATEGORY_LL)
-      return $False;
-    if (cat == UTF8PROC_CATEGORY_LU || cat == UTF8PROC_CATEGORY_LT)
-      hascased = 1;
-    p += nbytes;
-  }
-  return to$bool(hascased);
+    unsigned char *p = s->str;
+    int codepoint;
+    int nbytes;
+    int hascased = 0;
+    if (s->nchars == 0)
+        return $False;
+    for (int i = 0; i < s->nchars; i++) {
+        nbytes = utf8proc_iterate(p, -1, &codepoint);
+        utf8proc_category_t cat = utf8proc_category(codepoint);
+        if (cat == UTF8PROC_CATEGORY_LL)
+            return $False;
+        if (cat == UTF8PROC_CATEGORY_LU || cat == UTF8PROC_CATEGORY_LT)
+            hascased = 1;
+        p += nbytes;
+    }
+    return to$bool(hascased);
 }
 
 $str $str_join($str s, $Iterable wit, $WORD iter) {
-  int totchars = 0;
-  int totbytes = 0;
-  $list lst = $list_fromiter(wit->$class->__iter__(wit,iter));
-  $str nxt;
-  int len = lst->length;
-  for (int i=0; i<len; i++) {
-    nxt = ($str)lst->data[i];
-    totchars += nxt->nchars;
-    totbytes += nxt->nbytes;
-  }
-  if (len > 1) {
-    totchars += (len-1) * s->nchars;
-    totbytes += (len-1) * s->nbytes;
-  }
-  $str res;
-  NEW_UNFILLED_STR(res,totchars,totbytes);
-  if (len > 0) {
-    nxt = ($str)lst->data[0];
-    unsigned char *p = res->str;
-    memcpy(p,nxt->str,nxt->nbytes);
-    p += nxt->nbytes;
-    for (int i=1; i<len; i++) {
-      nxt = ($str)lst->data[i];
-      memcpy(p,s->str,s->nbytes);
-      p += s->nbytes;
-      memcpy(p,nxt->str,nxt->nbytes);
-      p += nxt->nbytes;
+    int totchars = 0;
+    int totbytes = 0;
+    $list lst = $list_fromiter(wit->$class->__iter__(wit, iter));
+    $str nxt;
+    int len = lst->length;
+    for (int i = 0; i < len; i++) {
+        nxt = ($str)lst->data[i];
+        totchars += nxt->nchars;
+        totbytes += nxt->nbytes;
     }
-  }
-  return res;
+    if (len > 1) {
+        totchars += (len - 1) * s->nchars;
+        totbytes += (len - 1) * s->nbytes;
+    }
+    $str res;
+    NEW_UNFILLED_STR(res, totchars, totbytes);
+    if (len > 0) {
+        nxt = ($str)lst->data[0];
+        unsigned char *p = res->str;
+        memcpy(p, nxt->str, nxt->nbytes);
+        p += nxt->nbytes;
+        for (int i = 1; i < len; i++) {
+            nxt = ($str)lst->data[i];
+            memcpy(p, s->str, s->nbytes);
+            p += s->nbytes;
+            memcpy(p, nxt->str, nxt->nbytes);
+            p += nxt->nbytes;
+        }
+    }
+    return res;
 }
 
 $str $str_ljust($str s, $int width, $str fill) {
-  if (!fill) fill = space_str;
-  if (fill->nchars != 1) {
-    $RAISE(($BaseException)$NEW($ValueError,to$str("ljust: fill str not single char")));
-  }
-  if (width->val <= s->nchars) {
-    return s;
-  }
-  int pad = (width->val-s->nchars);
-  $str res;
-  NEW_UNFILLED_STR(res,width->val, s->nbytes+pad*fill->nbytes);
-  unsigned char *c = fill->str;
-  unsigned char *p = res->str + s->nbytes;
-  for (int i = 0; i<pad; i++) {
-    for (int j = 0; j < fill->nbytes; j++) 
-      *p++ = c[j];
-  }
-  memcpy(res->str,s->str,s->nbytes);
-  return res;
+    if (!fill)
+        fill = space_str;
+    if (fill->nchars != 1) {
+        $RAISE(($BaseException)$NEW($ValueError, to$str("ljust: fill str not single char")));
+    }
+    if (width->val <= s->nchars) {
+        return s;
+    }
+    int pad = (width->val - s->nchars);
+    $str res;
+    NEW_UNFILLED_STR(res, width->val, s->nbytes + pad * fill->nbytes);
+    unsigned char *c = fill->str;
+    unsigned char *p = res->str + s->nbytes;
+    for (int i = 0; i < pad; i++) {
+        for (int j = 0; j < fill->nbytes; j++)
+            *p++ = c[j];
+    }
+    memcpy(res->str, s->str, s->nbytes);
+    return res;
 }
 
 $str $str_lower($str s) {
-  return str_transform(s,utf8proc_tolower);
+    return str_transform(s, utf8proc_tolower);
 }
 
 $str $str_lstrip($str s, $str cs) {
-  unsigned char *p = s->str;
-  int i, nbytes;
-  for (i=0; i<s->nchars; i++) {
-    $str c = mk_char(p);
-    if (cs == NULL ?  !$str_isspace(c) :
-      bmh(cs->str,p,cs->nbytes,byte_length2(*p)) < 0) 
-      break;
-    p += byte_length2(*p);
-  }
-  nbytes = s->nbytes + s->str - p;
-  $str res;
-  NEW_UNFILLED_STR(res,s->nchars-i,nbytes);
-  memcpy(res->str,p,nbytes);
-  return res;
+    unsigned char *p = s->str;
+    int i, nbytes;
+    for (i = 0; i < s->nchars; i++) {
+        $str c = mk_char(p);
+        if (cs == NULL ? !$str_isspace(c) : bmh(cs->str, p, cs->nbytes, byte_length2(*p)) < 0)
+            break;
+        p += byte_length2(*p);
+    }
+    nbytes = s->nbytes + s->str - p;
+    $str res;
+    NEW_UNFILLED_STR(res, s->nchars - i, nbytes);
+    memcpy(res->str, p, nbytes);
+    return res;
 }
 
 $tuple $str_partition($str s, $str sep) {
-  int n = from$int($str_find(s,sep,NULL,NULL));
-  if (n<0) {
-    return $NEWTUPLE(3,s,null_str,null_str);
-  } else {
-    int nb = bmh(s->str,sep->str,s->nbytes,sep->nbytes);
-    $str ls;
-    NEW_UNFILLED_STR(ls,n,nb);
-    memcpy(ls->str,s->str,nb);
-    $str rs;
-    int nbr = s->nbytes - sep->nbytes - nb;
-    NEW_UNFILLED_STR(rs,s->nchars-n-sep->nchars,nbr);
-    memcpy(rs->str,s->str+nb+sep->nbytes,nbr);
-    return $NEWTUPLE(3,ls,sep,rs);
-  }
+    int n = from$int($str_find(s, sep, NULL, NULL));
+    if (n < 0) {
+        return $NEWTUPLE(3, s, null_str, null_str);
+    } else {
+        int nb = bmh(s->str, sep->str, s->nbytes, sep->nbytes);
+        $str ls;
+        NEW_UNFILLED_STR(ls, n, nb);
+        memcpy(ls->str, s->str, nb);
+        $str rs;
+        int nbr = s->nbytes - sep->nbytes - nb;
+        NEW_UNFILLED_STR(rs, s->nchars - n - sep->nchars, nbr);
+        memcpy(rs->str, s->str + nb + sep->nbytes, nbr);
+        return $NEWTUPLE(3, ls, sep, rs);
+    }
 }
 
 $str $str_replace($str s, $str old, $str new, $int count) {
-  if (count==NULL)
-    count = to$int(INT_MAX);
-  int c = from$int($str_count(s,old,NULL,NULL));
-  int c0 = from$int(count) < c ? from$int(count) : c;
-  if (c0==0){
-    return s;
-  }
-  int nbytes = s->nbytes + c0*(new->nbytes-old->nbytes);
-  int nchars = s->nchars+c0*(new->nchars-old->nchars);
-  $str res;
-  NEW_UNFILLED_STR(res,nchars,nbytes);
-  unsigned char *p = s->str;
-  unsigned char *q = res->str;
-  unsigned char *pold = old->str;
-  unsigned char *pnew = new->str;
-  int plen = s->nbytes;
-  int n;
-  for (int i=0; i<c0; i++) {
-    n = i>0 && old->nbytes==0 ? 1 : bmh(p,pold,plen,old->nbytes);
-    if (n>0) {
-      memcpy(q,p,n);
-      p+=n; q+=n;
+    if (count == NULL)
+        count = to$int(INT_MAX);
+    int c = from$int($str_count(s, old, NULL, NULL));
+    int c0 = from$int(count) < c ? from$int(count) : c;
+    if (c0 == 0) {
+        return s;
     }
-    memcpy(q,pnew,new->nbytes);
-    p += old->nbytes;
-    q += new->nbytes;
-    plen -= n+old->nbytes;
-  }
-  if (plen>0)
-    memcpy(q,p,plen);
-  return res;
+    int nbytes = s->nbytes + c0 * (new->nbytes - old->nbytes);
+    int nchars = s->nchars + c0 * (new->nchars - old->nchars);
+    $str res;
+    NEW_UNFILLED_STR(res, nchars, nbytes);
+    unsigned char *p = s->str;
+    unsigned char *q = res->str;
+    unsigned char *pold = old->str;
+    unsigned char *pnew = new->str;
+    int plen = s->nbytes;
+    int n;
+    for (int i = 0; i < c0; i++) {
+        n = i > 0 && old->nbytes == 0 ? 1 : bmh(p, pold, plen, old->nbytes);
+        if (n > 0) {
+            memcpy(q, p, n);
+            p += n;
+            q += n;
+        }
+        memcpy(q, pnew, new->nbytes);
+        p += old->nbytes;
+        q += new->nbytes;
+        plen -= n + old->nbytes;
+    }
+    if (plen > 0)
+        memcpy(q, p, plen);
+    return res;
 }
-      
 
 $int $str_rfind($str s, $str sub, $int start, $int end) {
-  int isascii = s->nchars == s->nbytes;
-  $int st = start;
-  $int en = end;
-  if (fix_start_end(s->nchars,&st,&en) < 0) return to$int(-1);
-  unsigned char *p = skip_chars(s->str,from$int(st),isascii);
-  unsigned char *q = skip_chars(p,from$int(en)-from$int(st),isascii);
-  int n = rbmh(p,sub->str,q-p,sub->nbytes);
-  if (n<0) return to$int(-1);
-  return to$int(char_no(s,n+p-s->str));
+    int isascii = s->nchars == s->nbytes;
+    $int st = start;
+    $int en = end;
+    if (fix_start_end(s->nchars, &st, &en) < 0)
+        return to$int(-1);
+    unsigned char *p = skip_chars(s->str, from$int(st), isascii);
+    unsigned char *q = skip_chars(p, from$int(en) - from$int(st), isascii);
+    int n = rbmh(p, sub->str, q - p, sub->nbytes);
+    if (n < 0)
+        return to$int(-1);
+    return to$int(char_no(s, n + p - s->str));
 }
 
-
 $int $str_rindex($str s, $str sub, $int start, $int end) {
-  $int n = $str_rfind(s,sub,start,end);
-  if (from$int(n)<0) {
-    $RAISE(($BaseException)$NEW($ValueError,to$str("rindex: substring not found")));
-  };
-  return n;
+    $int n = $str_rfind(s, sub, start, end);
+    if (from$int(n) < 0) {
+        $RAISE(($BaseException)$NEW($ValueError, to$str("rindex: substring not found")));
+    };
+    return n;
 }
 
 $str $str_rjust($str s, $int width, $str fill) {
-  if (!fill) fill = space_str;
-  if (fill->nchars != 1) {
-    $RAISE(($BaseException)$NEW($ValueError,to$str("rjust: fill string not single char")));
-  }
-  if (width->val <= s->nchars) {
-    return s;
-  }
-  int pad = (width->val-s->nchars);
-  $str res;
-  NEW_UNFILLED_STR(res,width->val,s->nbytes+pad*fill->nbytes);
-  unsigned char *c = fill->str;
-  unsigned char *p = res->str;
-  for (int i = 0; i<pad; i++) {
-    for (int j = 0; j < fill->nbytes; j++) 
-      *p++ = c[j];
-  }
-  memcpy(p,s->str,s->nbytes);
-  return res;
-}
-                                
-$tuple $str_rpartition($str s, $str sep) {
-  int n = from$int($str_rfind(s,sep,NULL,NULL));
-  if (n<0) {
-    return $NEWTUPLE(3,null_str,null_str,s);
-  } else {
-    int nb = rbmh(s->str,sep->str,s->nbytes,sep->nbytes);
-    $str ls;
-    NEW_UNFILLED_STR(ls,n,nb);
-    memcpy(ls->str,s->str,nb);
-    int nbr = s->nbytes - sep->nbytes - nb;
-    $str rs;    
-    NEW_UNFILLED_STR(rs,s->nchars-n-sep->nchars,nbr);
-    memcpy(rs->str,s->str+nb+sep->nbytes,nbr);
-    return  $NEWTUPLE(3,ls,sep,rs);
-  }
+    if (!fill)
+        fill = space_str;
+    if (fill->nchars != 1) {
+        $RAISE(($BaseException)$NEW($ValueError, to$str("rjust: fill string not single char")));
+    }
+    if (width->val <= s->nchars) {
+        return s;
+    }
+    int pad = (width->val - s->nchars);
+    $str res;
+    NEW_UNFILLED_STR(res, width->val, s->nbytes + pad * fill->nbytes);
+    unsigned char *c = fill->str;
+    unsigned char *p = res->str;
+    for (int i = 0; i < pad; i++) {
+        for (int j = 0; j < fill->nbytes; j++)
+            *p++ = c[j];
+    }
+    memcpy(p, s->str, s->nbytes);
+    return res;
 }
 
+$tuple $str_rpartition($str s, $str sep) {
+    int n = from$int($str_rfind(s, sep, NULL, NULL));
+    if (n < 0) {
+        return $NEWTUPLE(3, null_str, null_str, s);
+    } else {
+        int nb = rbmh(s->str, sep->str, s->nbytes, sep->nbytes);
+        $str ls;
+        NEW_UNFILLED_STR(ls, n, nb);
+        memcpy(ls->str, s->str, nb);
+        int nbr = s->nbytes - sep->nbytes - nb;
+        $str rs;
+        NEW_UNFILLED_STR(rs, s->nchars - n - sep->nchars, nbr);
+        memcpy(rs->str, s->str + nb + sep->nbytes, nbr);
+        return $NEWTUPLE(3, ls, sep, rs);
+    }
+}
 
 $list $str_split($str s, $str sep, $int maxsplit) {
-  $list res = $NEW($list,NULL,NULL);
-  if (maxsplit == NULL || from$int(maxsplit) < 0) maxsplit = to$int(INT_MAX); 
-  int remaining = s->nchars;
-  if (sep == NULL) {
-    unsigned char *p = s->str;
-    int nbytes, codepoint, wordlength;
-    if (remaining==0) {
-      return res;
-    }
-    int inword = 0;
-    unsigned char *q;
-    while (remaining > 0) {
-      nbytes = utf8proc_iterate(p,-1,&codepoint);
-      if (!isspace_codepoint(codepoint)) {
-        if (!inword) {
-          inword = 1;
-          q = p;
-          wordlength = 1;
-          if ($list_len(res) == from$int(maxsplit))
-            break; // we have now removed leading whitespace in remainder
-        } else
-          wordlength++;
-      } else {
-          if (inword) {
-            inword = 0;
+    $list res = $NEW($list, NULL, NULL);
+    if (maxsplit == NULL || from$int(maxsplit) < 0)
+        maxsplit = to$int(INT_MAX);
+    int remaining = s->nchars;
+    if (sep == NULL) {
+        unsigned char *p = s->str;
+        int nbytes, codepoint, wordlength;
+        if (remaining == 0) {
+            return res;
+        }
+        int inword = 0;
+        unsigned char *q;
+        while (remaining > 0) {
+            nbytes = utf8proc_iterate(p, -1, &codepoint);
+            if (!isspace_codepoint(codepoint)) {
+                if (!inword) {
+                    inword = 1;
+                    q = p;
+                    wordlength = 1;
+                    if ($list_len(res) == from$int(maxsplit))
+                        break; // we have now removed leading whitespace in remainder
+                } else
+                    wordlength++;
+            } else {
+                if (inword) {
+                    inword = 0;
+                    $str word;
+                    NEW_UNFILLED_STR(word, wordlength, p - q);
+                    memcpy(word->str, q, p - q);
+                    $list_append(res, word);
+                }
+            }
+            remaining--;
+            p += nbytes;
+        }
+        // this if statement should be simplified; almost code duplication.
+        if (remaining == 0) {
+            if (inword) {
+                $str word;
+                NEW_UNFILLED_STR(word, wordlength, p - q);
+                memcpy(word->str, q, p - q);
+                $list_append(res, word);
+            }
+        } else {
             $str word;
-            NEW_UNFILLED_STR(word,wordlength,p-q);
-            memcpy(word->str,q,p-q);
-            $list_append(res,word);
-          }
-      }
-      remaining--;
-      p += nbytes;
+            p = s->str + s->nbytes;
+            NEW_UNFILLED_STR(word, remaining, p - q);
+            memcpy(word->str, q, p - q);
+            $list_append(res, word);
+        }
+        // $WORD w = list_getitem(res,0);
+        return res;
+    } else { // separator given
+        if (sep->nchars == 0) {
+            $RAISE(($BaseException)$NEW($ValueError, to$str("split: separator is empty string")));
+        }
+        if (remaining == 0) { // for some unfathomable reason, this is the behaviour of the Python method
+            $list_append(res, null_str);
+            return res;
+        }
+        $str ls, rs, ssep;
+        rs = s;
+        // Note: This builds many intermediate rs strings...
+        while (rs->nchars > 0 && $list_len(res) < from$int(maxsplit)) {
+            $tuple t = $str_partition(rs, sep);
+            ssep = ($str)t->components[1];
+            rs = ($str)t->components[2];
+            $list_append(res, ($str)t->components[0]);
+        }
+        if (ssep->nchars > 0)
+            $list_append(res, rs);
+        return res;
     }
-    // this if statement should be simplified; almost code duplication.
-    if (remaining == 0) {
-      if (inword) {
-        $str word;
-        NEW_UNFILLED_STR(word,wordlength,p-q);
-        memcpy(word->str,q,p-q);
-        $list_append(res,word);
-      }
-    } else {
-      $str word;
-      p = s->str+s->nbytes;
-      NEW_UNFILLED_STR(word,remaining,p-q);
-      memcpy(word->str,q,p-q);
-      $list_append(res,word);
-    }
-    // $WORD w = list_getitem(res,0);
-    return res;
-  } else { // separator given
-    if (sep->nchars==0) {
-      $RAISE(($BaseException)$NEW($ValueError,to$str("split: separator is empty string")));
-    }
-    if (remaining==0) { // for some unfathomable reason, this is the behaviour of the Python method
-      $list_append(res,null_str);
-      return res;
-    }
-    $str ls, rs, ssep;
-    rs = s;
-    // Note: This builds many intermediate rs strings...
-    while (rs->nchars>0 && $list_len(res) < from$int(maxsplit)) {
-     $tuple t = $str_partition(rs,sep);
-     ssep = ($str)t->components[1];
-     rs =  ($str)t->components[2];
-     $list_append(res,($str)t->components[0]);
-    }
-    if (ssep->nchars>0)
-      $list_append(res,rs);
-    return res;
-  }
 }
- 
+
 $list $str_splitlines($str s, $bool keepends) {
-  if (!keepends)
-    keepends = $False;
-  $list res = $NEW($list,NULL,NULL);
-  unsigned char *p = s->str;
-  unsigned char *q = p;
-  int nbytes, codepoint, linelength;
-  if (s->nbytes==0) {
-    return res;
-  }
-  while (p < s->str + s->nbytes) {
-    nbytes = utf8proc_iterate(p,-1,&codepoint);
-    utf8proc_category_t cat = utf8proc_category(codepoint);
-    if (!islinebreak_codepoint(codepoint)) {
-        linelength++;
-        p += nbytes;
-    } else {
-      // all the codepoints we count as linebreaks are ascii bytes, i.e. nbytes = 1.
-      $str line;
-      int winend = *p=='\r' && *(p+1)=='\n';
-      int size = p-q + (keepends->val ? 1 + winend : 0);
-      NEW_UNFILLED_STR(line,linelength + (keepends->val ? 1 + winend : 0),size);
-      memcpy(line->str,q,size);
-      p += 1 + winend;
-      q = p;
-      $list_append(res,line);
+    if (!keepends)
+        keepends = $False;
+    $list res = $NEW($list, NULL, NULL);
+    unsigned char *p = s->str;
+    unsigned char *q = p;
+    int nbytes, codepoint, linelength;
+    if (s->nbytes == 0) {
+        return res;
     }
-  }
-  if (q < p) {
-    $str line;
-    NEW_UNFILLED_STR(line,linelength,p-q);
-    memcpy(line->str,q,p-q);
-    $list_append(res,line);
-  }
-  return res;
-} 
+    while (p < s->str + s->nbytes) {
+        nbytes = utf8proc_iterate(p, -1, &codepoint);
+        utf8proc_category_t cat = utf8proc_category(codepoint);
+        if (!islinebreak_codepoint(codepoint)) {
+            linelength++;
+            p += nbytes;
+        } else {
+            // all the codepoints we count as linebreaks are ascii bytes, i.e. nbytes = 1.
+            $str line;
+            int winend = *p == '\r' && *(p + 1) == '\n';
+            int size = p - q + (keepends->val ? 1 + winend : 0);
+            NEW_UNFILLED_STR(line, linelength + (keepends->val ? 1 + winend : 0), size);
+            memcpy(line->str, q, size);
+            p += 1 + winend;
+            q = p;
+            $list_append(res, line);
+        }
+    }
+    if (q < p) {
+        $str line;
+        NEW_UNFILLED_STR(line, linelength, p - q);
+        memcpy(line->str, q, p - q);
+        $list_append(res, line);
+    }
+    return res;
+}
 
 $str $str_rstrip($str s, $str cs) {
-  unsigned char *p = s->str + s->nbytes;
-  int i, nbytes;
-  for (i=0; i<s->nchars; i++) {
-    p = skip_chars(p,-1,0);
-    $str c = mk_char(p);
-    if (cs == NULL ?  !$str_isspace(c) :
-      rbmh(cs->str,p,cs->nbytes,byte_length2(*p)) < 0) 
-      break;
-  }
-  nbytes = p + byte_length2(*p) - s->str;
-  $str res;
-  NEW_UNFILLED_STR(res,s->nchars-i,nbytes);
-  memcpy(res->str,s->str,nbytes);
-  return res;
+    unsigned char *p = s->str + s->nbytes;
+    int i, nbytes;
+    for (i = 0; i < s->nchars; i++) {
+        p = skip_chars(p, -1, 0);
+        $str c = mk_char(p);
+        if (cs == NULL ? !$str_isspace(c) : rbmh(cs->str, p, cs->nbytes, byte_length2(*p)) < 0)
+            break;
+    }
+    nbytes = p + byte_length2(*p) - s->str;
+    $str res;
+    NEW_UNFILLED_STR(res, s->nchars - i, nbytes);
+    memcpy(res->str, s->str, nbytes);
+    return res;
 }
 
 $bool $str_startswith($str s, $str sub, $int start, $int end) {
-  $int st = start;
-  $int en = end;
-  if (fix_start_end(s->nchars,&st,&en) < 0) return $False;
-  int isascii = s->nchars==s->nbytes;
-  unsigned char *p = skip_chars(s->str,from$int(st),isascii);
-  unsigned char *q = sub->str;
-  for (int i=0; i<sub->nbytes; i++) {
-    if (*p == 0 || *p++ != *q++) {
-      return $False;
+    $int st = start;
+    $int en = end;
+    if (fix_start_end(s->nchars, &st, &en) < 0)
+        return $False;
+    int isascii = s->nchars == s->nbytes;
+    unsigned char *p = skip_chars(s->str, from$int(st), isascii);
+    unsigned char *q = sub->str;
+    for (int i = 0; i < sub->nbytes; i++) {
+        if (*p == 0 || *p++ != *q++) {
+            return $False;
+        }
     }
-  }
-  return $True;
+    return $True;
 }
 
-
 $str $str_strip($str s, $str cs) {
-  return $str_lstrip($str_rstrip(s,cs),cs);
+    return $str_lstrip($str_rstrip(s, cs), cs);
 }
 
 $str $str_upper($str s) {
-  return str_transform(s,utf8proc_toupper);
+    return str_transform(s, utf8proc_toupper);
 }
 
 $str $str_zfill($str s, $int width) {
-  int fill = width->val - s->nchars;
-  if (fill < 0)
-    return s;
-  $str res;
-  NEW_UNFILLED_STR(res,width->val,s->nbytes+fill);
-  unsigned char *p = s->str;
-  unsigned char *q = res->str;
-  int hassign = (*p=='+' | *p=='-');
-  if (hassign) {
-    *q = *p;
-    q++;
-  }
-  for (int i=0; i < fill; i++) 
-    *q++ = '0';
-  memcpy(res->str+hassign+fill,s->str+hassign,s->nbytes-hassign);
-  return res;
+    int fill = width->val - s->nchars;
+    if (fill < 0)
+        return s;
+    $str res;
+    NEW_UNFILLED_STR(res, width->val, s->nbytes + fill);
+    unsigned char *p = s->str;
+    unsigned char *q = res->str;
+    int hassign = (*p == '+' | *p == '-');
+    if (hassign) {
+        *q = *p;
+        q++;
+    }
+    for (int i = 0; i < fill; i++)
+        *q++ = '0';
+    memcpy(res->str + hassign + fill, s->str + hassign, s->nbytes - hassign);
+    return res;
 }
 
-
 // End of str implementation ////////////////////////////////////////////////////
-
-
 
 // bytearray implementation //////////////////////////////////////////////////////////////////////////////
 
 // Conversion to and from C strings
 
 $bytearray to$bytearray(char *str) {
-  $bytearray res;
-  int len = strlen(str);
-  NEW_UNFILLED_BYTEARRAY(res,len);
-  memcpy(res->str,str,len);
-  return res;
+    $bytearray res;
+    int len = strlen(str);
+    NEW_UNFILLED_BYTEARRAY(res, len);
+    memcpy(res->str, str, len);
+    return res;
 }
 
 unsigned char *from$bytearray($bytearray b) {
-  return b->str;
+    return b->str;
 }
 
 // Auxiliaries
 
-static void expand_bytearray($bytearray b,int n) {
-   if (b->capacity >= b->nbytes + n)
-     return;
-   int newcapacity = b->capacity==0 ? 1 : b->capacity;
-   while (newcapacity < b->nbytes+n)
-     newcapacity <<= 1;
-   unsigned char *newstr = b->str==NULL
-     ? malloc(newcapacity+1)
-     : realloc(b->str,newcapacity+1);
-   if (newstr == NULL) {
-    $RAISE(($BaseException)$NEW($MemoryError,to$str("memory allocation failed")));
-   }
-   b->str = newstr;
-   b->capacity = newcapacity;
-}  
-
+static void expand_bytearray($bytearray b, int n) {
+    if (b->capacity >= b->nbytes + n)
+        return;
+    int newcapacity = b->capacity == 0 ? 1 : b->capacity;
+    while (newcapacity < b->nbytes + n)
+        newcapacity <<= 1;
+    unsigned char *newstr = b->str == NULL
+                                ? malloc(newcapacity + 1)
+                                : realloc(b->str, newcapacity + 1);
+    if (newstr == NULL) {
+        $RAISE(($BaseException)$NEW($MemoryError, to$str("memory allocation failed")));
+    }
+    b->str = newstr;
+    b->capacity = newcapacity;
+}
 
 // General methods, prototypes
 void $bytearray_init($bytearray, $value);
 $bool $bytearray_bool($bytearray);
 $str $bytearray_str($bytearray);
-void $bytearray_serialize($bytearray,$Serial$state);
-$bytearray $bytearray_deserialize($bytearray,$Serial$state);
-
+void $bytearray_serialize($bytearray, $Serial$state);
+$bytearray $bytearray_deserialize($bytearray, $Serial$state);
 
 // bytearray methods, prototypes
 
@@ -1570,7 +1559,7 @@ $bytearray $bytearray_center($bytearray s, $int width, $bytearray fill);
 $int $bytearray_count($bytearray s, $bytearray sub, $int start, $int end);
 $str $bytearray_decode($bytearray s);
 $bool $bytearray_endswith($bytearray s, $bytearray suffix, $int start, $int end);
-$bytearray $bytearray_expandtabs($bytearray s, $int tabsize);      
+$bytearray $bytearray_expandtabs($bytearray s, $int tabsize);
 $int $bytearray_find($bytearray s, $bytearray sub, $int start, $int end);
 $int $bytearray_index($bytearray s, $bytearray sub, $int start, $int end);
 $bool $bytearray_isalnum($bytearray s);
@@ -1586,629 +1575,632 @@ $bool $bytearray_isspace($bytearray s);
 $bool $bytearray_istitle($bytearray s);
 $bool $bytearray_isupper($bytearray s);
 $bytearray $bytearray_join($bytearray sep, $Iterable wit, $WORD iter);
-$bytearray $bytearray_ljust($bytearray s, $int width, $bytearray fill); 
+$bytearray $bytearray_ljust($bytearray s, $int width, $bytearray fill);
 $bytearray $bytearray_lower($bytearray s);
-$bytearray $bytearray_lstrip($bytearray s,$bytearray cs); 
+$bytearray $bytearray_lstrip($bytearray s, $bytearray cs);
 $tuple $bytearray_partition($bytearray s, $bytearray sep);
 $bytearray $bytearray_replace($bytearray s, $bytearray old, $bytearray new, $int count);
 $int $bytearray_rfind($bytearray s, $bytearray sub, $int start, $int end);
 $int $bytearray_rindex($bytearray s, $bytearray sub, $int start, $int end);
-$bytearray $bytearray_rjust($bytearray s, $int width, $bytearray fill);  
-$tuple $bytearray_rpartition($bytearray s, $bytearray sep); 
-$bytearray $bytearray_rstrip($bytearray s,$bytearray cs);
-$list $bytearray_split($bytearray s, $bytearray sep, $int maxsplit);  
-$list $bytearray_splitlines($bytearray s, $bool keepends); 
-$bool $bytearray_startswith($bytearray s, $bytearray prefix, $int start, $int end); 
-$bytearray $bytearray_strip($bytearray s,$bytearray cs);
+$bytearray $bytearray_rjust($bytearray s, $int width, $bytearray fill);
+$tuple $bytearray_rpartition($bytearray s, $bytearray sep);
+$bytearray $bytearray_rstrip($bytearray s, $bytearray cs);
+$list $bytearray_split($bytearray s, $bytearray sep, $int maxsplit);
+$list $bytearray_splitlines($bytearray s, $bool keepends);
+$bool $bytearray_startswith($bytearray s, $bytearray prefix, $int start, $int end);
+$bytearray $bytearray_strip($bytearray s, $bytearray cs);
 $bytearray $bytearray_upper($bytearray s);
 $bytearray $bytearray_zfill($bytearray s, $int width);
 
 // Method table
 
 struct $bytearray$class $bytearray$methods =
-  {"$bytearray",UNASSIGNED,($Super$class)&$value$methods, $bytearray_init, $bytearray_serialize, $bytearray_deserialize, $bytearray_bool,
-   $bytearray_str, $bytearray_capitalize, $bytearray_center, $bytearray_count,  $bytearray_decode, $bytearray_endswith,
-   $bytearray_expandtabs, $bytearray_find, $bytearray_index,
-   $bytearray_isalnum, $bytearray_isalpha, $bytearray_isascii, $bytearray_isdigit, $bytearray_islower, $bytearray_isspace,
-   $bytearray_istitle, $bytearray_isupper, $bytearray_join, $bytearray_ljust, $bytearray_lower, $bytearray_lstrip, $bytearray_partition, $bytearray_replace,
-   $bytearray_rfind, $bytearray_rindex, $bytearray_rjust,
-   $bytearray_rpartition, $bytearray_rstrip, $bytearray_split, $bytearray_splitlines, $bytearray_startswith, $bytearray_strip, $bytearray_upper, $bytearray_zfill};
+    {"$bytearray", UNASSIGNED, ($Super$class)&$value$methods, $bytearray_init, $bytearray_serialize, $bytearray_deserialize, $bytearray_bool,
+     $bytearray_str, $bytearray_capitalize, $bytearray_center, $bytearray_count, $bytearray_decode, $bytearray_endswith,
+     $bytearray_expandtabs, $bytearray_find, $bytearray_index,
+     $bytearray_isalnum, $bytearray_isalpha, $bytearray_isascii, $bytearray_isdigit, $bytearray_islower, $bytearray_isspace,
+     $bytearray_istitle, $bytearray_isupper, $bytearray_join, $bytearray_ljust, $bytearray_lower, $bytearray_lstrip, $bytearray_partition, $bytearray_replace,
+     $bytearray_rfind, $bytearray_rindex, $bytearray_rjust,
+     $bytearray_rpartition, $bytearray_rstrip, $bytearray_split, $bytearray_splitlines, $bytearray_startswith, $bytearray_strip, $bytearray_upper, $bytearray_zfill};
 
 // Bytearray methods, implementations
 
 static $bytearray $bytearray_copy($bytearray s) {
-  $bytearray res;
-  NEW_UNFILLED_BYTEARRAY(res,s->nbytes);
-  res->nbytes = s->nbytes;
-  memcpy(res->str,s->str,s->nbytes);
-  return res;
+    $bytearray res;
+    NEW_UNFILLED_BYTEARRAY(res, s->nbytes);
+    res->nbytes = s->nbytes;
+    memcpy(res->str, s->str, s->nbytes);
+    return res;
 }
 
 $bytearray $bytearray_capitalize($bytearray s) {
-  if (s->nbytes==0) {
-    return to$bytearray("");
-  }
-  $bytearray res;
-  NEW_UNFILLED_BYTEARRAY(res,s->nbytes);
-  for (int i=0; i<s->nbytes; i++) 
-    res->str[i] = i==0 ? toupper(s->str[i]) : tolower(s->str[i]);
-   return res;
+    if (s->nbytes == 0) {
+        return to$bytearray("");
+    }
+    $bytearray res;
+    NEW_UNFILLED_BYTEARRAY(res, s->nbytes);
+    for (int i = 0; i < s->nbytes; i++)
+        res->str[i] = i == 0 ? toupper(s->str[i]) : tolower(s->str[i]);
+    return res;
 }
 
 $bytearray $bytearray_center($bytearray s, $int width, $bytearray fill) {
-  if (!fill) fill = to$bytearray(" ");
-  if (fill->nbytes != 1) {
-    $RAISE(($BaseException)$NEW($ValueError,to$str("center: fill bytearray not single char")));
-  }
-  if (width->val <= s->nbytes) {
-    return $bytearray_copy(s);
-  }
-  int pad = (width->val-s->nbytes);
-  int padleft = pad/2; 
-  int padright = pad-padleft;
-  int sbytes = s->nbytes;
-  $bytearray res;
-  NEW_UNFILLED_BYTEARRAY(res, width->val);
-  unsigned char c = fill->str[0];
-  unsigned char *p = res->str;
-  p += padleft+sbytes;
-  for (int i = 0; i<padright; i++) {
-      p[i] = c;
-   }
-  memcpy(res->str,p,padleft);
-  p -= sbytes;
-  memcpy(p,s->str,sbytes);
-  return res;
+    if (!fill)
+        fill = to$bytearray(" ");
+    if (fill->nbytes != 1) {
+        $RAISE(($BaseException)$NEW($ValueError, to$str("center: fill bytearray not single char")));
+    }
+    if (width->val <= s->nbytes) {
+        return $bytearray_copy(s);
+    }
+    int pad = (width->val - s->nbytes);
+    int padleft = pad / 2;
+    int padright = pad - padleft;
+    int sbytes = s->nbytes;
+    $bytearray res;
+    NEW_UNFILLED_BYTEARRAY(res, width->val);
+    unsigned char c = fill->str[0];
+    unsigned char *p = res->str;
+    p += padleft + sbytes;
+    for (int i = 0; i < padright; i++) {
+        p[i] = c;
+    }
+    memcpy(res->str, p, padleft);
+    p -= sbytes;
+    memcpy(p, s->str, sbytes);
+    return res;
 }
 
 $int $bytearray_count($bytearray s, $bytearray sub, $int start, $int end) {
-  $int st = start;
-  $int en = end;
-  if (fix_start_end(s->nbytes,&st,&en) < 0) return to$int(0);
-  unsigned char *p = &s->str[st->val];
-  unsigned char *q = &p[en->val-st->val];
-  int res = 0;
-  int n = bmh(p,sub->str,q-p,sub->nbytes);
-  while (n>=0) {
-    res++;
-    p += n + (sub->nbytes>0 ? sub->nbytes : 1);
-    n = bmh(p,sub->str,q-p,sub->nbytes);
-  }
-  return to$int(res);
+    $int st = start;
+    $int en = end;
+    if (fix_start_end(s->nbytes, &st, &en) < 0)
+        return to$int(0);
+    unsigned char *p = &s->str[st->val];
+    unsigned char *q = &p[en->val - st->val];
+    int res = 0;
+    int n = bmh(p, sub->str, q - p, sub->nbytes);
+    while (n >= 0) {
+        res++;
+        p += n + (sub->nbytes > 0 ? sub->nbytes : 1);
+        n = bmh(p, sub->str, q - p, sub->nbytes);
+    }
+    return to$int(res);
 }
 
 $str $bytearray_decode($bytearray s) {
-  return to$str((char*)s->str);
+    return to$str((char *)s->str);
 }
 
 $bool $bytearray_endswith($bytearray s, $bytearray sub, $int start, $int end) {
-  $int st = start;
-  $int en = end;
-  if (fix_start_end(s->nbytes,&st,&en) < 0) return $False;
-  unsigned char *p = &s->str[en->val-sub->nbytes];
-  unsigned char *q = sub->str;
-  for (int i=0; i<sub->nbytes; i++) {
-    if (*p == 0 || *p++ != *q++) {
-      return $False;
+    $int st = start;
+    $int en = end;
+    if (fix_start_end(s->nbytes, &st, &en) < 0)
+        return $False;
+    unsigned char *p = &s->str[en->val - sub->nbytes];
+    unsigned char *q = sub->str;
+    for (int i = 0; i < sub->nbytes; i++) {
+        if (*p == 0 || *p++ != *q++) {
+            return $False;
+        }
     }
-  }
-  return $True;
+    return $True;
 }
 
-$bytearray $bytearray_expandtabs($bytearray s, $int tabsz){
-  int pos = 0;
-  int expanded = 0;
-  int tabsize = tabsz->val;
-  tabsize = tabsize <= 0 ? 1 : tabsize;
-  unsigned char buffer[tabsize * s->nbytes];
-  unsigned char *p = s->str;
-  unsigned char *q = buffer;
-  for (int i=0; i<s->nbytes; i++) {
-    if (*p == '\t') {
-      int n = tabsize - pos % tabsize;
-      for (int j=0; j < n; j++) {
-        *q++ = ' ';
-      }
-      p++;
-      expanded += n-1;
-      pos+=n;
-    } else if (*p=='\n' || *p == '\r') {
-      *q++ = *p++;
-      pos = 0;
-    } else {
-      for (int j=0; j< byte_length2(*p); j++) {
-        *q++ = *p++;
-        pos++;
-      }
+$bytearray $bytearray_expandtabs($bytearray s, $int tabsz) {
+    int pos = 0;
+    int expanded = 0;
+    int tabsize = tabsz->val;
+    tabsize = tabsize <= 0 ? 1 : tabsize;
+    unsigned char buffer[tabsize * s->nbytes];
+    unsigned char *p = s->str;
+    unsigned char *q = buffer;
+    for (int i = 0; i < s->nbytes; i++) {
+        if (*p == '\t') {
+            int n = tabsize - pos % tabsize;
+            for (int j = 0; j < n; j++) {
+                *q++ = ' ';
+            }
+            p++;
+            expanded += n - 1;
+            pos += n;
+        } else if (*p == '\n' || *p == '\r') {
+            *q++ = *p++;
+            pos = 0;
+        } else {
+            for (int j = 0; j < byte_length2(*p); j++) {
+                *q++ = *p++;
+                pos++;
+            }
+        }
     }
-  }
-  $bytearray res;
-  NEW_UNFILLED_BYTEARRAY(res,s->nbytes+expanded);
-  memcpy(res->str,buffer,s->nbytes+expanded);
-  return res;
+    $bytearray res;
+    NEW_UNFILLED_BYTEARRAY(res, s->nbytes + expanded);
+    memcpy(res->str, buffer, s->nbytes + expanded);
+    return res;
 }
 
 $int $bytearray_find($bytearray s, $bytearray sub, $int start, $int end) {
-  $int st = start;
-  $int en = end;
-  if (fix_start_end(s->nbytes,&st,&en) < 0) return to$int(-1);
-  unsigned char *p = &s->str[st->val];
-  unsigned char *q = &s->str[en->val];
-  int n = bmh(p,sub->str,q-p,sub->nbytes);
-  if (n<0) return to$int(-1);
-  return to$int(n+p-s->str);
+    $int st = start;
+    $int en = end;
+    if (fix_start_end(s->nbytes, &st, &en) < 0)
+        return to$int(-1);
+    unsigned char *p = &s->str[st->val];
+    unsigned char *q = &s->str[en->val];
+    int n = bmh(p, sub->str, q - p, sub->nbytes);
+    if (n < 0)
+        return to$int(-1);
+    return to$int(n + p - s->str);
 }
 
-
 $int $bytearray_index($bytearray s, $bytearray sub, $int start, $int end) {
-  $int n = $bytearray_find(s,sub,start,end);
-  if (n->val<0) {
-    $RAISE(($BaseException)$NEW($ValueError,to$str("index: substring not found")));
-  }
-  return n;
+    $int n = $bytearray_find(s, sub, start, end);
+    if (n->val < 0) {
+        $RAISE(($BaseException)$NEW($ValueError, to$str("index: substring not found")));
+    }
+    return n;
 }
 
 $bool $bytearray_isalnum($bytearray s) {
-  if (s->nbytes==0)
-    return $False;
-  for (int i=0; i<s->nbytes; i++) {
-    unsigned char c = s->str[i];
-    if (c < '0' || c > 'z' || (c > '9' && c < 'A') || (c > 'Z' && c < 'a'))
-      return $False;
-  }
-  return $True;
+    if (s->nbytes == 0)
+        return $False;
+    for (int i = 0; i < s->nbytes; i++) {
+        unsigned char c = s->str[i];
+        if (c < '0' || c > 'z' || (c > '9' && c < 'A') || (c > 'Z' && c < 'a'))
+            return $False;
+    }
+    return $True;
 }
 
 $bool $bytearray_isalpha($bytearray s) {
-  if (s->nbytes==0)
-    return $False;
-  for (int i=0; i<s->nbytes; i++) {
-    unsigned char c = s->str[i];
-    if (c < 'A' || c > 'z' || (c > 'Z' && c < 'a'))
-      return $False;
-  }
-  return $True;
+    if (s->nbytes == 0)
+        return $False;
+    for (int i = 0; i < s->nbytes; i++) {
+        unsigned char c = s->str[i];
+        if (c < 'A' || c > 'z' || (c > 'Z' && c < 'a'))
+            return $False;
+    }
+    return $True;
 }
 
 $bool $bytearray_isascii($bytearray s) {
-  for (int i=0; i<s->nbytes; i++) {
-    unsigned char c = s->str[i];
-    if (c > 0x7f)
-      return $False;
-  }
-  return $True;
+    for (int i = 0; i < s->nbytes; i++) {
+        unsigned char c = s->str[i];
+        if (c > 0x7f)
+            return $False;
+    }
+    return $True;
 }
 
 $bool $bytearray_isdigit($bytearray s) {
-  if (s->nbytes==0)
-    return $False;
-  for (int i=0; i<s->nbytes; i++) {
-    unsigned char c = s->str[i];
-    if (c<'0' || c > '9')
-      return $False;
-  }
-  return $True;
+    if (s->nbytes == 0)
+        return $False;
+    for (int i = 0; i < s->nbytes; i++) {
+        unsigned char c = s->str[i];
+        if (c < '0' || c > '9')
+            return $False;
+    }
+    return $True;
 }
- 
 
 $bool $bytearray_islower($bytearray s) {
-  int has_lower = 0;
-  for (int i=0; i < s->nbytes; i++) {
-    unsigned char c = s->str[i];
-    if (c >= 'A' && c <= 'Z')
-      return $False;
-    if (c >= 'a' && c <= 'z')
-      has_lower = 1;
-  }
-  return to$bool(has_lower);
+    int has_lower = 0;
+    for (int i = 0; i < s->nbytes; i++) {
+        unsigned char c = s->str[i];
+        if (c >= 'A' && c <= 'Z')
+            return $False;
+        if (c >= 'a' && c <= 'z')
+            has_lower = 1;
+    }
+    return to$bool(has_lower);
 }
 
 $bool $bytearray_isspace($bytearray s) {
-  if (s->nbytes==0)
-    return $False;
-  for (int i=0; i<s->nbytes; i++) {
-    unsigned char c = s->str[i];
-    if (c !=' ' && c != '\t' && c != '\n' && c != '\r' && c != '\x0b' && c != '\f')
-      return $False;
-  }
-  return $True;
+    if (s->nbytes == 0)
+        return $False;
+    for (int i = 0; i < s->nbytes; i++) {
+        unsigned char c = s->str[i];
+        if (c != ' ' && c != '\t' && c != '\n' && c != '\r' && c != '\x0b' && c != '\f')
+            return $False;
+    }
+    return $True;
 }
 
 $bool $bytearray_istitle($bytearray s) {
-  if (s->nbytes==0)
-    return $False;
-  int incasedrun = 0;
-  for (int i=0; i < s->nbytes; i++) {
-    unsigned char c = s->str[i];
-    if (c >='A' && c <= 'Z') {
-      if (incasedrun)
+    if (s->nbytes == 0)
         return $False;
-      incasedrun = 1;
-    } else if (c >='a' && c <= 'z') {
-      if (!incasedrun)
-        return $False;
-    } else
-        incasedrun = 0;
-  }
-  return $True;
+    int incasedrun = 0;
+    for (int i = 0; i < s->nbytes; i++) {
+        unsigned char c = s->str[i];
+        if (c >= 'A' && c <= 'Z') {
+            if (incasedrun)
+                return $False;
+            incasedrun = 1;
+        } else if (c >= 'a' && c <= 'z') {
+            if (!incasedrun)
+                return $False;
+        } else
+            incasedrun = 0;
+    }
+    return $True;
 }
 
 $bool $bytearray_isupper($bytearray s) {
-  int has_upper = 0;
-  for (int i=0; i < s->nbytes; i++) {
-    unsigned char c = s->str[i];
-    if (c >= 'a' && c <= 'z')
-      return $False;
-    if (c >= 'a' && c <= 'z')
-      has_upper = 1;
-  }
-  return to$bool(has_upper);
+    int has_upper = 0;
+    for (int i = 0; i < s->nbytes; i++) {
+        unsigned char c = s->str[i];
+        if (c >= 'a' && c <= 'z')
+            return $False;
+        if (c >= 'a' && c <= 'z')
+            has_upper = 1;
+    }
+    return to$bool(has_upper);
 }
 
 $bytearray $bytearray_join($bytearray s, $Iterable wit, $WORD iter) {
-  int totbytes = 0;
-  $list lst = $list_fromiter(wit->$class->__iter__(wit,iter));
-  $bytearray nxt;
-  int len = lst->length;
-  for (int i=0; i<len; i++) {
-    nxt = ($bytearray)lst->data[i];
-    totbytes += nxt->nbytes;
-  }
-  if (len > 1) {
-    totbytes += (len-1) * s->nbytes;
-  }
-  $bytearray res;
-  NEW_UNFILLED_BYTEARRAY(res,totbytes);
-  if (len > 0) {
-    nxt = ($bytearray)lst->data[0];
-    unsigned char *p = res->str;
-    memcpy(p,nxt->str,nxt->nbytes);
-    p += nxt->nbytes;
-    for (int i=1; i<len; i++) {
-      nxt = ($bytearray)lst->data[i];
-      memcpy(p,s->str,s->nbytes);
-      p += s->nbytes;
-      memcpy(p,nxt->str,nxt->nbytes);
-      p += nxt->nbytes;
+    int totbytes = 0;
+    $list lst = $list_fromiter(wit->$class->__iter__(wit, iter));
+    $bytearray nxt;
+    int len = lst->length;
+    for (int i = 0; i < len; i++) {
+        nxt = ($bytearray)lst->data[i];
+        totbytes += nxt->nbytes;
     }
-  }
-  return res;
+    if (len > 1) {
+        totbytes += (len - 1) * s->nbytes;
+    }
+    $bytearray res;
+    NEW_UNFILLED_BYTEARRAY(res, totbytes);
+    if (len > 0) {
+        nxt = ($bytearray)lst->data[0];
+        unsigned char *p = res->str;
+        memcpy(p, nxt->str, nxt->nbytes);
+        p += nxt->nbytes;
+        for (int i = 1; i < len; i++) {
+            nxt = ($bytearray)lst->data[i];
+            memcpy(p, s->str, s->nbytes);
+            p += s->nbytes;
+            memcpy(p, nxt->str, nxt->nbytes);
+            p += nxt->nbytes;
+        }
+    }
+    return res;
 }
 
 $bytearray $bytearray_ljust($bytearray s, $int width, $bytearray fill) {
-  if (fill->nbytes != 1) {
-    $RAISE(($BaseException)$NEW($ValueError,to$str("bytearray ljust: fill array not single char")));
-  }
-  if (width->val <= s->nbytes) {
-    return $bytearray_copy(s);
-  }
-  $bytearray res;
-  NEW_UNFILLED_BYTEARRAY(res,width->val);
-  memcpy(res->str,s->str,s->nbytes);
-  unsigned char c = fill->str[0];
-  for (int i = s->nbytes; i<width->val; i++) {
-      res->str[i] = c;
-  }
-  return res;
+    if (fill->nbytes != 1) {
+        $RAISE(($BaseException)$NEW($ValueError, to$str("bytearray ljust: fill array not single char")));
+    }
+    if (width->val <= s->nbytes) {
+        return $bytearray_copy(s);
+    }
+    $bytearray res;
+    NEW_UNFILLED_BYTEARRAY(res, width->val);
+    memcpy(res->str, s->str, s->nbytes);
+    unsigned char c = fill->str[0];
+    for (int i = s->nbytes; i < width->val; i++) {
+        res->str[i] = c;
+    }
+    return res;
 }
 
 $bytearray $bytearray_lower($bytearray s) {
-  $bytearray res;
-  NEW_UNFILLED_BYTEARRAY(res,s->nbytes);
-  for (int i=0; i< s->nbytes; i++)
-    res->str[i] = tolower(res->str[i]);
-  return res;
+    $bytearray res;
+    NEW_UNFILLED_BYTEARRAY(res, s->nbytes);
+    for (int i = 0; i < s->nbytes; i++)
+        res->str[i] = tolower(res->str[i]);
+    return res;
 }
 
 $bytearray $bytearray_lstrip($bytearray s, $bytearray cs) {
-  if (!cs)
-    cs = to$bytearray(" \t\n\r\x0b\x0c");
-  int nstrip = 0;
-  for (int i=0; i<s->nbytes; i++) {
-    unsigned char c = s->str[i];
-    int found = 0;
-    for (int j=0; j<cs->nbytes; j++)
-      if (c == cs->str[j]) {
-        found = 1;
-        break;
-      }
-    if (!found)
-      break;
-    nstrip++;
-  }
-  $bytearray res;
-  NEW_UNFILLED_BYTEARRAY(res,s->nbytes-nstrip);
-  memcpy(res->str,s->str+nstrip,res->nbytes);       
-  return res;
+    if (!cs)
+        cs = to$bytearray(" \t\n\r\x0b\x0c");
+    int nstrip = 0;
+    for (int i = 0; i < s->nbytes; i++) {
+        unsigned char c = s->str[i];
+        int found = 0;
+        for (int j = 0; j < cs->nbytes; j++)
+            if (c == cs->str[j]) {
+                found = 1;
+                break;
+            }
+        if (!found)
+            break;
+        nstrip++;
+    }
+    $bytearray res;
+    NEW_UNFILLED_BYTEARRAY(res, s->nbytes - nstrip);
+    memcpy(res->str, s->str + nstrip, res->nbytes);
+    return res;
 }
-
 
 $tuple $bytearray_partition($bytearray s, $bytearray sep) {
-  int n = from$int($bytearray_find(s,sep,NULL,NULL));
-  if (n<0) {
-    return $NEWTUPLE(3,s,to$bytearray(""),to$bytearray(""));
-  } else {
-    int nb = bmh(s->str,sep->str,s->nbytes,sep->nbytes);
-    $bytearray ls;
-    NEW_UNFILLED_BYTEARRAY(ls,nb);
-    memcpy(ls->str,s->str,nb);
-    $bytearray rs;
-    int nbr = s->nbytes - sep->nbytes - nb;
-    NEW_UNFILLED_BYTEARRAY(rs,nbr);
-    memcpy(rs->str,s->str+nb+sep->nbytes,nbr);
-    return $NEWTUPLE(3,ls,sep,rs);
-  }
+    int n = from$int($bytearray_find(s, sep, NULL, NULL));
+    if (n < 0) {
+        return $NEWTUPLE(3, s, to$bytearray(""), to$bytearray(""));
+    } else {
+        int nb = bmh(s->str, sep->str, s->nbytes, sep->nbytes);
+        $bytearray ls;
+        NEW_UNFILLED_BYTEARRAY(ls, nb);
+        memcpy(ls->str, s->str, nb);
+        $bytearray rs;
+        int nbr = s->nbytes - sep->nbytes - nb;
+        NEW_UNFILLED_BYTEARRAY(rs, nbr);
+        memcpy(rs->str, s->str + nb + sep->nbytes, nbr);
+        return $NEWTUPLE(3, ls, sep, rs);
+    }
 }
-
 
 $bytearray $bytearray_replace($bytearray s, $bytearray old, $bytearray new, $int count) {
-  if (count==NULL)
-    count = to$int(INT_MAX);
-  int c = from$int($bytearray_count(s,old,NULL,NULL));
-  int c0 = from$int(count) < c ? from$int(count) : c;
-  if (c0==0){
-    return $bytearray_copy(s);
-  }
-  int nbytes = s->nbytes + c0*(new->nbytes-old->nbytes);
-  $bytearray res;
-  NEW_UNFILLED_BYTEARRAY(res,nbytes);
-  unsigned char *p = s->str;
-  unsigned char *q = res->str;
-  unsigned char *pold = old->str;
-  unsigned char *pnew = new->str;
-  int plen = s->nbytes;
-  int n;
-  for (int i=0; i<c0; i++) {
-    n = i>0 && old->nbytes==0 ? 1 : bmh(p,pold,plen,old->nbytes);
-    if (n>0) {
-      memcpy(q,p,n);
-      p+=n; q+=n;
+    if (count == NULL)
+        count = to$int(INT_MAX);
+    int c = from$int($bytearray_count(s, old, NULL, NULL));
+    int c0 = from$int(count) < c ? from$int(count) : c;
+    if (c0 == 0) {
+        return $bytearray_copy(s);
     }
-    memcpy(q,pnew,new->nbytes);
-    p += old->nbytes;
-    q += new->nbytes;
-    plen -= n+old->nbytes;
-  }
-  if (plen>0)
-    memcpy(q,p,plen);
-  return res;
+    int nbytes = s->nbytes + c0 * (new->nbytes - old->nbytes);
+    $bytearray res;
+    NEW_UNFILLED_BYTEARRAY(res, nbytes);
+    unsigned char *p = s->str;
+    unsigned char *q = res->str;
+    unsigned char *pold = old->str;
+    unsigned char *pnew = new->str;
+    int plen = s->nbytes;
+    int n;
+    for (int i = 0; i < c0; i++) {
+        n = i > 0 && old->nbytes == 0 ? 1 : bmh(p, pold, plen, old->nbytes);
+        if (n > 0) {
+            memcpy(q, p, n);
+            p += n;
+            q += n;
+        }
+        memcpy(q, pnew, new->nbytes);
+        p += old->nbytes;
+        q += new->nbytes;
+        plen -= n + old->nbytes;
+    }
+    if (plen > 0)
+        memcpy(q, p, plen);
+    return res;
 }
-      
 
 $int $bytearray_rfind($bytearray s, $bytearray sub, $int start, $int end) {
-  $int st = start;
-  $int en = end;
-  if (fix_start_end(s->nbytes,&st,&en) < 0) return to$int(-1);
-  unsigned char *p = &s->str[st->val];
-  unsigned char *q = &s->str[en->val];
-  int n = rbmh(p,sub->str,q-p,sub->nbytes);
-  if (n<0) return to$int(-1);
-  return to$int(n+p-s->str);
+    $int st = start;
+    $int en = end;
+    if (fix_start_end(s->nbytes, &st, &en) < 0)
+        return to$int(-1);
+    unsigned char *p = &s->str[st->val];
+    unsigned char *q = &s->str[en->val];
+    int n = rbmh(p, sub->str, q - p, sub->nbytes);
+    if (n < 0)
+        return to$int(-1);
+    return to$int(n + p - s->str);
 }
 
-
 $int $bytearray_rindex($bytearray s, $bytearray sub, $int start, $int end) {
-  $int n = $bytearray_rfind(s,sub,start,end);
-  if (from$int(n)<0) {
-    $RAISE(($BaseException)$NEW($ValueError,to$str("rindex for bytearray: substring not found")));
-  };
-  return n;
+    $int n = $bytearray_rfind(s, sub, start, end);
+    if (from$int(n) < 0) {
+        $RAISE(($BaseException)$NEW($ValueError, to$str("rindex for bytearray: substring not found")));
+    };
+    return n;
 }
 
 $bytearray $bytearray_rjust($bytearray s, $int width, $bytearray fill) {
-  if (fill->nbytes != 1) {
-    $RAISE(($BaseException)$NEW($ValueError,to$str("rjust: fill string not single char")));
-  }
-  if (width->val <= s->nbytes) {
-    return $bytearray_copy(s);
-  }
-  int pad = (width->val-s->nbytes);
-  $bytearray res;
-  NEW_UNFILLED_BYTEARRAY(res,width->val);
-  unsigned char c = fill->str[0];
-  for (int i = 0; i<pad; i++) {
-      res->str[i] = c;
-  }
-  memcpy(&res->str[pad],s->str,s->nbytes);
-  return res;
+    if (fill->nbytes != 1) {
+        $RAISE(($BaseException)$NEW($ValueError, to$str("rjust: fill string not single char")));
+    }
+    if (width->val <= s->nbytes) {
+        return $bytearray_copy(s);
+    }
+    int pad = (width->val - s->nbytes);
+    $bytearray res;
+    NEW_UNFILLED_BYTEARRAY(res, width->val);
+    unsigned char c = fill->str[0];
+    for (int i = 0; i < pad; i++) {
+        res->str[i] = c;
+    }
+    memcpy(&res->str[pad], s->str, s->nbytes);
+    return res;
 }
-                                
+
 $tuple $bytearray_rpartition($bytearray s, $bytearray sep) {
-  int n = from$int($bytearray_rfind(s,sep,NULL,NULL));
-  if (n<0) {
-    return $NEWTUPLE(3,to$bytearray(""),to$bytearray(""),s);
-  } else {
-    int nb = rbmh(s->str,sep->str,s->nbytes,sep->nbytes);
-    $bytearray ls;
-    NEW_UNFILLED_BYTEARRAY(ls,nb);
-    memcpy(ls->str,s->str,nb);
-    int nbr = s->nbytes - sep->nbytes - nb;
-    $bytearray rs;    
-    NEW_UNFILLED_BYTEARRAY(rs,nbr);
-    memcpy(rs->str,s->str+nb+sep->nbytes,nbr);
-    return  $NEWTUPLE(3,ls,sep,rs);
-  }
+    int n = from$int($bytearray_rfind(s, sep, NULL, NULL));
+    if (n < 0) {
+        return $NEWTUPLE(3, to$bytearray(""), to$bytearray(""), s);
+    } else {
+        int nb = rbmh(s->str, sep->str, s->nbytes, sep->nbytes);
+        $bytearray ls;
+        NEW_UNFILLED_BYTEARRAY(ls, nb);
+        memcpy(ls->str, s->str, nb);
+        int nbr = s->nbytes - sep->nbytes - nb;
+        $bytearray rs;
+        NEW_UNFILLED_BYTEARRAY(rs, nbr);
+        memcpy(rs->str, s->str + nb + sep->nbytes, nbr);
+        return $NEWTUPLE(3, ls, sep, rs);
+    }
 }
 
 $bytearray $bytearray_rstrip($bytearray s, $bytearray cs) {
-  if (!cs)
-   cs = to$bytearray(" \t\n\r\x0b\x0c");
-   int nstrip = 0;
-  for (int i=s->nbytes-1; i>=0; i--) {
-    unsigned char c = s->str[i];
-    int found = 0;
-    for (int j=0; j<cs->nbytes; j++)
-      if (c == cs->str[j]) {
-        found = 1;
-        break;
-      }
-    if (!found)
-      break;
-    nstrip++;
-  }
-  $bytearray res;
-  NEW_UNFILLED_BYTEARRAY(res,s->nbytes-nstrip);
-  memcpy(res->str,s->str,res->nbytes);       
-  return res;
+    if (!cs)
+        cs = to$bytearray(" \t\n\r\x0b\x0c");
+    int nstrip = 0;
+    for (int i = s->nbytes - 1; i >= 0; i--) {
+        unsigned char c = s->str[i];
+        int found = 0;
+        for (int j = 0; j < cs->nbytes; j++)
+            if (c == cs->str[j]) {
+                found = 1;
+                break;
+            }
+        if (!found)
+            break;
+        nstrip++;
+    }
+    $bytearray res;
+    NEW_UNFILLED_BYTEARRAY(res, s->nbytes - nstrip);
+    memcpy(res->str, s->str, res->nbytes);
+    return res;
 }
- 
+
 $list $bytearray_split($bytearray s, $bytearray sep, $int maxsplit) {
-  $list res = $NEW($list,NULL,NULL);
-  if (maxsplit == NULL || from$int(maxsplit) < 0) maxsplit = to$int(INT_MAX); 
-  if (sep == NULL) {
-    unsigned char *p = s->str;
-    if (s->nbytes==0) {
-      return res;
-    }
-    int inword = 0;
-    unsigned char *q;
-    while (p < s->str + s->nbytes) {
-      if  (*p !=' ' && *p != '\t' && *p != '\n' && *p != '\r' && *p != '\x0b' && *p != '\f') {
-        if (!inword) {
-          inword = 1;
-          q = p;
-          if ($list_len(res) == from$int(maxsplit))
-            break; // we have now removed leading whitespace in remainder
-        } 
-      } else {
-          if (inword) {
-            inword = 0;
+    $list res = $NEW($list, NULL, NULL);
+    if (maxsplit == NULL || from$int(maxsplit) < 0)
+        maxsplit = to$int(INT_MAX);
+    if (sep == NULL) {
+        unsigned char *p = s->str;
+        if (s->nbytes == 0) {
+            return res;
+        }
+        int inword = 0;
+        unsigned char *q;
+        while (p < s->str + s->nbytes) {
+            if (*p != ' ' && *p != '\t' && *p != '\n' && *p != '\r' && *p != '\x0b' && *p != '\f') {
+                if (!inword) {
+                    inword = 1;
+                    q = p;
+                    if ($list_len(res) == from$int(maxsplit))
+                        break; // we have now removed leading whitespace in remainder
+                }
+            } else {
+                if (inword) {
+                    inword = 0;
+                    $bytearray word;
+                    NEW_UNFILLED_BYTEARRAY(word, p - q);
+                    memcpy(word->str, q, p - q);
+                    $list_append(res, word);
+                }
+            }
+            p++;
+        }
+        // this if statement should be simplified; almost code duplication.
+        if (p < s->str + s->nbytes) { // we did not break out of the while loop
+            if (inword) {
+                $bytearray word;
+                NEW_UNFILLED_BYTEARRAY(word, p - q);
+                memcpy(word->str, q, p - q);
+                $list_append(res, word);
+            }
+        } else {
             $bytearray word;
-            NEW_UNFILLED_BYTEARRAY(word,p-q);
-            memcpy(word->str,q,p-q);
-            $list_append(res,word);
-          }
-      }
-      p++;
+            p = s->str + s->nbytes;
+            NEW_UNFILLED_BYTEARRAY(word, p - q);
+            memcpy(word->str, q, p - q);
+            $list_append(res, word);
+        }
+        return res;
+    } else { // separator given
+        if (sep->nbytes == 0) {
+            $RAISE(($BaseException)$NEW($ValueError, to$str("split for bytearray: separator is empty string")));
+        }
+        if (s->nbytes == 0) { // for some unfathomable reason, this is the behaviour of the Python method
+            $list_append(res, null_str);
+            return res;
+        }
+        $bytearray ls, rs, ssep;
+        rs = s;
+        // Note: This builds many intermediate rs strings...
+        while (rs->nbytes > 0 && $list_len(res) < from$int(maxsplit)) {
+            $tuple t = $bytearray_partition(rs, sep);
+            ssep = ($bytearray)t->components[1];
+            rs = ($bytearray)t->components[2];
+            $list_append(res, ($bytearray)t->components[0]);
+        }
+        if (ssep->nbytes > 0)
+            $list_append(res, rs);
+        return res;
     }
-    // this if statement should be simplified; almost code duplication.
-    if (p < s->str + s->nbytes) { // we did not break out of the while loop
-      if (inword) {
-        $bytearray word;
-        NEW_UNFILLED_BYTEARRAY(word,p-q);
-        memcpy(word->str,q,p-q);
-        $list_append(res,word);
-      }
-    } else {
-      $bytearray word;
-      p = s->str+s->nbytes;
-      NEW_UNFILLED_BYTEARRAY(word,p-q);
-      memcpy(word->str,q,p-q);
-      $list_append(res,word);
-    }
-    return res;
-  } else { // separator given
-    if (sep->nbytes==0) {
-      $RAISE(($BaseException)$NEW($ValueError,to$str("split for bytearray: separator is empty string")));
-    }
-    if (s->nbytes==0) { // for some unfathomable reason, this is the behaviour of the Python method
-      $list_append(res,null_str);
-      return res;
-    }
-    $bytearray ls, rs, ssep;
-    rs = s;
-    // Note: This builds many intermediate rs strings...
-    while (rs->nbytes>0 && $list_len(res) < from$int(maxsplit)) {
-     $tuple t = $bytearray_partition(rs,sep);
-     ssep = ($bytearray)t->components[1];
-     rs =  ($bytearray)t->components[2];
-     $list_append(res,($bytearray)t->components[0]);
-    }
-    if (ssep->nbytes>0)
-      $list_append(res,rs);
-    return res;
-  }
 }
 
 $list $bytearray_splitlines($bytearray s, $bool keepends) {
-  if (!keepends)
-    keepends = $False;
-  $list res = $NEW($list,NULL,NULL);
-  if (s->nbytes==0) {
+    if (!keepends)
+        keepends = $False;
+    $list res = $NEW($list, NULL, NULL);
+    if (s->nbytes == 0) {
+        return res;
+    }
+    int winend;
+    unsigned char *p = s->str;
+    unsigned char *q = p;
+    while (p < s->str + s->nbytes) {
+        if (*p != '\n' && *p != '\r') {
+            p++;
+        } else {
+            $bytearray line;
+            winend = *p == '\r' && *(p + 1) == '\n';
+            int size = p - q + (keepends->val ? 1 + winend : 0);
+            NEW_UNFILLED_BYTEARRAY(line, size);
+            memcpy(line->str, q, size);
+            p += 1 + winend;
+            q = p;
+            $list_append(res, line);
+        }
+    }
+    if (q < p) {
+        $bytearray line;
+        NEW_UNFILLED_BYTEARRAY(line, p - q);
+        memcpy(line->str, q, p - q);
+        $list_append(res, line);
+    }
     return res;
-  }
-  int winend;
-  unsigned char *p = s->str;
-  unsigned char *q = p;
-  while (p < s->str + s->nbytes) {
-    if (*p != '\n' && *p != '\r') {
-      p++;
-    } else {
-      $bytearray line;
-      winend = *p=='\r' && *(p+1)=='\n';
-      int size = p-q + (keepends->val ? 1 + winend : 0);
-      NEW_UNFILLED_BYTEARRAY(line,size);
-      memcpy(line->str,q,size);
-      p+= 1 + winend;
-      q = p;
-      $list_append(res,line);
-    }
-  }
-  if (q < p) {
-    $bytearray line;
-    NEW_UNFILLED_BYTEARRAY(line,p-q);
-    memcpy(line->str,q,p-q);
-    $list_append(res,line);
-  }
-  return res;
-} 
-
-$bool $bytearray_startswith($bytearray s, $bytearray sub, $int start, $int end) {
-  $int st = start;
-  $int en = end;
-  if (fix_start_end(s->nbytes,&st,&en) < 0) return $False;
-  unsigned char *p = s->str + st->val;
-  if (p+sub->nbytes >= s->str+s->nbytes) return $False;
-  unsigned char *q = sub->str;
-  for (int i=0; i<sub->nbytes; i++) {
-    if (p >= s->str + en->val || *p++ != *q++) {
-      return $False;
-    }
-  }
-  return $True;
 }
 
+$bool $bytearray_startswith($bytearray s, $bytearray sub, $int start, $int end) {
+    $int st = start;
+    $int en = end;
+    if (fix_start_end(s->nbytes, &st, &en) < 0)
+        return $False;
+    unsigned char *p = s->str + st->val;
+    if (p + sub->nbytes >= s->str + s->nbytes)
+        return $False;
+    unsigned char *q = sub->str;
+    for (int i = 0; i < sub->nbytes; i++) {
+        if (p >= s->str + en->val || *p++ != *q++) {
+            return $False;
+        }
+    }
+    return $True;
+}
 
 $bytearray $bytearray_strip($bytearray s, $bytearray cs) {
-  return $bytearray_lstrip($bytearray_rstrip(s,cs),cs);
+    return $bytearray_lstrip($bytearray_rstrip(s, cs), cs);
 }
 
 $bytearray $bytearray_upper($bytearray s) {
-  $bytearray res;
-  NEW_UNFILLED_BYTEARRAY(res,s->nbytes);
-  for (int i=0; i< s->nbytes; i++)
-    res->str[i] = toupper(res->str[i]);
-  return res;
+    $bytearray res;
+    NEW_UNFILLED_BYTEARRAY(res, s->nbytes);
+    for (int i = 0; i < s->nbytes; i++)
+        res->str[i] = toupper(res->str[i]);
+    return res;
 }
 
 $bytearray $bytearray_zfill($bytearray s, $int width) {
-  int fill = width->val - s->nbytes;
-  if (fill < 0)
-    return $bytearray_copy(s);
-  $bytearray res;
-  NEW_UNFILLED_BYTEARRAY(res,width->val);
-  unsigned char *p = s->str;
-  unsigned char *q = res->str;
-  int hassign = (*p=='+' | *p=='-');
-  if (hassign) {
-    *q = *p;
-    q++;
-  }
-  for (int i=0; i < fill; i++) 
-    *q++ = '0';
-  memcpy(res->str+hassign+fill,s->str+hassign,s->nbytes-hassign);
-  return res;
+    int fill = width->val - s->nbytes;
+    if (fill < 0)
+        return $bytearray_copy(s);
+    $bytearray res;
+    NEW_UNFILLED_BYTEARRAY(res, width->val);
+    unsigned char *p = s->str;
+    unsigned char *q = res->str;
+    int hassign = (*p == '+' | *p == '-');
+    if (hassign) {
+        *q = *p;
+        q++;
+    }
+    for (int i = 0; i < fill; i++)
+        *q++ = '0';
+    memcpy(res->str + hassign + fill, s->str + hassign, s->nbytes - hassign);
+    return res;
 }
 
 // Protocol methods, prototypes for bytearrays
 
-
-int $bytearray_eq($bytearray,$bytearray);
-int $bytearray_neq($bytearray,$bytearray);
-int $bytearray_lt($bytearray,$bytearray);
-int $bytearray_le($bytearray,$bytearray);
-int $bytearray_gt($bytearray,$bytearray);
-int $bytearray_ge($bytearray,$bytearray);
+int $bytearray_eq($bytearray, $bytearray);
+int $bytearray_neq($bytearray, $bytearray);
+int $bytearray_lt($bytearray, $bytearray);
+int $bytearray_le($bytearray, $bytearray);
+int $bytearray_gt($bytearray, $bytearray);
+int $bytearray_ge($bytearray, $bytearray);
 
 $int $bytearray_getitem($bytearray, int);
 void $bytearray_setitem($bytearray, int, int);
@@ -2228,14 +2220,10 @@ $int $bytearray_len($bytearray str);
 $bytearray $bytearray_add($bytearray, $bytearray);
 $bytearray $bytearray_mul($bytearray, $int);
 
-int $bytearray_contains ($bytearray, $int);
-int $bytearray_containsnot ($bytearray, $int);
+int $bytearray_contains($bytearray, $int);
+int $bytearray_containsnot($bytearray, $int);
 
-
-
-
-// Protocol instances, using above prototypes 
-
+// Protocol instances, using above prototypes
 
 // Ord
 
@@ -2243,36 +2231,36 @@ void $Ord$bytearray$__serialize__($Ord$bytearray self, $Serial$state state) {
 }
 
 $Ord$bytearray $Ord$bytearray$__deserialize__($Ord$bytearray self, $Serial$state state) {
-   $Ord$bytearray res = $DNEW($Ord$bytearray,state);
-   return res;
+    $Ord$bytearray res = $DNEW($Ord$bytearray, state);
+    return res;
 }
 
 $Ord$bytearray $Ord$bytearray$new() {
-  return $NEW($Ord$bytearray);
+    return $NEW($Ord$bytearray);
 }
 
-$bool $Ord$bytearray$__eq__ ($Ord$bytearray wit, $bytearray a, $bytearray b) {
-  return to$bool($bytearray_eq(a,b));
+$bool $Ord$bytearray$__eq__($Ord$bytearray wit, $bytearray a, $bytearray b) {
+    return to$bool($bytearray_eq(a, b));
 }
 
-$bool $Ord$bytearray$__ne__ ($Ord$bytearray wit, $bytearray a, $bytearray b) {
-  return  to$bool($bytearray_neq(a,b));
+$bool $Ord$bytearray$__ne__($Ord$bytearray wit, $bytearray a, $bytearray b) {
+    return to$bool($bytearray_neq(a, b));
 }
 
-$bool $Ord$bytearray$__lt__ ($Ord$bytearray wit, $bytearray a, $bytearray b) {
-  return to$bool($bytearray_lt(a,b));
+$bool $Ord$bytearray$__lt__($Ord$bytearray wit, $bytearray a, $bytearray b) {
+    return to$bool($bytearray_lt(a, b));
 }
 
-$bool $Ord$bytearray$__le__ ($Ord$bytearray wit, $bytearray a, $bytearray b){
-  return to$bool($bytearray_le(a,b));
+$bool $Ord$bytearray$__le__($Ord$bytearray wit, $bytearray a, $bytearray b) {
+    return to$bool($bytearray_le(a, b));
 }
 
-$bool $Ord$bytearray$__gt__ ($Ord$bytearray wit, $bytearray a, $bytearray b){
-  return to$bool($bytearray_gt(a,b));
+$bool $Ord$bytearray$__gt__($Ord$bytearray wit, $bytearray a, $bytearray b) {
+    return to$bool($bytearray_gt(a, b));
 }
 
-$bool $Ord$bytearray$__ge__ ($Ord$bytearray wit, $bytearray a, $bytearray b){
-  return to$bool($bytearray_ge(a,b));
+$bool $Ord$bytearray$__ge__($Ord$bytearray wit, $bytearray a, $bytearray b) {
+    return to$bool($bytearray_ge(a, b));
 }
 
 // Sequence
@@ -2283,166 +2271,162 @@ void $Sequence$bytearray$__serialize__($Sequence$bytearray self, $Serial$state s
 }
 
 $Sequence$bytearray $Sequence$bytearray$__deserialize__($Sequence$bytearray self, $Serial$state state) {
-   $Sequence$bytearray res = $DNEW($Sequence$bytearray,state);
-   res->w$Collection = ($Collection)$step_deserialize(state);
-   res->w$Times = ($Times)$step_deserialize(state);
-   return res;
+    $Sequence$bytearray res = $DNEW($Sequence$bytearray, state);
+    res->w$Collection = ($Collection)$step_deserialize(state);
+    res->w$Times = ($Times)$step_deserialize(state);
+    return res;
 }
 
 $Sequence$bytearray $Sequence$bytearray$new() {
-  return $NEW($Sequence$bytearray);
+    return $NEW($Sequence$bytearray);
 }
 
-$int $Sequence$bytearray$__getitem__ ($Sequence$bytearray wit, $bytearray self, $int ix) {
-  return $bytearray_getitem(self,from$int(ix));
+$int $Sequence$bytearray$__getitem__($Sequence$bytearray wit, $bytearray self, $int ix) {
+    return $bytearray_getitem(self, from$int(ix));
 }
 
-void $Sequence$bytearray$__setitem__ ($Sequence$bytearray wit, $bytearray self, $int ix, $int val) {
-  $bytearray_setitem(self,from$int(ix),from$int(val));
+void $Sequence$bytearray$__setitem__($Sequence$bytearray wit, $bytearray self, $int ix, $int val) {
+    $bytearray_setitem(self, from$int(ix), from$int(val));
 }
 
-void $Sequence$bytearray$__delitem__ ($Sequence$bytearray wit, $bytearray self, $int ix) {
-  $bytearray_delitem(self,from$int(ix));
+void $Sequence$bytearray$__delitem__($Sequence$bytearray wit, $bytearray self, $int ix) {
+    $bytearray_delitem(self, from$int(ix));
 }
 
-$bytearray $Sequence$bytearray$__getslice__ ($Sequence$bytearray wit, $bytearray self, $slice slc) {
-  return $bytearray_getslice(self,slc);
+$bytearray $Sequence$bytearray$__getslice__($Sequence$bytearray wit, $bytearray self, $slice slc) {
+    return $bytearray_getslice(self, slc);
 }
 
-void $Sequence$bytearray$__setslice__ ($Sequence$bytearray wit,  $bytearray self, $Iterable wit2, $slice slc, $WORD iter) {
-  $bytearray_setslice(self,slc,wit2->$class->__iter__(wit2,iter));
+void $Sequence$bytearray$__setslice__($Sequence$bytearray wit, $bytearray self, $Iterable wit2, $slice slc, $WORD iter) {
+    $bytearray_setslice(self, slc, wit2->$class->__iter__(wit2, iter));
 }
 
-void $Sequence$bytearray$__delslice__ ($Sequence$bytearray wit, $bytearray self, $slice slc) {
-  $bytearray_delslice(self,slc);
+void $Sequence$bytearray$__delslice__($Sequence$bytearray wit, $bytearray self, $slice slc) {
+    $bytearray_delslice(self, slc);
 }
 
 $Iterator $Sequence$bytearray$__reversed__($Sequence$bytearray wit, $bytearray self) {
-  return $bytearray_reversed(self);
+    return $bytearray_reversed(self);
 }
 
 void $Sequence$bytearray$insert($Sequence$bytearray wit, $bytearray self, $int ix, $int val) {
-  $bytearray_insert(self, ix->val, val);
+    $bytearray_insert(self, ix->val, val);
 }
 
 void $Sequence$bytearray$append($Sequence$bytearray wit, $bytearray self, $int val) {
-  $bytearray_append(self, val);
+    $bytearray_append(self, val);
 }
 
 void $Sequence$bytearray$reverse($Sequence$bytearray wit, $bytearray self) {
-  $bytearray_reverse(self);
+    $bytearray_reverse(self);
 }
-
 
 // Collection
 
 void $Collection$bytearray$__serialize__($Collection$bytearray self, $Serial$state state) {
-  $step_serialize(self->w$Sequence, state);
+    $step_serialize(self->w$Sequence, state);
 }
 
 $Collection$bytearray $Collection$bytearray$__deserialize__($Collection$bytearray self, $Serial$state state) {
-   $Collection$bytearray res = $DNEW($Collection$bytearray,state);
-   res->w$Sequence = ($Sequence)$step_deserialize(state);
-   return res;
+    $Collection$bytearray res = $DNEW($Collection$bytearray, state);
+    res->w$Sequence = ($Sequence)$step_deserialize(state);
+    return res;
 }
 
 $Collection$bytearray $Collection$bytearray$new($Sequence wit) {
-  return $NEW($Collection$bytearray,wit);
+    return $NEW($Collection$bytearray, wit);
 }
 
-$Iterator $Collection$bytearray$__iter__ ($Collection$bytearray wit, $bytearray str) {
-  return $bytearray_iter(str);
+$Iterator $Collection$bytearray$__iter__($Collection$bytearray wit, $bytearray str) {
+    return $bytearray_iter(str);
 }
 
-$bytearray $Collection$bytearray$__fromiter__ ($Collection$bytearray wit, $Iterable wit2, $WORD iter) {
-  return $bytearray_join(to$bytearray(""),wit2,iter);
+$bytearray $Collection$bytearray$__fromiter__($Collection$bytearray wit, $Iterable wit2, $WORD iter) {
+    return $bytearray_join(to$bytearray(""), wit2, iter);
 }
 
-$int $Collection$bytearray$__len__ ($Collection$bytearray wit, $bytearray str) {
-  return $bytearray_len(str);
+$int $Collection$bytearray$__len__($Collection$bytearray wit, $bytearray str) {
+    return $bytearray_len(str);
 }
 
 // Times
 
 void $Times$bytearray$__serialize__($Times$bytearray self, $Serial$state state) {
-  $step_serialize(self->w$Sequence, state);
+    $step_serialize(self->w$Sequence, state);
 }
 
 $Times$bytearray $Times$bytearray$__deserialize__($Times$bytearray self, $Serial$state state) {
-   $Times$bytearray res = $DNEW($Times$bytearray,state);
-   res->w$Sequence = ($Sequence)$step_deserialize(state);
-   return res;
+    $Times$bytearray res = $DNEW($Times$bytearray, state);
+    res->w$Sequence = ($Sequence)$step_deserialize(state);
+    return res;
 }
 
 $Times$bytearray $Times$bytearray$new($Sequence wit) {
-  return $NEW($Times$bytearray,wit);
+    return $NEW($Times$bytearray, wit);
 }
 
-$bytearray $Times$bytearray$__add__ ($Times$bytearray wit, $bytearray a, $bytearray b) {
-  return $bytearray_add(a,b);
+$bytearray $Times$bytearray$__add__($Times$bytearray wit, $bytearray a, $bytearray b) {
+    return $bytearray_add(a, b);
 }
 
-$bytearray $Times$bytearray$__mul__ ($Times$bytearray wit, $bytearray a, $int n) {
-  return $bytearray_mul(a,n);
+$bytearray $Times$bytearray$__mul__($Times$bytearray wit, $bytearray a, $int n) {
+    return $bytearray_mul(a, n);
 }
 
 // Container
 
 void $Container$bytearray$__serialize__($Container$bytearray self, $Serial$state state) {
-  $step_serialize(self->w$Eq$A$Container$bytearray, state);
+    $step_serialize(self->w$Eq$A$Container$bytearray, state);
 }
 
 $Container$bytearray $Container$bytearray$__deserialize__($Container$bytearray self, $Serial$state state) {
-   $Container$bytearray res = $DNEW($Container$bytearray,state);
-   res->w$Eq$A$Container$bytearray = ($Eq)$step_deserialize(state);
-   return res;
+    $Container$bytearray res = $DNEW($Container$bytearray, state);
+    res->w$Eq$A$Container$bytearray = ($Eq)$step_deserialize(state);
+    return res;
 }
 
 $Container$bytearray $Container$bytearray$new($Eq wit) {
-  return $NEW($Container$bytearray, wit);
+    return $NEW($Container$bytearray, wit);
 }
 
-$Iterator $Container$bytearray$__iter__ ($Container$bytearray wit, $bytearray str) {
-  return $bytearray_iter(str);
+$Iterator $Container$bytearray$__iter__($Container$bytearray wit, $bytearray str) {
+    return $bytearray_iter(str);
 }
 
-$bytearray $Container$bytearray$__fromiter__ ($Container$bytearray wit, $Iterable wit2, $WORD iter) {
-  return $bytearray_join(to$bytearray(""),wit2,iter);
+$bytearray $Container$bytearray$__fromiter__($Container$bytearray wit, $Iterable wit2, $WORD iter) {
+    return $bytearray_join(to$bytearray(""), wit2, iter);
 }
 
-$int $Container$bytearray$__len__ ($Container$bytearray wit, $bytearray str) {
-  return $bytearray_len(str);
+$int $Container$bytearray$__len__($Container$bytearray wit, $bytearray str) {
+    return $bytearray_len(str);
 }
 
 $bool $Container$bytearray$__contains__($Container$bytearray wit, $bytearray self, $int n) {
-  return to$bool($bytearray_contains(self,n));
+    return to$bool($bytearray_contains(self, n));
 }
 
 $bool $Container$bytearray$__containsnot__($Container$bytearray wit, $bytearray self, $int n) {
-  return  to$bool(!$bytearray_contains(self,n));
+    return to$bool(!$bytearray_contains(self, n));
 }
-
 
 // Method tables for witness classes
 
-struct $Sequence$bytearray  $Sequence$bytearray_instance;
+struct $Sequence$bytearray $Sequence$bytearray_instance;
 struct $Collection$bytearray $Collection$bytearray_instance;
 struct $Times$bytearray $Times$bytearray_instance;
 
-
-struct $Ord$bytearray$class  $Ord$bytearray$methods = {
+struct $Ord$bytearray$class $Ord$bytearray$methods = {
     "$Ord$bytearray",
     UNASSIGNED,
     ($Super$class)&$Ord$methods,
     (void (*)($Ord$bytearray))$default__init__,
     $Ord$bytearray$__serialize__,
     $Ord$bytearray$__deserialize__,
-    ($bool (*)($Ord$bytearray))$default__bool__,
-    ($str (*)($Ord$bytearray))$default__str__,
+    ($bool(*)($Ord$bytearray))$default__bool__,
+    ($str(*)($Ord$bytearray))$default__str__,
     $Ord$bytearray$__eq__, $Ord$bytearray$__ne__,
     $Ord$bytearray$__lt__, $Ord$bytearray$__le__,
-    $Ord$bytearray$__gt__, $Ord$bytearray$__ge__
-};
+    $Ord$bytearray$__gt__, $Ord$bytearray$__ge__};
 struct $Ord$bytearray $Ord$bytearray_instance = {&$Ord$bytearray$methods};
 $Ord$bytearray $Ord$bytearray$witness = &$Ord$bytearray_instance;
 
@@ -2453,8 +2437,8 @@ struct $Sequence$bytearray$class $Sequence$bytearray$methods = {
     $Sequence$bytearray$__init__,
     $Sequence$bytearray$__serialize__,
     $Sequence$bytearray$__deserialize__,
-    ($bool (*)($Sequence$bytearray))$default__bool__,
-    ($str (*)($Sequence$bytearray))$default__str__,
+    ($bool(*)($Sequence$bytearray))$default__bool__,
+    ($str(*)($Sequence$bytearray))$default__str__,
     $Sequence$bytearray$__getitem__,
     $Sequence$bytearray$__setitem__,
     $Sequence$bytearray$__delitem__,
@@ -2464,13 +2448,11 @@ struct $Sequence$bytearray$class $Sequence$bytearray$methods = {
     $Sequence$bytearray$__reversed__,
     $Sequence$bytearray$insert,
     $Sequence$bytearray$append,
-    $Sequence$bytearray$reverse
-};
+    $Sequence$bytearray$reverse};
 struct $Sequence$bytearray $Sequence$bytearray_instance = {
     &$Sequence$bytearray$methods,
     ($Collection)&$Collection$bytearray_instance,
-    ($Times)&$Times$bytearray_instance
-};
+    ($Times)&$Times$bytearray_instance};
 $Sequence$bytearray $Sequence$bytearray$witness = &$Sequence$bytearray_instance;
 
 struct $Collection$bytearray$class $Collection$bytearray$methods = {
@@ -2480,28 +2462,27 @@ struct $Collection$bytearray$class $Collection$bytearray$methods = {
     $Collection$bytearray$__init__,
     $Collection$bytearray$__serialize__,
     $Collection$bytearray$__deserialize__,
-    ($bool (*)($Collection$bytearray))$default__bool__,
-    ($str (*)($Collection$bytearray))$default__str__,
+    ($bool(*)($Collection$bytearray))$default__bool__,
+    ($str(*)($Collection$bytearray))$default__str__,
     $Collection$bytearray$__iter__,
     $Collection$bytearray$__fromiter__,
-    $Collection$bytearray$__len__
-};
-struct $Collection$bytearray $Collection$bytearray_instance = {&$Collection$bytearray$methods,($Sequence)&$Sequence$bytearray_instance};
+    $Collection$bytearray$__len__};
+struct $Collection$bytearray $Collection$bytearray_instance = {&$Collection$bytearray$methods, ($Sequence)&$Sequence$bytearray_instance};
 $Collection$bytearray $Collection$bytearray$witness = &$Collection$bytearray_instance;
 
-struct $Times$bytearray$class  $Times$bytearray$methods = {
+struct $Times$bytearray$class $Times$bytearray$methods = {
     "$Times$bytearray",
     UNASSIGNED,
     ($Super$class)&$Times$methods,
     $Times$bytearray$__init__,
     $Times$bytearray$__serialize__,
     $Times$bytearray$__deserialize__,
-    ($bool (*)($Times$bytearray))$default__bool__,
-    ($str (*)($Times$bytearray))$default__str__,
+    ($bool(*)($Times$bytearray))$default__bool__,
+    ($str(*)($Times$bytearray))$default__str__,
     $Times$bytearray$__add__,
-    ($bytearray (*)($Times$bytearray, $bytearray, $bytearray))$Plus$__iadd__,
+    ($bytearray(*)($Times$bytearray, $bytearray, $bytearray))$Plus$__iadd__,
     $Times$bytearray$__mul__,
-    ($bytearray (*)($Times$bytearray, $bytearray, $int))$Times$__imul__,
+    ($bytearray(*)($Times$bytearray, $bytearray, $int))$Times$__imul__,
 };
 struct $Times$bytearray $Times$bytearray_instance = {&$Times$bytearray$methods};
 $Times$bytearray $Times$bytearray$witness = &$Times$bytearray_instance;
@@ -2513,233 +2494,232 @@ struct $Container$bytearray$class $Container$bytearray$methods = {
     $Container$bytearray$__init__,
     $Container$bytearray$__serialize__,
     $Container$bytearray$__deserialize__,
-    ($bool (*)($Container$bytearray))$default__bool__,
-    ($str (*)($Container$bytearray))$default__str__,
+    ($bool(*)($Container$bytearray))$default__bool__,
+    ($str(*)($Container$bytearray))$default__str__,
     $Container$bytearray$__iter__,
     $Container$bytearray$__len__,
     $Container$bytearray$__contains__,
-    $Container$bytearray$__containsnot__
-};
-struct $Container$bytearray $Container$bytearray_instance = {&$Container$bytearray$methods,($Eq)&$Ord$bytearray_instance};
+    $Container$bytearray$__containsnot__};
+struct $Container$bytearray $Container$bytearray_instance = {&$Container$bytearray$methods, ($Eq)&$Ord$bytearray_instance};
 $Container$bytearray $Container$bytearray$witness = &$Container$bytearray_instance;
 
 // init methods for witness classes
 
 void $Collection$bytearray$__init__($Collection$bytearray self, $Sequence master) {
-  self->w$Sequence = master;
+    self->w$Sequence = master;
 }
 
 void $Times$bytearray$__init__($Times$bytearray self, $Sequence master) {
-  self->w$Sequence = master;
+    self->w$Sequence = master;
 }
 
 void $Sequence$bytearray$__init__($Sequence$bytearray self) {
-  self->w$Collection = ($Collection)$NEW($Collection$bytearray, ($Sequence)self);
-  self->w$Times = ($Times)$NEW($Times$bytearray, ($Sequence)self);
+    self->w$Collection = ($Collection)$NEW($Collection$bytearray, ($Sequence)self);
+    self->w$Times = ($Times)$NEW($Times$bytearray, ($Sequence)self);
 }
 
-void $Container$bytearray$__init__ ($Container$bytearray wit, $Eq w$Eq$A$Container$bytearray) {
-  wit->w$Eq$A$Container$bytearray = w$Eq$A$Container$bytearray;
+void $Container$bytearray$__init__($Container$bytearray wit, $Eq w$Eq$A$Container$bytearray) {
+    wit->w$Eq$A$Container$bytearray = w$Eq$A$Container$bytearray;
 }
-
 
 // protocol methods for bytearrays, implementations
 
 // Eq
 
-int $bytearray_eq($bytearray a,$bytearray b) {
-  return strcmp((char *)a->str,(char *)b->str)==0;
+int $bytearray_eq($bytearray a, $bytearray b) {
+    return strcmp((char *)a->str, (char *)b->str) == 0;
 }
 
-int $bytearray_neq($bytearray a,$bytearray b) {
-  return strcmp((char *)a->str,(char *)b->str)!=0;
+int $bytearray_neq($bytearray a, $bytearray b) {
+    return strcmp((char *)a->str, (char *)b->str) != 0;
 }
 
 // Ord
 
-int $bytearray_lt($bytearray a,$bytearray b) {
-  return strcmp((char *)a->str,(char *)b->str)<0;
-}
- 
-int $bytearray_le($bytearray a,$bytearray b) {
-  return strcmp((char *)a->str,(char *)b->str)<=0;
+int $bytearray_lt($bytearray a, $bytearray b) {
+    return strcmp((char *)a->str, (char *)b->str) < 0;
 }
 
-int $bytearray_gt($bytearray a,$bytearray b) {
-  return strcmp((char *)a->str,(char *)b->str)>0;
+int $bytearray_le($bytearray a, $bytearray b) {
+    return strcmp((char *)a->str, (char *)b->str) <= 0;
 }
 
-int $bytearray_ge($bytearray a,$bytearray b) {
-  return strcmp((char *)a->str,(char *)b->str)>=0;
+int $bytearray_gt($bytearray a, $bytearray b) {
+    return strcmp((char *)a->str, (char *)b->str) > 0;
+}
+
+int $bytearray_ge($bytearray a, $bytearray b) {
+    return strcmp((char *)a->str, (char *)b->str) >= 0;
 }
 
 // Indexed
 
 $int $bytearray_getitem($bytearray self, int ix) {
-  int ix0 = ix < 0 ? self->nbytes + ix : ix;
-  if (ix0<0 || ix0 >= self->nbytes)
-    $RAISE(($BaseException)$NEW($IndexError,to$str("getitem for bytearray: indexing outside array")));
-  return to$int((long)self->str[ix0]);
+    int ix0 = ix < 0 ? self->nbytes + ix : ix;
+    if (ix0 < 0 || ix0 >= self->nbytes)
+        $RAISE(($BaseException)$NEW($IndexError, to$str("getitem for bytearray: indexing outside array")));
+    return to$int((long)self->str[ix0]);
 }
-    
+
 void $bytearray_setitem($bytearray self, int ix, int val) {
-  int ix0 = ix < 0 ? self->nbytes + ix : ix;
-  if (ix0<0 || ix0 >= self->nbytes)
-    $RAISE(($BaseException)$NEW($IndexError,to$str("setitem for bytearray: indexing outside array")));
-  if (val<0 || val>255)
-    $RAISE(($BaseException)$NEW($ValueError,to$str("setitem for bytearray: value outside [0..255]")));
-  self->str[ix0] = (unsigned char)val;
+    int ix0 = ix < 0 ? self->nbytes + ix : ix;
+    if (ix0 < 0 || ix0 >= self->nbytes)
+        $RAISE(($BaseException)$NEW($IndexError, to$str("setitem for bytearray: indexing outside array")));
+    if (val < 0 || val > 255)
+        $RAISE(($BaseException)$NEW($ValueError, to$str("setitem for bytearray: value outside [0..255]")));
+    self->str[ix0] = (unsigned char)val;
 }
-  
+
 void $bytearray_delitem($bytearray self, int ix) {
-  int len = self->nbytes;
-  int ix0 = ix < 0 ? len + ix : ix;
-  if (ix0 < 0 || ix0 >= len)
-    $RAISE(($BaseException)$NEW($IndexError,to$str("delitem for bytearray: indexing outside array")));
-  memmove(self->str + ix0,self->str + (ix0 + 1),len-(ix0+1));
-  self->nbytes--;
+    int len = self->nbytes;
+    int ix0 = ix < 0 ? len + ix : ix;
+    if (ix0 < 0 || ix0 >= len)
+        $RAISE(($BaseException)$NEW($IndexError, to$str("delitem for bytearray: indexing outside array")));
+    memmove(self->str + ix0, self->str + (ix0 + 1), len - (ix0 + 1));
+    self->nbytes--;
 }
 
 // Sliceable
 
 $bytearray $bytearray_getslice($bytearray self, $slice slc) {
-  int len = self->nbytes;
-  int start, stop, step, slen;
-  normalize_slice(slc, len, &slen, &start, &stop, &step);
-  $bytearray res;
-  NEW_UNFILLED_BYTEARRAY(res,slen);
-  int t = start;
-  for (int i=0; i<slen; i++) {
-    $int w;
-    w = $bytearray_getitem(self,t);
-    $bytearray_append(res,w);
-    t += step;
-  }
-  return res;
+    int len = self->nbytes;
+    int start, stop, step, slen;
+    normalize_slice(slc, len, &slen, &start, &stop, &step);
+    $bytearray res;
+    NEW_UNFILLED_BYTEARRAY(res, slen);
+    int t = start;
+    for (int i = 0; i < slen; i++) {
+        $int w;
+        w = $bytearray_getitem(self, t);
+        $bytearray_append(res, w);
+        t += step;
+    }
+    return res;
 }
 
 void $bytearray_setslice($bytearray self, $slice slc, $Iterator it) {
-  int len = self->nbytes;
-  $bytearray other;
-  NEW_UNFILLED_BYTEARRAY(other,0);
-  $WORD w;
-  while ((w=it->$class->__next__(it)))
-    $bytearray_append(other,($int)w);
-  int olen = other->nbytes; 
-  int start, stop, step, slen;
-  normalize_slice(slc, len, &slen, &start, &stop, &step);
-  if (step != 1 && olen != slen) {
-    $RAISE(($BaseException)$NEW($ValueError,to$str("setslice for bytearray: illegal slice")));
-  }
-  int copy = olen <= slen ? olen : slen;
-  int t = start;
-  for (int i= 0; i<copy; i++) {
-    self->str[t] = other->str[i];
-    t += step;
-  }
-  if (olen == slen)
-    return;
-  // now we know that step=1
-  if (olen < slen) {
-    memmove(self->str + start + copy,
-            self->str + start + slen,
-            len-(start+slen));
-     self->nbytes-=slen-olen;
-     return;
-  } else {
-    expand_bytearray(self,olen-slen);
-    int rest = len - (start+copy);
-    int incr = olen - slen;
-    memmove(self->str + start + copy + incr,
-            self->str + start + copy,
-            rest);
-    for (int i = copy; i < olen; i++)
-      self->str[start+i] = other->str[i];
-    self->nbytes += incr;
-  }
+    int len = self->nbytes;
+    $bytearray other;
+    NEW_UNFILLED_BYTEARRAY(other, 0);
+    $WORD w;
+    while ((w = it->$class->__next__(it)))
+        $bytearray_append(other, ($int)w);
+    int olen = other->nbytes;
+    int start, stop, step, slen;
+    normalize_slice(slc, len, &slen, &start, &stop, &step);
+    if (step != 1 && olen != slen) {
+        $RAISE(($BaseException)$NEW($ValueError, to$str("setslice for bytearray: illegal slice")));
+    }
+    int copy = olen <= slen ? olen : slen;
+    int t = start;
+    for (int i = 0; i < copy; i++) {
+        self->str[t] = other->str[i];
+        t += step;
+    }
+    if (olen == slen)
+        return;
+    // now we know that step=1
+    if (olen < slen) {
+        memmove(self->str + start + copy,
+                self->str + start + slen,
+                len - (start + slen));
+        self->nbytes -= slen - olen;
+        return;
+    } else {
+        expand_bytearray(self, olen - slen);
+        int rest = len - (start + copy);
+        int incr = olen - slen;
+        memmove(self->str + start + copy + incr,
+                self->str + start + copy,
+                rest);
+        for (int i = copy; i < olen; i++)
+            self->str[start + i] = other->str[i];
+        self->nbytes += incr;
+    }
 }
 
 void $bytearray_delslice($bytearray self, $slice slc) {
-  int len = self->nbytes;
-  int start, stop, step, slen;
-  normalize_slice(slc, len, &slen, &start, &stop, &step);
-  if (slen==0) return;
-  unsigned char *p = self->str + start;
-  for (int i=0; i<slen-1; i++) {
-    memmove(p,p+i+1,step-1);
-    p+=step-1;
-  }
-  memmove(p,p+slen,len-1-(start+step*(slen-1)));
-  self->nbytes-=slen;
-  self->str[self->nbytes] = '\0';
+    int len = self->nbytes;
+    int start, stop, step, slen;
+    normalize_slice(slc, len, &slen, &start, &stop, &step);
+    if (slen == 0)
+        return;
+    unsigned char *p = self->str + start;
+    for (int i = 0; i < slen - 1; i++) {
+        memmove(p, p + i + 1, step - 1);
+        p += step - 1;
+    }
+    memmove(p, p + slen, len - 1 - (start + step * (slen - 1)));
+    self->nbytes -= slen;
+    self->str[self->nbytes] = '\0';
 }
 
 // Sequence
 
 $Iterator $bytearray_reversed($bytearray self) {
-  $bytearray copy = $bytearray_copy(self);
-  $bytearray_reverse(copy);
-  return $bytearray_iter(copy);
+    $bytearray copy = $bytearray_copy(self);
+    $bytearray_reverse(copy);
+    return $bytearray_iter(copy);
 }
 
 void $bytearray_insert($bytearray self, int ix, $int elem) {
-  int len = self->nbytes;
-  expand_bytearray(self,1);
-  int ix0 = ix < 0 ? (len+ix < 0 ? 0 : len+ix) : (ix < len ? ix : len);
-  memmove(self->str + (ix0 + 1),
-          self->str + ix0 ,
-          len - ix0 + 1); // +1 to move also terminating '\0'
-  self->str[ix0] = (unsigned char)elem->val & 0xff;
-  self->nbytes++;
+    int len = self->nbytes;
+    expand_bytearray(self, 1);
+    int ix0 = ix < 0 ? (len + ix < 0 ? 0 : len + ix) : (ix < len ? ix : len);
+    memmove(self->str + (ix0 + 1),
+            self->str + ix0,
+            len - ix0 + 1); // +1 to move also terminating '\0'
+    self->str[ix0] = (unsigned char)elem->val & 0xff;
+    self->nbytes++;
 }
 
 void $bytearray_append($bytearray self, $int elem) {
-  expand_bytearray(self,1);
-  self->str[self->nbytes++] = (unsigned char)elem->val & 0xff;
-  self->str[self->nbytes] = '\0';
+    expand_bytearray(self, 1);
+    self->str[self->nbytes++] = (unsigned char)elem->val & 0xff;
+    self->str[self->nbytes] = '\0';
 }
 
 void $bytearray_reverse($bytearray self) {
-  int len = self->nbytes;
-  for (int i = 0; i < len/2; i++) {
-    unsigned char tmp = self->str[i];
-    self->str[i] = self->str[len-1-i];
-    self->str[len-1-i] = tmp;
-  }
+    int len = self->nbytes;
+    for (int i = 0; i < len / 2; i++) {
+        unsigned char tmp = self->str[i];
+        self->str[i] = self->str[len - 1 - i];
+        self->str[len - 1 - i] = tmp;
+    }
 }
 
 // Iterable
 
 static $int $Iterator$bytearray_next($Iterator$bytearray self) {
-  return self->nxt >= self->src->nbytes ? NULL : to$int(self->src->str[self->nxt++]);
+    return self->nxt >= self->src->nbytes ? NULL : to$int(self->src->str[self->nxt++]);
 }
 
 void $Iterator$bytearray_init($Iterator$bytearray self, $bytearray b) {
-  self->src = b;
-  self->nxt = 0;
+    self->src = b;
+    self->nxt = 0;
 }
 
 $bool $Iterator$bytearray_bool($Iterator$bytearray self) {
-  return $True;
+    return $True;
 }
 
 $str $Iterator$bytearray_str($Iterator$bytearray self) {
-  char *s;
-  asprintf(&s,"<bytearray iterator object at %p>",self);
-  return to$str(s);
+    char *s;
+    asprintf(&s, "<bytearray iterator object at %p>", self);
+    return to$str(s);
 }
 
-void $Iterator$bytearray_serialize($Iterator$bytearray self,$Serial$state state) {
-  $step_serialize(self->src,state);
-  $step_serialize(to$int(self->nxt),state);
+void $Iterator$bytearray_serialize($Iterator$bytearray self, $Serial$state state) {
+    $step_serialize(self->src, state);
+    $step_serialize(to$int(self->nxt), state);
 }
 
 $Iterator$bytearray $Iterator$bytearray$_deserialize($Iterator$bytearray res, $Serial$state state) {
-   if(!res)
-      res = $DNEW($Iterator$bytearray,state);
-   res->src = ($bytearray)$step_deserialize(state);
-   res->nxt = from$int(($int)$step_deserialize(state));
-   return res;
+    if (!res)
+        res = $DNEW($Iterator$bytearray, state);
+    res->src = ($bytearray)$step_deserialize(state);
+    res->nxt = from$int(($int)$step_deserialize(state));
+    return res;
 }
 
 struct $Iterator$bytearray$class $Iterator$bytearray$methods = {
@@ -2751,352 +2731,378 @@ struct $Iterator$bytearray$class $Iterator$bytearray$methods = {
     $Iterator$bytearray$_deserialize,
     $Iterator$bytearray_bool,
     $Iterator$bytearray_str,
-    $Iterator$bytearray_next
-};
+    $Iterator$bytearray_next};
 
 $Iterator $bytearray_iter($bytearray self) {
-  return ($Iterator)$NEW($Iterator$bytearray,self);
+    return ($Iterator)$NEW($Iterator$bytearray, self);
 }
 
 // Collection
-  
+
 $bytearray $bytearray_fromiter($Iterable wit, $WORD iter) {
-  $bytearray res;
-  NEW_UNFILLED_BYTEARRAY(res,0);
-  $Iterator it = wit->$class->__iter__(wit,iter);
-  $WORD nxt;
-  while ((nxt = it->$class->__next__(it))) {
-    $bytearray_append(res,($int)nxt);
-  }
-  return res;
+    $bytearray res;
+    NEW_UNFILLED_BYTEARRAY(res, 0);
+    $Iterator it = wit->$class->__iter__(wit, iter);
+    $WORD nxt;
+    while ((nxt = it->$class->__next__(it))) {
+        $bytearray_append(res, ($int)nxt);
+    }
+    return res;
 }
 
 $int $bytearray_len($bytearray self) {
-  return to$int(self->nbytes);
+    return to$int(self->nbytes);
 }
 
 // Times
- 
+
 $bytearray $bytearray_add($bytearray a, $bytearray b) {
-  $bytearray res;
-  NEW_UNFILLED_BYTEARRAY(res,a->nbytes+b->nbytes);
-  memcpy(res->str,a->str,a->nbytes);
-  memcpy(res->str+a->nbytes,b->str,b->nbytes);
-  return res;
+    $bytearray res;
+    NEW_UNFILLED_BYTEARRAY(res, a->nbytes + b->nbytes);
+    memcpy(res->str, a->str, a->nbytes);
+    memcpy(res->str + a->nbytes, b->str, b->nbytes);
+    return res;
 }
 
-$bytearray $bytearray_mul ($bytearray a, $int n) {
-  if (n->val <= 0)
-    return to$bytearray("");
-  else {
-      $bytearray res;
-      NEW_UNFILLED_BYTEARRAY(res, a->nbytes * n->val);
-      for (int i=0; i<n->val; i++)
-        memcpy(res->str + i*a->nbytes,a->str,a->nbytes);
-      return res;
-  }
+$bytearray $bytearray_mul($bytearray a, $int n) {
+    if (n->val <= 0)
+        return to$bytearray("");
+    else {
+        $bytearray res;
+        NEW_UNFILLED_BYTEARRAY(res, a->nbytes * n->val);
+        for (int i = 0; i < n->val; i++)
+            memcpy(res->str + i * a->nbytes, a->str, a->nbytes);
+        return res;
+    }
 }
 // Container
- 
-int $bytearray_contains ($bytearray self, $int c) {
-    for (int i=0; i < self->nbytes; i++) {
-      if (self->str[i] == (unsigned char)c->val)
-        return 1;
-  }
-  return 0;
+
+int $bytearray_contains($bytearray self, $int c) {
+    for (int i = 0; i < self->nbytes; i++) {
+        if (self->str[i] == (unsigned char)c->val)
+            return 1;
+    }
+    return 0;
 }
 
-int $bytearray_containsnot ($bytearray self, $int c) {
-  return !$bytearray_contains(self,c);
+int $bytearray_containsnot($bytearray self, $int c) {
+    return !$bytearray_contains(self, c);
 }
-
 
 // General methods, implementations
 
 void $bytearray_init($bytearray, $value);
-void $bytearray_serialize($bytearray,$Serial$state);
-$bytearray $bytearray_deserialize($bytearray,$Serial$state);
+void $bytearray_serialize($bytearray, $Serial$state);
+$bytearray $bytearray_deserialize($bytearray, $Serial$state);
 $bool $bytearray_bool($bytearray);
 $str $bytearray_str($bytearray);
 
 $bytearray $bytearray$new($value s) {
-  return $NEW($bytearray, s);
+    return $NEW($bytearray, s);
 }
 
 void $bytearray_init($bytearray self, $value s) {
-  if (!s) {
-    self->nbytes = 0;
-    self->str = NULL;
-    return;
-  }
-  if ($ISINSTANCE(s, $str)->val) {
-    $str str = ($str)s;
-    $bytearray b = str->$class->encode(str);
-    self->nbytes = b->nbytes;
-    self->str = b->str;
-  } else if ($ISINSTANCE(s, $list)->val) {  // must be a list of ints in range 0..255
-    $list lst = ($list)s;
-    int len = lst->length;
-    self->nbytes = len;
-    self->str = malloc(len+1);
-    self->str[len] = 0;
-    if (len > 0 && !($ISINSTANCE(lst->data[0],$int)->val))
-      $RAISE(($BaseException)$NEW($ValueError,to$str("illegal argument to bytearray constructor")));
-    for (int i = 0; i<len; i++) {
-      long v = (($int)lst->data[i])->val;
-      if (v < 0 || v > 255)
-        $RAISE(($BaseException)$NEW($ValueError,to$str("illegal argument to bytearray constructor")));
-      self->str[i] = v;
+    if (!s) {
+        self->nbytes = 0;
+        self->str = NULL;
+        return;
     }
-  } else if ($ISINSTANCE(s, $int)->val) {
-    $int n = ($int)s;
-    if (n->val < 0) 
-      $RAISE(($BaseException)$NEW($ValueError,to$str("illegal argument to bytearray constructor")));
-    self->nbytes = n->val;
-    self->str = malloc(n->val);
-    memset(self->str, 0, n->val);
-  } else
-    $RAISE(($BaseException)$NEW($ValueError,to$str("illegal argument to bytearray constructor")));
+    if ($ISINSTANCE(s, $str)->val) {
+        $str str = ($str)s;
+        $bytearray b = str->$class->encode(str);
+        self->nbytes = b->nbytes;
+        self->str = b->str;
+    } else if ($ISINSTANCE(s, $list)->val) { // must be a list of ints in range 0..255
+        $list lst = ($list)s;
+        int len = lst->length;
+        self->nbytes = len;
+        self->str = malloc(len + 1);
+        self->str[len] = 0;
+        if (len > 0 && !($ISINSTANCE(lst->data[0], $int)->val))
+            $RAISE(($BaseException)$NEW($ValueError, to$str("illegal argument to bytearray constructor")));
+        for (int i = 0; i < len; i++) {
+            long v = (($int)lst->data[i])->val;
+            if (v < 0 || v > 255)
+                $RAISE(($BaseException)$NEW($ValueError, to$str("illegal argument to bytearray constructor")));
+            self->str[i] = v;
+        }
+    } else if ($ISINSTANCE(s, $int)->val) {
+        $int n = ($int)s;
+        if (n->val < 0)
+            $RAISE(($BaseException)$NEW($ValueError, to$str("illegal argument to bytearray constructor")));
+        self->nbytes = n->val;
+        self->str = malloc(n->val);
+        memset(self->str, 0, n->val);
+    } else
+        $RAISE(($BaseException)$NEW($ValueError, to$str("illegal argument to bytearray constructor")));
 }
 
-
 $bool $bytearray_bool($bytearray s) {
-  return to$bool(s->nbytes > 0);
+    return to$bool(s->nbytes > 0);
 };
 
 $str $bytearray_str($bytearray s) {
-  $str bs;
-  NEW_UNFILLED_STR(bs,s->nbytes,s->nbytes);
-  bs->str = s->str;        // bs may not be a correctly UTF8-encoded string
-  $str as = $ascii(bs);    // but we can use $ascii on it anyhow.
-  $str res;
-  int n = as->nbytes + 14; // "bytearray(b'" + "')"
-  NEW_UNFILLED_STR(res,n,n);
-  memcpy(res->str, "bytearray(b'",12);
-  memcpy(&res->str[12],as->str,as->nbytes);
-  memcpy(&res->str[n-2],"')",2);
-  return res;
+    $str bs;
+    NEW_UNFILLED_STR(bs, s->nbytes, s->nbytes);
+    bs->str = s->str;     // bs may not be a correctly UTF8-encoded string
+    $str as = $ascii(bs); // but we can use $ascii on it anyhow.
+    $str res;
+    int n = as->nbytes + 14; // "bytearray(b'" + "')"
+    NEW_UNFILLED_STR(res, n, n);
+    memcpy(res->str, "bytearray(b'", 12);
+    memcpy(&res->str[12], as->str, as->nbytes);
+    memcpy(&res->str[n - 2], "')", 2);
+    return res;
 }
 
-
-void $bytearray_serialize($bytearray str,$Serial$state state) {
-  int nWords = str->nbytes/sizeof($WORD) + 1;         // # $WORDS needed to store str->str, including terminating 0.
-  $ROW row = $add_header(BYTEARRAY_ID,1+nWords,state);
-  long nbytes = (long)str->nbytes;                    
-  memcpy(row->blob,&nbytes,sizeof($WORD));            
-  memcpy(row->blob+1,str->str,nbytes+1);
+void $bytearray_serialize($bytearray str, $Serial$state state) {
+    int nWords = str->nbytes / sizeof($WORD) + 1; // # $WORDS needed to store str->str, including terminating 0.
+    $ROW row = $add_header(BYTEARRAY_ID, 1 + nWords, state);
+    long nbytes = (long)str->nbytes;
+    memcpy(row->blob, &nbytes, sizeof($WORD));
+    memcpy(row->blob + 1, str->str, nbytes + 1);
 }
 
 $bytearray $bytearray_deserialize($bytearray res, $Serial$state state) {
-  $ROW this = state->row;
-  state->row =this->next;
-  state->row_no++;
-  if(!res)
-    res = malloc(sizeof(struct $bytearray));
-  long nbytes;
-  memcpy(&nbytes,this->blob,sizeof($WORD));
-  res->$class = &$bytearray$methods;
-  res->nbytes = (int)nbytes;
-  res->str = malloc(nbytes+1);
-  memcpy(res->str,this->blob+1,nbytes+1);
-  return res;
+    $ROW this = state->row;
+    state->row = this->next;
+    state->row_no++;
+    if (!res)
+        res = malloc(sizeof(struct $bytearray));
+    long nbytes;
+    memcpy(&nbytes, this->blob, sizeof($WORD));
+    res->$class = &$bytearray$methods;
+    res->nbytes = (int)nbytes;
+    res->str = malloc(nbytes + 1);
+    memcpy(res->str, this->blob + 1, nbytes + 1);
+    return res;
 }
 
 // End of bytearray implementation ////////////////////////////////////////////////
 
-
 // Builtin functions involving strings /////////////////////////////////////////////
 
 $str $ascii($str s) {
-  unsigned char *hexdigits = (unsigned char *)"0123456789abcdef";
-  int printable = 0;
-  int escaped = 0; // Backslash, single and double quote
-  int non_printable = 0;
-  unsigned char c;
-  for (int i=0; i<s->nbytes; i++) {
-    c = s->str[i];
-    if ((c < 32 || c > 126)&& c != '\t' && c != '\r' && c != '\n')
-      non_printable++;
-    else if (c=='\\' || c=='\'' || c=='"' || c=='\n' || c=='\t' || c=='\r')
-      escaped++;
-    else 
-      printable++;
-  }
-  int nbytes = printable+2*escaped+4*non_printable;
-  $str res;
-  NEW_UNFILLED_STR(res,nbytes,nbytes);
-  unsigned char *p =res->str;
-  for (int i=0; i<s->nbytes; i++) {
-    c = s->str[i];
-    if ((c < 32 || c > 126) && c != '\t' && c != '\r' && c != '\n') {
-      *p = '\\'; p++;
-      *p = 'x'; p++;
-      *p = hexdigits[c >> 4]; p++;
-      *p = hexdigits[c & 0xf]; p++;
-    } else switch (c) {
-      case '\\':
-      case '\'':
-      case '\"':
-        *p = '\\'; p++;
-        *p = c; p++;
-        break;
-      case '\t':
-        *p = '\\'; p++;
-        *p = 't'; p++;
-        break;
-      case '\n':
-        *p = '\\'; p++;
-        *p = 'n'; p++;
-        break;
-      case '\r':
-        *p = '\\'; p++;
-        *p = 'r'; p++;
-        break;
-      default:        
-        *p = c; p++;
-      }
-  }
-  return res;
+    unsigned char *hexdigits = (unsigned char *)"0123456789abcdef";
+    int printable = 0;
+    int escaped = 0; // Backslash, single and double quote
+    int non_printable = 0;
+    unsigned char c;
+    for (int i = 0; i < s->nbytes; i++) {
+        c = s->str[i];
+        if ((c < 32 || c > 126) && c != '\t' && c != '\r' && c != '\n')
+            non_printable++;
+        else if (c == '\\' || c == '\'' || c == '"' || c == '\n' || c == '\t' || c == '\r')
+            escaped++;
+        else
+            printable++;
+    }
+    int nbytes = printable + 2 * escaped + 4 * non_printable;
+    $str res;
+    NEW_UNFILLED_STR(res, nbytes, nbytes);
+    unsigned char *p = res->str;
+    for (int i = 0; i < s->nbytes; i++) {
+        c = s->str[i];
+        if ((c < 32 || c > 126) && c != '\t' && c != '\r' && c != '\n') {
+            *p = '\\';
+            p++;
+            *p = 'x';
+            p++;
+            *p = hexdigits[c >> 4];
+            p++;
+            *p = hexdigits[c & 0xf];
+            p++;
+        } else
+            switch (c) {
+                case '\\':
+                case '\'':
+                case '\"':
+                    *p = '\\';
+                    p++;
+                    *p = c;
+                    p++;
+                    break;
+                case '\t':
+                    *p = '\\';
+                    p++;
+                    *p = 't';
+                    p++;
+                    break;
+                case '\n':
+                    *p = '\\';
+                    p++;
+                    *p = 'n';
+                    p++;
+                    break;
+                case '\r':
+                    *p = '\\';
+                    p++;
+                    *p = 'r';
+                    p++;
+                    break;
+                default:
+                    *p = c;
+                    p++;
+            }
+    }
+    return res;
 }
-   
+
 $str $bin($Integral wit, $WORD n) {
-  long v = wit->$class->__int__(wit,n)->val;
-  int sign = v<0;
-  int nbits = 1;
-  unsigned long u = labs(v);
-  if (u & 0xffffffff00000000) {
-    u >>= 32; nbits += 32;
-  }
-  if (u & 0x00000000ffff0000) {
-    u >>= 16; nbits += 16;
-  }
-  if (u & 0x000000000000ff00) {
-    u >>= 8; nbits += 8;
-  }
-  if (u & 0x00000000000000f0) {
-    u >>= 4; nbits += 4;
-  }
-  if (u & 0x000000000000000c) {
-    u >>= 2; nbits += 2;
-  }
-  if (u & 0x0000000000000002) {
-    u >>= 1; nbits += 1;
-  }
-  $str res;
-  int nbytes = sign+2+nbits;
-  NEW_UNFILLED_STR(res,nbytes,nbytes);
-  unsigned char *p = res->str;
-  if (sign) {
-    *p = '-'; p++;
-  }
-  *p = '0'; p++;
-  *p = 'b'; p++;
-  u = labs(v);
-  for (int i = nbits-1; i>=0; i--) {
-    *p = u & (1L << i) ? '1' : '0'; p++;
-  }
-  return res;
+    long v = wit->$class->__int__(wit, n)->val;
+    int sign = v < 0;
+    int nbits = 1;
+    unsigned long u = labs(v);
+    if (u & 0xffffffff00000000) {
+        u >>= 32;
+        nbits += 32;
+    }
+    if (u & 0x00000000ffff0000) {
+        u >>= 16;
+        nbits += 16;
+    }
+    if (u & 0x000000000000ff00) {
+        u >>= 8;
+        nbits += 8;
+    }
+    if (u & 0x00000000000000f0) {
+        u >>= 4;
+        nbits += 4;
+    }
+    if (u & 0x000000000000000c) {
+        u >>= 2;
+        nbits += 2;
+    }
+    if (u & 0x0000000000000002) {
+        u >>= 1;
+        nbits += 1;
+    }
+    $str res;
+    int nbytes = sign + 2 + nbits;
+    NEW_UNFILLED_STR(res, nbytes, nbytes);
+    unsigned char *p = res->str;
+    if (sign) {
+        *p = '-';
+        p++;
+    }
+    *p = '0';
+    p++;
+    *p = 'b';
+    p++;
+    u = labs(v);
+    for (int i = nbits - 1; i >= 0; i--) {
+        *p = u & (1L << i) ? '1' : '0';
+        p++;
+    }
+    return res;
 }
 
 $str $chr($Integral wit, $WORD n) {
-  long v = wit->$class->__int__(wit,n)->val;
-  if (v >=  0x110000)
-     $RAISE(($BaseException)$NEW($ValueError,to$str("chr: argument is not a valid Unicode code point")));
-  unsigned char code[4];
-  int nbytes = utf8proc_encode_char((int)v,(unsigned char*)&code);
-  if (nbytes==0)
-     $RAISE(($BaseException)$NEW($ValueError,to$str("chr: argument is not a valid Unicode code point")));
-  $str res;
-  NEW_UNFILLED_STR(res,1,nbytes);
-  for (int i=0; i<nbytes; i++)
-    res->str[i] = code[i];
-  return res;
+    long v = wit->$class->__int__(wit, n)->val;
+    if (v >= 0x110000)
+        $RAISE(($BaseException)$NEW($ValueError, to$str("chr: argument is not a valid Unicode code point")));
+    unsigned char code[4];
+    int nbytes = utf8proc_encode_char((int)v, (unsigned char *)&code);
+    if (nbytes == 0)
+        $RAISE(($BaseException)$NEW($ValueError, to$str("chr: argument is not a valid Unicode code point")));
+    $str res;
+    NEW_UNFILLED_STR(res, 1, nbytes);
+    for (int i = 0; i < nbytes; i++)
+        res->str[i] = code[i];
+    return res;
 }
 
 $str $hex($Integral wit, $WORD n) {
-  unsigned char *hexdigits = (unsigned char *)"0123456789abcdef";
-  long v = wit->$class->__int__(wit,n)->val;
-  int sign = v<0;
-  int nhexs = 1;
-  unsigned long u = labs(v);
-  if (u & 0xffffffff00000000) {
-    u >>= 32; nhexs += 8;
-  }
-  if (u & 0x00000000ffff0000) {
-    u >>= 16; nhexs += 4;
-  }
-  if (u & 0x000000000000ff00) {
-    u >>= 8; nhexs += 2;
-  }
-  if (u & 0x00000000000000f0) {
-    u >>= 4; nhexs += 1;
-  }
-  $str res;
-  int nbytes = sign+2+nhexs;
-  NEW_UNFILLED_STR(res,nbytes,nbytes);
-  unsigned char *p = res->str;
-  if (sign) {
-    *p = '-'; p++;
-  }
-  *p = '0'; p++;
-  *p = 'x'; p++;
-  u = labs(v);
-  for (int i = nhexs-1; i>=0; i--) {
-    *p = hexdigits[(u>>(4*i)) & 0xf]; p++;
-  }
-  return res;
+    unsigned char *hexdigits = (unsigned char *)"0123456789abcdef";
+    long v = wit->$class->__int__(wit, n)->val;
+    int sign = v < 0;
+    int nhexs = 1;
+    unsigned long u = labs(v);
+    if (u & 0xffffffff00000000) {
+        u >>= 32;
+        nhexs += 8;
+    }
+    if (u & 0x00000000ffff0000) {
+        u >>= 16;
+        nhexs += 4;
+    }
+    if (u & 0x000000000000ff00) {
+        u >>= 8;
+        nhexs += 2;
+    }
+    if (u & 0x00000000000000f0) {
+        u >>= 4;
+        nhexs += 1;
+    }
+    $str res;
+    int nbytes = sign + 2 + nhexs;
+    NEW_UNFILLED_STR(res, nbytes, nbytes);
+    unsigned char *p = res->str;
+    if (sign) {
+        *p = '-';
+        p++;
+    }
+    *p = '0';
+    p++;
+    *p = 'x';
+    p++;
+    u = labs(v);
+    for (int i = nhexs - 1; i >= 0; i--) {
+        *p = hexdigits[(u >> (4 * i)) & 0xf];
+        p++;
+    }
+    return res;
 }
 
 $int $ord($str c) {
-  if(c->nchars != 1)
-    $RAISE(($BaseException)$NEW($ValueError,to$str("ord: argument is not a single Unicode char")));
-  int cp;
-  int cpnbytes = utf8proc_iterate(c->str,-1,&cp);
-  if (cpnbytes < 0)
-    $RAISE(($BaseException)$NEW($ValueError,to$str("ord: argument is not a single Unicode char")));
-  return to$int(cp);
+    if (c->nchars != 1)
+        $RAISE(($BaseException)$NEW($ValueError, to$str("ord: argument is not a single Unicode char")));
+    int cp;
+    int cpnbytes = utf8proc_iterate(c->str, -1, &cp);
+    if (cpnbytes < 0)
+        $RAISE(($BaseException)$NEW($ValueError, to$str("ord: argument is not a single Unicode char")));
+    return to$int(cp);
 }
 
 // Auxiliary function used in __str__ for collections ////////////////////////////
 
 $str $str_join_par(char lpar, $list elems, char rpar) {
-  char *s = ", ";
-  int len = elems->length;
-  int totchars = 2;  //parens
-  int totbytes = 2;
-  $str nxt;
-  for (int i=0; i<len; i++) {
-    nxt = ($str)elems->data[i];
-    totchars += nxt->nchars;
-    totbytes += nxt->nbytes;
-  }
-  if (len > 1) {
-    totchars += (len-1) * 2; // 2 is length of ", "
-    totbytes += (len-1) * 2; 
-  }
-  $str res;
-  NEW_UNFILLED_STR(res,totchars,totbytes);
-  res->str[0] = lpar;
-  res->str[totbytes-1] = rpar;
-  if (len > 0) {
-    unsigned char *p = res->str+1;
-    nxt = elems->data[0];
-    memcpy(p,nxt->str,nxt->nbytes);
-    p += nxt->nbytes;
-    for (int i=1; i<len; i++) {
-      nxt = ($str)elems->data[i];
-      memcpy(p,s,2);
-      p += 2;
-      memcpy(p,nxt->str,nxt->nbytes);
-      p += nxt->nbytes;
+    char *s = ", ";
+    int len = elems->length;
+    int totchars = 2; //parens
+    int totbytes = 2;
+    $str nxt;
+    for (int i = 0; i < len; i++) {
+        nxt = ($str)elems->data[i];
+        totchars += nxt->nchars;
+        totbytes += nxt->nbytes;
     }
-  }
-  return res;
+    if (len > 1) {
+        totchars += (len - 1) * 2; // 2 is length of ", "
+        totbytes += (len - 1) * 2;
+    }
+    $str res;
+    NEW_UNFILLED_STR(res, totchars, totbytes);
+    res->str[0] = lpar;
+    res->str[totbytes - 1] = rpar;
+    if (len > 0) {
+        unsigned char *p = res->str + 1;
+        nxt = elems->data[0];
+        memcpy(p, nxt->str, nxt->nbytes);
+        p += nxt->nbytes;
+        for (int i = 1; i < len; i++) {
+            nxt = ($str)elems->data[i];
+            memcpy(p, s, 2);
+            p += 2;
+            memcpy(p, nxt->str, nxt->nbytes);
+            p += nxt->nbytes;
+        }
+    }
+    return res;
 }
 
 $str $default__str__($value self) {
-  char *s;
-  asprintf(&s,"<%s object at %p>",self->$class->$GCINFO,self);
-  return to$str(s);
+    char *s;
+    asprintf(&s, "<%s object at %p>", self->$class->$GCINFO, self);
+    return to$str(s);
 }
-

--- a/builtin/str.h
+++ b/builtin/str.h
@@ -1,61 +1,61 @@
 struct $str$class;
 
 struct $str {
-  struct $str$class *$class;
-  int nbytes;              // length of str in bytes
-  int nchars;              // length of str in Unicode chars
-  unsigned char *str;      // str is UTF-8 encoded.
+    struct $str$class *$class;
+    int nbytes;         // length of str in bytes
+    int nchars;         // length of str in Unicode chars
+    unsigned char *str; // str is UTF-8 encoded.
 };
 
 struct $str$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)($str, $value);
-  void (*__serialize__)($str,$Serial$state);
-  $str (*__deserialize__)($str,$Serial$state);
-  $bool (*__bool__)($str);
-  $str (*__str__)($str);
-  $str (*capitalize)($str s);
-  $str (*center)($str s, $int width, $str fill);                 // raises TYPEERROR if fill is not a single char
-  $int (*count)($str s, $str sub, $int start, $int end);
-  $bytearray (*encode)($str s);                                    // only utf-8 encoding and strict error handling
-  $bool (*endswith)($str s, $str suffix, $int start, $int end);
-  $str (*expandtabs)($str s, $int tabsize);     
-  $int (*find)($str s, $str sub, $int start, $int end);         // returns -1 when not found
-  $int (*index)($str s, $str sub, $int start, $int end);        // like find but raises VALUEERROR when not found
-  $bool (*isalnum)($str s);                                     // not exactly as in Python; all chars c satisfy isalpha(c) or isdecimal(c)
-  $bool (*isalpha)($str s);
-  $bool (*isascii)($str s);
-  $bool (*isdecimal)($str s);
-  //$bool (*isdigit)($str s);                                    // not implemented; relies on property NT(numeric_type)
-  //$bool (*isidentifier)($str s);                               // not implemented
-  $bool (*islower)($str s);
-  //$bool (*isnumeric)($str s);                                  // not implemented; relies on property NT(numeric_type)
-  $bool (*isprintable)($str s);
-  $bool (*isspace)($str s);
-  $bool (*istitle)($str s);
-  $bool (*isupper)($str s);
-  $str (*join)($str sep, $Iterable wit, $WORD iter);
-  $str (*ljust)($str s, $int width, $str fill);                   // raises TYPEERROR if fill is not a single char
-  $str (*lower)($str s);
-  $str (*lstrip)($str s,$str cs);                                // cs may be NULL, then defaulting to whitespace removal.
-  //maketrans not implemented
-  $tuple (*partition)($str s, $str sep);
-  $str (*replace)($str s, $str old, $str new, $int count);
-  $int (*rfind)($str s, $str sub, $int start, $int end);         // returns -1 when not found
-  $int (*rindex)($str s, $str sub, $int start, $int end);        // like rfind but raises VALUEERROR when not found
-  $str (*rjust)($str s, $int width, $str fill);                   // raises TYPEERROR if fill is not a single char
-  $tuple (*rpartition)($str s, $str sep); 
-  //$list (*rsplit)($str s, $str sep, int maxsplit);             // not implemented. sep may be NULL; then separation is indicated by a whitespace string. TODO!!!
-  $str (*rstrip)($str s,$str cs);                                //  cs may be NULL, then defaulting to whitespace removal.
-  $list (*split)($str s, $str sep, $int maxsplit);               // raises VALUEERROR when separator is empty string
-  $list (*splitlines)($str s, $bool);                                   // keepends parameter absent; only \n recognized as line separator
-  $bool (*startswith)($str s, $str prefix, $int start, $int end); 
-  $str (*strip)($str s, $str cs);                                // cs may be NULL, then defaulting to whitespace removal.
-// translate not implemented
-  $str (*upper)($str s);
-  $str (*zfill)($str s, $int width);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)($str, $value);
+    void (*__serialize__)($str, $Serial$state);
+    $str (*__deserialize__)($str, $Serial$state);
+    $bool (*__bool__)($str);
+    $str (*__str__)($str);
+    $str (*capitalize)($str s);
+    $str (*center)($str s, $int width, $str fill); // raises TYPEERROR if fill is not a single char
+    $int (*count)($str s, $str sub, $int start, $int end);
+    $bytearray (*encode)($str s); // only utf-8 encoding and strict error handling
+    $bool (*endswith)($str s, $str suffix, $int start, $int end);
+    $str (*expandtabs)($str s, $int tabsize);
+    $int (*find)($str s, $str sub, $int start, $int end);  // returns -1 when not found
+    $int (*index)($str s, $str sub, $int start, $int end); // like find but raises VALUEERROR when not found
+    $bool (*isalnum)($str s);                              // not exactly as in Python; all chars c satisfy isalpha(c) or isdecimal(c)
+    $bool (*isalpha)($str s);
+    $bool (*isascii)($str s);
+    $bool (*isdecimal)($str s);
+    //$bool (*isdigit)($str s);                                    // not implemented; relies on property NT(numeric_type)
+    //$bool (*isidentifier)($str s);                               // not implemented
+    $bool (*islower)($str s);
+    //$bool (*isnumeric)($str s);                                  // not implemented; relies on property NT(numeric_type)
+    $bool (*isprintable)($str s);
+    $bool (*isspace)($str s);
+    $bool (*istitle)($str s);
+    $bool (*isupper)($str s);
+    $str (*join)($str sep, $Iterable wit, $WORD iter);
+    $str (*ljust)($str s, $int width, $str fill); // raises TYPEERROR if fill is not a single char
+    $str (*lower)($str s);
+    $str (*lstrip)($str s, $str cs); // cs may be NULL, then defaulting to whitespace removal.
+    //maketrans not implemented
+    $tuple (*partition)($str s, $str sep);
+    $str (*replace)($str s, $str old, $str new, $int count);
+    $int (*rfind)($str s, $str sub, $int start, $int end);  // returns -1 when not found
+    $int (*rindex)($str s, $str sub, $int start, $int end); // like rfind but raises VALUEERROR when not found
+    $str (*rjust)($str s, $int width, $str fill);           // raises TYPEERROR if fill is not a single char
+    $tuple (*rpartition)($str s, $str sep);
+    //$list (*rsplit)($str s, $str sep, int maxsplit);             // not implemented. sep may be NULL; then separation is indicated by a whitespace string. TODO!!!
+    $str (*rstrip)($str s, $str cs);                 //  cs may be NULL, then defaulting to whitespace removal.
+    $list (*split)($str s, $str sep, $int maxsplit); // raises VALUEERROR when separator is empty string
+    $list (*splitlines)($str s, $bool);              // keepends parameter absent; only \n recognized as line separator
+    $bool (*startswith)($str s, $str prefix, $int start, $int end);
+    $str (*strip)($str s, $str cs); // cs may be NULL, then defaulting to whitespace removal.
+                                    // translate not implemented
+    $str (*upper)($str s);
+    $str (*zfill)($str s, $int width);
 };
 
 extern struct $str$class $str$methods;
@@ -86,85 +86,85 @@ unsigned char *from$str($str str);
 
 // Iterators over str's ///////////////////////////////////////////////////////
 
-typedef struct $Iterator$str *$Iterator$str; ;
+typedef struct $Iterator$str *$Iterator$str;
+;
 
 struct $Iterator$str$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)($Iterator$str, $str);
-  void (*__serialize__)($Iterator$str,$Serial$state);
-  $Iterator$str (*__deserialize__)($Iterator$str,$Serial$state);
-  $bool (*__bool__)($Iterator$str);
-  $str (*__str__)($Iterator$str);
-  $str (*__next__)($Iterator$str);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)($Iterator$str, $str);
+    void (*__serialize__)($Iterator$str, $Serial$state);
+    $Iterator$str (*__deserialize__)($Iterator$str, $Serial$state);
+    $bool (*__bool__)($Iterator$str);
+    $str (*__str__)($Iterator$str);
+    $str (*__next__)($Iterator$str);
 };
 
 struct $Iterator$str {
-  struct $Iterator$str$class *$class;
-  $str src;
-  int nxt;
+    struct $Iterator$str$class *$class;
+    $str src;
+    int nxt;
 };
 
-extern struct  $Iterator$str$class  $Iterator$str$methods;
+extern struct $Iterator$str$class $Iterator$str$methods;
 $Iterator$str $Iterator$str$new($str);
 
 // bytearray /////////////////////////////////////////////////////////////////////////////////////
 
-
 struct $bytearray$class;
 
 struct $bytearray {
-  struct $bytearray$class *$class;
-  int nbytes;
-  int capacity;
-  unsigned char *str;
+    struct $bytearray$class *$class;
+    int nbytes;
+    int capacity;
+    unsigned char *str;
 };
 
 struct $bytearray$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)($bytearray, $value);
-  void (*__serialize__)($bytearray,$Serial$state);
-  $bytearray (*__deserialize__)($bytearray,$Serial$state);
-  $bool (*__bool__)($bytearray);
-  $str (*__str__)($bytearray);
-  $bytearray (*capitalize)($bytearray s);
-  $bytearray (*center)($bytearray s, $int width, $bytearray fill);                 
-  $int (*count)($bytearray s, $bytearray sub, $int start, $int end);
-  $str (*decode)($bytearray);
-  $bool (*endswith)($bytearray s, $bytearray suffix, $int start, $int end);
-  $bytearray (*expandtabs)($bytearray s, $int tabsize);     
-  $int (*find)($bytearray s, $bytearray sub, $int start, $int end);         
-  $int (*index)($bytearray s, $bytearray sub, $int start, $int end);        
-  $bool (*isalnum)($bytearray s);                                     
-  $bool (*isalpha)($bytearray s);
-  $bool (*isascii)($bytearray s);
-  $bool (*isdigit)($bytearray s);
-  $bool (*islower)($bytearray s);
-  //  $bool (*isprintable)($bytearray s);
-  $bool (*isspace)($bytearray s);
-  $bool (*istitle)($bytearray s);
-  $bool (*isupper)($bytearray s);
-  $bytearray (*join)($bytearray sep, $Iterable wit, $WORD iter);
-  $bytearray (*ljust)($bytearray s, $int width, $bytearray fill);                  
-  $bytearray (*lower)($bytearray s);
-  $bytearray (*lstrip)($bytearray s,$bytearray cs);                               
-  $tuple (*partition)($bytearray s, $bytearray sep);
-  $bytearray (*replace)($bytearray s, $bytearray old, $bytearray new, $int count);
-  $int (*rfind)($bytearray s, $bytearray sub, $int start, $int end);
-  $int (*rindex)($bytearray s, $bytearray sub, $int start, $int end);       
-  $bytearray (*rjust)($bytearray s, $int width, $bytearray fill);                  
-  $tuple (*rpartition)($bytearray s, $bytearray sep); 
-  //$list (*rsplit)($bytearray s, $bytearray sep, int maxsplit);             
-  $bytearray (*rstrip)($bytearray s,$bytearray cs);                                
-  $list (*split)($bytearray s, $bytearray sep, $int maxsplit);               
-  $list (*splitlines)($bytearray s, $bool keepends);                                   
-  $bool (*startswith)($bytearray s, $bytearray prefix, $int start, $int end);
-  $bytearray (*strip)($bytearray s, $bytearray cs);                                
-  $bytearray (*upper)($bytearray s);
-  $bytearray (*zfill)($bytearray s, $int width);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)($bytearray, $value);
+    void (*__serialize__)($bytearray, $Serial$state);
+    $bytearray (*__deserialize__)($bytearray, $Serial$state);
+    $bool (*__bool__)($bytearray);
+    $str (*__str__)($bytearray);
+    $bytearray (*capitalize)($bytearray s);
+    $bytearray (*center)($bytearray s, $int width, $bytearray fill);
+    $int (*count)($bytearray s, $bytearray sub, $int start, $int end);
+    $str (*decode)($bytearray);
+    $bool (*endswith)($bytearray s, $bytearray suffix, $int start, $int end);
+    $bytearray (*expandtabs)($bytearray s, $int tabsize);
+    $int (*find)($bytearray s, $bytearray sub, $int start, $int end);
+    $int (*index)($bytearray s, $bytearray sub, $int start, $int end);
+    $bool (*isalnum)($bytearray s);
+    $bool (*isalpha)($bytearray s);
+    $bool (*isascii)($bytearray s);
+    $bool (*isdigit)($bytearray s);
+    $bool (*islower)($bytearray s);
+    //  $bool (*isprintable)($bytearray s);
+    $bool (*isspace)($bytearray s);
+    $bool (*istitle)($bytearray s);
+    $bool (*isupper)($bytearray s);
+    $bytearray (*join)($bytearray sep, $Iterable wit, $WORD iter);
+    $bytearray (*ljust)($bytearray s, $int width, $bytearray fill);
+    $bytearray (*lower)($bytearray s);
+    $bytearray (*lstrip)($bytearray s, $bytearray cs);
+    $tuple (*partition)($bytearray s, $bytearray sep);
+    $bytearray (*replace)($bytearray s, $bytearray old, $bytearray new, $int count);
+    $int (*rfind)($bytearray s, $bytearray sub, $int start, $int end);
+    $int (*rindex)($bytearray s, $bytearray sub, $int start, $int end);
+    $bytearray (*rjust)($bytearray s, $int width, $bytearray fill);
+    $tuple (*rpartition)($bytearray s, $bytearray sep);
+    //$list (*rsplit)($bytearray s, $bytearray sep, int maxsplit);
+    $bytearray (*rstrip)($bytearray s, $bytearray cs);
+    $list (*split)($bytearray s, $bytearray sep, $int maxsplit);
+    $list (*splitlines)($bytearray s, $bool keepends);
+    $bool (*startswith)($bytearray s, $bytearray prefix, $int start, $int end);
+    $bytearray (*strip)($bytearray s, $bytearray cs);
+    $bytearray (*upper)($bytearray s);
+    $bytearray (*zfill)($bytearray s, $int width);
 };
 
 extern struct $bytearray$class $bytearray$methods;
@@ -187,32 +187,33 @@ extern struct $Collection$bytearray *$Collection$bytearray$witness;
 extern struct $Times$bytearray *$Times$bytearray$witness;
 extern struct $Container$bytearray *$Container$bytearray$witness;
 
-$bytearray to$bytearray(char *str); 
+$bytearray to$bytearray(char *str);
 unsigned char *from$bytearray($bytearray b);
 
 // Iterators over bytearrays ///////////////////////////////////////////////////////
 
-typedef struct $Iterator$bytearray *$Iterator$bytearray; ;
+typedef struct $Iterator$bytearray *$Iterator$bytearray;
+;
 
 struct $Iterator$bytearray$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)($Iterator$bytearray, $bytearray);
-  void (*__serialize__)($Iterator$bytearray,$Serial$state);
-  $Iterator$bytearray (*__deserialize__)($Iterator$bytearray,$Serial$state);
-  $bool (*__bool__)($Iterator$bytearray);
-  $str (*__str__)($Iterator$bytearray);
-  $int (*__next__)($Iterator$bytearray);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)($Iterator$bytearray, $bytearray);
+    void (*__serialize__)($Iterator$bytearray, $Serial$state);
+    $Iterator$bytearray (*__deserialize__)($Iterator$bytearray, $Serial$state);
+    $bool (*__bool__)($Iterator$bytearray);
+    $str (*__str__)($Iterator$bytearray);
+    $int (*__next__)($Iterator$bytearray);
 };
 
 struct $Iterator$bytearray {
-  struct $Iterator$bytearray$class *$class;
-  $bytearray src;
-  int nxt;
+    struct $Iterator$bytearray$class *$class;
+    $bytearray src;
+    int nxt;
 };
 
-extern struct  $Iterator$bytearray$class  $Iterator$bytearray$methods;
+extern struct $Iterator$bytearray$class $Iterator$bytearray$methods;
 $Iterator$bytearray $Iterator$bytearray$new($bytearray);
 
 //builtin functions //////////////////////////////////////////////////////////////////////////////////
@@ -226,10 +227,9 @@ $str $chr($Integral wit, $WORD n);
 $str $hex($Integral wit, $WORD n);
 $int $ord($str c);
 
-
 // Internal auxiliary function /////////////////////////////////////////////
 
 // used in defining __str__ method for collection types (list, dict, set)
-$str $str_join_par(char lpar,$list elems, char rpar);
+$str $str_join_par(char lpar, $list elems, char rpar);
 
 $str $default__str__($value);

--- a/builtin/tuple.c
+++ b/builtin/tuple.c
@@ -14,61 +14,60 @@
 
 #include <stdarg.h>
 
-void $tuple_init($tuple self,int size ,...) {
-  va_list args;
-  va_start(args,size);
-  self->size = size;
-  self->components = malloc(size*sizeof($WORD));
-  for (int i=0; i<size; i++)
-    self->components[i] = va_arg(args,$WORD);
-  va_end(args);
+void $tuple_init($tuple self, int size, ...) {
+    va_list args;
+    va_start(args, size);
+    self->size = size;
+    self->components = malloc(size * sizeof($WORD));
+    for (int i = 0; i < size; i++)
+        self->components[i] = va_arg(args, $WORD);
+    va_end(args);
 }
 
 $bool $tuple_bool($tuple self) {
-  return to$bool(self->size>0);
+    return to$bool(self->size > 0);
 }
 
 $str $tuple_str($tuple self) {
-  $list s2 = $list_new(self->size);
-  for (int i=0; i< self->size; i++) {
-    $value elem = ($value)self->components[i];
-    $list_append(s2,elem->$class->__str__(elem));
-  }
-  return $str_join_par('(',s2,')');
+    $list s2 = $list_new(self->size);
+    for (int i = 0; i < self->size; i++) {
+        $value elem = ($value)self->components[i];
+        $list_append(s2, elem->$class->__str__(elem));
+    }
+    return $str_join_par('(', s2, ')');
 }
 
-
 void $tuple_serialize($tuple self, $Serial$state state) {
-  $int prevkey = ($int)$dict_get(state->done,($Hashable)$Hashable$WORD$witness,self,NULL);
-  if (prevkey) {
-    $val_serialize(-TUPLE_ID,&prevkey->val,state);
-    return;
-  }
-  $dict_setitem(state->done,($Hashable)$Hashable$WORD$witness,self,to$int(state->row_no));
-  long len = (long)self->size;
-  $val_serialize(TUPLE_ID,&len,state);
-  for (int i=0; i<self->size; i++) {
-    $step_serialize(self->components[i],state);
-  }
+    $int prevkey = ($int)$dict_get(state->done, ($Hashable)$Hashable$WORD$witness, self, NULL);
+    if (prevkey) {
+        $val_serialize(-TUPLE_ID, &prevkey->val, state);
+        return;
+    }
+    $dict_setitem(state->done, ($Hashable)$Hashable$WORD$witness, self, to$int(state->row_no));
+    long len = (long)self->size;
+    $val_serialize(TUPLE_ID, &len, state);
+    for (int i = 0; i < self->size; i++) {
+        $step_serialize(self->components[i], state);
+    }
 }
 
 $tuple $tuple_deserialize($tuple self, $Serial$state state) {
-  $ROW this = state->row;
-  state->row = this->next;
-  state->row_no++;
-  if (this->class_id < 0) {
-    return ($tuple)$dict_get(state->done,($Hashable)$Hashable$int$witness,to$int((long)this->blob[0]),NULL);
-  } else {
-    int len = (int)(long)this->blob[0];
-    $tuple res = malloc(sizeof(struct $tuple));
-    $dict_setitem(state->done,($Hashable)$Hashable$int$witness,to$int(state->row_no-1),res);
-    res->components = malloc(len * sizeof($WORD));
-    res->$class = &$tuple$methods;
-    res->size = len;
-    for (int i = 0; i < len; i++) 
-      res->components[i] = $step_deserialize(state);
-    return res;
-  }
+    $ROW this = state->row;
+    state->row = this->next;
+    state->row_no++;
+    if (this->class_id < 0) {
+        return ($tuple)$dict_get(state->done, ($Hashable)$Hashable$int$witness, to$int((long)this->blob[0]), NULL);
+    } else {
+        int len = (int)(long)this->blob[0];
+        $tuple res = malloc(sizeof(struct $tuple));
+        $dict_setitem(state->done, ($Hashable)$Hashable$int$witness, to$int(state->row_no - 1), res);
+        res->components = malloc(len * sizeof($WORD));
+        res->$class = &$tuple$methods;
+        res->size = len;
+        for (int i = 0; i < len; i++)
+            res->components[i] = $step_deserialize(state);
+        return res;
+    }
 }
 
 struct $tuple$class $tuple$methods = {
@@ -79,62 +78,60 @@ struct $tuple$class $tuple$methods = {
     $tuple_serialize,
     $tuple_deserialize,
     $tuple_bool,
-    $tuple_str
-};
+    $tuple_str};
 
 // Iterators over tuples ///////////////////////////////////////////////////////
 
 static $WORD $Iterator$tuple_next($Iterator$tuple self) {
-  return self->nxt >= self->src->size ? NULL : self->src->components[self->nxt++];
+    return self->nxt >= self->src->size ? NULL : self->src->components[self->nxt++];
 }
 
 void $Iterator$tuple_init($Iterator$tuple self, $tuple lst) {
-  self->src = lst;
-  self->nxt = 0;
+    self->src = lst;
+    self->nxt = 0;
 }
 
 $bool $Iterator$tuple_bool($Iterator$tuple self) {
-  return $True;
+    return $True;
 }
 
 $str $Iterator$tuple_str($Iterator$tuple self) {
-  char *s;
-  asprintf(&s,"<tuple iterator object at %p>",self);
-  return to$str(s);
+    char *s;
+    asprintf(&s, "<tuple iterator object at %p>", self);
+    return to$str(s);
 }
-void $Iterator$tuple_serialize($Iterator$tuple self,$Serial$state state) {
-  $step_serialize(self->src,state);
-  $step_serialize(to$int(self->nxt),state);
+void $Iterator$tuple_serialize($Iterator$tuple self, $Serial$state state) {
+    $step_serialize(self->src, state);
+    $step_serialize(to$int(self->nxt), state);
 }
 
 $Iterator$tuple $Iterator$tuple$_deserialize($Iterator$tuple res, $Serial$state state) {
-   if (!res)
-      res = $DNEW($Iterator$tuple,state);
-   res->src = $step_deserialize(state);
-   res->nxt = from$int(($int)$step_deserialize(state));
-   return res;
+    if (!res)
+        res = $DNEW($Iterator$tuple, state);
+    res->src = $step_deserialize(state);
+    res->nxt = from$int(($int)$step_deserialize(state));
+    return res;
 }
 
-struct $Iterator$tuple$class $Iterator$tuple$methods = {"$Iterator$tuple",UNASSIGNED,($Super$class)&$Iterator$methods,$Iterator$tuple_init,
-                                                        $Iterator$tuple_serialize,$Iterator$tuple$_deserialize,$Iterator$tuple_bool,$Iterator$tuple_str,$Iterator$tuple_next};
-
+struct $Iterator$tuple$class $Iterator$tuple$methods = {"$Iterator$tuple", UNASSIGNED, ($Super$class)&$Iterator$methods, $Iterator$tuple_init,
+                                                        $Iterator$tuple_serialize, $Iterator$tuple$_deserialize, $Iterator$tuple_bool, $Iterator$tuple_str, $Iterator$tuple_next};
 
 // Iterable ///////////////////////////////////////////////////////////////
 
 $Iterator $Iterable$tuple$__iter__($Iterable$tuple wit, $tuple self) {
-  return ($Iterator)$NEW($Iterator$tuple,self);
+    return ($Iterator)$NEW($Iterator$tuple, self);
 }
 
 void $Iterable$tuple$__init__($Iterable$tuple self) {
-  return;
+    return;
 }
 
 void $Iterable$tuple$__serialize__($Iterable$tuple self, $Serial$state state) {
 }
 
 $Iterable$tuple $Iterable$tuple$__deserialize__($Iterable$tuple self, $Serial$state state) {
-   $Iterable$tuple res = $DNEW($Iterable$tuple,state);
-   return res;
+    $Iterable$tuple res = $DNEW($Iterable$tuple, state);
+    return res;
 }
 struct $Iterable$tuple$class $Iterable$tuple$methods = {
     "$Iterable$tuple",
@@ -143,10 +140,9 @@ struct $Iterable$tuple$class $Iterable$tuple$methods = {
     $Iterable$tuple$__init__,
     $Iterable$tuple$__serialize__,
     $Iterable$tuple$__deserialize__,
-    ($bool (*)($Iterable$tuple))$default__bool__,
-    ($str (*)($Iterable$tuple))$default__str__,
-    $Iterable$tuple$__iter__
-};
+    ($bool(*)($Iterable$tuple))$default__bool__,
+    ($str(*)($Iterable$tuple))$default__str__,
+    $Iterable$tuple$__iter__};
 struct $Iterable$tuple $Iterable$tuple$instance = {&$Iterable$tuple$methods};
 struct $Iterable$tuple *$Iterable$tuple$witness = &$Iterable$tuple$instance;
 
@@ -156,62 +152,60 @@ void $Sliceable$tuple$__serialize__($Sliceable$tuple self, $Serial$state state) 
 }
 
 $Sliceable$tuple $Sliceable$tuple$__deserialize__($Sliceable$tuple self, $Serial$state state) {
-   $Sliceable$tuple res = $DNEW($Sliceable$tuple,state);
-   return res;
+    $Sliceable$tuple res = $DNEW($Sliceable$tuple, state);
+    return res;
 }
 
-void $Sliceable$tuple$__init__ ($Sliceable$tuple wit) {
-  return;
+void $Sliceable$tuple$__init__($Sliceable$tuple wit) {
+    return;
 }
 
-$WORD $Sliceable$tuple$__getitem__ ($Sliceable$tuple wit, $tuple self, $int n) {
-  int size = self->size;
-  int ix = (int)from$int(n);
-  int ix0 = ix < 0 ? size + ix : ix;
-  if (ix0 < 0 || ix0 >= size) {
-    $RAISE(($BaseException)$NEW($IndexError,to$str("getitem: indexing outside tuple")));
-  }
-  return self->components[ix0];
+$WORD $Sliceable$tuple$__getitem__($Sliceable$tuple wit, $tuple self, $int n) {
+    int size = self->size;
+    int ix = (int)from$int(n);
+    int ix0 = ix < 0 ? size + ix : ix;
+    if (ix0 < 0 || ix0 >= size) {
+        $RAISE(($BaseException)$NEW($IndexError, to$str("getitem: indexing outside tuple")));
+    }
+    return self->components[ix0];
 }
 
-
-void $Sliceable$tuple$__setitem__ ($Sliceable$tuple wit, $tuple self, $int ix, $WORD elem) {
-  fprintf(stderr,"%s\n","internal error: setitem on immutable tuple");
-  exit(-1);
+void $Sliceable$tuple$__setitem__($Sliceable$tuple wit, $tuple self, $int ix, $WORD elem) {
+    fprintf(stderr, "%s\n", "internal error: setitem on immutable tuple");
+    exit(-1);
 }
 
-void $Sliceable$tuple$__delitem__ ($Sliceable$tuple wit, $tuple self, $int ix) {
-  fprintf(stderr,"%s\n","internal error: delitem on immutable tuple");
-  exit(-1);
-}
-  
-
-$tuple $Sliceable$tuple$__getslice__ ($Sliceable$tuple wit, $tuple self, $slice slc) {
-  int size = self->size;
-  int start, stop, step, slen;
-  normalize_slice(slc, size, &slen, &start, &stop, &step);
-  //slice notation have been eliminated and default values applied.
-  // slen now is the length of the slice
-  $tuple res = malloc(sizeof(struct $tuple));
-  res->$class = self->$class;
-  res->size = slen;
-  res->components = malloc(slen * sizeof($WORD));
-  int t = start;
-  for (int i=0; i<slen; i++) {
-    res->components[i] = self->components[t];
-    t += step;
-  }
-  return res;
+void $Sliceable$tuple$__delitem__($Sliceable$tuple wit, $tuple self, $int ix) {
+    fprintf(stderr, "%s\n", "internal error: delitem on immutable tuple");
+    exit(-1);
 }
 
-void $Sliceable$tuple$__setslice__ ($Sliceable$tuple wit, $tuple self, $Iterable wit2, $slice slc, $WORD iter) {
-    fprintf(stderr,"%s\n","internal error: setslice on immutable tuple");
-  exit(-1);
+$tuple $Sliceable$tuple$__getslice__($Sliceable$tuple wit, $tuple self, $slice slc) {
+    int size = self->size;
+    int start, stop, step, slen;
+    normalize_slice(slc, size, &slen, &start, &stop, &step);
+    //slice notation have been eliminated and default values applied.
+    // slen now is the length of the slice
+    $tuple res = malloc(sizeof(struct $tuple));
+    res->$class = self->$class;
+    res->size = slen;
+    res->components = malloc(slen * sizeof($WORD));
+    int t = start;
+    for (int i = 0; i < slen; i++) {
+        res->components[i] = self->components[t];
+        t += step;
+    }
+    return res;
 }
 
-void $Sliceable$tuple$__delslice__ ($Sliceable$tuple wit, $tuple self, $slice slc) {
-    fprintf(stderr,"%s\n","internal error: delslice on immutable tuple");
-  exit(-1);
+void $Sliceable$tuple$__setslice__($Sliceable$tuple wit, $tuple self, $Iterable wit2, $slice slc, $WORD iter) {
+    fprintf(stderr, "%s\n", "internal error: setslice on immutable tuple");
+    exit(-1);
+}
+
+void $Sliceable$tuple$__delslice__($Sliceable$tuple wit, $tuple self, $slice slc) {
+    fprintf(stderr, "%s\n", "internal error: delslice on immutable tuple");
+    exit(-1);
 }
 
 struct $Sliceable$tuple$class $Sliceable$tuple$methods = {
@@ -221,52 +215,50 @@ struct $Sliceable$tuple$class $Sliceable$tuple$methods = {
     $Sliceable$tuple$__init__,
     $Sliceable$tuple$__serialize__,
     $Sliceable$tuple$__deserialize__,
-    ($bool (*)($Sliceable$tuple))$default__bool__,
-    ($str (*)($Sliceable$tuple))$default__str__,
+    ($bool(*)($Sliceable$tuple))$default__bool__,
+    ($str(*)($Sliceable$tuple))$default__str__,
     $Sliceable$tuple$__getitem__,
     $Sliceable$tuple$__setitem__,
     $Sliceable$tuple$__delitem__,
     $Sliceable$tuple$__getslice__,
     $Sliceable$tuple$__setslice__,
-    $Sliceable$tuple$__delslice__
-};
-struct  $Sliceable$tuple $Sliceable$tuple$instance = {&$Sliceable$tuple$methods};
+    $Sliceable$tuple$__delslice__};
+struct $Sliceable$tuple $Sliceable$tuple$instance = {&$Sliceable$tuple$methods};
 struct $Sliceable$tuple *$Sliceable$tuple$witness = &$Sliceable$tuple$instance;
 
 // Hashable ///////////////////////////////////////////////////////////////
 
-void $Hashable$tuple$__init__ ($Hashable$tuple wit, int n, $Hashable *comps) {
-  wit->w$Hashable$tuple$size = n;
-  wit->w$Hashable = comps;
+void $Hashable$tuple$__init__($Hashable$tuple wit, int n, $Hashable *comps) {
+    wit->w$Hashable$tuple$size = n;
+    wit->w$Hashable = comps;
 }
 
 void $Hashable$tuple$__serialize__($Hashable$tuple self, $Serial$state state) {
-  $step_serialize(to$int(self->w$Hashable$tuple$size), state);
-  // we need to serialize the array of Hashables!!
+    $step_serialize(to$int(self->w$Hashable$tuple$size), state);
+    // we need to serialize the array of Hashables!!
 }
 
 $Hashable$tuple $Hashable$tuple$__deserialize__($Hashable$tuple self, $Serial$state state) {
-   $Hashable$tuple res = $DNEW($Hashable$tuple,state);
-   res->w$Hashable$tuple$size = (int)from$int($step_deserialize(state));
-   res->w$Hashable = NULL; // We do not get hash functions for the tuple!
-   return res;
+    $Hashable$tuple res = $DNEW($Hashable$tuple, state);
+    res->w$Hashable$tuple$size = (int)from$int($step_deserialize(state));
+    res->w$Hashable = NULL; // We do not get hash functions for the tuple!
+    return res;
 }
 
-$bool $Hashable$tuple$__eq__ ($Hashable$tuple wit, $tuple tup1, $tuple tup2) {
-  //type-checking guarantees that sizes are equal
-  for (int i=0; i<tup1->size; i++)
-    if (!wit->w$Hashable[i]->$class->__eq__(wit->w$Hashable[i],tup1->components[i],tup2->components[i]))
-      return $False;
-  return $True;
+$bool $Hashable$tuple$__eq__($Hashable$tuple wit, $tuple tup1, $tuple tup2) {
+    //type-checking guarantees that sizes are equal
+    for (int i = 0; i < tup1->size; i++)
+        if (!wit->w$Hashable[i]->$class->__eq__(wit->w$Hashable[i], tup1->components[i], tup2->components[i]))
+            return $False;
+    return $True;
 }
 
-$bool $Hashable$tuple$__ne__ ($Hashable$tuple wit, $tuple tup1, $tuple tup2) {
-  return to$bool(!from$bool($Hashable$tuple$__eq__(wit,tup1,tup2)));
+$bool $Hashable$tuple$__ne__($Hashable$tuple wit, $tuple tup1, $tuple tup2) {
+    return to$bool(!from$bool($Hashable$tuple$__eq__(wit, tup1, tup2)));
 }
-    
-  
-$int $Hashable$tuple$__hash__ ($Hashable$tuple wit, $tuple tup) {
-  return to$int($tuple_hash(wit,tup));
+
+$int $Hashable$tuple$__hash__($Hashable$tuple wit, $tuple tup) {
+    return to$int($tuple_hash(wit, tup));
 }
 
 struct $Hashable$tuple$class $Hashable$tuple$methods = {
@@ -276,10 +268,8 @@ struct $Hashable$tuple$class $Hashable$tuple$methods = {
     $Hashable$tuple$__init__,
     $Hashable$tuple$__serialize__,
     $Hashable$tuple$__deserialize__,
-    ($bool (*)($Hashable$tuple))$default__bool__,
-    ($str (*)($Hashable$tuple))$default__str__,
+    ($bool(*)($Hashable$tuple))$default__bool__,
+    ($str(*)($Hashable$tuple))$default__str__,
     $Hashable$tuple$__eq__,
     $Hashable$tuple$__ne__,
-    $Hashable$tuple$__hash__
-};
-
+    $Hashable$tuple$__hash__};

--- a/builtin/tuple.h
+++ b/builtin/tuple.h
@@ -1,24 +1,24 @@
 struct $tuple$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)($tuple,int,...);
-  void (*__serialize__)($tuple,$Serial$state); 
-  $tuple (*__deserialize__)($tuple,$Serial$state);
-  $bool (*__bool__)($tuple);
-  $str (*__str__)($tuple);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)($tuple, int, ...);
+    void (*__serialize__)($tuple, $Serial$state);
+    $tuple (*__deserialize__)($tuple, $Serial$state);
+    $bool (*__bool__)($tuple);
+    $str (*__str__)($tuple);
 };
 
 struct $tuple {
-  struct $tuple$class *$class;
-  int size;
-  $WORD *components;
+    struct $tuple$class *$class;
+    int size;
+    $WORD *components;
 };
 
 extern struct $tuple$class $tuple$methods;
-$tuple $tuple$new(int,...);
+$tuple $tuple$new(int, ...);
 
-#define $NEWTUPLE($len, ...)  ({ $tuple $t = malloc(sizeof(struct $tuple)+$len*sizeof($WORD)); \
+#define $NEWTUPLE($len, ...) ({ $tuple $t = malloc(sizeof(struct $tuple)+$len*sizeof($WORD)); \
                                  $t->$class = &$tuple$methods; \
                                  $t->$class->__init__($t, $len, ##__VA_ARGS__); \
                                  $t; })
@@ -32,28 +32,29 @@ $Hashable$tuple $Hashable$tuple$new();
 
 extern struct $Iterable$tuple *$Iterable$tuple$witness;
 extern struct $Sliceable$tuple *$Sliceable$tuple$witness;
-extern struct $Hashable$tuple *$Hashable$tuple_new(int,$Hashable*);
+extern struct $Hashable$tuple *$Hashable$tuple_new(int, $Hashable *);
 
 // Iterators over tuples ///////////////////////////////////////////////////////
 
 typedef struct $Iterator$tuple *$Iterator$tuple;
 
 struct $Iterator$tuple$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)($Iterator$tuple, $tuple);
-  void (*__serialize__)($Iterator$tuple,$Serial$state);
-  $Iterator$tuple (*__deserialize__)($Iterator$tuple,$Serial$state);
-  $bool (*__bool__)($Iterator$tuple);
-  $str (*__str__)($Iterator$tuple);
-  $WORD(*__next__)($Iterator$tuple);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)($Iterator$tuple, $tuple);
+    void (*__serialize__)($Iterator$tuple, $Serial$state);
+    $Iterator$tuple (*__deserialize__)($Iterator$tuple, $Serial$state);
+    $bool (*__bool__)($Iterator$tuple);
+    $str (*__str__)($Iterator$tuple);
+    $WORD (*__next__)
+    ($Iterator$tuple);
 };
 
 struct $Iterator$tuple {
-  struct $Iterator$tuple$class *$class;
-  $tuple src;
-  int nxt;
+    struct $Iterator$tuple$class *$class;
+    $tuple src;
+    int nxt;
 };
 
 extern struct $Iterator$tuple$class $Iterator$tuple$methods;

--- a/rts/pingpong.c
+++ b/rts/pingpong.c
@@ -28,18 +28,18 @@ $bool lambda$1$__bool__(lambda$1 self) {
 
 $str lambda$1$__str__(lambda$1 self) {
     char *s;
-    asprintf(&s,"<lambda$1 object at %p>",self);
+    asprintf(&s, "<lambda$1 object at %p>", self);
     return to$str(s);
 }
 
 void lambda$1$__serialize__(lambda$1 self, $Serial$state state) {
-    $step_serialize(self->self,state);
-    $step_serialize(self->count,state);
-    $step_serialize(self->q,state);
+    $step_serialize(self->self, state);
+    $step_serialize(self->count, state);
+    $step_serialize(self->q, state);
 }
 
 lambda$1 lambda$1$__deserialize__(lambda$1 self, $Serial$state state) {
-    lambda$1 res = $DNEW(lambda$1,state);
+    lambda$1 res = $DNEW(lambda$1, state);
     res->self = $step_deserialize(state);
     res->count = $step_deserialize(state);
     res->q = $step_deserialize(state);
@@ -73,25 +73,23 @@ $bool lambda$2$__bool__(lambda$2 self) {
 
 $str lambda$2$__str__(lambda$2 self) {
     char *s;
-    asprintf(&s,"<lambda$2 object at %p>",self);
+    asprintf(&s, "<lambda$2 object at %p>", self);
     return to$str(s);
 }
 
 void lambda$2$__serialize__(lambda$2 self, $Serial$state state) {
-    $step_serialize(self->self,state);
-    $step_serialize(self->q,state);
+    $step_serialize(self->self, state);
+    $step_serialize(self->q, state);
 }
 
-
 lambda$2 lambda$2$__deserialize__(lambda$2 self, $Serial$state state) {
-    lambda$2 res = $DNEW(lambda$2,state);
+    lambda$2 res = $DNEW(lambda$2, state);
     res->self = $step_deserialize(state);
     res->q = $step_deserialize(state);
     return res;
 }
 
-
-$R lambda$2$__call__ (lambda$2 $this, $Cont then) {
+$R lambda$2$__call__(lambda$2 $this, $Cont then) {
     Pingpong self = $this->self;
     $int q = $this->q;
     return self->$class->ping(self, q, then);
@@ -116,21 +114,21 @@ $bool lambda$3$__bool__(lambda$3 self) {
 
 $str lambda$3$__str__(lambda$3 self) {
     char *s;
-    asprintf(&s,"<lambda$3 object at %p>",self);
+    asprintf(&s, "<lambda$3 object at %p>", self);
     return to$str(s);
 }
 
 void lambda$3$__serialize__(lambda$3 self, $Serial$state state) {
-    $step_serialize(self->cont,state);
+    $step_serialize(self->cont, state);
 }
 
 lambda$3 lambda$3$__deserialize__(lambda$3 self, $Serial$state state) {
-    lambda$3 res = $DNEW(lambda$3,state);
+    lambda$3 res = $DNEW(lambda$3, state);
     res->cont = $step_deserialize(state);
     return res;
 }
 
-$R lambda$3$__call__ (lambda$3 $this, $NoneType none) {
+$R lambda$3$__call__(lambda$3 $this, $NoneType none) {
     $OLDACT();
     $Cont cont = $this->cont;
     return $R_CONT(cont, none);
@@ -159,18 +157,18 @@ $bool Pingpong$__bool__(Pingpong self) {
 
 $str Pingpong$__str__(Pingpong self) {
     char *s;
-    asprintf(&s,"<Pingpong object at %p>",self);
+    asprintf(&s, "<Pingpong object at %p>", self);
     return to$str(s);
 }
 void Pingpong$__serialize__(Pingpong self, $Serial$state state) {
     $Actor$methods.__serialize__(($Actor)self, state);
-    $step_serialize(self->i,state);
-    $step_serialize(self->count,state);
+    $step_serialize(self->i, state);
+    $step_serialize(self->count, state);
 }
 
 Pingpong Pingpong$__deserialize__(Pingpong res, $Serial$state state) {
     if (!res)
-        res = $DNEW(Pingpong,state);
+        res = $DNEW(Pingpong, state);
     $Actor$methods.__deserialize__(($Actor)res, state);
     res->i = $step_deserialize(state);
     res->count = $step_deserialize(state);
@@ -194,7 +192,7 @@ $R Pingpong$pong(Pingpong self, $int n, $int q, $Cont then) {
 $R Pingpong$new($int i, $Cont then) {
     Pingpong obj = malloc(sizeof(struct Pingpong));
     obj->$class = &Pingpong$methods;
-    return Pingpong$methods.__init__(obj, i, $CONSTCONT(obj,then));
+    return Pingpong$methods.__init__(obj, i, $CONSTCONT(obj, then));
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////
@@ -208,8 +206,7 @@ struct lambda$1$class lambda$1$methods = {
     lambda$1$__deserialize__,
     lambda$1$__bool__,
     lambda$1$__str__,
-    lambda$1$__call__
-};
+    lambda$1$__call__};
 struct lambda$2$class lambda$2$methods = {
     "lambda$2",
     UNASSIGNED,
@@ -219,8 +216,7 @@ struct lambda$2$class lambda$2$methods = {
     lambda$2$__deserialize__,
     lambda$2$__bool__,
     lambda$2$__str__,
-    lambda$2$__call__
-};
+    lambda$2$__call__};
 struct lambda$3$class lambda$3$methods = {
     "lambda$3",
     UNASSIGNED,
@@ -230,8 +226,7 @@ struct lambda$3$class lambda$3$methods = {
     lambda$3$__deserialize__,
     lambda$3$__bool__,
     lambda$3$__str__,
-    lambda$3$__call__
-};
+    lambda$3$__call__};
 struct Pingpong$class Pingpong$methods = {
     "Pingpong",
     UNASSIGNED,
@@ -242,13 +237,11 @@ struct Pingpong$class Pingpong$methods = {
     Pingpong$__bool__,
     Pingpong$__str__,
     Pingpong$ping,
-    Pingpong$pong
-};
+    Pingpong$pong};
 
 $R $ROOT($Env env, $Cont then) {
     $register(&lambda$1$methods);
     $register(&lambda$2$methods);
     $register(&Pingpong$methods);
-    return Pingpong$new($int$new($list_getitem(env->args,1)), then);
+    return Pingpong$new($int$new($list_getitem(env->args, 1)), then);
 }
-

--- a/rts/pingpong.h
+++ b/rts/pingpong.h
@@ -21,7 +21,8 @@ struct lambda$1$class {
     lambda$1 (*__deserialize__)(lambda$1, $Serial$state);
     $bool (*__bool__)(lambda$1);
     $str (*__str__)(lambda$1);
-    $R (*__call__)(lambda$1, $Cont);
+    $R (*__call__)
+    (lambda$1, $Cont);
 };
 struct lambda$1 {
     struct lambda$1$class *$class;
@@ -40,7 +41,8 @@ struct lambda$2$class {
     lambda$2 (*__deserialize__)(lambda$2, $Serial$state);
     $bool (*__bool__)(lambda$2);
     $str (*__str__)(lambda$2);
-    $R (*__call__)(lambda$2, $Cont);
+    $R (*__call__)
+    (lambda$2, $Cont);
 };
 struct lambda$2 {
     struct lambda$2$class *$class;
@@ -58,7 +60,8 @@ struct lambda$3$class {
     lambda$3 (*__deserialize__)(lambda$3, $Serial$state);
     $bool (*__bool__)(lambda$3);
     $str (*__str__)(lambda$3);
-    $R (*__call__)(lambda$3, $NoneType);
+    $R (*__call__)
+    (lambda$3, $NoneType);
 };
 struct lambda$3 {
     struct lambda$3$class *$class;
@@ -70,13 +73,16 @@ struct Pingpong$class {
     char *$GCINFO;
     int $class_id;
     $Super$class $superclass;
-    $R (*__init__)(Pingpong, $int, $Cont);
+    $R (*__init__)
+    (Pingpong, $int, $Cont);
     void (*__serialize__)(Pingpong, $Serial$state);
     Pingpong (*__deserialize__)(Pingpong, $Serial$state);
     $bool (*__bool__)(Pingpong);
     $str (*__str__)(Pingpong);
-    $R (*ping)(Pingpong, $int, $Cont);
-    $R (*pong)(Pingpong, $int, $int, $Cont);
+    $R (*ping)
+    (Pingpong, $int, $Cont);
+    $R (*pong)
+    (Pingpong, $int, $int, $Cont);
 };
 struct Pingpong {
     struct Pingpong$class *$class;

--- a/rts/rts.h
+++ b/rts/rts.h
@@ -9,9 +9,9 @@
 #include <pthread.h>
 
 #ifdef __gnu_linux__
-    #define IS_GNU_LINUX
-#elif  __APPLE__ && __MACH__
-    #define IS_MACOS
+#define IS_GNU_LINUX
+#elif __APPLE__ && __MACH__
+#define IS_MACOS
 #endif
 
 #include "../builtin/builtin.h"
@@ -42,7 +42,10 @@ extern struct $Cont$class $Cont$methods;
 extern struct $Cont$class $Done$methods;
 extern struct $ConstCont$class $ConstCont$methods;
 
-enum $RTAG { $RDONE, $RFAIL, $RCONT, $RWAIT };
+enum $RTAG { $RDONE,
+             $RFAIL,
+             $RCONT,
+             $RWAIT };
 typedef enum $RTAG $RTAG;
 
 struct $R {
@@ -52,18 +55,22 @@ struct $R {
 };
 typedef struct $R $R;
 
-#define $R_CONT(cont, arg)      ($R){$RCONT, (cont), ($WORD)(arg)}
-#define $R_DONE(value)          ($R){$RDONE, NULL,   (value)}
-#define $R_FAIL(value)          ($R){$RFAIL, NULL,   (value)}
-#define $R_WAIT(cont, value)    ($R){$RWAIT, (cont), (value)}
+#define $R_CONT(cont, arg) \
+    ($R) { $RCONT, (cont), ($WORD)(arg) }
+#define $R_DONE(value) \
+    ($R) { $RDONE, NULL, (value) }
+#define $R_FAIL(value) \
+    ($R) { $RFAIL, NULL, (value) }
+#define $R_WAIT(cont, value) \
+    ($R) { $RWAIT, (cont), (value) }
 
-#define MSG_HEADER              "Msg"
-#define ACTOR_HEADER            "Actor"
-#define CATCHER_HEADER          "Catcher"
-#define CLOS_HEADER             "Clos"
-#define CONT_HEADER             "Cont"
+#define MSG_HEADER     "Msg"
+#define ACTOR_HEADER   "Actor"
+#define CATCHER_HEADER "Catcher"
+#define CLOS_HEADER    "Clos"
+#define CONT_HEADER    "Cont"
 
-#define $Lock                   volatile atomic_flag
+#define $Lock volatile atomic_flag
 
 struct $Msg$class {
     char *$GCINFO;
@@ -125,7 +132,6 @@ struct $Catcher {
     $Cont $cont;
 };
 
-
 struct $Cont$class {
     char *$GCINFO;
     int $class_id;
@@ -135,7 +141,8 @@ struct $Cont$class {
     $Cont (*__deserialize__)($Cont, $Serial$state);
     $bool (*__bool__)($Cont);
     $str (*__str__)($Cont);
-    $R (*__call__)($Cont, ...);
+    $R (*__call__)
+    ($Cont, ...);
 };
 struct $Cont {
     struct $Cont$class *$class;
@@ -150,7 +157,8 @@ struct $ConstCont$class {
     $ConstCont (*__deserialize__)($ConstCont, $Serial$state);
     $bool (*__bool__)($ConstCont);
     $str (*__str__)($ConstCont);
-    $R (*__call__)($ConstCont, $WORD);
+    $R (*__call__)
+    ($ConstCont, $WORD);
 };
 struct $ConstCont {
     struct $ConstCont$class *$class;
@@ -165,7 +173,7 @@ $R $AWAIT($Msg, $Cont);
 
 void init_db_queue(long);
 
-#define $NEWACTOR($T)       ({ $T $t = malloc(sizeof(struct $T)); \
+#define $NEWACTOR($T) ({ $T $t = malloc(sizeof(struct $T)); \
                                $t->$class = &$T ## $methods; \
                                $Actor$methods.__init__(($Actor)$t); \
                                init_db_queue($t->$globkey); \
@@ -187,6 +195,5 @@ void $Actor$deserialize($Actor, $Serial$state);
 
 $ROW $serialize_rts();
 void $deserialize_rts($ROW);
-
 
 void $register_rts();

--- a/stdlib/src/acton/rts.c
+++ b/stdlib/src/acton/rts.c
@@ -1,12 +1,13 @@
 #include "src/acton/rts.h"
 #include <unistd.h>
-$NoneType acton$rts$$sleep ($float sleep_time) {
-    int to_sleep = sleep_time->val*1000000;
+$NoneType acton$rts$$sleep($float sleep_time) {
+    int to_sleep = sleep_time->val * 1000000;
     usleep(to_sleep);
     return $None;
 }
 int acton$rts$$done$ = 0;
-void acton$rts$$__init__ () {
-    if (acton$rts$$done$) return;
+void acton$rts$$__init__() {
+    if (acton$rts$$done$)
+        return;
     acton$rts$$done$ = 1;
 }

--- a/stdlib/src/math.c
+++ b/stdlib/src/math.c
@@ -14,8 +14,7 @@
 
 #include "math.h"
 
-
-$NoneType math$$RealFuns$__init__ (math$$RealFuns w$self) {
+$NoneType math$$RealFuns$__init__(math$$RealFuns w$self) {
     return $None;
 }
 math$$RealFuns math$$RealFuns$new() {
@@ -25,7 +24,7 @@ math$$RealFuns math$$RealFuns$new() {
     return $tmp;
 }
 struct math$$RealFuns$class math$$RealFuns$methods;
-$NoneType math$$RealFuns$float$__init__ (math$$RealFuns$float w$self) {
+$NoneType math$$RealFuns$float$__init__(math$$RealFuns$float w$self) {
     math$$RealFuns$methods.__init__((math$$RealFuns)w$self);
     return $None;
 }
@@ -35,56 +34,55 @@ $NoneType math$$RealFuns$float$__serialize__(math$$RealFuns$float wit, $Serial$s
 }
 
 math$$RealFuns$float math$$RealFuns$float$__deserialize__(math$$RealFuns$float wit, $Serial$state state) {
-    math$$RealFuns$float res = $DNEW(math$$RealFuns$float,state);
+    math$$RealFuns$float res = $DNEW(math$$RealFuns$float, state);
     return res;
 }
 $float math$$RealFuns$float$sqrt(math$$RealFuns$float wit, $float x) {
-  return to$float(sqrt(x->val));
+    return to$float(sqrt(x->val));
 }
 $float math$$RealFuns$float$exp(math$$RealFuns$float wit, $float x) {
-  return to$float(exp(x->val));
+    return to$float(exp(x->val));
 }
 $float math$$RealFuns$float$log(math$$RealFuns$float wit, $float x) {
-  return to$float(log(x->val));
+    return to$float(log(x->val));
 }
 $float math$$RealFuns$float$sin(math$$RealFuns$float wit, $float x) {
-  return to$float(sin(x->val));
+    return to$float(sin(x->val));
 }
 $float math$$RealFuns$float$cos(math$$RealFuns$float wit, $float x) {
-  return to$float(cos(x->val));
+    return to$float(cos(x->val));
 }
 $float math$$RealFuns$float$tan(math$$RealFuns$float wit, $float x) {
-  return to$float(tan(x->val));
+    return to$float(tan(x->val));
 }
 $float math$$RealFuns$float$asin(math$$RealFuns$float wit, $float x) {
-  return to$float(asin(x->val));
+    return to$float(asin(x->val));
 }
 $float math$$RealFuns$float$acos(math$$RealFuns$float wit, $float x) {
-  return to$float(acos(x->val));
+    return to$float(acos(x->val));
 }
 $float math$$RealFuns$float$atan(math$$RealFuns$float wit, $float x) {
-  return to$float(atan(x->val));
+    return to$float(atan(x->val));
 }
 $float math$$RealFuns$float$sinh(math$$RealFuns$float wit, $float x) {
-  return to$float(sinh(x->val));
+    return to$float(sinh(x->val));
 }
 $float math$$RealFuns$float$cosh(math$$RealFuns$float wit, $float x) {
-  return to$float(cosh(x->val));
+    return to$float(cosh(x->val));
 }
 $float math$$RealFuns$float$tanh(math$$RealFuns$float wit, $float x) {
-  return to$float(tanh(x->val));
+    return to$float(tanh(x->val));
 }
 $float math$$RealFuns$float$asinh(math$$RealFuns$float wit, $float x) {
-  return to$float(asinh(x->val));
+    return to$float(asinh(x->val));
 }
 $float math$$RealFuns$float$acosh(math$$RealFuns$float wit, $float x) {
-  return to$float(acosh(x->val));
+    return to$float(acosh(x->val));
 }
 $float math$$RealFuns$float$atanh(math$$RealFuns$float wit, $float x) {
-  return to$float(atanh(x->val));
+    return to$float(atanh(x->val));
 }
 
-                      
 math$$RealFuns$float math$$RealFuns$float$new() {
     math$$RealFuns$float $tmp = malloc(sizeof(struct math$$RealFuns$float));
     $tmp->$class = &math$$RealFuns$float$methods;
@@ -93,8 +91,9 @@ math$$RealFuns$float math$$RealFuns$float$new() {
 }
 struct math$$RealFuns$float$class math$$RealFuns$float$methods;
 int math$$done$ = 0;
-void math$$__init__ () {
-    if (math$$done$) return;
+void math$$__init__() {
+    if (math$$done$)
+        return;
     math$$done$ = 1;
     {
         math$$RealFuns$methods.$GCINFO = "math$$RealFuns";
@@ -107,70 +106,70 @@ void math$$__init__ () {
         math$$RealFuns$float$methods.$superclass = ($Super$class)&math$$RealFuns$methods;
         math$$RealFuns$float$methods.__serialize__ = math$$RealFuns$float$__serialize__,
         math$$RealFuns$float$methods.__deserialize__ = math$$RealFuns$float$__deserialize__,
-        math$$RealFuns$float$methods.__bool__ = ($bool (*)(math$$RealFuns$float))$default__bool__,
-        math$$RealFuns$float$methods.__str__ = ($str (*)(math$$RealFuns$float))$default__str__,
+        math$$RealFuns$float$methods.__bool__ = ($bool(*)(math$$RealFuns$float))$default__bool__,
+        math$$RealFuns$float$methods.__str__ = ($str(*)(math$$RealFuns$float))$default__str__,
         math$$RealFuns$float$methods.__init__ = math$$RealFuns$float$__init__;
-        math$$RealFuns$float$methods.sqrt = math$$RealFuns$float$sqrt;        
-        math$$RealFuns$float$methods.exp = math$$RealFuns$float$exp;        
-        math$$RealFuns$float$methods.log = math$$RealFuns$float$log;        
-        math$$RealFuns$float$methods.sin = math$$RealFuns$float$sin;        
-        math$$RealFuns$float$methods.cos = math$$RealFuns$float$cos;        
-        math$$RealFuns$float$methods.tan = math$$RealFuns$float$tan;        
-        math$$RealFuns$float$methods.asin = math$$RealFuns$float$asin;        
-        math$$RealFuns$float$methods.acos = math$$RealFuns$float$acos;        
-        math$$RealFuns$float$methods.atan = math$$RealFuns$float$atan;        
-        math$$RealFuns$float$methods.sinh = math$$RealFuns$float$sinh;        
-        math$$RealFuns$float$methods.cosh = math$$RealFuns$float$cosh;        
-        math$$RealFuns$float$methods.tanh = math$$RealFuns$float$tanh;        
-        math$$RealFuns$float$methods.asinh = math$$RealFuns$float$asinh;        
-        math$$RealFuns$float$methods.acosh = math$$RealFuns$float$acosh;        
-        math$$RealFuns$float$methods.atanh = math$$RealFuns$float$atanh;        
+        math$$RealFuns$float$methods.sqrt = math$$RealFuns$float$sqrt;
+        math$$RealFuns$float$methods.exp = math$$RealFuns$float$exp;
+        math$$RealFuns$float$methods.log = math$$RealFuns$float$log;
+        math$$RealFuns$float$methods.sin = math$$RealFuns$float$sin;
+        math$$RealFuns$float$methods.cos = math$$RealFuns$float$cos;
+        math$$RealFuns$float$methods.tan = math$$RealFuns$float$tan;
+        math$$RealFuns$float$methods.asin = math$$RealFuns$float$asin;
+        math$$RealFuns$float$methods.acos = math$$RealFuns$float$acos;
+        math$$RealFuns$float$methods.atan = math$$RealFuns$float$atan;
+        math$$RealFuns$float$methods.sinh = math$$RealFuns$float$sinh;
+        math$$RealFuns$float$methods.cosh = math$$RealFuns$float$cosh;
+        math$$RealFuns$float$methods.tanh = math$$RealFuns$float$tanh;
+        math$$RealFuns$float$methods.asinh = math$$RealFuns$float$asinh;
+        math$$RealFuns$float$methods.acosh = math$$RealFuns$float$acosh;
+        math$$RealFuns$float$methods.atanh = math$$RealFuns$float$atanh;
         $register(&math$$RealFuns$float$methods);
     }
 }
 
-$WORD math$$sqrt (math$$RealFuns wit, $WORD x) {
-  return wit->$class->sqrt(wit,x);
+$WORD math$$sqrt(math$$RealFuns wit, $WORD x) {
+    return wit->$class->sqrt(wit, x);
 }
-$WORD math$$exp (math$$RealFuns wit, $WORD x) {
-  return wit->$class->exp(wit,x);
+$WORD math$$exp(math$$RealFuns wit, $WORD x) {
+    return wit->$class->exp(wit, x);
 }
-$WORD math$$log (math$$RealFuns wit, $WORD x) {
-  return wit->$class->log(wit,x);
+$WORD math$$log(math$$RealFuns wit, $WORD x) {
+    return wit->$class->log(wit, x);
 }
-$WORD math$$sin (math$$RealFuns wit, $WORD x) {
-  return wit->$class->sin(wit,x);
+$WORD math$$sin(math$$RealFuns wit, $WORD x) {
+    return wit->$class->sin(wit, x);
 }
-$WORD math$$cos (math$$RealFuns wit, $WORD x) {
-  return wit->$class->cos(wit,x);
+$WORD math$$cos(math$$RealFuns wit, $WORD x) {
+    return wit->$class->cos(wit, x);
 }
-$WORD math$$tan (math$$RealFuns wit, $WORD x) {
-  return wit->$class->tan(wit,x);
+$WORD math$$tan(math$$RealFuns wit, $WORD x) {
+    return wit->$class->tan(wit, x);
 }
-$WORD math$$asin (math$$RealFuns wit, $WORD x) {
-  return wit->$class->asin(wit,x);
+$WORD math$$asin(math$$RealFuns wit, $WORD x) {
+    return wit->$class->asin(wit, x);
 }
-$WORD math$$acos (math$$RealFuns wit, $WORD x) {
-  return wit->$class->acos(wit,x);
+$WORD math$$acos(math$$RealFuns wit, $WORD x) {
+    return wit->$class->acos(wit, x);
 }
-$WORD math$$atan (math$$RealFuns wit, $WORD x) {
-  return wit->$class->atan(wit,x);
+$WORD math$$atan(math$$RealFuns wit, $WORD x) {
+    return wit->$class->atan(wit, x);
 }
-$WORD math$$sinh (math$$RealFuns wit, $WORD x) {
-  return wit->$class->sinh(wit,x);
+$WORD math$$sinh(math$$RealFuns wit, $WORD x) {
+    return wit->$class->sinh(wit, x);
 }
-$WORD math$$cosh (math$$RealFuns wit, $WORD x) {
-  return wit->$class->cosh(wit,x);
+$WORD math$$cosh(math$$RealFuns wit, $WORD x) {
+    return wit->$class->cosh(wit, x);
 }
-$WORD math$$tanh (math$$RealFuns wit, $WORD x) {
-  return wit->$class->tanh(wit,x);
+$WORD math$$tanh(math$$RealFuns wit, $WORD x) {
+    return wit->$class->tanh(wit, x);
 }
-$WORD math$$asinh (math$$RealFuns wit, $WORD x) {
-  return wit->$class->asinh(wit,x);
+$WORD math$$asinh(math$$RealFuns wit, $WORD x) {
+    return wit->$class->asinh(wit, x);
 }
-$WORD math$$acosh (math$$RealFuns wit, $WORD x) {
-  return wit->$class->acosh(wit,x);
+$WORD math$$acosh(math$$RealFuns wit, $WORD x) {
+    return wit->$class->acosh(wit, x);
 }
-$WORD math$$atanh (math$$RealFuns wit, $WORD x) {
-  return wit->$class->atanh(wit,x);
+$WORD math$$atanh(math$$RealFuns wit, $WORD x) {
+    return wit->$class->atanh(wit, x);
 }

--- a/stdlib/src/numpy.h
+++ b/stdlib/src/numpy.h
@@ -9,11 +9,11 @@ struct numpy$$ndselect$class {
     char *$GCINFO;
     int $class_id;
     $Super$class $superclass;
-    void (*__init__) (numpy$$ndselect);
-    void (*__serialize__) (numpy$$ndselect, $Serial$state);
-    numpy$$ndselect (*__deserialize__) (numpy$$ndselect, $Serial$state);
-    $bool (*__bool__) (numpy$$ndselect);
-    $str (*__str__) (numpy$$ndselect);
+    void (*__init__)(numpy$$ndselect);
+    void (*__serialize__)(numpy$$ndselect, $Serial$state);
+    numpy$$ndselect (*__deserialize__)(numpy$$ndselect, $Serial$state);
+    $bool (*__bool__)(numpy$$ndselect);
+    $str (*__str__)(numpy$$ndselect);
 };
 struct numpy$$ndselect {
     struct numpy$$ndselect$class *$class;
@@ -26,11 +26,11 @@ struct numpy$$ndindex$class {
     char *$GCINFO;
     int $class_id;
     $Super$class $superclass;
-    void (*__init__) (numpy$$ndindex, $int);
-    void (*__serialize__) (numpy$$ndindex, $Serial$state);
-    numpy$$ndindex (*__deserialize__) (numpy$$ndindex, $Serial$state);
-    $bool (*__bool__) (numpy$$ndindex);
-    $str (*__str__) (numpy$$ndindex);
+    void (*__init__)(numpy$$ndindex, $int);
+    void (*__serialize__)(numpy$$ndindex, $Serial$state);
+    numpy$$ndindex (*__deserialize__)(numpy$$ndindex, $Serial$state);
+    $bool (*__bool__)(numpy$$ndindex);
+    $str (*__str__)(numpy$$ndindex);
 };
 struct numpy$$ndindex {
     struct numpy$$ndindex$class *$class;
@@ -39,18 +39,17 @@ struct numpy$$ndindex {
 extern struct numpy$$ndindex$class numpy$$ndindex$methods;
 numpy$$ndindex numpy$$ndindex$new($int);
 
-
 struct numpy$$ndslice;
 typedef struct numpy$$ndslice *numpy$$ndslice;
 struct numpy$$ndslice$class {
     char *$GCINFO;
     int $class_id;
     $Super$class $superclass;
-    void (*__init__) (numpy$$ndslice, $slice);
-    void (*__serialize__) (numpy$$ndslice, $Serial$state);
-    numpy$$ndslice (*__deserialize__) (numpy$$ndslice, $Serial$state);
-    $bool (*__bool__) (numpy$$ndslice);
-    $str (*__str__) (numpy$$ndslice);
+    void (*__init__)(numpy$$ndslice, $slice);
+    void (*__serialize__)(numpy$$ndslice, $Serial$state);
+    numpy$$ndslice (*__deserialize__)(numpy$$ndslice, $Serial$state);
+    $bool (*__bool__)(numpy$$ndslice);
+    $str (*__str__)(numpy$$ndslice);
 };
 struct numpy$$ndslice {
     struct numpy$$ndslice$class *$class;
@@ -59,14 +58,11 @@ struct numpy$$ndslice {
 extern struct numpy$$ndslice$class numpy$$ndslice$methods;
 numpy$$ndslice numpy$$ndslice$new($slice);
 
-
 // The bulk of data in an ndarray is stored in a C array of union $Bytes8 data.
 // Each ndarray also holds the address of an $UnboxedFunctions struct, containing conversion
 // functions to and from boxed data, and operators on unboxed data.
 // This file provides the necessary type definitions and $UnboxedFunctions structs for the
 // two Acton types supported at the moment, int and float (i.e., boxed long and double).
-
-
 
 struct numpy$$Primitive;
 typedef struct numpy$$Primitive *numpy$$Primitive;
@@ -91,62 +87,64 @@ struct numpy$$Primitive {
 };
 
 union $Bytes8 {
-  long l;
-  double d;
+    long l;
+    double d;
 };
 
-enum ElemType {LongType,DblType};
+enum ElemType { LongType,
+                DblType };
 
 int $elem_size(enum ElemType typ);
 
 struct numpy$$Primitive$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)(numpy$$Primitive);
-  void (*__serialize__)(numpy$$Primitive,$Serial$state);
-  numpy$$Primitive (*__deserialize__)(numpy$$Primitive,$Serial$state);
-  $bool (*__bool__)(numpy$$Primitive);
-  $str (*__str__)(numpy$$Primitive);
-  enum ElemType elem_type;
-  $WORD (*to$obj)(union $Bytes8);
-  union $Bytes8 (*from$obj)($WORD);
-  $str (*$prim_str)(union $Bytes8);
-  union $Bytes8 (*$add)(union $Bytes8, union $Bytes8);
-  union $Bytes8 (*$sub)(union $Bytes8, union $Bytes8);
-  union $Bytes8 (*$mul)(union $Bytes8, union $Bytes8);
-  union $Bytes8 (*$truediv)(union $Bytes8, union $Bytes8);
-  union $Bytes8 (*$floordiv)(union $Bytes8, union $Bytes8);
-  union $Bytes8 (*$mod)(union $Bytes8, union $Bytes8);
-  union $Bytes8 (*$land)(union $Bytes8, union $Bytes8);
-  union $Bytes8 (*$lor)(union $Bytes8, union $Bytes8);
-  union $Bytes8 (*$band)(union $Bytes8, union $Bytes8);
-  union $Bytes8 (*$bor)(union $Bytes8, union $Bytes8);
-  union $Bytes8 (*$bxor)(union $Bytes8, union $Bytes8);
-  union $Bytes8 (*$lsh)(union $Bytes8, union $Bytes8);
-  union $Bytes8 (*$rsh)(union $Bytes8, union $Bytes8);
-  union $Bytes8 (*$pow)(union $Bytes8, union $Bytes8);
-  void (*$iadd)(union $Bytes8*, union $Bytes8);
-  void (*$isub)(union $Bytes8*, union $Bytes8);
-  void (*$imul)(union $Bytes8*, union $Bytes8);
-  void (*$itruediv)(union $Bytes8*, union $Bytes8);
-  void (*$ifloordiv)(union $Bytes8*, union $Bytes8);
-  void (*$imod)(union $Bytes8*, union $Bytes8);
-  void (*$iband)(union $Bytes8*, union $Bytes8);
-  void (*$ibor)(union $Bytes8*, union $Bytes8);
-  void (*$ibxor)(union $Bytes8*, union $Bytes8);
-  void (*$ilsh)(union $Bytes8*, union $Bytes8);
-  void (*$irsh)(union $Bytes8*, union $Bytes8);
-  bool (*$eq)(union $Bytes8, union $Bytes8);
-  bool (*$neq)(union $Bytes8, union $Bytes8);
-  bool (*$lt)(union $Bytes8, union $Bytes8);
-  bool (*$le)(union $Bytes8, union $Bytes8);
-  bool (*$gt)(union $Bytes8, union $Bytes8);
-  bool (*$ge)(union $Bytes8, union $Bytes8);
-  union $Bytes8 (*$abs)(union $Bytes8);
-  union $Bytes8 (*$neg)(union $Bytes8);
-  union $Bytes8 (*$lnot)(union $Bytes8);
-  union $Bytes8 (*$bnot)(union $Bytes8);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)(numpy$$Primitive);
+    void (*__serialize__)(numpy$$Primitive, $Serial$state);
+    numpy$$Primitive (*__deserialize__)(numpy$$Primitive, $Serial$state);
+    $bool (*__bool__)(numpy$$Primitive);
+    $str (*__str__)(numpy$$Primitive);
+    enum ElemType elem_type;
+    $WORD (*to$obj)
+    (union $Bytes8);
+    union $Bytes8 (*from$obj)($WORD);
+    $str (*$prim_str)(union $Bytes8);
+    union $Bytes8 (*$add)(union $Bytes8, union $Bytes8);
+    union $Bytes8 (*$sub)(union $Bytes8, union $Bytes8);
+    union $Bytes8 (*$mul)(union $Bytes8, union $Bytes8);
+    union $Bytes8 (*$truediv)(union $Bytes8, union $Bytes8);
+    union $Bytes8 (*$floordiv)(union $Bytes8, union $Bytes8);
+    union $Bytes8 (*$mod)(union $Bytes8, union $Bytes8);
+    union $Bytes8 (*$land)(union $Bytes8, union $Bytes8);
+    union $Bytes8 (*$lor)(union $Bytes8, union $Bytes8);
+    union $Bytes8 (*$band)(union $Bytes8, union $Bytes8);
+    union $Bytes8 (*$bor)(union $Bytes8, union $Bytes8);
+    union $Bytes8 (*$bxor)(union $Bytes8, union $Bytes8);
+    union $Bytes8 (*$lsh)(union $Bytes8, union $Bytes8);
+    union $Bytes8 (*$rsh)(union $Bytes8, union $Bytes8);
+    union $Bytes8 (*$pow)(union $Bytes8, union $Bytes8);
+    void (*$iadd)(union $Bytes8 *, union $Bytes8);
+    void (*$isub)(union $Bytes8 *, union $Bytes8);
+    void (*$imul)(union $Bytes8 *, union $Bytes8);
+    void (*$itruediv)(union $Bytes8 *, union $Bytes8);
+    void (*$ifloordiv)(union $Bytes8 *, union $Bytes8);
+    void (*$imod)(union $Bytes8 *, union $Bytes8);
+    void (*$iband)(union $Bytes8 *, union $Bytes8);
+    void (*$ibor)(union $Bytes8 *, union $Bytes8);
+    void (*$ibxor)(union $Bytes8 *, union $Bytes8);
+    void (*$ilsh)(union $Bytes8 *, union $Bytes8);
+    void (*$irsh)(union $Bytes8 *, union $Bytes8);
+    bool (*$eq)(union $Bytes8, union $Bytes8);
+    bool (*$neq)(union $Bytes8, union $Bytes8);
+    bool (*$lt)(union $Bytes8, union $Bytes8);
+    bool (*$le)(union $Bytes8, union $Bytes8);
+    bool (*$gt)(union $Bytes8, union $Bytes8);
+    bool (*$ge)(union $Bytes8, union $Bytes8);
+    union $Bytes8 (*$abs)(union $Bytes8);
+    union $Bytes8 (*$neg)(union $Bytes8);
+    union $Bytes8 (*$lnot)(union $Bytes8);
+    union $Bytes8 (*$bnot)(union $Bytes8);
 };
 
 $str l$prim_str(union $Bytes8 n);
@@ -159,109 +157,111 @@ struct numpy$$Primitive$int {
 };
 
 struct numpy$$Primitive$int$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)(numpy$$Primitive$int);
-  void (*__serialize__)(numpy$$Primitive$int,$Serial$state);
-  numpy$$Primitive$int (*__deserialize__)(numpy$$Primitive$int,$Serial$state);
-  $bool (*__bool__)(numpy$$Primitive$int);
-  $str (*__str__)(numpy$$Primitive$int);
-  enum ElemType elem_type;
-  $WORD (*to$obj)(union $Bytes8);
-  union $Bytes8 (*from$obj)($WORD);
-  $str (*$prim_str)(union $Bytes8);
-  union $Bytes8 (*$add)(union $Bytes8, union $Bytes8);
-  union $Bytes8 (*$sub)(union $Bytes8, union $Bytes8);
-  union $Bytes8 (*$mul)(union $Bytes8, union $Bytes8);
-  union $Bytes8 (*$truediv)(union $Bytes8, union $Bytes8);
-  union $Bytes8 (*$floordiv)(union $Bytes8, union $Bytes8);
-  union $Bytes8 (*$mod)(union $Bytes8, union $Bytes8);
-  union $Bytes8 (*$land)(union $Bytes8, union $Bytes8);
-  union $Bytes8 (*$lor)(union $Bytes8, union $Bytes8);
-  union $Bytes8 (*$band)(union $Bytes8, union $Bytes8);
-  union $Bytes8 (*$bor)(union $Bytes8, union $Bytes8);
-  union $Bytes8 (*$bxor)(union $Bytes8, union $Bytes8);
-  union $Bytes8 (*$lsh)(union $Bytes8, union $Bytes8);
-  union $Bytes8 (*$rsh)(union $Bytes8, union $Bytes8);
-  union $Bytes8 (*$pow)(union $Bytes8, union $Bytes8);
-  void (*$iadd)(union $Bytes8*, union $Bytes8);
-  void (*$isub)(union $Bytes8*, union $Bytes8);
-  void (*$imul)(union $Bytes8*, union $Bytes8);
-  void (*$itruediv)(union $Bytes8*, union $Bytes8);
-  void (*$ifloordiv)(union $Bytes8*, union $Bytes8);
-  void (*$imod)(union $Bytes8*, union $Bytes8);
-  void (*$iband)(union $Bytes8*, union $Bytes8);
-  void (*$ibor)(union $Bytes8*, union $Bytes8);
-  void (*$ibxor)(union $Bytes8*, union $Bytes8);
-  void (*$ilsh)(union $Bytes8*, union $Bytes8);
-  void (*$irsh)(union $Bytes8*, union $Bytes8);
-  bool (*$eq)(union $Bytes8, union $Bytes8);
-  bool (*$neq)(union $Bytes8, union $Bytes8);
-  bool (*$lt)(union $Bytes8, union $Bytes8);
-  bool (*$le)(union $Bytes8, union $Bytes8);
-  bool (*$gt)(union $Bytes8, union $Bytes8);
-  bool (*$ge)(union $Bytes8, union $Bytes8);
-  union $Bytes8 (*$abs)(union $Bytes8);
-  union $Bytes8 (*$neg)(union $Bytes8);
-  union $Bytes8 (*$lnot)(union $Bytes8);
-  union $Bytes8 (*$bnot)(union $Bytes8);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)(numpy$$Primitive$int);
+    void (*__serialize__)(numpy$$Primitive$int, $Serial$state);
+    numpy$$Primitive$int (*__deserialize__)(numpy$$Primitive$int, $Serial$state);
+    $bool (*__bool__)(numpy$$Primitive$int);
+    $str (*__str__)(numpy$$Primitive$int);
+    enum ElemType elem_type;
+    $WORD (*to$obj)
+    (union $Bytes8);
+    union $Bytes8 (*from$obj)($WORD);
+    $str (*$prim_str)(union $Bytes8);
+    union $Bytes8 (*$add)(union $Bytes8, union $Bytes8);
+    union $Bytes8 (*$sub)(union $Bytes8, union $Bytes8);
+    union $Bytes8 (*$mul)(union $Bytes8, union $Bytes8);
+    union $Bytes8 (*$truediv)(union $Bytes8, union $Bytes8);
+    union $Bytes8 (*$floordiv)(union $Bytes8, union $Bytes8);
+    union $Bytes8 (*$mod)(union $Bytes8, union $Bytes8);
+    union $Bytes8 (*$land)(union $Bytes8, union $Bytes8);
+    union $Bytes8 (*$lor)(union $Bytes8, union $Bytes8);
+    union $Bytes8 (*$band)(union $Bytes8, union $Bytes8);
+    union $Bytes8 (*$bor)(union $Bytes8, union $Bytes8);
+    union $Bytes8 (*$bxor)(union $Bytes8, union $Bytes8);
+    union $Bytes8 (*$lsh)(union $Bytes8, union $Bytes8);
+    union $Bytes8 (*$rsh)(union $Bytes8, union $Bytes8);
+    union $Bytes8 (*$pow)(union $Bytes8, union $Bytes8);
+    void (*$iadd)(union $Bytes8 *, union $Bytes8);
+    void (*$isub)(union $Bytes8 *, union $Bytes8);
+    void (*$imul)(union $Bytes8 *, union $Bytes8);
+    void (*$itruediv)(union $Bytes8 *, union $Bytes8);
+    void (*$ifloordiv)(union $Bytes8 *, union $Bytes8);
+    void (*$imod)(union $Bytes8 *, union $Bytes8);
+    void (*$iband)(union $Bytes8 *, union $Bytes8);
+    void (*$ibor)(union $Bytes8 *, union $Bytes8);
+    void (*$ibxor)(union $Bytes8 *, union $Bytes8);
+    void (*$ilsh)(union $Bytes8 *, union $Bytes8);
+    void (*$irsh)(union $Bytes8 *, union $Bytes8);
+    bool (*$eq)(union $Bytes8, union $Bytes8);
+    bool (*$neq)(union $Bytes8, union $Bytes8);
+    bool (*$lt)(union $Bytes8, union $Bytes8);
+    bool (*$le)(union $Bytes8, union $Bytes8);
+    bool (*$gt)(union $Bytes8, union $Bytes8);
+    bool (*$ge)(union $Bytes8, union $Bytes8);
+    union $Bytes8 (*$abs)(union $Bytes8);
+    union $Bytes8 (*$neg)(union $Bytes8);
+    union $Bytes8 (*$lnot)(union $Bytes8);
+    union $Bytes8 (*$bnot)(union $Bytes8);
 };
 
 // Primitive instance for float ///////////////////////////////////////////////////////////////
 
 struct numpy$$Primitive$float {
-  numpy$$Primitive$float$class $class;
+    numpy$$Primitive$float$class $class;
 };
 
 struct numpy$$Primitive$float$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)(numpy$$Primitive$float);
-  void (*__serialize__)(numpy$$Primitive$float,$Serial$state);
-  numpy$$Primitive$float (*__deserialize__)(numpy$$Primitive$float,$Serial$state);
-  $bool (*__bool__)(numpy$$Primitive$float);
-  $str (*__str__)(numpy$$Primitive$float);
-  enum ElemType elem_type;
-  $WORD (*to$obj)(union $Bytes8);
-  union $Bytes8 (*from$obj)($WORD);
-  $str (*$prim_str)(union $Bytes8);
-  union $Bytes8 (*$add)(union $Bytes8, union $Bytes8);
-  union $Bytes8 (*$sub)(union $Bytes8, union $Bytes8);
-  union $Bytes8 (*$mul)(union $Bytes8, union $Bytes8);
-  union $Bytes8 (*$truediv)(union $Bytes8, union $Bytes8);
-  union $Bytes8 (*$floordiv)(union $Bytes8, union $Bytes8);
-  union $Bytes8 (*$mod)(union $Bytes8, union $Bytes8);
-  union $Bytes8 (*$land)(union $Bytes8, union $Bytes8);
-  union $Bytes8 (*$lor)(union $Bytes8, union $Bytes8);
-  union $Bytes8 (*$band)(union $Bytes8, union $Bytes8);
-  union $Bytes8 (*$bor)(union $Bytes8, union $Bytes8);
-  union $Bytes8 (*$bxor)(union $Bytes8, union $Bytes8);
-  union $Bytes8 (*$lsh)(union $Bytes8, union $Bytes8);
-  union $Bytes8 (*$rsh)(union $Bytes8, union $Bytes8);
-  union $Bytes8 (*$pow)(union $Bytes8, union $Bytes8);
-  void (*$iadd)(union $Bytes8*, union $Bytes8);
-  void (*$isub)(union $Bytes8*, union $Bytes8);
-  void (*$imul)(union $Bytes8*, union $Bytes8);
-  void (*$itruediv)(union $Bytes8*, union $Bytes8);
-  void (*$ifloordiv)(union $Bytes8*, union $Bytes8);
-  void (*$imod)(union $Bytes8*, union $Bytes8);
-  void (*$iband)(union $Bytes8*, union $Bytes8);
-  void (*$ibor)(union $Bytes8*, union $Bytes8);
-  void (*$ibxor)(union $Bytes8*, union $Bytes8);
-  void (*$ilsh)(union $Bytes8*, union $Bytes8);
-  void (*$irsh)(union $Bytes8*, union $Bytes8);
-  bool (*$eq)(union $Bytes8, union $Bytes8);
-  bool (*$neq)(union $Bytes8, union $Bytes8);
-  bool (*$lt)(union $Bytes8, union $Bytes8);
-  bool (*$le)(union $Bytes8, union $Bytes8);
-  bool (*$gt)(union $Bytes8, union $Bytes8);
-  bool (*$ge)(union $Bytes8, union $Bytes8);
-  union $Bytes8 (*$abs)(union $Bytes8);
-  union $Bytes8 (*$neg)(union $Bytes8);
-  union $Bytes8 (*$lnot)(union $Bytes8);
-  union $Bytes8 (*$bnot)(union $Bytes8);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)(numpy$$Primitive$float);
+    void (*__serialize__)(numpy$$Primitive$float, $Serial$state);
+    numpy$$Primitive$float (*__deserialize__)(numpy$$Primitive$float, $Serial$state);
+    $bool (*__bool__)(numpy$$Primitive$float);
+    $str (*__str__)(numpy$$Primitive$float);
+    enum ElemType elem_type;
+    $WORD (*to$obj)
+    (union $Bytes8);
+    union $Bytes8 (*from$obj)($WORD);
+    $str (*$prim_str)(union $Bytes8);
+    union $Bytes8 (*$add)(union $Bytes8, union $Bytes8);
+    union $Bytes8 (*$sub)(union $Bytes8, union $Bytes8);
+    union $Bytes8 (*$mul)(union $Bytes8, union $Bytes8);
+    union $Bytes8 (*$truediv)(union $Bytes8, union $Bytes8);
+    union $Bytes8 (*$floordiv)(union $Bytes8, union $Bytes8);
+    union $Bytes8 (*$mod)(union $Bytes8, union $Bytes8);
+    union $Bytes8 (*$land)(union $Bytes8, union $Bytes8);
+    union $Bytes8 (*$lor)(union $Bytes8, union $Bytes8);
+    union $Bytes8 (*$band)(union $Bytes8, union $Bytes8);
+    union $Bytes8 (*$bor)(union $Bytes8, union $Bytes8);
+    union $Bytes8 (*$bxor)(union $Bytes8, union $Bytes8);
+    union $Bytes8 (*$lsh)(union $Bytes8, union $Bytes8);
+    union $Bytes8 (*$rsh)(union $Bytes8, union $Bytes8);
+    union $Bytes8 (*$pow)(union $Bytes8, union $Bytes8);
+    void (*$iadd)(union $Bytes8 *, union $Bytes8);
+    void (*$isub)(union $Bytes8 *, union $Bytes8);
+    void (*$imul)(union $Bytes8 *, union $Bytes8);
+    void (*$itruediv)(union $Bytes8 *, union $Bytes8);
+    void (*$ifloordiv)(union $Bytes8 *, union $Bytes8);
+    void (*$imod)(union $Bytes8 *, union $Bytes8);
+    void (*$iband)(union $Bytes8 *, union $Bytes8);
+    void (*$ibor)(union $Bytes8 *, union $Bytes8);
+    void (*$ibxor)(union $Bytes8 *, union $Bytes8);
+    void (*$ilsh)(union $Bytes8 *, union $Bytes8);
+    void (*$irsh)(union $Bytes8 *, union $Bytes8);
+    bool (*$eq)(union $Bytes8, union $Bytes8);
+    bool (*$neq)(union $Bytes8, union $Bytes8);
+    bool (*$lt)(union $Bytes8, union $Bytes8);
+    bool (*$le)(union $Bytes8, union $Bytes8);
+    bool (*$gt)(union $Bytes8, union $Bytes8);
+    bool (*$ge)(union $Bytes8, union $Bytes8);
+    union $Bytes8 (*$abs)(union $Bytes8);
+    union $Bytes8 (*$neg)(union $Bytes8);
+    union $Bytes8 (*$lnot)(union $Bytes8);
+    union $Bytes8 (*$bnot)(union $Bytes8);
 };
 
 // Witnesses and creation ////////////////////////////////////////////////////////////////////////////
@@ -269,44 +269,41 @@ struct numpy$$Primitive$float$class {
 numpy$$Primitive$int numpy$$Primitive$int$new();
 numpy$$Primitive$float numpy$$Primitive$float$new();
 
-extern struct numpy$$Primitive$int$class  numpy$$Primitive$int$methods;
-extern struct numpy$$Primitive$float$class  numpy$$Primitive$float$methods;
+extern struct numpy$$Primitive$int$class numpy$$Primitive$int$methods;
+extern struct numpy$$Primitive$float$class numpy$$Primitive$float$methods;
 
 extern struct numpy$$Primitive$int *numpy$$Primitive$int$witness;
 extern struct numpy$$Primitive$float *numpy$$Primitive$float$witness;
-
-
-
 
 struct numpy$$ndarray;
 typedef struct numpy$$ndarray *numpy$$ndarray;
 
 struct numpy$$ndarray$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)(numpy$$ndarray,$WORD);
-  void (*__serialize__)(numpy$$ndarray,$Serial$state); 
-  numpy$$ndarray (*__deserialize__)(numpy$$ndarray,$Serial$state);
-  $bool (*__bool__)(numpy$$ndarray);
-  $str (*__str__)(numpy$$ndarray);
-  numpy$$ndarray (*reshape)(numpy$$ndarray,$list);
-  numpy$$ndarray (*transpose)(numpy$$ndarray,$list);
-  numpy$$ndarray (*flatten)(numpy$$ndarray);
-  numpy$$ndarray (*copy)(numpy$$ndarray);
-  numpy$$ndarray (*__ndgetslice__)(numpy$$ndarray,$list);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)(numpy$$ndarray, $WORD);
+    void (*__serialize__)(numpy$$ndarray, $Serial$state);
+    numpy$$ndarray (*__deserialize__)(numpy$$ndarray, $Serial$state);
+    $bool (*__bool__)(numpy$$ndarray);
+    $str (*__str__)(numpy$$ndarray);
+    numpy$$ndarray (*reshape)(numpy$$ndarray, $list);
+    numpy$$ndarray (*transpose)(numpy$$ndarray, $list);
+    numpy$$ndarray (*flatten)(numpy$$ndarray);
+    numpy$$ndarray (*copy)(numpy$$ndarray);
+    numpy$$ndarray (*__ndgetslice__)(numpy$$ndarray, $list);
 };
 
 struct numpy$$ndarray {
-  struct numpy$$ndarray$class *$class;
-  enum ElemType elem_type;
-  long ndim;
-  $int size;         // # of elements; equal to product of elements in shape.
-  long offset;
-  long elem_size;
-  $list shape;
-  $list strides;
-  union $Bytes8 *data;
+    struct numpy$$ndarray$class *$class;
+    enum ElemType elem_type;
+    long ndim;
+    $int size; // # of elements; equal to product of elements in shape.
+    long offset;
+    long elem_size;
+    $list shape;
+    $list strides;
+    union $Bytes8 *data;
 };
 
 extern struct numpy$$ndarray$class numpy$$ndarray$methods;
@@ -316,44 +313,44 @@ extern struct numpy$$ndarray$class numpy$$ndarray$methods;
 #define MAX_NDIM 16
 
 typedef struct numpy$$array_iterator_state {
-  union $Bytes8 *current;
-  long currentstride;
-  long lastshapepos;
-  long lastshapelength;
-  long ndim1;    // ndim-1
-  long shape[MAX_NDIM];
-  long strides[MAX_NDIM];
-  long jumps[MAX_NDIM];
-  long index[MAX_NDIM];
-} *numpy$$array_iterator_state;
+    union $Bytes8 *current;
+    long currentstride;
+    long lastshapepos;
+    long lastshapelength;
+    long ndim1; // ndim-1
+    long shape[MAX_NDIM];
+    long strides[MAX_NDIM];
+    long jumps[MAX_NDIM];
+    long index[MAX_NDIM];
+} * numpy$$array_iterator_state;
 
-
-
-typedef struct numpy$$Iterator$ndarray *numpy$$Iterator$ndarray; ;
+typedef struct numpy$$Iterator$ndarray *numpy$$Iterator$ndarray;
+;
 
 struct numpy$$Iterator$ndarray$class {
-  char *$GCINFO;
-  int $class_id;
-  $Super$class $superclass;
-  void (*__init__)(numpy$$Iterator$ndarray, numpy$$Primitive, numpy$$ndarray);
-  void (*__serialize__)(numpy$$Iterator$ndarray,$Serial$state);
-  numpy$$Iterator$ndarray (*__deserialize__)(numpy$$Iterator$ndarray,$Serial$state);
-  $bool (*__bool__)(numpy$$Iterator$ndarray);
-  $str (*__str__)(numpy$$Iterator$ndarray);
-  $WORD (*__next__)(numpy$$Iterator$ndarray);
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    void (*__init__)(numpy$$Iterator$ndarray, numpy$$Primitive, numpy$$ndarray);
+    void (*__serialize__)(numpy$$Iterator$ndarray, $Serial$state);
+    numpy$$Iterator$ndarray (*__deserialize__)(numpy$$Iterator$ndarray, $Serial$state);
+    $bool (*__bool__)(numpy$$Iterator$ndarray);
+    $str (*__str__)(numpy$$Iterator$ndarray);
+    $WORD (*__next__)
+    (numpy$$Iterator$ndarray);
 };
 
 numpy$$ndarray numpy$$ndarray$new($WORD);
 
 struct numpy$$Iterator$ndarray {
-  struct numpy$$Iterator$ndarray$class *$class;
-  numpy$$Primitive pwit;
-  numpy$$array_iterator_state it;
+    struct numpy$$Iterator$ndarray$class *$class;
+    numpy$$Primitive pwit;
+    numpy$$array_iterator_state it;
 };
 
-extern struct  numpy$$Iterator$ndarray$class  numpy$$Iterator$ndarray$methods;
+extern struct numpy$$Iterator$ndarray$class numpy$$Iterator$ndarray$methods;
 
-numpy$$Iterator$ndarray numpy$$Iterator$ndarray$new(numpy$$Primitive,numpy$$ndarray);
+numpy$$Iterator$ndarray numpy$$Iterator$ndarray$new(numpy$$Primitive, numpy$$ndarray);
 
 // Intended argument to constructor
 
@@ -364,11 +361,11 @@ numpy$$ndarray numpy$$fromatom($atom a);
 
 // Methods in ndarray class //////////////////////////////////////////////
 
-numpy$$ndarray numpy$$ndarray$reshape(numpy$$ndarray,$list);
-numpy$$ndarray numpy$$ndarray$transpose(numpy$$ndarray,$list);
+numpy$$ndarray numpy$$ndarray$reshape(numpy$$ndarray, $list);
+numpy$$ndarray numpy$$ndarray$transpose(numpy$$ndarray, $list);
 numpy$$ndarray numpy$$ndarray$flatten(numpy$$ndarray);
 numpy$$ndarray numpy$$ndarray$copy(numpy$$ndarray);
-numpy$$ndarray numpy$$ndarray$__ndgetslice__(numpy$$ndarray,$list);
+numpy$$ndarray numpy$$ndarray$__ndgetslice__(numpy$$ndarray, $list);
 
 // Functions to create ndarrays /////////////////////////////////////////
 
@@ -459,31 +456,39 @@ struct numpy$$Integral$ndarray$int$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)(numpy$$Integral$ndarray$int);
-    void (*__serialize__)(numpy$$Integral$ndarray$int,$Serial$state);
-    numpy$$Integral$ndarray$int (*__deserialize__)(numpy$$Integral$ndarray$int,$Serial$state);
+    void (*__serialize__)(numpy$$Integral$ndarray$int, $Serial$state);
+    numpy$$Integral$ndarray$int (*__deserialize__)(numpy$$Integral$ndarray$int, $Serial$state);
     $bool (*__bool__)(numpy$$Integral$ndarray$int);
     $str (*__str__)(numpy$$Integral$ndarray$int);
     numpy$$ndarray (*__add__)(numpy$$Integral$ndarray$int, numpy$$ndarray, numpy$$ndarray);
     numpy$$ndarray (*__iadd__)(numpy$$Integral$ndarray$int, numpy$$ndarray, numpy$$ndarray);
     numpy$$ndarray (*__mul__)(numpy$$Integral$ndarray$int, numpy$$ndarray, numpy$$ndarray);
     numpy$$ndarray (*__imul__)(numpy$$Integral$ndarray$int, numpy$$ndarray, numpy$$ndarray);
-    numpy$$ndarray (*__fromatom__)(numpy$$Integral$ndarray$int,$atom);
+    numpy$$ndarray (*__fromatom__)(numpy$$Integral$ndarray$int, $atom);
     $complex (*__complx__)(numpy$$Integral$ndarray$int, numpy$$ndarray);
     numpy$$ndarray (*__pow__)(numpy$$Integral$ndarray$int, numpy$$ndarray, numpy$$ndarray);
     numpy$$ndarray (*__ipow__)(numpy$$Integral$ndarray$int, numpy$$ndarray, numpy$$ndarray);
     numpy$$ndarray (*__neg__)(numpy$$Integral$ndarray$int, numpy$$ndarray);
     numpy$$ndarray (*__pos__)(numpy$$Integral$ndarray$int, numpy$$ndarray);
-    $WORD (*real)(numpy$$Integral$ndarray$int, numpy$$ndarray, $Real);
-    $WORD (*imag)(numpy$$Integral$ndarray$int, numpy$$ndarray, $Real);
-    $WORD (*__abs__)(numpy$$Integral$ndarray$int, numpy$$ndarray, $Real);
+    $WORD (*real)
+    (numpy$$Integral$ndarray$int, numpy$$ndarray, $Real);
+    $WORD (*imag)
+    (numpy$$Integral$ndarray$int, numpy$$ndarray, $Real);
+    $WORD (*__abs__)
+    (numpy$$Integral$ndarray$int, numpy$$ndarray, $Real);
     numpy$$ndarray (*conjugate)(numpy$$Integral$ndarray$int, numpy$$ndarray);
     $float (*__float__)(numpy$$Integral$ndarray$int, numpy$$ndarray);
-    $WORD (*__trunc__)(numpy$$Integral$ndarray$int, numpy$$ndarray, $Integral);
-    $WORD (*__floor__)(numpy$$Integral$ndarray$int, numpy$$ndarray, $Integral);
-    $WORD (*__ceil__)(numpy$$Integral$ndarray$int, numpy$$ndarray, $Integral);
+    $WORD (*__trunc__)
+    (numpy$$Integral$ndarray$int, numpy$$ndarray, $Integral);
+    $WORD (*__floor__)
+    (numpy$$Integral$ndarray$int, numpy$$ndarray, $Integral);
+    $WORD (*__ceil__)
+    (numpy$$Integral$ndarray$int, numpy$$ndarray, $Integral);
     numpy$$ndarray (*__round__)(numpy$$Integral$ndarray$int, numpy$$ndarray, numpy$$ndarray);
-    $WORD (*numerator)(numpy$$Integral$ndarray$int, numpy$$ndarray, $Integral);
-    $WORD (*denominator)(numpy$$Integral$ndarray$int, numpy$$ndarray, $Integral);
+    $WORD (*numerator)
+    (numpy$$Integral$ndarray$int, numpy$$ndarray, $Integral);
+    $WORD (*denominator)
+    (numpy$$Integral$ndarray$int, numpy$$ndarray, $Integral);
     numpy$$ndarray (*__int__)(numpy$$Integral$ndarray$int, numpy$$ndarray);
     numpy$$ndarray (*__index__)(numpy$$Integral$ndarray$int, numpy$$ndarray);
     $tuple (*__divmod__)(numpy$$Integral$ndarray$int, numpy$$ndarray, numpy$$ndarray);
@@ -498,12 +503,12 @@ struct numpy$$Integral$ndarray$int$class {
     numpy$$ndarray (*__invert__)(numpy$$Integral$ndarray$int, numpy$$ndarray);
 };
 
-void numpy$$Integral$ndarray$int$__init__ (numpy$$Integral$ndarray$int);
-void numpy$$Integral$ndarray$int$__serialize__(numpy$$Integral$ndarray$int,$Serial$state);
-numpy$$Integral$ndarray$int numpy$$Integral$ndarray$int$__deserialize__(numpy$$Integral$ndarray$int,$Serial$state);
+void numpy$$Integral$ndarray$int$__init__(numpy$$Integral$ndarray$int);
+void numpy$$Integral$ndarray$int$__serialize__(numpy$$Integral$ndarray$int, $Serial$state);
+numpy$$Integral$ndarray$int numpy$$Integral$ndarray$int$__deserialize__(numpy$$Integral$ndarray$int, $Serial$state);
 numpy$$ndarray numpy$$Integral$ndarray$int$__add__(numpy$$Integral$ndarray$int, numpy$$ndarray, numpy$$ndarray);
 numpy$$ndarray numpy$$Integral$ndarray$int$__iadd__(numpy$$Integral$ndarray$int, numpy$$ndarray, numpy$$ndarray);
-numpy$$ndarray numpy$$Integral$ndarray$int$__fromatom__(numpy$$Integral$ndarray$int,$atom);
+numpy$$ndarray numpy$$Integral$ndarray$int$__fromatom__(numpy$$Integral$ndarray$int, $atom);
 $complex numpy$$Integral$ndarray$int$__complx__(numpy$$Integral$ndarray$int, numpy$$ndarray);
 numpy$$ndarray numpy$$Integral$ndarray$int$__mul__(numpy$$Integral$ndarray$int, numpy$$ndarray, numpy$$ndarray);
 numpy$$ndarray numpy$$Integral$ndarray$int$__pow__(numpy$$Integral$ndarray$int, numpy$$ndarray, numpy$$ndarray);
@@ -513,21 +518,21 @@ $WORD numpy$$Integral$ndarray$int$real(numpy$$Integral$ndarray$int, numpy$$ndarr
 $WORD numpy$$Integral$ndarray$int$imag(numpy$$Integral$ndarray$int, numpy$$ndarray, $Real);
 $WORD numpy$$Integral$ndarray$int$__abs__(numpy$$Integral$ndarray$int, numpy$$ndarray, $Real);
 numpy$$ndarray numpy$$Integral$ndarray$int$conjugate(numpy$$Integral$ndarray$int, numpy$$ndarray);
-$float numpy$$Integral$ndarray$int$__float__ (numpy$$Integral$ndarray$int, numpy$$ndarray);
-$WORD numpy$$Integral$ndarray$int$__trunc__ (numpy$$Integral$ndarray$int, numpy$$ndarray, $Integral);
-$WORD numpy$$Integral$ndarray$int$__floor__ (numpy$$Integral$ndarray$int, numpy$$ndarray, $Integral);
-$WORD numpy$$Integral$ndarray$int$__ceil__ (numpy$$Integral$ndarray$int, numpy$$ndarray, $Integral);
-numpy$$ndarray numpy$$Integral$ndarray$int$__round__ (numpy$$Integral$ndarray$int, numpy$$ndarray, numpy$$ndarray);
-$WORD numpy$$Integral$ndarray$int$numerator (numpy$$Integral$ndarray$int, numpy$$ndarray, $Integral);
-$WORD numpy$$Integral$ndarray$int$denominator (numpy$$Integral$ndarray$int, numpy$$ndarray, $Integral);
-numpy$$ndarray numpy$$Integral$ndarray$int$__int__ (numpy$$Integral$ndarray$int, numpy$$ndarray);
-numpy$$ndarray numpy$$Integral$ndarray$int$__index__ (numpy$$Integral$ndarray$int, numpy$$ndarray);
-$tuple numpy$$Integral$ndarray$int$__divmod__ (numpy$$Integral$ndarray$int, numpy$$ndarray, numpy$$ndarray);
-numpy$$ndarray numpy$$Integral$ndarray$int$__floordiv__ (numpy$$Integral$ndarray$int, numpy$$ndarray, numpy$$ndarray);
-numpy$$ndarray numpy$$Integral$ndarray$int$__mod__ (numpy$$Integral$ndarray$int, numpy$$ndarray, numpy$$ndarray);
-numpy$$ndarray numpy$$Integral$ndarray$int$__lshift__ (numpy$$Integral$ndarray$int, numpy$$ndarray, numpy$$ndarray);
-numpy$$ndarray numpy$$Integral$ndarray$int$__rshift__ (numpy$$Integral$ndarray$int, numpy$$ndarray, numpy$$ndarray);
-numpy$$ndarray numpy$$Integral$ndarray$int$__invert__ (numpy$$Integral$ndarray$int, numpy$$ndarray);
+$float numpy$$Integral$ndarray$int$__float__(numpy$$Integral$ndarray$int, numpy$$ndarray);
+$WORD numpy$$Integral$ndarray$int$__trunc__(numpy$$Integral$ndarray$int, numpy$$ndarray, $Integral);
+$WORD numpy$$Integral$ndarray$int$__floor__(numpy$$Integral$ndarray$int, numpy$$ndarray, $Integral);
+$WORD numpy$$Integral$ndarray$int$__ceil__(numpy$$Integral$ndarray$int, numpy$$ndarray, $Integral);
+numpy$$ndarray numpy$$Integral$ndarray$int$__round__(numpy$$Integral$ndarray$int, numpy$$ndarray, numpy$$ndarray);
+$WORD numpy$$Integral$ndarray$int$numerator(numpy$$Integral$ndarray$int, numpy$$ndarray, $Integral);
+$WORD numpy$$Integral$ndarray$int$denominator(numpy$$Integral$ndarray$int, numpy$$ndarray, $Integral);
+numpy$$ndarray numpy$$Integral$ndarray$int$__int__(numpy$$Integral$ndarray$int, numpy$$ndarray);
+numpy$$ndarray numpy$$Integral$ndarray$int$__index__(numpy$$Integral$ndarray$int, numpy$$ndarray);
+$tuple numpy$$Integral$ndarray$int$__divmod__(numpy$$Integral$ndarray$int, numpy$$ndarray, numpy$$ndarray);
+numpy$$ndarray numpy$$Integral$ndarray$int$__floordiv__(numpy$$Integral$ndarray$int, numpy$$ndarray, numpy$$ndarray);
+numpy$$ndarray numpy$$Integral$ndarray$int$__mod__(numpy$$Integral$ndarray$int, numpy$$ndarray, numpy$$ndarray);
+numpy$$ndarray numpy$$Integral$ndarray$int$__lshift__(numpy$$Integral$ndarray$int, numpy$$ndarray, numpy$$ndarray);
+numpy$$ndarray numpy$$Integral$ndarray$int$__rshift__(numpy$$Integral$ndarray$int, numpy$$ndarray, numpy$$ndarray);
+numpy$$ndarray numpy$$Integral$ndarray$int$__invert__(numpy$$Integral$ndarray$int, numpy$$ndarray);
 
 // numpy$$Logical$ndarray$int ////////////////////////////////////////////////////////////
 
@@ -541,8 +546,8 @@ struct numpy$$Logical$ndarray$int$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)(numpy$$Logical$ndarray$int, $Integral);
-    void (*__serialize__)(numpy$$Logical$ndarray$int,$Serial$state);
-    numpy$$Logical$ndarray$int (*__deserialize__)(numpy$$Logical$ndarray$int,$Serial$state);
+    void (*__serialize__)(numpy$$Logical$ndarray$int, $Serial$state);
+    numpy$$Logical$ndarray$int (*__deserialize__)(numpy$$Logical$ndarray$int, $Serial$state);
     $bool (*__bool__)(numpy$$Logical$ndarray$int);
     $str (*__str__)(numpy$$Logical$ndarray$int);
     numpy$$ndarray (*__and__)(numpy$$Logical$ndarray$int, numpy$$ndarray, numpy$$ndarray);
@@ -553,12 +558,12 @@ struct numpy$$Logical$ndarray$int$class {
     numpy$$ndarray (*__ixor__)(numpy$$Logical$ndarray$int, numpy$$ndarray, numpy$$ndarray);
 };
 
-void numpy$$Logical$ndarray$int$__init__ (numpy$$Logical$ndarray$int, $Integral);
-void numpy$$Logical$ndarray$int$__serialize__(numpy$$Logical$ndarray$int,$Serial$state);
-numpy$$Logical$ndarray$int numpy$$Logical$ndarray$int$__deserialize__(numpy$$Logical$ndarray$int,$Serial$state);
-numpy$$ndarray numpy$$Logical$ndarray$int$__and__ (numpy$$Logical$ndarray$int, numpy$$ndarray, numpy$$ndarray);
-numpy$$ndarray numpy$$Logical$ndarray$int$__or__ (numpy$$Logical$ndarray$int, numpy$$ndarray, numpy$$ndarray);
-numpy$$ndarray numpy$$Logical$ndarray$int$__xor__ (numpy$$Logical$ndarray$int, numpy$$ndarray, numpy$$ndarray);
+void numpy$$Logical$ndarray$int$__init__(numpy$$Logical$ndarray$int, $Integral);
+void numpy$$Logical$ndarray$int$__serialize__(numpy$$Logical$ndarray$int, $Serial$state);
+numpy$$Logical$ndarray$int numpy$$Logical$ndarray$int$__deserialize__(numpy$$Logical$ndarray$int, $Serial$state);
+numpy$$ndarray numpy$$Logical$ndarray$int$__and__(numpy$$Logical$ndarray$int, numpy$$ndarray, numpy$$ndarray);
+numpy$$ndarray numpy$$Logical$ndarray$int$__or__(numpy$$Logical$ndarray$int, numpy$$ndarray, numpy$$ndarray);
+numpy$$ndarray numpy$$Logical$ndarray$int$__xor__(numpy$$Logical$ndarray$int, numpy$$ndarray, numpy$$ndarray);
 
 // numpy$$Minus$ndarray$int ////////////////////////////////////////////////////////////
 
@@ -572,18 +577,18 @@ struct numpy$$Minus$ndarray$int$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)(numpy$$Minus$ndarray$int, $Integral);
-    void (*__serialize__)(numpy$$Minus$ndarray$int,$Serial$state);
-    numpy$$Minus$ndarray$int (*__deserialize__)(numpy$$Minus$ndarray$int,$Serial$state);
+    void (*__serialize__)(numpy$$Minus$ndarray$int, $Serial$state);
+    numpy$$Minus$ndarray$int (*__deserialize__)(numpy$$Minus$ndarray$int, $Serial$state);
     $bool (*__bool__)(numpy$$Minus$ndarray$int);
     $str (*__str__)(numpy$$Minus$ndarray$int);
     numpy$$ndarray (*__sub__)(numpy$$Minus$ndarray$int, numpy$$ndarray, numpy$$ndarray);
     numpy$$ndarray (*__isub__)(numpy$$Minus$ndarray$int, numpy$$ndarray, numpy$$ndarray);
 };
 
-void numpy$$Minus$ndarray$int$__init__ (numpy$$Minus$ndarray$int, $Integral);
-void numpy$$Minus$ndarray$int$__serialize__(numpy$$Minus$ndarray$int,$Serial$state);
-numpy$$Minus$ndarray$int numpy$$Minus$ndarray$int$__deserialize__(numpy$$Minus$ndarray$int,$Serial$state);
-numpy$$ndarray numpy$$Minus$ndarray$int$__sub__ (numpy$$Minus$ndarray$int, numpy$$ndarray, numpy$$ndarray);
+void numpy$$Minus$ndarray$int$__init__(numpy$$Minus$ndarray$int, $Integral);
+void numpy$$Minus$ndarray$int$__serialize__(numpy$$Minus$ndarray$int, $Serial$state);
+numpy$$Minus$ndarray$int numpy$$Minus$ndarray$int$__deserialize__(numpy$$Minus$ndarray$int, $Serial$state);
+numpy$$ndarray numpy$$Minus$ndarray$int$__sub__(numpy$$Minus$ndarray$int, numpy$$ndarray, numpy$$ndarray);
 
 // numpy$$Real$ndarray ////////////////////////////////////////////////////////////
 
@@ -597,38 +602,44 @@ struct numpy$$Real$ndarray$class {
     char *$GCINFO;
     int $class_id;
     $Super$class $superclass;
-  void (*__init__)(numpy$$Real$ndarray, numpy$$Primitive);
-    void (*__serialize__)(numpy$$Real$ndarray,$Serial$state);
-    numpy$$Real$ndarray (*__deserialize__)(numpy$$Real$ndarray,$Serial$state);
+    void (*__init__)(numpy$$Real$ndarray, numpy$$Primitive);
+    void (*__serialize__)(numpy$$Real$ndarray, $Serial$state);
+    numpy$$Real$ndarray (*__deserialize__)(numpy$$Real$ndarray, $Serial$state);
     $bool (*__bool__)(numpy$$Real$ndarray);
     $str (*__str__)(numpy$$Real$ndarray);
     numpy$$ndarray (*__add__)(numpy$$Real$ndarray, numpy$$ndarray, numpy$$ndarray);
     numpy$$ndarray (*__iadd__)(numpy$$Real$ndarray, numpy$$ndarray, numpy$$ndarray);
     numpy$$ndarray (*__mul__)(numpy$$Real$ndarray, numpy$$ndarray, numpy$$ndarray);
     numpy$$ndarray (*__imul__)(numpy$$Real$ndarray, numpy$$ndarray, numpy$$ndarray);
-    numpy$$ndarray (*__fromatom__)(numpy$$Real$ndarray,$atom);
+    numpy$$ndarray (*__fromatom__)(numpy$$Real$ndarray, $atom);
     $complex (*__complx__)(numpy$$Real$ndarray, numpy$$ndarray);
     numpy$$ndarray (*__pow__)(numpy$$Real$ndarray, numpy$$ndarray, numpy$$ndarray);
     numpy$$ndarray (*__ipow__)(numpy$$Real$ndarray, numpy$$ndarray, numpy$$ndarray);
     numpy$$ndarray (*__neg__)(numpy$$Real$ndarray, numpy$$ndarray);
     numpy$$ndarray (*__pos__)(numpy$$Real$ndarray, numpy$$ndarray);
-    $WORD (*real)(numpy$$Real$ndarray, numpy$$ndarray, $Real);
-    $WORD (*imag)(numpy$$Real$ndarray, numpy$$ndarray, $Real);
-    $WORD (*__abs__)(numpy$$Real$ndarray, numpy$$ndarray, $Real);
+    $WORD (*real)
+    (numpy$$Real$ndarray, numpy$$ndarray, $Real);
+    $WORD (*imag)
+    (numpy$$Real$ndarray, numpy$$ndarray, $Real);
+    $WORD (*__abs__)
+    (numpy$$Real$ndarray, numpy$$ndarray, $Real);
     numpy$$ndarray (*conjugate)(numpy$$Real$ndarray, numpy$$ndarray);
     $float (*__float__)(numpy$$Real$ndarray, numpy$$ndarray);
-    $WORD (*__trunc__)(numpy$$Real$ndarray, numpy$$ndarray, $Integral);
-    $WORD (*__floor__)(numpy$$Real$ndarray, numpy$$ndarray, $Integral);
-    $WORD (*__ceil__)(numpy$$Real$ndarray, numpy$$ndarray, $Integral);
+    $WORD (*__trunc__)
+    (numpy$$Real$ndarray, numpy$$ndarray, $Integral);
+    $WORD (*__floor__)
+    (numpy$$Real$ndarray, numpy$$ndarray, $Integral);
+    $WORD (*__ceil__)
+    (numpy$$Real$ndarray, numpy$$ndarray, $Integral);
     numpy$$ndarray (*__round__)(numpy$$Real$ndarray, numpy$$ndarray, numpy$$ndarray);
 };
 
-void numpy$$Real$ndarray$__init__ (numpy$$Real$ndarray,numpy$$Primitive);
-void numpy$$Real$ndarray$__serialize__(numpy$$Real$ndarray,$Serial$state);
-numpy$$Real$ndarray numpy$$Real$ndarray$__deserialize__(numpy$$Real$ndarray,$Serial$state);
+void numpy$$Real$ndarray$__init__(numpy$$Real$ndarray, numpy$$Primitive);
+void numpy$$Real$ndarray$__serialize__(numpy$$Real$ndarray, $Serial$state);
+numpy$$Real$ndarray numpy$$Real$ndarray$__deserialize__(numpy$$Real$ndarray, $Serial$state);
 numpy$$ndarray numpy$$Real$ndarray$__add__(numpy$$Real$ndarray, numpy$$ndarray, numpy$$ndarray);
 numpy$$ndarray numpy$$Real$ndarray$__iadd__(numpy$$Real$ndarray, numpy$$ndarray, numpy$$ndarray);
-numpy$$ndarray numpy$$Real$ndarray$__fromatom__(numpy$$Real$ndarray,$atom);
+numpy$$ndarray numpy$$Real$ndarray$__fromatom__(numpy$$Real$ndarray, $atom);
 $complex numpy$$Real$ndarray$__complx__(numpy$$Real$ndarray, numpy$$ndarray);
 numpy$$ndarray numpy$$Real$ndarray$__mul__(numpy$$Real$ndarray, numpy$$ndarray, numpy$$ndarray);
 numpy$$ndarray numpy$$Real$ndarray$__pow__(numpy$$Real$ndarray, numpy$$ndarray, numpy$$ndarray);
@@ -638,11 +649,11 @@ $WORD numpy$$Real$ndarray$real(numpy$$Real$ndarray, numpy$$ndarray, $Real);
 $WORD numpy$$Real$ndarray$imag(numpy$$Real$ndarray, numpy$$ndarray, $Real);
 $WORD numpy$$Real$ndarray$__abs__(numpy$$Real$ndarray, numpy$$ndarray, $Real);
 numpy$$ndarray numpy$$Real$ndarray$conjugate(numpy$$Real$ndarray, numpy$$ndarray);
-$float numpy$$Real$ndarray$__float__ (numpy$$Real$ndarray, numpy$$ndarray);
-$WORD numpy$$Real$ndarray$__trunc__ (numpy$$Real$ndarray, numpy$$ndarray, $Integral);
-$WORD numpy$$Real$ndarray$__floor__ (numpy$$Real$ndarray, numpy$$ndarray, $Integral);
-$WORD numpy$$Real$ndarray$__ceil__ (numpy$$Real$ndarray, numpy$$ndarray, $Integral);
-numpy$$ndarray numpy$$Real$ndarray$__round__ (numpy$$Real$ndarray, numpy$$ndarray, numpy$$ndarray);
+$float numpy$$Real$ndarray$__float__(numpy$$Real$ndarray, numpy$$ndarray);
+$WORD numpy$$Real$ndarray$__trunc__(numpy$$Real$ndarray, numpy$$ndarray, $Integral);
+$WORD numpy$$Real$ndarray$__floor__(numpy$$Real$ndarray, numpy$$ndarray, $Integral);
+$WORD numpy$$Real$ndarray$__ceil__(numpy$$Real$ndarray, numpy$$ndarray, $Integral);
+numpy$$ndarray numpy$$Real$ndarray$__round__(numpy$$Real$ndarray, numpy$$ndarray, numpy$$ndarray);
 
 // numpy$$Minus$ndarray ////////////////////////////////////////////////////////////
 
@@ -656,18 +667,18 @@ struct numpy$$Minus$ndarray$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)(numpy$$Minus$ndarray, $Real);
-    void (*__serialize__)(numpy$$Minus$ndarray,$Serial$state);
-    numpy$$Minus$ndarray (*__deserialize__)(numpy$$Minus$ndarray,$Serial$state);
+    void (*__serialize__)(numpy$$Minus$ndarray, $Serial$state);
+    numpy$$Minus$ndarray (*__deserialize__)(numpy$$Minus$ndarray, $Serial$state);
     $bool (*__bool__)(numpy$$Minus$ndarray);
     $str (*__str__)(numpy$$Minus$ndarray);
     numpy$$ndarray (*__sub__)(numpy$$Minus$ndarray, numpy$$ndarray, numpy$$ndarray);
     numpy$$ndarray (*__isub__)(numpy$$Minus$ndarray, numpy$$ndarray, numpy$$ndarray);
 };
 
-void numpy$$Minus$ndarray$__init__ (numpy$$Minus$ndarray, $Real);
-void numpy$$Minus$ndarray$__serialize__(numpy$$Minus$ndarray,$Serial$state);
-numpy$$Minus$ndarray numpy$$Minus$ndarray$__deserialize__(numpy$$Minus$ndarray,$Serial$state);
-numpy$$ndarray numpy$$Minus$ndarray$__sub__ (numpy$$Minus$ndarray, numpy$$ndarray, numpy$$ndarray);
+void numpy$$Minus$ndarray$__init__(numpy$$Minus$ndarray, $Real);
+void numpy$$Minus$ndarray$__serialize__(numpy$$Minus$ndarray, $Serial$state);
+numpy$$Minus$ndarray numpy$$Minus$ndarray$__deserialize__(numpy$$Minus$ndarray, $Serial$state);
+numpy$$ndarray numpy$$Minus$ndarray$__sub__(numpy$$Minus$ndarray, numpy$$ndarray, numpy$$ndarray);
 
 // numpy$$Div$ndarray$int ////////////////////////////////////////////////////////////
 
@@ -681,18 +692,18 @@ struct numpy$$Div$ndarray$int$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)(numpy$$Div$ndarray$int);
-    void (*__serialize__)(numpy$$Div$ndarray$int,$Serial$state);
-    numpy$$Div$ndarray$int (*__deserialize__)(numpy$$Div$ndarray$int,$Serial$state);
+    void (*__serialize__)(numpy$$Div$ndarray$int, $Serial$state);
+    numpy$$Div$ndarray$int (*__deserialize__)(numpy$$Div$ndarray$int, $Serial$state);
     $bool (*__bool__)(numpy$$Div$ndarray$int);
     $str (*__str__)(numpy$$Div$ndarray$int);
     numpy$$ndarray (*__truediv__)(numpy$$Div$ndarray$int, numpy$$ndarray, numpy$$ndarray);
     numpy$$ndarray (*__itruediv__)(numpy$$Div$ndarray$int, numpy$$ndarray, numpy$$ndarray);
 };
 
-void numpy$$Div$ndarray$int$__init__ (numpy$$Div$ndarray$int);
-void numpy$$Div$ndarray$int$__serialize__(numpy$$Div$ndarray$int,$Serial$state);
-numpy$$Div$ndarray$int numpy$$Div$ndarray$int$__deserialize__(numpy$$Div$ndarray$int,$Serial$state);
-numpy$$ndarray numpy$$Div$ndarray$int$__truediv__ (numpy$$Div$ndarray$int, numpy$$ndarray, numpy$$ndarray);
+void numpy$$Div$ndarray$int$__init__(numpy$$Div$ndarray$int);
+void numpy$$Div$ndarray$int$__serialize__(numpy$$Div$ndarray$int, $Serial$state);
+numpy$$Div$ndarray$int numpy$$Div$ndarray$int$__deserialize__(numpy$$Div$ndarray$int, $Serial$state);
+numpy$$ndarray numpy$$Div$ndarray$int$__truediv__(numpy$$Div$ndarray$int, numpy$$ndarray, numpy$$ndarray);
 
 // numpy$$Div$ndarray$float ////////////////////////////////////////////////////////////
 
@@ -706,18 +717,18 @@ struct numpy$$Div$ndarray$float$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)(numpy$$Div$ndarray$float);
-    void (*__serialize__)(numpy$$Div$ndarray$float,$Serial$state);
-    numpy$$Div$ndarray$float (*__deserialize__)(numpy$$Div$ndarray$float,$Serial$state);
+    void (*__serialize__)(numpy$$Div$ndarray$float, $Serial$state);
+    numpy$$Div$ndarray$float (*__deserialize__)(numpy$$Div$ndarray$float, $Serial$state);
     $bool (*__bool__)(numpy$$Div$ndarray$float);
     $str (*__str__)(numpy$$Div$ndarray$float);
     numpy$$ndarray (*__truediv__)(numpy$$Div$ndarray$float, numpy$$ndarray, numpy$$ndarray);
     numpy$$ndarray (*__itruediv__)(numpy$$Div$ndarray$float, numpy$$ndarray, numpy$$ndarray);
 };
 
-void numpy$$Div$ndarray$float$__init__ (numpy$$Div$ndarray$float);
-void numpy$$Div$ndarray$float$__serialize__(numpy$$Div$ndarray$float,$Serial$state);
-numpy$$Div$ndarray$float numpy$$Div$ndarray$float$__deserialize__(numpy$$Div$ndarray$float,$Serial$state);
-numpy$$ndarray numpy$$Div$ndarray$float$__truediv__ (numpy$$Div$ndarray$float, numpy$$ndarray, numpy$$ndarray);
+void numpy$$Div$ndarray$float$__init__(numpy$$Div$ndarray$float);
+void numpy$$Div$ndarray$float$__serialize__(numpy$$Div$ndarray$float, $Serial$state);
+numpy$$Div$ndarray$float numpy$$Div$ndarray$float$__deserialize__(numpy$$Div$ndarray$float, $Serial$state);
+numpy$$ndarray numpy$$Div$ndarray$float$__truediv__(numpy$$Div$ndarray$float, numpy$$ndarray, numpy$$ndarray);
 
 // numpy$$Sliceable$ndarray /////////////////////////////////////////////////////////////////
 
@@ -728,28 +739,27 @@ struct numpy$$Sliceable$ndarray$class {
     char *$GCINFO;
     int $class_id;
     $Super$class $superclass;
-    void (*__init__) (numpy$$Sliceable$ndarray);
-    void (*__serialize__) (numpy$$Sliceable$ndarray, $Serial$state);
-    numpy$$Sliceable$ndarray (*__deserialize__) (numpy$$Sliceable$ndarray, $Serial$state);
+    void (*__init__)(numpy$$Sliceable$ndarray);
+    void (*__serialize__)(numpy$$Sliceable$ndarray, $Serial$state);
+    numpy$$Sliceable$ndarray (*__deserialize__)(numpy$$Sliceable$ndarray, $Serial$state);
     $bool (*__bool__)(numpy$$Sliceable$ndarray);
     $str (*__str__)(numpy$$Sliceable$ndarray);
-    numpy$$ndarray (*__getitem__) (numpy$$Sliceable$ndarray, numpy$$ndarray, $int);
-    void (*__setitem__) (numpy$$Sliceable$ndarray, numpy$$ndarray, $int, $WORD);
-    void (*__delitem__) (numpy$$Sliceable$ndarray, numpy$$ndarray, $int);
-    numpy$$ndarray (*__getslice__) (numpy$$Sliceable$ndarray, numpy$$ndarray, $slice);
-    void (*__setslice__) (numpy$$Sliceable$ndarray, numpy$$ndarray, $Iterable, $slice, $WORD);
-    void (*__delslice__) (numpy$$Sliceable$ndarray, numpy$$ndarray, $slice);
+    numpy$$ndarray (*__getitem__)(numpy$$Sliceable$ndarray, numpy$$ndarray, $int);
+    void (*__setitem__)(numpy$$Sliceable$ndarray, numpy$$ndarray, $int, $WORD);
+    void (*__delitem__)(numpy$$Sliceable$ndarray, numpy$$ndarray, $int);
+    numpy$$ndarray (*__getslice__)(numpy$$Sliceable$ndarray, numpy$$ndarray, $slice);
+    void (*__setslice__)(numpy$$Sliceable$ndarray, numpy$$ndarray, $Iterable, $slice, $WORD);
+    void (*__delslice__)(numpy$$Sliceable$ndarray, numpy$$ndarray, $slice);
 };
 struct numpy$$Sliceable$ndarray {
     struct numpy$$Sliceable$ndarray$class *$class;
 };
 
-
 // numpy$$Collection$ndarray ////////////////////////////////////////////////////////////
 
 struct numpy$$Collection$ndarray {
-  numpy$$Collection$ndarray$class $class;
-  numpy$$Primitive pwit;
+    numpy$$Collection$ndarray$class $class;
+    numpy$$Primitive pwit;
 };
 
 struct numpy$$Collection$ndarray$class {
@@ -757,8 +767,8 @@ struct numpy$$Collection$ndarray$class {
     int $class_id;
     $Super$class $superclass;
     void (*__init__)(numpy$$Collection$ndarray, numpy$$Primitive);
-    void (*__serialize__)(numpy$$Collection$ndarray,$Serial$state);
-    numpy$$Collection$ndarray (*__deserialize__)(numpy$$Collection$ndarray,$Serial$state);
+    void (*__serialize__)(numpy$$Collection$ndarray, $Serial$state);
+    numpy$$Collection$ndarray (*__deserialize__)(numpy$$Collection$ndarray, $Serial$state);
     $bool (*__bool__)(numpy$$Collection$ndarray);
     $str (*__str__)(numpy$$Collection$ndarray);
     $Iterator (*__iter__)(numpy$$Collection$ndarray, numpy$$ndarray);
@@ -766,17 +776,17 @@ struct numpy$$Collection$ndarray$class {
     $int (*__len__)(numpy$$Collection$ndarray, numpy$$ndarray);
 };
 
-void numpy$$Collection$ndarray$__init__ (numpy$$Collection$ndarray, numpy$$Primitive);
-void numpy$$Collection$ndarray$__serialize__(numpy$$Collection$ndarray,$Serial$state);
-numpy$$Collection$ndarray numpy$$Collection$ndarray$__deserialize__(numpy$$Collection$ndarray,$Serial$state);
-$Iterator numpy$$Collection$ndarray$__iter__ (numpy$$Collection$ndarray, numpy$$ndarray);
+void numpy$$Collection$ndarray$__init__(numpy$$Collection$ndarray, numpy$$Primitive);
+void numpy$$Collection$ndarray$__serialize__(numpy$$Collection$ndarray, $Serial$state);
+numpy$$Collection$ndarray numpy$$Collection$ndarray$__deserialize__(numpy$$Collection$ndarray, $Serial$state);
+$Iterator numpy$$Collection$ndarray$__iter__(numpy$$Collection$ndarray, numpy$$ndarray);
 numpy$$ndarray numpy$$Collection$ndarray$__fromiter__(numpy$$Collection$ndarray, $Iterable);
 $int numpy$$Collection$ndarray$__len__(numpy$$Collection$ndarray, numpy$$ndarray);
 
 // numpy$$RealFloat$ndarray ////////////////////////////////////////////////////////
 
-#define numpy$$RealFloat$ndarray (($Real)numpy$$Real$ndarray)
-#define numpy$$RealFloat$ndarray$new(...) ($Real)numpy$$Real$ndarray$new(__VA_ARGS__)
+#define numpy$$RealFloat$ndarray          (($Real)numpy$$Real$ndarray)
+#define numpy$$RealFloat$ndarray$new(...) ($Real) numpy$$Real$ndarray$new(__VA_ARGS__)
 
 // numpy$$RealFuns$math$ndarray ////////////////////////////////////////////////////
 
@@ -786,34 +796,33 @@ struct numpy$$RealFuns$math$ndarray$class {
     char *$GCINFO;
     int $class_id;
     $Super$class $superclass;
-    $NoneType (*__init__) (numpy$$RealFuns$math$ndarray, numpy$$Primitive, math$$RealFuns);
-    $NoneType (*__serialize__) (numpy$$RealFuns$math$ndarray, $Serial$state);
-    numpy$$RealFuns$math$ndarray (*__deserialize__) (numpy$$RealFuns$math$ndarray, $Serial$state);
+    $NoneType (*__init__)(numpy$$RealFuns$math$ndarray, numpy$$Primitive, math$$RealFuns);
+    $NoneType (*__serialize__)(numpy$$RealFuns$math$ndarray, $Serial$state);
+    numpy$$RealFuns$math$ndarray (*__deserialize__)(numpy$$RealFuns$math$ndarray, $Serial$state);
     $bool (*__bool__)(numpy$$RealFuns$math$ndarray);
     $str (*__str__)(numpy$$RealFuns$math$ndarray);
-    numpy$$ndarray (*sqrt) (numpy$$RealFuns$math$ndarray, numpy$$ndarray);
-    numpy$$ndarray (*exp) (numpy$$RealFuns$math$ndarray, numpy$$ndarray);
-    numpy$$ndarray (*log) (numpy$$RealFuns$math$ndarray, numpy$$ndarray);
-    numpy$$ndarray (*sin) (numpy$$RealFuns$math$ndarray, numpy$$ndarray);
-    numpy$$ndarray (*cos) (numpy$$RealFuns$math$ndarray, numpy$$ndarray);
-    numpy$$ndarray (*tan) (numpy$$RealFuns$math$ndarray, numpy$$ndarray);
-    numpy$$ndarray (*asin) (numpy$$RealFuns$math$ndarray, numpy$$ndarray);
-    numpy$$ndarray (*acos) (numpy$$RealFuns$math$ndarray, numpy$$ndarray);
-    numpy$$ndarray (*atan) (numpy$$RealFuns$math$ndarray, numpy$$ndarray);
-    numpy$$ndarray (*sinh) (numpy$$RealFuns$math$ndarray, numpy$$ndarray);
-    numpy$$ndarray (*cosh) (numpy$$RealFuns$math$ndarray, numpy$$ndarray);
-    numpy$$ndarray (*tanh) (numpy$$RealFuns$math$ndarray, numpy$$ndarray);
-    numpy$$ndarray (*asinh) (numpy$$RealFuns$math$ndarray, numpy$$ndarray);
-    numpy$$ndarray (*acosh) (numpy$$RealFuns$math$ndarray, numpy$$ndarray);
-    numpy$$ndarray (*atanh) (numpy$$RealFuns$math$ndarray, numpy$$ndarray);
+    numpy$$ndarray (*sqrt)(numpy$$RealFuns$math$ndarray, numpy$$ndarray);
+    numpy$$ndarray (*exp)(numpy$$RealFuns$math$ndarray, numpy$$ndarray);
+    numpy$$ndarray (*log)(numpy$$RealFuns$math$ndarray, numpy$$ndarray);
+    numpy$$ndarray (*sin)(numpy$$RealFuns$math$ndarray, numpy$$ndarray);
+    numpy$$ndarray (*cos)(numpy$$RealFuns$math$ndarray, numpy$$ndarray);
+    numpy$$ndarray (*tan)(numpy$$RealFuns$math$ndarray, numpy$$ndarray);
+    numpy$$ndarray (*asin)(numpy$$RealFuns$math$ndarray, numpy$$ndarray);
+    numpy$$ndarray (*acos)(numpy$$RealFuns$math$ndarray, numpy$$ndarray);
+    numpy$$ndarray (*atan)(numpy$$RealFuns$math$ndarray, numpy$$ndarray);
+    numpy$$ndarray (*sinh)(numpy$$RealFuns$math$ndarray, numpy$$ndarray);
+    numpy$$ndarray (*cosh)(numpy$$RealFuns$math$ndarray, numpy$$ndarray);
+    numpy$$ndarray (*tanh)(numpy$$RealFuns$math$ndarray, numpy$$ndarray);
+    numpy$$ndarray (*asinh)(numpy$$RealFuns$math$ndarray, numpy$$ndarray);
+    numpy$$ndarray (*acosh)(numpy$$RealFuns$math$ndarray, numpy$$ndarray);
+    numpy$$ndarray (*atanh)(numpy$$RealFuns$math$ndarray, numpy$$ndarray);
 };
 struct numpy$$RealFuns$math$ndarray {
     struct numpy$$RealFuns$math$ndarray$class *$class;
     numpy$$Primitive w$Primitive$A$RealFuns$math$ndarray;
-  math$$RealFuns w$RealFuns$math$A$RealFuns$math$ndarray;
+    math$$RealFuns w$RealFuns$math$A$RealFuns$math$ndarray;
 };
 extern struct numpy$$RealFuns$math$ndarray$class numpy$$RealFuns$math$ndarray$methods;
-
 
 // method tables /////////////////////////////////////////////////////////////////
 
@@ -838,8 +847,7 @@ numpy$$Sliceable$ndarray numpy$$Sliceable$ndarray$new();
 numpy$$Collection$ndarray numpy$$Collection$ndarray$new(numpy$$Primitive);
 numpy$$RealFuns$math$ndarray numpy$$RealFuns$math$ndarray$new(numpy$$Primitive, math$$RealFuns);
 
-
 void numpy$$__init__();
 
-void quickselect(union $Bytes8 *a, int left, int right, int k, bool (*lt)(union $Bytes8,union $Bytes8));
-void quicksort(union $Bytes8 *a, int left, int right, bool (*lt)(union $Bytes8,union $Bytes8));
+void quickselect(union $Bytes8 *a, int left, int right, int k, bool (*lt)(union $Bytes8, union $Bytes8));
+void quicksort(union $Bytes8 *a, int left, int right, bool (*lt)(union $Bytes8, union $Bytes8));

--- a/stdlib/src/random.c
+++ b/stdlib/src/random.c
@@ -12,7 +12,7 @@
 // the time, which is prolly good enough for now. In a future, we could cook up
 // something better.
 
-$int random$$randint ($int min, $int max) {
+$int random$$randint($int min, $int max) {
     // ensure we have a valid range where min is smaller than max
     if (min->val > max->val) {
         $RAISE((($BaseException)$ValueError$new(to$str("min value must be smaller than max"))));
@@ -27,16 +27,18 @@ $int random$$randint ($int min, $int max) {
     // run rand() until we get a value below end
     int r;
     // spin getting new values until we find one in range
-    while ((r = rand()) >= end);
+    while ((r = rand()) >= end)
+        ;
     // normalize back to the requested range
-    return to$int(min->val + r%range);
+    return to$int(min->val + r % range);
 }
 
 int random$$done$ = 0;
 int random$$seeded = 0;
-void random$$__init__ () {
+void random$$__init__() {
     // default to just seeding
     srand(time(NULL));
-    if (random$$done$) return;
+    if (random$$done$)
+        return;
     random$$done$ = 1;
 }

--- a/stdlib/src/time.c
+++ b/stdlib/src/time.c
@@ -1,6 +1,6 @@
 #include "time.h"
 
-$float time$$monotonic () {
+$float time$$monotonic() {
     struct timespec ts;
     if (clock_gettime(CLOCK_MONOTONIC, &ts) == -1) {
         $RAISE((($BaseException)$RuntimeError$new(to$str("Unable to get time"))));
@@ -8,7 +8,7 @@ $float time$$monotonic () {
     return to$float(ts.tv_sec + ts.tv_nsec);
 }
 
-$int time$$monotonic_ns () {
+$int time$$monotonic_ns() {
     struct timespec ts;
     if (clock_gettime(CLOCK_MONOTONIC, &ts) == -1) {
         $RAISE((($BaseException)$RuntimeError$new(to$str("Unable to get time"))));
@@ -16,15 +16,15 @@ $int time$$monotonic_ns () {
     return to$int(ts.tv_sec * 1000000000 + ts.tv_nsec);
 }
 
-$float time$$time () {
+$float time$$time() {
     struct timespec ts;
     if (clock_gettime(CLOCK_REALTIME, &ts) == -1) {
         $RAISE((($BaseException)$RuntimeError$new(to$str("Unable to get time"))));
     }
-    return to$float(ts.tv_sec + 0.000000001*ts.tv_nsec);
+    return to$float(ts.tv_sec + 0.000000001 * ts.tv_nsec);
 }
 
-$int time$$time_ns () {
+$int time$$time_ns() {
     struct timespec ts;
     if (clock_gettime(CLOCK_REALTIME, &ts) == -1) {
         $RAISE((($BaseException)$RuntimeError$new(to$str("Unable to get time"))));
@@ -32,9 +32,9 @@ $int time$$time_ns () {
     return to$int(ts.tv_sec * 1000000000 + ts.tv_nsec);
 }
 
-
 int time$$done$ = 0;
-void time$$__init__ () {
-    if (time$$done$) return;
+void time$$__init__() {
+    if (time$$done$)
+        return;
     time$$done$ = 1;
 }


### PR DESCRIPTION
To get a standard look and feel of code in our project, let's adopt a
clang-format config file!

Not quite sure about all the options. I'm not 100% happy with this, but
I think it's fairly close. I guess we can tweak some stuff later
although I want to get the broad strokes right from the beginning. Looks
rather nasty in the commit log when reformatting the whole repo...

Besides clang-format, I have tested a number of other C formatting tools and they all turned our code into crap. clang-format is the only thing that sort of works for our use of `$`. Or I'm just a n00b at configuring things... anyway, clang-format seems like a good choice.

Maybe we should add some CI check to ensure proper formatting after future changes too but that is for later...

Fixes #396.