### PR TITLE
Temp fix to issue 409

### DIFF
--- a/rts/rts.c
+++ b/rts/rts.c
@@ -1604,7 +1604,8 @@ int main(int argc, char **argv) {
             }
 
             rtsv_printf(LOGPFX "Using distributed database backend (DDB): %s:%d\n", ddb_host[i], port);
-            add_server_to_membership(ddb_host[i], port, db, &seed);
+            for(int replica=0;replica<ddb_replication;replica++)
+                add_server_to_membership(ddb_host[i], port+replica, db, &seed);
         }
     }
 


### PR DESCRIPTION
This is a temp fix to issue 409 to enable distributed DB tests before proper fix to client DB gossip.