### PR TITLE
Serialize env actor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Fixed
+- env actor is serialized to database backend during bootstrap [#430]
+  - Actor serialization ("snapshotting") to the database usually happens when a
+    continuation (roughly an actor method) has been run
+  - The env actor might never run, which meant it might not have been
+    serialized to the DB, so when resuming an Acton application from the
+    database, the env actor could be missing leading to a segfault [#408]
+
 
 ## [0.7.3] (2022-01-03)
 


### PR DESCRIPTION
The env actor was never serialized and as a result, for a system that resumes
from the database, we don't have a env actor and any actor method call on env
will fail catastrophically (segfault).

Since the env actor is a sort of constant actor that might not be scheduled for
execution by the main_loop, we might not serialize it. Thus, to fix this, we
simply serialize it just after it has been created.

Fixes #408.