### PR TITLE
In DB client wait_on_msg_callback, handle the case when a quorum of s…

### DIFF
--- a/backend/client_api.c
+++ b/backend/client_api.c
@@ -576,6 +576,13 @@ int wait_on_msg_callback(msg_callback * mc, remote_db_t * db)
 
 	int ret = pthread_mutex_lock(mc->lock);
 
+	if(mc->no_replies >= db->quorum_size)
+	// Enough replies arrived already
+	{
+		pthread_mutex_unlock(mc->lock);
+		return 0;
+	}
+
 	struct timespec ts;
 	clock_gettime(CLOCK_REALTIME, &ts);
 	ts.tv_sec += db->rpc_timeout;


### PR DESCRIPTION
…ervers manages to reply before the RPC got to pthread_cond_timedwait on the message callback