### PR TITLE
Exit App / RTS cleanly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
       - name: "Install build prerequisites"
         run: |
           apt-get update
-          apt-get install -qy bzip2 gcc haskell-stack libbsd-dev libprotobuf-c-dev libutf8proc-dev make python3 uuid-dev zlib1g-dev
+          apt-get install -qy bzip2 gcc haskell-stack libbsd-dev libprotobuf-c-dev libutf8proc-dev make procps python3 uuid-dev zlib1g-dev
       - name: chown our home dir to avoid stack complaining
         run: chown -R root:root /github/home
       - name: "Build Acton"

--- a/builtin/env.c
+++ b/builtin/env.c
@@ -23,6 +23,8 @@
 struct FileDescriptorData fd_data[MAX_FD];
 int wakeup_pipe[2];
 
+extern char rts_exit;
+extern int return_val;
 
 #ifdef IS_MACOS         // Use kqueue
 int kq;
@@ -704,7 +706,8 @@ $R $Env$listen$local ($Env __self__, $int port, $function cb, $Cont c$cont) {
     return $R_CONT(c$cont, $None);
 }
 $R $Env$exit$local ($Env __self__, $int n, $Cont c$cont) {
-    exit(n->val);
+    return_val = n->val;
+    rts_exit = 1;
     return $R_CONT(c$cont, $None);
 }
 $R $Env$openR$local ($Env __self__, $str nm, $Cont c$cont) {

--- a/rts/rts.c
+++ b/rts/rts.c
@@ -35,8 +35,10 @@
 
 char rts_verbose = 0;
 char rts_debug = 0;
-
 long num_wthreads;
+
+char rts_exit = 0;
+int return_val = 0;
 
 char *rts_mon_path = NULL;
 
@@ -1173,6 +1175,15 @@ void *main_loop(void *idx) {
 
     struct timespec ts1, ts2, ts3;
     while (1) {
+        if (rts_exit) {
+            wt_stats[(int)idx].state = WT_NoExist;
+            rtsd_printf(LOGPFX "Worker thread %d exiting\n", (int)idx);
+            // Wake up all sleeping threads so they too can exit
+            pthread_mutex_lock(&sleep_lock);
+            pthread_cond_broadcast(&work_to_do);
+            pthread_mutex_unlock(&sleep_lock);
+            break;
+        }
         $Actor current = DEQ_ready();
         if (current) {
             new_work();
@@ -1303,6 +1314,16 @@ void *main_loop(void *idx) {
             wt_stats[(int)idx].state = WT_Idle;
         } else {
             pthread_mutex_lock(&sleep_lock);
+
+            if (rts_exit) {
+                wt_stats[(int)idx].state = WT_NoExist;
+                rtsd_printf(LOGPFX "Worker thread %d exiting\n", (int)idx);
+                // Wake up all sleeping threads so they too can exit
+                pthread_cond_broadcast(&work_to_do);
+                pthread_mutex_unlock(&sleep_lock);
+                break;
+            }
+
             wt_stats[(int)idx].state = WT_Sleeping;
             wt_stats[(int)idx].sleeps++;
             pthread_cond_wait(&work_to_do, &sleep_lock);
@@ -1699,23 +1720,23 @@ int main(int argc, char **argv) {
         num_threads++;
     }
 
-    // We start on index 1 for pretty names, like Worker 1 is first, not 0, plus
-    // when doing CPU affinity, we want to bind worker threads to CPU 1, so we
-    // can reuse idx for that
-    for(int idx = 1; idx <= num_wthreads; idx++) {
-        pthread_create(&threads[num_threads+idx], NULL, main_loop, (void*)idx);
+    int wthread_start = num_threads;
+    for(int idx = 0; idx < num_wthreads; idx++) {
+        pthread_create(&threads[num_threads+idx], NULL, main_loop, (void*)idx+1);
         // Note how we pin thread index + 1, so worker thread 0 is on CPU 1
         // We use CPU 0 for misc threads, like IO / mon etc
         if (cpu_pin) {
             CPU_ZERO(&cpu_set);
-            CPU_SET(idx, &cpu_set);
+            CPU_SET(idx+1, &cpu_set);
             pthread_setaffinity_np(threads[num_threads+idx], sizeof(cpu_set), &cpu_set);
         }
     }
     num_threads = num_threads + num_wthreads;
 
-    for(int idx = 0; idx <= num_threads; ++idx) {
+    // Only joining the worker threads, we don't care about gracefully shutting
+    // down IO / Mon threads
+    for(int idx = wthread_start; idx < num_threads; ++idx) {
         pthread_join(threads[idx], NULL);
     }
-    return 0;
+    return return_val;
 }

--- a/test/Makefile
+++ b/test/Makefile
@@ -33,7 +33,10 @@ test_db_app:
 
 
 # -- RTS --
-RTS_TESTS = rts/argv1 rts/argv2 rts/argv3
+RTS_TESTS = rts/argv1 rts/argv2 rts/argv3 rts/exit_0 rts/exit_1
+.PHONY: $(RTS_TESTS)
+
+test-rts: $(RTS_TESTS)
 
 # Test normal argument parsing
 rts/argv1:
@@ -53,11 +56,20 @@ rts/argv3:
 	./$@ --rts-wthreads 2>&1 | grep "ERROR: --rts-wthreads requires an argument."
 	@echo "Test success, saw expected error message"
 
+rts/exit_0:
+	$(ACTONC) --root main $@.act
+	./$@
+
+rts/exit_1:
+	$(ACTONC) --root main $@.act
+	./$@; EXIT_CODE=$$?; if [ $$EXIT_CODE -ne 1 ]; then exit 1; fi
+
 # Expect 9 threads given 7 workers + main process + IO
 rts/wthreads1:
 	$(ACTONC) --root main $@.act
 	./$@ --rts-wthreads 7 & PID=$$! && ps -o thcount $${PID} | tail -n1 | awk '{ print $$1 }' | grep "^9$$"
 
+#--
 
 test_acton_rts_sleep:
 	$(ACTONC) --root main $@.act
@@ -84,4 +96,4 @@ stdlib/test_numpy: stdlib/test_numpy.act
 	$(ACTONC) --root main $<
 	./$@
 
-.PHONY: rts/argv1 rts/argv2 rts/argv3 rts/wthreads1 test_acton_rts_sleep test_async test_random test_time regression rts_sleep
+.PHONY: test_acton_rts_sleep test_async test_random test_time regression rts_sleep

--- a/test/rts/exit_0.act
+++ b/test/rts/exit_0.act
@@ -1,0 +1,2 @@
+actor main(env):
+    env.exit(0)

--- a/test/rts/exit_1.act
+++ b/test/rts/exit_1.act
@@ -1,0 +1,2 @@
+actor main(env):
+    env.exit(1)

--- a/test/rts/wthreads1.act
+++ b/test/rts/wthreads1.act
@@ -1,0 +1,6 @@
+actor main(env):
+
+    def exit():
+        env.exit(0)
+
+    after 10: exit()


### PR DESCRIPTION
This changes how env.exit() is implemented and rather than directly
calling the C exit() function and abruptly killing everything, we now
let the RTS worker threads process any currently running continuation
until completion and then shut them down one by one until no worker
threads remain.

Fixes #454.