### PR TITLE
Ensure enough DDB hosts to meet replication factor

### DIFF
--- a/rts/rts.c
+++ b/rts/rts.c
@@ -1711,6 +1711,12 @@ int main(int argc, char **argv) {
         rtsv_printf(LOGPFX "Detected %ld CPUs: Using %ld worker threads. No CPU affinity used.\n", num_cores, num_wthreads);
     }
 
+    if (ddb_host && ddb_no_host < ddb_replication) {
+        fprintf(stderr, "ERROR: Not enough DDB servers specified (%d) for replication factor %d.\n", ddb_no_host, ddb_replication);
+        fprintf(stderr, "HINT: Supply multiple --rts-ddb-host HOST arguments for all DDB servers.\n");
+        exit(1);
+    }
+
     // Zeroize statistics
     for (uint i=0; i < MAX_WTHREADS; i++) {
         wt_stats[i].idx = i;
@@ -1766,8 +1772,7 @@ int main(int argc, char **argv) {
             }
 
             rtsv_printf(LOGPFX "Using distributed database backend (DDB): %s:%d\n", ddb_host[i], port);
-            for(int replica=0;replica<ddb_replication;replica++)
-                add_server_to_membership(ddb_host[i], port+replica, db, &seed);
+            add_server_to_membership(ddb_host[i], port, db, &seed);
         }
     }
 

--- a/test/test_db.py
+++ b/test/test_db.py
@@ -29,6 +29,8 @@ def parse_membership(line):
     raise ValueError("Unable to parse Membership agreement")
 
 
+def get_db_args(replication_factor):
+    return [item for sublist in map(lambda x: ("--rts-ddb-host", x), [f"127.0.0.1:{32000+idx}" for idx in range(replication_factor)]) for item in sublist]
 
 class Db:
     def __repr__(self):
@@ -120,8 +122,9 @@ class DbCluster:
         return True
 
 
-def test_app_recovery(db_nodes):
-    cmd = ["./test_db_recovery", "--rts-verbose", "--rts-ddb-host", "127.0.0.1", "--rts-ddb-replication", str(db_nodes)]
+def test_app_recovery(replication_factor):
+    cmd = ["./test_db_recovery", "--rts-verbose", "--rts-ddb-replication", str(replication_factor)] + get_db_args(replication_factor)
+
 
 
     def so1(line, p, s):
@@ -218,7 +221,8 @@ def run_cmd(cmd, cb_so=None, cb_se=None, cb_end=None, state=None):
 
 
 def test_app(replication_factor):
-    cmd = ["./test_db_app", "--rts-verbose", "--rts-ddb-host", "127.0.0.1", "--rts-ddb-replication", str(replication_factor)]
+    cmd = (["./test_db_app", "--rts-verbose", "--rts-ddb-replication", str(replication_factor)] +
+           get_db_args(replication_factor))
 
     def so(line, p, s):
         log.info(f"App output: {line}")


### PR DESCRIPTION
We now enforce that the user must specify enough database hosts, using
--rts-ddb-host to reach the replication factor, i.e. if
--rts-ddb-replication is 3, --rts-ddb-host must be specified at least 3
times, like ./app --rts-ddb-host localhost:32000 --rts-ddb-host
localhost:32001 --rts-ddb-host localhost:32002

The idea is that when we connect to a database node, we will communicate
with it and find out about other database nodes that we can connect to,
so that we will reach the required number for the configured replication
factor. With a replication factor of 3, we want to connect to 3 servers!

However, the dissemination of DB servers isn't implemented yet, so the
DB client has to be given all the DB servers, yet we didn't force this,
so setting a higher replication factor than the number of available
servers would lead to an error.

We fixed this with a quick hack, simply assuming that all DB servers are
running on the same machine on sequential ports, so if we specify port
32000 and replication factor 3, we will connect to servers on port
32000, 32001 and 32002. It's an assumption that works while we are doing
development... Naturally, we want to be able to run an actual
distributed system, like on different computers, so we must break free
of this assumption. We now do that by placing the burden on the user
until we can get that gossip protocol implemented!

Related to #409 and IMHO an improvement over #427.