### PR TITLE
Avoid rewriting argv

### DIFF
--- a/rts/rts.c
+++ b/rts/rts.c
@@ -1764,15 +1764,17 @@ int main(int argc, char **argv) {
         rtsv_printf(LOGPFX "Using distributed database backend replication factor of %d\n", ddb_replication);
         db = get_remote_db(ddb_replication);
         for (int i=0; i<ddb_no_host; i++) {
-            char * colon = strchr(ddb_host[i], ':');
+            char *host = strdup(ddb_host[i]);
+
             int port = ddb_port;
+            char *colon = strchr(host, ':');
             if (colon) {
                 *colon = '\0';
                 port = atoi(colon + 1);
             }
 
-            rtsv_printf(LOGPFX "Using distributed database backend (DDB): %s:%d\n", ddb_host[i], port);
-            add_server_to_membership(ddb_host[i], port, db, &seed);
+            rtsv_printf(LOGPFX "Using distributed database backend (DDB): %s:%d\n", host, port);
+            add_server_to_membership(host, port, db, &seed);
         }
     }
 


### PR DESCRIPTION
It's not very pretty rewriting argv since the ps output will lie about
the command line, thus we do a bit of extra copying to avoid mangling
argv!