### PR TITLE
Let CI jobs depend on all previous jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,7 +123,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: debian:bullseye
-    needs: build-debs
+    needs: [test-darwin, test-linux, build-debs]
     steps:
       - name: Install build prerequisites
         run: |
@@ -269,7 +269,7 @@ jobs:
   update-homebrew:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
-    needs: [test-darwin, test-linux]
+    needs: [test-darwin, test-linux, build-debs]
     steps:
       - name: "Get the version"
         id: get_version


### PR DESCRIPTION
Although technically we can update the apt repo after we've built the
.deb files, we really do want to wait for the test jobs as to ensure we
pass all tests before we update the repo with new releases etc.

Fixes #467.