### PR TITLE
Fix --opt=arg style parsing of argument

### DIFF
--- a/rts/rts.c
+++ b/rts/rts.c
@@ -1625,7 +1625,7 @@ int main(int argc, char **argv) {
                         if (strlen(argv[i]) > 2+strlen(long_options[j].name)
                             && argv[i][2+strlen(long_options[j].name)] == '=') {
                             // option argument is in --opt=arg style, so dig out
-                            optarg = (char *)argv[i]+(2+strlen(long_options[j].name+1));
+                            optarg = (char *)argv[i]+(2+strlen(long_options[j].name)+1);
                         } else {
                             // argument has to be next in argv
                             if (i+1 == argc) { // check we are not at end

--- a/test/Makefile
+++ b/test/Makefile
@@ -53,6 +53,8 @@ rts/argv1:
 	./$@ --rts-verbose foo --bar --rts-verbose
 	./$@ --rts-verbose --rts-wthreads 7 foo --bar
 	./$@ --rts-verbose --rts-wthreads=7 foo --bar
+	./$@ --rts-verbose --rts-wthreads 7 foo --bar | grep "Using 7 worker threads"
+	./$@ --rts-verbose --rts-wthreads=7 foo --bar | grep "Using 7 worker threads"
 
 # Test argument parsing when using --
 rts/argv2:


### PR DESCRIPTION
Silly misplaced +1 resulted in just getting the wrong value, like for
--rts-wthreads=7, we would read s=7 as the argument, when it should just
be 7.

Even sillier that I (manually) tested this but I believe I made some
final cleanups to the code after that testing, which is probably when I
misplaced the parentheses.

Fixed a test case for it too.