### PR TITLE
Replaced the incorrect use of $NEW($Connection,fd)

### DIFF
--- a/builtin/env.c
+++ b/builtin/env.c
@@ -161,7 +161,7 @@ int new_socket ($function handler) {
 }
 
 void setupConnection (int fd) {
-  $Connection conn = $NEW($Connection,fd);
+  $Connection conn = $Connection$newact(fd);
   fd_data[fd].conn = conn;
   fd_data[fd].chandler->$class->__call__(fd_data[fd].chandler, conn);
 }


### PR DESCRIPTION
with $Connection$newact(fd). Fixes #484.

However, it should be noted that in the context of issue #485, the actor constructors of env.c still differ from the compiler generated signatures because the former take the liberty of avoiding the continuation-passing style where it's not strictly needed. See #485 for further elaboration.