### PR TITLE
Opened up for 'abstract' actors.

### DIFF
--- a/compiler/Acton/Env.hs
+++ b/compiler/Acton/Env.hs
@@ -720,10 +720,14 @@ inheritedAttrs env n        = inh (dom $ snd $ splitSigs te) us
                 (_,_,te)    = findConName c env
                 ns1         = (dom $ snd $ splitSigs te) \\ ns0
 
-abstractAttrs               :: EnvF x -> QName -> [Name]
-abstractAttrs env n         = (initKW : dom sigs) \\ dom terms
+abstractAttrs               :: EnvF x -> QName -> [Name] -> [Name]
+abstractAttrs env n ns      = (ns ++ dom sigs) \\ dom terms
   where (_,us,te)           = findConName n env
         (sigs,terms)        = sigTerms $ concat $ te : [ te | (w,u) <- us, let (_,_,te) = findConName (tcname u) env ]
+
+abstractClass env n         = not $ null (abstractAttrs env n [initKW])
+
+abstractActor env n         = not $ null (abstractAttrs env n [])
 
 allCons                     :: EnvF x -> [CCon]
 allCons env                 = reverse locals ++ concat [ cons m (lookupMod m env) | m <- moduleRefs (names env), m /= mPrim ]

--- a/stdlib/src/__builtin__.act
+++ b/stdlib/src/__builtin__.act
@@ -583,8 +583,8 @@ actor Env (args):
     def connect(host,port,cb): pass
     def listen(port,cb): pass
     def exit(n): pass
-    def openR(nm): return RFile()
-    def openW(nm): return WFile()
+#    def openR(nm): return RFile()
+#    def openW(nm): return WFile()
 
 actor Connection ():
     write       : action(str) -> None


### PR DESCRIPTION
That is, actors with method signatures that lack a corresponding def.
Currently this is only allowed when compiling with the --stub flag.
Moreover, the compiler now checks that abstract actors aren't instantiated (from within Acton code).