### PR TITLE
Add monitor interface to ActonDB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,7 +239,7 @@ DB_OFILES += backend/db.o backend/queue.o backend/skiplist.o backend/txn_state.o
 DBCLIENT_OFILES += backend/client_api.o rts/empty.o
 REMOTE_OFILES += backend/failure_detector/db_messages.pb-c.o backend/failure_detector/cells.o backend/failure_detector/db_queries.o backend/failure_detector/fd.o
 VC_OFILES += backend/failure_detector/vector_clock.o
-BACKEND_OFILES=$(COMM_OFILES) $(DB_OFILES) $(DBCLIENT_OFILES) $(REMOTE_OFILES) $(VC_OFILES)
+BACKEND_OFILES=$(COMM_OFILES) $(DB_OFILES) $(DBCLIENT_OFILES) $(REMOTE_OFILES) $(VC_OFILES) deps/netstring_rel.o deps/yyjson.o
 OFILES += $(BACKEND_OFILES)
 lib/libActonDB.a: $(BACKEND_OFILES)
 	ar rcs $@ $^

--- a/backend/failure_detector/vector_clock.c
+++ b/backend/failure_detector/vector_clock.c
@@ -362,7 +362,7 @@ char * to_string_vc(vector_clock * vc, char * msg_buff)
 
 	for(int i=0;i<vc->no_nodes;i++)
 	{
-		sprintf(crt_ptr, "%d:%" PRId64 ", ", vc->node_ids[i].node_id, vc->node_ids[i].counter);
+		sprintf(crt_ptr, "%s%d:%" PRId64, i>0?", ":"", vc->node_ids[i].node_id, vc->node_ids[i].counter);
 		crt_ptr += strlen(crt_ptr);
 	}
 

--- a/rts/rts.c
+++ b/rts/rts.c
@@ -1632,7 +1632,7 @@ int main(int argc, char **argv) {
         {"rts-ddb-port", "PORT", 'p', "DDB port [32000]"},
         {"rts-ddb-replication", "FACTOR", 'r', "DDB replication factor [3]"},
         {"rts-help", NULL, 'H', "Show this help"},
-        {"rts-mon-log-path", "PATH", 'l', "Path to write log RTS mon stats"},
+        {"rts-mon-log-path", "PATH", 'l', "Path to write RTS mon stats log"},
         {"rts-mon-log-period", "PERIOD", 'k', "Periodicity of writing RTS mon stats log entry"},
         {"rts-mon-on-exit", NULL, 'E', "Print RTS mon stats to stdout on exit"},
         {"rts-mon-socket-path", "PATH", 'm', "Path to unix socket to expose RTS mon stats"},

--- a/utils/actonmon
+++ b/utils/actonmon
@@ -242,6 +242,17 @@ def mon(address, interval, once):
         time.sleep(interval)
 
 
+def actdb_membership(address, interval, once):
+    ms = MonSock(address)
+    while True:
+        data = ms.cmd("membership")
+        print(json.dumps(data))
+
+        if once:
+            break
+        time.sleep(interval)
+
+
 def richmon(address, interval, once):
     import random
     import time
@@ -442,10 +453,13 @@ if __name__ == '__main__':
     parser.add_argument("--rich", action="store_true")
     parser.add_argument("--once", action="store_true", default=False)
     parser.add_argument("--prom", action="store_true")
+    parser.add_argument("--actdb-membership", action="store_true")
 
     args = parser.parse_args()
 
-    if args.prom:
+    if args.actdb_membership:
+        actdb_membership(args.socket, args.interval, args.once)
+    elif args.prom:
         prompom(args.socket)
     elif args.rich:
         richmon(args.socket, args.interval, args.once)


### PR DESCRIPTION
This adds a monitor interface to the ActonDB, just like we support in
the RTS. It uses a unix domain socket to expose JSON encoded data via
netstrings as a line protocol.

There is only a single supported query command now called "membership"
and it returns the local node ID and the vector clock view. By comparing
this view between the nodes in a cluster we can see if they all agree on
whose a member.

Unlike the RTS, the implementation here does not use a separate
monitoring thread but is rather part of the one big main loop that we
have. This means we do not have to worry about locking data structures.

Similar to the RTS, we limit ourselves to a single client at a time. The
second client that tries to connect will simply have to wait for the
first one to finish.

actonmon supports fetching the DB membership information but doesn't
bother pretty printing it, rather just dumping JSON to the user. My plan
is to wait a bit and see what other information we add before going all
fancy with formatting. Not currently sure what output format is best...

Fixes #401.