### PR TITLE
Add TCP based app recovery test

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -19,7 +19,7 @@ regression:
 ddb-tests:
 	$(MAKE) $(DDB_TESTS)
 
-DDB_TESTS=test_db_app test_db_app_no_quorum test_db_app_recovery
+DDB_TESTS=test_db_app test_db_app_no_quorum test_db_app_recovery test_db_app_tcp
 .PHONY: $(DDB_TESTS)
 
 # Starts up a database cluster, checks membership is ok before proceeding to run
@@ -37,6 +37,10 @@ test_db_app_no_quorum:
 test_db_app_recovery:
 	$(ACTONC) --root main test_db_recovery.act
 	./test_db.py TestDbApps.test_app_recovery
+
+test_db_app_tcp:
+	$(ACTONC) --root main rts/ddb_test_server.act
+	./test_db.py TestDbApps.test_app_tcp_recovery
 
 
 # -- RTS --

--- a/test/rts/ddb_test_server.act
+++ b/test/rts/ddb_test_server.act
@@ -1,0 +1,40 @@
+actor main(env):
+    var client = None
+    var i = 0
+    var port = 12345
+
+    def init_listen():
+        env.listen(port, connect_handler)
+
+        # TODO: register listen socket error handler, but RTS does not support this today
+        #env.listen(port, conn_handler, sock_err_handler)
+
+    def sock_err_handler():
+        print("Error with our listening socket, attempting to re-establish listening socket")
+        init_listen()
+        # Maybe do a slight sleep to avoid hammering? or even better, do increasing backoff
+        #after 1: init_listen()
+
+    def recv_handler(msg):
+        print("RECV", msg)
+        if msg == "GET":
+            if client is not None:
+                client.write(str(i))
+        if msg == "INC":
+            i += 1
+            if client is not None:
+                client.write("OK")
+
+    def err_handler(msg):
+        pass
+
+    def connect_handler(conn):
+        if conn is not None:
+            print("Got connection")
+            client = conn
+            conn.on_receipt(recv_handler, err_handler)
+        else:
+            raise Exception("Unable to bind")
+
+    port = int(env.argv[1])
+    init_listen()

--- a/test/test_db.py
+++ b/test/test_db.py
@@ -267,12 +267,19 @@ def run_cmd(cmd, cb_so=None, cb_se=None, cb_end=None, state=None):
 class TestDbApps(unittest.TestCase):
     replication_factor = 3
     dbc = None
+    p = None
 
     def setUp(self):
         self.dbc = DbCluster(self.replication_factor)
         self.dbc.start()
 
     def tearDown(self):
+        if self.p:
+            try:
+                self.p.kill()
+                self.p.wait()
+            except:
+                pass
         self.dbc.stop()
 
 
@@ -280,7 +287,7 @@ class TestDbApps(unittest.TestCase):
         cmd = ["./test_db_app", "--rts-verbose",
                "--rts-ddb-replication", str(self.replication_factor)
                ] + get_db_args(self.dbc.base_port, self.replication_factor)
-        p = subprocess.run(cmd, capture_output=True, timeout=3)
+        self.p = subprocess.run(cmd, capture_output=True, timeout=3)
 
         self.assertEqual(p.returncode, 0)
 

--- a/test/test_db.py
+++ b/test/test_db.py
@@ -101,7 +101,6 @@ class Db:
                 "-p", str(self.port), "-m", str(self.gossip_port),
                 "-s", f"127.0.0.1:{self.seed_port}"]
         self.p = subprocess.Popen(cmd, stdout=self.logfile, stderr=self.logfile)
-        time.sleep(0.1)
         self.get_membership()
         for i in range(9999):
             if i > 100:


### PR DESCRIPTION
This adds an app recovery test, where we want to check that an
application has correctly recovered its state from the database upon
restart. Unlike the existing app recovery test, this one is based on a
TCP server, which makes it much faster, more robust and avoids the
timing issues that we have with the current app recovery test.

The count app outputs a number every second. We cannot lower the sleep
in between numbers, partly because after X doesn't take integer seconds
as arguments but also because we depend on killing the application
precisely when it has counted to 3. We then expect it to continue
counting from there. If the app is too fast, we might get racy
conditions and end up killing the app too late.

Since we now interact over TCP, a query completes in "no time at all"
and the whole test that runs a few calls rounds down to "no time at all"
as well ;) So beyond the improvement in robustness by talking over TCP,
it is sooooo much faster.

Unfortunately, the RTS doesn't properly support recovery of TCP sockets,
so that particular part of the test is currently disabled. We should
have a socket error handler that we install in the env.listen() call,
like we should do:

    env.listen(port, on_connect, on_error)

If there's a problem establishing the listening socket or there is ever
a problem later on with the socket (such as when doing recovery from
DB), we can call the on_error callback and let the application handle
it. See #440 for details.

Also sped up testing quite a bit by shortening DB startup (removed a sleep) and made sure we clean up the app process if tests fail.