### PR TITLE
Separate env.listen error callback

### DIFF
--- a/builtin/env.h
+++ b/builtin/env.h
@@ -123,7 +123,7 @@ struct $l$4lambda$class {
     char *$GCINFO;
     int $class_id;
     $Super$class $superclass;
-    $NoneType (*__init__) ($l$4lambda, $Env, $int, $function);
+    $NoneType (*__init__) ($l$4lambda, $Env, $int, $function, $function);
     void (*__serialize__) ($l$4lambda, $Serial$state);
     $l$4lambda (*__deserialize__) ($l$4lambda, $Serial$state);
     $bool (*__bool__) ($l$4lambda);
@@ -134,7 +134,8 @@ struct $l$4lambda {
     struct $l$4lambda$class *$class;
     $Env __self__;
     $int port;
-    $function cb;
+    $function cb_on_connect;
+    $function cb_on_error;
 };
 struct $l$5lambda$class {
     char *$GCINFO;
@@ -300,7 +301,7 @@ $l$2lambda $l$2lambda$new($Env, $function);
 extern struct $l$3lambda$class $l$3lambda$methods;
 $l$3lambda $l$3lambda$new($Env, $str, $int, $function);
 extern struct $l$4lambda$class $l$4lambda$methods;
-$l$4lambda $l$4lambda$new($Env, $int, $function);
+$l$4lambda $l$4lambda$new($Env, $int, $function, $function);
 extern struct $l$5lambda$class $l$5lambda$methods;
 $l$5lambda $l$5lambda$new($Env, $int);
 extern struct $l$6lambda$class $l$6lambda$methods;
@@ -340,14 +341,14 @@ struct $Env$class {
     $R (*stdout_write$local) ($Env, $str, $Cont);
     $R (*stdin_install$local) ($Env, $function, $Cont);
     $R (*connect$local) ($Env, $str, $int, $function, $Cont);
-    $R (*listen$local) ($Env, $int, $function, $Cont);
+    $R (*listen$local) ($Env, $int, $function, $function, $Cont);
     $R (*exit$local) ($Env, $int, $Cont);
     $R (*openR$local) ($Env, $str, $Cont);
     $R (*openW$local) ($Env, $str, $Cont);
     $Msg (*stdout_write) ($Env, $str);
     $Msg (*stdin_install) ($Env, $function);
     $Msg (*connect) ($Env, $str, $int, $function);
-    $Msg (*listen) ($Env, $int, $function);
+    $Msg (*listen) ($Env, $int, $function, $function);
     $Msg (*exit) ($Env, $int);
     $Msg (*openR) ($Env, $str);
     $Msg (*openW) ($Env, $str);

--- a/stdlib/src/__builtin__.act
+++ b/stdlib/src/__builtin__.act
@@ -573,7 +573,7 @@ actor Env (args):
     stdout_write : action(str) -> None
     stdin_install: action(action(str)->None) -> None
     connect      : action(str, int, action(?Connection)->None) -> None
-    listen       : action(int, action(?Connection)->None) -> None
+    listen       : action(int, action(?Connection)->None, action()->None) -> None
     exit         : action(int) -> None
     openR        : action(str) -> ?RFile
     openW        : action(str) -> ?WFile
@@ -581,7 +581,7 @@ actor Env (args):
     def stdout_write(s): pass
     def stdin_install(cb): pass
     def connect(host,port,cb): pass
-    def listen(port,cb): pass
+    def listen(port, cb_on_connect, cb_on_error): pass
     def exit(n): pass
     def openR(nm): pass
     def openW(nm): pass

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,6 +1,7 @@
 ACTONC=../dist/bin/actonc --cpedantic
 DDB_SERVER=../dist/bin/actondb
 TESTS= \
+	$(ENV_TESTS) \
 	$(RTS_TESTS) \
 	$(DDB_TESTS) \
 	test_acton_rts_sleep \
@@ -14,6 +15,13 @@ test:
 
 regression:
 	$(MAKE) -C regression
+
+
+ENV_TESTS=env/listen_err
+.PHONY: $(ENV_TESTS)
+env/listen_err:
+	$(ACTONC) --root main $@.act
+	./$@
 
 
 ddb-tests:

--- a/test/env/listen_err.act
+++ b/test/env/listen_err.act
@@ -1,0 +1,19 @@
+actor main(env):
+    def conn_handler(conn):
+        print("Not expecting any connection on socket1... fail :/")
+        await async env.exit(1)
+
+    def err_handler():
+        print("Some socket error occurred on socket1, not supposed to happen..")
+        await async env.exit(1)
+
+    def conn_handler2(conn):
+        print("We should not end up here...")
+        await async env.exit(1)
+
+    def err_handler2():
+        print("This is the second error handler, which we expect to be called because we cannot bind... now exiting")
+        await async env.exit(0)
+
+    env.listen(1234, conn_handler, err_handler)
+    env.listen(1234, conn_handler2, err_handler2)

--- a/test/rts/ddb_test_server.act
+++ b/test/rts/ddb_test_server.act
@@ -4,10 +4,7 @@ actor main(env):
     var port = 12345
 
     def init_listen():
-        env.listen(port, connect_handler)
-
-        # TODO: register listen socket error handler, but RTS does not support this today
-        #env.listen(port, conn_handler, sock_err_handler)
+        env.listen(port, connect_handler, sock_err_handler)
 
     def sock_err_handler():
         print("Error with our listening socket, attempting to re-establish listening socket")


### PR DESCRIPTION
env.listen(port, cb) has previously taken a single callback cb that is
invoked both when there are incoming connections to the listening socket
as well as for errors, in which case the callback was called with a None
argument. This is confusing, bad, bla bla. Better to have a separate
callback, which we are now introducing, so the new signature is:

    env.listen(port, cb_on_connect, cb_on_error)

An error when trying to establish the listening socket will now be
reported by calling the callback function provided via cb_on_error.

There's a new test case to cover precisely this test case.

Fixes #471.