### PR TITLE
Skip generating header for some funcs

### DIFF
--- a/builtin/env.h
+++ b/builtin/env.h
@@ -321,10 +321,6 @@ extern struct $l$13lambda$class $l$13lambda$methods;
 $l$13lambda $l$13lambda$new($WFile, $str);
 extern struct $l$14lambda$class $l$14lambda$methods;
 $l$14lambda $l$14lambda$new($WFile);
-$R $Env$new($list, $Cont);
-$R $Connection$new($Cont);
-$R $RFile$new($Cont);
-$R $WFile$new($Cont);
 // END GENERATED __builtin__.act
 ///////////////////////////////////////////////////////////////////////////////////////////
 

--- a/utils/gen_env.py
+++ b/utils/gen_env.py
@@ -201,7 +201,7 @@ def get_env_hgen_stuff():
     for thing in get_stuff(hgen_builtin(), input_generated=True):
         if re.match(r"struct .l.1lambda;", thing.body[0]):
             found = True
-        if found:
+        if found and thing.name not in skip_funcs:
             res.append(thing)
     return res
 


### PR DESCRIPTION
Same as I did for env.c, just for env.c.