### PR TITLE
Allow specifying actonc temp dir

### DIFF
--- a/compiler/package.yaml.in
+++ b/compiler/package.yaml.in
@@ -36,6 +36,7 @@ dependencies:
 - hashable
 - process
 - temporary
+- unix
 
 executables:
   actonc:


### PR DESCRIPTION
If we are not compiling a source file that is located in an Acton
project, we create a temporary directory where we place all the
intermediate output files. For debugging purposes it can be rather
useful to inspect and even modify these files, which is made rather
tricky when it's always a temporary directory.

To allow for simple debugging actonc now takes a --tempdir option
that allows us to specify the directory to use for the intermediate
output. It also implies that actonc will not remove the temporary
directory. Additionally, the commands that actonc run to compile the C
files and place O-files into libraries are written to a build.sh script,
so that it can easily be run again manually once the files have been
modified.

Fixes #444.