### PR TITLE
Add actor resume method

### DIFF
--- a/builtin/env.c
+++ b/builtin/env.c
@@ -908,6 +908,10 @@ $NoneType $ListenSocket$__init__ ($ListenSocket __self__, int fd, $function cb_o
     __self__->cb_err = cb_on_error;
     return $None;
 }
+$NoneType $ListenSocket$__resume__($ListenSocket self) {
+    printf("Resuming ListenSocket\n");
+    return $None;
+}
 $R $ListenSocket$close$local ($ListenSocket __self__, $Cont c$cont) {
     close(__self__->fd);
     return $R_CONT(c$cont, $None);
@@ -1144,6 +1148,7 @@ void $__init__ () {
         $Env$methods.$superclass = ($Super$class)&$Actor$methods;
         $Env$methods.__bool__ = ($bool (*) ($Env))$Actor$methods.__bool__;
         $Env$methods.__str__ = ($str (*) ($Env))$Actor$methods.__str__;
+        $Env$methods.__resume__ = ($NoneType (*) ($Env))$Actor$methods.__resume__;
         $Env$methods.__init__ = $Env$__init__;
         $Env$methods.stdout_write$local = $Env$stdout_write$local;
         $Env$methods.stdin_install$local = $Env$stdin_install$local;
@@ -1168,6 +1173,7 @@ void $__init__ () {
         $Connection$methods.$superclass = ($Super$class)&$Actor$methods;
         $Connection$methods.__bool__ = ($bool (*) ($Connection))$Actor$methods.__bool__;
         $Connection$methods.__str__ = ($str (*) ($Connection))$Actor$methods.__str__;
+        $Connection$methods.__resume__ = ($NoneType (*) ($Connection))$Actor$methods.__resume__;
         $Connection$methods.__init__ = $Connection$__init__;
         $Connection$methods.write$local = $Connection$write$local;
         $Connection$methods.close$local = $Connection$close$local;
@@ -1184,6 +1190,7 @@ void $__init__ () {
         $RFile$methods.$superclass = ($Super$class)&$Actor$methods;
         $RFile$methods.__bool__ = ($bool (*) ($RFile))$Actor$methods.__bool__;
         $RFile$methods.__str__ = ($str (*) ($RFile))$Actor$methods.__str__;
+        $RFile$methods.__resume__ = ($NoneType (*) ($RFile))$Actor$methods.__resume__;
         $RFile$methods.__init__ = $RFile$__init__;
         $RFile$methods.readln$local = $RFile$readln$local;
         $RFile$methods.close$local = $RFile$close$local;
@@ -1198,6 +1205,7 @@ void $__init__ () {
         $WFile$methods.$superclass = ($Super$class)&$Actor$methods;
         $WFile$methods.__bool__ = ($bool (*) ($WFile))$Actor$methods.__bool__;
         $WFile$methods.__str__ = ($str (*) ($WFile))$Actor$methods.__str__;
+        $WFile$methods.__resume__ = ($NoneType (*) ($WFile))$Actor$methods.__resume__;
         $WFile$methods.__init__ = $WFile$__init__;
         $WFile$methods.write$local = $WFile$write$local;
         $WFile$methods.close$local = $WFile$close$local;
@@ -1212,6 +1220,7 @@ void $__init__ () {
         $ListenSocket$methods.$superclass = ($Super$class)&$Actor$methods;
         $ListenSocket$methods.__bool__ = ($bool (*) ($ListenSocket))$Actor$methods.__bool__;
         $ListenSocket$methods.__str__ = ($str (*) ($ListenSocket))$Actor$methods.__str__;
+        $ListenSocket$methods.__resume__ = ($NoneType (*) ($ListenSocket))$ListenSocket$__resume__;
         $ListenSocket$methods.__init__ = $ListenSocket$__init__;
         $ListenSocket$methods.close$local = $ListenSocket$close$local;
         $ListenSocket$methods.close = $ListenSocket$close;

--- a/builtin/env.h
+++ b/builtin/env.h
@@ -355,6 +355,7 @@ struct $Env$class {
     $Env (*__deserialize__) ($Env, $Serial$state);
     $bool (*__bool__) ($Env);
     $str (*__str__) ($Env);
+    $NoneType (*__resume__) ($Env);
     $R (*stdout_write$local) ($Env, $str, $Cont);
     $R (*stdin_install$local) ($Env, $function, $Cont);
     $R (*connect$local) ($Env, $str, $int, $function, $Cont);
@@ -392,6 +393,7 @@ struct $ListenSocket$class {
     $ListenSocket (*__deserialize__) ($ListenSocket, $Serial$state);
     $bool (*__bool__) ($ListenSocket);
     $str (*__str__) ($ListenSocket);
+    $NoneType (*__resume__) ($ListenSocket);
     $R (*close$local) ($ListenSocket, $Cont);
     $Msg (*close) ($ListenSocket);
 };
@@ -418,6 +420,7 @@ struct $Connection$class {
     $Connection (*__deserialize__) ($Connection, $Serial$state);
     $bool (*__bool__) ($Connection);
     $str (*__str__) ($Connection);
+    $NoneType (*__resume__) ($Connection);
     $R (*write$local) ($Connection, $str, $Cont);
     $R (*close$local) ($Connection, $Cont);
     $R (*on_receipt$local) ($Connection, $function, $function, $Cont);
@@ -447,6 +450,7 @@ struct $RFile$class {
     $RFile (*__deserialize__) ($RFile, $Serial$state);
     $bool (*__bool__) ($RFile);
     $str (*__str__) ($RFile);
+    $NoneType (*__resume__) ($RFile);
     $R (*readln$local) ($RFile, $Cont);
     $R (*close$local) ($RFile, $Cont);
     $Msg (*readln) ($RFile);
@@ -474,6 +478,7 @@ struct $WFile$class {
     $WFile (*__deserialize__) ($WFile, $Serial$state);
     $bool (*__bool__) ($WFile);
     $str (*__str__) ($WFile);
+    $NoneType (*__resume__) ($WFile);
     $R (*write$local) ($WFile, $str, $Cont);
     $R (*close$local) ($WFile, $Cont);
     $Msg (*write) ($WFile, $str);

--- a/compiler/Acton/Builtin.hs
+++ b/compiler/Acton/Builtin.hs
@@ -38,6 +38,7 @@ appendKW                            = name "append"
 callKW                              = name "__call__"
 boolKW                              = name "__bool__"
 strKW                               = name "__str__"
+resumeKW                            = name "__resume__"
 
 valueKWs                            = [boolKW, strKW]
 

--- a/compiler/Acton/Prim.hs
+++ b/compiler/Acton/Prim.hs
@@ -147,7 +147,8 @@ clActor cls def sig = cls [] (leftpath [cValue]) te
                         (primKW "msg_lock",   sig (monotype $ tCon $ TC (gPrim "Lock") []) Property),
                         (primKW "globkey",    sig (monotype $ tCon $ TC (gPrim "long") []) Property),
                         (boolKW,              def (monotype $ tFun fxPure posNil kwdNil tBool) NoDec),
-                        (strKW,               def (monotype $ tFun fxPure posNil kwdNil tStr) NoDec)
+                        (strKW,               def (monotype $ tFun fxPure posNil kwdNil tStr) NoDec),
+                        (resumeKW,            def (monotype $ tFun fxPure posNil kwdNil tNone) NoDec)
                       ]
         
 

--- a/rts/rts.c
+++ b/rts/rts.c
@@ -310,6 +310,10 @@ $str $Actor$__str__($Actor self) {
   return to$str(s);
 }
 
+$NoneType $Actor$__resume__($Actor self) {
+  return $None;
+}
+
 void $Actor$__serialize__($Actor self, $Serial$state state) {
     $step_serialize(self->$waitsfor,state);
     $val_serialize(ITEM_ID,&self->$consume_hd,state);
@@ -447,7 +451,8 @@ struct $Actor$class $Actor$methods = {
     $Actor$__serialize__,
     $Actor$__deserialize__,
     $Actor$__bool__,
-    $Actor$__str__
+    $Actor$__str__,
+    $Actor$__resume__
 };
 
 struct $Catcher$class $Catcher$methods = {
@@ -1021,6 +1026,15 @@ void deserialize_system(snode_t *actors_start) {
             }
             print_actor(act);
         }
+    }
+
+    rtsd_printf(LOGPFX "#### Actor resume:\n");
+    for(snode_t * node = actors_start; node!=NULL; node=NEXT(node)) {
+        db_row_t* r = (db_row_t*) node->value;
+        long key = (long)r->key;
+        $Actor act = ($Actor)$dict_get(globdict, ($Hashable)$Hashable$int$witness, to$int(key), NULL);
+        rtsd_printf(LOGPFX "####### Resuming actor %p = %ld of class %s = %d\n", act, act->$globkey, act->$class->$GCINFO, act->$class->$class_id);
+        act->$class->__resume__(act);
     }
 
     rtsd_printf(LOGPFX "\n#### Reading timer queue contents:\n");

--- a/rts/rts.h
+++ b/rts/rts.h
@@ -96,6 +96,7 @@ struct $Actor$class {
     $Actor (*__deserialize__)($Actor, $Serial$state);
     $bool (*__bool__)($Actor);
     $str (*__str__)($Actor);
+    $NoneType (*__resume__)($Actor);
 };
 struct $Actor {
     struct $Actor$class *$class;


### PR DESCRIPTION
The __resume__ method is run immediately after an actor has been
deserialized from the database upon resumption of the system and allows
us to add extra hooks when necessary. For example, for socket related
actors, we want to invoke the error callback so that the user
application code can recreate the socket.