### PR TITLE
Call error handler on resume of ListenSocket

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,10 +79,10 @@ backend/actondb: backend/actondb.c lib/libActonDB.a
 		$(LDLIBS)
 
 backend/%.o: backend/%.c
-	$(CC) -o$@ $< -c $(CFLAGS)
+	$(CC) -g -o$@ $< -c $(CFLAGS)
 
 backend/failure_detector/%.o: backend/failure_detector/%.c
-	$(CC) -o$@ $< -c $(CFLAGS)
+	$(CC) -g -o$@ $< -c $(CFLAGS)
 
 # This target is just to override the above target and turn it into a NOP for
 # the protobuf files. We have the generated files committed to git, so this

--- a/builtin/env.c
+++ b/builtin/env.c
@@ -655,16 +655,16 @@ $l$14lambda $l$14lambda$new($WFile p$1) {
     return $tmp;
 }
 struct $l$14lambda$class $l$14lambda$methods;
-$NoneType $l$15lambda$__init__ ($l$15lambda p$self, $ListenSocket __self__) {
-    p$self->__self__ = __self__;
+$NoneType $l$15lambda$__init__ ($l$15lambda p$self, $function cb_on_error) {
+    p$self->cb_on_error = cb_on_error;
     return $None;
 }
 $R $l$15lambda$__call__ ($l$15lambda p$self, $Cont c$cont) {
-    $ListenSocket __self__ = p$self->__self__;
-    return __self__->$class->close$local(__self__, c$cont);
+    $function cb_on_error = p$self->cb_on_error;
+    return $R_CONT(c$cont, (($Msg (*) ($function))cb_on_error->$class->__call__)(cb_on_error));
 }
 void $l$15lambda$__serialize__ ($l$15lambda self, $Serial$state state) {
-    $step_serialize(self->__self__, state);
+    $step_serialize(self->cb_on_error, state);
 }
 $l$15lambda $l$15lambda$__deserialize__ ($l$15lambda self, $Serial$state state) {
     if (!self) {
@@ -675,16 +675,46 @@ $l$15lambda $l$15lambda$__deserialize__ ($l$15lambda self, $Serial$state state) 
         }
         self = $DNEW($l$15lambda, state);
     }
-    self->__self__ = $step_deserialize(state);
+    self->cb_on_error = $step_deserialize(state);
     return self;
 }
-$l$15lambda $l$15lambda$new($ListenSocket p$1) {
+$l$15lambda $l$15lambda$new($function p$1) {
     $l$15lambda $tmp = malloc(sizeof(struct $l$15lambda));
     $tmp->$class = &$l$15lambda$methods;
     $l$15lambda$methods.__init__($tmp, p$1);
     return $tmp;
 }
 struct $l$15lambda$class $l$15lambda$methods;
+$NoneType $l$16lambda$__init__ ($l$16lambda p$self, $ListenSocket __self__) {
+    p$self->__self__ = __self__;
+    return $None;
+}
+$R $l$16lambda$__call__ ($l$16lambda p$self, $Cont c$cont) {
+    $ListenSocket __self__ = p$self->__self__;
+    return __self__->$class->close$local(__self__, c$cont);
+}
+void $l$16lambda$__serialize__ ($l$16lambda self, $Serial$state state) {
+    $step_serialize(self->__self__, state);
+}
+$l$16lambda $l$16lambda$__deserialize__ ($l$16lambda self, $Serial$state state) {
+    if (!self) {
+        if (!state) {
+            self = malloc(sizeof(struct $l$16lambda));
+            self->$class = &$l$16lambda$methods;
+            return self;
+        }
+        self = $DNEW($l$16lambda, state);
+    }
+    self->__self__ = $step_deserialize(state);
+    return self;
+}
+$l$16lambda $l$16lambda$new($ListenSocket p$1) {
+    $l$16lambda $tmp = malloc(sizeof(struct $l$16lambda));
+    $tmp->$class = &$l$16lambda$methods;
+    $l$16lambda$methods.__init__($tmp, p$1);
+    return $tmp;
+}
+struct $l$16lambda$class $l$16lambda$methods;
 $Msg $Env$stdout_write ($Env __self__, $str s) {
     return $ASYNC((($Actor)__self__), (($Cont)$l$1lambda$new((($Env)__self__), s)));
 }
@@ -719,10 +749,11 @@ $Msg $WFile$close ($WFile __self__) {
     return $ASYNC((($Actor)__self__), (($Cont)$l$14lambda$new((($WFile)__self__))));
 }
 $Msg $ListenSocket$close ($ListenSocket __self__) {
-    return $ASYNC((($Actor)__self__), (($Cont)$l$15lambda$new((($ListenSocket)__self__))));
+    return $ASYNC((($Actor)__self__), (($Cont)$l$16lambda$new((($ListenSocket)__self__))));
 }
 void $ListenSocket$__serialize__ ($ListenSocket self, $Serial$state state) {
     $Actor$methods.__serialize__(($Actor)self, state);
+    $step_serialize(self->cb_err, state);
 }
 $ListenSocket $ListenSocket$__deserialize__ ($ListenSocket self, $Serial$state state) {
     if (!self) {
@@ -734,6 +765,7 @@ $ListenSocket $ListenSocket$__deserialize__ ($ListenSocket self, $Serial$state s
         self = $DNEW($ListenSocket, state);
     }
     $Actor$methods.__deserialize__(($Actor)self, state);
+    self->cb_err = $step_deserialize(state);
     return self;
 }
 struct $ListenSocket$class $ListenSocket$methods;
@@ -909,7 +941,7 @@ $NoneType $ListenSocket$__init__ ($ListenSocket __self__, int fd, $function cb_o
     return $None;
 }
 $NoneType $ListenSocket$__resume__($ListenSocket self) {
-    printf("Resuming ListenSocket\n");
+    self->cb_err->$class->__call__(self->cb_err);
     return $None;
 }
 $R $ListenSocket$close$local ($ListenSocket __self__, $Cont c$cont) {
@@ -1144,6 +1176,15 @@ void $__init__ () {
         $register(&$l$15lambda$methods);
     }
     {
+        $l$16lambda$methods.$GCINFO = "$l$16lambda";
+        $l$16lambda$methods.$superclass = ($Super$class)&$Cont$methods;
+        $l$16lambda$methods.__init__ = $l$16lambda$__init__;
+        $l$16lambda$methods.__call__ = $l$16lambda$__call__;
+        $l$16lambda$methods.__serialize__ = $l$16lambda$__serialize__;
+        $l$16lambda$methods.__deserialize__ = $l$16lambda$__deserialize__;
+        $register(&$l$16lambda$methods);
+    }
+    {
         $Env$methods.$GCINFO = "$Env";
         $Env$methods.$superclass = ($Super$class)&$Actor$methods;
         $Env$methods.__bool__ = ($bool (*) ($Env))$Actor$methods.__bool__;
@@ -1220,7 +1261,7 @@ void $__init__ () {
         $ListenSocket$methods.$superclass = ($Super$class)&$Actor$methods;
         $ListenSocket$methods.__bool__ = ($bool (*) ($ListenSocket))$Actor$methods.__bool__;
         $ListenSocket$methods.__str__ = ($str (*) ($ListenSocket))$Actor$methods.__str__;
-        $ListenSocket$methods.__resume__ = ($NoneType (*) ($ListenSocket))$ListenSocket$__resume__;
+        $ListenSocket$methods.__resume__ = ($NoneType (*) ($ListenSocket))$ListenSocket$__resume__; // XXX: manually modified, do not touch
         $ListenSocket$methods.__init__ = $ListenSocket$__init__;
         $ListenSocket$methods.close$local = $ListenSocket$close$local;
         $ListenSocket$methods.close = $ListenSocket$close;

--- a/builtin/env.h
+++ b/builtin/env.h
@@ -48,6 +48,7 @@ struct $l$12lambda;
 struct $l$13lambda;
 struct $l$14lambda;
 struct $l$15lambda;
+struct $l$16lambda;
 struct $Env;
 struct $Connection;
 struct $RFile;
@@ -68,6 +69,7 @@ typedef struct $l$12lambda *$l$12lambda;
 typedef struct $l$13lambda *$l$13lambda;
 typedef struct $l$14lambda *$l$14lambda;
 typedef struct $l$15lambda *$l$15lambda;
+typedef struct $l$16lambda *$l$16lambda;
 typedef struct $Env *$Env;
 typedef struct $Connection *$Connection;
 typedef struct $RFile *$RFile;
@@ -302,7 +304,7 @@ struct $l$15lambda$class {
     char *$GCINFO;
     int $class_id;
     $Super$class $superclass;
-    $NoneType (*__init__) ($l$15lambda, $ListenSocket);
+    $NoneType (*__init__) ($l$15lambda, $function);
     void (*__serialize__) ($l$15lambda, $Serial$state);
     $l$15lambda (*__deserialize__) ($l$15lambda, $Serial$state);
     $bool (*__bool__) ($l$15lambda);
@@ -311,6 +313,21 @@ struct $l$15lambda$class {
 };
 struct $l$15lambda {
     struct $l$15lambda$class *$class;
+    $function cb_on_error;
+};
+struct $l$16lambda$class {
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    $NoneType (*__init__) ($l$16lambda, $ListenSocket);
+    void (*__serialize__) ($l$16lambda, $Serial$state);
+    $l$16lambda (*__deserialize__) ($l$16lambda, $Serial$state);
+    $bool (*__bool__) ($l$16lambda);
+    $str (*__str__) ($l$16lambda);
+    $R (*__call__) ($l$16lambda, $Cont);
+};
+struct $l$16lambda {
+    struct $l$16lambda$class *$class;
     $ListenSocket __self__;
 };
 extern struct $l$1lambda$class $l$1lambda$methods;
@@ -342,7 +359,9 @@ $l$13lambda $l$13lambda$new($WFile, $str);
 extern struct $l$14lambda$class $l$14lambda$methods;
 $l$14lambda $l$14lambda$new($WFile);
 extern struct $l$15lambda$class $l$15lambda$methods;
-$l$15lambda $l$15lambda$new($ListenSocket);
+$l$15lambda $l$15lambda$new($function);
+extern struct $l$16lambda$class $l$16lambda$methods;
+$l$16lambda $l$16lambda$new($ListenSocket);
 // END GENERATED __builtin__.act
 ///////////////////////////////////////////////////////////////////////////////////////////
 

--- a/rts/rts.c
+++ b/rts/rts.c
@@ -1648,6 +1648,9 @@ int main(int argc, char **argv) {
     signal(SIGINT, sigint_handler);
     signal(SIGTERM, sigterm_handler);
 
+
+    pthread_key_create(&self_key, NULL);
+    pthread_setspecific(self_key, NULL);
     /*
      * A note on argument parsing: The RTS has its own command line arguments,
      * all prefixed with --rts-, which we need to parse out. The remainder of
@@ -1883,7 +1886,6 @@ int main(int argc, char **argv) {
         BOOTSTRAP(new_argc, new_argv);
     }
 
-    pthread_key_create(&self_key, NULL);
     cpu_set_t cpu_set;
 
     // RTS Monitor Log

--- a/rts/rts.c
+++ b/rts/rts.c
@@ -1037,7 +1037,7 @@ void deserialize_system(snode_t *actors_start) {
         act->$class->__resume__(act);
     }
 
-    rtsd_printf(LOGPFX "\n#### Reading timer queue contents:\n");
+    rtsd_printf(LOGPFX "#### Reading timer queue contents:\n");
     time_t now = current_time();
     queue_callback * qc = get_queue_callback(dummy_callback);
 	int64_t prev_read_head = -1, prev_consume_head = -1;

--- a/stdlib/src/__builtin__.act
+++ b/stdlib/src/__builtin__.act
@@ -617,7 +617,9 @@ actor WFile ():
     
     _abstract   : () -> None
 
-actor ListenSocket ():
+actor ListenSocket (cb_on_connection: action() -> None, cb_on_error: action() -> None):
+    cb_err = cb_on_error
+
     close       : action() -> None
 
     def close(): pass

--- a/test/test_db.py
+++ b/test/test_db.py
@@ -351,9 +351,7 @@ class TestDbApps(unittest.TestCase):
         self.p.terminate()
         self.p.communicate()
         self.p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        # TODO: App should resume from DB and give us back same number
-#        self.assertEqual(tcp_cmd(self.p, app_port, "GET"), "2")
-        time.sleep(0.1)
+        self.assertEqual(tcp_cmd(self.p, app_port, "GET"), "2")
         self.p.terminate()
         self.p.communicate()
 


### PR DESCRIPTION
When a ListenSocket actor is resumed from the database, its error
handler is now called so that the Acton application is notified that the
ListenSocket is no longer working.

We unconditionally call the error handler because there is no way that
the ListenSocket survives a resume. We serialize it many times to the
database in normal operations but we only deserialize and resume it when
we start up fresh (or in the future when we migrate an actor). Either
way, the listen socket has a local fd in the kernel and that will not
survive either circumstance so it assuming it broken and reporting via
the on_error callback is the only sane recourse. The Acton application
should have an error handler that sets up the listening socket anew.

We really should not need to create the cb_err attribute, the actor
argument cb_on_error should be saved and available, however the compiler
currently prunes it away. It runs an analysis to see if actor arguments
are used by methods in the actor, in which case they are persisted.
Since this is a abstract actor with stub methods, the analysis comes up
with the wrong result that the arguments are not needed. We will try to
address this separately, see #524.

Fixes #440.