### PR TITLE
Always pass Connection to on_connect callback

### DIFF
--- a/examples/server.act
+++ b/examples/server.act
@@ -1,10 +1,11 @@
-actor server(env):
+actor main(env):
 
-    def session(conn):
-        if conn is not None:
-            conn.on_receive(conn.write, env.stdout_write)
-        else:
-            print("couldn't establish listening")
-            env.exit(0)
+    def connect_handler(conn):
+        print("Got a connection...")
+        conn.on_receive(conn.write, env.stdout_write)
 
-    env.listen(12345,session)
+    def err_handler():
+        print("An error occurred trying to establish listening socket")
+        env.exit(1)
+
+    env.listen(12345, connect_handler, err_handler)

--- a/stdlib/src/__builtin__.act
+++ b/stdlib/src/__builtin__.act
@@ -573,7 +573,7 @@ actor Env (args):
     stdout_write : action(str) -> None
     stdin_install: action(action(str)->None) -> None
     connect      : action(str, int, action(?Connection)->None) -> None
-    listen       : action(int, action(?Connection)->None, action()->None) -> ?ListenSocket
+    listen       : action(int, action(Connection)->None, action()->None) -> ?ListenSocket
     exit         : action(int) -> None
     openR        : action(str) -> ?RFile
     openW        : action(str) -> ?WFile

--- a/test/rts/ddb_test_server.act
+++ b/test/rts/ddb_test_server.act
@@ -24,13 +24,10 @@ actor Tester(env, port):
     def err_handler(msg):
         pass
 
-    def connect_handler(conn):
-        if conn is not None:
-            print("Got connection")
-            client = conn
-            conn.on_receive(recv_handler, err_handler)
-        else:
-            raise Exception("Unable to bind")
+    def connect_handler(conn : Connection):
+        print("Got connection")
+        client = conn
+        conn.on_receive(recv_handler, err_handler)
 
     lsock = init_listen()
 


### PR DESCRIPTION
Previously env.listen only took a single callback which was used to
signal both new client connections as well as errors in establishing the
listening socket. The argument would either be a Connection or None to
indicate an error. Now that we have separated errors into its own
callback we can always pass a Connection to the on_connect callback
handler. This makes it easier and cleaner to write application code.

Fixes #536.