### PR TITLE
Pass connection argument to on_receive

### DIFF
--- a/builtin/env.c
+++ b/builtin/env.c
@@ -1362,7 +1362,7 @@ void *$eventloop(void *arg) {
                     count = read(fd,&fd_data[fd].buffer,BUF_SIZE);
                     if (count < BUF_SIZE)
                         fd_data[fd].buffer[count] = 0;
-                    fd_data[fd].rhandler->$class->__call__(fd_data[fd].rhandler,to$str(fd_data[fd].buffer));
+                    fd_data[fd].rhandler->$class->__call__(fd_data[fd].rhandler, fd_data[fd].conn, to$str(fd_data[fd].buffer));
                 } else {
                     fprintf(stderr,"internal error: readhandler/event filter mismatch on descriptor %d\n",fd);
                     exit(-1);

--- a/stdlib/src/__builtin__.act
+++ b/stdlib/src/__builtin__.act
@@ -591,7 +591,7 @@ actor Env (args):
 actor Connection ():
     write       : action(str) -> None
     close       : action() -> None
-    on_receive  : action(action(str)->None, action(str)->None) -> None
+    on_receive  : action(action(Connection, str)->None, action(str)->None) -> None
 
     def write(s): pass
     def close() : pass

--- a/test/rts/ddb_test_server.act
+++ b/test/rts/ddb_test_server.act
@@ -1,5 +1,4 @@
 actor Tester(env, port):
-    var client = None
     var lsock = None
     var i = 0
 
@@ -11,22 +10,19 @@ actor Tester(env, port):
         print("Error with our listening socket, attempting to re-establish listening socket")
         lsock = init_listen()
 
-    def recv_handler(msg):
-        print("RECV", msg)
+    def recv_handler(conn, msg):
+        print("RECV", conn, msg)
         if msg == "GET":
-            if client is not None:
-                client.write(str(i))
+            conn.write(str(i))
         if msg == "INC":
             i += 1
-            if client is not None:
-                client.write("OK")
+            conn.write("OK")
 
     def err_handler(msg):
         pass
 
     def connect_handler(conn : Connection):
         print("Got connection")
-        client = conn
         conn.on_receive(recv_handler, err_handler)
 
     lsock = init_listen()


### PR DESCRIPTION
We install a receive handler on a Connection actor by calling the
on_receive() method and when a message is received by the Connection it
will execute this callback. The only argument passed used to be the
message content itself, which could make it somewhat difficult to
understand on which Connection the message was received. We now pass
both the connection and the message so that the handler function can
more easily understand which client Connection is being dealt with.

Fixes #520.