### PR TITLE
Fix epoll stuff for TCP client connection

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -46,6 +46,11 @@ test_db_app_resume_tcp_server:
 	$(ACTONC) --root main --dev rts/ddb_test_server.act
 	./test_db.py TestDbApps.test_app_resume_tcp_server
 
+test_db_app_resume_tcp_client:
+	$(ACTONC) --root main --dev rts/ddb_test_server.act
+	$(ACTONC) --root main --dev rts/ddb_test_client.act
+	./test_db.py TestDbApps.test_app_resume_tcp_client
+
 
 # -- RTS --
 RTS_TESTS = rts/argv1 rts/argv2 rts/argv3 rts/exit_0 rts/exit_1

--- a/test/rts/ddb_test_client.act
+++ b/test/rts/ddb_test_client.act
@@ -1,0 +1,25 @@
+actor main(env):
+    port = int(env.argv[1])
+
+    def recv_handler(conn, msg):
+        if msg == "0":
+            print("Got a 0, doing noooothing...")
+
+        if msg == "1":
+            print("Got a 1, I'm happy, exiting...")
+            await async env.exit(0)
+
+    def connection_handler(conn):
+        if conn is not None:
+            print("Installing on_receive handler...")
+            await async conn.on_receive(recv_handler, err_handler)
+            conn.write("GET")
+
+    def err_handler(msg):
+        print("Error with our connection occurred, attempting to re-establish connection")
+        connect()
+
+    def connect():
+        env.connect("127.0.0.1", port, connection_handler)
+
+    connect()


### PR DESCRIPTION
We're getting an error when we try to add the same fd to epoll twice but with different filters. By clearing out the old stuff first, we can then register our interest in EPOLLIN.

Fixes #542.