### PR TITLE
Implement Connection resume support

### DIFF
--- a/builtin/env.h
+++ b/builtin/env.h
@@ -458,6 +458,7 @@ struct $Connection {
     $Lock $msg_lock;
     $long $globkey;
     int descriptor;
+    $function cb_err;
 };
 
 struct $RFile$class {

--- a/stdlib/src/__builtin__.act
+++ b/stdlib/src/__builtin__.act
@@ -588,7 +588,9 @@ actor Env (args):
 
     _abstract   : () -> None
 
-actor Connection ():
+actor Connection (on_error):
+    cb_err = on_error
+
     write       : action(str) -> None
     close       : action() -> None
     on_receive  : action(action(Connection, str)->None, action(str)->None) -> None

--- a/test/test_db.py
+++ b/test/test_db.py
@@ -380,13 +380,14 @@ class TestDbApps(unittest.TestCase):
                "--rts-ddb-replication", str(self.replication_factor)
                ] + get_db_args(self.dbc.base_port, self.replication_factor)
          # TODO: enable this when Connection calls error cb on resume
-#        self.p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-#        time.sleep(0.1)
-#        self.p.terminate()
+        self.p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        time.sleep(0.1)
+        self.p.terminate()
 
         tcp_cmd(self.p2, app_port, "INC")
 
-        self.p = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=1)
+        #self.p = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=1)
+        self.p = subprocess.run(cmd, timeout=1)
         self.assertEqual(self.p.returncode, 0)
 
 


### PR DESCRIPTION
Just like for ListenSocket we call the registered error handler when we
resume from the database.

Fixes #534.