### PR TITLE
Pass Connection / ListenSocket to error handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@
 ### Changed
 - `on_receipt` is now called `on_receive` on `Connection` [#522]
 - `on_connection` is now called `on_connect` on `env.listen` [#535]
+- The error callbacks of Connection & ListenSocket now receive the Connection or
+  ListenSocket as an argument so that it is easy to identify which instance the
+  error pertains too [#547]
 - The main program thread is no longer named `main` [#528]
   - The thread name is reported in various tools like top and ps or when there
     is no thread name, the process name is used

--- a/builtin/env.c
+++ b/builtin/env.c
@@ -844,16 +844,16 @@ $R $Env$connect$local ($Env __self__, $str host, $int port, $function cb, $Cont 
 $R $Env$listen$local ($Env __self__, $int port, $function on_connect, $function on_error, $Cont c$cont) {
     struct sockaddr_in addr;
     int fd = new_socket(on_connect);
+    $ListenSocket lsock = $ListenSocket$newact(fd, on_error);
     addr.sin_addr.s_addr = INADDR_ANY;
     addr.sin_port = htons(port->val);
     addr.sin_family = AF_INET;
     if (bind(fd,(struct sockaddr *)&addr,sizeof(struct sockaddr)) < 0)
-        on_error->$class->__call__(on_error);
+        on_error->$class->__call__(on_error, lsock);
     if (listen(fd, 5) < 0)
-        on_error->$class->__call__(on_error);
+        on_error->$class->__call__(on_error, lsock);
     EVENT_add_read_once(fd);
 
-    $ListenSocket lsock = $ListenSocket$newact(fd, on_error);
     return $R_CONT(c$cont, lsock);
 }
 $R $Env$exit$local ($Env __self__, $int n, $Cont c$cont) {
@@ -909,9 +909,8 @@ $NoneType $Connection$__init__ ($Connection __self__, int descr) {
     return $None;
 }
 $NoneType $Connection$__resume__($Connection self) {
-    printf("$Connection$__resume__\n");
     if (self->cb_err)
-        self->cb_err->$class->__call__(self->cb_err);
+        self->cb_err->$class->__call__(self->cb_err, self);
     return $None;
 }
 $R $Connection$write$local ($Connection __self__, $str s, $Cont c$cont) {
@@ -960,7 +959,7 @@ $NoneType $ListenSocket$__init__ ($ListenSocket __self__, int fd, $function on_e
     return $None;
 }
 $NoneType $ListenSocket$__resume__($ListenSocket self) {
-    self->cb_err->$class->__call__(self->cb_err);
+    self->cb_err->$class->__call__(self->cb_err, self);
     return $None;
 }
 $R $ListenSocket$close$local ($ListenSocket __self__, $Cont c$cont) {

--- a/stdlib/src/__builtin__.act
+++ b/stdlib/src/__builtin__.act
@@ -573,7 +573,7 @@ actor Env (args):
     stdout_write : action(str) -> None
     stdin_install: action(action(str)->None) -> None
     connect      : action(str, int, action(?Connection)->None) -> None
-    listen       : action(int, action(Connection)->None, action()->None) -> ?ListenSocket
+    listen       : action(int, action(Connection)->None, action(ListenSocket)->None) -> ?ListenSocket
     exit         : action(int) -> None
     openR        : action(str) -> ?RFile
     openW        : action(str) -> ?WFile
@@ -593,7 +593,7 @@ actor Connection (on_error):
 
     write       : action(str) -> None
     close       : action() -> None
-    on_receive  : action(action(Connection, str)->None, action(str)->None) -> None
+    on_receive  : action(action(Connection, str)->None, action(Connection, str)->None) -> None
 
     def write(s): pass
     def close() : pass

--- a/test/env/listen_err.act
+++ b/test/env/listen_err.act
@@ -3,7 +3,7 @@ actor main(env):
         print("Not expecting any connection on socket1... fail :/")
         await async env.exit(1)
 
-    def err_handler():
+    def err_handler(lsock):
         print("Some socket error occurred on socket1, not supposed to happen..")
         await async env.exit(1)
 
@@ -11,7 +11,7 @@ actor main(env):
         print("We should not end up here...")
         await async env.exit(1)
 
-    def err_handler2():
+    def err_handler2(lsock):
         print("This is the second error handler, which we expect to be called because we cannot bind... now exiting")
         await async env.exit(0)
 

--- a/test/rts/ddb_test_server.act
+++ b/test/rts/ddb_test_server.act
@@ -6,7 +6,7 @@ actor Tester(env, port):
         s = env.listen(port, connect_handler, sock_err_handler)
         return s
 
-    def sock_err_handler():
+    def sock_err_handler(lsock):
         print("Error with our listening socket, attempting to re-establish listening socket")
         lsock = init_listen()
 
@@ -18,7 +18,7 @@ actor Tester(env, port):
             i += 1
             conn.write("OK")
 
-    def err_handler(msg):
+    def err_handler(conn, msg):
         pass
 
     def connect_handler(conn : Connection):


### PR DESCRIPTION
The Connection or ListenSocket instance that generates an error which
calls the registered error handler is now passed as an argument to the
error handler, so it knows which instance is reporting an error.

This makes it much easier to write an application dealing with these
errors.

Fixes #547.