### PR TITLE
Cleanup fds

### DIFF
--- a/builtin/env.c
+++ b/builtin/env.c
@@ -1362,20 +1362,22 @@ void *$eventloop(void *arg) {
                 exit(-1);
             }
             EVENT_del_read(fd);
-        }
-        switch (fd_data[fd].kind) {
+            $init_FileDescriptorData(fd);
+            close(fd);
+        } else {
+            switch (fd_data[fd].kind) {
             case connecthandler:
                 if (EVENT_is_read(&kev)) {              // we are a listener and someone tries to connect
                     while ((fd2 = accept(fd, (struct sockaddr *)&fd_data[fd].sock_addr,&socklen)) != -1) {
-                      fcntl(fd2,F_SETFL,O_NONBLOCK);
-                      fd_data[fd2].kind = connecthandler;
-                      fd_data[fd2].chandler = fd_data[fd].chandler;
-                      fd_data[fd2].sock_addr = fd_data[fd].sock_addr;
-                      bzero(fd_data[fd2].buffer,BUF_SIZE);
-                      EVENT_add_read(fd2);
-                      EVENT_mod_read_once(fd);
-                      setupConnection(fd2);
-                      printf("%s %s\n","Connection from",$getName(fd2)->str);
+                        fcntl(fd2,F_SETFL,O_NONBLOCK);
+                        fd_data[fd2].kind = connecthandler;
+                        fd_data[fd2].chandler = fd_data[fd].chandler;
+                        fd_data[fd2].sock_addr = fd_data[fd].sock_addr;
+                        bzero(fd_data[fd2].buffer,BUF_SIZE);
+                        EVENT_add_read(fd2);
+                        EVENT_mod_read_once(fd);
+                        setupConnection(fd2);
+                        printf("%s %s\n","Connection from",$getName(fd2)->str);
                     }
                 } else { // we are a client and a delayed connection attempt has succeeded
 #ifdef IS_GNU_LINUX
@@ -1399,7 +1401,9 @@ void *$eventloop(void *arg) {
             case nohandler:
                 fprintf(stderr,"internal error: no event handler on descriptor %d\n",fd);
                 exit(-1);
+            }
         }
+
         pthread_mutex_lock(&sleep_lock);
         pthread_cond_signal(&work_to_do);
         pthread_mutex_unlock(&sleep_lock);

--- a/builtin/env.h
+++ b/builtin/env.h
@@ -26,7 +26,7 @@ typedef struct epoll_event EVENT_type;
 
 #define BUF_SIZE 1024
 
-#define MAX_FD  100
+#define MAX_FD  1024
 
 typedef enum HandlerCase {nohandler, readhandler, connecthandler} HandlerCase;
 

--- a/test/rts/ddb_test_server.act
+++ b/test/rts/ddb_test_server.act
@@ -19,7 +19,7 @@ actor Tester(env, port):
             conn.write("OK")
 
     def err_handler(conn, msg):
-        pass
+        print("Some error, probably client disconnecting")
 
     def connect_handler(conn : Connection):
         print("Got connection")

--- a/test/test_db.py
+++ b/test/test_db.py
@@ -416,6 +416,17 @@ class TestDbApps(unittest.TestCase):
         self.assertEqual(self.p.returncode, 0)
 
 
+class TestTcpServer(unittest.TestCase):
+    def test_tcp_server(self):
+        app_port = random.randint(10000, 20000)
+        cmd = ["./rts/ddb_test_server", str(app_port), "--rts-verbose"]
+        self.p = subprocess.Popen(cmd)
+        for i in range(2000):
+            self.assertEqual(tcp_cmd(self.p, app_port, "GET"), str(i))
+            tcp_cmd(self.p, app_port, "INC")
+        self.p.terminate()
+        self.p.communicate()
+
 
 class TestDbAppsNoQuorum(unittest.TestCase):
     def test_app(self):


### PR DESCRIPTION
Add a simple test case for light stressing of our TCP server stack. It now connects 2000 times (though sequentially) to a test server. This doesn't work unless we clean up fds since the default open file descriptor limit is 1024.

We now clean up fds when a client disconnects!

Our MAX_FD is now 1024, to align with the default fd limit of 1024. This does need to be improved further though, since a user can increase the fd limit beyond 1024 and we will still crash.