### PR TITLE
DB client now does exit(1) on error

### DIFF
--- a/backend/client_api.c
+++ b/backend/client_api.c
@@ -607,7 +607,7 @@ int free_remote_db(remote_db_t * db)
  */
 void error(char *msg) {
     perror(msg);
-    exit(0);
+    exit(1);
 }
 
 int send_packet(void * buf, unsigned len, int sockfd)


### PR DESCRIPTION
Rather than exit(0), so now we can differentiate it from a normal
program run, much better!

Related to #579.