### PR TITLE
Do not exit on error in DB client api

### DIFF
--- a/backend/client_api.c
+++ b/backend/client_api.c
@@ -607,7 +607,6 @@ int free_remote_db(remote_db_t * db)
  */
 void error(char *msg) {
     perror(msg);
-    exit(1);
 }
 
 int send_packet(void * buf, unsigned len, int sockfd)


### PR DESCRIPTION
This was a sort of catch-all during development and it's time to remove
it. We should try to deal with errors in a more fine granular way.

Fixes #579.