### PR TITLE
Use log.c lib in ActonDB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ backend/actondb: backend/actondb.c lib/libActonDB.a
 		$(LDLIBS)
 
 backend/%.o: backend/%.c
-	$(CC) -g -o$@ $< -c $(CFLAGS)
+	$(CC) -DLOG_USE_COLOR -g -o$@ $< -c $(CFLAGS)
 
 backend/failure_detector/%.o: backend/failure_detector/%.c
 	$(CC) -g -o$@ $< -c $(CFLAGS)
@@ -239,7 +239,7 @@ DB_OFILES += backend/db.o backend/queue.o backend/skiplist.o backend/txn_state.o
 DBCLIENT_OFILES += backend/client_api.o rts/empty.o
 REMOTE_OFILES += backend/failure_detector/db_messages.pb-c.o backend/failure_detector/cells.o backend/failure_detector/db_queries.o backend/failure_detector/fd.o
 VC_OFILES += backend/failure_detector/vector_clock.o
-BACKEND_OFILES=$(COMM_OFILES) $(DB_OFILES) $(DBCLIENT_OFILES) $(REMOTE_OFILES) $(VC_OFILES) deps/netstring_rel.o deps/yyjson.o
+BACKEND_OFILES=$(COMM_OFILES) $(DB_OFILES) $(DBCLIENT_OFILES) $(REMOTE_OFILES) $(VC_OFILES) backend/log.o deps/netstring_rel.o deps/yyjson.o
 OFILES += $(BACKEND_OFILES)
 lib/libActonDB.a: $(BACKEND_OFILES)
 	ar rcs $@ $^

--- a/backend/actondb.c
+++ b/backend/actondb.c
@@ -2192,7 +2192,7 @@ int main(int argc, char **argv) {
   int ret = 0;
   char msg_buf[1024];
   int verbosity = SERVER_VERBOSITY;
-  FILE *logf;
+  FILE *logf = NULL;
 
   pid = getpid();
 

--- a/backend/actondb.c
+++ b/backend/actondb.c
@@ -25,6 +25,7 @@
 #include "failure_detector/fd.h"
 #include "comm.h"
 #include "fastrand.h"
+#include "log.h"
 #include "netstring.h"
 #include "yyjson.h"
 
@@ -185,11 +186,11 @@ int create_state_schema(db_t * db, unsigned int * fastrandstate)
 
 	int ret = db_create_table(ACTORS_TABLE, db_schema, db, fastrandstate);
 
-	printf("%s - %s (%d)\n", "Create ACTORS_TABLE", ret==0?"OK":"FAILED", ret);
+	log_debug("%s - %s (%d)", "Create ACTORS_TABLE", ret==0?"OK":"FAILED", ret);
 
 	ret = db_create_table(MSGS_TABLE, db_schema, db, fastrandstate);
 
-	printf("%s - %s (%d)\n", "Create MSGS_TABLE", ret==0?"OK":"FAILED", ret);
+	log_debug("%s - %s (%d)", "Create MSGS_TABLE", ret==0?"OK":"FAILED", ret);
 
 	return ret;
 }
@@ -202,7 +203,7 @@ int create_queue_schema(db_t * db, unsigned int * fastrandstate)
 	col_types[no_queue_cols] = DB_TYPE_BLOB; // Include blob
 
 	int ret = create_queue_table(MSG_QUEUE, no_queue_cols + 1, col_types, db,  fastrandstate);
-	printf("Test %s - %s (%d)\n", "create MSG_QUEUE table", ret==0?"OK":"FAILED", ret);
+	log_debug("%s - %s (%d)", "Create MSG_QUEUE table", ret==0?"OK":"FAILED", ret);
 
 	return ret;
 }
@@ -231,7 +232,7 @@ int get_ack_packet(int status, write_query * q,
 #if (VERBOSE_RPC > 0)
 	char print_buff[1024];
 	to_string_ack_message(ack, (char *) print_buff);
-	printf("Sending ack message: %s\n", print_buff);
+	log_debug("Sending ack message: %s", print_buff);
 #endif
 
 	int ret = serialize_ack_message(ack, snd_buf, snd_msg_len, vc);
@@ -362,7 +363,7 @@ cell * serialize_cells(db_row_t* result, cell * cells, int64_t table_key, int64_
 		return cells + 1;
 	}
 
-//	printf("serialize_cells:\n");
+//	log_debug("serialize_cells:");
 //	print_long_row(result);
 
 	cell * cells_ptr = cells;
@@ -434,7 +435,7 @@ int get_read_response_packet(db_row_t* result, read_query * q, db_schema_t * sch
 #if (VERBOSE_RPC > 0)
 	char print_buff[PRINT_BUFSIZE];
 	to_string_range_read_response_message(m, (char *) print_buff);
-	printf("Sending range read response message: %s\n", print_buff);
+	log_debug("Sending range read response message: %s", print_buff);
 #endif
 
 	int ret = serialize_range_read_response_message(m, snd_buf, snd_msg_len, vc);
@@ -510,7 +511,7 @@ int get_range_read_response_packet(snode_t* start_row, snode_t* end_row, int no_
 #if (VERBOSE_RPC > 0)
 		char print_buff[PRINT_BUFSIZE];
 		to_string_range_read_response_message(m, (char *) print_buff);
-		printf("Sending range read response message: %s\n", print_buff);
+		log_debug("Sending range read response message: %s", print_buff);
 #endif
 
 		int ret = serialize_range_read_response_message(m, snd_buf, snd_msg_len, vc);
@@ -556,7 +557,7 @@ int get_queue_ack_packet(int status, queue_query_message * q,
 #if (VERBOSE_RPC > 0)
 	char print_buff[1024];
 	to_string_ack_message(ack, (char *) print_buff);
-	printf("Sending queue ack message: %s\n", print_buff);
+	log_debug("Sending queue ack message: %s", print_buff);
 #endif
 
 	int ret = serialize_ack_message(ack, snd_buf, snd_msg_len, vc);
@@ -611,7 +612,7 @@ int get_queue_read_response_packet(snode_t* start_row, snode_t* end_row, int no_
 #if (VERBOSE_RPC > 0)
 		char print_buff[1024];
 		to_string_queue_message(m, (char *) print_buff);
-		printf("Sending read queue response message: %s\n", print_buff);
+		log_debug("Sending read queue response message: %s", print_buff);
 #endif
 
 		int ret = serialize_queue_message(m, snd_buf, snd_msg_len, 0, vc);
@@ -740,7 +741,7 @@ int get_txn_ack_packet(int status, txn_message * q,
 #if (VERBOSE_RPC > 0)
 	char print_buff[1024];
 	to_string_ack_message(ack, (char *) print_buff);
-	printf("Sending txn ack message: %s\n", print_buff);
+	log_debug("Sending txn ack message: %s", print_buff);
 #endif
 
 	int ret = serialize_ack_message(ack, snd_buf, snd_msg_len, vc);
@@ -821,8 +822,8 @@ int handle_socket_nop(int * childfd, int * status)
 	int addrlen;
 	getpeername(*childfd, (struct sockaddr*)&address,
 				(socklen_t*)&addrlen);
-	printf("Host disconnected, ip %s , port %d, status=%d, fd, NOP %d\n" ,
-      inet_ntoa(address.sin_addr) , ntohs(address.sin_port), *status, *childfd);
+	log_info("Host disconnected, ip %s, port %d, status=%d, fd, NOP %d" ,
+			  inet_ntoa(address.sin_addr) , ntohs(address.sin_port), *status, *childfd);
 
 	*status = NODE_DEAD;
 
@@ -835,8 +836,8 @@ int handle_socket_close(int * childfd, int * status)
 	int addrlen;
 	getpeername(*childfd, (struct sockaddr*)&address,
 				(socklen_t*)&addrlen);
-	printf("Host disconnected, ip %s, port %d, old_status=%d, closing fd %d\n" ,
-      inet_ntoa(address.sin_addr) , ntohs(address.sin_port), *status, *childfd);
+	log_info("Host disconnected, ip %s, port %d, old_status=%d, closing fd %d" ,
+			  inet_ntoa(address.sin_addr) , ntohs(address.sin_port), *status, *childfd);
 
 	//Close the socket and mark as 0 for reuse:
 	close(*childfd);
@@ -893,7 +894,7 @@ int add_peer_to_membership(char *hostname, unsigned short portno, struct sockadd
 
     if(rs == NULL)
     {
-		printf("ERROR: Failed joining server %s:%d (it looks down)!\n", hostname, portno);
+		log_debug("ERROR: Failed joining server %s:%d (it looks down)!", hostname, portno);
     		return 1;
     }
 
@@ -1176,7 +1177,7 @@ int get_join_packet(int status, int rack_id, int dc_id, char * hostname, unsigne
 #if (VERBOSE_RPC > 0)
 	char print_buff[1024];
 	to_string_membership_agreement_msg(jm, (char *) print_buff);
-	printf("Sending Join message: %s\n", print_buff);
+	log_debug("Sending Join message: %s", print_buff);
 #endif
 
 	int ret = serialize_membership_agreement_msg(jm, snd_buf, snd_msg_len);
@@ -1194,7 +1195,7 @@ int get_agreement_propose_packet(int status, membership_state * membership, int6
 #if (VERBOSE_RPC > 0)
 	char print_buff[1024];
 	to_string_membership_agreement_msg(amr, (char *) print_buff);
-	printf("Sending Membership Propose message: %s\n", print_buff);
+	log_debug("Sending Membership Propose message: %s", print_buff);
 #endif
 
 	int ret = serialize_membership_agreement_msg(amr, snd_buf, snd_msg_len);
@@ -1212,7 +1213,7 @@ int get_agreement_response_packet(int status, membership_state * membership, mem
 #if (VERBOSE_RPC > 0)
 	char print_buff[1024];
 	to_string_membership_agreement_msg(amr, (char *) print_buff);
-	printf("Sending Membership Response message: %s\n", print_buff);
+	log_debug("Sending Membership Response message: %s", print_buff);
 #endif
 
 	int ret = serialize_membership_agreement_msg(amr, snd_buf, snd_msg_len);
@@ -1231,7 +1232,7 @@ int get_agreement_notify_packet(int status, membership_state * membership, membe
 #if (VERBOSE_RPC > 0)
 	char print_buff[1024];
 	to_string_membership_agreement_msg(*amr, (char *) print_buff);
-	printf("Sending Membership Notify message: %s\n", print_buff);
+	log_debug("Sending Membership Notify message: %s", print_buff);
 #endif
 
 	int ret = serialize_membership_agreement_msg(*amr, snd_buf, snd_msg_len);
@@ -1247,7 +1248,7 @@ int get_agreement_notify_ack_packet(int status, membership_agreement_msg * am,
 #if (VERBOSE_RPC > 0)
 	char print_buff[1024];
 	to_string_membership_agreement_msg(amr, (char *) print_buff);
-	printf("Sending Membership Notify ACK message: %s\n", print_buff);
+	log_debug("Sending Membership Notify ACK message: %s", print_buff);
 #endif
 
 	int ret = serialize_membership_agreement_msg(amr, snd_buf, snd_msg_len);
@@ -1489,7 +1490,7 @@ int merge_membership_agreement_msg_to_list(membership_agreement_msg * ma, skipli
 		{
 #if (VERBOSE_RPC > 0)
 			char msg_buf[1024];
-			printf("SERVER: merge_membership_agreement_msg_to_list: Learned about node %s from proposal, status=%d.\n", rs->id, rs->status);
+			log_debug("SERVER: merge_membership_agreement_msg_to_list: Learned about node %s from proposal, status=%d.", rs->id, rs->status);
 #endif
 
 			int status = connect_remote_server(rs);
@@ -1516,7 +1517,7 @@ int merge_membership_agreement_msg_to_list(membership_agreement_msg * ma, skipli
 			if(rs_local->status == NODE_UNKNOWN)
 			{
 #if (VERBOSE_RPC > 0)
-				printf("SERVER: merge_membership_agreement_msg_to_list: Updating status of node %s from NODE_UNKNOWN to %d.\n", rs->id, nd.status);
+				log_debug("SERVER: merge_membership_agreement_msg_to_list: Updating status of node %s from NODE_UNKNOWN to %d.", rs->id, nd.status);
 #endif
 
 				rs_local->status = nd.status;
@@ -1529,7 +1530,7 @@ int merge_membership_agreement_msg_to_list(membership_agreement_msg * ma, skipli
 				if(proposed_counter > local_counter)
 				{
 #if (VERBOSE_RPC > 0)
-					printf("SERVER: merge_membership_agreement_msg_to_list: Updating status of node %s from %d to %d, because local_counter=%" PRId64 ", proposed_counter=%" PRId64 ".\n", rs->id, rs_local->status, nd.status, local_counter, proposed_counter);
+					log_debug("SERVER: merge_membership_agreement_msg_to_list: Updating status of node %s from %d to %d, because local_counter=%" PRId64 ", proposed_counter=%" PRId64 ".", rs->id, rs_local->status, nd.status, local_counter, proposed_counter);
 #endif
 
 					rs_local->status = nd.status;
@@ -1537,7 +1538,7 @@ int merge_membership_agreement_msg_to_list(membership_agreement_msg * ma, skipli
 				else
 				{
 #if (VERBOSE_RPC > 0)
-					printf("SERVER: merge_membership_agreement_msg_to_list: Requesting membership ammend, because for node %s, local_status=%d, proposed_status=%d, local_counter=%" PRId64 ", proposed_counter=%" PRId64 ".\n", rs->id, rs_local->status, nd.status, local_counter, proposed_counter);
+					log_debug("SERVER: merge_membership_agreement_msg_to_list: Requesting membership ammend, because for node %s, local_status=%d, proposed_status=%d, local_counter=%" PRId64 ", proposed_counter=%" PRId64 ".", rs->id, rs_local->status, nd.status, local_counter, proposed_counter);
 #endif
 
 					memberships_differ = 1;
@@ -1553,7 +1554,7 @@ int handle_agreement_propose_message(membership_agreement_msg * ma, membership_s
 {
 #if (VERBOSE_RPC > 0)
 	char msg_buf[1024];
-	printf("SERVER: Received new view proposal %s!\n", to_string_membership_agreement_msg(ma, msg_buf));
+	log_debug("SERVER: Received new view proposal %s!", to_string_membership_agreement_msg(ma, msg_buf));
 #endif
 
 	if(compare_vc(m->view_id, ma->vc) > 0)
@@ -1583,7 +1584,7 @@ int handle_agreement_response_message(membership_agreement_msg * ma, membership_
 {
 #if (VERBOSE_RPC > 0)
 	char msg_buf[1024];
-	printf("SERVER: Received agreement response message %s, outstanding_proposal_acks=%d!\n", to_string_membership_agreement_msg(ma, msg_buf), m->outstanding_proposal_acks);
+	log_debug("SERVER: Received agreement response message %s, outstanding_proposal_acks=%d!", to_string_membership_agreement_msg(ma, msg_buf), m->outstanding_proposal_acks);
 #endif
 
 	*merged_membership = NULL;
@@ -1738,7 +1739,7 @@ int install_agreed_view(membership_agreement_msg * ma, membership * m, vector_cl
 	update_or_replace_vc(&(m->view_id), ma->vc);
 
 #if (VERBOSE_RPC > -1)
-	printf("SERVER: Installed new agreed view %s, local_view_disagrees=%d\n",
+	log_debug("SERVER: Installed new agreed view %s, local_view_disagrees=%d",
 					to_string_membership_agreement_msg(ma, msg_buf),
 					local_view_disagrees);
 #endif
@@ -1768,7 +1769,7 @@ int parse_gossip_message(void * rcv_buf, size_t rcv_msg_len, membership_agreemen
 #if (VERBOSE_RPC > 0)
 		char print_buff[PRINT_BUFSIZE];
 		to_string_membership_agreement_msg((*ma), (char *) print_buff);
-		printf("Received gossip message: %s\n", print_buff);
+		log_debug("Received gossip message: %s", print_buff);
 #endif
 	}
 	else
@@ -1803,7 +1804,7 @@ int handle_join_message(int childfd, int msg_len, membership * m, db_t * db, uns
 
 #if (VERBOSE_RPC > 0)
 	char msg_buf[1024];
-	printf("SERVER: Received new join message %s!\n", to_string_membership_agreement_msg(ma, msg_buf));
+	log_debug("SERVER: Received new join message %s!", to_string_membership_agreement_msg(ma, msg_buf));
 #endif
 
 	// Update peer socket address to announced one:
@@ -1827,7 +1828,7 @@ int handle_join_message(int childfd, int msg_len, membership * m, db_t * db, uns
 		if(strcmp((char *) &(rs->id), (char *) &(old_rs_local->id)) != 0)
 		{
 #if (VERBOSE_RPC > 0)
-			printf("SERVER: Removing old peer entry from local_peers: %s\n", old_rs_local->id);
+			log_debug("SERVER: Removing old peer entry from local_peers: %s", old_rs_local->id);
 #endif
 			skiplist_delete(m->local_peers, &rs->serveraddr);
 
@@ -1845,7 +1846,7 @@ int handle_join_message(int childfd, int msg_len, membership * m, db_t * db, uns
 				assert(old_rs_local->sockfd <= 0 || my_id < new_joiner_id);
 
 #if (VERBOSE_RPC > 0)
-				printf("SERVER: Peer %s %s. Updating its sockfd from %d to %d, old_status=%d, and marking node live!\n",
+				log_debug("SERVER: Peer %s %s. Updating its sockfd from %d to %d, old_status=%d, and marking node live!",
 												old_rs_local->id, (old_status == NODE_DEAD)?"came back up":"sent join request",
 												old_rs_local->sockfd, rs->sockfd, old_rs_local->status);
 #endif
@@ -1859,7 +1860,7 @@ int handle_join_message(int childfd, int msg_len, membership * m, db_t * db, uns
 				assert(old_rs_local->sockfd > 0);
 
 #if (VERBOSE_RPC > 0)
-				printf("SERVER: I am already connected to peer %s (status = %d), and my id > his id. NOT updating its sockfd from %d to %d, and closing new socket!\n",
+				log_debug("SERVER: I am already connected to peer %s (status = %d), and my id > his id. NOT updating its sockfd from %d to %d, and closing new socket!",
 										old_rs_local->id, old_rs_local->status, old_rs_local->sockfd, rs->sockfd);
 #endif
 
@@ -1912,14 +1913,14 @@ int handle_server_message(int childfd, int msg_len, membership * m, db_t * db, u
 
 #if (VERBOSE_RPC > 2)
     	    	char msg_buf[1024];
-		printf("SERVER: Received message with LC %s.\n", to_string_vc(lc_read, msg_buf));
-		printf("SERVER: My LC before update is %s.\n", to_string_vc(my_lc, msg_buf));
+		log_debug("SERVER: Received message with LC %s.", to_string_vc(lc_read, msg_buf));
+		log_debug("SERVER: My LC before update is %s.", to_string_vc(my_lc, msg_buf));
 #endif
 
     	    	update_vc(my_lc, lc_read);
 
 #if (VERBOSE_RPC > 2)
-		printf("SERVER: Updated local LC to %s.\n", to_string_vc(my_lc, msg_buf));
+		log_debug("SERVER: Updated local LC to %s.", to_string_vc(my_lc, msg_buf));
 #endif
 
     	    	increment_vc(my_lc, m->my_id);
@@ -2231,7 +2232,7 @@ int main(int argc, char **argv) {
 	  error("sigaction(SIG_IGN SIGPIPE) failed");
   }
 
-  printf("SERVER: Using args: portno=%d, gportno=%d, verbosity=%d, seeds:\n", arguments.portno, arguments.gportno, arguments.verbosity);
+  log_info("Using args: portno=%d, gportno=%d, verbosity=%d, seeds:", arguments.portno, arguments.gportno, arguments.verbosity);
   for(int i=0;i<arguments.no_seeds;i++)
   {
 	  struct hostent * host = gethostbyname(arguments.seeds[i]);
@@ -2244,7 +2245,7 @@ int main(int argc, char **argv) {
       free(arguments.seeds[i]);
       arguments.seeds[i] = strdup(host->h_name);
 
-	  printf("SERVER: %s:%d\n", arguments.seeds[i], arguments.seed_ports[i]);
+	  log_info("%s:%d\n", arguments.seeds[i], arguments.seed_ports[i]);
   }
 
   skiplist_t * clients = create_skiplist(&sockaddr_cmp); // List of remote clients
@@ -2260,10 +2261,18 @@ int main(int argc, char **argv) {
 
   // Create schema:
   ret = create_state_schema(db, &seed);
-  printf("Test %s - %s\n", "create_state_schema", ret==0?"OK":"FAILED");
+  if (ret == 0) {
+      log_info("State schema successfully created");
+  } else {
+      log_fatal("Failed to create state schema");
+  }
 
   ret = create_queue_schema(db, &seed);
-  printf("Test %s - %s\n", "create_queue_schema", ret==0?"OK":"FAILED");
+  if (ret == 0) {
+      log_info("Queue schema successfully created");
+  } else {
+      log_fatal("Failed to create queue schema");
+  }
 
   struct hostent * local_iface_hostent = gethostbyname(arguments.local_iface);
 
@@ -2301,7 +2310,7 @@ int main(int argc, char **argv) {
 
   membership * m = get_membership(my_id);
 
-  printf("SERVER: Started [%s:%d, %s:%d], my_lc = %s\n", inet_ntoa(serveraddr.sin_addr), ntohs(serveraddr.sin_port), my_address, my_port, to_string_vc(my_lc, msg_buf));
+  log_info("Started [%s:%d, %s:%d], my_lc = %s", inet_ntoa(serveraddr.sin_addr), ntohs(serveraddr.sin_port), my_address, my_port, to_string_vc(my_lc, msg_buf));
 
   // Set up monitoring socket
   int mon_sock=-1, mon_client_sock=-1;
@@ -2355,7 +2364,7 @@ int main(int argc, char **argv) {
 	  // Skip connecting to myself:
 	  if(cmp_res == 0 && arguments.seed_ports[i] == my_port)
 	  {
-		  printf("SERVER: Skipping connecting to seed %s:%d (myself)\n", arguments.seeds[i], arguments.seed_ports[i]);
+		  log_debug("SERVER: Skipping connecting to seed %s:%d (myself)", arguments.seeds[i], arguments.seed_ports[i]);
 		  continue;
 	  }
 
@@ -2363,12 +2372,12 @@ int main(int argc, char **argv) {
 	  // Also skip connecting to seed nodes with IP:port bigger (lexicographycally) than myself (they will connect to me as they come up):
 	  if(cmp_res > 0 || ((cmp_res == 0) && (arguments.seed_ports[i] > my_port)) )
 	  {
-		  printf("SERVER: Skipping connecting to seed %s:%d (> myself)\n", arguments.seeds[i], arguments.seed_ports[i]);
+		  log_debug("SERVER: Skipping connecting to seed %s:%d (> myself)", arguments.seeds[i], arguments.seed_ports[i]);
 	  }
 	  else
 	  {
 #endif
-	  	  printf("SERVER: Connecting to %s:%d..\n", arguments.seeds[i], arguments.seed_ports[i]);
+	  	  log_debug("SERVER: Connecting to %s:%d..", arguments.seeds[i], arguments.seed_ports[i]);
 		  ret = add_peer_to_membership(arguments.seeds[i], arguments.seed_ports[i], dummy_serveraddr, -2, 1, m, LOCAL_PEERS, &rsp, &seed);
 		  if(ret == 0 && rsp->status == NODE_LIVE)
 		  {
@@ -2400,13 +2409,13 @@ int main(int argc, char **argv) {
 			client_descriptor * rs = (client_descriptor *) crt->value;
 			if(rs->sockfd > 0)
 			{
-//				printf("SERVER: Listening to client socket %s..\n", rs->id);
+//				log_debug("SERVER: Listening to client socket %s..", rs->id);
 				FD_SET(rs->sockfd, &readfds);
 				max_fd = (rs->sockfd > max_fd)? rs->sockfd : max_fd;
 			}
 			else
 			{
-//				printf("SERVER: Not listening to disconnected client socket %s..\n", rs->id);
+//				log_debug("SERVER: Not listening to disconnected client socket %s..", rs->id);
 			}
 		}
 
@@ -2420,16 +2429,16 @@ int main(int argc, char **argv) {
 				if(verbosity > 3)
 				{
 					ret = fcntl(rs->sockfd, F_GETFL);
-					printf("active peer %s, sockfd=%d, status=%d, flags=%d\n", rs->id, rs->sockfd, rs->status, ret);
+					log_debug("active peer %s, sockfd=%d, status=%d, flags=%d", rs->id, rs->sockfd, rs->status, ret);
 				}
 
-//				printf("SERVER: Listening to peer socket %s..\n", rs->id);
+//				log_debug("SERVER: Listening to peer socket %s..", rs->id);
 				FD_SET(rs->sockfd, &readfds);
 				max_fd = (rs->sockfd > max_fd)? rs->sockfd : max_fd;
 			}
 			else
 			{
-//				printf("SERVER: Not listening to disconnected peer socket %s..\n", rs->id);
+//				log_debug("SERVER: Not listening to disconnected peer socket %s..", rs->id);
 			}
 		}
 
@@ -2443,16 +2452,16 @@ int main(int argc, char **argv) {
 				if(verbosity > 3)
 				{
 					ret = fcntl(rs->sockfd, F_GETFL);
-					printf("pre-joined peer %s, sockfd=%d, status=%d, flags=%d\n", rs->id, rs->sockfd, rs->status, ret);
+					log_debug("pre-joined peer %s, sockfd=%d, status=%d, flags=%d", rs->id, rs->sockfd, rs->status, ret);
 				}
 
-//				printf("SERVER: Listening to peer socket %s..\n", rs->id);
+//				log_debug("SERVER: Listening to peer socket %s..", rs->id);
 				FD_SET(rs->sockfd, &readfds);
 				max_fd = (rs->sockfd > max_fd)? rs->sockfd : max_fd;
 			}
 			else
 			{
-//				printf("SERVER: Not listening to disconnected peer socket %s..\n", rs->id);
+//				log_debug("SERVER: Not listening to disconnected peer socket %s..", rs->id);
 			}
 		}
 
@@ -2470,13 +2479,13 @@ int main(int argc, char **argv) {
 
 		if ((status < 0) && (errno != EINTR) && (errno != EBADF))
 		{
-			printf("select error %d/%d!\n", status, errno);
+			log_debug("select error %d/%d!", status, errno);
 
 			assert(0);
 		}
 
 		if(verbosity > 3)
-			printf("select returned %d/%d!\n", status, errno);
+			log_debug("select returned %d/%d!", status, errno);
 
         // Monitor socket
         if (FD_ISSET(mon_sock, &readfds)) {
@@ -2551,8 +2560,7 @@ int main(int argc, char **argv) {
 			  if (hostaddrp == NULL)
 			    error("ERROR on inet_ntoa\n");
 
-			  if(verbosity > 0)
-				  printf("SERVER: accepted connection from client: %s (%s:%d)\n", hostp->h_name, hostaddrp, ntohs(clientaddr.sin_port));
+              log_info("SERVER: accepted connection from client: %s (%s:%d)", hostp->h_name, hostaddrp, ntohs(clientaddr.sin_port));
 
 			  ret = add_client_to_membership(clientaddr, childfd, hostaddrp, ntohs(clientaddr.sin_port), clients, &seed); // hostp->h_name
 
@@ -2582,10 +2590,9 @@ int main(int argc, char **argv) {
 			  if (hostaddrp == NULL)
 			    error("ERROR on inet_ntoa\n");
 
-			  if(verbosity > 0)
-				  printf("SERVER: accepted connection from peer: %s (%s:%d), sockfd=%d\n", hostp->h_name, hostaddrp, ntohs(clientaddr.sin_port), childfd);
+              log_info("SERVER: accepted connection from peer: %s (%s:%d), sockfd=%d", hostp->h_name, hostaddrp, ntohs(clientaddr.sin_port), childfd);
 
-			  ret = add_peer_to_membership(hostaddrp, ntohs(clientaddr.sin_port), clientaddr, childfd, 0, m, CONNECTED_PEERS, &rsp, &seed); // hostp->h_name
+              ret = add_peer_to_membership(hostaddrp, ntohs(clientaddr.sin_port), clientaddr, childfd, 0, m, CONNECTED_PEERS, &rsp, &seed); // hostp->h_name
 			  rsp->status = NODE_PREJOINED;
 
 //			  assert(ret == 0);
@@ -2618,8 +2625,7 @@ int main(int argc, char **argv) {
 			if(rs->sockfd > 0 && FD_ISSET(rs->sockfd , &readfds))
 			// Received a msg from this server:
 			{
-				if(verbosity > 3)
-					printf("active peer %s, sockfd=%d, status=%d is ready for reading\n", rs->id, rs->sockfd, rs->status);
+                log_debug("active peer %s, sockfd=%d, status=%d is ready for reading", rs->id, rs->sockfd, rs->status);
 
 				ret = read_full_packet(&(rs->sockfd), (char *) in_buf, SERVER_BUFSIZE, &msg_len, &(rs->status), &handle_socket_close);
 
@@ -2644,8 +2650,7 @@ int main(int argc, char **argv) {
 			if(rs->status == NODE_PREJOINED && rs->sockfd > 0 && FD_ISSET(rs->sockfd , &readfds))
 			// Received a msg from this server:
 			{
-				if(verbosity > 3)
-					printf("pre-joined peer %s, sockfd=%d, status=%d is ready for reading\n", rs->id, rs->sockfd, rs->status);
+                log_trace("pre-joined peer %s, sockfd=%d, status=%d is ready for reading\n", rs->id, rs->sockfd, rs->status);
 
 				ret = read_full_packet(&(rs->sockfd), (char *) in_buf, SERVER_BUFSIZE, &msg_len, &(rs->status), &handle_socket_nop);
 
@@ -2665,14 +2670,14 @@ int main(int argc, char **argv) {
 				if(ret > 0) // local membership changed
 				{
 					if(verbosity > 0)
-						printf("Membership changed after %s/%d/%d joined, proposing new membership\n", rs->id, rs->sockfd, rs->status);
+						log_debug("Membership changed after %s/%d/%d joined, proposing new membership", rs->id, rs->sockfd, rs->status);
 
 					propose_local_membership(m, copy_vc(my_lc), &seed);
 				}
 				else
 				{
 					if(verbosity > 0)
-						printf("Membership did not change after %s/%d/%d joined, NOT proposing new membership\n", rs->id, rs->sockfd, rs->status);
+						log_debug("Membership did not change after %s/%d/%d joined, NOT proposing new membership", rs->id, rs->sockfd, rs->status);
 				}
 			}
 		}
@@ -2698,6 +2703,3 @@ int main(int argc, char **argv) {
 		}
 	}
 }
-
-
-

--- a/backend/comm.c
+++ b/backend/comm.c
@@ -19,6 +19,7 @@
  */
 
 #include "comm.h"
+#include "log.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -46,7 +47,7 @@ int parse_message_v1(void * rcv_buf, size_t rcv_msg_len, void ** out_msg, short 
 		{
 #if (VERBOSE_RPC > 0)
 			to_string_write_query(wq, (char *) print_buff);
-			printf("Received write query: %s\n", print_buff);
+			log_debug("Received write query: %s", print_buff);
 #endif
 			*out_msg = (void *) wq;
 			*out_msg_type = RPC_TYPE_WRITE;
@@ -59,7 +60,7 @@ int parse_message_v1(void * rcv_buf, size_t rcv_msg_len, void ** out_msg, short 
 		{
 #if (VERBOSE_RPC > 0)
 			to_string_read_query(rq, (char *) print_buff);
-			printf("Received read query: %s\n", print_buff);
+			log_debug("Received read query: %s", print_buff);
 #endif
 			*out_msg = (void *) rq;
 			*out_msg_type = RPC_TYPE_READ;
@@ -72,7 +73,7 @@ int parse_message_v1(void * rcv_buf, size_t rcv_msg_len, void ** out_msg, short 
 		{
 #if (VERBOSE_RPC > 0)
 			to_string_range_read_query(rrq, (char *) print_buff);
-			printf("Received range read query: %s\n", print_buff);
+			log_debug("Received range read query: %s", print_buff);
 #endif
 			*out_msg = (void *) rrq;
 			*out_msg_type = RPC_TYPE_RANGE_READ;
@@ -85,7 +86,7 @@ int parse_message_v1(void * rcv_buf, size_t rcv_msg_len, void ** out_msg, short 
 		{
 #if (VERBOSE_RPC > 0)
 			to_string_txn_message(tm, (char *) print_buff);
-			printf("Received txn message: %s\n", print_buff);
+			log_debug("Received txn message: %s", print_buff);
 #endif
 			*out_msg = (void *) tm;
 			*out_msg_type = RPC_TYPE_TXN;
@@ -98,7 +99,7 @@ int parse_message_v1(void * rcv_buf, size_t rcv_msg_len, void ** out_msg, short 
 		{
 #if (VERBOSE_RPC > 0)
 			to_string_queue_message(qq, (char *) print_buff);
-			printf("Received queue query: %s\n", print_buff);
+			log_debug("Received queue query: %s", print_buff);
 #endif
 			*out_msg = (void *) qq;
 			*out_msg_type = RPC_TYPE_QUEUE;
@@ -111,7 +112,7 @@ int parse_message_v1(void * rcv_buf, size_t rcv_msg_len, void ** out_msg, short 
 		{
 #if (VERBOSE_RPC > 0)
 			to_string_ack_message(am, (char *) print_buff);
-			printf("Received ack message: %s\n", print_buff);
+			log_debug("Received ack message: %s", print_buff);
 #endif
 			*out_msg = (void *) am;
 			*out_msg_type = RPC_TYPE_ACK;
@@ -127,7 +128,7 @@ int parse_message_v1(void * rcv_buf, size_t rcv_msg_len, void ** out_msg, short 
 		{
 #if (VERBOSE_RPC > 0)
 			to_string_ack_message(am, (char *) print_buff);
-			printf("Received ack message: %s\n", print_buff);
+			log_debug("Received ack message: %s", print_buff);
 #endif
 			*out_msg = (void *) am;
 			*out_msg_type = RPC_TYPE_ACK;
@@ -141,7 +142,7 @@ int parse_message_v1(void * rcv_buf, size_t rcv_msg_len, void ** out_msg, short 
 		{
 #if (VERBOSE_RPC > 0)
 			to_string_write_query(wq, (char *) print_buff);
-			printf("Received write query: %s\n", print_buff);
+			log_debug("Received write query: %s", print_buff);
 #endif
 			*out_msg = (void *) wq;
 			*out_msg_type = RPC_TYPE_READ_RESPONSE;
@@ -155,7 +156,7 @@ int parse_message_v1(void * rcv_buf, size_t rcv_msg_len, void ** out_msg, short 
 		{
 #if (VERBOSE_RPC > 0)
 			to_string_range_read_response_message(rrr, (char *) print_buff);
-			printf("Received range read response: %s\n", print_buff);
+			log_debug("Received range read response: %s", print_buff);
 #endif
 			*out_msg = (void *) rrr;
 			*out_msg_type = RPC_TYPE_RANGE_READ_RESPONSE;
@@ -169,7 +170,7 @@ int parse_message_v1(void * rcv_buf, size_t rcv_msg_len, void ** out_msg, short 
 		{
 #if (VERBOSE_RPC > 0)
 			to_string_queue_message(qq, (char *) print_buff);
-			printf("Received queue read response: %s\n", print_buff);
+			log_debug("Received queue read response: %s", print_buff);
 #endif
 			*out_msg = (void *) qq;
 			*out_msg_type = RPC_TYPE_QUEUE;
@@ -214,7 +215,7 @@ int parse_message(void * rcv_buf, size_t rcv_msg_len, void ** out_msg, short * o
 					write_query * wq = (write_query *) *(out_msg);
 #if (VERBOSE_RPC > 0)
 					to_string_write_query(wq, (char *) print_buff);
-					printf("Received write query: %s\n", print_buff);
+					log_debug("Received write query: %s", print_buff);
 #endif
 					*nonce = wq->nonce;
 					return 0;
@@ -224,7 +225,7 @@ int parse_message(void * rcv_buf, size_t rcv_msg_len, void ** out_msg, short * o
 					read_query * wq = (read_query *) *(out_msg);
 #if (VERBOSE_RPC > 0)
 					to_string_read_query(wq, (char *) print_buff);
-					printf("Received read query: %s\n", print_buff);
+					log_debug("Received read query: %s", print_buff);
 #endif
 					*nonce = wq->nonce;
 					return 0;
@@ -234,7 +235,7 @@ int parse_message(void * rcv_buf, size_t rcv_msg_len, void ** out_msg, short * o
 					range_read_query * wq = (range_read_query *) *(out_msg);
 #if (VERBOSE_RPC > 0)
 					to_string_range_read_query(wq, (char *) print_buff);
-					printf("Received range read query: %s\n", print_buff);
+					log_debug("Received range read query: %s", print_buff);
 #endif
 					*nonce = wq->nonce;
 					return 0;
@@ -244,7 +245,7 @@ int parse_message(void * rcv_buf, size_t rcv_msg_len, void ** out_msg, short * o
 					queue_query_message * wq = (queue_query_message *) *(out_msg);
 #if (VERBOSE_RPC > 0)
 					to_string_queue_message(wq, (char *) print_buff);
-					printf("Received queue message: %s\n", print_buff);
+					log_debug("Received queue message: %s", print_buff);
 #endif
 					*nonce = wq->nonce;
 					return 0;
@@ -254,7 +255,7 @@ int parse_message(void * rcv_buf, size_t rcv_msg_len, void ** out_msg, short * o
 					txn_message * wq = (txn_message *) *(out_msg);
 #if (VERBOSE_RPC > 0)
 					to_string_txn_message(wq, (char *) print_buff);
-					printf("Received txn message: %s\n", print_buff);
+					log_debug("Received txn message: %s", print_buff);
 #endif
 					*nonce = wq->nonce;
 					return 0;
@@ -279,7 +280,7 @@ int parse_message(void * rcv_buf, size_t rcv_msg_len, void ** out_msg, short * o
 					ack_message * wq = (ack_message *) *(out_msg);
 	#if (VERBOSE_RPC > 0)
 					to_string_ack_message(wq, (char *) print_buff);
-					printf("Received ack message: %s\n", print_buff);
+					log_debug("Received ack message: %s", print_buff);
 	#endif
 					*nonce = wq->nonce;
 					return 0;
@@ -289,7 +290,7 @@ int parse_message(void * rcv_buf, size_t rcv_msg_len, void ** out_msg, short * o
 					write_query * wq = (write_query *) *(out_msg);
 #if (VERBOSE_RPC > 0)
 					to_string_write_query(wq, (char *) print_buff);
-					printf("Received write query: %s\n", print_buff);
+					log_debug("Received write query: %s", print_buff);
 #endif
 					*nonce = wq->nonce;
 					return 0;
@@ -299,7 +300,7 @@ int parse_message(void * rcv_buf, size_t rcv_msg_len, void ** out_msg, short * o
 					range_read_response_message * wq = (range_read_response_message *) *(out_msg);
 #if (VERBOSE_RPC > 0)
 					to_string_range_read_response_message(wq, (char *) print_buff);
-					printf("Received range read response message: %s\n", print_buff);
+					log_debug("Received range read response message: %s", print_buff);
 #endif
 					*nonce = wq->nonce;
 					return 0;
@@ -309,7 +310,7 @@ int parse_message(void * rcv_buf, size_t rcv_msg_len, void ** out_msg, short * o
 					queue_query_message * wq = (queue_query_message *) *(out_msg);
 #if (VERBOSE_RPC > 0)
 					to_string_queue_message(wq, (char *) print_buff);
-					printf("Received queue message: %s\n", print_buff);
+					log_debug("Received queue message: %s", print_buff);
 #endif
 					*nonce = wq->nonce;
 					return 0;
@@ -319,7 +320,7 @@ int parse_message(void * rcv_buf, size_t rcv_msg_len, void ** out_msg, short * o
 					txn_message * wq = (txn_message *) *(out_msg);
 #if (VERBOSE_RPC > 0)
 					to_string_txn_message(wq, (char *) print_buff);
-					printf("Received txn message: %s\n", print_buff);
+					log_debug("Received txn message: %s", print_buff);
 #endif
 					*nonce = wq->nonce;
 					return 0;
@@ -386,7 +387,7 @@ int read_full_packet(int * sockfd, char * inbuf, size_t inbuf_size, int * msg_le
 	    *msg_len = read(*sockfd, inbuf + sizeof(int) + read_buf_offset, announced_msg_len - read_buf_offset);
 
 #if COMM_VERBOSITY > 2
-		printf("announced_msg_len=%d, msg_len=%d, read_buf_offset=%d\n", announced_msg_len, *msg_len, read_buf_offset);
+		log_debug("announced_msg_len=%d, msg_len=%d, read_buf_offset=%d", announced_msg_len, *msg_len, read_buf_offset);
 #endif
 
 	    if (*msg_len < 0)
@@ -414,7 +415,7 @@ int read_full_packet(int * sockfd, char * inbuf, size_t inbuf_size, int * msg_le
 //    read_buf_offset = 0; // Reset
 
 #if COMM_VERBOSITY > 2
-    printf("server received %d / %d bytes\n", announced_msg_len, *msg_len);
+    log_debug("server received %d / %d bytes", announced_msg_len, *msg_len);
 #endif
 
 	return status;
@@ -570,11 +571,11 @@ int update_listen_socket(remote_server * rs, char *hostname, unsigned short port
 		}
 		else
 		{
-			printf("SERVER: Updated listen socket of %s/%s:%d (%s:%d) from %d to %d\n", rs->id, rs->hostname, rs->portno, hostname, portno, old_sockfd, rs->sockfd);
+			log_debug("SERVER: Updated listen socket of %s/%s:%d (%s:%d) from %d to %d", rs->id, rs->hostname, rs->portno, hostname, portno, old_sockfd, rs->sockfd);
 		}
 	}
 
-	printf("SERVER: Updating listen socket of %s/%s:%d (%d) to %s:%d\n", rs->id, rs->hostname, rs->portno, rs->sockfd, hostname, portno);
+	log_debug("SERVER: Updating listen socket of %s/%s:%d (%d) to %s:%d", rs->id, rs->hostname, rs->portno, rs->sockfd, hostname, portno);
 
     snprintf((char *) &rs->id, 256, "%s:%d", hostname, portno);
 

--- a/backend/db.c
+++ b/backend/db.c
@@ -1265,8 +1265,3 @@ void free_queue_callback(queue_callback * qc)
 {
 	free(qc);
 }
-
-
-
-
-

--- a/backend/failure_detector/db_queries.c
+++ b/backend/failure_detector/db_queries.c
@@ -18,6 +18,7 @@
  *      Author: aagapi
  */
 
+#include "../log.h"
 #include "db_queries.h"
 #include "db_messages.pb-c.h"
 
@@ -766,7 +767,7 @@ int deserialize_ack_message(void * buf, unsigned msg_len, ack_message ** ca)
 	*ca = init_ack_message_from_msg(msg);
 
 //	to_string_ack_message(*ca, (char *) print_buff);
-//	printf("Received ACK message: %s\n", print_buff);
+//	log_debug("Received ACK message: %s", print_buff);
 
 	ack_message__free_unpacked(msg, NULL);
 

--- a/backend/log.c
+++ b/backend/log.c
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2020 rxi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "log.h"
+
+#define MAX_CALLBACKS 32
+
+typedef struct {
+  log_LogFn fn;
+  void *udata;
+  int level;
+} Callback;
+
+static struct {
+  void *udata;
+  log_LockFn lock;
+  int level;
+  bool quiet;
+  Callback callbacks[MAX_CALLBACKS];
+} L;
+
+
+static const char *level_strings[] = {
+  "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL"
+};
+
+#ifdef LOG_USE_COLOR
+static const char *level_colors[] = {
+  "\x1b[94m", "\x1b[36m", "\x1b[32m", "\x1b[33m", "\x1b[31m", "\x1b[35m"
+};
+#endif
+
+
+static void stdout_callback(log_Event *ev) {
+  char buf[16];
+  buf[strftime(buf, sizeof(buf), "%H:%M:%S", ev->date)] = '\0';
+#ifdef LOG_USE_COLOR
+  fprintf(
+    ev->udata, "%s.%06lu %s%-5s\x1b[0m \x1b[90m%-20s:%5d:\x1b[0m ",
+    buf, ev->ts.tv_nsec/1000, level_colors[ev->level], level_strings[ev->level],
+    ev->file, ev->line);
+#else
+  fprintf(
+    ev->udata, "%s.%06lu %-5s %-20s:%5d: ",
+    buf, ev->ts.tv_nsec/1000, level_strings[ev->level], ev->file, ev->line);
+#endif
+  vfprintf(ev->udata, ev->fmt, ev->ap);
+  fprintf(ev->udata, "\n");
+  fflush(ev->udata);
+}
+
+
+static void file_callback(log_Event *ev) {
+  char buf[64];
+  buf[strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", ev->date)] = '\0';
+  fprintf(
+    ev->udata, "%s.%09lu %-5s %-20s:%5d: ",
+    buf, ev->ts.tv_nsec, level_strings[ev->level], ev->file, ev->line);
+  vfprintf(ev->udata, ev->fmt, ev->ap);
+  fprintf(ev->udata, "\n");
+  fflush(ev->udata);
+}
+
+
+static void lock(void)   {
+  if (L.lock) { L.lock(true, L.udata); }
+}
+
+
+static void unlock(void) {
+  if (L.lock) { L.lock(false, L.udata); }
+}
+
+
+const char* log_level_string(int level) {
+  return level_strings[level];
+}
+
+
+void log_set_lock(log_LockFn fn, void *udata) {
+  L.lock = fn;
+  L.udata = udata;
+}
+
+
+void log_set_level(int level) {
+  L.level = level;
+}
+
+
+void log_set_quiet(bool enable) {
+  L.quiet = enable;
+}
+
+
+int log_add_callback(log_LogFn fn, void *udata, int level) {
+  for (int i = 0; i < MAX_CALLBACKS; i++) {
+    if (!L.callbacks[i].fn) {
+      L.callbacks[i] = (Callback) { fn, udata, level };
+      return 0;
+    }
+  }
+  return -1;
+}
+
+
+int log_add_fp(FILE *fp, int level) {
+  return log_add_callback(file_callback, fp, level);
+}
+
+
+static void init_event(log_Event *ev, void *udata) {
+  if (!ev->date) {
+    clock_gettime(CLOCK_REALTIME, &ev->ts);
+    ev->date = localtime(&ev->ts.tv_sec);
+  }
+  ev->udata = udata;
+}
+
+
+void log_log(int level, const char *file, int line, const char *fmt, ...) {
+  log_Event ev = {
+    .fmt   = fmt,
+    .file  = file,
+    .line  = line,
+    .level = level,
+  };
+
+  lock();
+
+  if (!L.quiet && level >= L.level) {
+    init_event(&ev, stderr);
+    va_start(ev.ap, fmt);
+    stdout_callback(&ev);
+    va_end(ev.ap);
+  }
+
+  for (int i = 0; i < MAX_CALLBACKS && L.callbacks[i].fn; i++) {
+    Callback *cb = &L.callbacks[i];
+    if (level >= cb->level) {
+      init_event(&ev, cb->udata);
+      va_start(ev.ap, fmt);
+      cb->fn(&ev);
+      va_end(ev.ap);
+    }
+  }
+
+  unlock();
+}

--- a/backend/log.h
+++ b/backend/log.h
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2020 rxi
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the MIT license. See `log.c` for details.
+ */
+
+#ifndef LOG_H
+#define LOG_H
+
+#include <stdio.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <time.h>
+
+#define LOG_VERSION "0.1.0"
+
+typedef struct {
+  va_list ap;
+  const char *fmt;
+  const char *file;
+  struct timespec ts;
+  struct tm *date;
+  void *udata;
+  int line;
+  int level;
+} log_Event;
+
+typedef void (*log_LogFn)(log_Event *ev);
+typedef void (*log_LockFn)(bool lock, void *udata);
+
+enum { LOG_TRACE, LOG_DEBUG, LOG_INFO, LOG_WARN, LOG_ERROR, LOG_FATAL };
+
+#define log_trace(...) log_log(LOG_TRACE, __FILE__, __LINE__, __VA_ARGS__)
+#define log_debug(...) log_log(LOG_DEBUG, __FILE__, __LINE__, __VA_ARGS__)
+#define log_info(...)  log_log(LOG_INFO,  __FILE__, __LINE__, __VA_ARGS__)
+#define log_warn(...)  log_log(LOG_WARN,  __FILE__, __LINE__, __VA_ARGS__)
+#define log_error(...) log_log(LOG_ERROR, __FILE__, __LINE__, __VA_ARGS__)
+#define log_fatal(...) log_log(LOG_FATAL, __FILE__, __LINE__, __VA_ARGS__)
+
+const char* log_level_string(int level);
+void log_set_lock(log_LockFn fn, void *udata);
+void log_set_level(int level);
+void log_set_quiet(bool enable);
+int log_add_callback(log_LogFn fn, void *udata, int level);
+int log_add_fp(FILE *fp, int level);
+
+void log_log(int level, const char *file, int line, const char *fmt, ...);
+
+#endif

--- a/backend/skiplist.c
+++ b/backend/skiplist.c
@@ -25,6 +25,7 @@
 #include <inttypes.h>
 
 #include "skiplist.h"
+#include "log.h"
 #include "fastrand.h"
 
 int long_cmp(WORD e1, WORD e2) {
@@ -83,7 +84,7 @@ int skiplist_insert(skiplist_t *list, WORD key, WORD value, unsigned int * seedp
     for (; i >= 0; i--) {
         while (x->forward[i] != NULL && (list->cmp(x->forward[i]->key, key) < 0))
             x = x->forward[i];
-//		printf("Item %" PRId64 " will update node %" PRId64 " at level %d\n", key, x->key, i);
+//		log_debug("Item %" PRId64 " will update node %" PRId64 " at level %d", key, x->key, i);
         	update[i] = x;
     }
 //    x = x->forward[0];
@@ -93,7 +94,7 @@ int skiplist_insert(skiplist_t *list, WORD key, WORD value, unsigned int * seedp
         return 0;
     } else {
         level = rand_level(seedptr);
-//		printf("Item %" PRId64 ", picking level %d\n", key, level);
+//		log_debug("Item %" PRId64 ", picking level %d", key, level);
         if (level > list->level) {
             for (i = list->level + 1; i <= level; i++) {
                 update[i] = list->header;
@@ -106,7 +107,7 @@ int skiplist_insert(skiplist_t *list, WORD key, WORD value, unsigned int * seedp
         x->value = value;
         x->forward = (snode_t **) malloc(sizeof(snode_t*) * (level+1));
         for (i = 0; i <= level; i++) {
-//        		printf("Item %" PRId64 " chaining myself after node %" PRId64 " at level %d\n", key, update[i]->key, i);
+//        		log_debug("Item %" PRId64 " chaining myself after node %" PRId64 " at level %d", key, update[i]->key, i);
             x->forward[i] = update[i]->forward[i];
             update[i]->forward[i] = x;
         }
@@ -278,10 +279,10 @@ void skiplist_free_val(skiplist_t *list, void (*free_val)(WORD))
 void skiplist_dump(skiplist_t *list) {
     snode_t *x = list->header;
     while (x && x->forward[0] != NULL) {
-        printf("%" PRId64 "[%" PRId64 "]->", (int64_t) x->forward[0]->key, (int64_t) x->forward[0]->value);
+        log_trace("%" PRId64 "[%" PRId64 "]->", (int64_t) x->forward[0]->key, (int64_t) x->forward[0]->value);
         x = x->forward[0];
     }
-    printf("NIL\n");
+    log_trace("NIL");
 }
 
 

--- a/rts/rts.c
+++ b/rts/rts.c
@@ -1640,7 +1640,7 @@ int main(int argc, char **argv) {
     num_wthreads = num_cores;
     bool mon_on_exit = false;
     char *log_path = NULL;
-    FILE *logf;
+    FILE *logf = NULL;
     bool log_stderr = false;
 
     appname = argv[0];

--- a/rts/rts.c
+++ b/rts/rts.c
@@ -2015,7 +2015,7 @@ int main(int argc, char **argv) {
         printf("%s\n", stats_json);
     }
 
-    if (log_path) {
+    if (logf) {
         fclose(logf);
     }
 


### PR DESCRIPTION
Rather than printf() log message, we now use the same log.c library that
is used in RTS, though with a slightly different set of modifications.

Log output is now sent to stderr rather than to stdout as previously.

Not all printf() statements have been replaced but most have. I've
mapped most log lines to log_debug() but have lowered the level of some
messages to log_info(). Rather than scrub all this in one go, I figured
we could over time adjust the levels as we see fit.

We support writing the log to a file with `--log-file=foobar.log`. If
file logging is enabled, no log output is written to stderr.

It might seem weird to have two log libraries and in particular with
different set of modifications but that was quite deliberate, since the
use in the DB and RTS are quite different. For example, RTS is threaded
while the DB is not (although it could become). The RTS log.c prints the
worker thread id, so it's possible to track what log lines belong to
what worker thread. The DB doesn't have worker threads, so such a change
would otherwise have to be made conditional. Keeping them separate is
thus, for the time being, simpler. There might be more changes that we
want to apply. If we see the two log libs being rather stable over time
and can find a way to combine, that would be fine too.

Example output:
```
09:12:40.680991 INFO  backend/actondb.c   : 2235: Using args: portno=32000, gportno=34000, verbosity=1, seeds:
09:12:40.681060 DEBUG backend/actondb.c   :  189: Create ACTORS_TABLE - OK (0)
09:12:40.681074 DEBUG backend/actondb.c   :  193: Create MSGS_TABLE - OK (0)
09:12:40.681080 INFO  backend/actondb.c   : 2265: State schema successfully created
09:12:40.681087 INFO  backend/queue.c     :   68: Queue table 2 created
09:12:40.681093 DEBUG backend/actondb.c   :  206: Create MSG_QUEUE table - OK (0)
09:12:40.681098 INFO  backend/actondb.c   : 2272: Queue schema successfully created
09:12:40.681170 INFO  backend/actondb.c   : 2313: Started [0.0.0.0:32000, 127.0.0.1:34000], my_lc = VC(99536:0)
09:12:44.400878 INFO  backend/actondb.c   : 2563: SERVER: accepted connection from client: localhost (127.0.0.1:51288)
09:12:44.401147 DEBUG backend/queue.c     :  796: BACKEND: Queue 2/0 created
09:12:44.401233 DEBUG backend/queue.c     :  651: BACKEND: Subscriber 0/0/0 subscribed queue 2/0 with callback (nil)
09:12:44.401299 DEBUG backend/queue.c     :  796: BACKEND: Queue 2/-11 created
09:12:44.401353 DEBUG backend/queue.c     :  651: BACKEND: Subscriber 0/0/-11 subscribed queue 2/-11 with callback (nil)
09:12:44.401660 DEBUG backend/queue.c     :  796: BACKEND: Queue 2/-12 created
09:12:44.401715 DEBUG backend/queue.c     :  651: BACKEND: Subscriber 0/0/-12 subscribed queue 2/-12 with callback (nil)
09:12:44.401760 DEBUG backend/queue.c     :  202: BACKEND: Inserted queue entry 0 in queue 2/-12, status=0
09:12:44.401772 DEBUG backend/queue.c     :  272: BACKEND: Notified remote subscriber -12
09:12:44.402747 DEBUG backend/queue.c     :  422: BACKEND: Subscriber -12 read 1 queue entries, new_read_head=0
09:12:44.402902 DEBUG backend/queue.c     :  202: BACKEND: Inserted queue entry 0 in queue 2/0, status=0
09:12:44.402920 DEBUG backend/queue.c     :  272: BACKEND: Notified remote subscriber 0
09:12:45.402799 DEBUG backend/queue.c     :  422: BACKEND: Subscriber 0 read 1 queue entries, new_read_head=0
09:12:45.403267 DEBUG backend/queue.c     :  202: BACKEND: Inserted queue entry 1 in queue 2/-12, status=0
09:12:45.403290 DEBUG backend/queue.c     :  272: BACKEND: Notified remote subscriber -12
09:12:45.403527 DEBUG backend/queue.c     :  202: BACKEND: Inserted queue entry 0 in queue 2/-11, status=0
09:12:45.403541 DEBUG backend/queue.c     :  272: BACKEND: Notified remote subscriber -11
09:12:45.405014 INFO  backend/actondb.c   :  839: Host disconnected, ip 127.0.0.1, port 51288, old_status=0, closing fd 5
```

Fixes #581.

Fixes #588.