### PR TITLE
Do not look at .c for up-to-date-check

### DIFF
--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -284,7 +284,7 @@ chaseImportedFiles args paths imps task
 
 doTask :: Args -> Paths -> Acton.Env.Env0 -> CompileTask -> IO Acton.Env.Env0
 doTask args paths env t@(ActonTask mn src m)
-                            = do ok <- checkUptoDate paths actFile tyFile [hFile, cFile] (importsOf t)
+                            = do ok <- checkUptoDate paths actFile tyFile [hFile] (importsOf t)
                                  if ok && mn /= modName paths then do
                                           iff (verbose args) (putStrLn ("Skipping  "++ actFile ++ " (files are up to date)."))
                                           return env


### PR DESCRIPTION
When actonc determines if the output files are newer than the source
file, it used to look at .ty, .h and .c. This cannot be right since the
.c file is a temporary file that should normally be removed and thus we
cannot expect it to exist across invokations of actonc. This check would
always fail.

Thus, we now only check for the .ty and .h file. One could argue that we
should look at the .o file too, but on the other hand, it should always
have the same modification times as the .ty or .h file. Right now, we do
leave the .o file but it should probably be removed after the module has
been added into the libActonProject_x.a archive. Inspecting modification
times inside of the archive is harder, so leaving it as is for the time
being.