### PR TITLE
Revamp stdlib build process, improving actonc and restructure time module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -295,20 +295,20 @@ stdlib/out/release/random_rel.o: stdlib/src/random.c
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) $(CFLAGS_REL) -Istdlib/ -Istdlib/out/ -c $< -o$@
 
-# -- time --
-stdlib/out/types/time.ty: stdlib/src/time.act dist/types/__builtin__.ty $(ACTONC)
+# -- _time --
+stdlib/out/types/_time.ty: stdlib/src/_time.act dist/types/__builtin__.ty $(ACTONC)
 	@mkdir -p $(dir $@)
 	$(ACTC) $< --stub
 
-stdlib/out/types/time.h: stdlib/src/time.h
+stdlib/out/types/_time.h: stdlib/src/_time.h
 	@mkdir -p $(dir $@)
 	cp $< $@
 
-stdlib/out/release/time_dev.o: stdlib/src/time.c
+stdlib/out/release/_time_dev.o: stdlib/src/_time.c
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) $(CFLAGS_DEV) -Istdlib/ -Istdlib/out/ -c $< -o$@
 
-stdlib/out/release/time_rel.o: stdlib/src/time.c
+stdlib/out/release/_time_rel.o: stdlib/src/_time.c
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) $(CFLAGS_REL) -Istdlib/ -Istdlib/out/ -c $< -o$@
 

--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,7 @@ clean-compiler:
 	cd compiler && stack clean >/dev/null 2>&1 || true
 	rm -f compiler/actonc compiler/package.yaml compiler/acton.cabal
 
+OFILES += deps/netstring_dev.o deps/netstring_rel.o deps/yyjson_dev.o deps/yyjson_rel.o
 deps/netstring_dev.o: deps/netstring.c
 	$(CC) $(CFLAGS) $(CFLAGS_DEV) -c $< -o$@
 
@@ -336,13 +337,14 @@ DB_OFILES += backend/db.o backend/queue.o backend/skiplist.o backend/txn_state.o
 DBCLIENT_OFILES += backend/client_api.o rts/empty.o
 REMOTE_OFILES += backend/failure_detector/db_messages.pb-c.o backend/failure_detector/cells.o backend/failure_detector/db_queries.o backend/failure_detector/fd.o
 VC_OFILES += backend/failure_detector/vector_clock.o
-BACKEND_OFILES=$(COMM_OFILES) $(DB_OFILES) $(DBCLIENT_OFILES) $(REMOTE_OFILES) $(VC_OFILES) backend/log.o deps/netstring_rel.o deps/yyjson.o
+BACKEND_OFILES=$(COMM_OFILES) $(DB_OFILES) $(DBCLIENT_OFILES) $(REMOTE_OFILES) $(VC_OFILES) backend/log.o deps/netstring_rel.o deps/yyjson_rel.o
 OFILES += $(BACKEND_OFILES)
 lib/libActonDB.a: $(BACKEND_OFILES)
 	ar rcs $@ $^
 
 
 # /rts --------------------------------------------------
+OFILES += rts/log.o rts/rts_dev.o rts/rts_rel.o rts/empty.o
 rts/log.o: rts/log.c rts/log.h
 	$(CC) $(CFLAGS) $(CFLAGS_DEV) -DLOG_USE_COLOR -c $< -o$@
 

--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,9 @@ STDLIB_ACTFILES_NS=$(filter-out stdlib/src/__builtin__.act,$(STDLIB_ACTFILES))
 STDLIB_CFILES=$(wildcard stdlib/src/*.c stdlib/src/**/*.c)
 STDLIB_ACTON_MODULES=$(filter-out $(STDLIB_CFILES:.c=.act),$(STDLIB_ACTFILES_NS))
 STDLIB_TYFILES=$(subst src,out/types,$(STDLIB_ACTFILES:.act=.ty))
+STDLIB_TYFILES_C=$(subst src,out/types,$(STDLIB_CFILES:.c=.ty))
 STDLIB_HFILES=$(subst src,out/types,$(STDLIB_ACTFILES_NS:.act=.h))
+STDLIB_HFILES_C=$(subst src,out/types,$(STDLIB_CFILES:.c=.h))
 STDLIB_OFILES_C=$(subst src,out/release,$(STDLIB_CFILES:.c=.o))
 STDLIB_DEV_OFILES_ACT=$(subst src,out/lib,$(STDLIB_ACTS:.act=_dev.o))
 STDLIB_REL_OFILES_ACT=$(subst src,out/lib,$(STDLIB_ACTS:.act=_rel.o))
@@ -258,7 +260,7 @@ stdlib/out/release/math_rel.o: stdlib/src/math.c
 	$(CC) $(CFLAGS) $(CFLAGS_REL) -Istdlib/ -Istdlib/out/ -c $< -o$@
 
 # -- numpy --
-stdlib/out/types/numpy.ty: stdlib/src/numpy.act dist/types/__builtin__.ty $(ACTONC)
+stdlib/out/types/numpy.ty: stdlib/src/numpy.act stdlib/out/types/math.ty dist/types/__builtin__.ty $(ACTONC)
 	@mkdir -p $(dir $@)
 	$(ACTC) $< --stub
 

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,19 @@ include common.mk
 CHANGELOG_VERSION=$(shell grep '^\#\# \[[0-9]' CHANGELOG.md | sed 's/\#\# \[\([^]]\{1,\}\)].*/\1/' | head -n1)
 
 ACTONC=dist/bin/actonc
+ACTC=dist/bin/actonc
+
+# Determine which xargs we have. BSD xargs does not have --no-run-if-empty,
+# rather, it is the default behavior so the argument is superfluous. We check if
+# we are using GNU xargs by trying to run xargs --version and grep for 'GNU', if
+# that returns 0 we are on GNU and will use 'xargs --no-run-if-empty', otherwise
+# we are on BSD and will use 'xargs' straight up.
+XARGS_CHECK := $(shell xargs --version 2>&1 | grep GNU >/dev/null 2>&1; echo $$?)
+ifeq ($(XARGS_CHECK),0)
+	XARGS := xargs --no-run-if-empty
+else
+	XARGS := xargs
+endif
 
 # This is the version we will stamp into actonc
 BUILD_TIME=$(shell date "+%Y%m%d.%-H.%-M.%-S")
@@ -168,13 +181,18 @@ deps/yyjson_rel.o: deps/yyjson.c
 # Building the builtin, rts and stdlib is a little tricky as we have to be
 # careful about order. First comes the __builtin__.act file,
 STDLIB_ACTFILES=$(wildcard stdlib/src/*.act stdlib/src/**/*.act)
+STDLIB_ACTFILES_NS=$(filter-out stdlib/src/__builtin__.act,$(STDLIB_ACTFILES))
 STDLIB_CFILES=$(wildcard stdlib/src/*.c stdlib/src/**/*.c)
-STDLIB_TYFILES=$(subst src,out/types,$(STDLIB_CFILES:.c=.ty))
-STDLIB_HFILES=$(subst src,out/types,$(STDLIB_CFILES:.c=.h))
-STDLIB_OFILES=$(subst src,out/release,$(STDLIB_CFILES:.c=.o))
-STDLIB_DEV_OFILES=$(STDLIB_OFILES:.o=_dev.o)
-STDLIB_REL_OFILES=$(STDLIB_OFILES:.o=_rel.o)
-STDLIB_ACTS=$(not-in $(STDLIB_ACTFILES),$(STDLIB_CFILES))
+STDLIB_ACTON_MODULES=$(filter-out $(STDLIB_CFILES:.c=.act),$(STDLIB_ACTFILES_NS))
+STDLIB_TYFILES=$(subst src,out/types,$(STDLIB_ACTFILES:.act=.ty))
+STDLIB_HFILES=$(subst src,out/types,$(STDLIB_ACTFILES_NS:.act=.h))
+STDLIB_OFILES_C=$(subst src,out/release,$(STDLIB_CFILES:.c=.o))
+STDLIB_DEV_OFILES_ACT=$(subst src,out/lib,$(STDLIB_ACTS:.act=_dev.o))
+STDLIB_REL_OFILES_ACT=$(subst src,out/lib,$(STDLIB_ACTS:.act=_rel.o))
+STDLIB_DEV_OFILES=$(STDLIB_DEV_OFILES_ACT) $(STDLIB_OFILES_C:.o=_dev.o)
+STDLIB_REL_OFILES=$(STDLIB_REL_OFILES_ACT) $(STDLIB_OFILES_C:.o=_rel.o)
+STDLIB_OFILES=$(STDLIB_DEV_OFILES) $(STDLIB_REL_OFILES)
+
 
 # __builtin__.ty is special, it even has special handling in actonc. Essentially
 # all other modules depend on it, so it must be compiled first. While we use
@@ -187,23 +205,65 @@ dist/types/__builtin__.ty: stdlib/out/types/__builtin__.ty
 
 stdlib/out/types/__builtin__.ty: stdlib/src/__builtin__.act $(ACTONC)
 	@mkdir -p $(dir $@)
-	$(ACTONC) $< --stub
+	$(ACTC) $< --stub
 
-stdlib/out/types/%.ty: stdlib/src/%.act dist/types/__builtin__.ty $(ACTONC)
+# Build our standard library
+# We use a single target as a focal point to get serialization since we cannot
+# build these things in parallel
+# Compiling these .act files with and with --dev will produce
+# stdlib/out/lib/libActonProject_rel.a and stdlib/out/lib/libActonProject_dev.a which we then rename
+.PHONY: stdlib_project
+stdlib_project: $(STDLIB_ACTON_MODULES) $(STDLIB_TYFILES_C) $(STDLIB_HFILES_C) dist/types/__builtin__.ty $(ACTONC)
+	echo $(STDLIB_ACTON_MODULES) | $(XARGS) -n1 $(ACTC)
+	echo $(STDLIB_ACTON_MODULES) | $(XARGS) -n1 $(ACTC) --dev
+	cp -a stdlib/out/types/. dist/types/
+
+stdlib/out/lib/libActonProject_rel.a stdlib/out/lib/libActonProject_dev.a: $(STDLIB_ACTFILES) $(ACTONC)
+	$(MAKE) stdlib_project
+
+# == Specific targets for modules written in C
+# -- acton/rts --
+stdlib/out/types/acton/rts.ty: stdlib/src/acton/rts.act dist/types/__builtin__.ty $(ACTONC)
 	@mkdir -p $(dir $@)
-	$(ACTONC) $< --stub
+	$(ACTC) $< --stub
 
-stdlib/out/types/%.h: stdlib/src/%.h
+stdlib/out/types/acton/rts.h: stdlib/src/acton/rts.h
 	@mkdir -p $(dir $@)
 	cp $< $@
 
-stdlib/out/release/%_dev.o: stdlib/src/%.c
+stdlib/out/release/acton/rts_dev.o: stdlib/src/acton/rts.c
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) $(CFLAGS_DEV) -Istdlib/ -Istdlib/out/ -c $< -o$@
 
-stdlib/out/release/%_rel.o: stdlib/src/%.c
+stdlib/out/release/acton/rts_rel.o: stdlib/src/acton/rts.c
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) $(CFLAGS_REL) -Istdlib/ -Istdlib/out/ -c $< -o$@
+
+# -- math --
+stdlib/out/types/math.ty: stdlib/src/math.act dist/types/__builtin__.ty $(ACTONC)
+	@mkdir -p $(dir $@)
+	$(ACTC) $< --stub
+
+stdlib/out/types/math.h: stdlib/src/math.h
+	@mkdir -p $(dir $@)
+	cp $< $@
+
+stdlib/out/release/math_dev.o: stdlib/src/math.c
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) $(CFLAGS_DEV) -Istdlib/ -Istdlib/out/ -c $< -o$@
+
+stdlib/out/release/math_rel.o: stdlib/src/math.c
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) $(CFLAGS_REL) -Istdlib/ -Istdlib/out/ -c $< -o$@
+
+# -- numpy --
+stdlib/out/types/numpy.ty: stdlib/src/numpy.act dist/types/__builtin__.ty $(ACTONC)
+	@mkdir -p $(dir $@)
+	$(ACTC) $< --stub
+
+stdlib/out/types/numpy.h: stdlib/src/numpy.h
+	@mkdir -p $(dir $@)
+	cp $< $@
 
 NUMPY_CFILES=$(wildcard stdlib/c_src/numpy/*.h)
 ifeq ($(shell uname -s),Linux)
@@ -217,6 +277,41 @@ stdlib/out/release/numpy_rel.o: stdlib/src/numpy.c stdlib/src/numpy.h stdlib/out
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) $(CFLAGS_REL) -Wno-unused-result -r -Istdlib/out/ $< -o$@ $(NUMPY_CFLAGS) stdlib/out/release/math_rel.o
 
+# -- random --
+stdlib/out/types/random.ty: stdlib/src/random.act dist/types/__builtin__.ty $(ACTONC)
+	@mkdir -p $(dir $@)
+	$(ACTC) $< --stub
+
+stdlib/out/types/random.h: stdlib/src/random.h
+	@mkdir -p $(dir $@)
+	cp $< $@
+
+stdlib/out/release/random_dev.o: stdlib/src/random.c
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) $(CFLAGS_DEV) -Istdlib/ -Istdlib/out/ -c $< -o$@
+
+stdlib/out/release/random_rel.o: stdlib/src/random.c
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) $(CFLAGS_REL) -Istdlib/ -Istdlib/out/ -c $< -o$@
+
+# -- time --
+stdlib/out/types/time.ty: stdlib/src/time.act dist/types/__builtin__.ty $(ACTONC)
+	@mkdir -p $(dir $@)
+	$(ACTC) $< --stub
+
+stdlib/out/types/time.h: stdlib/src/time.h
+	@mkdir -p $(dir $@)
+	cp $< $@
+
+stdlib/out/release/time_dev.o: stdlib/src/time.c
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) $(CFLAGS_DEV) -Istdlib/ -Istdlib/out/ -c $< -o$@
+
+stdlib/out/release/time_rel.o: stdlib/src/time.c
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) $(CFLAGS_REL) -Istdlib/ -Istdlib/out/ -c $< -o$@
+
+
 # /lib --------------------------------------------------
 ARCHIVES=lib/libActon_dev.a lib/libActon_rel.a lib/libActonDB.a
 
@@ -226,13 +321,15 @@ ARCHIVES=lib/libActon_dev.a lib/libActon_rel.a lib/libActonDB.a
 
 LIBACTON_DEV_OFILES=builtin/builtin_dev.o builtin/env_dev.o $(STDLIB_DEV_OFILES) stdlib/out/release/numpy_dev.o rts/empty.o rts/log.o rts/rts_dev.o deps/netstring_dev.o deps/yyjson_dev.o
 OFILES += $(LIBACTON_DEV_OFILES)
-lib/libActon_dev.a: $(LIBACTON_DEV_OFILES)
-	ar rcs $@ $^
+lib/libActon_dev.a: stdlib/out/lib/libActonProject_dev.a  $(LIBACTON_DEV_OFILES)
+	cp -a $< $@
+	ar rcs $@ $(filter-out libActonProject_,$^)
 
 LIBACTON_REL_OFILES=$(LIBACTON_DEV_OFILES:_dev.o=_rel.o)
 OFILES += $(LIBACTON_REL_OFILES)
-lib/libActon_rel.a: $(LIBACTON_REL_OFILES)
-	ar rcs $@ $^
+lib/libActon_rel.a: stdlib/out/lib/libActonProject_dev.a $(LIBACTON_REL_OFILES)
+	cp -a $< $@
+	ar rcs $@ $(filter-out libActonProject_,$^)
 
 COMM_OFILES += backend/comm.o rts/empty.o
 DB_OFILES += backend/db.o backend/queue.o backend/skiplist.o backend/txn_state.o backend/txns.o rts/empty.o
@@ -296,7 +393,7 @@ clean-backend:
 
 .PHONY: clean-rts
 clean-rts:
-	rm -f $(ARCHIVES) $(OFILES) $(STDLIB_HFILES) $(STDLIB_OFILES) $(STDLIB_TYFILES)
+	rm -f $(ARCHIVES) $(OFILES) $(STDLIB_HFILES) $(STDLIB_OFILES) $(STDLIB_TYFILES) stdlib/out/lib/libActonProject_dev.a stdlib/out/lib/libActonProject_rel.a stdlib/out/lib/*.o
 
 # == DIST ==
 #
@@ -323,7 +420,7 @@ dist/rts/%: rts/%
 	@mkdir -p $(dir $@)
 	cp $< $@
 
-dist/types/%: stdlib/out/types/%
+dist/types/%: stdlib/out/types/% stdlib
 	@mkdir -p $(dir $@)
 	cp $< $@
 
@@ -342,9 +439,7 @@ dist/lib/libActon_rel.a: lib/libActon_rel.a
 DIST_BINS=$(ACTONC) dist/bin/actondb
 DIST_HFILES=dist/rts/rts.h \
 	dist/builtin/env.h \
-	$(addprefix dist/,$(BUILTIN_HFILES)) \
-	$(subst stdlib/out/types,dist/types,$(STDLIB_HFILES))
-DIST_TYFILES=$(subst stdlib/out/types,dist/types,$(STDLIB_TYFILES))
+	$(addprefix dist/,$(BUILTIN_HFILES))
 DIST_ARCHIVES=$(addprefix dist/,$(ARCHIVES))
 
 .PHONY: distribution clean-distribution

--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -284,7 +284,7 @@ chaseImportedFiles args paths imps task
 
 doTask :: Args -> Paths -> Acton.Env.Env0 -> CompileTask -> IO Acton.Env.Env0
 doTask args paths env t@(ActonTask mn src m)
-                            = do ok <- checkUptoDate paths actFile tyFile [hFile, cFile] (importsOf t)
+                            = do ok <- checkUptoDate paths actFile tyFile [hFile] (importsOf t)
                                  if ok && mn /= modName paths then do
                                           iff (verbose args) (putStrLn ("Skipping  "++ actFile ++ " (files are up to date)."))
                                           return env

--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -366,8 +366,9 @@ runRestPasses args paths env0 parsed = do
                       iff (not $ stub args) $ do
                           let cFile = outbase ++ ".c"
                               hFile = outbase ++ ".h"
-                              oFile = joinPath [projLib paths, n++".o"]
-                              aFile = joinPath [projLib paths, "libActonProject.a"]
+                              oFile = joinPath [projLib paths, n++ if (dev args) then "_dev.o" else "_rel.o"]
+                              aFile = joinPath [projLib paths,
+                                                if (dev args) then "libActonProject_dev.a" else "libActonProject_rel.a"]
                               buildF = joinPath [projPath paths, "build.sh"]
                               ccCmd = ("cc " ++ pedantArg ++
                                        (if (dev args) then " -g " else "") ++
@@ -430,7 +431,7 @@ buildExecutable env args paths task
         buildF              = joinPath [projPath paths, "build.sh"]
         outbase             = outBase paths mn
         rootFile            = outbase ++ ".root.c"
-        libFilesBase        = " -lActonProject " ++ libActonArg ++ " -lActonDB -lprotobuf-c -lutf8proc -lpthread -lm"
+        libFilesBase        = " " ++ libActonProjArg ++ " " ++ libActonArg ++ " -lActonDB -lprotobuf-c -lutf8proc -lpthread -lm"
         libPathsBase        = " -L" ++ projLib paths ++ " -L" ++ sysLib paths
 #if defined(darwin_HOST_OS) && defined(aarch64_HOST_ARCH)
         libFiles            = libFilesBase
@@ -447,6 +448,7 @@ buildExecutable env args paths task
         ccArgs              = " -no-pie "
 #endif
         libActonArg         = if (dev args) then "-lActon_dev" else "-lActon_rel"
+        libActonProjArg     = if (dev args) then "-lActonProject_dev" else "-lActonProject_rel"
         binFilename         = takeFileName $ dropExtension srcbase
         binFile             = joinPath [binDir paths, binFilename]
         srcbase             = srcFile paths mn

--- a/stdlib/src/_time.act
+++ b/stdlib/src/_time.act
@@ -1,0 +1,7 @@
+monotonic : () -> float
+
+monotonic_ns : () -> int
+
+time : () -> float
+
+time_ns : () -> int

--- a/stdlib/src/_time.c
+++ b/stdlib/src/_time.c
@@ -1,6 +1,6 @@
-#include "time.h"
+#include "_time.h"
 
-$float time$$monotonic () {
+$float _time$$monotonic () {
     struct timespec ts;
     if (clock_gettime(CLOCK_MONOTONIC, &ts) == -1) {
         $RAISE((($BaseException)$RuntimeError$new(to$str("Unable to get time"))));
@@ -8,7 +8,7 @@ $float time$$monotonic () {
     return to$float(ts.tv_sec + ts.tv_nsec);
 }
 
-$int time$$monotonic_ns () {
+$int _time$$monotonic_ns () {
     struct timespec ts;
     if (clock_gettime(CLOCK_MONOTONIC, &ts) == -1) {
         $RAISE((($BaseException)$RuntimeError$new(to$str("Unable to get time"))));
@@ -16,7 +16,7 @@ $int time$$monotonic_ns () {
     return to$int(ts.tv_sec * 1000000000 + ts.tv_nsec);
 }
 
-$float time$$time () {
+$float _time$$time () {
     struct timespec ts;
     if (clock_gettime(CLOCK_REALTIME, &ts) == -1) {
         $RAISE((($BaseException)$RuntimeError$new(to$str("Unable to get time"))));
@@ -24,7 +24,7 @@ $float time$$time () {
     return to$float(ts.tv_sec + 0.000000001*ts.tv_nsec);
 }
 
-$int time$$time_ns () {
+$int _time$$time_ns () {
     struct timespec ts;
     if (clock_gettime(CLOCK_REALTIME, &ts) == -1) {
         $RAISE((($BaseException)$RuntimeError$new(to$str("Unable to get time"))));
@@ -33,8 +33,8 @@ $int time$$time_ns () {
 }
 
 
-int time$$done$ = 0;
-void time$$__init__ () {
-    if (time$$done$) return;
-    time$$done$ = 1;
+int _time$$done$ = 0;
+void _time$$__init__ () {
+    if (_time$$done$) return;
+    _time$$done$ = 1;
 }

--- a/stdlib/src/_time.h
+++ b/stdlib/src/_time.h
@@ -1,0 +1,9 @@
+#pragma once
+#include "builtin/builtin.h"
+#include "builtin/env.h"
+#include "rts/rts.h"
+$float _time$$monotonic ();
+$int _time$$monotonic_ns ();
+$float _time$$time ();
+$int _time$$time_ns ();
+void _time$$__init__ ();

--- a/stdlib/src/time.act
+++ b/stdlib/src/time.act
@@ -1,7 +1,13 @@
-monotonic : () -> float
+import _time
 
-monotonic_ns : () -> int
+def monotonic():
+    return _time.monotonic()
 
-time : () -> float
+def monotonic_ns():
+    return _time.monotonic_ns()
 
-time_ns : () -> int
+def time():
+    return _time.time()
+
+def time_ns():
+    return _time.time_ns()

--- a/stdlib/src/time.h
+++ b/stdlib/src/time.h
@@ -1,9 +1,0 @@
-#pragma once
-#include "builtin/builtin.h"
-#include "builtin/env.h"
-#include "rts/rts.h"
-$float time$$monotonic ();
-$int time$$monotonic_ns ();
-$float time$$time ();
-$int time$$time_ns ();
-void time$$__init__ ();


### PR DESCRIPTION
With this change the stdlib is now able to build native Acton modules. Previously, all modules have been implemented in C and thus we've only used actonc stub compilation to get .ty files. Now we support both with correct dependencies in between (assume all C modules need to be built first).

The time module, written in C, has been renamed to _time and a new time module in Acton has been added. It wraps all the existing functions in _time, so the interface of the time module is backwards compatible. We can now add in other functions to the time module, written in Acton.

actonc now correctly keeps dev and release profile compiled output apart by including _dev or _rel file ending for the libActonProject archive. Further, the up-to-date-check of output files has been fixed to not inspect .c files, since those files are not expected to exist between actonc invokations.

The Makefile has gotten a bunch of improvements around stdlib, with more dependencies being correctly set. It's also gotten a lot longer since many targets are sort of complex and need to be explicitly specified rather than being able to rely on pattern mathing rules. Our longer term goal of using actonc to compile all of this should once again reduce the size of the Makefile.

Some filenames were missing so the clean targets missed removing those files. This has been fixed.

Fixes #591.

Fixes #595.