### PR TITLE
Add custom stub compilation via Makefile

### DIFF
--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -1,0 +1,50 @@
+
+CFLAGS+= -I.. -Ideps -Wno-int-to-pointer-cast -Wno-pointer-to-int-cast -Wformat -Werror=format-security
+CFLAGS_REL= -O3 -DREL
+CFLAGS_DEV= -g -DDEV
+
+out/lib/acton$$rts_dev.o: src/acton/rts.c
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) $(CFLAGS_DEV) -I. -Iout/ -c $< -o'$@'
+
+
+out/lib/acton$$rts_rel.o: src/acton/rts.c
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) $(CFLAGS_REL) -I. -Iout/ -c $< -o'$@'
+
+out/lib/math_dev.o: src/math.c
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) $(CFLAGS_DEV) -Iout/ -c $< -o$@
+
+out/lib/math_rel.o: src/math.c
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) $(CFLAGS_REL) -Iout/ -c $< -o$@
+
+
+NUMPY_CFILES=$(wildcard c_src/numpy/*.h)
+ifeq ($(shell uname -s),Linux)
+NUMPY_CFLAGS+=-lbsd -ldl -lmd
+endif
+out/lib/numpy_dev.o: src/numpy.c src/numpy.h out/types/math.h $(NUMPY_CFILES) out/lib/math_dev.o
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) $(CFLAGS_DEV) -Wno-unused-result -r -Iout/ $< -o$@ $(NUMPY_CFLAGS) out/lib/math_dev.o
+
+out/lib/numpy_rel.o: src/numpy.c src/numpy.h out/types/math.h $(NUMPY_CFILES) out/lib/math_rel.o
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) $(CFLAGS_REL) -Wno-unused-result -r -Iout/ $< -o$@ $(NUMPY_CFLAGS) out/lib/math_rel.o
+
+out/lib/random_dev.o: src/random.c
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) $(CFLAGS_DEV) -c $< -o$@
+
+out/lib/random_rel.o: src/random.c
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) $(CFLAGS_REL) -c $< -o$@
+
+out/lib/_time_dev.o: src/_time.c
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) $(CFLAGS_DEV) -I -Iout/ -c $< -o$@
+
+out/lib/_time_rel.o: src/_time.c
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) $(CFLAGS_REL) -I -Iout/ -c $< -o$@


### PR DESCRIPTION
For a stub compiled .act files we will now run make for the
corresponding .c and .h targets, if there is a Makefile at the root of
the project directory and if the files exist. For example, actonc will
compile accordingly:
- src/foo.act  -> out/types/foo.ty
- src/foo.c    -> out/lib/foo_dev.o
- src/foo.h    -> out/types/foo.h (just copied)

Given the presence of foo.c and foo.h, src/foo.act will be stub compiled
into out/types/foo.ty and src/foo.h will be copied as-is to
out/types/foo.h. If a Makefile exists at the root of the project
directory, src/foo.c will be compiled by running `make
out/lib/foo_dev.o` (or _rel.o). Thus, we offer a hook point for custom
compilation rules, since many C modules will need to be linked or
include various flags.

Our stdlib, being organized as an Acton project, now uses such a custom
Makefile. The stdlib targets have thus been removed from the main
Makefile.

Fixes #600.