### PR TITLE
Hardcode stub compilation for __builtin__.act

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,7 @@ dist/types/__builtin__.ty: stdlib/out/types/__builtin__.ty
 
 stdlib/out/types/__builtin__.ty: stdlib/src/__builtin__.act $(ACTONC)
 	@mkdir -p $(dir $@)
-	$(ACTC) $< --stub
+	$(ACTC) $<
 
 # Build our standard library
 # We use a single target as a focal point to get serialization since we cannot

--- a/compiler/Acton/Env.hs
+++ b/compiler/Acton/Env.hs
@@ -404,6 +404,7 @@ unSig te                    = map f te
 -- Env construction and modification -------------------------------------------------------------------------------------------
 
 
+-- first variant is special case for compiling __builtin__.act
 initEnv                    :: FilePath -> Bool -> Bool -> IO Env0
 initEnv path stub True     = return $ EnvF{ names = [(nPrim,NMAlias mPrim)],
                                             modules = [(nPrim,NModule envPrim)],

--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -143,8 +143,11 @@ main            = do cv <- getCcVer
                                `catch` handle "IOException" (\exc -> (l0,displayException (exc :: IOException))) "" paths mn
                                `catch` handle "Error" (\exc -> (l0,displayException (exc :: ErrorCall))) "" paths mn
 
-stubMode srcfile args = do exists <- doesFileExist cFile
-                           if (stub args || exists) then return True else return False
+stubMode srcfile args = do
+    exists <- doesFileExist cFile
+    if ((takeFileName srcfile) == "__builtin__.act" || stub args || exists)
+      then return True
+      else return False
   where cFile = replaceExtension srcfile ".c"
 
 


### PR DESCRIPTION
Since we're already hard coding stuff for __builtin__.act it doesn't
hurt hard-coding some more, in this case stub mode compilation.

We no longer need to specify --stub anywhere in our Makefile, which
means that we could potentially remove the --stub argument completely
but as I'm uncertain on whether there might be other weird edge cases
where it could be useful, I'm leaving it in for now.

This is also in preparation for the actonc build command where we won't
be able to specify --stub specifically for __builtin__.act since we are
just running build for the entire stdlib project.

Part of #594.