### PR TITLE
Implement new project naming in actonc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,13 +220,13 @@ stdlib_project: $(STDLIB_ACTFILES_NS) dist/types/__builtin__.ty $(ACTONC)
 	echo $(STDLIB_ACTFILES_NS) | $(XARGS) -n1 $(ACTC) --dev
 	cp -a stdlib/out/types/. dist/types/
 
-stdlib/out/lib/libActonProject_rel.a stdlib/out/lib/libActonProject_dev.a: $(STDLIB_ACTFILES) $(ACTONC)
+stdlib/out/dev/lib/libActonProject.a stdlib/out/rel/lib/libActonProject.a: $(STDLIB_ACTFILES) $(ACTONC)
 	$(MAKE) stdlib_project
 
 
 # /lib --------------------------------------------------
 DBARCHIVE=lib/libActonDB.a
-ARCHIVES=lib/libActon_dev.a lib/libActon_rel.a
+ARCHIVES=lib/dev/libActon.a lib/rel/libActon.a
 
 # If we later let actonc build things, it would produce a libActonProject.a file
 # in the stdlib directory, which we would need to join together with rts.o etc
@@ -234,15 +234,17 @@ ARCHIVES=lib/libActon_dev.a lib/libActon_rel.a
 
 LIBACTON_DEV_OFILES=builtin/builtin_dev.o builtin/env_dev.o rts/empty.o rts/log.o rts/rts_dev.o deps/netstring_dev.o deps/yyjson_dev.o
 OFILES += $(LIBACTON_DEV_OFILES)
-lib/libActon_dev.a: stdlib/out/lib/libActonProject_dev.a  $(LIBACTON_DEV_OFILES)
+lib/dev/libActon.a: stdlib/out/dev/lib/libActonProject.a  $(LIBACTON_DEV_OFILES)
+	@mkdir -p $(dir $@)
 	cp -a $< $@
-	ar rcs $@ $(filter-out libActonProject_,$^)
+	ar rcs $@ $(filter-out stdlib/out/dev/lib/libActonProject.a,$^)
 
 LIBACTON_REL_OFILES=$(LIBACTON_DEV_OFILES:_dev.o=_rel.o)
 OFILES += $(LIBACTON_REL_OFILES)
-lib/libActon_rel.a: stdlib/out/lib/libActonProject_dev.a $(LIBACTON_REL_OFILES)
+lib/rel/libActon.a: stdlib/out/rel/lib/libActonProject.a $(LIBACTON_REL_OFILES)
+	@mkdir -p $(dir $@)
 	cp -a $< $@
-	ar rcs $@ $(filter-out libActonProject_,$^)
+	ar rcs $@ $(filter-out stdlib/out/rel/lib/libActonProject.a,$^)
 
 COMM_OFILES += backend/comm.o rts/empty.o
 DB_OFILES += backend/db.o backend/queue.o backend/skiplist.o backend/txn_state.o backend/txns.o rts/empty.o
@@ -339,14 +341,6 @@ dist/types/%: stdlib/out/types/% stdlib
 	cp $< $@
 
 dist/lib/%: lib/%
-	@mkdir -p $(dir $@)
-	cp $< $@
-
-dist/lib/libActon_dev.a: lib/libActon_dev.a
-	@mkdir -p $(dir $@)
-	cp $< $@
-
-dist/lib/libActon_rel.a: lib/libActon_rel.a
 	@mkdir -p $(dir $@)
 	cp $< $@
 

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -3,20 +3,20 @@ CFLAGS+= -I.. -Ideps -Wno-int-to-pointer-cast -Wno-pointer-to-int-cast -Wformat 
 CFLAGS_REL= -O3 -DREL
 CFLAGS_DEV= -g -DDEV
 
-out/lib/acton$$rts_dev.o: src/acton/rts.c
+out/dev/lib/acton$$rts.o: src/acton/rts.c
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) $(CFLAGS_DEV) -I. -Iout/ -c $< -o'$@'
 
 
-out/lib/acton$$rts_rel.o: src/acton/rts.c
+out/rel/lib/acton$$rts.o: src/acton/rts.c
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) $(CFLAGS_REL) -I. -Iout/ -c $< -o'$@'
 
-out/lib/math_dev.o: src/math.c
+out/dev/lib/math.o: src/math.c
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) $(CFLAGS_DEV) -Iout/ -c $< -o$@
 
-out/lib/math_rel.o: src/math.c
+out/rel/lib/math.o: src/math.c
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) $(CFLAGS_REL) -Iout/ -c $< -o$@
 
@@ -25,26 +25,26 @@ NUMPY_CFILES=$(wildcard c_src/numpy/*.h)
 ifeq ($(shell uname -s),Linux)
 NUMPY_CFLAGS+=-lbsd -ldl -lmd
 endif
-out/lib/numpy_dev.o: src/numpy.c src/numpy.h out/types/math.h $(NUMPY_CFILES) out/lib/math_dev.o
+out/dev/lib/numpy.o: src/numpy.c src/numpy.h out/types/math.h $(NUMPY_CFILES) out/dev/lib/math.o
 	@mkdir -p $(dir $@)
-	$(CC) $(CFLAGS) $(CFLAGS_DEV) -Wno-unused-result -r -Iout/ $< -o$@ $(NUMPY_CFLAGS) out/lib/math_dev.o
+	$(CC) $(CFLAGS) $(CFLAGS_DEV) -Wno-unused-result -r -Iout/ $< -o$@ $(NUMPY_CFLAGS) out/dev/lib/math.o
 
-out/lib/numpy_rel.o: src/numpy.c src/numpy.h out/types/math.h $(NUMPY_CFILES) out/lib/math_rel.o
+out/rel/lib/numpy.o: src/numpy.c src/numpy.h out/types/math.h $(NUMPY_CFILES) out/rel/lib/math.o
 	@mkdir -p $(dir $@)
-	$(CC) $(CFLAGS) $(CFLAGS_REL) -Wno-unused-result -r -Iout/ $< -o$@ $(NUMPY_CFLAGS) out/lib/math_rel.o
+	$(CC) $(CFLAGS) $(CFLAGS_REL) -Wno-unused-result -r -Iout/ $< -o$@ $(NUMPY_CFLAGS) out/rel/lib/math.o
 
-out/lib/random_dev.o: src/random.c
+out/dev/lib/random.o: src/random.c
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) $(CFLAGS_DEV) -c $< -o$@
 
-out/lib/random_rel.o: src/random.c
+out/rel/lib/random.o: src/random.c
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) $(CFLAGS_REL) -c $< -o$@
 
-out/lib/_time_dev.o: src/_time.c
+out/dev/lib/_time.o: src/_time.c
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) $(CFLAGS_DEV) -I -Iout/ -c $< -o$@
 
-out/lib/_time_rel.o: src/_time.c
+out/rel/lib/_time.o: src/_time.c
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) $(CFLAGS_REL) -I -Iout/ -c $< -o$@


### PR DESCRIPTION
We agreed on the structure in a project but somehow ended up not
implementing it completely. I guess it comes from all modules being
manually compiled from C, so what actonc did wasn't as relevant.

Anyway, now actonc does the right thing!

For example, here's the layout of stdlib:
```
stdlib/out
├── dev
│   ├── bin
│   └── lib
│       ├── acton$rts.o
│       ├── libActonProject.a
│       ├── math.o
│       ├── numpy.o
│       ├── random.o
│       ├── _time.o
│       └── time.o
├── rel
│   ├── bin
│   └── lib
│       ├── acton$rts.o
│       ├── libActonProject.a
│       ├── math.o
│       ├── numpy.o
│       ├── random.o
│       ├── _time.o
│       └── time.o
└── types
    ├── acton
    │   ├── rts.h
    │   └── rts.ty
    ├── __builtin__.ty
    ├── math.h
    ├── math.ty
    ├── numpy.h
    ├── numpy.ty
    ├── random.h
    ├── random.ty
    ├── time.c
    ├── _time.h
    ├── time.h
    ├── _time.ty
    └── time.ty

```

Fixes #603.