### PR TITLE
Change actonc default output

### DIFF
--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -158,7 +158,7 @@ compileFile actFile args = do
         putStrLn ("## fileExt  : " ++ fileExt paths)
         putStrLn ("## modName  : " ++ prstr (modName paths))
     stubM <- stubMode actFile args
-    when (stubM) $ do putStrLn("Found matching C file (" ++ (replaceExtension actFile ".c") ++ "), assuming stub compilation")
+    when (stubM && verbose args) $ do putStrLn("Found matching C file (" ++ (replaceExtension actFile ".c") ++ "), assuming stub compilation")
     let mn = modName paths
     src <- readFile actFile
     tree <- Acton.Parser.parseModule mn actFile src
@@ -415,8 +415,11 @@ runRestPasses args paths env0 parsed = do
                           aFile = joinPath [projLib paths, "libActonProject.a"]
 
                       stubM <- stubMode actFile args
+                      putStrLn("Compiling " ++ makeRelative (srcDir paths) actFile
+                               ++ if (dev args) then " for development" else " for release"
+                               ++ if stubM then " in stub mode" else ""
+                              )
                       if stubM then do
-                          putStrLn("Doing stub compilation for " ++ actFile)
                           let makeFile = projPath paths ++ "/Makefile"
                           makeExist <- doesFileExist makeFile
                           iff (makeExist) (do


### PR DESCRIPTION
This gives nice concise output per default, for example:

    Compiling foo.act for release
    Compiling math.act for release in stub mode
    Compiling numpy.act for release in stub mode
    Compiling random.act for release in stub mode
    Compiling _time.act for release in stub mode
    Compiling time.act for release
    Compiling acton/rts.act for release in stub mode