### PR TITLE
Implement build command for actonc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,20 +181,6 @@ deps/yyjson_rel.o: deps/yyjson.c
 
 # Building the builtin, rts and stdlib is a little tricky as we have to be
 # careful about order. First comes the __builtin__.act file,
-STDLIB_ACTFILES=$(wildcard stdlib/src/*.act stdlib/src/**/*.act)
-STDLIB_ACTFILES_NS=$(filter-out stdlib/src/__builtin__.act,$(STDLIB_ACTFILES))
-STDLIB_CFILES=$(wildcard stdlib/src/*.c stdlib/src/**/*.c)
-STDLIB_ACTON_MODULES=$(filter-out $(STDLIB_CFILES:.c=.act),$(STDLIB_ACTFILES_NS))
-STDLIB_TYFILES=$(subst src,out/types,$(STDLIB_ACTFILES:.act=.ty))
-STDLIB_TYFILES_C=$(subst src,out/types,$(STDLIB_CFILES:.c=.ty))
-STDLIB_HFILES=$(subst src,out/types,$(STDLIB_ACTFILES_NS:.act=.h))
-STDLIB_HFILES_C=$(subst src,out/types,$(STDLIB_CFILES:.c=.h))
-STDLIB_DEV_OFILES_ACT=$(subst src,out/lib,$(STDLIB_ACTS:.act=_dev.o))
-STDLIB_REL_OFILES_ACT=$(subst src,out/lib,$(STDLIB_ACTS:.act=_rel.o))
-STDLIB_DEV_OFILES=$(STDLIB_DEV_OFILES_ACT)
-STDLIB_REL_OFILES=$(STDLIB_REL_OFILES_ACT)
-STDLIB_OFILES=$(STDLIB_DEV_OFILES) $(STDLIB_REL_OFILES)
-
 
 # __builtin__.ty is special, it even has special handling in actonc. Essentially
 # all other modules depend on it, so it must be compiled first. While we use
@@ -214,10 +200,11 @@ stdlib/out/types/__builtin__.ty: stdlib/src/__builtin__.act $(ACTONC)
 # build these things in parallel
 # Compiling these .act files with and with --dev will produce
 # stdlib/out/lib/libActonProject_rel.a and stdlib/out/lib/libActonProject_dev.a which we then rename
+STDLIB_ACTFILES=$(wildcard stdlib/src/*.act stdlib/src/**/*.act)
 .PHONY: stdlib_project
-stdlib_project: $(STDLIB_ACTFILES_NS) dist/types/__builtin__.ty $(ACTONC)
-	echo $(STDLIB_ACTFILES_NS) | $(XARGS) -n1 $(ACTC)
-	echo $(STDLIB_ACTFILES_NS) | $(XARGS) -n1 $(ACTC) --dev
+stdlib_project: $(STDLIB_ACTFILES) dist/types/__builtin__.ty $(ACTONC)
+	cd stdlib && ../$(ACTC) build
+	cd stdlib && ../$(ACTC) build --dev
 	cp -a stdlib/out/types/. dist/types/
 
 stdlib/out/dev/lib/libActonProject.a stdlib/out/rel/lib/libActonProject.a: $(STDLIB_ACTFILES) $(ACTONC)
@@ -309,7 +296,7 @@ clean-backend:
 
 .PHONY: clean-rts
 clean-rts:
-	rm -rf $(ARCHIVES) $(DBARCHIVE) $(OFILES) $(STDLIB_HFILES) $(STDLIB_OFILES) $(STDLIB_TYFILES) stdlib/out/
+	rm -rf $(ARCHIVES) $(DBARCHIVE) $(OFILES) stdlib/out/
 
 # == DIST ==
 #

--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -40,6 +40,7 @@ import Data.Monoid ((<>))
 import Data.Graph
 import Data.Version (showVersion)
 import qualified Data.List
+import System.Directory.Recursive
 import System.IO
 import System.IO.Temp
 import System.Info
@@ -112,17 +113,26 @@ getCcVer        = do verStr <- readProcess "cc" ["--version"] []
 showVer cv      = "acton " ++ getVer ++ "\n" ++ getVerExtra ++ "\ncc: " ++ cv
 
 
+filterActFile :: FilePath -> IO Bool
+filterActFile file =
+    return (fileExt == ".act")
+  where (fileBody,fileExt) = splitExtension $ takeFileName file
+
 main = do
     cv <- getCcVer
     args <- execParser (info (getArgs (showVer cv) <**> helper) descr)
     cmdIsFile <- checkCmdIsFile (cmd args)
     if cmdIsFile
-      then compileFile (cmd args) args
+      then compileFile args (cmd args)
       else
         case (cmd args) of
             "build" -> do
-                errorWithoutStackTrace("Build is not implemented :/")
-                System.Exit.exitFailure
+                -- find all .act files in src/ directory and invoke compileFile for each
+                curDir <- getCurrentDirectory
+                paths <- findPaths (joinPath [ curDir, "Acton.toml" ]) args
+                srcFiles <- getDirFiltered filterActFile (joinPath [projPath paths, "src"])
+                mapM (compileFile args) srcFiles
+                System.Exit.exitSuccess
             "dump" -> do
                 if null $ file args
                   then do
@@ -142,8 +152,8 @@ main = do
                 errorWithoutStackTrace("Unknown command: " ++ cmd args)
                 System.Exit.exitFailure
 
-compileFile :: String -> Args -> IO ()
-compileFile actFile args = do
+compileFile :: Args -> String -> IO ()
+compileFile args actFile = do
     paths <- findPaths actFile args
     when (verbose args) $ do
         putStrLn ("## sysPath  : " ++ sysPath paths)

--- a/compiler/package.yaml.in
+++ b/compiler/package.yaml.in
@@ -37,6 +37,7 @@ dependencies:
 - process
 - temporary
 - unix
+- dir-traverse
 
 executables:
   actonc:

--- a/compiler/stack.yaml
+++ b/compiler/stack.yaml
@@ -42,7 +42,7 @@ packages:
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
 # extra-deps: []
-#extra-deps: [megaparsec-9.0.1,directory-1.3.3.1, parser-combinators-1.0.0,process-1.6.8.0]
+extra-deps: [dir-traverse-0.2.3.0]
 # Override default flag values for local packages and extra-deps
 # flags: {}
 

--- a/compiler/stack.yaml.lock
+++ b/compiler/stack.yaml.lock
@@ -3,7 +3,14 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
+packages:
+- completed:
+    hackage: dir-traverse-0.2.3.0@sha256:adcc128f201ff95131b15ffe41365dc99c50dc3fa3a910f021521dc734013bfa,2137
+    pantry-tree:
+      size: 389
+      sha256: b19f0562746dfd0f8f21eccab6584592f55fb781ca3e043da9132cc23d8a5b99
+  original:
+    hackage: dir-traverse-0.2.3.0
 snapshots:
 - completed:
     size: 586041


### PR DESCRIPTION
Running `actonc build` will find all .act files in the project source
directory and compile them! There's a big hole in this as we cannot
build any binaries! Binaries are built by specifying the --root actor
but since we can't send in arguments per module, that won't work for a
project build. We can still build those by specifying the file though,
like `actonc src/foo.act`.

Fixes #594.