### PR TITLE
Fix build output to include stub mode

### DIFF
--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -416,8 +416,8 @@ runRestPasses args paths env0 parsed = do
 
                       stubM <- stubMode actFile args
                       putStrLn("Compiling " ++ makeRelative (srcDir paths) actFile
-                               ++ if (dev args) then " for development" else " for release"
-                               ++ if stubM then " in stub mode" else ""
+                               ++ (if (dev args) then " for development" else " for release")
+                               ++ (if stubM then " in stub mode" else "")
                               )
                       if stubM then do
                           let makeFile = projPath paths ++ "/Makefile"


### PR DESCRIPTION
Previously we wouldn't print out "in stub mode" when compiling in
developer profile. We do now, for example for stdlib:

    Compiling foo.act for release
    Compiling math.act for release in stub mode
    Compiling numpy.act for release in stub mode
    Compiling random.act for release in stub mode
    Compiling _time.act for release in stub mode
    Compiling time.act for release
    Compiling acton/rts.act for release in stub mode

    Compiling foo.act for development
    Compiling math.act for development in stub mode
    Compiling numpy.act for development in stub mode
    Compiling random.act for development in stub mode
    Compiling _time.act for development in stub mode
    Compiling time.act for development
    Compiling acton/rts.act for development in stub mode