### PR TITLE
Correctly implement stub mode

### DIFF
--- a/compiler/Acton/Env.hs
+++ b/compiler/Acton/Env.hs
@@ -405,19 +405,19 @@ unSig te                    = map f te
 
 
 -- first variant is special case for compiling __builtin__.act
-initEnv                    :: FilePath -> Bool -> Bool -> IO Env0
-initEnv path stub True     = return $ EnvF{ names = [(nPrim,NMAlias mPrim)],
+initEnv                    :: FilePath -> Bool -> IO Env0
+initEnv path True          = return $ EnvF{ names = [(nPrim,NMAlias mPrim)],
                                             modules = [(nPrim,NModule envPrim)],
                                             witnesses = [],
                                             thismod = Nothing,
-                                            stub = stub,
+                                            stub = False,
                                             envX = () }
-initEnv path stub False    = do envBuiltin <- InterfaceFiles.readFile (joinPath [path,"__builtin__.ty"])
+initEnv path False         = do envBuiltin <- InterfaceFiles.readFile (joinPath [path,"__builtin__.ty"])
                                 let env0 = EnvF{ names = [(nPrim,NMAlias mPrim), (nBuiltin,NMAlias mBuiltin)],
                                                  modules = [(nPrim,NModule envPrim), (nBuiltin,NModule envBuiltin)],
                                                  witnesses = [],
                                                  thismod = Nothing,
-                                                 stub = stub,
+                                                 stub = False,
                                                  envX = () }
                                     env = importAll mBuiltin envBuiltin $ importWits mBuiltin envBuiltin $ env0
                                 return env


### PR DESCRIPTION
The environment (env) record has a stub field which controls

We used to initialize this value in initEnv and keep that value
throughout the current actonc invokation, affecting all compiled files,
which meant it was only the initial file that would really affect
whether stub compilation was used or not. Now we instead change the stub
mode in the local environment used for the compilation in runRestPasses,
effectively setting stub mode per file. It means it's now irrelevant for
initEnv, so the arg is removed from there.

Also improved output a bit.

Fixes #621.