### PR TITLE
Correct Debian dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,8 @@ Depends:
  ${shlibs:Depends},
  ${misc:Depends},
  gcc,
- libprotobuf-c1,
- libutf8proc2
+ libprotobuf-c-dev,
+ libutf8proc-dev,
+ uuid-dev
 Description: Acton Programming Language
  An awesome programming language.


### PR DESCRIPTION
I think this was just a brainfart on my part. I was thinking that we
need the -dev libraries when we are building Acton itself but for later
use of actonc itself we would be fine with like libprotobuf-c1, but
we're not! libprotobuf-c1 is a shared library and since actonc is a
compiler and we want the executables that actonc produces to have as few
run time dependencies, we do not use shared libs but rather prefer to
link it at compile time. Thus, we need the -dev version of the packages,
that include the non-shared libs, at run time of actonc.

Also added in uuid-dev since it seems to have been missing.

I've verified things work correctly by running it in a Debian container.