### PR TITLE
Let dump command take positional argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@
 
 ### Changed
 - RTS log output is now sent to stderr rather than stdout
+- `actonc dump foo.ty` now takes the filename of the `.ty` file to dump as a
+  positional argument rather than the old way of using an option (`actonc dump
+  --file foo.ty`)
 
 ### Fixed
 - Avoid segfault in actondb due to uninitialized mon fds [#627] [#633]


### PR DESCRIPTION
Rather than take a option, actonc dump now takes a positional argument.
Before:
  actonc dump --file foo.ty

Now:
  actonc dump foo.ty