### PR TITLE
Do not fail-fast matrix builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   test-darwin:
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-10.15, macos-11]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
fail-fast means if one job in a matrix fails, the other jobs in the
matrix will be canceled. Since we are seeing some intermittent build
failures on MacOS, we don't want this. It is better to let the tests
complete on all versions.