### PR TITLE
Exit after printing [ch]gen output

### DIFF
--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -472,8 +472,12 @@ runRestPasses args paths env0 parsed stubMode = do
                       --traceM (Pretty.render (Pretty.pretty liftEnv))
 
                       (n,h,c) <- Acton.CodeGen.generate liftEnv lifted
-                      iff (hgen args) $ putStrLn(h)
-                      iff (cgen args) $ putStrLn(c)
+                      iff (hgen args) $ do
+                          putStrLn(h)
+                          System.Exit.exitSuccess
+                      iff (cgen args) $ do
+                          putStrLn(c)
+                          System.Exit.exitSuccess
 
                       let pedantArg = if (cpedantic args) then "-Werror" else ""
 


### PR DESCRIPTION
--cgen or --hgen is just supposed to print the generated content to
stdout so that the output could be piped to a file. As we continued to
compile the module after printing the output, we would also output
errors or other output not related. We now exit immediately after
printing the output!