### PR TITLE
Expose list of actors over RTS mon interface

### DIFF
--- a/backend/client_api.h
+++ b/backend/client_api.h
@@ -306,6 +306,8 @@ char * to_string_rts_membership(remote_db_t * db, char * msg_buff);
 #define ACTOR_STATUS_RUNNING 0
 #define ACTOR_STATUS_MIGRATING 1
 #define ACTOR_STATUS_STOPPED 2
+static const char *Actor_status_name[] = {"running", "migrating", "stopped"};
+
 
 typedef struct actor_descriptor
 {

--- a/utils/actonmon
+++ b/utils/actonmon
@@ -242,6 +242,59 @@ def mon(address, interval, once):
         time.sleep(interval)
 
 
+def actors(address, interval, once):
+    ms = MonSock(address)
+    while True:
+        data = ms.cmd("actors")
+        print("Actor#  RTS              Local  Status")
+        print("--------------------------------------------------------------------------------")
+        for k, v in data['actors'].items():
+            print(f"{k:>6}: {v['rts']:16} {v['local']:6} {v['status']}")
+
+        if once:
+            break
+        time.sleep(interval)
+
+
+def rich_actors(address, interval, once):
+    from rich.live import Live
+    from rich.table import Table
+
+    ms = MonSock(address)
+
+    def generate_table() -> Table:
+        table = Table(title="Actors")
+
+        table.add_column("ID", style="cyan", no_wrap=True)
+        table.add_column("RTS", style="magenta")
+        table.add_column("Local", style="magenta")
+        table.add_column("Status")
+
+        while True:
+            try:
+                data = ms.cmd("actors")
+                break
+            except ConnectionError:
+                time.sleep(0.5)
+
+        status_to_color = {
+            'running': 'green',
+            'migrating': 'orange',
+            'stopped': 'yellow'
+        }
+        for k,v in data['actors'].items():
+            table.add_row(k, v['rts'], v['local'], f"[{status_to_color[v['status']]}]{v['status']}")
+
+        return table
+
+    with Live(generate_table(), refresh_per_second=(1.0/interval)) as live:
+        while True:
+            time.sleep(interval)
+            live.update(generate_table())
+            if once:
+                break
+
+
 def actdb_membership(address, interval, once):
     ms = MonSock(address)
     while True:
@@ -489,11 +542,17 @@ if __name__ == '__main__':
     parser.add_argument("--rich", action="store_true")
     parser.add_argument("--once", action="store_true", default=False)
     parser.add_argument("--prom", action="store_true")
+    parser.add_argument("--actors", action="store_true")
     parser.add_argument("--actdb-membership", action="store_true")
 
     args = parser.parse_args()
 
-    if args.actdb_membership:
+    if args.actors:
+        if args.rich:
+            rich_actors(args.socket, args.interval, args.once)
+        else:
+            actors(args.socket, args.interval, args.once)
+    elif args.actdb_membership:
         if args.rich:
             rich_actdb_membership(args.socket, args.interval, args.once)
         else:


### PR DESCRIPTION
It is now possible to display the actors in the system. They are exposed
over the RTS mon interface through the "actors" query.

actonmon supports displaying them both in a rich table or as more basic
output without requiring rich being installed.

Unlike the other JSON output, we here create an artificial key since the
actor_id struct doesn't have a char key and we didn't feel like adding
one. Downside is more memory usage while running the mon command but on
the other hand the memory usage is reduced in other places.

Fixes #654.