### PR TITLE
Run Tasty tests in parallel

### DIFF
--- a/compiler/package.yaml.in
+++ b/compiler/package.yaml.in
@@ -58,3 +58,7 @@ tests:
       - system-filepath
       - tasty
       - tasty-hunit
+    ghc-options:
+      - -threaded
+      - -rtsopts
+      - -with-rtsopts=-N


### PR DESCRIPTION
This brings down the test time from a staggering 0.7s to 0.2s on my
machine ;)   but it's a good thing to make them run in parallel since it
might make a much bigger difference down the line.