### PR TITLE
changed TCP content to be bytes instead of strings

### DIFF
--- a/builtin/env.c
+++ b/builtin/env.c
@@ -438,14 +438,14 @@ $l$7lambda $l$7lambda$new($Env p$1, $str p$2) {
     return $tmp;
 }
 struct $l$7lambda$class $l$7lambda$methods;
-$NoneType $l$8lambda$__init__ ($l$8lambda p$self, $Connection __self__, $str s) {
+$NoneType $l$8lambda$__init__ ($l$8lambda p$self, $Connection __self__, $bytes s) {
     p$self->__self__ = __self__;
     p$self->s = s;
     return $None;
 }
 $R $l$8lambda$__call__ ($l$8lambda p$self, $Cont c$cont) {
     $Connection __self__ = p$self->__self__;
-    $str s = p$self->s;
+    $bytes s = p$self->s;
     return __self__->$class->write$local(__self__, s, c$cont);
 }
 void $l$8lambda$__serialize__ ($l$8lambda self, $Serial$state state) {
@@ -465,7 +465,7 @@ $l$8lambda $l$8lambda$__deserialize__ ($l$8lambda self, $Serial$state state) {
     self->s = $step_deserialize(state);
     return self;
 }
-$l$8lambda $l$8lambda$new($Connection p$1, $str p$2) {
+$l$8lambda $l$8lambda$new($Connection p$1, $bytes p$2) {
     $l$8lambda $tmp = malloc(sizeof(struct $l$8lambda));
     $tmp->$class = &$l$8lambda$methods;
     $l$8lambda$methods.__init__($tmp, p$1, p$2);
@@ -917,7 +917,7 @@ $NoneType $Connection$__resume__($Connection self) {
         self->cb_err->$class->__call__(self->cb_err, self);
     return $None;
 }
-$R $Connection$write$local ($Connection __self__, $str s, $Cont c$cont) {
+$R $Connection$write$local ($Connection __self__, $bytes s, $Cont c$cont) {
     memcpy(fd_data[__self__->descriptor].buffer,s->str,s->nbytes+1);
     int chunk_size = s->nbytes > BUF_SIZE ? BUF_SIZE : s->nbytes; 
     int r = write(__self__->descriptor,fd_data[__self__->descriptor].buffer,chunk_size);
@@ -937,7 +937,7 @@ $R $Connection$on_receive$local ($Connection __self__, $function cb1, $function 
     EVENT_add_read(__self__->descriptor);
     return $R_CONT(c$cont, $None);
 }
-$Msg $Connection$write ($Connection __self__, $str s) {
+$Msg $Connection$write ($Connection __self__, $bytes s) {
     return $ASYNC((($Actor)__self__), (($Cont)$l$8lambda$new(__self__, s)));
 }
 $Msg $Connection$close ($Connection __self__) {
@@ -1396,7 +1396,7 @@ void *$eventloop(void *arg) {
                     if (count < BUF_SIZE)
                         fd_data[fd].buffer[count] = 0;
                     if (fd==STDIN_FILENO)
-                        fd_data[fd].rhandler->$class->__call__(fd_data[fd].rhandler, to$str(fd_data[fd].buffer));
+                        fd_data[fd].rhandler->$class->__call__(fd_data[fd].rhandler, to$bytes(fd_data[fd].buffer));
                     else
                       fd_data[fd].rhandler->$class->__call__(fd_data[fd].rhandler, fd_data[fd].conn, to$str(fd_data[fd].buffer));
                 } else {

--- a/builtin/env.h
+++ b/builtin/env.h
@@ -195,7 +195,7 @@ struct $l$8lambda$class {
     char *$GCINFO;
     int $class_id;
     $Super$class $superclass;
-    $NoneType (*__init__) ($l$8lambda, $Connection, $str);
+    $NoneType (*__init__) ($l$8lambda, $Connection, $bytes);
     void (*__serialize__) ($l$8lambda, $Serial$state);
     $l$8lambda (*__deserialize__) ($l$8lambda, $Serial$state);
     $bool (*__bool__) ($l$8lambda);
@@ -205,7 +205,7 @@ struct $l$8lambda$class {
 struct $l$8lambda {
     struct $l$8lambda$class *$class;
     $Connection __self__;
-    $str s;
+    $bytes s;
 };
 struct $l$9lambda$class {
     char *$GCINFO;
@@ -345,7 +345,7 @@ $l$6lambda $l$6lambda$new($Env, $str);
 extern struct $l$7lambda$class $l$7lambda$methods;
 $l$7lambda $l$7lambda$new($Env, $str);
 extern struct $l$8lambda$class $l$8lambda$methods;
-$l$8lambda $l$8lambda$new($Connection, $str);
+$l$8lambda $l$8lambda$new($Connection, $bytes);
 extern struct $l$9lambda$class $l$9lambda$methods;
 $l$9lambda $l$9lambda$new($Connection);
 extern struct $l$10lambda$class $l$10lambda$methods;
@@ -440,10 +440,10 @@ struct $Connection$class {
     $bool (*__bool__) ($Connection);
     $str (*__str__) ($Connection);
     $NoneType (*__resume__) ($Connection);
-    $R (*write$local) ($Connection, $str, $Cont);
+    $R (*write$local) ($Connection, $bytes, $Cont);
     $R (*close$local) ($Connection, $Cont);
     $R (*on_receive$local) ($Connection, $function, $function, $Cont);
-    $Msg (*write) ($Connection, $str);
+    $Msg (*write) ($Connection, $bytes);
     $Msg (*close) ($Connection);
     $Msg (*on_receive) ($Connection, $function, $function);
 };

--- a/builtin/ty/src/__builtin__.act
+++ b/builtin/ty/src/__builtin__.act
@@ -638,9 +638,9 @@ actor Env (args):
 actor Connection (on_error):
     cb_err = on_error
 
-    write       : action(str) -> None
+    write       : action(bytes) -> None
     close       : action() -> None
-    on_receive  : action(action(Connection, str)->None, action(Connection, str)->None) -> None
+    on_receive  : action(action(Connection, bytes)->None, action(Connection, str)->None) -> None
 
     def write(s): pass
     def close() : pass

--- a/examples/client.act
+++ b/examples/client.act
@@ -1,14 +1,20 @@
 actor client(env):
 
-    session : action(?Connection) -> None
-
     def stdout_w(conn,str):
-      env.stdout_write(str)
-    
+        env.stdout_write(str)
+      
+    def stdout_wb(conn,b):
+        env.stdout_write(b.decode())
+       
     def session(conn):
         if conn is not None:
-           conn.on_receive(stdout_w, stdout_w)
-           env.stdin_install(conn.write)
+           conn_write : action(str)->None
+           
+           def conn_write(s):
+               conn.write(s.encode())
+        
+           conn.on_receive(stdout_wb, stdout_w)
+           env.stdin_install(conn_write)
         else:
            print("couldn't connect to",env.argv[1])
            env.exit(0)

--- a/examples/server.act
+++ b/examples/server.act
@@ -3,9 +3,9 @@ actor main(env):
     def stdout_w(conn,str):
         env.stdout_write(str)
 
-    def echo(conn,str):
-        env.stdout_write(str)
-        conn.write(str)
+    def echo(conn,b):
+        env.stdout_write(b.decode())
+        conn.write(b)
         
     def connect_handler(conn):
         print("Got a connection...")

--- a/test/rts/ddb_test_client.act
+++ b/test/rts/ddb_test_client.act
@@ -2,10 +2,10 @@ actor main(env):
     port = int(env.argv[1])
 
     def recv_handler(conn, msg):
-        if msg == "0":
+        if msg == b"0":
             print("Got a 0, doing noooothing...")
 
-        if msg == "1":
+        if msg == b"1":
             print("Got a 1, I'm happy, exiting...")
             await async env.exit(0)
 
@@ -13,7 +13,7 @@ actor main(env):
         if conn is not None:
             print("Installing on_receive handler...")
             await async conn.on_receive(recv_handler, err_handler)
-            conn.write("GET")
+            conn.write(b"GET")
 
     def err_handler(conn, msg):
         print("Error with our connection occurred, attempting to re-establish connection")

--- a/test/rts/ddb_test_server.act
+++ b/test/rts/ddb_test_server.act
@@ -11,12 +11,12 @@ actor Tester(env, port):
         lsock = init_listen()
 
     def recv_handler(conn, msg):
-        print("RECV", conn, msg)
-        if msg == "GET":
-            conn.write(str(i))
-        if msg == "INC":
+        print("RECV", conn, msg.decode())
+        if msg == b"GET":
+            conn.write(str(i).encode())
+        if msg == b"INC":
             i += 1
-            conn.write("OK")
+            conn.write(b"OK")
 
     def err_handler(conn, msg):
         print("Some error, probably client disconnecting")


### PR DESCRIPTION
This is for you to review; there is one problem that should be checked before we merge:

The file examples/client.act does not compile:

acton> actonc examples/client.act --root client
Compiling client.act for release
actonc: No match in record selector rtail
acton> 

I believe that this has very little to do with this change (but it compiled before), but this is for Johan to judge.

The only changes are that in Connection, method .write takes a bytes parameter instead of a str. The same for the first callback parameter in  on_receive.

Applications like server/client in examples and ddb_test_server_client/server  in test/rts need to do some calls to encode(() and decode().

I  believe that the test suite passes, but there is a lot of output which I don't understand completely...
