### PR TITLE
Add (failing) test for creating imported actor

### DIFF
--- a/compiler/test.hs
+++ b/compiler/test.hs
@@ -19,11 +19,19 @@ main = do
     let exampleFilesExp = map exampleExpFail exampleFiles
         exampleTests = map genExampleTests exampleFilesExp
     defaultMain $ testGroup "Tests" $ [
+        actoncBasicTests,
         actoncProjTests,
         actoncRootArgTests,
         testGroup "Examples" exampleTests
         ]
 
+
+actoncBasicTests =
+  testGroup "actonc basic tests"
+  [ expectFail $ testCase "create imported actor" $ do
+        (returnCode, cmdOut, cmdErr) <- buildProject "test/actonc/regressions/import_actor" "build"
+        assertEqual "actonc should return success" ExitSuccess returnCode
+  ]
 
 actoncProjTests =
   testGroup "actonc project tests"

--- a/compiler/test/.gitignore
+++ b/compiler/test/.gitignore
@@ -1,0 +1,2 @@
+**/build.sh
+**/out

--- a/compiler/test/actonc/project/.gitignore
+++ b/compiler/test/actonc/project/.gitignore
@@ -1,2 +1,0 @@
-*/build.sh
-*/out

--- a/compiler/test/actonc/regressions/import_actor/src/foo.act
+++ b/compiler/test/actonc/regressions/import_actor/src/foo.act
@@ -1,0 +1,2 @@
+actor Bar():
+    pass

--- a/compiler/test/actonc/regressions/import_actor/src/import.act
+++ b/compiler/test/actonc/regressions/import_actor/src/import.act
@@ -1,0 +1,5 @@
+import foo
+
+actor main(env):
+    b = foo.Bar()
+    await async env.exit(0)


### PR DESCRIPTION
Importing a module and then instantiating an actor from that module does
not work. This adds a test case to prove it and marks it as currently
failing.