### PR TITLE
Add regression for abstract actors

### DIFF
--- a/compiler/test.hs
+++ b/compiler/test.hs
@@ -31,6 +31,9 @@ actoncBasicTests =
   [ expectFail $ testCase "create imported actor" $ do
         (returnCode, cmdOut, cmdErr) <- buildProject "test/actonc/regressions/import_actor" "build"
         assertEqual "actonc should return success" ExitSuccess returnCode
+  , expectFail $ testCase "instantiate concrete actor" $ do
+        (returnCode, cmdOut, cmdErr) <- buildProject "test/actonc/regressions/abstract_actor_from_type_signature" "build"
+        assertEqual "actonc should return success" ExitSuccess returnCode
   ]
 
 actoncProjTests =

--- a/compiler/test/actonc/regressions/abstract_actor_from_type_signature/README.org
+++ b/compiler/test/actonc/regressions/abstract_actor_from_type_signature/README.org
@@ -1,0 +1,12 @@
+* abstract_actor_from_type_signature
+abstract_actor_from_type_signature is a cool Acton project!
+
+** Compile
+#+BEGIN_SRC shell
+actonc build
+#+END_SRC
+
+** Run
+#+BEGIN_SRC shell
+out/rel/bin/abstract_actor_from_type_signature
+#+END_SRC

--- a/compiler/test/actonc/regressions/abstract_actor_from_type_signature/src/abstract_actor_from_type_signature.act
+++ b/compiler/test/actonc/regressions/abstract_actor_from_type_signature/src/abstract_actor_from_type_signature.act
@@ -1,0 +1,12 @@
+
+actor Foo():
+    # actonc will interpret this type signature to mean the actor is abstract - clearly wrong
+    # If we remove the type signature, this program works
+    hello : action() -> None
+    def hello():
+        print("Hello World!")
+
+actor main(env):
+    f = Foo()
+    f.hello()
+    await async env.exit(0)


### PR DESCRIPTION
Whenever an actor has a type signature defined it appears actonc thinks
it should be abstract and so fails on trying to instantiate the actor.
This seems wrong.