### PR TITLE
Add new libuv based IO thread to RTS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
             ~/.stack
           key: ${{ matrix.os }}-${{ secrets.CACHE_VERSION }}
       - name: "Install build prerequisites"
-        run: brew install argp-standalone haskell-stack protobuf-c
+        run: brew install argp-standalone haskell-stack libuv protobuf-c
       - name: "Build Acton"
         run: make -j2 -C ${{ github.workspace }} BUILD_RELEASE=${{ env.BUILD_RELEASE }}
       - name: "Build a release"
@@ -98,7 +98,7 @@ jobs:
       - name: "Install build prerequisites"
         run: |
           apt-get update
-          apt-get install -qy bzip2 gcc haskell-stack libbsd-dev libprotobuf-c-dev libutf8proc-dev make procps python3 uuid-dev zlib1g-dev
+          apt-get install -qy bzip2 gcc haskell-stack libbsd-dev libprotobuf-c-dev libutf8proc-dev libuv1-dev make pkg-config procps python3 uuid-dev zlib1g-dev
       - name: chown our home dir to avoid stack complaining
         run: chown -R root:root /github/home
       - name: "Build Acton"
@@ -128,7 +128,7 @@ jobs:
       - name: "Install build prerequisites"
         run: |
           apt-get update
-          apt-get install -qy build-essential debhelper devscripts gcc haskell-stack libbsd-dev libprotobuf-c-dev libutf8proc-dev make uuid-dev zlib1g-dev
+          apt-get install -qy build-essential debhelper devscripts gcc haskell-stack libbsd-dev libprotobuf-c-dev libutf8proc-dev libuv1-dev make pkg-config uuid-dev zlib1g-dev
       - name: "Build Debian packages"
         run: make -C ${GITHUB_WORKSPACE} debs BUILD_RELEASE=${{ env.BUILD_RELEASE }}
       - name: "Compute variables"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,6 +97,7 @@ jobs:
           key: ${{ matrix.os }}-${{ matrix.version }}-${{ secrets.CACHE_VERSION }}
       - name: "Install build prerequisites"
         run: |
+          export DEBIAN_FRONTEND=noninteractive
           apt-get update
           apt-get install -qy bzip2 gcc haskell-stack libbsd-dev libprotobuf-c-dev libutf8proc-dev libuv1-dev make pkg-config procps python3 uuid-dev zlib1g-dev
       - name: chown our home dir to avoid stack complaining

--- a/Makefile
+++ b/Makefile
@@ -262,7 +262,7 @@ ARCHIVES=lib/dev/libActon.a lib/rel/libActon.a lib/libuv_a.a
 # in the stdlib directory, which we would need to join together with rts.o etc
 # to form the final libActon (or maybe produce a libActonStdlib and link with?)
 
-LIBACTON_DEV_OFILES=builtin/builtin_dev.o builtin/env_dev.o rts/empty.o rts/log.o rts/rts_dev.o deps/netstring_dev.o deps/yyjson_dev.o
+LIBACTON_DEV_OFILES=builtin/builtin_dev.o builtin/env_dev.o rts/empty.o rts/io_dev.o rts/log.o rts/rts_dev.o deps/netstring_dev.o deps/yyjson_dev.o
 OFILES += $(LIBACTON_DEV_OFILES)
 lib/dev/libActon.a: stdlib/out/dev/lib/libActonProject.a  $(LIBACTON_DEV_OFILES)
 	@mkdir -p $(dir $@)
@@ -295,7 +295,15 @@ lib/libActonDB.a: $(BACKEND_OFILES)
 
 
 # /rts --------------------------------------------------
-OFILES += rts/log.o rts/rts_dev.o rts/rts_rel.o rts/empty.o
+OFILES += rts/io_dev.o rts/io_rel.o rts/log.o rts/rts_dev.o rts/rts_rel.o rts/empty.o
+rts/io_dev.o: rts/io.c rts/io.h
+	$(CC) $(CFLAGS) $(CFLAGS_DEV) $(LDFLAGS) \
+		-c $< -o $@
+
+rts/io_rel.o: rts/io.c rts/io.h
+	$(CC) $(CFLAGS) $(CFLAGS_REL) $(LDFLAGS) \
+		-c $< -o $@
+
 rts/log.o: rts/log.c rts/log.h
 	$(CC) $(CFLAGS) $(CFLAGS_DEV) -DLOG_USE_COLOR -c $< -o$@
 

--- a/Makefile
+++ b/Makefile
@@ -256,7 +256,7 @@ DBARCHIVE=lib/libActonDB.a
 # be libActon, and we compile that serialized to avoid collisions between dev &
 # rel profiles... this now also hits libuv. Maybe better to keep separate for
 # concurrency?
-ARCHIVES=lib/dev/libActon.a lib/rel/libActon.a lib/libuv_a.a
+ARCHIVES=lib/dev/libActon.a lib/rel/libActon.a lib/libprotobuf-c_a.a lib/libutf8proc_a.a lib/libuv_a.a
 
 # If we later let actonc build things, it would produce a libActonProject.a file
 # in the stdlib directory, which we would need to join together with rts.o etc
@@ -276,7 +276,17 @@ lib/rel/libActon.a: stdlib/out/rel/lib/libActonProject.a $(LIBACTON_REL_OFILES)
 	cp -a $< $@
 	ar rcs $@ $(filter-out stdlib/out/rel/lib/libActonProject.a,$^)
 
-# No proper dependencies means we
+# Include static libs
+LIBPROTOBUFC_LIBDIR:=$(shell pkg-config --variable=libdir libprotobuf-c)
+LIBPROTOBUFC_A:=$(shell ls $(LIBPROTOBUFC_LIBDIR)/libprotobuf-c_a.a $(LIBPROTOBUFC_LIBDIR)/libprotobuf-c.a 2>/dev/null | head -n1)
+lib/libprotobuf-c_a.a: $(LIBPROTOBUFC_A)
+	cp $< $@
+
+LIBUTF8PROC_LIBDIR:=$(shell pkg-config --variable=libdir libutf8proc)
+LIBUTF8PROC_A:=$(shell ls $(LIBUTF8PROC_LIBDIR)/libutf8proc_a.a $(LIBUTF8PROC_LIBDIR)/libutf8proc.a 2>/dev/null | head -n1)
+lib/libutf8proc_a.a: $(LIBUTF8PROC_A)
+	cp $< $@
+
 LIBUV_LIBDIR:=$(shell pkg-config --variable=libdir libuv)
 LIBUV_A:=$(shell ls $(LIBUV_LIBDIR)/libuv_a.a $(LIBUV_LIBDIR)/libuv.a 2>/dev/null | head -n1)
 lib/libuv_a.a: $(LIBUV_A)

--- a/builtin/env.c
+++ b/builtin/env.c
@@ -862,7 +862,7 @@ $R $Env$listen$local ($Env __self__, $int port, $function on_connect, $function 
 }
 $R $Env$exit$local ($Env __self__, $int n, $Cont c$cont) {
     return_val = n->val;
-    rts_exit = 1;
+    rts_shutdown();
     return $R_CONT(c$cont, $None);
 }
 $R $Env$openR$local ($Env __self__, $str nm, $Cont c$cont) {

--- a/builtin/env.h
+++ b/builtin/env.h
@@ -12,6 +12,8 @@
 #include <pthread.h>
 
 #include "builtin.h"
+#include "../rts/io.h"
+#include "../rts/log.h"
 #include "../rts/rts.h"
 
 #ifdef IS_MACOS

--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -530,7 +530,8 @@ runRestPasses args paths env0 parsed stubMode = do
                               buildF = joinPath [projPath paths, "build.sh"]
                               ccCmd = ("cc " ++ pedantArg ++
                                        (if (dev args) then " -g " else "") ++
-                                       " -c -I" ++ projOut paths ++
+                                       " -c " ++
+                                       " -I" ++ projOut paths ++
                                        " -I" ++ sysPath paths ++
                                        " -o" ++ oFile ++
                                        " " ++ cFile)
@@ -590,7 +591,7 @@ buildExecutable env args paths binTask
         buildF              = joinPath [projPath paths, "build.sh"]
         outbase             = outBase paths mn
         rootFile            = outbase ++ ".root.c"
-        libFilesBase        = " -lActonProject -lActon -lActonDB -lprotobuf-c -lutf8proc -lpthread -lm"
+        libFilesBase        = " -lActonProject -lActon -lActonDB -lprotobuf-c -lutf8proc -luv_a -lpthread -lm -ldl "
         libPathsBase        = " -L " ++ sysPath paths ++ "/lib -L" ++ sysLib paths ++ " -L" ++ projLib paths
 #if defined(darwin_HOST_OS) && defined(aarch64_HOST_ARCH)
         libFiles            = libFilesBase

--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -591,7 +591,7 @@ buildExecutable env args paths binTask
         buildF              = joinPath [projPath paths, "build.sh"]
         outbase             = outBase paths mn
         rootFile            = outbase ++ ".root.c"
-        libFilesBase        = " -lActonProject -lActon -lActonDB -lprotobuf-c -lutf8proc -luv_a -lpthread -lm -ldl "
+        libFilesBase        = " -lActonProject -lActon -lActonDB -lprotobuf-c_a -lutf8proc_a -luv_a -lpthread -lm -ldl "
         libPathsBase        = " -L " ++ sysPath paths ++ "/lib -L" ++ sysLib paths ++ " -L" ++ projLib paths
 #if defined(darwin_HOST_OS) && defined(aarch64_HOST_ARCH)
         libFiles            = libFilesBase

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,9 @@ Build-Depends:
  libbsd-dev,
  libprotobuf-c-dev,
  libutf8proc-dev,
- make
+ libuv1-dev,
+ make,
+ pkg-config
 Standards-Version: 4.6.0
 Homepage: http://www.acton-lang.org
 Rules-Requires-Root: no

--- a/rts/io.c
+++ b/rts/io.c
@@ -1,0 +1,51 @@
+#include "io.h"
+
+#include <uv.h>
+
+extern char rts_exit;
+uv_async_t stop_event;
+
+bool ioloop_started = false;
+
+void stop_ioloop() {
+    // We are not allowed to call uv_async_send before the ioloop has started.
+    // We set ioloop_stop_request so that if the loop has not yet started, it
+    // will see this value once it has started up and immediately exit.
+    if (ioloop_started)
+        uv_async_send(&stop_event);
+}
+void ioloop_init_cb(uv_timer_t *timer) {
+    // startup takes time and if we are asked to stop before we have started
+    // (and this function is called) we will then stop immediately
+    ioloop_started = true;
+    uv_timer_stop(timer);
+    if (rts_exit == 1) {
+        log_debug("RTS exiting before ioloop started, stopping ioloop now...");
+        uv_stop(uv_default_loop());
+    }
+}
+
+void stop_cb(uv_async_t *ev) {
+    uv_stop(uv_default_loop());
+}
+
+int ioloop(void *arg) {
+    log_info("Starting ioloop");
+
+#if defined(IS_MACOS)
+    pthread_setname_np("IO");
+#else
+    pthread_setname_np(pthread_self(), "IO");
+#endif
+
+    uv_timer_t init_timer;
+    uv_timer_init(uv_default_loop(), &init_timer);
+    uv_timer_start(&init_timer, ioloop_init_cb, 0, 0);
+
+    uv_async_init(uv_default_loop(), &stop_event, stop_cb);
+
+    log_debug("starting uv_run");
+    int r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+    log_debug("uv_run has stopped");
+    return r;
+}

--- a/rts/io.h
+++ b/rts/io.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#ifdef __linux__
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE 1
+#endif
+#endif
+
+#include <pthread.h>
+
+#include "log.h"
+
+#ifdef __gnu_linux__
+    #define IS_GNU_LINUX
+#elif  __APPLE__ && __MACH__
+    #define IS_MACOS
+#endif
+
+int ioloop(void *);
+void stop_ioloop();

--- a/rts/rts.h
+++ b/rts/rts.h
@@ -188,6 +188,7 @@ extern $Msg timerQ;
 time_t current_time();
 time_t next_timeout();
 void handle_timeout();
+void rts_shutdown();
 
 //typedef $int $Env;
 

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -1,5 +1,5 @@
 
-CFLAGS+= -fno-common -I.. -Ideps -Wno-int-to-pointer-cast -Wno-pointer-to-int-cast -Wformat -Werror=format-security
+CFLAGS+= -fno-common -I.. -I../dist -I../dist/include -L../lib -Wno-int-to-pointer-cast -Wno-pointer-to-int-cast -Wformat -Werror=format-security
 CFLAGS_REL= -O3 -DREL
 CFLAGS_DEV= -g -DDEV
 

--- a/stdlib/c_src/numpy/ndarray.c
+++ b/stdlib/c_src/numpy/ndarray.c
@@ -607,7 +607,7 @@ numpy$$ndarray numpy$$unirandint($int a, $int b, $int n) {
   return res;
 }
 
-#define MAX 1000000000
+#define NDARRAY_MAX 1000000000
 numpy$$ndarray numpy$$unirandfloat($float a, $float b, $int n) {
   if (a->val >= b->val)
      $RAISE(($BaseException)$NEW($ValueError,to$str("lower limit not smaller than upper in numpy.unirand")));
@@ -618,7 +618,7 @@ numpy$$ndarray numpy$$unirandfloat($float a, $float b, $int n) {
   double s = (b->val - a->val);
   numpy$$ndarray res = $newarray(DblType,1,n,shape,strides,true);
   for (int i = 0; i<n->val; i++)
-    res->data[i].d = a->val + s * (double)arc4random_uniform(MAX)/(double)MAX;
+    res->data[i].d = a->val + s * (double)arc4random_uniform(NDARRAY_MAX)/(double)NDARRAY_MAX;
   return res;
 }
 


### PR DESCRIPTION
This adds a new IO thread based on libuv. It doesn't really do anything besides existing but lays the foundation for using libuv in the RTS, env and modules. While we have yet to properly use it, I think this is correct, like linking is done as it should etc.

libuv header files are in dist/include. Previously we've had header files that are required at actonc run time in dist/builtin and dist/rts but I think it would be good to collect them in a single place so rather than create a uv specific directory, I added dist/include and endgame might be to move rts.h and builtin/*.h in there!?

libuv_.a is placed in dist/lib. We do not compile it differently for rel/dev profile (as of yet). It is linked in at actonc run time. I think this is the only way, for example; we could try to link io.o with libuv at compile time but as we would also need to link any module interacting with libuv with libuv, we would end up with duplicate symbols. Thus I think it's better we ship the libuv.a archive as part of the Acton system.

Fixes #691 