### PR TITLE
Improve error message in test to include thing

### DIFF
--- a/compiler/test.hs
+++ b/compiler/test.hs
@@ -217,7 +217,7 @@ testBuildAndRun buildOpts runOpts expRet expFail thing = do
     testBuildThing buildOpts ExitSuccess False thing
     (returnCode, cmdOut, cmdErr) <- runThing runOpts thing
     iff (expFail == False && returnCode /= expRet) (
-        putStrLn("\nERROR: application return code (" ++ (show returnCode) ++ ") not as expected (" ++ (show expRet) ++ ")\nSTDOUT:\n" ++ cmdOut ++ "STDERR:\n" ++ cmdErr)
+        putStrLn("\nERROR: when running application " ++ thing ++ ", the return code (" ++ (show returnCode) ++ ") not as expected (" ++ (show expRet) ++ ")\nSTDOUT:\n" ++ cmdOut ++ "STDERR:\n" ++ cmdErr)
         )
     assertEqual ("application should return " ++ (show expRet)) expRet returnCode
 


### PR DESCRIPTION
Not always easy to tell from which app the error message comes since we
run the tests concurrently. Now we include the app name (the thing) in
the message so should be simple.