### PR TITLE
Added support for functions with NotImplemented bodies.

### DIFF
--- a/compiler/Acton/LambdaLifter.hs
+++ b/compiler/Acton/LambdaLifter.hs
@@ -218,9 +218,13 @@ instance Lift Stmt where
     ll env (Signature l ns sc dec)      = pure $ Signature l ns (convTop sc) dec
     ll env s                            = error ("ll unexpected: " ++ prstr s)
 
+llBody env b
+  | isNotImpl b                         = return b
+  | otherwise                           = llSuite env b
+
 instance Lift Decl where
     ll env (Def l n q p KwdNIL a b d fx)
-                                        = do b' <- llSuite (setCtxt InDef env1) b
+                                        = do b' <- llBody (setCtxt InDef env1) b
                                              return $ Def l n' q' p' KwdNIL (conv a) b' d fx
       where env1                        = extLocals p $ define (envOf p) $ defineTVars q env
             q'                          = if ctxt env == InDef then quantScope env ++ q else q

--- a/compiler/Acton/Names.hs
+++ b/compiler/Acton/Names.hs
@@ -74,6 +74,8 @@ instance Fallsthru a => Fallsthru [a] where
     fallsthru                       = all fallsthru
     
 instance Fallsthru Stmt where
+    fallsthru (Expr _ (NotImplemented _))
+                                    = False
     fallsthru Return{}              = False
     fallsthru Raise{}               = False
     fallsthru Break{}               = False

--- a/compiler/Acton/Normalizer.hs
+++ b/compiler/Acton/Normalizer.hs
@@ -188,9 +188,13 @@ normItem env (WithItem e (Just p))  = do e' <- norm env e
                                          (p',ss) <- normPat env p
                                          return (e', Just p', ss)
 
+normBody env b
+  | isNotImpl b                     = return b
+  | otherwise                       = norm env b
+
 instance Norm Decl where
     norm env (Def l n q p k t b d x)= do p' <- joinPar <$> norm env0 p <*> norm (define (envOf p) env0) k
-                                         b' <- norm env1 b
+                                         b' <- normBody env1 b
                                          return $ Def l n q p' KwdNIL t (ret b') d x
       where env1                    = define (envOf p ++ envOf k) env0
             env0                    = defineTVars q env

--- a/compiler/Acton/Syntax.hs
+++ b/compiler/Acton/Syntax.hs
@@ -646,6 +646,9 @@ isKeyword x                         = x `Data.Set.member` rws
                                         "while","with","yield"
                                       ]
 
+isNotImpl [Expr _ (NotImplemented _)]   = True
+isNotImpl _                             = False
+
 isHidden (Name _ str)               = length (takeWhile (=='_') str) == 1
 isHidden _                          = True
 

--- a/compiler/Acton/Types.hs
+++ b/compiler/Acton/Types.hs
@@ -786,7 +786,9 @@ infProperties env as b
 
 infDefBody env n (PosPar x _ _ _) b
   | inClass env && n == initKW          = infInitEnv env x b
-infDefBody env _ _ b                    = do (cs,_,b') <- infSuiteEnv env b; return (cs, b')
+infDefBody env _ _ b
+  | isNotImpl b                         = return ([], b)
+  | otherwise                           = do (cs,_,b') <- infSuiteEnv env b; return (cs, b')
 
 infInitEnv env self (MutAssign l (Dot l' e1@(Var _ (NoQ x)) n) e2 : b)
   | x == self                           = do (cs1,t1,e1') <- infer env e1

--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -450,7 +450,8 @@ printIce errMsg = do ccVer <- getCcVer
 runRestPasses :: Args -> Paths -> Acton.Env.Env0 -> A.Module -> Bool -> IO (Acton.Env.Env0, Acton.Env.TEnv)
 runRestPasses args paths env0 parsed stubMode = do
                       let outbase = outBase paths (A.modname parsed)
-                      let actFile = srcBase paths (A.modname parsed) ++ ".act"
+                      let srcbase = srcBase paths (A.modname parsed)
+                      let actFile = srcbase ++ ".act"
                       envTmp <- Acton.Env.mkEnv (sysTypes paths) (projTypes paths) env0 parsed
                       let env = envTmp { Acton.Env.stub = stubMode }
 
@@ -481,7 +482,7 @@ runRestPasses args paths env0 parsed stubMode = do
                       --traceM ("#################### lifteded env0:")
                       --traceM (Pretty.render (Pretty.pretty liftEnv))
 
-                      (n,h,c) <- Acton.CodeGen.generate liftEnv lifted
+                      (n,h,c) <- Acton.CodeGen.generate liftEnv srcbase lifted
                       iff (hgen args) $ do
                           putStrLn(h)
                           System.Exit.exitSuccess

--- a/test/regression_auto/not_implemented.act
+++ b/test/regression_auto/not_implemented.act
@@ -1,0 +1,17 @@
+def here():
+    return there("hello")
+
+def there(x: str) -> int:
+    NotImplemented
+
+def generic[A(Eq)](x: A) -> A:
+    NotImplemented
+
+actor main(env):
+    var s = 0
+    def present(i):
+        s = i
+    action def absent(i: int) -> int:
+        NotImplemented
+    after 2: absent(7)
+    await async env.exit(0)

--- a/test/regression_auto/not_implemented.ext.c
+++ b/test/regression_auto/not_implemented.ext.c
@@ -1,0 +1,14 @@
+$int not_implemented$$there ($str x) {
+    return to$int(0);
+}
+
+$WORD not_implemented$$generic ($Eq w$25, $WORD x) {
+    if ((($bool (*) ($Eq, $WORD, $WORD))w$25->$class->__eq__)(w$25, x, x)->val) {
+        return x;
+    }
+    return x;
+}
+
+$R not_implemented$$main$absent$local (not_implemented$$main __self__, $int i, $Cont c$cont) {
+    return $R_CONT(c$cont, i);
+}


### PR DESCRIPTION
Such functions can have any type, but since no type inference is done for NotImplemented bodies, annotations are typically required
to obtained the desired function type.
A NotImplemented function will pass through the compiler and obtain the appropriate transformations, although its generated C code
will just consist of a function header.
For an Acton source file NAME.act, actual C implementations of any NotImplemented functions are instead supposed to reside in a
sibling source file NAME.ext.c, which is automatically included in the generated code whenever NotImplemented functions are detected.
Let us ponder whether we want to control this behavior with some compiler flag or whether it should be automatic (as of now).