### PR TITLE
Add test for failing imported class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ test/**
 !test/**/*.*
 test/**/*.log
 !test/**/*/
+
+# tests organized as acton projects; ignore all but source
+test/*/*/out/**
+test/*/*/build.sh

--- a/test/core_lang_auto/imported-class__bf/README.org
+++ b/test/core_lang_auto/imported-class__bf/README.org
@@ -1,0 +1,12 @@
+* import-class__bf
+import-class__bf is a cool Acton project!
+
+** Compile
+#+BEGIN_SRC shell
+actonc build
+#+END_SRC
+
+** Run
+#+BEGIN_SRC shell
+out/rel/bin/import-class__bf
+#+END_SRC

--- a/test/core_lang_auto/imported-class__bf/src/foo.act
+++ b/test/core_lang_auto/imported-class__bf/src/foo.act
@@ -1,0 +1,4 @@
+
+class Foo():
+    def __init__(self):
+        pass

--- a/test/core_lang_auto/imported-class__bf/src/ic.act
+++ b/test/core_lang_auto/imported-class__bf/src/ic.act
@@ -1,0 +1,5 @@
+import foo
+
+actor main(env):
+    f = foo.Foo()
+    await async env.exit(0)


### PR DESCRIPTION
It is not possible to instantiate a class from an imported module.
Currently fails with:

    kll@Boxy:~/acton/test/core_lang/imported-class__bf$ ../../../dist/bin/actonc build
    Compiling foo.act for release
    Compiling ic.act for release
    actonc: Acton/CodeGen.hs:187:1-70: Non-exhaustive patterns in function conName

    kll@Boxy:~/acton/test/core_lang/imported-class__bf$