### PR TITLE
Select single linux tar ball for release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,17 +68,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [ "debian:bullseye", "ubuntu:21.10", "ubuntu:22.04", "ubuntu:22.10"]
+        include:
+          - os: "debian"
+            version: "11"
+          - os: "ubuntu"
+            version: "21.10"
+          - os: "ubuntu"
+            version: "22.04"
+          - os: "ubuntu"
+            version: "22.10"
     runs-on: ubuntu-latest
     container:
-      image: ${{ matrix.image }}
+      image: ${{ matrix.os }}:${{ matrix.version }}
     steps:
       - name: "Print env"
         run: env
       - name: "Set BUILD_RELEASE when we are building for a version tag"
+        if: startsWith(github.ref, 'refs/tags/v')
         run: |
           echo "BUILD_RELEASE=1" >> $GITHUB_ENV
-        if: startsWith(github.ref, 'refs/tags/v')
       - name: "Check out repository code"
         uses: actions/checkout@v2
       - name: "Cache ~/.stack"
@@ -86,7 +94,7 @@ jobs:
         with:
           path: |
             ~/.stack
-          key: ${{ matrix.image }}-${{ secrets.CACHE_VERSION }}
+          key: ${{ matrix.os }}-${{ matrix.version }}-${{ secrets.CACHE_VERSION }}
       - name: "Install build prerequisites"
         run: |
           apt-get update
@@ -100,7 +108,7 @@ jobs:
       - name: "Upload artifact"
         uses: actions/upload-artifact@v2
         with:
-          name: acton-linux
+          name: acton-${{ matrix.os }}-${{ matrix.version }}
           path: ${{ github.workspace }}/acton-linux-x86_64*
           if-no-files-found: error
       - name: "Run tests"
@@ -135,7 +143,7 @@ jobs:
       - name: "Upload artifact"
         uses: actions/upload-artifact@v2
         with:
-          name: acton-debian
+          name: acton-debs
           # Using a wildcard and then deb here to force the entire directory to
           # be part of resulting artifact.
           path: ${{ steps.vars.outputs.artifact_dir }}/*deb/
@@ -203,18 +211,18 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: "Check out repository code"
         uses: actions/checkout@v2
-      - name: "Download artifacts for darwin / macos-11"
+      - name: "Download artifacts for Macos, built on macos-11"
         uses: actions/download-artifact@v2
         with:
           name: acton-macos-11
-      - name: "Download artifacts for Linux"
+      - name: "Download artifacts for Linux, built on Debian:11"
         uses: actions/download-artifact@v2
         with:
-          name: acton-linux
+          name: acton-debian-11
       - name: "Download artifacts for Debian Linux"
         uses: actions/download-artifact@v2
         with:
-          name: acton-debian
+          name: acton-debs
       - name: "List downloaded artifacts"
         run: ls
       - name: "Workaround for changelog extractor that looks for number versions in headlines, which won't work for 'Unreleased'"
@@ -236,8 +244,10 @@ jobs:
           replacesArtifacts: true
       - name: "Remove version number from darwin tar ball"
         run: mv acton-darwin-x86_64*tar.bz2 acton-darwin-x86_64.tar.bz2
-      - name: "Remove version number from darwin tar ball"
+      - name: "Remove version number from linux tar ball"
         run: mv acton-linux-x86_64*tar.bz2 acton-linux-x86_64.tar.bz2
+      - name: "List files for debug"
+        run: ls
       - name: "Upload artifacts without version number for stable links"
         uses: ncipollo/release-action@v1
         with:
@@ -260,18 +270,18 @@ jobs:
     steps:
       - name: "Check out repository code"
         uses: actions/checkout@v2
-      - name: "Download artifacts for darwin / macos-11"
+      - name: "Download artifacts for Macos, built on macos-11"
         uses: actions/download-artifact@v2
         with:
           name: acton-macos-11
-      - name: "Download artifacts for Linux"
+      - name: "Download artifacts for Linux, built on Debian:11"
         uses: actions/download-artifact@v2
         with:
-          name: acton-linux
+          name: acton-debian-11
       - name: "Download artifacts for Debian Linux"
         uses: actions/download-artifact@v2
         with:
-          name: acton-debian
+          name: acton-debs
       - name: "List downloaded artifacts"
         run: ls
       - name: "Extract release notes"


### PR DESCRIPTION
Now that we run the test suite on multiple Linux distros we produce an
artifact for each which confused the release jobs. Pick a single one,
the one built on debian:11, for the release artifact. The rest are still
available but not as release assets.

Fixes #707