### PR TITLE
Ensure dependencies are included & specified

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,6 +115,7 @@ jobs:
       - name: "Run tests"
         run: make -C ${GITHUB_WORKSPACE} test
 
+
   build-debs:
     runs-on: ubuntu-latest
     container:
@@ -149,6 +150,40 @@ jobs:
           # be part of resulting artifact.
           path: ${{ steps.vars.outputs.artifact_dir }}/*deb/
           if-no-files-found: error
+
+
+  run-linux:
+    needs: build-debs
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: "debian"
+            version: "11"
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.os }}:${{ matrix.version }}
+    steps:
+      - name: "Download .deb files"
+        uses: actions/download-artifact@v2
+        with:
+          name: acton-debs
+      - name: "Install acton from .deb"
+        run: |
+          apt-get update
+          dpkg -i deb/acton_*.deb || true
+          apt-get -fy install
+          actonc --version
+      - name: "Compile acton program"
+        run: |
+          echo 'actor main(env):'          > test-runtime.act
+          echo '    print("Hello, world")' >> test-runtime.act
+          echo '    env.exit(0)'           >> test-runtime.act
+          ls
+          actonc --root main test-runtime.act
+          ./test-runtime
+          ./test-runtime | grep "Hello, world"
+
 
   update-apt-repo:
     if: startsWith(github.ref, 'refs/tags/v')

--- a/Makefile
+++ b/Makefile
@@ -428,6 +428,7 @@ dist/lib/%: lib/%
 
 DIST_BINS=$(ACTONC) dist/bin/actondb
 DIST_HFILES=\
+	dist/rts/io.h \
 	dist/rts/rts.h \
 	dist/builtin/env.h \
 	$(addprefix dist/,$(BUILTIN_HFILES))

--- a/builtin/env.c
+++ b/builtin/env.c
@@ -20,6 +20,8 @@
 
 #include "env.h"
 
+#include "../rts/log.h"
+
 struct FileDescriptorData fd_data[MAX_FD];
 int wakeup_pipe[2];
 

--- a/builtin/env.h
+++ b/builtin/env.h
@@ -13,7 +13,6 @@
 
 #include "builtin.h"
 #include "../rts/io.h"
-#include "../rts/log.h"
 #include "../rts/rts.h"
 
 #ifdef IS_MACOS

--- a/debian/control
+++ b/debian/control
@@ -22,8 +22,6 @@ Depends:
  ${shlibs:Depends},
  ${misc:Depends},
  gcc,
- libprotobuf-c-dev,
- libutf8proc-dev,
  uuid-dev
 Description: Acton Programming Language
  An awesome programming language.

--- a/rts/io.c
+++ b/rts/io.c
@@ -2,6 +2,8 @@
 
 #include <uv.h>
 
+#include "log.h"
+
 extern char rts_exit;
 uv_async_t stop_event;
 

--- a/rts/io.h
+++ b/rts/io.h
@@ -8,8 +8,6 @@
 
 #include <pthread.h>
 
-#include "log.h"
-
 #ifdef __gnu_linux__
     #define IS_GNU_LINUX
 #elif  __APPLE__ && __MACH__


### PR DESCRIPTION
Add new test job running on debian:11. Pull down .deb file produced in
earlier job, install and run actonc on a simple program to ensure
dependencies are correctly specified.

We have dependencies at compile time of actonc itself and then a
different set of dependencies at run time of actonc (when a user is
compiling a program).  We want to minimize the number of dependencies we
have at run time. In order to ensure we get this right, we have to
install on a fresh machine that does not have the actonc compile time
dependencies installed. Further, for the dependencies we do have, we
try to include them in the Acton system distribution itself.