### PR TITLE
Cache build-debs job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,7 +118,7 @@ jobs:
   build-debs:
     runs-on: ubuntu-latest
     container:
-      image: debian:bullseye
+      image: debian:11
     steps:
       - name: "Set BUILD_RELEASE when we are building for a version tag"
         run: |
@@ -126,6 +126,13 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
       - name: "Check out repository code"
         uses: actions/checkout@v2
+      - name: "Cache ~/.stack"
+        if: ${{ github.ref != 'refs/heads/master' }}
+        uses: actions/cache@v2
+        with:
+          path: |
+            debian/.debhelper
+          key: build-debs-${{ secrets.CACHE_VERSION }}
       - name: "Install build prerequisites"
         run: |
           apt-get update


### PR DESCRIPTION
This should speed up the build-debs job by a fair bit. We only do it
when not running on the main branch, since then we want to be absolutely
cerain we're doing a fresh build.