### PR TITLE
Test running actonc on Ubuntu

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -160,6 +160,12 @@ jobs:
         include:
           - os: "debian"
             version: "11"
+          - os: "ubuntu"
+            version: "21.10"
+          - os: "ubuntu"
+            version: "22.04"
+          - os: "ubuntu"
+            version: "22.10"
     runs-on: ubuntu-latest
     container:
       image: ${{ matrix.os }}:${{ matrix.version }}


### PR DESCRIPTION
This tests that the acton system we've produced on our main build
platform (debian:11) is able to run on other distributions.