### PR TITLE
Add net module with basic DNS lookup functions

### DIFF
--- a/stdlib/src/net.act
+++ b/stdlib/src/net.act
@@ -1,0 +1,41 @@
+"""Network IO
+"""
+
+class NetAuth():
+    # TODO: this should take a WorldAuth token
+    def __init__(self, auth: None):
+        pass
+
+class DNSAuth():
+    def __init__(self, auth: NetAuth):
+        pass
+
+class TCPAuth():
+    def __init__(self, auth: NetAuth):
+        pass
+
+class TCPConnectAuth():
+    def __init__(self, auth: TCPAuth):
+        pass
+
+class TCPListenAuth():
+    def __init__(self, auth: TCPAuth):
+        pass
+
+
+def lookup_a(auth: DNSAuth, name: str, on_resolve: (list[str]) -> None, on_error: (str) -> None) -> None:
+    """Perform DNS lookup for name of record type A
+    """
+    _lookup_a(name, on_resolve, on_error)
+
+def lookup_aaaa(auth: DNSAuth, name: str, on_resolve: (list[str]) -> None, on_error: (str) -> None) -> None:
+    """Perform DNS lookup for name of record type AAAA
+    """
+    _lookup_aaaa(name, on_resolve, on_error)
+
+# Internal implementations
+def _lookup_a(name: str, on_resolve: (list[str]) -> None, on_error: (str) -> None) -> None:
+    NotImplemented
+
+def _lookup_aaaa(name: str, on_resolve: (list[str]) -> None, on_error: (str) -> None) -> None:
+    NotImplemented

--- a/stdlib/src/net.ext.c
+++ b/stdlib/src/net.ext.c
@@ -1,0 +1,113 @@
+//#include "net.ext.h"
+
+#include <uv.h>
+#include "../rts/log.h"
+
+struct dns_cb_data {
+    struct addrinfo *hints;
+    $function on_resolve;
+    $function on_error;
+};
+
+void net$$_lookup_a__on_resolve (uv_getaddrinfo_t *req, int status, struct addrinfo *dns_res) {
+    struct dns_cb_data *cb_data = req->data;
+    $list $res = $list$new(NULL, NULL);
+
+    if (status == -1) {
+        cb_data->on_error->$class->__call__(cb_data->on_error, to$str("Error during DNS lookup"));
+
+        uv_freeaddrinfo(dns_res);
+        free(cb_data->hints);
+        free(cb_data);
+        free(req);
+        return;
+    }
+
+    struct addrinfo *rp;
+    char addr[17] = {'\0'};
+    for (rp = dns_res; rp != NULL; rp = rp->ai_next) {
+        uv_ip4_name((struct sockaddr_in*) rp->ai_addr, addr, 16);
+        $Sequence$list$witness->$class->append($Sequence$list$witness, $res, to$str(addr));
+    }
+
+    cb_data->on_resolve->$class->__call__(cb_data->on_resolve, $res);
+
+    uv_freeaddrinfo(dns_res);
+    free(cb_data->hints);
+    free(cb_data);
+    free(req);
+}
+
+$NoneType net$$_lookup_a ($str name, $function on_resolve, $function on_error) {
+    struct addrinfo *hints = (struct addrinfo *)malloc(sizeof(struct addrinfo));
+    hints->ai_family = PF_INET;
+    hints->ai_socktype = SOCK_STREAM;
+    hints->ai_protocol = IPPROTO_TCP;
+    hints->ai_flags = 0;
+
+    struct dns_cb_data *cb_data = (struct dns_cb_data *)malloc(sizeof(struct dns_cb_data));
+    cb_data->hints = hints;
+    cb_data->on_resolve = on_resolve;
+    cb_data->on_error = on_error;
+
+    uv_getaddrinfo_t *req = (uv_getaddrinfo_t*)malloc(sizeof(uv_getaddrinfo_t));
+    req->data = cb_data;
+
+    int r = uv_getaddrinfo(uv_default_loop(), req, net$$_lookup_a__on_resolve, from$str(name), NULL, hints);
+    if (r != 0)
+        $RAISE((($BaseException)$RuntimeError$new(to$str("Unable to run DNS query"))));
+
+    return $None;
+}
+
+void net$$lookup_aaaa__on_resolve (uv_getaddrinfo_t *req, int status, struct addrinfo *dns_res) {
+    struct dns_cb_data *cb_data = req->data;
+    $list $res = $list$new(NULL, NULL);
+
+    if (status == -1) {
+        cb_data->on_error->$class->__call__(cb_data->on_error, to$str("Error during DNS lookup"));
+
+        uv_freeaddrinfo(dns_res);
+        free(cb_data->hints);
+        free(cb_data);
+        free(req);
+        return;
+    }
+
+    struct addrinfo *rp;
+    char addr[40] = {'\0'};
+    for (rp = dns_res; rp != NULL; rp = rp->ai_next) {
+        //uv_ip6_name((struct sockaddr_in6*) rp->ai_addr, addr, 39);
+        uv_ip6_name((struct sockaddr_in6*)(rp->ai_addr), addr, 39);
+        $Sequence$list$witness->$class->append($Sequence$list$witness, $res, to$str(addr));
+    }
+
+    cb_data->on_resolve->$class->__call__(cb_data->on_resolve, $res);
+
+    uv_freeaddrinfo(dns_res);
+    free(cb_data->hints);
+    free(cb_data);
+    free(req);
+}
+
+$NoneType net$$_lookup_aaaa ($str name, $function on_resolve, $function on_error) {
+    struct addrinfo *hints = (struct addrinfo *)malloc(sizeof(struct addrinfo));
+    hints->ai_family = PF_INET6;
+    hints->ai_socktype = SOCK_STREAM;
+    hints->ai_protocol = IPPROTO_TCP;
+    hints->ai_flags = 0;
+
+    struct dns_cb_data *cb_data = (struct dns_cb_data *)malloc(sizeof(struct dns_cb_data));
+    cb_data->hints = hints;
+    cb_data->on_resolve = on_resolve;
+    cb_data->on_error = on_error;
+
+    uv_getaddrinfo_t *req = (uv_getaddrinfo_t*)malloc(sizeof(uv_getaddrinfo_t));
+    req->data = cb_data;
+
+    int r = uv_getaddrinfo(uv_default_loop(), req, net$$lookup_aaaa__on_resolve, from$str(name), NULL, hints);
+    if (r != 0)
+        $RAISE((($BaseException)$RuntimeError$new(to$str("Unable to run DNS query"))));
+
+    return $None;
+}

--- a/test/stdlib_auto/test_net.act
+++ b/test/stdlib_auto/test_net.act
@@ -1,0 +1,26 @@
+import net
+#import test
+
+
+actor main(env):
+    def test_dns():
+        def on_resolved(result):
+            print("got a result:", result)
+            # TODO: enable this and do some checking of the result
+            # env.exit(0)
+
+        def on_error(msg):
+            print("Got some form of error during DNS resolution:", msg)
+            # TODO: enable this
+            # env.exit(1)
+
+        print("== DNS test")
+        da = net.DNSAuth(net.NetAuth(None))
+        net.lookup_a(da, "localhost", on_resolved, on_error)
+        net.lookup_aaaa(da, "localhost", on_resolved, on_error)
+
+    def exit():
+        env.exit(0)
+
+    test_dns()
+    after 1: exit()


### PR DESCRIPTION
This adds a new module called 'net'. The intention is to collect all of
the network related things currently existing in the env actor and place
them in the net module instead and perhaps to expand it further.

The only functions currently added are for doing DNS lookups of A and
AAAA records. The interface is not really what we want in the end but
quite similar to what we currently have.

The module is built using the new external C function style, which means
that functions in the .act file whose body consists of a NotImplemented
statement are not generated by the compiler but rather expected to be
manually or EXTernally implemented in the file net.ext.c, if such a file
exists.

libuv is used for these new functions also marking our first use of libuv.

lookup_a and lookup_aaaa (the public functions in the net module) take
an auth argument, which is expected to be a DNSAuth token, which in turn
must be created from a NetAuth token. The idea is to have a WorldAuth
token fed it to the root actor but we're not there yet, so the NetAuth
token currently accepts a None token as input. That should change once
we have the other bits in place.