### PR TITLE
Add WorldAuth token to env

### DIFF
--- a/builtin/env.c
+++ b/builtin/env.c
@@ -726,6 +726,23 @@ $l$16lambda $l$16lambda$new($ListenSocket p$1) {
     return $tmp;
 }
 struct $l$16lambda$class $l$16lambda$methods;
+$NoneType $WorldAuth$__init__ ($WorldAuth self) {
+    return $None;
+}
+void $WorldAuth$__serialize__ ($WorldAuth self, $Serial$state state) {
+}
+$WorldAuth $WorldAuth$__deserialize__ ($WorldAuth self, $Serial$state state) {
+    if (!self) {
+        if (!state) {
+            self = malloc(sizeof(struct $WorldAuth));
+            self->$class = &$WorldAuth$methods;
+            return self;
+        }
+        self = $DNEW($WorldAuth, state);
+    }
+    return self;
+}
+struct $WorldAuth$class $WorldAuth$methods;
 $Msg $Env$stdout_write ($Env __self__, $str s) {
     return $ASYNC((($Actor)__self__), (($Cont)$l$1lambda$new((($Env)__self__), s)));
 }
@@ -801,10 +818,17 @@ struct $ListenSocket$class $ListenSocket$methods;
 ///////////////////////////////////////////////////////////////////////////////////////////
 
 
+$WorldAuth $WorldAuth$new() {
+    $WorldAuth $tmp = malloc(sizeof(struct $WorldAuth));
+    $tmp->$class = &$WorldAuth$methods;
+    $WorldAuth$methods.__init__($tmp);
+    return $tmp;
+}
+
 // Env /////////////////////////////////////////////////////////////////////////
 
-$NoneType $Env$__init__ ($Env __self__, $list argv) {
-struct $l$14lambda$class $l$14lambda$methods;
+$NoneType $Env$__init__ ($Env __self__, $WorldAuth token, $list argv) {
+    __self__->auth = token;
     __self__->argv = argv;
     return $None;
 }
@@ -898,9 +922,9 @@ $Env $Env$__deserialize__ ($Env self, $Serial$state state) {
     self->argv = $step_deserialize(state);
     return self;
 }
-$Env $Env$newact($list p$1) {
+$Env $Env$newact($WorldAuth token, $list p$1) {
     $Env $tmp = $NEWACTOR($Env);
-    $tmp->$class->__init__($tmp, p$1);  // Inline this message, note that $Env$__init__ is *not* CPS'ed
+    $tmp->$class->__init__($tmp, token, p$1);  // Inline this message, note that $Env$__init__ is *not* CPS'ed
     serialize_state_shortcut(($Actor)$tmp);
     return $tmp;
 }
@@ -1215,11 +1239,20 @@ void $__init__ () {
         $register(&$l$16lambda$methods);
     }
     {
+        $WorldAuth$methods.$GCINFO = "$WorldAuth";
+        $WorldAuth$methods.$superclass = ($Super$class)&$value$methods;
+        ;
+        $WorldAuth$methods.__init__ = $WorldAuth$__init__;
+        $WorldAuth$methods.__serialize__ = $WorldAuth$__serialize__;
+        $WorldAuth$methods.__deserialize__ = $WorldAuth$__deserialize__;
+        $register(&$WorldAuth$methods);
+    }
+    {
         $Env$methods.$GCINFO = "$Env";
         $Env$methods.$superclass = ($Super$class)&$Actor$methods;
         $Env$methods.__bool__ = ($bool (*) ($Env))$Actor$methods.__bool__;
         $Env$methods.__str__ = ($str (*) ($Env))$Actor$methods.__str__;
-        $Env$methods.__repr__ = ($str (*) ($Env))$Actor$methods.__str__;
+        $Env$methods.__repr__ = ($str (*) ($Env))$Actor$methods.__repr__;
         $Env$methods.__resume__ = ($NoneType (*) ($Env))$Actor$methods.__resume__;
         $Env$methods.__init__ = $Env$__init__;
         $Env$methods.stdout_write$local = $Env$stdout_write$local;
@@ -1245,8 +1278,8 @@ void $__init__ () {
         $Connection$methods.$superclass = ($Super$class)&$Actor$methods;
         $Connection$methods.__bool__ = ($bool (*) ($Connection))$Actor$methods.__bool__;
         $Connection$methods.__str__ = ($str (*) ($Connection))$Actor$methods.__str__;
-        $Connection$methods.__repr__ = ($str (*) ($Connection))$Actor$methods.__str__;
         $Connection$methods.__resume__ = ($NoneType (*) ($Connection))$Connection$__resume__;
+        $Connection$methods.__repr__ = ($str (*) ($Connection))$Actor$methods.__repr__;
         $Connection$methods.__init__ = $Connection$__init__;
         $Connection$methods.write$local = $Connection$write$local;
         $Connection$methods.close$local = $Connection$close$local;
@@ -1263,7 +1296,7 @@ void $__init__ () {
         $RFile$methods.$superclass = ($Super$class)&$Actor$methods;
         $RFile$methods.__bool__ = ($bool (*) ($RFile))$Actor$methods.__bool__;
         $RFile$methods.__str__ = ($str (*) ($RFile))$Actor$methods.__str__;
-        $RFile$methods.__repr__ = ($str (*) ($RFile))$Actor$methods.__str__;
+        $RFile$methods.__repr__ = ($str (*) ($RFile))$Actor$methods.__repr__;
         $RFile$methods.__resume__ = ($NoneType (*) ($RFile))$Actor$methods.__resume__;
         $RFile$methods.__init__ = $RFile$__init__;
         $RFile$methods.readln$local = $RFile$readln$local;
@@ -1279,7 +1312,7 @@ void $__init__ () {
         $WFile$methods.$superclass = ($Super$class)&$Actor$methods;
         $WFile$methods.__bool__ = ($bool (*) ($WFile))$Actor$methods.__bool__;
         $WFile$methods.__str__ = ($str (*) ($WFile))$Actor$methods.__str__;
-        $WFile$methods.__repr__ = ($str (*) ($WFile))$Actor$methods.__str__;
+        $WFile$methods.__repr__ = ($str (*) ($WFile))$Actor$methods.__repr__;
         $WFile$methods.__resume__ = ($NoneType (*) ($WFile))$Actor$methods.__resume__;
         $WFile$methods.__init__ = $WFile$__init__;
         $WFile$methods.write$local = $WFile$write$local;
@@ -1295,8 +1328,8 @@ void $__init__ () {
         $ListenSocket$methods.$superclass = ($Super$class)&$Actor$methods;
         $ListenSocket$methods.__bool__ = ($bool (*) ($ListenSocket))$Actor$methods.__bool__;
         $ListenSocket$methods.__str__ = ($str (*) ($ListenSocket))$Actor$methods.__str__;
-        $ListenSocket$methods.__repr__ = ($str (*) ($ListenSocket))$Actor$methods.__str__;
         $ListenSocket$methods.__resume__ = ($NoneType (*) ($ListenSocket))$ListenSocket$__resume__; // XXX: manually modified, do not touch
+        $ListenSocket$methods.__repr__ = ($str (*) ($ListenSocket))$Actor$methods.__repr__;
         $ListenSocket$methods.__init__ = $ListenSocket$__init__;
         $ListenSocket$methods.close$local = $ListenSocket$close$local;
         $ListenSocket$methods.close = $ListenSocket$close;

--- a/builtin/env.h
+++ b/builtin/env.h
@@ -50,6 +50,7 @@ struct $l$13lambda;
 struct $l$14lambda;
 struct $l$15lambda;
 struct $l$16lambda;
+struct $WorldAuth;
 struct $Env;
 struct $Connection;
 struct $RFile;
@@ -71,6 +72,7 @@ typedef struct $l$13lambda *$l$13lambda;
 typedef struct $l$14lambda *$l$14lambda;
 typedef struct $l$15lambda *$l$15lambda;
 typedef struct $l$16lambda *$l$16lambda;
+typedef struct $WorldAuth *$WorldAuth;
 typedef struct $Env *$Env;
 typedef struct $Connection *$Connection;
 typedef struct $RFile *$RFile;
@@ -347,6 +349,21 @@ struct $l$16lambda {
     struct $l$16lambda$class *$class;
     $ListenSocket __self__;
 };
+struct $WorldAuth$class {
+    char *$GCINFO;
+    int $class_id;
+    $Super$class $superclass;
+    $NoneType (*__init__) ($WorldAuth);
+    void (*__serialize__) ($WorldAuth, $Serial$state);
+    $WorldAuth (*__deserialize__) ($WorldAuth, $Serial$state);
+    $bool (*__bool__) ($WorldAuth);
+    $str (*__str__) ($WorldAuth);
+    $str (*__repr__) ($WorldAuth);
+};
+struct $WorldAuth {
+    struct $WorldAuth$class *$class;
+};
+$WorldAuth $WorldAuth$new();
 extern struct $l$1lambda$class $l$1lambda$methods;
 $l$1lambda $l$1lambda$new($Env, $str);
 extern struct $l$2lambda$class $l$2lambda$methods;
@@ -379,6 +396,7 @@ extern struct $l$15lambda$class $l$15lambda$methods;
 $l$15lambda $l$15lambda$new($function);
 extern struct $l$16lambda$class $l$16lambda$methods;
 $l$16lambda $l$16lambda$new($ListenSocket);
+extern struct $WorldAuth$class $WorldAuth$methods;
 // END GENERATED __builtin__.act
 ///////////////////////////////////////////////////////////////////////////////////////////
 
@@ -386,7 +404,7 @@ struct $Env$class {
     char *$GCINFO;
     int $class_id;
     $Super$class $superclass;
-    $NoneType (*__init__) ($Env, $list);
+    $NoneType (*__init__) ($Env, $WorldAuth, $list);
     void (*__serialize__) ($Env, $Serial$state);
     $Env (*__deserialize__) ($Env, $Serial$state);
     $bool (*__bool__) ($Env);
@@ -418,6 +436,7 @@ struct $Env {
     $Catcher $catcher;
     $Lock $msg_lock;
     $long $globkey;
+    $WorldAuth auth;
     $list argv;
 };
 
@@ -540,7 +559,7 @@ struct $WFile {
 };
 
 extern struct $Env$class $Env$methods;
-$Env $Env$newact($list);
+$Env $Env$newact($WorldAuth, $list);
 extern struct $Connection$class $Connection$methods;
 $Connection $Connection$newact(int);
 extern struct $ListenSocket$class $ListenSocket$methods;

--- a/builtin/ty/src/__builtin__.act
+++ b/builtin/ty/src/__builtin__.act
@@ -623,7 +623,15 @@ zip : (Iterable[A], Iterable[B]) -> Iterator[(A,B)]
 
 ## Environment ################################################
 
-actor Env (args):
+class WorldAuth():
+    """WorldAuth is the root of the capability based authentication chain,
+    providing access to everything.
+    """
+    pass
+
+actor Env (token : WorldAuth, args):
+    auth : WorldAuth
+    auth = token
     argv : list[str]
     argv = args
 

--- a/rts/rts.c
+++ b/rts/rts.c
@@ -1177,7 +1177,7 @@ void BOOTSTRAP(int argc, char *argv[]) {
     for (int i=0; i< argc; i++)
       $list_append(args,to$str(argv[i]));
 
-    env_actor = $Env$newact(args);
+    env_actor = $Env$newact($WorldAuth$new(), args);
 
     root_actor = $ROOT();                           // Assumed to return $NEWACTOR(X) for the selected root actor X
     time_t now = current_time();


### PR DESCRIPTION
This creates a new abstract class called WorldAuth which is our auth
token that grants access to the entire world, i.e. everything. It's
injected into the env actor and can thus be accessed by anyone with
access to the env actor.