### PR TITLE
Restructure DNS lookup functions as DNS actor

### DIFF
--- a/rts/io.c
+++ b/rts/io.c
@@ -1,6 +1,7 @@
 #include "io.h"
 
 #include <uv.h>
+#include <unistd.h>
 
 #include "log.h"
 
@@ -8,6 +9,16 @@ extern char rts_exit;
 uv_async_t stop_event;
 
 bool ioloop_started = false;
+
+void await_ioloop_started() {
+    int i = 0;
+    while (!ioloop_started) {
+        i++;
+        usleep(100);
+    }
+    if (i > 1)
+        log_debug("Took %d spins for ioloop to start", i);
+}
 
 void stop_ioloop() {
     // We are not allowed to call uv_async_send before the ioloop has started.

--- a/rts/io.h
+++ b/rts/io.h
@@ -16,3 +16,5 @@
 
 int ioloop(void *);
 void stop_ioloop();
+
+void await_ioloop_started();

--- a/rts/rts.c
+++ b/rts/rts.c
@@ -2143,6 +2143,11 @@ int main(int argc, char **argv) {
         pthread_setaffinity_np(threads[1], sizeof(cpu_set), &cpu_set);
     }
 
+    // await ioloop startup
+    // We cannot make calls to register callback in the ioloop before it has
+    // started.
+    await_ioloop_started();
+
     for(int idx = 2; idx < num_wthreads+2; idx++) {
         pthread_create(&threads[idx], NULL, main_loop, (void*)idx);
         // Index start at 1 and we pin wthreads to CPU 1...n

--- a/stdlib/src/net.act
+++ b/stdlib/src/net.act
@@ -22,20 +22,22 @@ class TCPListenAuth():
     def __init__(self, auth: TCPAuth):
         pass
 
+actor DNS(auth: DNSAuth):
+    def lookup_a(name: str, on_resolve: action(list[str]) -> None, on_error: action(str) -> None) -> None:
+        """Perform DNS lookup for name of record type A
+        """
+        NotImplemented
 
-def lookup_a(auth: DNSAuth, name: str, on_resolve: (list[str]) -> None, on_error: (str) -> None) -> None:
-    """Perform DNS lookup for name of record type A
+    def lookup_aaaa(name: str, on_resolve: action(list[str]) -> None, on_error: action(str) -> None) -> None:
+        """Perform DNS lookup for name of record type AAAA
+        """
+        NotImplemented
+
+
+def _force_ext():
+    """Force compilation using .ext.c
+
+    Only top level functions are recognized as externally defined by actonc
+    TODO: fix in actonc and remove this
     """
-    _lookup_a(name, on_resolve, on_error)
-
-def lookup_aaaa(auth: DNSAuth, name: str, on_resolve: (list[str]) -> None, on_error: (str) -> None) -> None:
-    """Perform DNS lookup for name of record type AAAA
-    """
-    _lookup_aaaa(name, on_resolve, on_error)
-
-# Internal implementations
-def _lookup_a(name: str, on_resolve: (list[str]) -> None, on_error: (str) -> None) -> None:
-    NotImplemented
-
-def _lookup_aaaa(name: str, on_resolve: (list[str]) -> None, on_error: (str) -> None) -> None:
     NotImplemented

--- a/stdlib/src/net.ext.c
+++ b/stdlib/src/net.ext.c
@@ -9,7 +9,7 @@ struct dns_cb_data {
     $function on_error;
 };
 
-void net$$_lookup_a__on_resolve (uv_getaddrinfo_t *req, int status, struct addrinfo *dns_res) {
+void net$$DNS$lookup_a__on_resolve (uv_getaddrinfo_t *req, int status, struct addrinfo *dns_res) {
     struct dns_cb_data *cb_data = req->data;
     $list $res = $list$new(NULL, NULL);
 
@@ -38,7 +38,7 @@ void net$$_lookup_a__on_resolve (uv_getaddrinfo_t *req, int status, struct addri
     free(req);
 }
 
-$NoneType net$$_lookup_a ($str name, $function on_resolve, $function on_error) {
+$NoneType net$$DNS$lookup_a (net$$DNS __self__, $str name, $function on_resolve, $function on_error) {
     struct addrinfo *hints = (struct addrinfo *)malloc(sizeof(struct addrinfo));
     hints->ai_family = PF_INET;
     hints->ai_socktype = SOCK_STREAM;
@@ -53,14 +53,14 @@ $NoneType net$$_lookup_a ($str name, $function on_resolve, $function on_error) {
     uv_getaddrinfo_t *req = (uv_getaddrinfo_t*)malloc(sizeof(uv_getaddrinfo_t));
     req->data = cb_data;
 
-    int r = uv_getaddrinfo(uv_default_loop(), req, net$$_lookup_a__on_resolve, from$str(name), NULL, hints);
+    int r = uv_getaddrinfo(uv_default_loop(), req, net$$DNS$lookup_a__on_resolve, from$str(name), NULL, hints);
     if (r != 0)
         $RAISE((($BaseException)$RuntimeError$new(to$str("Unable to run DNS query"))));
 
     return $None;
 }
 
-void net$$lookup_aaaa__on_resolve (uv_getaddrinfo_t *req, int status, struct addrinfo *dns_res) {
+void net$$DNS$lookup_aaaa__on_resolve (uv_getaddrinfo_t *req, int status, struct addrinfo *dns_res) {
     struct dns_cb_data *cb_data = req->data;
     $list $res = $list$new(NULL, NULL);
 
@@ -90,7 +90,7 @@ void net$$lookup_aaaa__on_resolve (uv_getaddrinfo_t *req, int status, struct add
     free(req);
 }
 
-$NoneType net$$_lookup_aaaa ($str name, $function on_resolve, $function on_error) {
+$NoneType net$$DNS$lookup_aaaa (net$$DNS __self__, $str name, $function on_resolve, $function on_error) {
     struct addrinfo *hints = (struct addrinfo *)malloc(sizeof(struct addrinfo));
     hints->ai_family = PF_INET6;
     hints->ai_socktype = SOCK_STREAM;
@@ -105,7 +105,7 @@ $NoneType net$$_lookup_aaaa ($str name, $function on_resolve, $function on_error
     uv_getaddrinfo_t *req = (uv_getaddrinfo_t*)malloc(sizeof(uv_getaddrinfo_t));
     req->data = cb_data;
 
-    int r = uv_getaddrinfo(uv_default_loop(), req, net$$lookup_aaaa__on_resolve, from$str(name), NULL, hints);
+    int r = uv_getaddrinfo(uv_default_loop(), req, net$$DNS$lookup_aaaa__on_resolve, from$str(name), NULL, hints);
     if (r != 0)
         $RAISE((($BaseException)$RuntimeError$new(to$str("Unable to run DNS query"))));
 

--- a/test/stdlib_auto/test_net.act
+++ b/test/stdlib_auto/test_net.act
@@ -1,26 +1,38 @@
 import net
 #import test
 
-
 actor main(env):
     def test_dns():
+        res = {
+            "ipv4": False,
+            "ipv6": False
+        }
+
         def on_resolved(result):
             print("got a result:", result)
-            # TODO: enable this and do some checking of the result
-            # env.exit(0)
+            for r in result:
+                if r == "127.0.0.1":
+                   res["ipv4"] = True
+                if r == "::1":
+                   res["ipv6"] = True
+
+            if res["ipv4"] and res["ipv6"]:
+                print("Got both IPv4 and IPv6 result, exiting happily")
+                env.exit(0)
+
 
         def on_error(msg):
             print("Got some form of error during DNS resolution:", msg)
-            # TODO: enable this
-            # env.exit(1)
+            env.exit(1)
 
         print("== DNS test")
         da = net.DNSAuth(net.NetAuth(None))
-        net.lookup_a(da, "localhost", on_resolved, on_error)
-        net.lookup_aaaa(da, "localhost", on_resolved, on_error)
+        dns = net.DNS(da)
+        dns.lookup_a("localhost", on_resolved, on_error)
+        dns.lookup_aaaa("localhost", on_resolved, on_error)
 
     def exit():
-        env.exit(0)
+        env.exit(1)
 
     test_dns()
     after 1: exit()


### PR DESCRIPTION
I think this is a better fit. Also brings the added benefit of being able to call impure functions (which wasn't the case before due to wrong type signatures).

The test program is now correct (thanks to being able to use impure callbacks) and runs much faster. It used to take 1 second due to a after 1 but now runs in millieseconds.

We now await the ioloop to start up before proceeding with starting worker threads. This has eliminated a race which lead to deadlocks.

Fixes #750.

Fixes #749.