### PR TITLE
Add process module

### DIFF
--- a/rts/io.c
+++ b/rts/io.c
@@ -21,6 +21,7 @@ void await_ioloop_started() {
 }
 
 void stop_ioloop() {
+    log_debug("Stopping ioloop");
     // We are not allowed to call uv_async_send before the ioloop has started.
     // We set ioloop_stop_request so that if the loop has not yet started, it
     // will see this value once it has started up and immediately exit.
@@ -57,8 +58,7 @@ int ioloop(void *arg) {
 
     uv_async_init(uv_default_loop(), &stop_event, stop_cb);
 
-    log_debug("starting uv_run");
     int r = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
-    log_debug("uv_run has stopped");
+    log_debug("ioloop has stopped");
     return r;
 }

--- a/stdlib/src/process.act
+++ b/stdlib/src/process.act
@@ -1,0 +1,34 @@
+"""Constructs for spawning and interacting with sub-processes
+"""
+
+class ProcessAuth():
+    def __init__(self, auth: WorldAuth):
+        pass
+
+actor Process(auth: ProcessAuth, cmd: list[str], on_stdout: action(bytes) -> None, on_stderr: action(bytes) -> None, on_exit: action(int, int) -> None):
+    """A process
+    """
+    def _force_persistance():
+        """Trick compiler into persisting the actor arguments we need.
+
+        Compiler optimizes so that only variables that are used are persisted to
+        the DB. Since we use these variables from C, the compiler doesn't see
+        them, thus we need to trick it. This method should never be called.
+        """
+        print(cmd, on_stdout, on_stderr, on_exit)
+
+    def _create_process():
+        """Do the C magic to actually create a process and talk to it
+        """
+        NotImplemented
+
+    _create_process()
+
+
+def _force_ext():
+    """Force compilation using .ext.c
+
+    Only top level functions are recognized as externally defined by actonc
+    TODO: fix in actonc and remove this
+    """
+    NotImplemented

--- a/stdlib/src/process.ext.c
+++ b/stdlib/src/process.ext.c
@@ -1,0 +1,101 @@
+
+#include <uv.h>
+#include "../rts/log.h"
+
+#define MAX_CMD_ARGS 32768
+
+struct process_data {
+    $function on_stdout;
+    $function on_stderr;
+    $function on_exit;
+    uv_pipe_t stdin_pipe;
+    uv_pipe_t stdout_pipe;
+    uv_pipe_t stderr_pipe;
+};
+
+
+void exit_handler(uv_process_t *req, int64_t exit_status, int term_signal) {
+    struct process_data *process_data = req->data;
+    uv_close((uv_handle_t *)&process_data->stdin_pipe, NULL);
+    uv_close((uv_handle_t *)req, NULL);
+    process_data->on_exit->$class->__call__(process_data->on_exit, to$int(exit_status), to$int(term_signal));
+}
+
+void alloc_buffer(uv_handle_t *handle, size_t size, uv_buf_t *buf) {
+    *buf = uv_buf_init((char*) malloc(size), size);
+}
+
+void read_stderrout(uv_stream_t *stream, ssize_t nread, const uv_buf_t *buf) {
+    if (nread < 0){
+        if (nread == UV_EOF) {
+            uv_close((uv_handle_t *)stream, NULL);
+        }
+    } else if (nread > 0) {
+        if (stream->data) {
+            $function cb = stream->data;
+            cb->$class->__call__(cb, to$bytes(buf->base));
+        }
+    }
+
+    if (buf->base)
+        free(buf->base);
+}
+
+$R process$$Process$_create_process (process$$Process __self__, $Cont c$cont) {
+    struct process_data *process_data = calloc(1, sizeof(struct process_data));
+    process_data->on_stdout = __self__->on_stdout;
+    process_data->on_stderr = __self__->on_stderr;
+    process_data->on_exit = __self__->on_exit;
+
+    uv_process_options_t *options = calloc(1, sizeof(uv_process_options_t));
+
+    uv_process_t *req = calloc(1, sizeof(uv_process_t));
+    req->data = process_data;
+
+    char *args[MAX_CMD_ARGS];
+
+    if ($list_len(__self__->cmd) > MAX_CMD_ARGS) {
+        $RAISE((($BaseException)$RuntimeError$new(to$str("Unable to span process; cmd too large (>MAX_CMD_ARGS)"))));
+    }
+    int i;
+    for (i = 0; i < $list_len(__self__->cmd); i++) {
+        args[i] = from$str($list_getitem(__self__->cmd, i));
+    }
+    args[++i] = NULL;
+
+    uv_pipe_init(uv_default_loop(), &process_data->stdin_pipe, 0);
+    uv_pipe_init(uv_default_loop(), &process_data->stdout_pipe, 0);
+    process_data->stdout_pipe.data = __self__->on_stdout;
+    uv_pipe_init(uv_default_loop(), &process_data->stderr_pipe, 0);
+    process_data->stderr_pipe.data = __self__->on_stderr;
+
+    uv_stdio_container_t process_stdio[3];
+    options->stdio = process_stdio;
+
+    process_stdio[0].flags = UV_CREATE_PIPE | UV_READABLE_PIPE;
+    process_stdio[0].data.stream = (uv_stream_t*)&(process_data->stdin_pipe);
+
+    process_stdio[1].flags = UV_CREATE_PIPE | UV_WRITABLE_PIPE;
+    process_stdio[1].data.stream = (uv_stream_t*)&(process_data->stdout_pipe);
+
+    process_stdio[2].flags = UV_CREATE_PIPE | UV_WRITABLE_PIPE;
+    process_stdio[2].data.stream = (uv_stream_t*)&(process_data->stderr_pipe);
+
+    options->stdio_count = 3;
+
+    options->exit_cb = exit_handler;
+    options->file = args[0];
+    options->args = args;
+
+    int r;
+    if ((r = uv_spawn(uv_default_loop(), req, options))) {
+        log_debug("Failed to spawn process: %s", uv_strerror(r));
+        $RAISE((($BaseException)$RuntimeError$new(to$str("Unable to spawn process"))));
+    }
+    // TODO: do we need to do some magic to read any data produced before this
+    // callback is installed?
+    uv_read_start((uv_stream_t*)&process_data->stdout_pipe, alloc_buffer, read_stderrout);
+    uv_read_start((uv_stream_t*)&process_data->stderr_pipe, alloc_buffer, read_stderrout);
+
+    return $R_CONT(c$cont, $None);
+}

--- a/test/stdlib_auto/test_process.act
+++ b/test/stdlib_auto/test_process.act
@@ -1,0 +1,31 @@
+import process
+
+
+actor main(env):
+    def on_stderr(data):
+        print("Received output on stderr:", data)
+        env.exit(0)
+
+    def on_stdout(data):
+        print("Received output on stdout:", data.decode())
+        if data == b"HELLO\n":
+            print("All good, exiting..")
+            await async env.exit(0)
+        else:
+            print("Unexpected output, blargh")
+            await async env.exit(1)
+
+    def on_exit(exit_code, term_signal):
+        print("Process exited with code: ", exit_code, " terminated with signal:", term_signal)
+
+    def test():
+        print("Starting process..")
+        pa = process.ProcessAuth(env.auth)
+        p = process.Process(pa, ["echo", "HELLO"], on_stdout, on_stderr, on_exit)
+
+    def ex():
+        print("Test timeout, exiting with error..")
+        env.exit(1)
+
+    test()
+    after 1: ex()


### PR DESCRIPTION
The process module can be used to run child or sub-processes. A process
is modeled as an actor.

A new auth type called ProcessAuth has been introduced, which grants the
ability to start new processes.

It is not yet possible to write to stdin of a running process.

Fixes #156.