### PR TITLE
Use new ext style for random & acton.rts modules

### DIFF
--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -4,15 +4,6 @@ CFLAGS+= -L$(TD)/deps/instdir/lib -I$(TD)/deps/instdir/include -fno-common -I.. 
 CFLAGS_REL= -O3 -DREL
 CFLAGS_DEV= -g -DDEV
 
-out/dev/lib/acton.rts.o: src/acton/rts.c
-	@mkdir -p $(dir $@)
-	$(CC) $(CFLAGS) $(CFLAGS_DEV) -I. -Iout/ -c $< -o'$@'
-
-
-out/rel/lib/acton.rts.o: src/acton/rts.c
-	@mkdir -p $(dir $@)
-	$(CC) $(CFLAGS) $(CFLAGS_REL) -I. -Iout/ -c $< -o'$@'
-
 out/dev/lib/math.o: src/math.c
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) $(CFLAGS_DEV) -Iout/ -c $< -o$@
@@ -30,11 +21,3 @@ out/dev/lib/numpy.o: src/numpy.c src/numpy.h out/types/math.h $(NUMPY_CFILES)
 out/rel/lib/numpy.o: src/numpy.c src/numpy.h out/types/math.h $(NUMPY_CFILES)
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) $(CFLAGS_REL) -Wno-unused-result -Iout/ -c $< -o$@
-
-out/dev/lib/random.o: src/random.c
-	@mkdir -p $(dir $@)
-	$(CC) $(CFLAGS) $(CFLAGS_DEV) -c $< -o$@
-
-out/rel/lib/random.o: src/random.c
-	@mkdir -p $(dir $@)
-	$(CC) $(CFLAGS) $(CFLAGS_REL) -c $< -o$@

--- a/stdlib/src/acton/rts.ext.c
+++ b/stdlib/src/acton/rts.ext.c
@@ -1,4 +1,5 @@
 #include <uv.h>
+#include <unistd.h>
 
 void acton$rts$$__ext_init__() {
     // NOP

--- a/stdlib/src/random.ext.c
+++ b/stdlib/src/random.ext.c
@@ -1,5 +1,8 @@
-#include "random.h"
 #include <stdlib.h>
+
+void random$$__ext_init__() {
+    srand(time(NULL));
+}
 
 // NOTE: the standard srand / rand functions are not thread safe, but what does
 // that really mean in this context? While we could use thread safe functions
@@ -32,13 +35,4 @@ $int random$$randint ($int min, $int max) {
     while ((r = rand()) >= end);
     // normalize back to the requested range
     return to$int(minval + r%range);
-}
-
-int random$$done$ = 0;
-int random$$seeded = 0;
-void random$$__init__ () {
-    // default to just seeding
-    srand(time(NULL));
-    if (random$$done$) return;
-    random$$done$ = 1;
 }

--- a/stdlib/src/random.h
+++ b/stdlib/src/random.h
@@ -1,6 +1,0 @@
-#pragma once
-#include "builtin/builtin.h"
-#include "builtin/env.h"
-#include "rts/rts.h"
-$int random$$randint ($int, $int);
-void random$$__init__ ();


### PR DESCRIPTION
Rather than have the whole module implement in C with a .c file, we now
use the newer ext.c style to implement certain functions (which in this
case happens to be 100% of the module contents but that's besides the
point).

ext.c do not require manual Makefile targets, so those have been removed.

Also removed unused _time make targets.

Fixes #758.