### PR TITLE
Drop CI tests on Ubuntu 21.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,8 +72,6 @@ jobs:
           - os: "debian"
             version: "11"
           - os: "ubuntu"
-            version: "21.10"
-          - os: "ubuntu"
             version: "22.04"
           - os: "ubuntu"
             version: "22.10"
@@ -160,8 +158,6 @@ jobs:
         include:
           - os: "debian"
             version: "11"
-          - os: "ubuntu"
-            version: "21.10"
           - os: "ubuntu"
             version: "22.04"
           - os: "ubuntu"


### PR DESCRIPTION
As of (end of) July 2022 (like now), it is no longer supported and thus
fails. Dropping it from the list of releases we are testing on...