### PR TITLE
Fix NetAuth auth

### DIFF
--- a/stdlib/src/net.act
+++ b/stdlib/src/net.act
@@ -2,8 +2,7 @@
 """
 
 class NetAuth():
-    # TODO: this should take a WorldAuth token
-    def __init__(self, auth: None):
+    def __init__(self, auth: WorldAuth):
         pass
 
 class DNSAuth():

--- a/test/stdlib_auto/test_net.act
+++ b/test/stdlib_auto/test_net.act
@@ -26,7 +26,7 @@ actor main(env):
             env.exit(1)
 
         print("== DNS test")
-        da = net.DNSAuth(net.NetAuth(None))
+        da = net.DNSAuth(net.NetAuth(env.auth))
         dns = net.DNS(da)
         dns.lookup_a("localhost", on_resolved, on_error)
         dns.lookup_aaaa("localhost", on_resolved, on_error)


### PR DESCRIPTION
We didn't initially take a WorldAuth argument since we didn't have an
instance but that's been fixed for quite some time now, thus NetAuth now
requires a WorldAuth token for initialization!