### PR TITLE
Stop testing on macos 10.15

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-10.15, macos-11, macos-12]
+        os: [macos-11, macos-12]
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Print env"
@@ -162,7 +162,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-10.15, macos-11, macos-12]
+        os: [macos-11, macos-12]
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Download artifacts for Macos, built on macos-11"


### PR DESCRIPTION
GitHub Actions has deprecated support for macos 10.15 and it is going
away, so we'll stop testing on it!

https://github.com/actions/virtual-environments/issues/5583

Fixes #779