### PR TITLE
Use on_exit callback for errors

### DIFF
--- a/stdlib/src/process.act
+++ b/stdlib/src/process.act
@@ -5,7 +5,7 @@ class ProcessAuth():
     def __init__(self, auth: WorldAuth):
         pass
 
-actor Process(auth: ProcessAuth, cmd: list[str], workdir: ?str, env: ?dict[str, str], on_stdout: action(Process, bytes) -> None, on_stderr: action(Process, bytes) -> None, on_exit: action(Process, int, int) -> None):
+actor Process(auth: ProcessAuth, cmd: list[str], workdir: ?str, env: ?dict[str, str], on_stdout: action(Process, bytes) -> None, on_stderr: action(Process, bytes) -> None, on_exit: action(Process, ?str, int, int) -> None):
     """A process
     - auth: authentication token
     - cmd: the command to run
@@ -14,6 +14,10 @@ actor Process(auth: ProcessAuth, cmd: list[str], workdir: ?str, env: ?dict[str, 
     - on_stdout: stdout callback actor method
     - on_stderr: stderr callback actor method
     - on_exit: exit callback, also used for errors
+      - process
+      - error, or None if no error
+      - exit code
+      - signal that caused program to exit
     """
     _p = 0
 

--- a/stdlib/src/process.ext.c
+++ b/stdlib/src/process.ext.c
@@ -25,7 +25,7 @@ void exit_handler(uv_process_t *req, int64_t exit_status, int term_signal) {
     if (uv_is_closing(stdin) == 0)
         uv_close((uv_handle_t *)stdin, NULL);
     uv_close((uv_handle_t *)req, NULL);
-    process_data->on_exit->$class->__call__(process_data->on_exit, process_data->process, to$int(exit_status), to$int(term_signal));
+    process_data->on_exit->$class->__call__(process_data->on_exit, process_data->process, $None, to$int(exit_status), to$int(term_signal));
 }
 
 void alloc_buffer(uv_handle_t *handle, size_t size, uv_buf_t *buf) {
@@ -96,7 +96,7 @@ $R process$$Process$_create_process (process$$Process __self__, $Cont c$cont) {
     if (__self__->env == $None) {
         options->env = NULL;
     } else {
-        char **env = (char *)calloc(($dict_len(__self__->env)+1), sizeof(char *));
+        char **env = (char **)calloc(($dict_len(__self__->env)+1), sizeof(char *));
         $Iterator$dict$items iter = $NEW($Iterator$dict$items, __self__->env);
         $tuple item;
         for (i=0; i < $dict_len(__self__->env); i++) {
@@ -142,7 +142,7 @@ $R process$$Process$_create_process (process$$Process __self__, $Cont c$cont) {
         char errmsg[1024] = "Failed to spawn process: ";
         uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
         log_warn(errmsg);
-        $RAISE((($BaseException)$RuntimeError$new(to$str(errmsg))));
+        __self__->on_exit->$class->__call__(__self__->on_exit, process_data->process, to$str(errmsg), to$int(0), to$int(0));
     }
     // TODO: do we need to do some magic to read any data produced before this
     // callback is installed?

--- a/test/stdlib_auto/test_process.act
+++ b/test/stdlib_auto/test_process.act
@@ -15,8 +15,12 @@ actor main(env):
             print("Unexpected output, blargh")
             await async env.exit(1)
 
-    def on_exit(p, exit_code, term_signal):
-        print("Process exited with code: ", exit_code, " terminated with signal:", term_signal)
+    def on_exit(p, error, exit_code, term_signal):
+        if error is not None:
+            print("Error from process:", error)
+            await async env.exit(1)
+        else:
+            print("Process exited with code: ", exit_code, " terminated with signal:", term_signal)
 
     def test():
         print("Starting process..")

--- a/test/stdlib_auto/test_process_env.act
+++ b/test/stdlib_auto/test_process_env.act
@@ -16,10 +16,14 @@ actor main(env):
             print("Unexpected environment variables, exiting with error...")
             await async env.exit(1)
 
-    def on_exit(p, exit_code, term_signal):
-        print("Process exited with code: ", exit_code, " terminated with signal:", term_signal)
-        print("Exited in unexpected way, error...")
-        await async env.exit(1)
+    def on_exit(p, error, exit_code, term_signal):
+        if error is not None:
+            print("Error from process:", error)
+            await async env.exit(1)
+        else:
+            print("Process exited with code: ", exit_code, " terminated with signal:", term_signal)
+            print("Exited in unexpected way, error...")
+            await async env.exit(1)
 
     def test():
         print("Starting process..")

--- a/test/stdlib_auto/test_process_pid.act
+++ b/test/stdlib_auto/test_process_pid.act
@@ -12,14 +12,18 @@ actor main(env):
         print("... but not expecting any, exiting with error")
         await async env.exit(1)
 
-    def on_exit(p, exit_code, term_signal):
-        print("Process exited with code: ", exit_code, " terminated with signal:", term_signal)
-        if term_signal == 15:
-            print("Got expected terminal signal 15, yay")
-            await async env.exit(0)
-        else:
-            print("Exited in unexpected way, error...")
+    def on_exit(p, error, exit_code, term_signal):
+        if error is not None:
+            print("Error from process:", error)
             await async env.exit(1)
+        else:
+            print("Process exited with code: ", exit_code, " terminated with signal:", term_signal)
+            if term_signal == 15:
+                print("Got expected terminal signal 15, yay")
+                await async env.exit(0)
+            else:
+                print("Exited in unexpected way, error...")
+                await async env.exit(1)
 
     def test():
         print("Starting process..")

--- a/test/stdlib_auto/test_process_wdir.act
+++ b/test/stdlib_auto/test_process_wdir.act
@@ -16,10 +16,14 @@ actor main(env):
             print("Unexpected working directory, exiting with error...")
             await async env.exit(1)
 
-    def on_exit(p, exit_code, term_signal):
-        print("Process exited with code: ", exit_code, " terminated with signal:", term_signal)
-        print("Exited in unexpected way, error...")
-        await async env.exit(1)
+    def on_exit(p, error, exit_code, term_signal):
+        if error is not None:
+            print("Error from process:", error)
+            await async env.exit(1)
+        else:
+            print("Process exited with code: ", exit_code, " terminated with signal:", term_signal)
+            print("Exited in unexpected way, error...")
+            await async env.exit(1)
 
     def test():
         print("Starting process..")

--- a/test/stdlib_auto/test_process_write.act
+++ b/test/stdlib_auto/test_process_write.act
@@ -16,14 +16,18 @@ actor main(env):
             print("Unexpected output, blargh")
             await async env.exit(1)
 
-    def on_exit(p, exit_code, term_signal):
-        print("Process exited with code: ", exit_code, " terminated with signal:", term_signal)
-        if exit_code == 0:
-            print("Exited with 0, all good, yay!")
-            await async env.exit(0)
-        else:
-            print("Exited in unexpected way, error...")
+    def on_exit(p, error, exit_code, term_signal):
+        if error is not None:
+            print("Error from process:", error)
             await async env.exit(1)
+        else:
+            print("Process exited with code: ", exit_code, " terminated with signal:", term_signal)
+            if exit_code == 0:
+                print("Exited with 0, all good, yay!")
+                await async env.exit(0)
+            else:
+                print("Exited in unexpected way, error...")
+                await async env.exit(1)
 
     def test():
         print("Starting process..")


### PR DESCRIPTION
Rather than raising an exception when we encounter an error in spawning
the process, we call the on_exit callback. It now receives a new
argument which is the error message. If there is no error and the
process exited for some other reason, the error variable is None.

The reasoning for this approach is that it's likely we need to write
less code and have a more consistent control flow when using callbacks.
If a process exits abnormally, we would write a on_exit callback to
handle this and perhaps restart it. If a process doesn't start / spawn
properly, that is sort of in the same category of events and should
probably lead to a restart.

Part of #795.