### PR TITLE
Add on_error callback for errors

### DIFF
--- a/stdlib/src/process.act
+++ b/stdlib/src/process.act
@@ -5,7 +5,7 @@ class ProcessAuth():
     def __init__(self, auth: WorldAuth):
         pass
 
-actor Process(auth: ProcessAuth, cmd: list[str], workdir: ?str, env: ?dict[str, str], on_stdout: action(Process, bytes) -> None, on_stderr: action(Process, bytes) -> None, on_exit: action(Process, int, int) -> None):
+actor Process(auth: ProcessAuth, cmd: list[str], workdir: ?str, env: ?dict[str, str], on_stdout: action(Process, bytes) -> None, on_stderr: action(Process, bytes) -> None, on_exit: action(Process, int, int) -> None, on_error: action(str) -> None):
     """A process
     - auth: authentication token
     - cmd: the command to run
@@ -13,7 +13,11 @@ actor Process(auth: ProcessAuth, cmd: list[str], workdir: ?str, env: ?dict[str, 
     - env: environment for process, use None to inherit current environment
     - on_stdout: stdout callback actor method
     - on_stderr: stderr callback actor method
-    - on_exit: exit callback, also used for errors
+    - on_exit: exit callback
+      - process
+      - exit code
+      - signal that caused program to exit
+    - on_error: error callback
     """
     _p = 0
 
@@ -24,7 +28,7 @@ actor Process(auth: ProcessAuth, cmd: list[str], workdir: ?str, env: ?dict[str, 
         the DB. Since we use these variables from C, the compiler doesn't see
         them, thus we need to trick it. This method should never be called.
         """
-        print(cmd, workdir, env, on_stdout, on_stderr, on_exit, _p)
+        print(cmd, workdir, env, on_stdout, on_stderr, on_exit, on_error, _p)
 
     def _create_process():
         """Do the C magic to actually create a process and talk to it

--- a/stdlib/src/process.ext.c
+++ b/stdlib/src/process.ext.c
@@ -96,7 +96,7 @@ $R process$$Process$_create_process (process$$Process __self__, $Cont c$cont) {
     if (__self__->env == $None) {
         options->env = NULL;
     } else {
-        char **env = (char *)calloc(($dict_len(__self__->env)+1), sizeof(char *));
+        char **env = (char **)calloc(($dict_len(__self__->env)+1), sizeof(char *));
         $Iterator$dict$items iter = $NEW($Iterator$dict$items, __self__->env);
         $tuple item;
         for (i=0; i < $dict_len(__self__->env); i++) {
@@ -142,7 +142,7 @@ $R process$$Process$_create_process (process$$Process __self__, $Cont c$cont) {
         char errmsg[1024] = "Failed to spawn process: ";
         uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
         log_warn(errmsg);
-        $RAISE((($BaseException)$RuntimeError$new(to$str(errmsg))));
+        __self__->on_error->$class->__call__(__self__->on_exit, process_data->process, to$str(errmsg));
     }
     // TODO: do we need to do some magic to read any data produced before this
     // callback is installed?

--- a/test/stdlib_auto/test_process.act
+++ b/test/stdlib_auto/test_process.act
@@ -18,10 +18,14 @@ actor main(env):
     def on_exit(p, exit_code, term_signal):
         print("Process exited with code: ", exit_code, " terminated with signal:", term_signal)
 
+    def on_error(error):
+        print("Error from process:", error)
+        await async env.exit(1)
+
     def test():
         print("Starting process..")
         pa = process.ProcessAuth(env.auth)
-        p = process.Process(pa, ["echo", "HELLO"], None, None, on_stdout, on_stderr, on_exit)
+        p = process.Process(pa, ["echo", "HELLO"], None, None, on_stdout, on_stderr, on_exit, on_error)
 
     def ex():
         print("Test timeout, should exit with error but not now... disabled due to faulty error")

--- a/test/stdlib_auto/test_process_env.act
+++ b/test/stdlib_auto/test_process_env.act
@@ -21,10 +21,14 @@ actor main(env):
         print("Exited in unexpected way, error...")
         await async env.exit(1)
 
+    def on_error(error):
+        print("Error from process:", error)
+        await async env.exit(1)
+
     def test():
         print("Starting process..")
         pa = process.ProcessAuth(env.auth)
-        p = process.Process(pa, ["env"], None, {"FOO": "BAR"}, on_stdout, on_stderr, on_exit)
+        p = process.Process(pa, ["env"], None, {"FOO": "BAR"}, on_stdout, on_stderr, on_exit, on_error)
 
     def ex():
         print("Test timeout, exiting with error")

--- a/test/stdlib_auto/test_process_pid.act
+++ b/test/stdlib_auto/test_process_pid.act
@@ -21,10 +21,14 @@ actor main(env):
             print("Exited in unexpected way, error...")
             await async env.exit(1)
 
+    def on_error(error):
+        print("Error from process:", error)
+        await async env.exit(1)
+
     def test():
         print("Starting process..")
         pa = process.ProcessAuth(env.auth)
-        p = process.Process(pa, ["sleep", "2"], None, None, on_stdout, on_stderr, on_exit)
+        p = process.Process(pa, ["sleep", "2"], None, None, on_stdout, on_stderr, on_exit, on_error)
         pid = p.pid()
 
         print("PID:", pid)

--- a/test/stdlib_auto/test_process_wdir.act
+++ b/test/stdlib_auto/test_process_wdir.act
@@ -21,10 +21,14 @@ actor main(env):
         print("Exited in unexpected way, error...")
         await async env.exit(1)
 
+    def on_error(error):
+        print("Error from process:", error)
+        await async env.exit(1)
+
     def test():
         print("Starting process..")
         pa = process.ProcessAuth(env.auth)
-        p = process.Process(pa, ["pwd"], "/", None, on_stdout, on_stderr, on_exit)
+        p = process.Process(pa, ["pwd"], "/", None, on_stdout, on_stderr, on_exit, on_error)
 
     def ex():
         print("Test timeout, exiting with error")

--- a/test/stdlib_auto/test_process_write.act
+++ b/test/stdlib_auto/test_process_write.act
@@ -25,10 +25,14 @@ actor main(env):
             print("Exited in unexpected way, error...")
             await async env.exit(1)
 
+    def on_error(error):
+        print("Error from process:", error)
+        await async env.exit(1)
+
     def test():
         print("Starting process..")
         pa = process.ProcessAuth(env.auth)
-        p = process.Process(pa, ["cat"], None, None, on_stdout, on_stderr, on_exit)
+        p = process.Process(pa, ["cat"], None, None, on_stdout, on_stderr, on_exit, on_error)
         p.write(b"hejsan\n")
 
     def ex():


### PR DESCRIPTION
Rather than raising an exception when we encounter an error in spawning
the process, we call the on_error callback. It receives one argument
which is the error message.

Part of #795.