### PR TITLE
Remove arg from pin_actor_affinity

### DIFF
--- a/rts/rts.c
+++ b/rts/rts.c
@@ -215,7 +215,8 @@ pthread_key_t pkey_uv_loop;
 pthread_mutex_t rts_exit_lock = PTHREAD_MUTEX_INITIALIZER;
 pthread_cond_t rts_exit_signal = PTHREAD_COND_INITIALIZER;
 
-void pin_actor_affinity($Actor a) {
+void pin_actor_affinity() {
+    $Actor a = ($Actor)pthread_getspecific(self_key);
     int i = (int)pthread_getspecific(pkey_wtid);
     log_debug("Pinning affinity for actor to current WT %d", i);
     a->$affinity = i;

--- a/rts/rts.h
+++ b/rts/rts.h
@@ -200,7 +200,7 @@ time_t next_timeout();
 void handle_timeout();
 void rts_shutdown();
 
-void pin_actor_affinity($Actor);
+void pin_actor_affinity();
 
 //typedef $int $Env;
 

--- a/stdlib/src/file.ext.c
+++ b/stdlib/src/file.ext.c
@@ -1,0 +1,95 @@
+#include <uv.h>
+#include "../rts/io.h"
+#include "../rts/log.h"
+
+void file$$__ext_init__() {
+
+}
+
+$R file$$ReadFile$_open_file (file$$ReadFile __self__, $Cont c$cont) {
+    pin_actor_affinity();
+    uv_fs_t *req = (uv_fs_t *)calloc(1, sizeof(uv_fs_t));
+    int r = uv_fs_open(get_uv_loop(), req, from$str(__self__->filename), UV_FS_O_RDONLY, 0, NULL);
+    if (r < 0) {
+        char errmsg[1024] = "Error opening file for reading: ";
+        uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
+        log_warn(errmsg);
+        $RAISE((($BaseException)$RuntimeError$new(to$str(errmsg))));
+
+    }
+    __self__->_fd = to$int(r);
+    return $R_CONT(c$cont, $None);
+}
+
+
+$R file$$ReadFile$close$local (file$$ReadFile __self__, $Cont c$cont) {
+    uv_fs_t *req = (uv_fs_t *)calloc(1, sizeof(uv_fs_t));
+    int r = uv_fs_close(get_uv_loop(), req, (uv_file)from$int(__self__->_fd), NULL);
+    if (r < 0) {
+        char errmsg[1024] = "Error closing file: ";
+        uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
+        log_warn(errmsg);
+        $RAISE((($BaseException)$RuntimeError$new(to$str(errmsg))));
+    }
+    return $R_CONT(c$cont, $None);
+}
+
+$R file$$ReadFile$read$local (file$$ReadFile __self__, $Cont c$cont) {
+    uv_fs_t *req = (uv_fs_t *)calloc(1, sizeof(uv_fs_t));
+    // TODO: handle arbitrary sized files
+    char buf[1024];
+    uv_buf_t iovec = uv_buf_init(buf, sizeof(buf));
+
+    int r = uv_fs_read(get_uv_loop(), req, (uv_file)from$int(__self__->_fd), &iovec, 1, 0, NULL);
+    if (r < 0) {
+        char errmsg[1024] = "Error reading from file: ";
+        uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
+        log_warn(errmsg);
+        $RAISE((($BaseException)$RuntimeError$new(to$str(errmsg))));
+
+    }
+    return $R_CONT(c$cont, to$bytes(buf));
+}
+
+
+$R file$$WriteFile$_open_file (file$$WriteFile __self__, $Cont c$cont) {
+    pin_actor_affinity();
+    uv_fs_t *req = (uv_fs_t *)calloc(1, sizeof(uv_fs_t));
+    int r = uv_fs_open(get_uv_loop(), req, from$str(__self__->filename),  UV_FS_O_RDWR | UV_FS_O_CREAT, S_IWUSR|S_IRUSR|S_IRGRP|S_IROTH, NULL);
+    if (r < 0) {
+        char errmsg[1024] = "Error opening file for writing: ";
+        uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
+        log_warn(errmsg);
+        $RAISE((($BaseException)$RuntimeError$new(to$str(errmsg))));
+
+    }
+    __self__->_fd = to$int(r);
+    return $R_CONT(c$cont, $None);
+}
+
+$R file$$WriteFile$close$local (file$$WriteFile __self__, $Cont c$cont) {
+    uv_fs_t *req = (uv_fs_t *)calloc(1, sizeof(uv_fs_t));
+    int r = uv_fs_close(get_uv_loop(), req, (uv_file)from$int(__self__->_fd), NULL);
+    if (r < 0) {
+        char errmsg[1024] = "Error closing file: ";
+        uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
+        log_warn(errmsg);
+        $RAISE((($BaseException)$RuntimeError$new(to$str(errmsg))));
+    }
+    return $R_CONT(c$cont, $None);
+}
+
+$R file$$WriteFile$write$local (file$$WriteFile __self__, $bytes data, $Cont c$cont) {
+    uv_fs_t *req = (uv_fs_t *)calloc(1, sizeof(uv_fs_t));
+    uv_buf_t buf = uv_buf_init(data->str, data->nbytes);
+
+    int r = uv_fs_write(get_uv_loop(), req, (uv_file)from$int(__self__->_fd), &buf, 1, 0, NULL);
+    if (r < 0) {
+        char errmsg[1024] = "Error writing to file: ";
+        uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
+        log_warn(errmsg);
+        $RAISE((($BaseException)$RuntimeError$new(to$str(errmsg))));
+
+    }
+    return $R_CONT(c$cont, $None);
+}

--- a/stdlib/src/net.ext.c
+++ b/stdlib/src/net.ext.c
@@ -123,6 +123,6 @@ $R net$$DNS$lookup_aaaa$local (net$$DNS __self__, $str name, $function on_resolv
 }
 
 $R net$$DNS$_pin_affinity (net$$DNS __self__, $Cont c$cont) {
-    pin_actor_affinity(($Actor)__self__);
+    pin_actor_affinity();
     return $R_CONT(c$cont, $None);
 }

--- a/stdlib/src/process.ext.c
+++ b/stdlib/src/process.ext.c
@@ -67,7 +67,7 @@ void read_stdout(uv_stream_t *stream, ssize_t nread, const uv_buf_t *buf) {
 }
 
 $R process$$Process$_create_process (process$$Process __self__, $Cont c$cont) {
-    pin_actor_affinity(($Actor)__self__);
+    pin_actor_affinity();
     struct process_data *process_data = calloc(1, sizeof(struct process_data));
     process_data->process = __self__;
     process_data->on_stdout = __self__->on_stdout;


### PR DESCRIPTION
This makes it easier to call, since we can do it from any function and
not just an actor. All functions are called by an actor anyway, it's
just that we dig it out of the pthread store rather than having to
thread through the argument (which is only possible in C anyway, making
it impossible to call such a function directly in Acton).