### PR TITLE
Always treat return type warnings as errors

### DIFF
--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -587,7 +587,7 @@ runRestPasses args paths env0 parsed stubMode = do
                               aFile = joinPath [projLib paths, "libActonProject.a"]
                               buildF = joinPath [projPath paths, "build.sh"]
                               wd = takeFileName (projPath paths)
-                              ccCmd = ("cc " ++ pedantArg ++
+                              ccCmd = ("cc -Werror=return-type " ++ pedantArg ++
                                        (if (dev args) then " -g " else "") ++
                                        " -c " ++
                                        " -I" ++ wd ++


### PR DESCRIPTION
Been hit by this a couple of times now and the consequences are dire.
The RTS will behave very weirdly when it doesn't get a R_CONT or
similar, so better detect at compile time.