### PR TITLE
Add TCP client actor net.TCPIPConnection

### DIFF
--- a/builtin/str.c
+++ b/builtin/str.c
@@ -2911,6 +2911,13 @@ $bytes to$bytes(char *str) {
   return res;
 }
 
+$bytes to$bytes_len(char *str, int len) {
+  $bytes res;
+  NEW_UNFILLED_BYTES(res, len);
+  memcpy(res->str, str, len);
+  return res;
+}
+
 unsigned char *from$bytes($bytes b) {
   return b->str;
 }

--- a/builtin/str.h
+++ b/builtin/str.h
@@ -298,7 +298,8 @@ extern struct $Times$bytes *$Times$bytes$witness;
 extern struct $Sliceable$bytes *$Sliceable$bytes$witness;
 extern struct $Container$bytes *$Container$bytes$witness;
 
-$bytes to$bytes(char *str); 
+$bytes to$bytes(char *str);
+$bytes to$bytes_len(char *str, int len);
 unsigned char *from$bytes($bytes b);
 
 

--- a/examples/client.act
+++ b/examples/client.act
@@ -1,27 +1,23 @@
+import net
+
 actor main(env):
 
-    def stdout_w(conn,str):
-        env.stdout_write(str)
-      
-    def stdout_wb(conn,b):
-        env.stdout_write(b.decode())
-       
-    def session(conn):
-        if conn is not None:
-           conn_write : action(str)->None
-           
-           def conn_write(s):
-               conn.write(s.encode())
-        
-           conn.on_receive(stdout_wb, stdout_w)
-           env.stdin_install(conn_write)
-        else:
-           print("couldn't connect to",env.argv[1])
-           env.exit(0)
+    def on_connect(c):
+        print("Client established connection")
+        def conn_write(s):
+            c.write(s.encode())
+
+        env.stdin_install(conn_write)
+
+    def on_receive(c, data):
+        env.stdout_write(data.decode())
+
+    def on_error(c, msg):
+        print("Client ERR", msg)
 
     if len(env.argv) != 3:
-        print("usage: client host port")
-        env.exit(-1)
-    else:
-        env.connect(env.argv[1],int(env.argv[2]),session)
+        print("usage: client [HOST] [PORT]")
+        await async env.exit(-1)
 
+    connect_auth = net.TCPConnectAuth(net.TCPAuth(net.NetAuth(env.auth)))
+    client = net.TCPIPConnection(connect_auth, env.argv[1], int(env.argv[2]), on_connect, on_receive, on_error)

--- a/rts/rts.c
+++ b/rts/rts.c
@@ -218,7 +218,7 @@ pthread_cond_t rts_exit_signal = PTHREAD_COND_INITIALIZER;
 void pin_actor_affinity() {
     $Actor a = ($Actor)pthread_getspecific(self_key);
     int i = (int)pthread_getspecific(pkey_wtid);
-    log_debug("Pinning affinity for actor to current WT %d", i);
+    log_debug("Pinning affinity for %s actor %ld to current WT %d", a->$class->$GCINFO, a->$globkey, i);
     a->$affinity = i;
 }
 

--- a/stdlib/src/net.act
+++ b/stdlib/src/net.act
@@ -48,6 +48,30 @@ actor DNS(auth: DNSAuth):
     _pin_affinity()
 
 
+actor TCPIPConnection(auth: TCPConnectAuth, address: str, port: int, on_connect: action(TCPIPConnection) -> None, on_receive: action(TCPIPConnection, bytes) -> None, on_error: action(TCPIPConnection, str) -> None):
+    """TCP IP Connection"""
+    _socket = -1
+
+    action def write(data: bytes) -> None:
+        """Write data to remote"""
+        NotImplemented
+
+    def __resume__() -> None:
+        NotImplemented
+
+    def _force_persistance():
+        """Trick compiler into persisting the actor arguments we need.
+
+        Compiler optimizes so that only variables that are used are persisted to
+        the DB. Since we use these variables from C, the compiler doesn't see
+        them, thus we need to trick it. This method should never be called.
+        """
+        print(address, port, on_connect, on_receive, on_error, _socket)
+
+    def _init():
+        NotImplemented
+    _init()
+
 actor TCPListenConnection(auth: _TCPListenConnectAuth, client: int, on_receive: action(TCPListenConnection, bytes) -> None, on_error: action(TCPListenConnection, str) -> None):
     """TCP Listener Connection"""
     action def write(data: bytes) -> None:

--- a/test/rts/ddb_test_client.act
+++ b/test/rts/ddb_test_client.act
@@ -1,25 +1,29 @@
+import net
+
 actor main(env):
     port = int(env.argv[1])
+    var client = None
 
-    def recv_handler(conn, msg):
-        if msg == b"0":
+    def on_connect(c):
+        print("Client established connection")
+        await async c.write(b"GET")
+
+    def on_receive(c, data):
+        print("Client RECV", data)
+        if data == b"0":
             print("Got a 0, doing noooothing...")
 
-        if msg == b"1":
+        if data == b"1":
             print("Got a 1, I'm happy, exiting...")
             await async env.exit(0)
 
-    def connection_handler(conn):
-        if conn is not None:
-            print("Installing on_receive handler...")
-            await async conn.on_receive(recv_handler, err_handler)
-            conn.write(b"GET")
-
-    def err_handler(conn, msg):
-        print("Error with our connection occurred, attempting to re-establish connection")
+    def on_error(c, msg):
+        print("Client error:", msg)
+        print("Attempting to re-establish connection...")
         connect()
 
     def connect():
-        env.connect("127.0.0.1", port, connection_handler)
+        connect_auth = net.TCPConnectAuth(net.TCPAuth(net.NetAuth(env.auth)))
+        client = net.TCPIPConnection(connect_auth, "127.0.0.1", port, on_connect, on_receive, on_error)
 
     connect()

--- a/test/stdlib_auto/test_net_tcp.act
+++ b/test/stdlib_auto/test_net_tcp.act
@@ -14,7 +14,7 @@ actor Server(env, port):
         pass
 
     def on_server_receive(c, data):
-        print("Server Received some data:", data, " from:", c)
+        print("Server received some data:", data, " from:", c)
         if data == b"PING":
             c.write(b"PONG")
 
@@ -26,26 +26,24 @@ actor Server(env, port):
 
 
 actor Client(env: Env, port: int):
-    def recv_handler(c, msg):
-        print("Client RECV", msg)
-        if msg == b"PONG":
+    def on_connect(c):
+        print("Client established connection")
+        await async c.write(b"PING")
+
+    def on_receive(c, data):
+        print("Client RECV", data)
+        if data == b"PONG":
             print("Got PONG, all good, yay")
             await async env.exit(0)
         else:
             print("Got bad response, exiting with error..")
             await async env.exit(1)
 
-    def err_handler(c, msg):
+    def on_error(c, msg):
         print("Client ERR", msg)
 
-    def conn_handler(conn):
-        print("Client established connection")
-        if conn is not None:
-            await async conn.on_receive(recv_handler, err_handler)
-            await async conn.write(b"PING")
-
-    print("Client connecting...")
-    env.connect("127.0.0.1", port, conn_handler)
+    connect_auth = net.TCPConnectAuth(net.TCPAuth(net.NetAuth(env.auth)))
+    client = net.TCPIPConnection(connect_auth, "127.0.0.1", port, on_connect, on_receive, on_error)
 
 actor main(env):
     def timeout_error():


### PR DESCRIPTION
The net.TCPIPConnection actor is a TPC client which connects to remote
systems. It takes an IP address as argument. The idea is to wrap this up
in a net.TCPConnection which does name resolution including happy
eyeballs.

It handles resume for distributed DB systems, which is also verified by
a test. A few tests have been updated to use this rather than the old
TCP client connection actor.