### PR TITLE
Ensure we grab latest artifact

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -316,9 +316,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           replacesArtifacts: true
       - name: "Remove version number from darwin tar ball"
-        run: mv acton-darwin-x86_64*tar.bz2 acton-darwin-x86_64.tar.bz2
+        run: mv $(ls acton-darwin*.tar.bz2 | tail -n1) acton-darwin-x86_64.tar.bz2
       - name: "Remove version number from linux tar ball"
-        run: mv acton-linux-x86_64*tar.bz2 acton-linux-x86_64.tar.bz2
+        run: mv $(ls acton-linux-x86_64*.tar.bz2 | tail -n1) acton-linux-x86_64.tar.bz2
       - name: "List files for debug"
         run: ls
       - name: "Upload artifacts without version number for stable links"


### PR DESCRIPTION
There could be multiple artifacts when there have been failures during
the job that produced it. The artifacts are uploaded immediately after
the build completes so it can upload and then fail in the subsequent
testing, the job is rerun and thus we get multiple artifacts.

This makes the pre-release-tip handle that scenario by picking the
latest available artifact.

Fixes #825.