### PR TITLE
Add JSON module

### DIFF
--- a/stdlib/src/json.act
+++ b/stdlib/src/json.act
@@ -1,0 +1,32 @@
+# TODO: flip around Json actor with free encode/decode functions, i.e. we want
+# the free encode/decode functions to actually do the work, which can be called
+# as json.encode() or json.decode() and will run as procs, i.e. synchronous
+# whereas if you want to run them async, you can use the Json actor. The Json
+# actor should just wrap the free functions. Now it's the other way around (only
+# way it works with compiler currently due to some bug), which means that every
+# invocation of encode / decode will also allocate a new actor.
+
+actor Json():
+    action def decode(data: str) -> dict[str, value]:
+        NotImplemented
+
+    action def encode(data: dict[str, value]) -> str:
+        NotImplemented
+
+
+def decode(data: str) -> dict[str, value]:
+    j = Json()
+    return j.decode(data)
+
+def encode(data: dict[str, value]) -> str:
+    j = Json()
+    return j.encode(data)
+
+
+def _force_ext():
+    """Force compilation using .ext.c
+
+    Only top level functions are recognized as externally defined by actonc
+    TODO: fix in actonc and remove this
+    """
+    NotImplemented

--- a/stdlib/src/json.ext.c
+++ b/stdlib/src/json.ext.c
@@ -1,0 +1,189 @@
+
+#include "../rts/io.h"
+#include "../rts/log.h"
+#include "../deps/yyjson.h"
+
+void json$$__ext_init__() {
+    // NOP
+}
+
+void json$$encode_list(yyjson_mut_doc *doc, yyjson_mut_val *node, $list data);
+void json$$encode_dict(yyjson_mut_doc *doc, yyjson_mut_val *node, $dict data) {
+    $Iterator$dict$items iter = $NEW($Iterator$dict$items, data);
+    $tuple item;
+
+    for (int i=0; i < $dict_len(data); i++) {
+        item = ($tuple)iter->$class->__next__(iter);
+        char *key = from$str(($str)item->components[0]);
+        char *value = from$str(($str)item->components[1]);
+        $value v = item->components[1];
+        //log_info("key: %s  class_id: %d  type: %s", key, v->$class->$class_id, v->$class->$GCINFO);
+        switch (v->$class->$class_id) {
+            case 2:; // $int
+                yyjson_mut_obj_add_int(doc, node, key, from$int(($int)v));
+                break;
+            case 5:; // $bool
+                yyjson_mut_obj_add_bool(doc, node, key, from$bool(($bool)v));
+                break;
+            case 6:; // $str
+                yyjson_mut_obj_add_str(doc, node, key, from$str(($str)v));
+                break;
+            case 7:; // $list
+                yyjson_mut_val *l = yyjson_mut_arr(doc);
+                yyjson_mut_obj_add_val(doc, node, key, l);
+                json$$encode_list(doc, l, ($list)v);
+                break;
+            case 8:; // $dict
+                yyjson_mut_val *d = yyjson_mut_obj(doc);
+                yyjson_mut_obj_add_val(doc, node, key, d);
+                json$$encode_dict(doc, d, ($dict)v);
+                break;
+        }
+
+
+    }
+}
+
+void json$$encode_list(yyjson_mut_doc *doc, yyjson_mut_val *node, $list data) {
+    for (int i = 0; i < $list_len(data); i++) {
+        $value v = $list_getitem(data, i);
+        switch (v->$class->$class_id) {
+            case 2:; // $int
+                yyjson_mut_arr_add_int(doc, node, from$int(($int)v));
+                break;
+            case 5:; // $bool
+                yyjson_mut_arr_add_bool(doc, node, from$bool(($bool)v));
+                break;
+            case 6:; // $str
+                yyjson_mut_arr_add_str(doc, node, from$str(($str)v));
+                break;
+            case 7:; // $list
+                yyjson_mut_val *l = yyjson_mut_arr_add_arr(doc, node);
+                if (l) {
+                    json$$encode_list(doc, l, ($list)v);
+                } else {
+                    // TODO: raise exception
+                }
+                break;
+            case 8:; // $dict
+                yyjson_mut_val *d = yyjson_mut_arr_add_obj(doc, node);
+                if (d) {
+                    json$$encode_dict(doc, d, ($dict)v);
+                } else {
+                    // TODO: raise exception
+                }
+                break;
+        }
+    }
+}
+
+$R json$$Json$encode$local (json$$Json __self__, $dict data, $Cont c$cont) {
+    // Create JSON document
+    yyjson_mut_doc *doc = yyjson_mut_doc_new(NULL);
+    yyjson_mut_val *root = yyjson_mut_obj(doc);
+    yyjson_mut_doc_set_root(doc, root);
+
+    // TODO: do the thing
+    json$$encode_dict(doc, root, data);
+
+    const char *json = yyjson_mut_write(doc, 0, NULL);
+    //yyjson_doc_free(doc);
+    return $R_CONT(c$cont, to$str(json));
+}
+
+$list json$$decode_arr(yyjson_val *);
+
+$dict json$$decode_obj(yyjson_val *obj) {
+
+    $Hashable wit = ($Hashable)$Hashable$str$witness;
+    $dict res = $NEW($dict, wit, NULL, NULL);
+    yyjson_obj_iter iter;
+    yyjson_obj_iter_init(obj, &iter);
+    yyjson_val *key, *val;
+    while ((key = yyjson_obj_iter_next(&iter))) {
+        val = yyjson_obj_iter_get_val(key);
+
+        switch (yyjson_get_type(val)) {
+            case YYJSON_TYPE_NONE:;
+                break;
+            case YYJSON_TYPE_NULL:;
+                // TODO: this is broken?
+                $dict_setitem(res, wit, to$str(yyjson_get_str(key)), $None);
+                break;
+            case YYJSON_TYPE_BOOL:;
+                $dict_setitem(res, wit, to$str(yyjson_get_str(key)), to$bool(yyjson_get_bool(val)));
+                break;
+            case YYJSON_TYPE_NUM:;
+                $dict_setitem(res, wit, to$str(yyjson_get_str(key)), to$int(yyjson_get_int(val)));
+                break;
+            case YYJSON_TYPE_STR:;
+                $dict_setitem(res, wit, to$str(yyjson_get_str(key)), to$str(yyjson_get_str(val)));
+                break;
+            case YYJSON_TYPE_ARR:;
+                $list l = json$$decode_arr(val);
+                $dict_setitem(res, wit, to$str(yyjson_get_str(key)), l);
+                break;
+            case YYJSON_TYPE_OBJ:;
+                $dict d = json$$decode_obj(val);
+                $dict_setitem(res, wit, to$str(yyjson_get_str(key)), d);
+                break;
+        }
+    }
+    return res;
+}
+
+$list json$$decode_arr(yyjson_val *arr) {
+    $list res = $list$new(NULL, NULL);
+    yyjson_val *val;
+    yyjson_arr_iter iter;
+    yyjson_arr_iter_init(arr, &iter);
+    while ((val = yyjson_arr_iter_next(&iter))) {
+        switch (yyjson_get_type(val)) {
+            case YYJSON_TYPE_NONE:
+                break;
+            case YYJSON_TYPE_NULL:;
+                // TODO: this is broken?
+                $list_append(res, $None);
+                break;
+            case YYJSON_TYPE_BOOL:;
+                $list_append(res, to$bool(yyjson_get_bool(val)));
+                break;
+            case YYJSON_TYPE_NUM:;
+                $list_append(res, to$int(yyjson_get_int(val)));
+                break;
+            case YYJSON_TYPE_STR:;
+                $list_append(res, to$str(yyjson_get_str(val)));
+                break;
+            case YYJSON_TYPE_ARR:;
+                $list l = json$$decode_arr(val);
+                $list_append(res, l);
+                break;
+            case YYJSON_TYPE_OBJ:;
+                $dict d = json$$decode_obj(val);
+                $list_append(res, d);
+                break;
+        }
+    }
+    return res;
+}
+
+$R json$$Json$decode$local (json$$Json __self__, $str data, $Cont c$cont) {
+    // Read JSON and get root
+    yyjson_read_err err;
+    yyjson_doc *doc = yyjson_read_opts(from$str(data), strlen(from$str(data)), 0, NULL, &err);
+    yyjson_val *root = yyjson_doc_get_root(doc);
+
+    $dict res = $NEW($dict,($Hashable)$Hashable$str$witness,NULL,NULL);
+    // Iterate over the root object
+    if (doc) {
+        yyjson_val *obj = yyjson_doc_get_root(doc);
+        res = json$$decode_obj(obj);
+    } else {
+        char errmsg[1024];
+        snprintf(errmsg, sizeof(errmsg), "JSON parsing error: %s (%u) at position %ld", err.msg, err.code, err.pos);
+        $RAISE(($BaseException)$NEW($ValueError, to$str(errmsg)));
+    }
+
+    yyjson_doc_free(doc);
+    return $R_CONT(c$cont, res);
+}

--- a/test/stdlib_auto/test_json.act
+++ b/test/stdlib_auto/test_json.act
@@ -1,0 +1,28 @@
+
+import json
+
+actor main(env):
+    # TODO: issue report that we can't declare nested dict
+    d1 = {"b": "1", "c": 2, "d": [1, 2]}
+    l1 = [1, 2, 3]
+    test_data = [
+        {"a": True, "b": False},
+        {"a": "1", "b": 2},
+        {"a": d1},
+        {"a": [1, 2, 3]},
+        {"a": [l1, l1]},
+        {"a": [d1, d1]},
+    ]
+    for s in test_data:
+        print(s)
+        e = json.encode(s)
+        print(e)
+        d = json.decode(e)
+        print(d)
+#        if s is not None and d is not None and s != d:
+#            print("MISMATCH")
+#            await async env.exit(1)
+
+        print()
+
+    await async env.exit(0)


### PR DESCRIPTION
This adds a JSON module with encoding and decoding abilities. There's a
json.Json actor that does the actual work. I was originally going for
just having a free decode and encode function in the module but that
doesn't work (compiler bug) so had to make it look like an actor, which
does bring the benefit of allowing async work. There are free
encode/decode functions, so that you can encode or decode JSON with a
single line of code. They just wrap up the Json actor so every
invocation also means creating an instance of the Json actor. It should
really be the other way around, but we'll have to sort out the compiler
bug first.

Fixes #184.