### PR TITLE
Revamp actonc output & include timing

### DIFF
--- a/compiler/package.yaml.in
+++ b/compiler/package.yaml.in
@@ -27,6 +27,7 @@ executables:
       - base >= 4.7 && < 5
       - binary
       - bytestring
+      - clock
       - containers
       - deepseq
       - dir-traverse


### PR DESCRIPTION
actonc now outputs some information about what it is doing per default, like our default verbosity has increased. A new --quiet flag is introduced to make it quiet again. New default looks like this for stdlib:
```
  Building project in /home/kll/terastream/acton/stdlib
    Compiling time.act for release
     Finished compilation in   0.045 s
    Compiling test.act for release
     Finished compilation in   0.047 s
    Compiling random.act for release in stub mode
     Finished compilation in   0.048 s
    Compiling process.act for release
     Finished compilation in   0.116 s
    Compiling net.act for release
     Finished compilation in   0.176 s
    Compiling math.act for release in stub mode
     Finished compilation in   0.088 s
    Compiling numpy.act for release in stub mode
     Finished compilation in   0.753 s
    Compiling json.act for release
     Finished compilation in   0.109 s
    Compiling file.act for release
     Finished compilation in   0.107 s
    Compiling acton/rts.act for release in stub mode
     Finished compilation in   0.047 s
    Compiling acton/internal.act for release
     Finished compilation in   0.049 s
```
--timing is introduced for detailed timing, like so:
```
  Building project in /home/kll/terastream/acton/stdlib
  Reading file net.act:  0.001 s
  Parsing file net.act:  0.008 s
  Reading file file.act:  0.000 s
  Parsing file file.act:  0.005 s
  Reading file math.act:  0.000 s
  Parsing file math.act:  0.002 s
  Reading file numpy.act:  0.000 s
  Parsing file numpy.act:  0.002 s
  Reading file random.act:  0.000 s
  Parsing file random.act:  0.000 s
  Reading file test.act:  0.000 s
  Parsing file test.act:  0.000 s
  Reading file process.act:  0.000 s
  Parsing file process.act:  0.006 s
  Reading file json.act:  0.000 s
  Parsing file json.act:  0.001 s
  Reading file time.act:  0.000 s
  Parsing file time.act:  0.001 s
  Reading file acton/rts.act:  0.000 s
  Parsing file acton/rts.act:  0.000 s
  Reading file acton/internal.act:  0.000 s
  Parsing file acton/internal.act:  0.000 s
    Compiling time.act for release
      Pass: Make environment:  0.000 s
      Pass: Kinds check     :  0.000 s
      Pass: Type check      :  0.001 s
      Pass: Normalizer      :  0.000 s
      Pass: Deactorizer     :  0.000 s
      Pass: CPS             :  0.000 s
      Pass: Lambda Lifting  :  0.000 s
      Pass: Generating code :  0.000 s
      Pass: Writing code    :  0.000 s
      Pass: C compilation   :  0.042 s
     Finished compilation in   0.043 s
    Compiling test.act for release
      Pass: Make environment:  0.000 s
      Pass: Kinds check     :  0.000 s
      Pass: Type check      :  0.000 s
      Pass: Normalizer      :  0.000 s
      Pass: Deactorizer     :  0.000 s
      Pass: CPS             :  0.000 s
      Pass: Lambda Lifting  :  0.001 s
      Pass: Generating code :  0.000 s
      Pass: Writing code    :  0.000 s
      Pass: C compilation   :  0.044 s
     Finished compilation in   0.046 s
    Compiling random.act for release in stub mode
      Custom make           :  0.045 s
      Pass: Make environment:  0.000 s
      Pass: Kinds check     :  0.000 s
      Pass: Type check      :  0.000 s
      Pass: Normalizer      :  0.000 s
      Pass: Deactorizer     :  0.000 s
      Pass: CPS             :  0.000 s
      Pass: Lambda Lifting  :  0.000 s
      Pass: Generating code :  0.000 s
      Pass: Writing code    :  0.000 s
     Finished compilation in   0.046 s
    Compiling process.act for release
      Pass: Make environment:  0.000 s
      Pass: Kinds check     :  0.000 s
      Pass: Type check      :  0.005 s
      Pass: Normalizer      :  0.000 s
      Pass: Deactorizer     :  0.000 s
      Pass: CPS             :  0.000 s
      Pass: Lambda Lifting  :  0.006 s
      Pass: Generating code :  0.000 s
      Pass: Writing code    :  0.000 s
      Pass: C compilation   :  0.116 s
     Finished compilation in   0.127 s
  ...
```
All things that used to be conditioned on --verbose are now under --debug, leaving --verbose unused as I think --debug is a better name but I have the feeling we want different verbosity levels even for users of compiler, thus leaving --verbose in. Let's see how this develops over time...

Fixes #830.