### PR TITLE
after now takes float seconds as argument

### DIFF
--- a/compiler/Acton/Deactorizer.hs
+++ b/compiler/Acton/Deactorizer.hs
@@ -184,7 +184,7 @@ instance Deact Stmt where
     deact env (VarAssign l [p@(PVar _ n _)] e)
                                     = MutAssign l (selfRef n) <$> deactExp env t e
       where t                       = typeOf env p
-    deact env (After l e1 e2)       = do delta <- deactExp env tInt e1
+    deact env (After l e1 e2)       = do delta <- deactExp env tFloat e1
                                          lambda <- deactExp env t $ Lambda l0 PosNIL KwdNIL e2 fxAction
                                          return $ Expr l $ Call l0 (tApp (eQVar primAFTERf) [t2]) (PosArg delta $ PosArg lambda PosNil) KwdNil
       where t2                      = typeOf env e2

--- a/compiler/Acton/Prim.hs
+++ b/compiler/Acton/Prim.hs
@@ -170,9 +170,9 @@ scASYNCf            = tSchema [quant a] tASYNC
         a           = TV KType $ name "A"
         tFun'       = tFun fxAsync posNil kwdNil (tVar a)
 
---  $AFTERf         : [A] => action(int, action()->A) -> Msg[A]
+--  $AFTERf         : [A] => action(float, action()->A) -> Msg[A]
 scAFTERf            = tSchema [quant a] tAFTER
-  where tAFTER      = tFun fxAction (posRow tInt $ posRow tFun' posNil) kwdNil (tMsg $ tVar a)
+  where tAFTER      = tFun fxAction (posRow tFloat $ posRow tFun' posNil) kwdNil (tMsg $ tVar a)
         a           = TV KType $ name "A"
         tFun'       = tFun fxAction posNil kwdNil (tVar a)
 
@@ -189,9 +189,9 @@ scASYNCc            = tSchema [quant a] tASYNC
         tCont'      = tFun fxMut (posRow tCont'' posNil) kwdNil tR
         tCont''     = tFun fxMut (posRow (tVar a) posNil) kwdNil tR
 
---  $AFTERc         : [A] => mut(int, mut(mut(A)->$R)->$R) -> Msg[A]
+--  $AFTERc         : [A] => mut(float, mut(mut(A)->$R)->$R) -> Msg[A]
 scAFTERc            = tSchema [quant a] tAFTER
-  where tAFTER      = tFun fxMut (posRow tInt $ posRow tCont' posNil) kwdNil (tMsg $ tVar a)
+  where tAFTER      = tFun fxMut (posRow tFloat $ posRow tCont' posNil) kwdNil (tMsg $ tVar a)
         a           = TV KType $ name "A"
         tCont'      = tFun fxMut (posRow tCont'' posNil) kwdNil tR
         tCont''     = tFun fxMut (posRow (tVar a) posNil) kwdNil tR
@@ -210,9 +210,9 @@ scASYNC             = tSchema [quant a] tASYNC
         tCont'      = tCont fxMut tCont''
         tCont''     = tCont fxMut (tVar a)
 
---  $AFTER          : [A] => mut(int, $Cont[mut,($Cont[mut,A],)]) -> Msg[A]
+--  $AFTER          : [A] => mut(float, $Cont[mut,($Cont[mut,A],)]) -> Msg[A]
 scAFTER             = tSchema [quant a] tAFTER
-  where tAFTER      = tFun fxMut (posRow tInt $ posRow tCont' posNil) kwdNil (tMsg $ tVar a)
+  where tAFTER      = tFun fxMut (posRow tFloat $ posRow tCont' posNil) kwdNil (tMsg $ tVar a)
         a           = TV KType $ name "A"
         tCont'      = tCont fxMut tCont''
         tCont''     = tCont fxMut (tVar a)

--- a/compiler/Acton/Types.hs
+++ b/compiler/Acton/Types.hs
@@ -278,7 +278,7 @@ instance InfEnv Stmt where
                                              (cs2,e') <- inferSub env t e
                                              return (cs1++cs2, [ (n,NSVar t) | (n,NVar t) <- te], VarAssign l pats' e')
     
-    infEnv env (After l e1 e2)          = do (cs1,e1') <- inferSub env tInt e1
+    infEnv env (After l e1 e2)          = do (cs1,e1') <- inferSub env tFloat e1
                                              (cs2,t,e2') <- infer env e2
                                              fx <- currFX
                                              return (Cast fxAction fx :

--- a/rts/rts.c
+++ b/rts/rts.c
@@ -815,7 +815,7 @@ $Msg $ASYNC($Actor to, $Cont cont) {
     return m;
 }
 
-$Msg $AFTER($int sec, $Cont cont) {
+$Msg $AFTER($float sec, $Cont cont) {
     $Actor self = ($Actor)pthread_getspecific(self_key);
     rtsd_printf("# AFTER by %ld", self->$globkey);
     time_t baseline = self->$msg->$baseline + sec->val * 1000000;

--- a/rts/rts.h
+++ b/rts/rts.h
@@ -170,7 +170,7 @@ struct $ConstCont {
 $Cont $CONSTCONT($WORD, $Cont);
 
 $Msg $ASYNC($Actor, $Cont);
-$Msg $AFTER($int, $Cont);
+$Msg $AFTER($float, $Cont);
 $R $AWAIT($Msg, $Cont);
 
 void init_db_queue(long);

--- a/test/regression_auto/11-int-float__bf.act
+++ b/test/regression_auto/11-int-float__bf.act
@@ -1,9 +1,0 @@
-# https://github.com/actonlang/acton/issues/11
-actor main(env):
-    var foo = 1
-    var bar = foo * 0.5
-
-    def finish():
-        env.exit(0)
-
-    after foo: finish()


### PR DESCRIPTION
The after statement has thus far taken an integer argument for the number of seconds after which to run a method. It is now changed to a float so we can do sub-second delays.

Fixes #9.