### PR TITLE
Make DB test retry actually work

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -1,5 +1,5 @@
 MK_PATH:=$(shell dirname $(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
-ACTONC=$(MK_PATH)/dist/bin/actonc
+ACTONC=$(MK_PATH)/dist/bin/actonc --quiet
 DDB_SERVER=../dist/bin/actondb
 TESTS= \
 	$(DDB_TESTS)


### PR DESCRIPTION
While we did retry the test function we have basic state in our environment that is automatically set up in the setUp function and later torn down in tearDown(). The retry wrapper wouldn't rerun those methods.

Instead, the test is refactored slightly and we explicitly call dbc_restart() from the test function to ensure the DB cluster is up and running in a fresh state.

Fixes #853