### PR TITLE
Include and use runacton in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -171,17 +171,17 @@ jobs:
           name: acton-macos-11
       - name: "Extract acton"
         run: |
-          ls
           tar jxvf $(ls acton-darwin*.tar.bz2 | tail -n1)
       - name: "Compile acton program"
         run: |
-          echo 'actor main(env):'          > test-runtime.act
+          echo '#!/usr/bin/env runacton'   > test-runtime.act
+          echo 'actor main(env):'          >> test-runtime.act
           echo '    print("Hello, world")' >> test-runtime.act
           echo '    env.exit(0)'           >> test-runtime.act
-          ls
-          acton/bin/actonc --root main test-runtime.act
-          ./test-runtime
-          ./test-runtime | grep "Hello, world"
+          chmod a+x test-runtime.act
+          export PATH=$(pwd)/acton/bin:$PATH
+          ./test-runtime.act
+          ./test-runtime.act | grep "Hello, world"
 
   run-linux:
     needs: build-debs
@@ -213,13 +213,13 @@ jobs:
           actonc --version
       - name: "Compile acton program"
         run: |
-          echo 'actor main(env):'          > test-runtime.act
+          echo '#!/usr/bin/env runacton'   > test-runtime.act
+          echo 'actor main(env):'          >> test-runtime.act
           echo '    print("Hello, world")' >> test-runtime.act
           echo '    env.exit(0)'           >> test-runtime.act
-          ls
-          actonc --root main test-runtime.act
-          ./test-runtime
-          ./test-runtime | grep "Hello, world"
+          chmod a+x test-runtime.act
+          ./test-runtime.act
+          ./test-runtime.act | grep "Hello, world"
 
 
   update-apt-repo:

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ ifeq ($(shell uname -s),Linux)
 ARCHIVES+=lib/libbsd_a.a lib/libmd_a.a
 endif
 
-DIST_BINS=$(ACTONC) dist/bin/actondb
+DIST_BINS=$(ACTONC) dist/bin/actondb dist/bin/runacton
 DIST_HFILES=\
 	dist/rts/io.h \
 	dist/rts/rts.h \
@@ -421,6 +421,12 @@ dist/bin/actondb: backend/actondb
 	cp $< $@.tmp
 	mv $@.tmp $@
 
+dist/bin/runacton: bin/runacton
+	@mkdir -p $(dir $@)
+	cp $< $@.tmp
+	mv $@.tmp $@
+
+
 dist/builtin/%: builtin/%
 	@mkdir -p $(dir $@)
 	cp $< $@
@@ -468,6 +474,7 @@ install:
 	cp -a dist/. $(DESTDIR)/usr/lib/acton/
 	cd $(DESTDIR)/usr/bin && ln -s ../lib/acton/bin/actonc
 	cd $(DESTDIR)/usr/bin && ln -s ../lib/acton/bin/actondb
+	cd $(DESTDIR)/usr/bin && ln -s ../lib/acton/bin/runacton
 
 .PHONY: debian/changelog
 debian/changelog: debian/changelog.in CHANGELOG.md


### PR DESCRIPTION
Forgot to actually include runacton into our distribution. That's fixed now and in order to properly test that, we now use it in both the run-linux and run-macos tests!

On mac we need to modify the PATH since we don't actually install acton on the system but just extract it in a directory in our home dir. It would be preferable if we actually did a brew install or somesuch so that acton would be installed in the system...

Fixes #861.