### PR TITLE
Use apt install rather than dpkg -i

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -207,9 +207,8 @@ jobs:
           name: acton-debs
       - name: "Install acton from .deb"
         run: |
-          apt-get update
-          dpkg -i deb/acton_*.deb || true
-          apt-get -fy install
+          apt update
+          apt install -y ./deb/acton_*.deb
           actonc --version
       - name: "Compile acton program"
         run: |


### PR DESCRIPTION
dpkg -i doesn't install dependencies so we have to accept a failure and run apt-get -f install to resolve and install those dependencies for us.

apt install does it all in one operation and is available since around the time of Ubuntu 16.04, i.e. available "everywhere".

Fixes #865.