### PR TITLE
Uniformly use 'macos' in CI test job names

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ on:
 # a better way to match?
 
 jobs:
-  test-darwin:
+  test-macos:
     strategy:
       fail-fast: false
       matrix:
@@ -158,7 +158,7 @@ jobs:
 
 
   run-macos:
-    needs: test-darwin
+    needs: test-macos
     strategy:
       fail-fast: false
       matrix:
@@ -227,7 +227,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: debian:bullseye
-    needs: [test-darwin, test-linux, build-debs]
+    needs: [test-macos, test-linux, build-debs]
     steps:
       - name: Install build prerequisites
         run: |
@@ -273,7 +273,7 @@ jobs:
     # Only run on the main branch
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    needs: [test-darwin, test-linux, build-debs]
+    needs: [test-macos, test-linux, build-debs]
     steps:
       - name: "Delete current tip release & tag"
         uses: dev-drprasad/delete-tag-and-release@v0.2.0
@@ -339,7 +339,7 @@ jobs:
   release:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
-    needs: [test-darwin, test-linux, build-debs]
+    needs: [test-macos, test-linux, build-debs]
     steps:
       - name: "Check out repository code"
         uses: actions/checkout@v2
@@ -375,7 +375,7 @@ jobs:
   update-homebrew:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
-    needs: [test-darwin, test-linux, build-debs]
+    needs: [test-macos, test-linux, build-debs]
     steps:
       - name: "Get the version"
         id: get_version


### PR DESCRIPTION
We had a mix of macos & darwin. It's now more uniform.

'darwin' comes from the architecture, i.e. uname reports itself as darwin so that is what our package names are called but still, it's easier to understand what it is if we refer to it as macos in most places I think...

Fixes #864.