### PR TITLE
Add auto-release CI job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  if_merged:
+    if: ${{ startsWith(github.head_ref, 'release-') && github.event.pull_request.merged == true }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo The PR was merged
+      - name: "Check out repository code"
+        uses: actions/checkout@v2
+      - name: "Get the version"
+        id: get_version
+        run: echo ::set-output name=version::$(grep VERSION= common.mk | cut -d = -f 2)
+      - name: "Add version tag and push"
+        run: |
+          git tag v${{steps.get_version.outputs.version}}
+          git push origin v${{steps.get_version.outputs.version}}


### PR DESCRIPTION
Releasing thus far has consisted of:
- updating the VERSION variable common.mk
- updating CHANGELOG.md
- pushing a tag

It's slightly annoying because the first two means changing files, opening PR and merging and then git pulling main, add a tag and push the tag. It's a lot back and forth.

We now automate the last bit of pushing a tag by having a new CI job doing it for us.

New process is thus:
- updating the VERSION variable common.mk
- updating CHANGELOG.md
- open PR with name starting with release-
  - when PR is merged, tag based on VERSION in common.mk will automatically be pushed to main branch