### PR TITLE
Use deploy key for pushing tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,17 +5,22 @@ on:
 
 jobs:
   if_merged:
-    if: ${{ startsWith(github.head_ref, 'release-') && github.event.pull_request.merged == true }}
+    # name should be e.g. release-v1.2.3
+    if: ${{ startsWith(github.head_ref, 'release-v') && github.event.pull_request.merged == true }}
     runs-on: ubuntu-latest
     steps:
       - run: |
           echo The PR was merged
       - name: "Check out repository code"
         uses: actions/checkout@v2
+        with:
+          ssh-key: ${{ secrets.ACTONBOT_DEPLOY_KEY }}
       - name: "Get the version"
         id: get_version
         run: echo ::set-output name=version::$(grep VERSION= common.mk | cut -d = -f 2)
       - name: "Add version tag and push"
         run: |
+          git config user.name "Apt Bot"
+          git config user.email apt@acton-lang.org
           git tag v${{steps.get_version.outputs.version}}
           git push origin v${{steps.get_version.outputs.version}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ release! ;)
   - No longer have to manually re-run CI jobs on failures
   - Retry just the DB test itself, which takes a few seconds instead of
     rerunning entire CI job which takes minutes
+- New automatic release process
+  - Removes adding git tag as manual step
+  - Now push branch `release-vX.Y.Z` updating `common.mk` & version in
+    `CHANGELOG.md`, once this PR is merged, a new workflow adds the git tag
+    which in turn triggers the release build
 
 
 ## [0.11.1] (2022-09-14)


### PR DESCRIPTION
The push used the defaults credentials provided when checking out the repository, which equates to github.token. For some reason, perhaps to avoid cyclic errors, the CI runner is not supposed to trigger itself and so using github.token for auth will not trigger any workflows. By switching to our own SSH deploy key for checking and pushing the repo we can trigger workflows!

Fixes #877