### PR TITLE
Suppress git error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 include common.mk
 CHANGELOG_VERSION=$(shell grep '^\#\# \[[0-9]' CHANGELOG.md | sed 's/\#\# \[\([^]]\{1,\}\)].*/\1/' | head -n1)
-GIT_VERSION_TAG=$(shell git tag --points-at HEAD | sed -e 's/^v//')
+GIT_VERSION_TAG=$(shell git tag --points-at HEAD 2>/dev/null | sed -e 's/^v//')
 
 PKGCONFIG=$(shell which pkg-config)
 ifeq ($(PKGCONFIG),)


### PR DESCRIPTION
Sometimes, like when this repo is downloaded as a tar ball, we are not in a git repo and so we get an error from running git. We suppress that since it's pointless and doesn't have a negative effect.