### PR TITLE
Add homebrew on include path

### DIFF
--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -659,6 +659,9 @@ runRestPasses args paths env0 parsed stubMode = do
                               ccCmd = ("cc -Werror=return-type " ++ pedantArg ++
                                        (if (dev args) then " -g " else "") ++
                                        " -c " ++
+                                       " -I/opt/homebrew/include" ++
+                                       " -I/usr/local/include" ++
+                                       " -I/usr/include" ++
                                        " -I" ++ wd ++
                                        " -I" ++ wd ++ "/out" ++
                                        " -I" ++ sysPath paths ++


### PR DESCRIPTION
Homebrew on x86 places headers in /usr/local/include whereas on M1 it is placed in /opt/homebrew/include. gcc / clang includes /usr/local/include per default but for M1 we must explicitly add the include path.

We now also explicitly list the standard include paths so we can work with compilers, like zig, that do not seem to have any default include paths?