### PR TITLE
Also find .ty files in stdlib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Fixed
+- Add /opt/homebrew/include to header include path [#892]
+  - Actually fixes builds on M1!
+  - This has "worked" because the only M2 where Acton was tested also had header
+    files in /usr/local/include but on a fresh install it errored out.
+- Fix up-to-date check in compiler for imported modules from stdlib [#890]
+
 
 ## [0.11.6] (2022-09-20)
 


### PR DESCRIPTION
The checkUptoDate function has only considered imported modules that are in the local project. If we import a module from the standard library, it has errored out as it cannot find the .ty file.

We now look both in the local project and stdlib to find the .ty file.

Fixes #890.