### PR TITLE
fixes issue 869

### DIFF
--- a/builtin/tuple.h
+++ b/builtin/tuple.h
@@ -21,7 +21,12 @@ $tuple $tuple$new(int,...);
 
 #define $NEWTUPLE($len, ...)  ({ $tuple $t = malloc(sizeof(struct $tuple)+$len*sizeof($WORD)); \
                                  $t->$class = &$tuple$methods; \
-                                 $t->$class->__init__($t, $len, ##__VA_ARGS__); \
+                                 $t->$class->__init__($t, $len, __VA_ARGS__); \
+                                 $t; })
+
+#define $NEWTUPLE0  ({ $tuple $t = malloc(sizeof(struct $tuple)); \
+                                 $t->$class = &$tuple$methods; \
+                                 $t->$class->__init__($t); \
                                  $t; })
 
 extern struct $Iterable$tuple$class $Iterable$tuple$methods;

--- a/compiler/Acton/CodeGen.hs
+++ b/compiler/Acton/CodeGen.hs
@@ -225,6 +225,7 @@ primStepSerialize                   = gPrim "step_serialize"
 primStepDeserialize                 = gPrim "step_deserialize"
 primDNEW                            = gPrim "DNEW"
 primNEWTUPLE                        = gPrim "NEWTUPLE"
+primNEWTUPLE0                       = gPrim "NEWTUPLE0"
 
 
 -- Implementation -----------------------------------------------------------------------------------
@@ -657,7 +658,10 @@ instance Gen Expr where
     gen env (Dot _ e n)             = genDot env [] e n
     gen env (DotI _ e i)            = gen env e <> text "->" <> gen env componentsKW <> brackets (pretty i)
     gen env (RestI _ e i)           = gen env eNone <> semi <+> text "// CodeGen for tuple tail not implemented"
-    gen env (Tuple _ p KwdNil)      = gen env primNEWTUPLE <> parens (text (show $ nargs p) <> comma' (gen env p))
+    gen env (Tuple _ p KwdNil)      
+       | n == 0                    = gen env primNEWTUPLE0
+       | otherwise                 = gen env primNEWTUPLE <> parens (text (show n) <> comma' (gen env p))
+       where n                     = nargs p
     gen env (List _ es)
       | null es                     = newcon' env n <> parens (text "NULL" <> comma <+> text "NULL")
       | otherwise                   = parens (lbrace <+> (


### PR DESCRIPTION
The bug is caused by a dark corner in C macro expansion.  The macro $NEWTUPLE in tuple.h uses the tuple pasting operator ## in order to avoid a spurious "," in the call of __init__ for an empty tuple. This is a gcc extension which does not work for nested macro calls.

Fixed by introducing a special macro $NEWTUPLE0 for empty tuples and removing the ## operator in $NEWTUPLE.

Probably one should think through other macros in common.h which also use ## and would fail on nested calls.