### PR TITLE
Avoid crash during TCP client resume test

### DIFF
--- a/test/test_db.py
+++ b/test/test_db.py
@@ -465,7 +465,7 @@ class TestDbApps(unittest.TestCase):
                "--rts-ddb-replication", str(self.replication_factor)
                ] + get_db_args(self.dbc.port_chunk, self.replication_factor)
         self.p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        time.sleep(0.1)
+        time.sleep(0.5)
         self.p.terminate()
 
         tcp_cmd(self.p2, app_port, "INC")


### PR DESCRIPTION
On my AMD 5950X machine I'm rather consistently seeing this test fail. We stop the first invocation and by altering the timing of when we stop it, starting the program a second time might lead to a crash. 0.1 seconds fairly consistently leads to crashes on my machine. By bumping our 0.1 second sleep to 0.2 avoids the crash. Lowering it to 0.01 also avoids the crash. Thus, there is some time window during which we are doing something important, that if interrupted will lead to crashes the next time we try to resume the program from DB.

It's likely my machine is faster than CI, so in order to have a better chance of steering clear of the "bad time window" we're now sleeping for 0.5 seconds.

We should naturally get to the bottom of this but meanwhile it's pretty annoying not being able to run tests...