### PR TITLE
Change actondb default gossip port

### DIFF
--- a/backend/actondb.c
+++ b/backend/actondb.c
@@ -83,7 +83,7 @@ void error(char *msg) {
 #define SERVER_VERBOSITY 1
 
 #define DEFAULT_DATA_PORT 32000
-#define DEFAULT_GOSSIP_PORT 34000
+#define DEFAULT_GOSSIP_PORT 32001
 
 #define RANDOM_NONCES
 int64_t requests = 0;


### PR DESCRIPTION
I think it's a short-coming in the gossip protocol so we only gossip one of the ports, the normal port that clients connect to, so to find the gossip port we just take that port + 1. Thus, users are not really free to set the gossip port however they want. Maybe it shouldn't even be configurable given this constraint... however, changing the default port is at least a simple way of leading users to the right thing.