### PR TITLE
Properly initialize WT state

### DIFF
--- a/rts/rts.c
+++ b/rts/rts.c
@@ -1286,6 +1286,11 @@ void arm_timer_ev() {
         }
     } else {
         int r = uv_timer_stop(timer_ev);
+        if (r != 0) {
+            char errmsg[1024] = "Unable to stop timer: ";
+            uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
+            log_fatal(errmsg);
+        }
     }
 }
 
@@ -1474,6 +1479,7 @@ void *main_loop(void *idx) {
     uv_check_init(uv_loop, &work_ev[wtid]);
     uv_check_start(&work_ev[wtid], (uv_check_cb)wt_work_cb);
 
+    wt_stats[wtid].state = WT_Idle;
     int r = uv_run(uv_loop, UV_RUN_DEFAULT);
     wt_stats[wtid].state = WT_NoExist;
     rtsd_printf("Exiting...");


### PR DESCRIPTION
When the worker threads are created they are first in a no-exist / poof state and once they're initialized in the main_loop function they should be marked as Idle. They were not, which lead to problems as the wake_wt function specifically looks for worker threads in the idle state to wake up. Since it was in poof state, it would not be woken up. Now fixed!

Fixes #907.