### PR TITLE
Only communicate with live nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,14 @@
     WTs will stay in the `NoExist` state and then `wake_wt` will do nothing, so
     the system is blocked.
   - WT now properly transition into `Idle`.
+- Only communicate with live DB nodes from RTS DB client [#910] [#916]
+  - When the RTS communicates with the DB nodes, we've broadcast messages to all
+    servers we know about. If they are down, they've had their socket fd set to
+    0 to signal that the server is down. However, fd=0 is not invalid, it is
+    stdin, so we ended up sending data to stdin creating lots of garbage output
+    on the terminal.
+  - fd -1 is used to signal an invalid fd, which prevents similar mistakes.
+  - The DB node status is inspected and messages are only sent to live servers.
 
 
 ## [0.11.6] (2022-09-20)

--- a/backend/actondb.c
+++ b/backend/actondb.c
@@ -1631,8 +1631,8 @@ int merge_membership_agreement_msg_to_list(membership_agreement_msg * ma, skipli
 
 			if(status != 0)
 			{
-				rs->sockfd = 0;
 				rs->status = NODE_DEAD;
+				rs->sockfd = -1;
 				if(nd.status == NODE_LIVE)
 					memberships_differ = 1;
 			}
@@ -1714,8 +1714,8 @@ int merge_membership_agreement_msg_to_client_list(membership_agreement_msg * ma,
 
 				if(status != 0)
 				{
-					rs->sockfd = 0;
 					rs->status = NODE_DEAD;
+					rs->sockfd = -1;
 					if(nd.status == NODE_LIVE)
 						memberships_differ = 1;
 				}
@@ -1913,8 +1913,8 @@ int install_agreed_view(membership_agreement_msg * ma, membership * m, vector_cl
 
 			if(status != 0)
 			{
-				rs->sockfd = 0;
 				rs->status = NODE_DEAD;
+				rs->sockfd = -1;
 				local_view_disagrees = 1;
 			}
 

--- a/backend/actondb.c
+++ b/backend/actondb.c
@@ -961,9 +961,9 @@ int handle_socket_close(int * childfd, int * status)
 	log_info("Host disconnected, ip %s, port %d, old_status=%d, closing fd %d" ,
 			  inet_ntoa(address.sin_addr) , ntohs(address.sin_port), *status, *childfd);
 
-	//Close the socket and mark as 0 for reuse:
+	//Close the socket and mark as -1 for reuse:
 	close(*childfd);
-	*childfd = 0;
+	*childfd = -1;
 
 	*status = NODE_DEAD;
 

--- a/backend/client_api.c
+++ b/backend/client_api.c
@@ -1129,11 +1129,7 @@ void error(char *msg) {
 
 int send_packet(void * buf, unsigned len, int sockfd)
 {
-	if(sockfd == 0)
-	{
-		log_error("ERROR: Attempted to write packet to fd 0!");
-		return -1;
-	}
+	assert(sockfd > 0);
     int n = write(sockfd, buf, len);
     if (n < 0)
     {

--- a/backend/client_api.c
+++ b/backend/client_api.c
@@ -1215,6 +1215,8 @@ int send_packet_wait_replies_async(void * out_buf, unsigned out_len, int64_t non
 	for(snode_t * server_node = HEAD(db->servers); server_node!=NULL; server_node=NEXT(server_node))
 	{
 		remote_server * rs = (remote_server *) server_node->value;
+		if (rs->status != NODE_LIVE)
+			continue;
 #if SYNC_SOCKET > 0
 		pthread_mutex_lock(rs->sockfd_lock);
 #endif

--- a/backend/comm.c
+++ b/backend/comm.c
@@ -506,9 +506,7 @@ remote_server * get_remote_server(char *hostname, unsigned short portno,
 
         if(do_connect)
         {
-            rs->status = NODE_LIVE;
-
-        		rs->sockfd = socket(AF_INET, SOCK_STREAM, 0);
+			rs->sockfd = socket(AF_INET, SOCK_STREAM, 0);
 			if (rs->sockfd < 0)
 			{
 				fprintf(stderr, "ERROR opening socket!\n");
@@ -523,11 +521,12 @@ remote_server * get_remote_server(char *hostname, unsigned short portno,
         			if(connect_success != 0)
         				sleep(1);
         		}
-			if(connect_success != 0)
-			{
+			if (connect_success == 0) {
+				rs->status = NODE_LIVE;
+			} else {
 				fprintf(stderr, "get_remote_server: ERROR connecting to %s:%d\n", hostname, portno);
 				rs->status = NODE_DEAD;
-				rs->sockfd = 0;
+				rs->sockfd = -1;
 			}
         }
     }
@@ -582,7 +581,7 @@ int update_listen_socket(remote_server * rs, char *hostname, unsigned short port
 		{
 			fprintf(stderr, "update_listen_socket: ERROR connecting to %s:%d\n", hostname, portno);
 			rs->status = NODE_DEAD;
-			rs->sockfd = 0;
+			rs->sockfd = -1;
 		}
 		else
 		{
@@ -629,7 +628,7 @@ int connect_remote_server(remote_server * rs)
 	{
 		fprintf(stderr, "connect_remote_server: ERROR connecting to %s:%d\n", rs->hostname, rs->portno);
 		rs->status = NODE_DEAD;
-		rs->sockfd = 0;
+		rs->sockfd = -1;
 	}
 
 	return connect_success;

--- a/backend/comm.c
+++ b/backend/comm.c
@@ -506,7 +506,9 @@ remote_server * get_remote_server(char *hostname, unsigned short portno,
 
         if(do_connect)
         {
-			rs->sockfd = socket(AF_INET, SOCK_STREAM, 0);
+			rs->status = NODE_LIVE;
+
+        		rs->sockfd = socket(AF_INET, SOCK_STREAM, 0);
 			if (rs->sockfd < 0)
 			{
 				fprintf(stderr, "ERROR opening socket!\n");
@@ -521,9 +523,8 @@ remote_server * get_remote_server(char *hostname, unsigned short portno,
         			if(connect_success != 0)
         				sleep(1);
         		}
-			if (connect_success == 0) {
-				rs->status = NODE_LIVE;
-			} else {
+			if (connect_success != 0)
+			{
 				fprintf(stderr, "get_remote_server: ERROR connecting to %s:%d\n", hostname, portno);
 				rs->status = NODE_DEAD;
 				rs->sockfd = -1;


### PR DESCRIPTION
The DB client interaction functions have unconditionally tried to communicate with all remote servers in our list. If a server is dead, it's socket is invalid and trying to communicate with it doesn't make any sense. We now only communicate with servers that we think are live.

This has been a long running issue and a rather annoying one where we've seen lots of garbage written to the screen when RTS fails to connect to a DB server. It happened because the sockfd gets rewritten to 0, which is stdin, and then the message meant for a DB server is written to our terminal. It's a binary protocol so it looks like a bunch of garble garble.

Now also using -1 for sockfd so we get an error if we try to write to it and tightened up so we only set NODE_LIVE after connection is successful.

Same changes also goes for the actondb server which has had similar problems with garbage output in the past.

Fixes #910.

Fixes #402.