### PR TITLE
Invalidate fds on resume

### DIFF
--- a/stdlib/src/net.act
+++ b/stdlib/src/net.act
@@ -78,6 +78,9 @@ actor TCPListenConnection(auth: _TCPListenConnectAuth, client: int, on_receive: 
         """Write data to remote"""
         NotImplemented
 
+    def __resume__() -> None:
+        NotImplemented
+
     def _force_persistance():
         """Trick compiler into persisting the actor arguments we need.
 

--- a/stdlib/src/net.ext.c
+++ b/stdlib/src/net.ext.c
@@ -211,6 +211,7 @@ $R net$$TCPIPConnection$write$local (net$$TCPIPConnection __self__, $bytes data,
 }
 
 $NoneType net$$TCPIPConnection$__resume__ (net$$TCPIPConnection __self__) {
+    __self__->_socket = to$int(-1);
     $function2 f = __self__->on_error;
     f->$class->__call__(f, __self__, to$str("resume"));
     return $None;
@@ -292,6 +293,7 @@ $R net$$TCPListener$_init (net$$TCPListener __self__, $Cont c$cont) {
 }
 
 $NoneType net$$TCPListener$__resume__ (net$$TCPListener __self__) {
+    __self__->_stream = to$int(-1);
     $function2 f = __self__->on_listen_error;
     f->$class->__call__(f, __self__, to$str("resume"));
     return $None;
@@ -343,4 +345,9 @@ $R net$$TCPListenConnection$write$local (net$$TCPListenConnection __self__, $byt
         f->$class->__call__(f, __self__, to$str(errmsg));
     }
     return $R_CONT(c$cont, $None);
+}
+
+$NoneType net$$TCPListenConnection$__resume__ (net$$TCPListenConnection __self__) {
+    __self__->client = to$int(-1);
+    return $None;
 }


### PR DESCRIPTION
After we resume a TCP actor, its fd is invalid. While we do already call the registered error callback to notify the user application and let them deal with it (reconnecting), there are probably cases where a method is already scheduled to run and it will attempt to use the invalid fd. By setting it to an invalid fd, -1, we should see errors reported (provided that all our calls to uv_write and similar are correctly error handled) instead of segfaults.

Part of #908.