### PR TITLE
In client API, reconnect to servers that came back alive when installing new gossip views

### DIFF
--- a/backend/client_api.h
+++ b/backend/client_api.h
@@ -182,7 +182,7 @@ typedef struct gossip_callback
 
 remote_db_t * get_remote_db(int replication_factor, int rack_id, int dc_id, char * hostname, unsigned short local_rts_id,
 							int no_seeds, char ** seed_hosts, int * seed_ports, unsigned int * seedptr);
-int add_server_to_membership(char *hostname, int portno, remote_db_t * db, unsigned int * seedptr);
+int add_server_to_membership(char *hostname, int portno, int status, remote_db_t * db, unsigned int * seedptr);
 msg_callback * add_msg_callback(int64_t nonce, void (*callback)(void *), remote_db_t * db);
 int delete_msg_callback(int64_t nonce, remote_db_t * db);
 int wait_on_msg_callback(msg_callback * mc, remote_db_t * db);

--- a/backend/comm.c
+++ b/backend/comm.c
@@ -478,10 +478,11 @@ remote_server * get_remote_server(char *hostname, unsigned short portno,
 {
 	remote_server * rs = (remote_server *) malloc(sizeof(remote_server));
     bzero(rs, sizeof(remote_server));
-    rs->status = NODE_UNKNOWN;
+    rs->status = NODE_DEAD;
+    assert(serverfd != NULL_FD);
     memcpy(&(rs->client_socket_addr), &client_socket_addr, sizeof(struct sockaddr_in));
 
-    if(serverfd > 0 || serverfd == -1) // For own node (-1), use provided serveraddr
+    if(serverfd > 0 || serverfd == OWN_FD) // For own node, use provided serveraddr and mark as live
     {
     		memcpy(&(rs->serveraddr), &serveraddr, sizeof(struct sockaddr_in));
     		rs->sockfd = serverfd;

--- a/backend/comm.h
+++ b/backend/comm.h
@@ -26,8 +26,12 @@
 
 #define NODE_LIVE 0
 #define NODE_DEAD 1
-#define NODE_UNKNOWN 2
-#define NODE_PREJOINED 3
+#define NODE_PREJOINED 2
+
+#define NULL_FD -1
+#define OWN_FD -2
+#define DUMMY_FD -3
+
 static const char *RS_status_name[] = {"live", "dead", "unknown", "prejoined"};
 
 // Comm loop fctns:


### PR DESCRIPTION

In client API, reconnect to servers that came back alive once we learn they are back from gossip, to get a fresh sock fd. This was happening on the server side (via update_listen_socket()), but not on the client side.
Remove NODE_UNKNOWN gossip status.
Typedef special socket fd values that we use throughout code (NULL_FD, OWN_FD etc)