### PR TITLE
Only check for fd == 0

### DIFF
--- a/backend/client_api.c
+++ b/backend/client_api.c
@@ -1129,7 +1129,7 @@ void error(char *msg) {
 
 int send_packet(void * buf, unsigned len, int sockfd)
 {
-	assert(sockfd > 0);
+	assert(sockfd != 0);
     int n = write(sockfd, buf, len);
     if (n < 0)
     {


### PR DESCRIPTION
We might actually end up with invalid fds, like -1, since we don't mutex protect everything.. and that should be fine, so changing the assert accordingly.

Initially, 0 was used as an error signal. That was wrong since 0 is actually a valid fd and when we meant to signal "invalid fd" we just ended up writing data to stdin which in turned led to garbage output on terminals... anyhow, we changed the "invalid fd" to use -1, so this assert is really just to check that we haven't forgotten anywhere.

Part of #923.