### PR TITLE
Remove new lines from DB log messages

### DIFF
--- a/backend/actondb.c
+++ b/backend/actondb.c
@@ -329,7 +329,7 @@ int get_gossip_ack_packet(int status, gossip_listen_message * q,
 #if (VERBOSE_RPC > 0)
 	char print_buff[1024];
 	to_string_ack_message(ack, (char *) print_buff);
-	log_debug("Sending ack message: %s\n", print_buff);
+	log_debug("Sending ack message: %s", print_buff);
 #endif
 
 	int ret = serialize_ack_message(ack, snd_buf, snd_msg_len, vc);
@@ -1531,7 +1531,7 @@ int propose_local_membership(membership * m, vector_clock * my_vc, membership_ag
     if(is_min_live_node(m->my_id, m->local_peers) != 1)
     {
 #if (VERBOSE_RPC > 0)
-		log_debug("SERVER: Skipping proposing new view, as I am not the min live node!\n");
+		log_debug("SERVER: Skipping proposing new view, as I am not the min live node!");
 #endif
 		skip_proposal = 1;
     }
@@ -2953,7 +2953,7 @@ int main(int argc, char **argv) {
 			if(rs->status == NODE_PREJOINED && rs->sockfd > 0 && FD_ISSET(rs->sockfd , &readfds))
 			// Received a msg from this server:
 			{
-                log_trace("pre-joined peer %s, sockfd=%d, status=%d is ready for reading\n", rs->id, rs->sockfd, rs->status);
+                log_trace("pre-joined peer %s, sockfd=%d, status=%d is ready for reading", rs->id, rs->sockfd, rs->status);
 
 				ret = read_full_packet(&(rs->sockfd), (char *) in_buf, SERVER_BUFSIZE, &msg_len, &(rs->status), &handle_socket_nop);
 

--- a/backend/client_api.c
+++ b/backend/client_api.c
@@ -195,7 +195,7 @@ int install_gossiped_view(membership_agreement_msg * ma, remote_db_t * db, unsig
 	if(compare_vc(db->current_view_id, ma->vc) > 0)
 	{
 #if (VERBOSE_RPC > -1)
-		log_debug("CLIENT: Skipping installing notified view %s because it is older than my installed view %s!\n",
+		log_debug("CLIENT: Skipping installing notified view %s because it is older than my installed view %s!",
 							to_string_vc(ma->vc, msg_buf), to_string_vc(db->current_view_id, msg_buf));
 #endif
 
@@ -219,7 +219,7 @@ int install_gossiped_view(membership_agreement_msg * ma, remote_db_t * db, unsig
 			if(nd.status != NODE_LIVE)
 			{
 #if (VERBOSE_RPC > -1)
-				log_debug("CLIENT: Skipping installing notified view %s because it transiently marks local RTS as dead.\n",
+				log_debug("CLIENT: Skipping installing notified view %s because it transiently marks local RTS as dead.",
 							to_string_vc(ma->vc, msg_buf));
 #endif
 
@@ -233,7 +233,7 @@ int install_gossiped_view(membership_agreement_msg * ma, remote_db_t * db, unsig
 	if(found_local == 0)
 	{
 #if (VERBOSE_RPC > -1)
-		log_debug("CLIENT: Skipping installing notified view %s because it transiently lacks knowledge of local RTS.\n",
+		log_debug("CLIENT: Skipping installing notified view %s because it transiently lacks knowledge of local RTS.",
 							to_string_vc(ma->vc, msg_buf));
 #endif
 
@@ -266,10 +266,10 @@ int install_gossiped_view(membership_agreement_msg * ma, remote_db_t * db, unsig
 	pthread_mutex_unlock(db->gossip_lock);
 
 #if (VERBOSE_RPC > -1)
-	log_debug("CLIENT: Installed new agreed view %s\n", to_string_membership_agreement_msg(ma, msg_buf));
+	log_debug("CLIENT: Installed new agreed view %s", to_string_membership_agreement_msg(ma, msg_buf));
 #endif
 
-    log_debug("CLIENT: RTS membership: %s\n", to_string_rts_membership(db, msg_buf));
+    log_debug("CLIENT: RTS membership: %s", to_string_rts_membership(db, msg_buf));
 
 	return 0;
 }
@@ -511,7 +511,7 @@ int add_server_to_membership(char *hostname, int portno, int status, remote_db_t
 
     if(rs == NULL)
     {
-		log_error("ERROR: Failed joining server %s:%d (DNS/network problem?)!\n", hostname, portno);
+		log_error("ERROR: Failed joining server %s:%d (DNS/network problem?)!", hostname, portno);
     		return 1;
     }
 
@@ -519,12 +519,12 @@ int add_server_to_membership(char *hostname, int portno, int status, remote_db_t
 
     if(prev_entry != NULL)
     {
-    		log_info("Server address %s:%d was already added to membership!\n", hostname, portno);
+		log_info("Server address %s:%d already in membership!", hostname, portno);
 		remote_server * prev_rems = (remote_server *) prev_entry->value;
 		if(rs->status == NODE_LIVE && (prev_rems->status == NODE_DEAD || prev_rems->sockfd <= 0))
 		{
 			// Delete previous entry, reconnect to node and update socket descriptor if we've been disconnected in the mean time:
-			log_info("Reconnecting to server %s:%d\n", hostname, portno);
+			log_info("Reconnecting to server %s:%d", hostname, portno);
 			skiplist_delete(db->servers, &rs->serveraddr);
 		}
 		else
@@ -541,14 +541,14 @@ int add_server_to_membership(char *hostname, int portno, int status, remote_db_t
 
     if((skiplist_insert(db->servers, &rs->serveraddr, rs, seedptr)) != 0)
     {
-    		log_error("ERROR: Error adding server address %s:%d to membership!\n", hostname, portno);
+    		log_error("ERROR: Error adding server address %s:%d to membership!", hostname, portno);
 		free_remote_server(rs);
 		return -2;
     }
 
     if(rs->status == NODE_DEAD)
     {
-    		log_error("ERROR: Failed joining server %s:%d (it looks down)!\n", hostname, portno);
+    		log_error("ERROR: Failed joining server %s:%d (it looks down)!", hostname, portno);
     		return 1;
     }
 	comm_wake_up(db);
@@ -601,7 +601,7 @@ int add_rts_to_membership(int rack_id, int dc_id, char *hostname, int local_rts_
 	snode_t * prev_entry = skiplist_search(rtss, &(rts_d->addr));
     if(prev_entry != NULL)
     {
-    		log_debug("RTS address %s:%d was already added to membership, updating status and metadata!\n", hostname, local_rts_id);
+		log_debug("RTS address %s:%d already in membership, updating status and metadata!", hostname, local_rts_id);
 		rts_descriptor * prev_descriptor = (rts_descriptor *) prev_entry->value;
 		prev_descriptor->status = rts_d->status;
 		prev_descriptor->rack_id = rts_d->rack_id;
@@ -615,7 +615,7 @@ int add_rts_to_membership(int rack_id, int dc_id, char *hostname, int local_rts_
 
     if(status != 0)
     {
-    		log_debug("ERROR: Error adding RTS %s:%d to membership!\n", hostname, local_rts_id);
+    		log_debug("ERROR: Error adding RTS %s:%d to membership!", hostname, local_rts_id);
     		free_rts_descriptor(rts_d);
 		return -2;
     }
@@ -830,7 +830,7 @@ int update_actor_placement(remote_db_t * db)
 {
 	char msg_buf[4096];
 
-    log_debug("CLIENT: Updating actor placement. Previous actor membership: %s\n", to_string_actor_membership(db, msg_buf));
+    log_debug("CLIENT: Updating actor placement. Previous actor membership: %s", to_string_actor_membership(db, msg_buf));
 
 	int host_id = -1;
 	for(snode_t * crt = HEAD(db->actors); crt!=NULL; crt = NEXT(crt))
@@ -867,7 +867,7 @@ int update_actor_placement(remote_db_t * db)
 		}
 	}
 
-    log_debug("CLIENT: Actor membership: %s\n", to_string_actor_membership(db, msg_buf));
+    log_debug("CLIENT: Actor membership: %s", to_string_actor_membership(db, msg_buf));
 
 	return 0;
 }
@@ -883,7 +883,7 @@ int add_actor_to_membership(long actor_id, remote_db_t * db)
 	snode_t * prev_entry = skiplist_search(db->actors, (WORD) a->actor_id);
     if(prev_entry != NULL)
     {
-    		log_debug("Actor %ld was already added to membership, skipping.\n", a->actor_id);
+		log_debug("Actor %ld already in membership, skipping.", a->actor_id);
 		return -1;
     }
 
@@ -891,7 +891,7 @@ int add_actor_to_membership(long actor_id, remote_db_t * db)
 
     if(status != 0)
     {
-    		log_debug("ERROR: Error adding actor %ld to membership!\n", a->actor_id);
+    		log_debug("ERROR: Error adding actor %ld to membership!", a->actor_id);
     		free_actor_descriptor(a);
 		return -2;
     }
@@ -911,7 +911,7 @@ int add_actor_to_membership(long actor_id, remote_db_t * db)
 
     log_debug("Added actor %ld (%d) to membership!", a->actor_id, hash32((int) actor_id));
 
-    log_debug("CLIENT: Actor membership: %s\n", to_string_actor_membership(db, msg_buf));
+    log_debug("CLIENT: Actor membership: %s", to_string_actor_membership(db, msg_buf));
 
     return 0;
 }

--- a/backend/comm.c
+++ b/backend/comm.c
@@ -265,7 +265,7 @@ int parse_message(void * rcv_buf, size_t rcv_msg_len, void ** out_msg, short * o
 					gossip_listen_message * wq = (gossip_listen_message *) *(out_msg);
 #if (VERBOSE_RPC > 0)
 					to_string_gossip_listen_msg(wq, (char *) print_buff);
-					log_debug("Received gossip listen message: %s\n", print_buff);
+					log_debug("Received gossip listen message: %s", print_buff);
 #endif
 					*nonce = wq->nonce;
 					return 0;

--- a/backend/failure_detector/db_queries.c
+++ b/backend/failure_detector/db_queries.c
@@ -212,9 +212,11 @@ int deserialize_write_query(void * buf, unsigned msg_len, write_query ** ca)
 {
 	WriteQueryMessage * msg = write_query_message__unpack (NULL, msg_len, buf);
 
-	if (msg == NULL || msg->mtype != RPC_TYPE_WRITE)
-	{
-		log_error("error unpacking write query message\n");
+	if (msg == NULL) {
+		log_error("Error unpacking write query message, msg is NULL");
+	    return 1;
+	} else if (msg->mtype != RPC_TYPE_WRITE) {
+		log_error("Error unpacking write query message, msg->mtype is not RPC_TYPE_WRITE: %d", msg->mtype);
 	    return 1;
 	}
 
@@ -397,9 +399,11 @@ int deserialize_read_query(void * buf, unsigned msg_len, read_query ** ca)
 {
 	ReadQueryMessage * msg = read_query_message__unpack (NULL, msg_len, buf);
 
-	if (msg == NULL || msg->mtype != RPC_TYPE_READ)
-	{
-		log_error("error unpacking read query message\n");
+	if (msg == NULL) {
+		log_error("Error unpacking read query message, msg is NULL");
+	    return 1;
+	} else if (msg->mtype != RPC_TYPE_READ) {
+		log_error("Error unpacking read query message, msg->mtype is not RPC_TYPE_READ: %d", msg->mtype);
 	    return 1;
 	}
 
@@ -592,9 +596,10 @@ int deserialize_range_read_query(void * buf, unsigned msg_len, range_read_query 
 {
 	RangeReadQueryMessage * msg = range_read_query_message__unpack (NULL, msg_len, buf);
 
-	if (msg == NULL || msg->mtype != RPC_TYPE_RANGE_READ)
-	{
-		log_error("error unpacking range read query message\n");
+	if (msg == NULL) {
+		log_error("Error unpacking range read query message, msg is NULL");
+	} else if (msg->mtype != RPC_TYPE_RANGE_READ) {
+		log_error("Error unpacking range read query message, msg->mtype is not RPC_TYPE_RANGE_READ: %d", msg->mtype);
 	    return 1;
 	}
 
@@ -761,16 +766,18 @@ int deserialize_ack_message(void * buf, unsigned msg_len, ack_message ** ca)
 	AckMessage * msg = ack_message__unpack (NULL, msg_len, buf);
 	char print_buff[100];
 
-	if (msg == NULL || msg->mtype != RPC_TYPE_ACK)
-	{
-		log_error("error unpacking ack query message\n");
+	if (msg == NULL) {
+		log_error("Error unpacking ack query message, msg is NULL");
+	    return 1;
+	} else if (msg->mtype != RPC_TYPE_ACK) {
+		log_error("Error unpacking ack query message, msg->mtype is not RPC_TYPE_ACK: %d", msg->mtype);
 	    return 1;
 	}
 
 	*ca = init_ack_message_from_msg(msg);
 
 //	to_string_ack_message(*ca, (char *) print_buff);
-//	log_debug("Received ACK message: %s\n", print_buff);
+//	log_debug("Received ACK message: %s", print_buff);
 
 	ack_message__free_unpacked(msg, NULL);
 
@@ -952,9 +959,11 @@ int deserialize_range_read_response_message(void * buf, unsigned msg_len, range_
 {
 	RangeReadResponseMessage * msg = range_read_response_message__unpack (NULL, msg_len, buf);
 
-	if (msg == NULL || msg->mtype != RPC_TYPE_RANGE_READ_RESPONSE)
-	{
-		log_error("error unpacking range read response message\n");
+	if (msg == NULL) {
+		log_error("Error unpacking range read response message, msg is NULL");
+	    return 1;
+	} else if (msg->mtype != RPC_TYPE_RANGE_READ_RESPONSE) {
+		log_error("Error unpacking range read response message, msg->mtype is not RPC_TYPE_RANGE_READ_RESPONSE: %d", msg->mtype);
 	    return 1;
 	}
 
@@ -1399,9 +1408,11 @@ int deserialize_queue_message(void * buf, unsigned msg_len, queue_query_message 
 {
 	QueueQueryMessage * msg = queue_query_message__unpack (NULL, msg_len, buf);
 
-	if (msg == NULL || msg->mtype != RPC_TYPE_QUEUE)
-	{
-		log_error("error unpacking queue query message\n");
+	if (msg == NULL) {
+		log_error("Error unpacking queue query message, msg is NULL");
+	    return 1;
+	} else if (msg->mtype != RPC_TYPE_QUEUE) {
+		log_error("Error unpacking queue query message, msg->mtype is not RPC_TYPE_QUEUE: %d", msg->mtype);
 	    return 1;
 	}
 
@@ -1864,9 +1875,11 @@ int deserialize_txn_message(void * buf, unsigned msg_len, txn_message ** ca)
 {
 	TxnMessage * msg = txn_message__unpack (NULL, msg_len, buf);
 
-	if (msg == NULL || msg->mtype != RPC_TYPE_TXN)
-	{
-		log_error("error unpacking read query message\n");
+	if (msg == NULL) {
+		log_error("Error unpacking txn query message, msg is NULL");
+	    return 1;
+	} else if (msg->mtype != RPC_TYPE_TXN) {
+		log_error("Error unpacking txn query message, msg->mtype is not RPC_TYPE_TXN: %d", msg->mtype);
 	    return 1;
 	}
 
@@ -2032,9 +2045,8 @@ int deserialize_gossip_listen_msg(void * buf, unsigned msg_len, gossip_listen_me
 {
 	GossipListenMessage * msg = gossip_listen_message__unpack(NULL, msg_len, buf);
 
-	if (msg == NULL)
-	{ // Something failed
-	    log_error("error unpacking gossip_state message\n");
+	if (msg == NULL) {
+	    log_error("Error unpacking gossip_state message, msg is NULL");
 	    return 1;
 	}
 
@@ -2103,7 +2115,7 @@ void free_server_msg(ServerMessage * sm)
 		}
 		default:
 		{
-			log_fatal("Wrong server message type %d\n", sm->mtype);
+			log_fatal("Wrong server message type %d", sm->mtype);
 		}
 	}
 
@@ -2118,7 +2130,7 @@ int deserialize_server_message(void * buf, unsigned msg_len, void ** dest_buf, s
 	if (sm == NULL)
 	{
 		*mtype = -1;
-		log_error("error unpacking server message\n");
+		log_error("Error unpacking server message, msg is NULL");
 	    return 1;
 	}
 
@@ -2163,7 +2175,7 @@ int deserialize_server_message(void * buf, unsigned msg_len, void ** dest_buf, s
 		}
 		default:
 		{
-			log_fatal("Wrong server message type %d\n", sm->mtype);
+			log_fatal("Wrong server message type %d", sm->mtype);
 		    return 1;
 		}
 	}
@@ -2215,7 +2227,7 @@ void free_client_msg(ClientMessage * cm)
 		}
 		default:
 		{
-			log_fatal("Wrong client message type %d\n", cm->mtype);
+			log_fatal("Wrong client message type %d", cm->mtype);
 		}
 	}
 
@@ -2230,7 +2242,7 @@ int deserialize_client_message(void * buf, unsigned msg_len, void ** dest_buf, s
 
 	if (cm == NULL)
 	{
-		log_error("error unpacking client message\n");
+		log_error("Error unpacking client message, msg is NULL");
 
 		// This might be a gossiped membership notification:
 
@@ -2257,7 +2269,7 @@ int deserialize_client_message(void * buf, unsigned msg_len, void ** dest_buf, s
 				}
 				default:
 				{
-					log_fatal("Wrong gossip message type %d\n", ma->msg_type);
+					log_fatal("Wrong gossip message type %d", ma->msg_type);
 				}
 			}
 
@@ -2265,7 +2277,7 @@ int deserialize_client_message(void * buf, unsigned msg_len, void ** dest_buf, s
 		}
 		else
 		{
-			log_error("error unpacking gossip message\n");
+			log_error("Error unpacking gossip message");
 			return 1;
 		}
 	}
@@ -2304,7 +2316,7 @@ int deserialize_client_message(void * buf, unsigned msg_len, void ** dest_buf, s
 		}
 		default:
 		{
-			log_fatal("Wrong client message type %d\n", cm->mtype);
+			log_fatal("Wrong client message type %d", cm->mtype);
 		    return 1;
 		}
 	}

--- a/test/rts_db/test_db_app.act
+++ b/test/rts_db/test_db_app.act
@@ -65,17 +65,16 @@ actor Tester(env, verbose, port_chunk):
 
         report()
 
+    def log_process_output(p, prefix, data):
+        for line in data.decode().splitlines(False):
+            combined_output += psp[p_id(p)] + " " + prefix + ": " + line + "\n"
+
     def on_stderr(p, data):
-        for line in data.decode().splitlines(True):
-            combined_output += psp[p_id(p)]
-            combined_output += " ERR: "
-            combined_output += line
+        log_process_output(p, "ERR", data)
 
     def on_stdout(p, data):
-        for line in data.decode().splitlines(True):
-            combined_output += psp[p_id(p)]
-            combined_output += " OUT: "
-            combined_output += line
+        log_process_output(p, "OUT", data)
+
 
     def db_on_exit(p, exit_code, term_signal):
         log("DB Process exited with code: %d terminated with signal: %d" % (exit_code, term_signal))

--- a/test/rts_db/test_tcp_client.act
+++ b/test/rts_db/test_tcp_client.act
@@ -87,17 +87,15 @@ actor Tester(env, verbose, port_chunk):
 
         report()
 
+    def log_process_output(p, prefix, data):
+        for line in data.decode().splitlines(False):
+            combined_output += psp[p_id(p)] + " " + prefix + ": " + line + "\n"
+
     def on_stderr(p, data):
-        for line in data.decode().splitlines(True):
-            combined_output += psp[p_id(p)]
-            combined_output += " ERR: "
-            combined_output += line
+        log_process_output(p, "ERR", data)
 
     def on_stdout(p, data):
-        for line in data.decode().splitlines(True):
-            combined_output += psp[p_id(p)]
-            combined_output += " OUT: "
-            combined_output += line
+        log_process_output(p, "OUT", data)
 
     def db_on_exit(p, exit_code, term_signal):
         log("DB Process exited with code: %d terminated with signal: %d" % (exit_code, term_signal))
@@ -163,7 +161,7 @@ actor Tester(env, verbose, port_chunk):
 
         # TCP server
         def app_server_on_stdout(p, data):
-            on_stdout(p, data)
+            log_process_output(p, "OUT: state " + str(state), data)
 
         def app_server_on_exit(p, exit_code, term_signal):
             log("Server app exited in state %d with exit code %d and termination signal %d" % (state, exit_code, term_signal))

--- a/test/rts_db/test_tcp_server.act
+++ b/test/rts_db/test_tcp_server.act
@@ -89,8 +89,8 @@ actor Tester(env, verbose, port_chunk):
 
 
     def log_process_output(p, prefix, data):
-        for line in data.decode().splitlines(True):
-            combined_output += psp[p_id(p)] + " " + prefix + ": " + line
+        for line in data.decode().splitlines(False):
+            combined_output += psp[p_id(p)] + " " + prefix + ": " + line + "\n"
 
     def on_stderr(p, data):
         log_process_output(p, "ERR", data)


### PR DESCRIPTION
This removes ending new lines from a bunch of the DB log messages.

Some log messages have been changed for improved wording. For parsing various messages the errors have been broken into NULL / type check (to help me debug an issue).

Also fix test script output.