### PR TITLE
Only look at version tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 include common.mk
 CHANGELOG_VERSION=$(shell grep '^\#\# \[[0-9]' CHANGELOG.md | sed 's/\#\# \[\([^]]\{1,\}\)].*/\1/' | head -n1)
-GIT_VERSION_TAG=$(shell git tag --points-at HEAD 2>/dev/null | sed -e 's/^v//')
+GIT_VERSION_TAG=$(shell git tag --points-at HEAD 2>/dev/null | grep "v[0-9]" | sed -e 's/^v//')
 
 PKGCONFIG=$(shell which pkg-config)
 ifeq ($(PKGCONFIG),)


### PR DESCRIPTION
Found this problem in CI where we end up having both the tip tag and v0.x.y and so we fail the version-check target. In this context, we only care about version tags, so we now grep those out!