### PR TITLE
No newlines in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -7,8 +7,7 @@ body:
       value: |
         A bug is when something works differently than it is expected to.
         ## Remember to search before filing a new report
-        Please search for this bug in the issue tracker, and use a bug report title that
-        would have made your bug report turn up in the search results for your search query.
+        Please search for this bug in the issue tracker, and use a bug report title that would have made your bug report turn up in the search results for your search query.
   - type: input
     id: version
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -5,12 +5,9 @@ body:
   - type: markdown
     attributes:
       value: |
-        A feature is when you would like to add new functionality or change
-        current functionality / behavior.
+        A feature is when you would like to add new functionality or change current functionality / behavior.
         ## Remember to search before filing a new report
-        Please search for this feature request in the issue tracker, and use a
-        feature request title that would have made your feature request turn up
-        in the search results for your search query.
+        Please search for this feature request in the issue tracker, and use a feature request title that would have made your feature request turn up in the search results for your search query.
   - type: textarea
     id: repro
     attributes:


### PR DESCRIPTION
I just thought it'd look nice in the text version of it but Github honours the newlines and breaks text which is worse in the HTML page.

Fixes #921.