### PR TITLE
Return status from exact row search functions as well

### DIFF
--- a/backend/client_api.c
+++ b/backend/client_api.c
@@ -1740,7 +1740,7 @@ int remote_search_clustering_in_txn(WORD* primary_keys, int no_primary_keys, WOR
 	return 0;
 }
 
-db_row_t* remote_search_columns_in_txn(WORD* primary_keys, int no_primary_keys, WORD* clustering_keys, int no_clustering_keys,
+int remote_search_columns_in_txn(WORD* primary_keys, int no_primary_keys, WORD* clustering_keys, int no_clustering_keys,
 									WORD* col_keys, int no_columns, db_row_t** result_row, WORD table_key,
 									uuid_t * txnid, remote_db_t * db)
 {
@@ -1748,7 +1748,7 @@ db_row_t* remote_search_columns_in_txn(WORD* primary_keys, int no_primary_keys, 
 	return 0;
 }
 
-db_row_t* remote_search_index_in_txn(WORD index_key, int idx_idx, db_row_t** result_row, WORD table_key, uuid_t * txnid, remote_db_t * db)
+int remote_search_index_in_txn(WORD index_key, int idx_idx, db_row_t** result_row, WORD table_key, uuid_t * txnid, remote_db_t * db)
 {
 	assert (0); // Not supported; TO DO
 	return 0;

--- a/backend/client_api.h
+++ b/backend/client_api.h
@@ -206,14 +206,14 @@ int remote_delete_by_index_in_txn(WORD index_key, int idx_idx, WORD table_key, u
 
 // Read ops:
 
-db_row_t* remote_search_in_txn(WORD* primary_keys, int no_primary_keys, WORD table_key,
+int remote_search_in_txn(WORD* primary_keys, int no_primary_keys, db_row_t** result_row, WORD table_key,
 								uuid_t * txnid, remote_db_t * db);
-db_row_t* remote_search_clustering_in_txn(WORD* primary_keys, int no_primary_keys, WORD* clustering_keys, int no_clustering_keys,
-											WORD table_key, uuid_t * txnid, remote_db_t * db);
-db_row_t* remote_search_columns_in_txn(WORD* primary_keys, int no_primary_keys, WORD* clustering_keys, int no_clustering_keys,
-									WORD* col_keys, int no_columns, WORD table_key,
+int remote_search_clustering_in_txn(WORD* primary_keys, int no_primary_keys, WORD* clustering_keys, int no_clustering_keys,
+									db_row_t** result_row, WORD table_key, uuid_t * txnid, remote_db_t * db);
+int remote_search_columns_in_txn(WORD* primary_keys, int no_primary_keys, WORD* clustering_keys, int no_clustering_keys,
+									WORD* col_keys, int no_columns, db_row_t** result_row, WORD table_key,
 									uuid_t * txnid, remote_db_t * db);
-db_row_t* remote_search_index_in_txn(WORD index_key, int idx_idx, WORD table_key, uuid_t * txnid, remote_db_t * db);
+int remote_search_index_in_txn(WORD index_key, int idx_idx, db_row_t** result_row, WORD table_key, uuid_t * txnid, remote_db_t * db);
 int remote_range_search_in_txn(WORD* start_primary_keys, WORD* end_primary_keys, int no_primary_keys,
 							snode_t** start_row, snode_t** end_row,
 							WORD table_key, uuid_t * txnid, remote_db_t * db);

--- a/backend/test/test_client.c
+++ b/backend/test/test_client.c
@@ -129,7 +129,8 @@ int test_search_pk(db_schema_t * schema, remote_db_t * db, uuid_t * txnid, unsig
 
 	for(int64_t aid=0;aid<no_actors;aid++)
 	{
-		db_row_t * row = remote_search_in_txn((WORD *) &aid, schema->no_primary_keys, (WORD) 0, txnid, db);
+		db_row_t * row = NULL;
+		remote_search_in_txn((WORD *) &aid, schema->no_primary_keys, &row, (WORD) 0, txnid, db);
 
 		if(txnid != NULL && row == NULL)
 			continue;
@@ -162,7 +163,9 @@ int test_search_pk_ck1(db_schema_t * schema, remote_db_t * db, uuid_t * txnid, u
 	{
 		for(int64_t cid=0;cid<no_collections;cid++)
 		{
-			db_row_t * row = remote_search_clustering_in_txn((WORD *) &aid, schema->no_primary_keys, (WORD *) &cid, 1, (WORD) 0, txnid, db);
+			db_row_t * row = NULL;
+
+			remote_search_clustering_in_txn((WORD *) &aid, schema->no_primary_keys, (WORD *) &cid, 1, &row, (WORD) 0, txnid, db);
 
 			if(txnid != NULL && row == NULL)
 				continue;
@@ -202,7 +205,9 @@ int test_search_pk_ck1_ck2(db_schema_t * schema, remote_db_t * db, uuid_t * txni
 				cks[0] = (WORD) cid;
 				cks[1] = (WORD) iid;
 
-				db_row_t * row = remote_search_clustering_in_txn((WORD *) &aid, schema->no_primary_keys, cks, 2, (WORD) 0, txnid, db);
+				db_row_t * row = NULL;
+
+				remote_search_clustering_in_txn((WORD *) &aid, schema->no_primary_keys, cks, 2, &row, (WORD) 0, txnid, db);
 
 				if(txnid != NULL && row == NULL)
 					continue;


### PR DESCRIPTION
Functions that did non-range search of DB rows in the client API did not return a status. This PR fixes that.