### PR TITLE
Add garbage collection using libgc

### DIFF
--- a/backend/client_api.c
+++ b/backend/client_api.c
@@ -22,6 +22,9 @@
 #include "hashes.h"
 #include "log.h"
 
+#define GC_THREADS 1
+#include "gc.h"
+
 struct dbc_stat dbc_stats;
 
 void zeroize_dbc_ops_stats(struct dbc_ops_stat *ops_stat, const char *name) {

--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -723,7 +723,7 @@ buildExecutable env opts paths binTask
         buildF              = joinPath [projPath paths, "build.sh"]
         outbase             = outBase paths mn
         rootFile            = outbase ++ ".root.c"
-        libFiles            = " -lActonProject -lActon -lActonDB -lActonDeps -lpthread -lm -ldl "
+        libFiles            = " -lActonProject -lActon -lActonDB -lActonDeps -lactongc -lpthread -lm -ldl "
         libPaths            = " -L " ++ sysPath paths ++ "/lib -L" ++ sysLib paths ++ " -L" ++ projLib paths
         binFile             = joinPath [binDir paths, (binName binTask)]
         srcbase             = srcFile paths mn

--- a/rts/rts.c
+++ b/rts/rts.c
@@ -35,6 +35,8 @@
 
 #include <uv.h>
 
+#define GC_THREADS 1
+#include "gc.h"
 #include "yyjson.h"
 #include "rts.h"
 
@@ -2100,8 +2102,12 @@ void print_help(struct option *opt) {
     exit(0);
 }
 
+void DaveNull () {}
 
 int main(int argc, char **argv) {
+    // Init garbage collector and suppress warnings
+    GC_INIT();
+    GC_set_warn_proc(DaveNull);
     uint ddb_no_host = 0;
     char **ddb_host = NULL;
     char *rts_host = "localhost";


### PR DESCRIPTION
This adds garbage collection to the Acton run time system through the
use of libgc. We use link time redirection of malloc and friends in
order to catch all occurrences. Thread creation is hooked by including
gc.h in RTS and the DB client (which are the two places where we create
threads).

An earlier attempt was made to change our source code from using malloc
& friend to GC_MALLOC & friends but as it is exceedingly difficult to
find all mallocs, it regularly produced programs that segfaulted. libuv
and yyjson allows using a custom malloc but other libraries, like
utf8proc, doesn't appear to have functionality for specifying which
malloc to use and so it becomes rather difficult. Thus, this approach
was abandoned in preference of link time redirection of `malloc`.

Thread creation is hooked in source code as this is the only way that
works on MacOS. GC_USE_DLOPEN_WRAP allows wrapping dlopen so that on
Linux, hooks are installed at run time when the application is
dynamically linked with libpthreads. This facility does not exist on
MacOS which is why we are instead hooking it via source (by setting
GC_THREADS 1 and including gc.h). It ought to be more stable setting
this in source too. This is however untested, libgc even has an error in
gcconfig.h defined for this, so there's some uncertainty if there might
be bugs. It seems to work though.

libgc allows control via environment variables, most notably export
GC_DONT_GC=1 will disable the GC. This can be useful in case we suspect
the GC causes some problems. Once we've gained confidence with the GC,
we should disable this at compile time by setting -DNO_GETENV.

I've tested this primarily with the perf/ring program, which is a form
of benchmarking program that sends messages between actors as fast as
possible. Before this patch, on my laptop, ring consumes around 12GB of
RAM after running for about 1 minute sustaining around 800k messages per
second. With libgc, memory consumption stays constant at 4.5MB while
maintaining roughly the same message rate. I haven't collected a lot of
statistics and the variation between test rounds is probably around 10%.
I cannot see a clear pattern between using GC and not on this
performance.

As far as I understand, libgc does pause all threads every now and then
in order to collect a correct view of registers and similar. This means
that concurrency likely will be hit harder in Acton than the kind of
single threaded / low concurrency applications used in the above
mentioned benchmarking. ring is actually quite "single threaded" in that
there is only one outstanding message in total being passed between the
actors so we might not see those effects clearly.

The longer term plan is obviously to implement our own GC that does
things the Acton way and will be way more efficient in various but until
then... this'll do I think :)