### PR TITLE
OLD: Add `xml` module to stdlib

### DIFF
--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -739,7 +739,7 @@ buildExecutable env args paths binTask
         buildF              = joinPath [projPath paths, "build.sh"]
         outbase             = outBase paths mn
         rootFile            = outbase ++ ".root.c"
-        libFilesBase        = " -lActonProject -lActon -lActonDB -lprotobuf-c_a -lutf8proc_a -luv_a -lpthread -lm -ldl "
+        libFilesBase        = " -lActonProject -lActon -lActonDB -lprotobuf-c_a -lutf8proc_a -luv_a -lpthread -lm -ldl -lz -llzma -liconv -lxml2 "
         libPathsBase        = " -L " ++ sysPath paths ++ "/lib -L" ++ sysLib paths ++ " -L" ++ projLib paths
 #if defined(darwin_HOST_OS) && defined(aarch64_HOST_ARCH)
         libFiles            = libFilesBase

--- a/examples/xmltest.act
+++ b/examples/xmltest.act
@@ -1,0 +1,13 @@
+import xml
+import file
+ 
+actor main(env):
+    fa = file.FileAuth(env.auth)
+    rfa = file.ReadFileAuth(fa)
+    rf  = file.ReadFile(rfa,env.argv[1])
+    bs = rf.read()
+    s = bs.decode()
+    t : xml.Tag = xml.decode(s)
+    print(xml.encode(t))
+    env.exit(0)
+

--- a/examples/xmltest.act
+++ b/examples/xmltest.act
@@ -2,12 +2,13 @@ import xml
 import file
  
 actor main(env):
-    fa = file.FileAuth(env.auth)
-    rfa = file.ReadFileAuth(fa)
-    rf  = file.ReadFile(rfa,env.argv[1])
-    bs = rf.read()
-    s = bs.decode()
-    t : xml.Tag = xml.decode(s)
+#    fa = file.FileAuth(env.auth)
+#    rfa = file.ReadFileAuth(fa)
+#    rf  = file.ReadFile(rfa,env.argv[1])
+#    bs = rf.read()
+#    s = bs.decode()
+#    t = xml.decode(s)
+    t = xml.decodeFile(env.argv[1])
     print(xml.encode(t))
     env.exit(0)
 

--- a/stdlib/src/xml.act
+++ b/stdlib/src/xml.act
@@ -10,5 +10,8 @@ class Tag():
 pure def decode(data : str) -> Tag:
     NotImplemented
 
+pure def decodeFile(filename : str) -> Tag:
+    NotImplemented
+
 def encode(root : Tag) -> str:
     NotImplemented

--- a/stdlib/src/xml.act
+++ b/stdlib/src/xml.act
@@ -1,0 +1,14 @@
+class Tag():
+   def __init__(self, name : ?str, nsdefs : ?list[(?str,str)], prefix : ?str, attributes : list[(str, str)], content : ?str, children : list[Tag]): 
+      self.name = name                  # Tags with name==None are text nodes; they have content but no attributes or children
+      self.nsdefs = nsdefs              # If (prefix,href) (prefix may be None)
+      self.prefix = prefix              # namespace prefix to use
+      self.attributes = attributes
+      self.content = content            # Only non-None for text nodes
+      self.children = children
+
+pure def decode(data : str) -> Tag:
+    NotImplemented
+
+def encode(root : Tag) -> str:
+    NotImplemented

--- a/stdlib/src/xml.ext.c
+++ b/stdlib/src/xml.ext.c
@@ -75,7 +75,23 @@ xml$$Tag xml$$decode($str data) {
   }
   xmlNodePtr root = xmlDocGetRootElement(doc);
   xmlNodePtr c = root->children;
-  return $Doc2Tag(root);
+  xml$$Tag t = $Doc2Tag(root);
+  xmlFreeDoc(doc);
+  return t;
+}
+
+xml$$Tag xml$$decodeFile($str filename) {
+  xmlDocPtr doc = xmlReadFile((char *)filename->str,NULL,XML_PARSE_NOBLANKS);
+  if (!doc) {
+    // xmlErrorPtr err = xmlGetLastError();
+    fprintf(stderr,"xml parse error; quitting\n");
+    exit(1);
+  }
+  xmlNodePtr root = xmlDocGetRootElement(doc);
+  xmlNodePtr c = root->children;
+  xml$$Tag t = $Doc2Tag(root);
+  xmlFreeDoc(doc);
+  return t;
 }
 
 

--- a/stdlib/src/xml.ext.c
+++ b/stdlib/src/xml.ext.c
@@ -1,0 +1,216 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <libxml/xmlmemory.h>
+#include <libxml/parser.h>
+#include "../out/types/xml.h"
+
+// The macro below is from builtin/str.c. We should not duplicate it...
+
+#define NEW_UNFILLED_STR(nm,nchrs,nbtes)         \
+nm = malloc(sizeof(struct $str)); \
+(nm)->$class = &$str$methods; \
+(nm)->nchars = nchrs;            \
+(nm)->nbytes = nbtes;            \
+(nm)->str = malloc((nm)->nbytes + 1);    \
+(nm)->str[(nm)->nbytes] = 0
+
+#define TABSTEP 4
+
+xml$$Tag $Doc2Tag(xmlNodePtr root) {
+  $Hashable w1 = ($Hashable)$Hashable$str$witness;
+  $Mapping w2 = ($Mapping)$Mapping$dict$new(w1);
+  $Eq w3 = ($Eq)$Ord$str$witness;
+  $Indexed w4 = ($Indexed) $Indexed$dict$new(w2, w3);
+  $str name = NULL;
+  $list nsdefs = $list_new(0);
+  nsdefs->length = 0;
+  $list attributes = $list_new(0);
+  attributes->length = 0;
+  $str content = NULL;
+  $str prefix = NULL;
+  if (root->ns) prefix = to$str((char *)root->ns->prefix);
+  $list children = $list_new(0);
+  children->length = 0;
+  if (root->type == XML_ELEMENT_NODE) {
+     xmlNodePtr cur = root->xmlChildrenNode;
+     while (cur != NULL) {
+       if (cur->type == XML_ELEMENT_NODE || cur->type == XML_TEXT_NODE ) 
+         $list_append(children, $Doc2Tag(cur));
+       cur = cur->next;
+     }
+     name = to$str((char *)root->name);
+     xmlAttrPtr attr = root->properties;
+     while (attr) {
+       $list_append(attributes, $NEWTUPLE(2,to$str((char *)attr->name),to$str((char *)xmlGetProp(root,attr->name))));
+       attr = attr->next;
+     }
+     xmlNsPtr nsDef = root->nsDef;
+     while (nsDef) {
+       $str prefix = NULL;
+       if (nsDef->prefix) prefix =  to$str((char *)nsDef->prefix);
+       $str href = to$str((char *)nsDef->href); 
+       $list_append(nsdefs, $NEWTUPLE(2,prefix,href));
+       nsDef=nsDef->next;
+     }
+  } else if (root->type == XML_TEXT_NODE) {
+    if (strcmp((char *)root->name,"text")) {
+      fprintf(stderr,"Internal error: Unknown XML text node");
+      exit(1);
+    }
+    content = to$str((char *)root->content);
+  } else {
+      fprintf(stderr,"Internal error: Unknown XML node type");
+      exit(1);
+  }
+  return $NEW(xml$$Tag,name,nsdefs,prefix,attributes,content,children);
+}
+
+xml$$Tag xml$$decode($str data) {
+  xmlDocPtr doc = xmlReadMemory((char *)data->str,data->nbytes,NULL,NULL,XML_PARSE_NOBLANKS);
+  if (!doc) {
+    // xmlErrorPtr err = xmlGetLastError();
+    fprintf(stderr,"xml parse error; quitting\n");
+    exit(1);
+  }
+  xmlNodePtr root = xmlDocGetRootElement(doc);
+  xmlNodePtr c = root->children;
+  return $Doc2Tag(root);
+}
+
+
+$str xml$$mk_node(int indent, $str tag, $str nsdefs, $str prefix, $str attrs, $str cont) {
+  int tag_len = tag->nbytes;
+  int cont_len = cont->nbytes;
+  int res_bytes = 2*tag->nbytes + 2*(prefix ? prefix->nbytes+1:0) + nsdefs->nbytes + attrs->nbytes + cont->nbytes +2*indent + 7; // 7 = len ("<" + ">" + "\n" + "</" + ">" + "\n")
+  int res_chars = 2*tag->nchars + 2*(prefix ? prefix->nchars+1:0) + nsdefs->nchars + attrs->nchars + cont->nchars +2*indent + 7;
+  $str res;
+  NEW_UNFILLED_STR(res,res_bytes,res_chars);
+  unsigned char *p = res->str;
+  memset(p,' ',indent); p += indent;
+  *p++ = '<';
+  if (prefix) {
+    memcpy(p,prefix->str,prefix->nbytes); p += prefix->nbytes;
+    *p++ = ':';
+  }
+  memcpy(p, tag->str, tag_len); p += tag_len;
+  memcpy(p, nsdefs->str, nsdefs->nbytes); p += nsdefs->nbytes;
+  memcpy(p, attrs->str, attrs->nbytes); p += attrs->nbytes;
+  *p++ = '>';
+  *p++ = '\n';
+  memcpy(p, cont->str, cont_len); p += cont_len;
+  *p++ = '\n';
+  memset(p,' ',indent); p += indent;
+  *p++ = '<';
+  *p++ = '/';
+  if (prefix) {
+    memcpy(p,prefix->str,prefix->nbytes); p += prefix->nbytes;
+    *p++ = ':';
+  }
+  memcpy(p, tag->str, tag_len); p += tag_len;
+  *p++ = '>';  
+  return res;
+}
+
+
+static $str xml$$encode_node(int indent, xml$$Tag node);
+
+static $list xml$$encode_nodes(int indent, $list nodes) {
+  $list strs = $list_new(nodes->length);
+  strs->length = nodes->length;
+  for (int i=0; i< nodes->length; i++) 
+    strs->data[i] = xml$$encode_node(indent,nodes->data[i]);
+  return strs;
+}
+
+static $str xml$$encode_nsdefs($list nsdefs) {
+  int res_bytes = 0;
+  int res_chars = 0;
+  for (int i=0; i<nsdefs->length;i++) {
+     $tuple nsdef = nsdefs->data[i];
+     $str prefix = ($str)nsdef->components[0];
+     $str href = ($str)nsdef->components[1];
+     res_bytes += (prefix ? prefix->nbytes+1 : 0) + href->nbytes + 9;
+     res_chars += (prefix ? prefix->nchars+1 : 0) + href->nchars + 9;
+  }
+  $str res;
+  NEW_UNFILLED_STR(res,res_bytes,res_chars);
+  unsigned char *p = res->str;
+  for (int i=0; i<nsdefs->length; i++) {
+    $tuple nsdef = nsdefs->data[i];
+    *p++ = ' ';
+    $str prefix =  ($str)nsdef->components[0];
+    $str href =  ($str)nsdef->components[1];
+    char * xmlns = "xmlns";
+    memcpy(p,xmlns,5); p += 5;
+    if (prefix) {
+      *p++ = ':';
+      memcpy(p,prefix->str,prefix->nbytes); p += prefix->nbytes;
+    }
+    *p++ = '=';
+    *p++ = '"';
+    memcpy(p,href->str,href->nbytes); p += href->nbytes;
+    *p++ = '"';
+  }
+  return res;
+}
+ 
+
+static $str xml$$encode_attrs($list attrs) {
+  int res_bytes = 0;
+  int res_chars = 0;
+  for (int i=0; i<attrs->length;i++) {
+     $tuple attr = attrs->data[i];
+     res_bytes += (($str)attr->components[0])->nbytes +  (($str)attr->components[1])->nbytes + 4; // 4 = ' ','=,'"', '"'
+     res_chars +=  (($str)attr->components[0])->nchars +  (($str)attr->components[1])->nchars + 4;
+  }
+  $str res;
+  NEW_UNFILLED_STR(res,res_bytes,res_chars);
+  
+  unsigned char *p = res->str;
+  for (int i=0; i<attrs->length; i++) {
+     $tuple attr = attrs->data[i];
+    *p++ = ' ';
+    $str key =  ($str)attr->components[0];
+    $str value =  ($str)attr->components[1];
+    memcpy(p,key->str,key->nbytes); p += key->nbytes;
+    *p++ = '=';
+    *p++ = '"';
+    memcpy(p,value->str,value->nbytes); p += value->nbytes;
+    *p++ = '"';
+  }
+  return res;
+}
+
+static $str xml$$encode_node(int indent, xml$$Tag node) {
+  $str nl = to$str("\n");
+  if (node->name) {
+    $Iterable wit = (($Iterable)(($Collection)$Sequence$list$new()->w$Collection));
+    $list children = xml$$encode_nodes(indent+TABSTEP,node->children);
+    $str s =  nl->$class->join(nl,wit,children);
+    $str nsdefs = xml$$encode_nsdefs(node->nsdefs);
+    $str attrs = xml$$encode_attrs(node->attributes);
+    return xml$$mk_node(indent,node->name,nsdefs,node->prefix,attrs,s);
+  } else {
+     return node->content;
+  }
+}
+$str xml$$encode(xml$$Tag root) {
+  $str nl = to$str("\n");
+  $str res;
+  if (root->name) {
+    $Iterable wit = (($Iterable)(($Collection)$Sequence$list$new()->w$Collection));
+    $str s = nl->$class->join(nl,wit,xml$$encode_nodes(3,root->children));
+    $str nsdefs = xml$$encode_nsdefs(root->nsdefs);
+    $str attrs = xml$$encode_attrs(root->attributes);
+    res = xml$$mk_node(0,root->name,nsdefs,root->prefix,attrs,s); 
+  } else {
+    $RAISE(($BaseException)$NEW($ValueError,to$str("xml.encode: No root element")));
+  }
+  return res;
+}
+
+ 
+void xml$$__ext_init__() {
+    // NOP
+}


### PR DESCRIPTION
- [ ] move / rewrite examples/xmltest.act to test/stdlib_auto/test_xml.act
  - [ ] make sure we have some automatic test cases
- [ ] fix dependencies, install, copy libs etc
- [ ] decide something for indent, either remove it or make it optional through argument?
- [ ] empty nodes for storing text? why? shouldn't it go in content field?
- [ ] should we have decodeFile? isn't it better to leave xml module completely pure with no IO and leave it to acton file module to read data? then we also go through acton for content encoding
  - libxml2 depends on libicu (on Linux) or iconv (on mac) for internationalization and conversion between formats
  - seems more acton-way to make 
  - if we compile libxml2 ourselves we can keep down its size by not doing internationalization - thus only supporting utf-8, but since that is what we do internally anyway, that's ok?
    - if we want to support other formats later we should add that as a generic feature in acton, not specific to xml