### PR TITLE
Combine all external libs in one .a archive

### DIFF
--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -739,7 +739,7 @@ buildExecutable env args paths binTask
         buildF              = joinPath [projPath paths, "build.sh"]
         outbase             = outBase paths mn
         rootFile            = outbase ++ ".root.c"
-        libFilesBase        = " -lActonProject -lActon -lActonDB -lprotobuf-c_a -lutf8proc_a -luv_a -lpthread -lm -ldl "
+        libFilesBase        = " -lActonProject -lActon -lActonDB -lActonDeps -lpthread -lm -ldl "
         libPathsBase        = " -L " ++ sysPath paths ++ "/lib -L" ++ sysLib paths ++ " -L" ++ projLib paths
 #if defined(darwin_HOST_OS) && defined(aarch64_HOST_ARCH)
         libFiles            = libFilesBase
@@ -751,7 +751,7 @@ buildExecutable env args paths binTask
         ccArgs              = ""
 -- Linux? and what else? maybe split
 #else
-        libFiles            = libFilesBase ++ " -luuid -lbsd_a -lmd_a "
+        libFiles            = libFilesBase ++ " -luuid"
         libPaths            = libPathsBase
         ccArgs              = " -no-pie "
 #endif

--- a/test/rts_db/test_db_app.act
+++ b/test/rts_db/test_db_app.act
@@ -150,5 +150,5 @@ actor main(env):
         t.report()
         await async env.exit(1)
 
-    after 2: test_timeout()
-    after 4: unconditional_exit()
+    after 20: test_timeout()
+    after 30: unconditional_exit()


### PR DESCRIPTION
We depend on multiple external libraries and in order to produce a known and consistent result, we include those libraries in the Acton distribution.

When actonc compiles, since we produce C code, we need to link that with the libraries of our external dependencies which means the acton compiler needs to have an exhaustive list of all libraries. This includes libraries required by builtins and by stdlib. It is not desirable to have to maintain such a list in multiple places (both Makefile where we copy files and in compiler for correct linking).

We now combine all .a libraries into one big .a archive which we can then link with and so it's up to cc/ld to figure things out. Thus we've remove the definition of all these libraries from actonc!

Fixes #849.