### PR TITLE
Build all library deps from source

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
             ~/.stack
           key: ${{ matrix.os }}-${{ secrets.CACHE_VERSION }}
       - name: "Install build prerequisites"
-        run: brew install argp-standalone automake gettext haskell-stack libtool libuv protobuf-c
+        run: brew install argp-standalone automake gettext haskell-stack libtool protobuf-c
       - name: "Build Acton"
         run: make -j2 -C ${{ github.workspace }} BUILD_RELEASE=${{ env.BUILD_RELEASE }}
       - name: "Build a release"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
             ~/.stack
           key: ${{ matrix.os }}-${{ secrets.CACHE_VERSION }}
       - name: "Install build prerequisites"
-        run: brew install argp-standalone haskell-stack libuv protobuf-c
+        run: brew install argp-standalone automake gettext haskell-stack libtool libuv protobuf-c
       - name: "Build Acton"
         run: make -j2 -C ${{ github.workspace }} BUILD_RELEASE=${{ env.BUILD_RELEASE }}
       - name: "Build a release"
@@ -117,8 +117,8 @@ jobs:
         run: |
           export DEBIAN_FRONTEND=noninteractive
           apt-get update
-          apt-get install -qy bzip2 gcc haskell-stack make pkg-config procps python3
-          apt-get install -qy libbsd-dev libmd-dev libprotobuf-c-dev libutf8proc-dev libuv1-dev uuid-dev zlib1g-dev
+          apt-get install -qy automake autopoint bison bzip2 git gcc haskell-stack libtool make pkg-config procps python3
+          apt-get install -qy libprotobuf-c-dev zlib1g-dev
       - name: "Upgrade stack on old distributions"
         if: ${{ (matrix.os == 'ubuntu') && (matrix.version == '20.04') }}
         run: |
@@ -152,8 +152,8 @@ jobs:
       - name: "Install build prerequisites"
         run: |
           apt-get update
-          apt-get install -qy bzip2 gcc haskell-stack make pkg-config procps python3
-          apt-get install -qy libbsd-dev libmd-dev libprotobuf-c-dev libutf8proc-dev libuv1-dev uuid-dev zlib1g-dev
+          apt-get install -qy automake autopoint bison bzip2 git gcc haskell-stack libtool make pkg-config procps python3
+          apt-get install -qy libprotobuf-c-dev zlib1g-dev
           apt-get install -qy bash-completion build-essential debhelper devscripts
       - name: "Build Debian packages"
         run: make -C ${GITHUB_WORKSPACE} debs BUILD_RELEASE=${{ env.BUILD_RELEASE }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,7 +117,8 @@ jobs:
         run: |
           export DEBIAN_FRONTEND=noninteractive
           apt-get update
-          apt-get install -qy bzip2 gcc haskell-stack libbsd-dev libmd-dev libprotobuf-c-dev libutf8proc-dev libuv1-dev make pkg-config procps python3 uuid-dev zlib1g-dev
+          apt-get install -qy bzip2 gcc haskell-stack make pkg-config procps python3
+          apt-get install -qy libbsd-dev libmd-dev libprotobuf-c-dev libutf8proc-dev libuv1-dev uuid-dev zlib1g-dev
       - name: "Upgrade stack on old distributions"
         if: ${{ (matrix.os == 'ubuntu') && (matrix.version == '20.04') }}
         run: |
@@ -151,7 +152,9 @@ jobs:
       - name: "Install build prerequisites"
         run: |
           apt-get update
-          apt-get install -qy bash-completion build-essential debhelper devscripts gcc haskell-stack libbsd-dev libprotobuf-c-dev libutf8proc-dev libuv1-dev make pkg-config uuid-dev zlib1g-dev
+          apt-get install -qy bzip2 gcc haskell-stack make pkg-config procps python3
+          apt-get install -qy libbsd-dev libmd-dev libprotobuf-c-dev libutf8proc-dev libuv1-dev uuid-dev zlib1g-dev
+          apt-get install -qy bash-completion build-essential debhelper devscripts
       - name: "Build Debian packages"
         run: make -C ${GITHUB_WORKSPACE} debs BUILD_RELEASE=${{ env.BUILD_RELEASE }}
       - name: "Compute variables"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,8 +88,6 @@ jobs:
           - os: "debian"
             version: "11"
           - os: "ubuntu"
-            version: "20.04"
-          - os: "ubuntu"
             version: "22.04"
           - os: "ubuntu"
             version: "22.10"

--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -629,12 +629,13 @@ runRestPasses opts paths env0 parsed stubMode = do
                               ccCmd = ("cc -Werror=return-type " ++ pedantArg ++
                                        (if (C.dev opts) then " -g " else "") ++
                                        " -c " ++
-                                       " -I/opt/homebrew/include" ++
-                                       " -I/usr/local/include" ++
-                                       " -I/usr/include" ++
                                        " -I" ++ wd ++
                                        " -I" ++ wd ++ "/out" ++
                                        " -I" ++ sysPath paths ++
+                                       -- TODO: how to get rid of this? we need
+                                       -- to specify the include path for C
+                                       -- libraries we depend on...
+                                       " -I" ++ sysPath paths ++ "/../deps/instdir/include" ++
                                        " -o" ++ oFile ++
                                        " " ++ makeRelative (takeDirectory (projPath paths)) cFile)
                               arCmd = "ar rcs " ++ aFile ++ " " ++ oFile
@@ -710,7 +711,7 @@ buildExecutable env opts paths binTask
         ccArgs              = ""
 -- Linux? and what else? maybe split
 #else
-        libFiles            = libFilesBase ++ " -luuid"
+        libFiles            = libFilesBase
         libPaths            = libPathsBase
         ccArgs              = " -no-pie "
 #endif

--- a/debian/control
+++ b/debian/control
@@ -7,11 +7,7 @@ Build-Depends:
  debhelper-compat (= 13),
  gcc,
  haskell-stack,
- libbsd-dev,
- libmd-dev,
  libprotobuf-c-dev,
- libutf8proc-dev,
- libuv1-dev,
  make,
  pkg-config
 Standards-Version: 4.6.0
@@ -23,7 +19,6 @@ Architecture: any
 Depends:
  ${shlibs:Depends},
  ${misc:Depends},
- gcc,
- uuid-dev
+ gcc
 Description: Acton Programming Language
  An awesome programming language.

--- a/homebrew/Formula/acton.rb
+++ b/homebrew/Formula/acton.rb
@@ -6,12 +6,14 @@ class Acton < Formula
   license "BSD-3-Clause"
   head "https://github.com/actonlang/acton.git", branch: "main"
 
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "gettext" => :build
   depends_on "ghc@8.10" => :build
   depends_on "haskell-stack" => :build
-  depends_on "libuv" => :build
+  depends_on "libtool" => :build
   depends_on "pkg-config" => :build
   depends_on "protobuf-c" => :build
-  depends_on "utf8proc" => :build
 
   on_macos do
     depends_on "argp-standalone" => :build

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -1,5 +1,5 @@
-
-CFLAGS+= -fno-common -I.. -I../dist -I../dist/include -L../lib -Wno-int-to-pointer-cast -Wno-pointer-to-int-cast -Wformat -Werror=format-security
+TD:=$(shell dirname $(realpath ../$(firstword $(MAKEFILE_LIST))))
+CFLAGS+= -L$(TD)/deps/instdir/lib -I$(TD)/deps/instdir/include -fno-common -I.. -I../dist -I../dist/include -L../lib -Wno-int-to-pointer-cast -Wno-pointer-to-int-cast -Wformat -Werror=format-security
 CFLAGS_REL= -O3 -DREL
 CFLAGS_DEV= -g -DDEV
 


### PR DESCRIPTION
Our strategy thus far has been to rely on the package manager of system on which we are being built. On Linux (Debian) we've used apt to install packages and then copy the .a archives from those packages into the Acton distribution, which means we get a library built with some set of options which we are unable to influence. On Mac we do the similar thing but using Homebrew.

Not all libraries are available in apt or brew, so there is a point where we have to start compile things from source. We now do and beyond being able to bring in libraries that are not available in apt/brew, we also gain better control over what compilation flags are used, so for example, we include libxml2 but without z, lzma or python support, making it a much smaller library with no other dependencies.

Our build time naturally increases due to this but it's not too bad, perhaps a minute or two on a fast machine.

I have opted to use neither git submodules nor git subtree for the dependencies simply because it is not needed. subtree is a no go for things like libuuid, which is part of util-linux, which weighs in at 250MB!!

Each dependency is pulled in via git over https and we check out a particular tag or commit for each, so they are effectively pinned. I have not spent much time considering the tag / commit to use, rather just picked like the latest and it seems to work.

Make target prerequisites are not correctly setup, so we will not correctly invalidate these dependencies nor make sure they are up to date. Pretty much the only check is that lib/libActonDeps.a exists. If it does not, we will try to build all the libraries, whereas if it does exist, we will do nothing. Thus, caching works but cache invalidation does not. It's a manual process for now. make clean will clean out the libs but leave the repositories, making it possible to recompile with other flags without having to redownload (good for airplane mode!).