### PR TITLE
Add & use actonc --always-build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -415,14 +415,14 @@ dist/types/__builtin__.ty: builtin/ty/out/types/__builtin__.ty
 
 builtin/ty/out/types/__builtin__.ty: builtin/ty/src/__builtin__.act $(ACTONC)
 	@mkdir -p $(dir $@)
-	$(ACTC) $<
+	$(ACTC) --always-build $<
 
 # Build our standard library
 stdlib/out/dev/lib/libActonProject.a: $(STDLIB_SRCFILES) dist/types/__builtin__.ty $(DIST_HFILES) $(ACTONC) lib/libActonDeps.a
-	cd stdlib && ../$(ACTC) build --dev
+	cd stdlib && ../$(ACTC) build --always-build --dev
 
 stdlib/out/rel/lib/libActonProject.a: $(STDLIB_SRCFILES) dist/types/__builtin__.ty $(DIST_HFILES) $(ACTONC) lib/libActonDeps.a
-	cd stdlib && ../$(ACTC) build
+	cd stdlib && ../$(ACTC) build --always-build
 	cp -a stdlib/out/types/. dist/types/
 
 

--- a/compiler/Acton/CommandLineParser.hs
+++ b/compiler/Acton/CommandLineParser.hs
@@ -27,33 +27,35 @@ data NewOptions     = NewOptions {
                     }  deriving Show
 
 data CompileOptions   = CompileOptions {
-                         parse     :: Bool,
-                         kinds     :: Bool,
-                         types     :: Bool,
-                         sigs      :: Bool,
-                         norm      :: Bool,
-                         deact     :: Bool,
-                         cps       :: Bool,
-                         llift     :: Bool,
-                         hgen      :: Bool,
-                         cgen      :: Bool,
-                         ccmd      :: Bool,
-                         verbose   :: Bool,
-                         timing    :: Bool,
-                         stub      :: Bool,
-                         cpedantic :: Bool,
-                         quiet     :: Bool,
-                         debug     :: Bool,
-                         dev       :: Bool,
-                         root      :: String,
-                         tempdir   :: String,
-                         syspath   :: String
+                         alwaysbuild :: Bool,
+                         parse       :: Bool,
+                         kinds       :: Bool,
+                         types       :: Bool,
+                         sigs        :: Bool,
+                         norm        :: Bool,
+                         deact       :: Bool,
+                         cps         :: Bool,
+                         llift       :: Bool,
+                         hgen        :: Bool,
+                         cgen        :: Bool,
+                         ccmd        :: Bool,
+                         verbose     :: Bool,
+                         timing      :: Bool,
+                         stub        :: Bool,
+                         cpedantic   :: Bool,
+                         quiet       :: Bool,
+                         debug       :: Bool,
+                         dev         :: Bool,
+                         root        :: String,
+                         tempdir     :: String,
+                         syspath     :: String
                      } deriving Show
 
 data BuildOptions = BuildOptions {
-                         devB       :: Bool,
-                         rootB      :: String,
-                         quietB     :: Bool
+                         alwaysB     :: Bool,
+                         devB        :: Bool,
+                         rootB       :: String,
+                         quietB      :: Bool
                      } deriving Show
                          
 
@@ -97,45 +99,50 @@ generalOptions         = GeneralOptions <$>
                          <*> switch (long "dev"        <> help "Development mode; include debug symbols etc")
  -}                       
 
-newCommand          = New <$> (NewOptions <$> argument (str :: ReadM String) (metavar "PROJECTDIR"))
+newCommand = New <$> (NewOptions <$> argument (str :: ReadM String) (metavar "PROJECTDIR"))
 
-compileOptions      = CompileOptions
-                         <$> switch (long "parse"   <> help "Show the result of parsing")
-                         <*> switch (long "kinds"   <> help "Show all the result after kind-checking")
-                         <*> switch (long "types"   <> help "Show all inferred expression types")
-                         <*> switch (long "sigs"    <> help "Show the inferred type signatures")
-                         <*> switch (long "norm"    <> help "Show the result after syntactic normalization")
-                         <*> switch (long "deact"   <> help "Show the result after deactorization")
-                         <*> switch (long "cps"     <> help "Show the result after CPS conversion")
-                         <*> switch (long "llift"   <> help "Show the result of lambda-lifting")
-                         <*> switch (long "hgen"    <> help "Show the generated .h header")
-                         <*> switch (long "cgen"    <> help "Show the generated .c code")
-                         <*> switch (long "ccmd"    <> help "Show CC / LD commands")
-                         <*> switch (long "verbose" <> help "Print progress info during execution")
-                         <*> switch (long "timing"  <> help "Print timing information")
-                         <*> switch (long "stub"    <> help "Stub (.ty) file generation only")
-                         <*> switch (long "cpedantic"<> help "Pedantic C compilation with -Werror")
-                         <*> switch (long "quiet"   <> help "Don't print stuff")
-                         <*> switch (long "debug"   <> help "Print debug stuff")
-                         <*> switch (long "dev"     <> help "Development mode; include debug symbols etc")
-                         <*> strOption (long "root" <> metavar "ROOTACTOR" <> value "" <> help "Set root actor")
-                         <*> strOption (long "tempdir" <> metavar "TEMPDIR" <> value "" <> help "Set directory for build files")
-                         <*> strOption (long "syspath" <> metavar "TARGETDIR" <>  value "" <> help "Set syspath")
+compileOptions = CompileOptions
+        <$> switch (long "always-build" <> help "Show the result of parsing")
+        <*> switch (long "parse"        <> help "Show the result of parsing")
+        <*> switch (long "kinds"        <> help "Show all the result after kind-checking")
+        <*> switch (long "types"        <> help "Show all inferred expression types")
+        <*> switch (long "sigs"         <> help "Show the inferred type signatures")
+        <*> switch (long "norm"         <> help "Show the result after syntactic normalization")
+        <*> switch (long "deact"        <> help "Show the result after deactorization")
+        <*> switch (long "cps"          <> help "Show the result after CPS conversion")
+        <*> switch (long "llift"        <> help "Show the result of lambda-lifting")
+        <*> switch (long "hgen"         <> help "Show the generated .h header")
+        <*> switch (long "cgen"         <> help "Show the generated .c code")
+        <*> switch (long "ccmd"         <> help "Show CC / LD commands")
+        <*> switch (long "verbose"      <> help "Print progress info during execution")
+        <*> switch (long "timing"       <> help "Print timing information")
+        <*> switch (long "stub"         <> help "Stub (.ty) file generation only")
+        <*> switch (long "cpedantic"    <> help "Pedantic C compilation with -Werror")
+        <*> switch (long "quiet"        <> help "Don't print stuff")
+        <*> switch (long "debug"        <> help "Print debug stuff")
+        <*> switch (long "dev"          <> help "Development mode; include debug symbols etc")
+        <*> strOption (long "root"      <> metavar "ROOTACTOR" <> value "" <> help "Set root actor")
+        <*> strOption (long "tempdir"   <> metavar "TEMPDIR" <> value "" <> help "Set directory for build files")
+        <*> strOption (long "syspath"   <> metavar "TARGETDIR" <>  value "" <> help "Set syspath")
 
-buildCommand          = Build <$> (BuildOptions
-                          <$> switch (long "dev"     <> help "Development mode; include debug symbols etc")
-                          <*> strOption (long "root" <> metavar "ROOTACTOR" <> value "" <> help "Set root actor")
-                          <*> switch (long "quiet"   <> help "Don't print stuff"))
+buildCommand          = Build <$> (
+    BuildOptions
+        <$> switch (long "always-build" <> help "Development mode; include debug symbols etc")
+        <*> switch (long "dev"          <> help "Development mode; include debug symbols etc")
+        <*> strOption (long "root"      <> metavar "ROOTACTOR" <> value "" <> help "Set root actor")
+        <*> switch (long "quiet"        <> help "Don't print stuff"))
                  
-cloudCommand        = Cloud <$> (CloudOptions
-                        <$> switch (long "run" <> help "Help run!")
-                        <*> switch (long "list" <> help "Help list!")
-                        <*> switch (long "show" <> help "Help show!")
-                        <*> switch (long "stop" <> help "Help stop!"))
+cloudCommand        = Cloud <$> (
+    CloudOptions
+        <$> switch (long "run"          <> help "Help run!")
+        <*> switch (long "list"         <> help "Help list!")
+        <*> switch (long "show"         <> help "Help show!")
+        <*> switch (long "stop"         <> help "Help stop!"))
 
-docCommand          = Doc <$> (DocOptions
-                        <$> strOption (long "signs" <> metavar "TYFILE" <> value "" <> help "Show type signatures")
-                        <*> strOption (long "full" <> metavar "ACTONFILE" <> value "" <> help "Show type signatures and docstrings"))
+docCommand          = Doc <$> (
+    DocOptions
+        <$> strOption (long "signs" <> metavar "TYFILE" <> value "" <> help "Show type signatures")
+        <*> strOption (long "full" <> metavar "ACTONFILE" <> value "" <> help "Show type signatures and docstrings"))
 
 descr               = fullDesc <> progDesc "Compilation and management of Acton source code and projects"
                       <> header "actonc - the Acton compiler"

--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -66,12 +66,12 @@ main                     =  do arg <- C.parseCmdLine
                                case arg of
                                    C.VersionOpt opts       -> printVersion opts
                                    C.CmdOpt (C.New opts)   -> createProject (C.file opts)
-                                   C.CmdOpt (C.Build opts) -> buildProject $ defaultOpts {C.dev = C.devB opts, C.root = C.rootB opts, C.quiet = C.quietB opts}
+                                   C.CmdOpt (C.Build opts) -> buildProject $ defaultOpts {C.alwaysbuild = C.alwaysB opts, C.dev = C.devB opts, C.root = C.rootB opts, C.quiet = C.quietB opts}
                                    C.CmdOpt (C.Cloud opts) -> undefined
                                    C.CmdOpt (C.Doc opts)   -> printDocs opts
                                    C.CompileOpt nms opts   -> compileFiles opts (catMaybes $ map filterActFile nms)
 
-defaultOpts   = C.CompileOptions False False False False False False False False False False
+defaultOpts   = C.CompileOptions False False False False False False False False False False False
                                  False False False False False False False False "" "" ""
 
 
@@ -458,8 +458,8 @@ doTask opts paths env t@(ActonTask mn src m stubMode) = do
         cFile               = outbase ++ ".c"
         oFile               = joinPath [projLib paths, prstr mn] ++  ".o"
         forceCompilation :: C.CompileOptions -> Bool
-        forceCompilation args = (C.parse args) || (C.kinds args) || (C.types args) || (C.sigs args)  ||  (C.norm args) 
-                              || (C.deact args) || (C.cps args)  || (C.llift args) || (C.hgen args)  ||(C.cgen args)
+        forceCompilation args = (C.alwaysbuild args) || (C.parse args) || (C.kinds args) || (C.types args) || (C.sigs args)
+                                || (C.norm args) || (C.deact args) || (C.cps args) || (C.llift args) || (C.hgen args) ||(C.cgen args)
 
 runCustomMake paths mn = do
     -- copy header file in place, if it exists

--- a/compiler/test.hs
+++ b/compiler/test.hs
@@ -281,7 +281,7 @@ buildThing opts thing = do
     projPath <- canonicalizePath thing
     curDir <- getCurrentDirectory
     let wd = if proj then projPath else curDir
-    let actCmd    = (id actonc) ++ " " ++ if proj then "build " ++ opts else thing ++ " " ++ opts
+    let actCmd    = (id actonc) ++ " " ++ (if proj then "build " else thing) ++ " --always-build " ++ opts
     (returnCode, cmdOut, cmdErr) <- readCreateProcessWithExitCode (shell $ actCmd){ cwd = Just wd } ""
     return (returnCode, cmdOut, cmdErr)
 


### PR DESCRIPTION
--always-build skips the up-to-date check in actonc and always builds, which is necessary for correct tests since we otherwise risk relying on outdated results. The up-to-date check only inspects source and output files on disk. For example, if a .ty file is newer than its source .act file. If actonc itself has changed and updated the format of the .ty file, we won't catch this. --always-build is thus the only safe option for testing.

Fixes #967.