### PR TITLE
Add bsdnt for bigint support

### DIFF
--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -629,6 +629,7 @@ runRestPasses opts paths env0 parsed stubMode = do
                               ccCmd = ("cc -Werror=return-type " ++ pedantArg ++
                                        (if (C.dev opts) then " -g " else "") ++
                                        " -c " ++
+                                       " -isystem " ++ sysPath paths ++ "/include" ++
                                        " -I" ++ wd ++
                                        " -I" ++ wd ++ "/out" ++
                                        " -I" ++ sysPath paths ++
@@ -720,6 +721,7 @@ buildExecutable env opts paths binTask
         pedantArg           = if (C.cpedantic opts) then "-Werror" else ""
         ccCmd               = ("cc " ++ ccArgs ++ pedantArg ++
                                (if (C.dev opts) then " -g " else " -O3 ") ++
+                               " -isystem " ++ sysPath paths ++ "/include" ++
                                " -I" ++ projOut paths ++
                                " -I" ++ sysPath paths ++
                                " " ++ rootFile ++


### PR DESCRIPTION
This adds in the bsdnt library which we plan to use for bigint support. I'm opening a separate PR in order to land these changes immediately thereby reducing the risk of git conflicts in the build system files since there's a bunch of work relating to that which is currently ongoing (most notably using zig).

Part of #146