### PR TITLE
Pull libxml2 from github

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -381,7 +381,7 @@ deps/instdir/lib/libuv.a: deps/libuv
 # /deps/libxml2 ------------------------------------------
 LIBXML2_REF=644a89e080bced793295f61f18aac8cfad6bece2
 deps/libxml2:
-	ls $@ >/dev/null 2>&1 || git clone https://gitlab.gnome.org/GNOME/libxml2.git $@
+	ls $@ >/dev/null 2>&1 || git clone https://github.com/GNOME/libxml2.git $@
 
 deps/instdir/lib/libxml2.a: deps/libxml2
 	mkdir -p $(dir $@)


### PR DESCRIPTION
Seems to be problems pulling it from gitlab from github actions, so let's try pulling from github instead, where there's a read-only mirror.