### PR TITLE
Do not clean compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -551,7 +551,7 @@ test-stdlib:
 
 
 .PHONY: clean
-clean: clean-compiler clean-deps clean-distribution clean-backend clean-rts
+clean: clean-deps clean-distribution clean-backend clean-rts
 
 .PHONY: clean-backend
 clean-backend:


### PR DESCRIPTION
We have a make clean target to clean out stuff if dependency updates have gone wrong or similar. This certainly has happened in places like the builtins or stdlib but I don't think I've ever seen it happen to the compiler... it always recompiles correctly! And since it's rather slow rebuilding the compiler, I think what most people what when they do "make clean && make" is to just rebuild the other stuff and thus I'm removing the compiler from the default clean action. If you really want to clean away the compiler, do make clean clean-compiler