### PR TITLE
Use -target for all & include protobuf headers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
             ~/.stack
           key: ${{ matrix.os }}-${{ secrets.CACHE_VERSION }}
       - name: "Install build prerequisites"
-        run: brew install argp-standalone automake gettext haskell-stack libtool protobuf-c
+        run: brew install argp-standalone automake coreutils gettext haskell-stack libtool protobuf-c
       - name: "Build Acton"
         run: make -j2 -C ${{ github.workspace }} BUILD_RELEASE=${{ env.BUILD_RELEASE }}
       - name: "Build a release"


### PR DESCRIPTION
Now the -target argument is applied universally. While we previously applied it to dependencies and ran it from actonc, thus covering stdlib, we didn't use it for CFLAGS throughout the Makefile, so actondb for example was not compiled with -target, thus it would get dynamically linked towards the glibc on the machine instead of the fixed version we have set. That prevented actondb from being run on older machines.

Also, using -target changes the include paths and this revelead that we didn't have a working inclusion of protobuf headers. protobuf is a dependency where we still rely on a system provided library rather than compiling it ourselves. This is somewhat risky since we want to guarantee compatibility with some given glibc version but it's tricky compiling protobuf-c and since presumably protobuf-c only calls functions that are available in older glibcs, it actually works?