### PR TITLE
Move pidigits benchgame

### DIFF
--- a/test/perf-benchgames/pidigits/1.act
+++ b/test/perf-benchgames/pidigits/1.act
@@ -1,4 +1,4 @@
-# Acton port of https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/pidigits-python3-4.html
+# Acton port of https://github.com/actonlang/Programming-Language-Benchmarks/blob/main/bench/algorithm/pidigits/4.py
 actor main(env):
     n=int(env.argv[1])
 


### PR DESCRIPTION
Follow directory structure in programmings-language benchmark repo under bench/algorithm so we can easily copy programs between the two.