### PR TITLE
Add --auto-stub to actonc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -452,10 +452,10 @@ builtin/ty/out/types/__builtin__.ty: builtin/ty/src/__builtin__.act $(ACTONC)
 
 # Build our standard library
 stdlib/out/dev/lib/libActonProject.a: $(STDLIB_SRCFILES) dist/types/__builtin__.ty $(DIST_HFILES) $(ACTONC) $(DEPSA)
-	cd stdlib && ../$(ACTC) build --always-build --dev
+	cd stdlib && ../$(ACTC) build --always-build --auto-stub --dev
 
 stdlib/out/rel/lib/libActonProject.a: $(STDLIB_SRCFILES) dist/types/__builtin__.ty $(DIST_HFILES) $(ACTONC) $(DEPSA)
-	cd stdlib && ../$(ACTC) build --always-build
+	cd stdlib && ../$(ACTC) build --always-build --auto-stub
 	cp -a stdlib/out/types/. dist/types/
 
 

--- a/compiler/Acton/CommandLineParser.hs
+++ b/compiler/Acton/CommandLineParser.hs
@@ -41,6 +41,7 @@ data CompileOptions   = CompileOptions {
                          ccmd        :: Bool,
                          verbose     :: Bool,
                          timing      :: Bool,
+                         autostub    :: Bool,
                          stub        :: Bool,
                          cpedantic   :: Bool,
                          quiet       :: Bool,
@@ -54,6 +55,7 @@ data CompileOptions   = CompileOptions {
 data BuildOptions = BuildOptions {
                          alwaysB     :: Bool,
                          devB        :: Bool,
+                         autostubB   :: Bool,
                          rootB       :: String,
                          quietB      :: Bool,
                          timingB     :: Bool
@@ -117,6 +119,7 @@ compileOptions = CompileOptions
         <*> switch (long "ccmd"         <> help "Show CC / LD commands")
         <*> switch (long "verbose"      <> help "Print progress info during execution")
         <*> switch (long "timing"       <> help "Print timing information")
+        <*> switch (long "auto-stub"    <> help "Allow automatic stub detection")
         <*> switch (long "stub"         <> help "Stub (.ty) file generation only")
         <*> switch (long "cpedantic"    <> help "Pedantic C compilation with -Werror")
         <*> switch (long "quiet"        <> help "Don't print stuff")
@@ -130,6 +133,7 @@ buildCommand          = Build <$> (
     BuildOptions
         <$> switch (long "always-build" <> help "Development mode; include debug symbols etc")
         <*> switch (long "dev"          <> help "Development mode; include debug symbols etc")
+        <*> switch (long "auto-stub"    <> help "Allow automatic stub detection")
         <*> strOption (long "root"      <> metavar "ROOTACTOR" <> value "" <> help "Set root actor")
         <*> switch (long "quiet"        <> help "Don't print stuff")
         <*> switch (long "timing"       <> help "Print timing information")

--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -74,13 +74,13 @@ main                     =  do arg <- C.parseCmdLine
                                case arg of
                                    C.VersionOpt opts       -> printVersion opts
                                    C.CmdOpt (C.New opts)   -> createProject (C.file opts)
-                                   C.CmdOpt (C.Build opts) -> buildProject $ defaultOpts {C.alwaysbuild = C.alwaysB opts, C.dev = C.devB opts, C.root = C.rootB opts, C.quiet = C.quietB opts, C.timing = C.timingB opts}
+                                   C.CmdOpt (C.Build opts) -> buildProject $ defaultOpts {C.alwaysbuild = C.alwaysB opts, C.autostub = C.autostubB opts, C.dev = C.devB opts, C.root = C.rootB opts, C.quiet = C.quietB opts, C.timing = C.timingB opts}
                                    C.CmdOpt (C.Cloud opts) -> undefined
                                    C.CmdOpt (C.Doc opts)   -> printDocs opts
                                    C.CompileOpt nms opts   -> compileFiles opts (catMaybes $ map filterActFile nms)
 
 defaultOpts   = C.CompileOptions False False False False False False False False False False False
-                                 False False False False False False False False "" "" ""
+                                 False False False False False False False False False "" "" ""
 
 
 -- Auxiliary functions ---------------------------------------------------------------------------------------
@@ -367,9 +367,10 @@ parseActFile opts paths actFile = do
     where detectStubMode :: Paths -> String -> C.CompileOptions -> IO Bool
           detectStubMode paths srcfile opts = do
                     exists <- doesFileExist cFile
-                    when (exists && C.debug opts) $ do putStrLn("Found matching C file (" ++ makeRelative (srcDir paths) cFile
+                    let doStub = exists && C.autostub opts
+                    when (doStub && C.debug opts) $ do putStrLn("Found matching C file (" ++ makeRelative (srcDir paths) cFile
                                                         ++ "), assuming stub compilation for " ++ makeRelative (srcDir paths) srcfile)
-                    return ((takeFileName srcfile) == "__builtin__.act" || C.stub opts || exists)
+                    return ((takeFileName srcfile) == "__builtin__.act" || C.stub opts || doStub)
               where cFile = replaceExtension srcfile ".c"
 
 


### PR DESCRIPTION
This enables the automatic detection of stub mode compilation. Previously it was the default to always do stub mode detection, but this is problematic if there happens to be .c files with the same name as our .act file in the same directory but it's entirely unrelated, i.e. not an Acton C module implementation.

This is the case with the Programming Languages Benchmark where all test files are in the same directory and named by a sequence number, like 1.act is the first Acton solution to a particular problem and 1.c is the C solution to the same problem.

It is saner and safer to not do automatic stub compilation per default. For some places, like our stdlib, we now have to provide --auto-stub, which feels just fine!

Fixes #1047.