### PR TITLE
Include argp in libActonDeps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
             ~/.stack
           key: ${{ matrix.os }}-${{ secrets.CACHE_VERSION }}
       - name: "Install build prerequisites"
-        run: brew install argp-standalone automake gettext haskell-stack libtool protobuf-c
+        run: brew install automake gettext haskell-stack libtool protobuf-c
       - name: "Build Acton"
         run: make -j2 -C ${{ github.workspace }} BUILD_RELEASE=${{ env.BUILD_RELEASE }}
       - name: "Build a release"

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ backend/actondb: backend/actondb.c lib/libActonDB.a $(DEPSA)
 	$(CC) -o$@ $< $(CFLAGS) \
 		$(LDFLAGS) \
 		-lActonDB \
-		$(LDLIBS)
+		$(LDLIBS) -lActonDeps
 
 # Listing DEPSA as prerequisites in a target means it is dependent upon at least
 # one of  the external libraries that we place in libActonDeps

--- a/homebrew/Formula/acton.rb
+++ b/homebrew/Formula/acton.rb
@@ -15,10 +15,6 @@ class Acton < Formula
   depends_on "pkg-config" => :build
   depends_on "protobuf-c" => :build
 
-  on_macos do
-    depends_on "argp-standalone" => :build
-  end
-
   on_linux do
     depends_on "libbsd" => :build
     depends_on "gcc"


### PR DESCRIPTION
This avoids a dependency on an external libargp on MacOS, so we now get to control how it is compiled.

For Linux, this should have preference over the system provided argp.

Fixes #1037.