### PR TITLE
Remove deps for Linux in CI & in debs

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,6 @@ Package: acton
 Architecture: any
 Depends:
  ${shlibs:Depends},
- ${misc:Depends},
- gcc
+ ${misc:Depends}
 Description: Acton Programming Language
  An awesome programming language.

--- a/docs/development_workflow.md
+++ b/docs/development_workflow.md
@@ -1,4 +1,5 @@
-# Development Workflow
+# Development Workflow n stuff
+
 
 ## Git workflow
 
@@ -50,3 +51,16 @@ There are two types of releases, "version releases" and the `tip` release.
       available
   - the release has a stable URL:
     https://github.com/actonlang/acton/releases/tag/tip
+
+
+# Dependencies
+
+## Build time
+- automake, autopoint, bison, libtool, pkg-config
+  - required by external library dependencies
+- libprotobuf-c-dev
+  - required by libprotobuf-c, this is all very complicated
+- gcc
+  - required by ghc
+- zlib1g-dev
+  - required by ghc


### PR DESCRIPTION
These external library dependencies are part of libActonDeps now, so no need to install. Nor do we need gcc at run time of actonc since we bundle zig.

Fixes #1079.