### PR TITLE
Lower test timeouts

### DIFF
--- a/test/rts_db/test_tcp_server.act
+++ b/test/rts_db/test_tcp_server.act
@@ -279,5 +279,5 @@ actor main(env):
         await async t.report()
         await async env.exit(1)
 
-    after 90: test_timeout()
-    after 100: unconditional_exit()
+    after 21: test_timeout()
+    after 25: unconditional_exit()


### PR DESCRIPTION
We should always reach a no quorum error in 10 seconds. We set the test timeout to 2 times that plus a second of margin so we really should be able to see 2 such messages. It's just unnecessary waiting any longer and we could probably consider lowering it even further (maybe changing no quorum error timeout too?). This should speed up failure cases in tests a bit (if we run a lot of tests and expect some level of failures).