### PR TITLE
Make RTS clients sticky to partitions

### DIFF
--- a/backend/client_api.c
+++ b/backend/client_api.c
@@ -192,7 +192,8 @@ int install_gossiped_view(membership_agreement_msg * ma, remote_db_t * db, unsig
 
     pthread_mutex_lock(db->gossip_lock);
 
-    if(db->current_view_id != NULL && compare_vc(db->current_view_id, ma->vc) == VC_INCOMPARABLE)
+    if(db->current_view_id != NULL && (compare_vc(db->current_view_id, ma->vc) == VC_INCOMPARABLE ||
+                                        compare_vc(db->current_view_id, ma->vc) == VC_DISJOINT))
     {
 #if (VERBOSE_RPC > -1)
         log_debug("CLIENT: Skipping installing notified view %s because it is incomparable to my installed view %s (client is remaining sticky to previous partition)!",

--- a/backend/client_api.c
+++ b/backend/client_api.c
@@ -188,7 +188,7 @@ int handle_socket_close(int * childfd)
 
 int install_gossiped_view(membership_agreement_msg * ma, remote_db_t * db, unsigned int * fastrandstate)
 {
-    char msg_buf[4096];
+    char msg_buf[4096], msg_buf2[1024];
 
     pthread_mutex_lock(db->gossip_lock);
 
@@ -197,7 +197,7 @@ int install_gossiped_view(membership_agreement_msg * ma, remote_db_t * db, unsig
     {
 #if (VERBOSE_RPC > -1)
         log_debug("CLIENT: Skipping installing notified view %s because it is incomparable to my installed view %s (client is remaining sticky to previous partition)!",
-                            to_string_vc(ma->vc, msg_buf), to_string_vc(db->current_view_id, msg_buf));
+                            to_string_vc(ma->vc, msg_buf), to_string_vc(db->current_view_id, msg_buf2));
 #endif
 
         pthread_mutex_unlock(db->gossip_lock);
@@ -209,7 +209,7 @@ int install_gossiped_view(membership_agreement_msg * ma, remote_db_t * db, unsig
     {
 #if (VERBOSE_RPC > -1)
         log_debug("CLIENT: Skipping installing notified view %s because it is older than my installed view %s!",
-                            to_string_vc(ma->vc, msg_buf), to_string_vc(db->current_view_id, msg_buf));
+                            to_string_vc(ma->vc, msg_buf), to_string_vc(db->current_view_id, msg_buf2));
 #endif
 
         pthread_mutex_unlock(db->gossip_lock);

--- a/backend/failure_detector/vector_clock.c
+++ b/backend/failure_detector/vector_clock.c
@@ -52,17 +52,17 @@ int compare_vc(vector_clock * vc1, vector_clock * vc2)
         return 0;
 
     if(vc1 == NULL || vc2 == NULL)
-        return -2;
+        return VC_INCOMPARABLE;
 
     if(vc1->no_nodes != vc2->no_nodes)
-        return -2;
+        return VC_INCOMPARABLE;
 
     int first_bigger = 0, second_bigger = 0;
 
     for(int i=0;i<vc1->no_nodes;i++)
     {
         if(vc1->node_ids[i].node_id != vc2->node_ids[i].node_id)
-            return -2;
+            return VC_INCOMPARABLE;
 
         if(vc1->node_ids[i].counter > vc2->node_ids[i].counter)
             first_bigger = 1;
@@ -71,7 +71,7 @@ int compare_vc(vector_clock * vc1, vector_clock * vc2)
     }
 
     if(first_bigger && second_bigger)
-        return -2;
+        return VC_DISJOINT;
     else if(first_bigger)
         return 1;
     else if(second_bigger)

--- a/backend/failure_detector/vector_clock.h
+++ b/backend/failure_detector/vector_clock.h
@@ -10,6 +10,9 @@
 #define DEFAULT_SIZE 8
 #define GROWTH_RATE 2.0
 
+#define VC_INCOMPARABLE -2
+#define VC_DISJOINT -3
+
 #include "db_messages.pb-c.h"
 #include <sys/socket.h>
 #include <netinet/in.h>


### PR DESCRIPTION
Make sure that clients (RTSs) do not hop between different DB server partitions if these exist, even if they learn about disjoint gossip views.
This handles a problem that can happen if incomplete partitions happen. For instance, the distributed DB servers might be partitioned from each other, but the clients (RTSs) might still be able to talk to servers in both partitions. Consequently, clients might receive a stream of diverging gossip views from each of the partitions. If this happens, this PR enforces that the clients stick to one of the partitions only to prevent data inconsistency.
This is implemented by comparing the vector clocks of the currently installed view, and the new view to be installed, and skipping view installs at the client as long as these vector clocks are incomparable or diverge.
When partition is healed between servers, the vector clocks will become comparable again and the RTS clients will join the new merged partition.