### PR TITLE
Correct error handling in comm thread

### DIFF
--- a/backend/client_api.c
+++ b/backend/client_api.c
@@ -313,10 +313,10 @@ void * comm_thread_loop(void * args)
 
         int status = select(max_fd + 1 , &(db->readfds) , NULL , NULL , &timeout);
 
-        if ((status < 0) && (errno!=EINTR))
-        {
-            log_error("select error!");
-            assert(0);
+        if (status < 0) {
+            if (errno != EINTR)
+                log_error("select error, errno: %d", errno);
+            continue;
         }
 
         if (FD_ISSET(db->wakeup_pipe[0], &(db->readfds))) {


### PR DESCRIPTION
If we get an error we take another spin in the loop rather than try to continue processing.

I've seen the comm thread hanging on a read on the wakeup_pipe, which shouldn't be possible. I wonder if it might be that we have continued processing after getting EINTR and that is just invalid. Think this fixes it.