### PR TITLE
Test on Ubuntu 20.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,6 +88,8 @@ jobs:
           - os: "debian"
             version: "11"
           - os: "ubuntu"
+            version: "20.04"
+          - os: "ubuntu"
             version: "22.04"
           - os: "ubuntu"
             version: "22.10"

--- a/Makefile
+++ b/Makefile
@@ -428,6 +428,7 @@ deps/instdir/lib/libxml2.a: deps/libxml2 $(ZIG)
 	mkdir -p $(dir $@)
 	cd $< \
 	&& git checkout $(LIBXML2_REF) \
+	&& sed -i -e 's/1.16.3/1.16.1/' configure.ac \
 	&& ./autogen.sh --without-python --without-iconv --without-zlib --without-lzma --prefix=$(TD)/deps/instdir --enable-static --disable-shared CFLAGS="$(CFLAGS_DEPS)" \
 	&& make -j && make install \
 	&& mv $(TD)/deps/instdir/include/libxml2/libxml $(TD)/deps/instdir/include/libxml


### PR DESCRIPTION
We dropped Ubuntu 20.04 when it was clear that libxml2 required a newer version of automake than available on Ubuntu 20.04 and it was just too much to handle at the time. As it turns out, that requirement is probably not a very hard requirement at all, likely the artifact of running autoupdate on a relatively new machine and voila, the required version is bumped to something quite new.

It seems to work just fine compiling and running after we rewrite the required version to what is available on Ubuntu 20.04.