### PR TITLE
Add actonc --cc for what CC to use & add --verbose

### DIFF
--- a/compiler/Acton/CommandLineParser.hs
+++ b/compiler/Acton/CommandLineParser.hs
@@ -49,7 +49,8 @@ data CompileOptions   = CompileOptions {
                          dev         :: Bool,
                          root        :: String,
                          tempdir     :: String,
-                         syspath     :: String
+                         syspath     :: String,
+                         cc          :: String
                      } deriving Show
 
 data BuildOptions = BuildOptions {
@@ -58,7 +59,8 @@ data BuildOptions = BuildOptions {
                          autostubB   :: Bool,
                          rootB       :: String,
                          quietB      :: Bool,
-                         timingB     :: Bool
+                         timingB     :: Bool,
+                         ccB         :: String
                      } deriving Show
                          
 
@@ -128,6 +130,7 @@ compileOptions = CompileOptions
         <*> strOption (long "root"      <> metavar "ROOTACTOR" <> value "" <> help "Set root actor")
         <*> strOption (long "tempdir"   <> metavar "TEMPDIR" <> value "" <> help "Set directory for build files")
         <*> strOption (long "syspath"   <> metavar "TARGETDIR" <>  value "" <> help "Set syspath")
+        <*> strOption (long "cc"        <> metavar "PATH" <>  value "" <> help "CC")
 
 buildCommand          = Build <$> (
     BuildOptions
@@ -137,6 +140,7 @@ buildCommand          = Build <$> (
         <*> strOption (long "root"      <> metavar "ROOTACTOR" <> value "" <> help "Set root actor")
         <*> switch (long "quiet"        <> help "Don't print stuff")
         <*> switch (long "timing"       <> help "Print timing information")
+        <*> strOption (long "cc"        <> metavar "PATH" <>  value "" <> help "CC")
     )
                  
 cloudCommand        = Cloud <$> (


### PR DESCRIPTION
This makes it possible to pick what C compiler is used when compiling an Acton program. While the default is still zig cc I have noticed that we get poor performance in certain situations and it makes things a lot easier to debug if we can easily switch CC at run time rather than having to recompile actonc.

In the few cases where I have tested this, it has been enough to only change CC during the final acton program compilation, i.e. the acton system, including RTS, builtins and stdlib is still built with zig cc. There might be other cases where we would need to recompile that as well, which is then an entirely different matter.

Also, some of the options we pass to zig are known to be zig specific, so those are now only thrown in for the default of zig cc.

When we compile using zig cc, we now run with --verbose which might help debug some scenarios.

Fixes #1096.