### PR TITLE
Add tests of list

### DIFF
--- a/test/builtins_auto/list.act
+++ b/test/builtins_auto/list.act
@@ -1,0 +1,72 @@
+"""Test lists
+"""
+
+actor main(env):
+    l: list[int] = [1, 2]
+
+    l.append(3)
+    if l != [1, 2, 3]:
+        print("Unexpected result of list.append(3):", l)
+        await async env.exit(1)
+
+    l.insert(0, 0)
+    if l != [0, 1, 2, 3]:
+        print("Unexpected result of list.insert(0, 0):", l)
+        await async env.exit(1)
+
+    l.insert(2, 37)
+    if l != [0, 1, 37, 2, 3]:
+        print("Unexpected result of list.insert(2, 37):", l)
+        await async env.exit(1)
+
+#    if l.index(37) != 2:
+#        print("Unexpected result of list.index(37):", l)
+#        await async env.exit(1)
+
+    l2 = l.copy()
+    if l2 != [0, 1, 37, 2, 3]:
+        print("Unexpected result of list.copy():", l2)
+        await async env.exit(1)
+
+#    c = l.count(37, None, None)
+#    if c != 1:
+#        print("Unexpected result of list.count(37):", c)
+#        await async env.exit(1)
+
+#    l.extend([45, 56])
+#    if l != [0, 1, 37, 2, 3, 45, 56]:
+#        print("Unexpected result of list.extend([45, 56]):", l)
+#        await async env.exit(1)
+
+    l.reverse()
+    if l != [3, 2, 37, 1, 0]:
+        print("Unexpected result of list.reverse():", l)
+        await async env.exit(1)
+
+    del l[1]
+    if l != [3, 37, 1, 0]:
+        print("Unexpected result of del list[1]:", l)
+        await async env.exit(1)
+
+#    l.pop()
+#    if l != [3, 37, 1]:
+#        print("Unexpected result of list.pop():", l)
+#        await async env.exit(1)
+
+#    l.remove(37)
+#    if l != [3, 1]:
+#        print("Unexpected result of list.remove(37):", l)
+#        await async env.exit(1)
+
+
+#    l.clear()
+#    if l != []:
+#        print("Unexpected result of list.clear():", l)
+#        await async env.exit(1)
+
+#    l.sort()
+#    if l != [0, 1, 2, 3, 37]:
+#        print("Unexpected result of list.sort():", l)
+#        await async env.exit(1)
+
+    await async env.exit(0)


### PR DESCRIPTION
Test various methods of lists. A bunch of things are commented out as it doesn't work in Acton, although perhaps it should given that we more or less copy Python lists? If we decide this is not to be implemented, then let's just remove it.

Related to #1132 