### PR TITLE
Always statically compile actonc

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,7 +156,7 @@ jobs:
           apt-get install -qy libprotobuf-c-dev zlib1g-dev
           apt-get install -qy bash-completion build-essential debhelper devscripts
       - name: "Build Debian packages"
-        run: make -C ${GITHUB_WORKSPACE} debs BUILD_RELEASE=${{ env.BUILD_RELEASE }} STATIC_ACTONC=true
+        run: make -C ${GITHUB_WORKSPACE} debs BUILD_RELEASE=${{ env.BUILD_RELEASE }}
       - name: "Compute variables"
         id: vars
         run: |

--- a/Makefile
+++ b/Makefile
@@ -232,17 +232,12 @@ builtin/env_rel.o: builtin/env.c builtin/env.h builtin/builtin_rel.o
 ACTONC_ALL_HS=$(wildcard compiler/*.hs compiler/**/*.hs)
 ACTONC_TEST_HS=$(wildcard compiler/tests/*.hs)
 ACTONC_HS=$(filter-out $(ACTONC_TEST_HS),$(ACTONC_ALL_HS))
-# Set STATIC_ACTONC=true to build a static actonc binary. This works on Debian
-# 11 and distributions of similar age while it seems to fail on newer versions.
-ifeq ($(STATIC_ACTONC),true)
-ACTC_GHC_OPTS=-optl-static
-endif
 # NOTE: we're unsetting CC to avoid using zig cc for stack / ghc, which doesn't
 # seem to work properly
 compiler/actonc: compiler/package.yaml.in compiler/stack.yaml $(ACTONC_HS)
 	cd compiler && unset CC && unset CFLAGS && stack build --dry-run 2>&1 | grep "Nothing to build" || \
 		(sed 's,^version:.*,version:      "$(VERSION_INFO)",' < package.yaml.in > package.yaml \
-		&& stack build --ghc-options='-j4 $(ACTC_GHC_OPTS)' \
+		&& stack build --ghc-options='-j4 -optl-static' \
 		&& stack --local-bin-path=. install 2>/dev/null)
 
 .PHONY: clean-compiler
@@ -730,4 +725,4 @@ debian/changelog: debian/changelog.in CHANGELOG.md
 
 .PHONY: debs
 debs: debian/changelog
-	debuild --preserve-envvar VERSION_INFO --preserve-envvar STATIC_ACTONC -i -us -uc -b
+	debuild --preserve-envvar VERSION_INFO -i -us -uc -b


### PR DESCRIPTION
Instead of conditionally doing static build of actonc (on Debian 11), we do it all the time. Less options is a good thing!