### PR TITLE
Handle signal interrupts in rts.sleep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -502,10 +502,10 @@ builtin/ty/out/types/__builtin__.ty: builtin/ty/src/__builtin__.act $(ACTONC)
 	$(ACTC) --always-build $<
 
 # Build our standard library
-stdlib/out/dev/lib/libActonProject.a: $(STDLIB_SRCFILES) dist/types/__builtin__.ty $(DIST_HFILES) $(ACTONC) $(DEPSA)
+stdlib/out/dev/lib/libActonProject.a: $(STDLIB_SRCFILES) dist/types/__builtin__.ty $(DIST_HFILES) $(ACTONC) $(DEPSA) $(LIBGC)
 	cd stdlib && ../$(ACTC) build --always-build --auto-stub --dev
 
-stdlib/out/rel/lib/libActonProject.a: $(STDLIB_SRCFILES) dist/types/__builtin__.ty $(DIST_HFILES) $(ACTONC) $(DEPSA)
+stdlib/out/rel/lib/libActonProject.a: $(STDLIB_SRCFILES) dist/types/__builtin__.ty $(DIST_HFILES) $(ACTONC) $(DEPSA) $(LIBGC)
 	cd stdlib && ../$(ACTC) build --always-build --auto-stub
 	cp -a stdlib/out/types/. dist/types/
 
@@ -556,7 +556,7 @@ rts/rts_dev.o: rts/rts.c rts/rts.h $(DEPSA) $(LIBGC)
 		-Wno-int-to-void-pointer-cast -Wno-unused-result \
 		-c $< -o $@
 
-rts/rts_rel.o: rts/rts.c rts/rts.h $(DEPSA)
+rts/rts_rel.o: rts/rts.c rts/rts.h $(DEPSA) $(LIBGC)
 	$(CC) $(CFLAGS) $(CFLAGS_REL) \
 		-Wno-int-to-void-pointer-cast -Wno-unused-result \
 		-c $< -o $@

--- a/stdlib/src/acton/rts.act
+++ b/stdlib/src/acton/rts.act
@@ -1,4 +1,7 @@
 
+def gc() -> None:
+    NotImplemented
+
 # sleep is sort of dangerous - it will actually put the RTS thread executing the
 # actor calling this function to sleep. This could be seen as ultrabad, like we
 # would want to just pause execution of one actor and let the RTS thread process

--- a/stdlib/src/acton/rts.ext.c
+++ b/stdlib/src/acton/rts.ext.c
@@ -1,13 +1,36 @@
+#include <time.h>
 #include <uv.h>
-#include <unistd.h>
+#include "gc.h"
 
 void actonQ_rtsQ___ext_init__() {
     // NOP
 }
 
+B_NoneType actonQ_rtsQ_gc () {
+    GC_gcollect();
+    return B_None;
+}
+
 B_NoneType actonQ_rtsQ_sleep (B_float sleep_time) {
-    int to_sleep = sleep_time->val*1000000;
-    usleep(to_sleep);
+    double st = fromB_float(sleep_time);
+    struct timespec ts;
+    ts.tv_sec = (int)st;
+    ts.tv_nsec = (st - (float)ts.tv_sec)*1e9;
+
+    // Handle overflow of nanoseconds into seconds
+    if (ts.tv_nsec >= 1e9) {
+        ts.tv_sec += 1;
+        ts.tv_nsec -= 1e9;
+    }
+
+    // Unlike usleep, nanosleep() tolerates signal interrupts and will write the
+    // remaining time (that it didn't sleep) into the third argument. We spin
+    // until it completes successfully.
+    while (1) {
+        int r = nanosleep(&ts, &ts);
+        if (r == 0)
+            break;
+    }
     return B_None;
 }
 

--- a/test/stdlib_auto/test_acton_rts_sleep.act
+++ b/test/stdlib_auto/test_acton_rts_sleep.act
@@ -1,6 +1,12 @@
 import acton.rts
 import time
 
+actor Interruptor():
+    def interrupt():
+        acton.rts.gc()
+        after 0.001: interrupt()
+    interrupt()
+
 actor main(env):
     def test():
         t1 = time.time_ns()
@@ -13,5 +19,6 @@ actor main(env):
         else:
             return 0
 
+#    i = Interruptor()
     r = test()
     env.exit(r)


### PR DESCRIPTION
Calling usleep isn't signal safe and since our GC is using signals
rather extensively to pause threads, we ended up with a fairly broken
rts.sleep. By switching to nanosleep we not only tolerate signals but
can also resume sleeping to the correct amount as nanosleep will return
the remaining time that it didn't sleep.

Also added in a acton.rts.gc() function that will explicitly invoke the
GC since this was fairly useful to trigger bugs during testing. There's
an "Interruptor" actor in the test of acton.rts.sleep which was helpful
during development but as it seems we have some unknown deadlock!? I am
not leaving it enabled, though just commented out so we can investigate
further.

Fixes #1171