### PR TITLE
Remove redundant CFLAGS path on linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,6 @@ endif # -- END: Apple Mac OS X -------------------------------------------------
 CFLAGS += -Werror
 # -- Linux ---------------------------------------------------------------------
 ifeq ($(shell uname -s),Linux)
-CFLAGS += -I$(TD)/deps/instdir/include
 ZIG_OS:=linux
 ifeq ($(shell uname -m),x86_64)
 CFLAGS_TARGET := -target x86_64-linux-gnu.2.28


### PR DESCRIPTION
We already set this argument in CFLAGS for all platforms higher up.