### PR TITLE
Revamp & fix bugs in TCPListener

### DIFF
--- a/examples/server.act
+++ b/examples/server.act
@@ -1,22 +1,25 @@
 import net
 
-actor Server(listen_auth, port):
 
-    def on_lsock_error(l, error):
-        print("There was an error with the TCPListener socket:", error)
-
-    def on_server_accept(c):
-        pass
-
-    def on_server_receive(c, data):
+actor Server(conn):
+    def on_receive(c, data):
         print("Server Received some data:", data, " from:", c)
         if data == b"PING":
             c.write(b"PONG")
 
-    def on_server_error(c, error):
+    def on_error(c, error):
         print("There was an error:", error, " from:", c)
 
-    var server = net.TCPListener(listen_auth, "0.0.0.0", port, on_lsock_error, on_server_accept, on_server_receive, on_server_error)
+actor Listener(listen_auth, port):
+
+    def on_error(l, error):
+        print("There was an error with the TCPListener socket:", error)
+
+    def on_accept(c):
+        s = Server(c)
+        c.cb_install(s.on_receive, s.on_error)
+
+    var server = net.TCPListener(listen_auth, "0.0.0.0", port, on_error, on_accept)
 
 actor main(env):
     port = 12345
@@ -24,4 +27,4 @@ actor main(env):
     # Set up specific auth token
     listen_auth = net.TCPListenAuth(net.TCPAuth(net.NetAuth(env.auth)))
 
-    s = Server(listen_auth, port)
+    l = Listener(listen_auth, port)

--- a/stdlib/src/net.act
+++ b/stdlib/src/net.act
@@ -62,8 +62,29 @@ actor TCPIPConnection(auth: TCPConnectAuth, address: str, port: int, on_connect:
         NotImplemented
     _init()
 
-actor TCPListenConnection(auth: _TCPListenConnectAuth, client: int, on_receive: action(TCPListenConnection, bytes) -> None, on_error: action(TCPListenConnection, str) -> None):
+actor TCPListenConnection(auth: _TCPListenConnectAuth, server_client: int):
     """TCP Listener Connection"""
+    var client: int = -1
+    var on_receive: ?action(TCPListenConnection, bytes) -> None = None
+    var on_error: ?action(TCPListenConnection, str) -> None = None
+    var _initialized = False
+
+    proc def _read_start():
+        """Implementation internal"""
+        NotImplemented
+
+    action def cb_install(new_on_receive: action(TCPListenConnection, bytes) -> None, new_on_error: action(TCPListenConnection, str) -> None) -> None:
+        """Install callback handlers"""
+        on_receive = new_on_receive
+        on_error = new_on_error
+        if not _initialized:
+            _read_start()
+            _initialized = True
+
+    action def close() -> None:
+        """Close connection"""
+        NotImplemented
+
     action def write(data: bytes) -> None:
         """Write data to remote"""
         NotImplemented
@@ -71,18 +92,17 @@ actor TCPListenConnection(auth: _TCPListenConnectAuth, client: int, on_receive: 
     mut def __resume__() -> None:
         NotImplemented
 
-    proc def _init():
+    proc def _init() -> None:
         """Implementation internal"""
         NotImplemented
     _init()
 
-
-actor TCPListener(auth: TCPListenAuth, address: str, port: int, on_listen_error: action(TCPListener, str) -> None, on_accept: action(TCPListenConnection) -> None, on_receive: action(TCPListenConnection, bytes) -> None, on_error: action(TCPListenConnection, str) -> None):
+actor TCPListener(auth: TCPListenAuth, address: str, port: int, on_error: action(TCPListener, str) -> None, on_accept: action(TCPListenConnection) -> None):
     """TCP Listener"""
     _stream = -1
     def create_tcp_listen_connection(auth: _TCPListenConnectAuth, client: int):
         """Implementation internal"""
-        c = TCPListenConnection(auth, client, on_receive, on_error)
+        c = TCPListenConnection(auth, client)
         on_accept(c)
 
     mut def __resume__() -> None:

--- a/test/rts_db/ddb_test_server.act
+++ b/test/rts_db/ddb_test_server.act
@@ -14,7 +14,7 @@ actor Tester(env, port):
         lsock = init_listen()
 
     def on_server_accept(c):
-        pass
+        c.cb_install(on_server_receive, on_server_error)
 
     def on_server_receive(c, data):
         print("RECV", c, data.decode())
@@ -30,11 +30,10 @@ actor Tester(env, port):
     def on_server_error(c, error):
         print("There was an error:", error, " from:", c)
 
-
     def init_listen():
         listen_auth = net.TCPListenAuth(net.TCPAuth(net.NetAuth(env.auth)))
         print("Starting to listen...")
-        s = net.TCPListener(listen_auth, "0.0.0.0", port, on_listen_error, on_server_accept, on_server_receive, on_server_error)
+        s = net.TCPListener(listen_auth, "0.0.0.0", port, on_listen_error, on_server_accept)
         print("NOW LISTENING ON", str(port))
 
         return s

--- a/test/stdlib_auto/test_net_tcp.act
+++ b/test/stdlib_auto/test_net_tcp.act
@@ -5,24 +5,27 @@
 import net
 import random
 
+actor Server(conn):
+    def on_receive(c, data):
+        print("Server received some data:", data, " from:", c)
+        if data == b"PING":
+            c.write(b"PONG")
+            c.close()
 
-actor Server(env, port):
+    def on_error(c, error):
+        print("There was an error:", error, " from:", c)
+
+
+actor Listener(env, port):
     def on_lsock_error(l, error):
         print("There was an error with the TCPListener socket:", error)
 
     def on_server_accept(c):
-        pass
-
-    def on_server_receive(c, data):
-        print("Server received some data:", data, " from:", c)
-        if data == b"PING":
-            c.write(b"PONG")
-
-    def on_server_error(c, error):
-        print("There was an error:", error, " from:", c)
+        s = Server(c)
+        c.cb_install(s.on_receive, s.on_error)
 
     listen_auth = net.TCPListenAuth(net.TCPAuth(net.NetAuth(env.auth)))
-    server = net.TCPListener(listen_auth, "0.0.0.0", port, on_lsock_error, on_server_accept, on_server_receive, on_server_error)
+    server = net.TCPListener(listen_auth, "0.0.0.0", port, on_lsock_error, on_server_accept)
 
 
 actor Client(env: Env, port: int):
@@ -34,7 +37,7 @@ actor Client(env: Env, port: int):
         print("Client RECV", data)
         if data == b"PONG":
             print("Got PONG, all good, yay")
-            await async env.exit(0)
+            after 0.1: _exit()
         else:
             print("Got bad response, exiting with error..")
             await async env.exit(1)
@@ -42,8 +45,12 @@ actor Client(env: Env, port: int):
     def on_error(c, msg):
         print("Client ERR", msg)
 
+    def _exit():
+        await async env.exit(0)
+
     connect_auth = net.TCPConnectAuth(net.TCPAuth(net.NetAuth(env.auth)))
     client = net.TCPIPConnection(connect_auth, "127.0.0.1", port, on_connect, on_receive, on_error)
+
 
 actor main(env):
     def timeout_error():
@@ -54,6 +61,6 @@ actor main(env):
 
     port = random.randint(10000, 20000)
     print("Using port", port)
-    s = Server(env, port)
+    l = Listener(env, port)
     c = Client(env, port)
 


### PR DESCRIPTION
The on_receive and on_error handler for individual client connections (TCPListenConnection) are now registered after instantiation of each TCPListenConnection actor by calling cb_install(). This is most appropriately done in the on_accept callback. Unlike the old pattern, where we provided these callbacks up front to the TCPIPListener actor, having them registered per client connection naturally opens up to having different handlers per client.

There are two ways of handling connections;
- one actor that handles many TCP clients
  - means we need to keep track of individual TCP client actors so we respond to the right one etc
- one actor per TCP client
  - each actor implementing business logic only speaks to a single TCP client, so the actor code can be quite simple
  - scale out by serving a client from one actor

Previously we could only support the former. Now we support both!

I also found and addressed two bugs. We didn't pin the client connections so they could be scheduled on any worker thread. It's rather surprising we haven't seen crashes related to this but I suppose we don't exercise our TCP server code very much. Second, since we allow the client connections to run on a worker thread that's different from the listener socket, we must move the socket over to the local worker threads uv loop. That is now done!