### PR TITLE
Fix use of deprecated set-output

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -160,8 +160,8 @@ jobs:
       - name: "Compute variables"
         id: vars
         run: |
-          echo "::set-output name=debdir::$(realpath ${GITHUB_WORKSPACE}/../deb)"
-          echo "::set-output name=artifact_dir::$(dirname ${{ github.workspace }})"
+          echo "debdir=$(realpath ${GITHUB_WORKSPACE}/../deb)" >> $GITHUB_OUTPUT
+          echo "artifact_dir=$(dirname ${{ github.workspace }})" >> $GITHUB_OUTPUT
       - name: "Move deb files into place for easy artifact extraction"
         run: |
           mkdir -p ${{ steps.vars.outputs.debdir }}
@@ -212,7 +212,7 @@ jobs:
         uses: actions/checkout@v3
       - name: "Get the version"
         id: get_version
-        run: echo ::set-output name=version::$(grep VERSION= common.mk | cut -d = -f 2)
+        run: echo "version=$(grep VERSION= common.mk | cut -d = -f 2)" >> $GITHUB_OUTPUT
       - name: "Hacky hacky homebrew formula"
         # NOTE: brew --prefix gives us path to Homebrew installation directory,
         #       which differs between Intel and M1 mac. However, on Intel the
@@ -263,7 +263,7 @@ jobs:
           ./test-runtime.act | grep "Hello, world"
       - name: "Get the actonc version"
         id: get_actonc_version
-        run: echo ::set-output name=version::$(actonc --numeric-version)
+        run: echo "version=$(actonc --numeric-version)" >> $GITHUB_OUTPUT
       - name: "brew bottle"
         run: |
           brew bottle acton
@@ -506,11 +506,11 @@ jobs:
         uses: actions/checkout@v3
       - name: "Get the version from common.mk"
         id: get_version
-        run: echo ::set-output name=version::$(grep VERSION= common.mk | cut -d = -f 2)
+        run: echo "version=$(grep VERSION= common.mk | cut -d = -f 2)" >> $GITHUB_OUTPUT
       - run: wget https://github.com/actonlang/acton/archive/refs/tags/v${{ steps.get_version.outputs.version }}.tar.gz
       - run: sha256sum v${{ steps.get_version.outputs.version }}.tar.gz
       - id: shasum
-        run: echo "::set-output name=sum::$(sha256sum v${{ steps.get_version.outputs.version }}.tar.gz | cut -d' ' -f1)"
+        run: echo "sum=$(sha256sum v${{ steps.get_version.outputs.version }}.tar.gz | cut -d' ' -f1)" >> $GITHUB_OUTPUT
       - name: "Check out code of our brew repo"
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Now using the newer style as recommended in
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Fixes #1073 