### PR TITLE
Align B_slice def

### DIFF
--- a/builtin/slice.h
+++ b/builtin/slice.h
@@ -1,9 +1,9 @@
 
-typedef struct B_slice {
+struct B_slice {
   struct B_sliceG_class *$class;
   long *start;
   long *stop;
   long *step;
-} *B_slice;
+};
 
 void normalize_slice(B_slice slc, long len, long *slen, long *start, long *stop, long *step);

--- a/builtin/tests/dict_test2.c
+++ b/builtin/tests/dict_test2.c
@@ -33,7 +33,7 @@ long fromWord($WORD w) {
 }
 
 B_Iterable dict_iterable(B_MappingD_dict wit) {
-  B_IterableG_class cl = malloc(sizeof(struct  B_IterableG_class));
+  B_IterableG_class cl = malloc(sizeof(struct B_IterableG_class));
   cl->__iter__ = (B_Iterator (*)(B_Iterable, $WORD))wit->$class->items;
   B_Iterable wit2 = malloc(sizeof(struct B_Iterable));
   wit2->$class = cl;


### PR DESCRIPTION
typedef for B_slice is already in __builtin__.h like it is for all other types, so just defining the struct here.

Remove superfluous space