### PR TITLE
Build projects using `zig build`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ backend/test/queue_unit_tests
 backend/test/skiplist_test
 backend/test/test_client
 
+builder/zig-cache
+
 compiler/actonc
 compiler/package.yaml
 compiler/tests/*.ty

--- a/builder/build.zig
+++ b/builder/build.zig
@@ -1,0 +1,155 @@
+// Acton Project Builder
+// Performs the final build of the project by compiling the generated C code.
+
+const std = @import("std");
+const print = @import("std").debug.print;
+const ArrayList = std.ArrayList;
+
+pub const FilePath = struct {
+    filename: []const u8,
+    full_path: []const u8,
+    dir: []const u8,
+    file_path: []const u8,
+};
+
+pub fn build(b: *std.build.Builder) void {
+    const optimize = b.standardOptimizeOption(.{});
+    const target = b.standardTargetOptions(.{});
+    const projpath_out = b.option([]const u8, "projpath_out", "") orelse "";
+    const projpath_outtypes = b.option([]const u8, "projpath_outtypes", "") orelse "";
+    const syspath = b.option([]const u8, "syspath", "") orelse "";
+    const syspath_include = b.option([]const u8, "syspath_include", "") orelse "";
+    const syspath_lib = b.option([]const u8, "syspath_lib", "") orelse "";
+    const syspath_libreldev = b.option([]const u8, "syspath_libreldev", "") orelse "";
+    const libactondeps = b.option([]const u8, "libactondeps", "") orelse "";
+    const libactongc = b.option([]const u8, "libactongc", "") orelse "";
+    const wd = b.option([]const u8, "wd", "") orelse "";
+
+    var iter_dir = std.fs.cwd().openIterableDir(
+        "out/types/",
+        .{},
+    ) catch |err| {
+        std.log.err("Error opening iterable dir: {}", .{err});
+        std.os.exit(1);
+    };
+
+    var c_files = ArrayList([]const u8).init(b.allocator);
+    var root_c_files = ArrayList(*FilePath).init(b.allocator);
+    var walker = iter_dir.walk(b.allocator) catch |err| {
+        std.log.err("Error walking dir: {}", .{err});
+        std.os.exit(1);
+    };
+    defer walker.deinit();
+
+    // Find all .c files
+    while (true) {
+        const next_result = walker.next() catch |err| {
+            std.log.err("Error getting next: {}", .{err});
+            std.os.exit(1);
+        };
+        if (next_result) |entry| {
+            if (entry.kind == .File) {
+                if (std.mem.endsWith(u8, entry.basename, ".c")) {
+                    const fPath = b.allocator.create(FilePath) catch |err| {
+                        std.log.err("Error allocating FilePath entry: {}", .{err});
+                        std.os.exit(1);
+                    };
+                    const full_path = entry.dir.realpathAlloc(b.allocator, entry.basename) catch |err| {
+                        std.log.err("Error getting dir name: {}", .{err});
+                        std.os.exit(1);
+                    };
+                    const dir = entry.dir.realpathAlloc(b.allocator, ".") catch |err| {
+                        std.log.err("Error getting dir name: {}", .{err});
+                        std.os.exit(1);
+                    };
+                    fPath.full_path = full_path;
+                    fPath.dir = dir;
+                    fPath.filename = b.allocator.dupe(u8, entry.basename) catch |err| {
+                        std.log.err("Error allocating filename entry: {}", .{err});
+                        std.os.exit(1);
+                    };
+                    const file_path = b.allocator.alloc(u8, full_path.len - projpath_outtypes.len) catch |err| {
+                        std.log.err("Error allocating file_path entry: {}", .{err});
+                        std.os.exit(1);
+                    };
+                    @memcpy(file_path, full_path[projpath_outtypes.len..]);
+                    fPath.file_path = file_path;
+
+                    print("-- filename : {s}\n", .{fPath.filename});
+                    print("   full_path: {s}\n", .{fPath.full_path});
+                    print("   dir      : {s}\n", .{fPath.dir});
+                    print("   file_path: {s}\n", .{fPath.file_path});
+
+                    if (std.mem.endsWith(u8, entry.basename, ".root.c")) {
+                        root_c_files.append(fPath) catch |err| {
+                            std.log.err("Error appending to root .c files: {}", .{err});
+                            std.os.exit(1);
+                        };
+                    } else {
+                        c_files.append(fPath.full_path) catch |err| {
+                            std.log.err("Error appending to .c files: {}", .{err});
+                            std.os.exit(1);
+                        };
+                    }
+                }
+            }
+        } else {
+            break;
+        }
+    }
+
+    const libActonProject = b.addStaticLibrary(.{
+        .name = "ActonProject",
+        .target = target,
+        .optimize = optimize,
+    });
+    const cflags = [_][]const u8{
+        wd
+    };
+    for (c_files.items) |entry| {
+        libActonProject.addCSourceFile(entry, &cflags);
+    }
+
+    libActonProject.addIncludePath(projpath_out);
+    libActonProject.addIncludePath(".");
+    libActonProject.addIncludePath(syspath);
+    libActonProject.addIncludePath(syspath_include);
+    libActonProject.addIncludePath("../deps/instdir/include"); // hack hack for stdlib TODO: sort out
+    libActonProject.linkLibC();
+    b.installArtifact(libActonProject);
+
+    for (root_c_files.items) |entry| {
+        // Get the binary name, by removing .root.c from end and having it relative to the projpath_outtypes
+        const binname = b.allocator.alloc(u8, entry.file_path.len-8) catch |err| {
+            std.log.err("Error allocating binname: {}", .{err});
+            std.os.exit(1);
+        };
+        @memcpy(binname, entry.file_path[1..(entry.file_path.len-7)]);
+
+        // Replace / with . in the binary name
+        for (binname) |*ch| {
+            if (ch.* == '/') ch.* = '.';
+        }
+        print("Building executable from: {s} -> {s}\n", .{entry.full_path, binname});
+
+        const executable = b.addExecutable(.{
+            .name = binname,
+            .target = target,
+            .optimize = optimize,
+        });
+        executable.addCSourceFile(entry.full_path, &[_][]const u8{});
+        executable.addIncludePath(projpath_out);
+        executable.addIncludePath(syspath);
+        executable.addIncludePath(syspath_include);
+        executable.addLibraryPath("out/rel/lib/");
+        executable.addLibraryPath(syspath_libreldev);
+        executable.addLibraryPath(syspath_lib);
+        executable.linkLibrary(libActonProject);
+        executable.linkSystemLibraryName("Acton");
+        executable.linkSystemLibraryName(libactondeps);
+        executable.linkSystemLibraryName("ActonDB");
+        executable.linkSystemLibraryName(libactongc);
+        executable.linkLibC();
+        b.installArtifact(executable);
+    }
+}

--- a/compiler/Acton/CommandLineParser.hs
+++ b/compiler/Acton/CommandLineParser.hs
@@ -50,7 +50,9 @@ data CompileOptions   = CompileOptions {
                          root        :: String,
                          tempdir     :: String,
                          syspath     :: String,
-                         cc          :: String
+                         cc          :: String,
+                         zigbuild    :: Bool,
+                         nozigbuild  :: Bool
                      } deriving Show
 
 data BuildOptions = BuildOptions {
@@ -59,9 +61,12 @@ data BuildOptions = BuildOptions {
                          devB        :: Bool,
                          autostubB   :: Bool,
                          rootB       :: String,
+                         ccmdB       :: Bool,
                          quietB      :: Bool,
                          timingB     :: Bool,
-                         ccB         :: String
+                         ccB         :: String,
+                         zigbuildB   :: Bool,
+                         nozigbuildB :: Bool
                      } deriving Show
                          
 
@@ -130,6 +135,8 @@ compileOptions = CompileOptions
         <*> strOption (long "tempdir"   <> metavar "TEMPDIR" <> value "" <> help "Set directory for build files")
         <*> strOption (long "syspath"   <> metavar "TARGETDIR" <>  value "" <> help "Set syspath")
         <*> strOption (long "cc"        <> metavar "PATH" <>  value "" <> help "CC")
+        <*> switch (long "zigbuild"     <> help "Use zig build")
+        <*> switch (long "no-zigbuild"  <> help "Don't use zig build")
 
 buildCommand          = Build <$> (
     BuildOptions
@@ -138,9 +145,12 @@ buildCommand          = Build <$> (
         <*> switch (long "dev"          <> help "Development mode; include debug symbols etc")
         <*> switch (long "auto-stub"    <> help "Allow automatic stub detection")
         <*> strOption (long "root"      <> metavar "ROOTACTOR" <> value "" <> help "Set root actor")
+        <*> switch (long "ccmd"         <> help "Show CC / LD commands")
         <*> switch (long "quiet"        <> help "Don't print stuff")
         <*> switch (long "timing"       <> help "Print timing information")
         <*> strOption (long "cc"        <> metavar "PATH" <>  value "" <> help "CC")
+        <*> switch (long "zigbuild"     <> help "Use zig build")
+        <*> switch (long "no-zigbuild"  <> help "Don't use zig build")
     )
                  
 cloudCommand        = Cloud <$> (

--- a/compiler/project-build.zig
+++ b/compiler/project-build.zig
@@ -1,0 +1,136 @@
+
+const std = @import("std");
+const print = @import("std").debug.print;
+const ArrayList = std.ArrayList;
+
+pub fn build(b: *std.build.Builder) void {
+    const optimize = b.standardOptimizeOption(.{});
+    const target = b.standardTargetOptions(.{});
+    const projpath = b.option([]const u8, "projpath", "") orelse "";
+    const syspath = b.option([]const u8, "syspath", "") orelse "";
+    const reldev = b.option([]const u8, "reldev", "") orelse "";
+    const binsrc = b.option([]const u8, "binsrc", "") orelse "";
+    const binname = b.option([]const u8, "binname", "") orelse "";
+    const wd = b.option([]const u8, "wd", "") orelse "";
+    var syspath_include_buf: [1024]u8 = undefined;
+    const syspath_include = std.fmt.bufPrint(&syspath_include_buf, "{s}/include/", .{ syspath }) catch {
+        std.log.err("Error concatenating strings: ", .{});
+        std.os.exit(1);
+    };
+    var syspath_lib_buf: [1024]u8 = undefined;
+    var syspath_libreldev_buf: [1024]u8 = undefined;
+    const syspath_lib = std.fmt.bufPrint(&syspath_lib_buf, "{s}/lib/", .{ syspath }) catch {
+        std.log.err("Error concatenating strings: ", .{});
+        std.os.exit(1);
+    };
+    const syspath_libreldev = std.fmt.bufPrint(&syspath_libreldev_buf, "{s}/lib/{s}/", .{ syspath, reldev }) catch {
+        std.log.err("Error concatenating strings: ", .{});
+        std.os.exit(1);
+    };
+
+    var iter_dir = std.fs.cwd().openIterableDir(
+        "out/types/",
+        .{},
+    ) catch |err| {
+        std.log.err("Error opening iterable dir: {}", .{err});
+        std.os.exit(1);
+    };
+
+    var c_files = ArrayList([]u8).init(b.allocator);
+    var root_c_files = ArrayList([]u8).init(b.allocator);
+    var walker = iter_dir.walk(b.allocator) catch |err| {
+        std.log.err("Error walking dir: {}", .{err});
+        std.os.exit(1);
+    };
+    defer walker.deinit();
+
+    // Find all .c files
+    while (true) {
+        const next_result = walker.next() catch |err| {
+            std.log.err("Error getting next: {}", .{err});
+            std.os.exit(1);
+        };
+        if (next_result) |entry| {
+            if (entry.kind == .File) {
+                if (std.mem.endsWith(u8, entry.basename, ".c")) {
+                    const fname = b.allocator.alloc(u8, 1024) catch |err| {
+                        std.log.err("Error allocating fname: {}", .{err});
+                        std.os.exit(1);
+                    };
+                    @memset(fname, 0);
+                    _ = entry.dir.realpath(entry.basename, fname) catch |err| {
+                        std.log.err("Error doing realpath: {}", .{err});
+                        std.os.exit(1);
+                    };
+
+                    if (std.mem.endsWith(u8, entry.basename, ".root.c")) {
+                        root_c_files.append(fname) catch |err| {
+                            std.log.err("Error appending to root .c files: {}", .{err});
+                            std.os.exit(1);
+                        };
+                    } else {
+                        c_files.append(fname) catch |err| {
+                            std.log.err("Error appending to .c files: {}", .{err});
+                            std.os.exit(1);
+                        };
+                    }
+                }
+            }
+        } else {
+            break;
+        }
+    }
+
+    const libActonProject = b.addStaticLibrary(.{
+        .name = "ActonProject",
+        .target = target,
+        .optimize = optimize,
+    });
+    const cflags = [_][]const u8{
+        wd
+    };
+    for (c_files.items) |entry| {
+        libActonProject.addCSourceFile(entry, &cflags);
+    }
+
+    var projpath_out_buf: [1024]u8 = undefined;
+    const projpath_out = std.fmt.bufPrint(&projpath_out_buf, "{s}/out", .{ projpath }) catch {
+        std.log.err("Error concatenating strings: ", .{});
+        std.os.exit(1);
+    };
+    libActonProject.addIncludePath(projpath_out);
+
+    libActonProject.addIncludePath(".");
+    libActonProject.addIncludePath(syspath);
+    libActonProject.addIncludePath(syspath_include);
+    libActonProject.addIncludePath("../deps/instdir/include"); // hack hack for stdlib
+    libActonProject.linkLibC();
+    b.installArtifact(libActonProject);
+
+    if (!(std.mem.eql(u8, binname, "") and std.mem.eql(u8, binsrc, ""))) {
+        const executable = b.addExecutable(.{
+            .name = binname,
+            .target = target,
+            .optimize = optimize,
+        });
+        var absbinsrc_buf: [1024]u8 = undefined;
+        const absbinsrc = std.fmt.bufPrint(&absbinsrc_buf, "{s}/{s}", .{ projpath, binsrc }) catch {
+            std.log.err("Error concatenating strings: ", .{});
+            std.os.exit(1);
+        };
+        executable.addCSourceFile(absbinsrc, &[_][]const u8{});
+        executable.addIncludePath(projpath_out);
+        executable.addIncludePath(syspath);
+        executable.addIncludePath(syspath_include);
+        executable.addLibraryPath("out/rel/lib/");
+        executable.addLibraryPath(syspath_libreldev);
+        executable.addLibraryPath(syspath_lib);
+        executable.linkLibrary(libActonProject);
+        executable.linkSystemLibraryName("Acton");
+        executable.linkSystemLibraryName("ActonDeps");
+        executable.linkSystemLibraryName("ActonDB");
+        executable.linkSystemLibraryName("actongc");
+        executable.linkLibC();
+        b.installArtifact(executable);
+    }
+}


### PR DESCRIPTION
This switches to using zig build for building Acton projects. There are a number of advantages and unlocked potential advantages:
- zig has a very advanced caching system
  - invoking zig cc as a C compiler, like before, does not use this caching system
  - invoking zig build, like with this change, we make use of the cache!
- zig has awesome cross-compilation support and we can better utilize it when we call zigs high-level build command rather than the lower level cc compatibility commands
  - by directly adding in RTS, builtins etc, we can even skip building libActon libary archives in rel / dev flavors and let it be built per project with the exact compilation flags we want, or for cross-compilation! This could open up for more compilation options that affects builtins, RTS etc.
- build.zig is first compiled into a binary executable whish is then run to build the C parts of the Acton project
  - zig is sort of slow today, mostly due to LLVM, but it should be a lot faster in future versions
  - build.zig should not need to be recompiled unless the project changes, like new modules are added or removed
    - if a source file merely changes, build.zig still does not change

It's fairly simple: Write generated build.zig file and execute `zig build` in order to let zig build the C-parts of the project! We add two extra arguments, syspath and reldev which are passed in from actonc to zig build as to convey where acton is installed and if we are building for dev or release.

To illustrate the caching, including caching of the build.zig executable, the first build is rather slow while rerunning actonc build is rather quick:
```sh
  kll@ThinkYoga:~/terastream/acton/hello$ ../dist/bin/actonc build
  Building project in /home/kll/terastream/acton/hello
    Compiling hello.act for release
     Finished compilation in   0.040 s
    Final compilation step
     Finished final compilation step in   6.593 s
  kll@ThinkYoga:~/terastream/acton/hello$ ../dist/bin/actonc build
  Building project in /home/kll/terastream/acton/hello
    Compiling hello.act for release
     Finished compilation in   0.067 s
    Final compilation step
     Finished final compilation step in   0.059 s
  kll@ThinkYoga:~/terastream/acton/hello$
```
The vast majority of time is spent building build.zig into a program. Once this is done, it's fast. Modifications to individual .act files does not affect build.zig, i.e. we don't need to rebuild the build program, so it is fast. Since it is also caching, it ends up being much faster than gcc or similar both during the individual module compilation and for the final compilation of binary executables, in a small example project, we saved ~50% going from ~1s to ~0.5s (on a slow laptop).

If we add or remove a module in a project, the build.zig program needs to be recompiled, which takes considerable time:
```sh
  kll@ThinkYoga:~/terastream/acton/hello$ ../dist/bin/actonc build
  Building project in /home/kll/terastream/acton/hello
    Compiling hello.act for release
     Finished compilation in   0.066 s
    Compiling foo.act for release
     Finished compilation in   0.023 s
    Final compilation step
     Finished final compilation step in   6.653 s
  kll@ThinkYoga:~/terastream/acton/hello$
```
This should be improved with future versions of zig. Smart people are working hard on the problem.

The long build times doesn't have that much impact on Acton projects since it's mostly just on the initial build. However, for non-project builds, like compilation of individual .act files, the hit of using zig build is considerable. To avoid this, zig build is only used for projects and traditional build is used for non-projects! It is possible to force one or the other using --zigbuild or --no-zigbuild.