### PR TITLE
Enable concurrent builds in CI for MacOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
       - name: "Build Acton"
         run: |
           export ZIG_LOCAL_CACHE_DIR=~/zig-cache
-          make -C ${{ github.workspace }} BUILD_RELEASE=${{ env.BUILD_RELEASE }}
+          make -j2 -C ${{ github.workspace }} BUILD_RELEASE=${{ env.BUILD_RELEASE }}
       - name: "Build a release"
         run: make -C ${{ github.workspace }} release
       - name: "Upload artifact"


### PR DESCRIPTION
We had some issues with concurrent builds specifically on MacOS that we could never really pinpoint. They appeared out of thin air one day, perhaps they've also gone away by themselves...?

Fixes #1147 