### PR TITLE
Run CC process assuming utf8 on stdout/err

### DIFF
--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -36,7 +36,11 @@ import qualified Pretty
 import qualified InterfaceFiles
 
 import Control.Applicative
+import Control.Concurrent.Async
+import Control.Concurrent.MVar
 import Control.Exception (throw,catch,displayException,IOException,ErrorCall)
+import Control.Exception (bracketOnError)
+import Control.Concurrent (forkIO)
 import Control.Monad
 import Data.List.Split
 import Data.Monoid ((<>))
@@ -60,6 +64,8 @@ import qualified System.Environment
 import qualified System.Exit
 import qualified Paths_acton
 import Text.Printf
+
+import qualified Data.ByteString.Char8 as B
 
 #if defined(darwin_HOST_OS) && defined(aarch64_HOST_ARCH)
 ccTarget = " -target aarch64-macos-none "
@@ -709,18 +715,38 @@ runRestPasses opts paths env0 parsed stubMode = do
                                  putStrLn ccCmd
                                  putStrLn arCmd
                              writeFile buildF $ unlines ["#!/bin/sh", "cd ..", ccCmd, arCmd]
-                             (returnCode, ccStdout, ccStderr) <- readCreateProcessWithExitCode (shell $ ccCmd ++ " && " ++ arCmd){ cwd = Just (takeDirectory (projPath paths)) } ""
+                             runCc (ccCmd ++ " && " ++ arCmd) (Just (takeDirectory (projPath paths)))
                              timeCC <- getTime Monotonic
                              iff (C.timing opts) $ putStrLn("    Pass: C compilation   : " ++ fmtTime (timeCC - timeCodeWrite))
-                             case returnCode of
-                                 ExitSuccess -> return()
-                                 ExitFailure _ -> do printIce "compilation of generated C code failed"
-                                                     putStrLn $ "cc stdout:\n" ++ ccStdout
-                                                     putStrLn $ "cc stderr:\n" ++ ccStderr
-                                                     System.Exit.exitFailure
                                             )
 
                       return $ Acton.Env.addMod mn iface (env0 `Acton.Env.withModulesFrom` env)
+
+executeProcess :: String -> Maybe FilePath -> IO (ExitCode, String, String)
+executeProcess command workingDir = do
+    let process = (shell command) {
+            cwd = workingDir,
+            std_out = CreatePipe,
+            std_err = CreatePipe
+        }
+    (_, Just std_out, Just std_err, processHandle) <- createProcess process
+    hSetEncoding std_out utf8
+    hSetEncoding std_err utf8
+    let readStdout = hGetContents std_out
+        readStderr = hGetContents std_err
+    (stdoutData, stderrData) <- runConcurrently $ (,) <$> Concurrently readStdout <*> Concurrently readStderr
+    exitCode <- waitForProcess processHandle
+    return (exitCode, stdoutData, stderrData)
+
+runCc cmd wd = do
+    (exitCode, out, err) <- executeProcess cmd wd
+    case exitCode of
+        ExitSuccess -> return ()
+        ExitFailure _ -> do
+            printIce "compilation of C code failed"
+            putStrLn $ "cc stdout:\n" ++ out
+            putStrLn $ "cc stderr:\n" ++ err
+            System.Exit.exitFailure
 
 handle errKind f src paths mn ex = do putStrLn ("\nERROR: Error when compiling " ++ (prstr mn) ++ " module: " ++ errKind)
                                       putStrLn (Acton.Parser.makeReport (f ex) src)
@@ -745,14 +771,9 @@ buildExecutable env opts paths binTask
                                       appendFile buildF ccCmd
                                       setFileMode buildF 0o755
                                       timeStart <- getTime Monotonic
-                                      (returnCode, ccStdout, ccStderr) <- readCreateProcessWithExitCode (shell $ ccCmd) ""
+                                      runCc ccCmd Nothing
                                       timeEnd <- getTime Monotonic
-                                      case returnCode of
-                                          ExitSuccess -> iff (C.timing opts) $ putStrLn(" Finished in " ++ fmtTime(timeEnd - timeStart))
-                                          ExitFailure _ -> do printIce "compilation of generated C code of the root actor failed"
-                                                              putStrLn $ "cc stdout:\n" ++ ccStdout
-                                                              putStrLn $ "cc stderr:\n" ++ ccStderr
-                                                              System.Exit.exitFailure
+                                      iff (C.timing opts) $ putStrLn(" Finished in " ++ fmtTime(timeEnd - timeStart))
                                       return ()
                                    | otherwise -> handle "Type error" Acton.Types.typeError "" paths m
                                      (Acton.Types.TypeError NoLoc ("Illegal type "++ prstr t ++ " of parameter to root actor " ++ prstr qn))

--- a/compiler/package.yaml.in
+++ b/compiler/package.yaml.in
@@ -24,6 +24,7 @@ executables:
       - happy
     dependencies:
       - array
+      - async
       - base >= 4.7 && < 5
       - binary
       - bytestring
@@ -49,6 +50,8 @@ executables:
       - unix
       - utf8-string
       - zlib
+    ghc-options:
+      - -threaded
 
 tests:
   test_actonc:


### PR DESCRIPTION
With readCreateProcessWithExitCode() as we previously used it, we got an error while compiling test/builtin_auto/builtin_functions_test.act:

  ...
  actonc: fd:7: hGetContents: invalid argument (invalid byte sequence)

The problem was noticed in CI for a new branch, which does not modify these parts of the compiler, yet fails on an existing test. It is reproducible on a Linux machine when LANG is not set (CI does not set LANG), so the system defaults to LANG=C (I think). The hGetContents is not called directly from our code (we enforce encoding where we do), but it must be called from within readCreateProcessWithExitCode() from the standard System.Process library. We have no way of modifying it. It's puzzling because the output of the commands run do not appear to contain anything but US ASCII, so it's unclear how we can get an invalid byte sequence. And why is this only happening in a branch with seemingly unrelated changes?

I refactored the code to use withCreateProcess context instead, which allows more direct control over the stdout & stderr pipes. I now force utf8 encoding but it should be noted that I got all of this to work *before* forcing encoding. Simply refactoring and running hGetContents ourselves made it work. I do not understand why.

Running CC is also moved to a separate function that can be called from the two places where we run CC. Less code!

Also, while we now enforce encoding, this is just enforcing our assumed encoding when reading. The processes we run could be outputting something else. I presume they honor locale, so it might in fact not be UTF-8 now. But can we influence that in a portable way? I don't see how, setting LANG=en_US.UTF-8 won't work on a machine with sv_SE.UTF-8 and it won't work on another OS?