### PR TITLE
Run CC process treating stdout / err as ByteString

### DIFF
--- a/compiler/package.yaml.in
+++ b/compiler/package.yaml.in
@@ -24,6 +24,7 @@ executables:
       - happy
     dependencies:
       - array
+      - async
       - base >= 4.7 && < 5
       - binary
       - bytestring
@@ -49,6 +50,8 @@ executables:
       - unix
       - utf8-string
       - zlib
+    ghc-options:
+      - -threaded
 
 tests:
   test_actonc:


### PR DESCRIPTION
With readCreateProcessWithExitCode() as we previously used it, we got an error while compiling test/builtin_auto/builtin_functions_test.act:

  ...
  actonc: fd:7: hGetContents: invalid argument (invalid byte sequence)

The problem was noticed in CI for a new branch, which does not modify these parts of the compiler, yet fails on an existing test. It is reproducible on a Linux machine when LANG is not set (CI does not set LANG), so the system defaults to LANG=C (I think). The hGetContents is not called directly from our code (we enforce encoding where we do), but it must be called from within readCreateProcessWithExitCode() from the standard System.Process library. We have no way of modifying it. It's puzzling because the output of the commands run do not appear to contain anything but US ASCII, so it's unclear how we can get an invalid byte sequence. And why is this only happening in a branch with seemingly unrelated changes?

I refactored the code to use createProcess and async reading of stdout and stderr (to avoid blocking), which allows more direct control over the stdout & stderr pipes. We now treat stdout and stderr as ByteStrings, so we should transparently pass whatever is written and effectively, the encoding is no longer any of our problem. This should be fine and safe because we only pass through the entire output. If we for example would start slicing it, we would need to honour UTF-8 or whatever encoding is being used, but since we are not, this is OK.

Running CC is also moved to a separate function that can be called from the two places where we run CC. Less code!