### PR TITLE
Include platform in libactongc lib name

### DIFF
--- a/.github/workflows/deps-builds.yml
+++ b/.github/workflows/deps-builds.yml
@@ -30,6 +30,7 @@ jobs:
           name: deps-x86_64-macos
           path: |
             ${{ github.workspace }}/lib/libActonDeps-x86_64-macos.a
+            ${{ github.workspace }}/lib/libactongc-x86_64-macos.a
 
   build-linux:
     strategy:
@@ -60,6 +61,7 @@ jobs:
           name: deps-x86_64-linux
           path: |
             ${{ github.workspace }}/lib/libActonDeps-x86_64-linux.a
+            ${{ github.workspace }}/lib/libactongc-x86_64-linux.a
 
   # Release job, only run for version tagged releases.
   upload-deps:
@@ -82,7 +84,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           allowUpdates: true
-          artifacts: "libActonDeps-*"
+          artifacts: "libActonDeps-*,libactongc-*"
           body: "libActonDeps"
           token: ${{ secrets.GITHUB_TOKEN }}
           replacesArtifacts: true

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ZIG_VERSION:=0.11.0-dev.2985+3f3b1a680
 CC=$(TD)/deps/zig/zig cc
 CXX=$(TD)/deps/zig/zig c++
 ZIG=deps/zig
-LIBGC=lib/libactongc.a
+LIBGC=lib/libactongc-$(PLATFORM).a
 export CC
 export CXX
 
@@ -113,7 +113,7 @@ BUILTIN_HFILES=$(wildcard builtin/*.h) builtin/__builtin__.h
 BUILTIN_CFILES=$(wildcard builtin/*.c) builtin/__builtin__.c
 
 DBARCHIVE=lib/libActonDB.a
-ARCHIVES=lib/dev/libActon.a lib/rel/libActon.a lib/libActonDeps-$(PLATFORM).a lib/libactongc.a
+ARCHIVES=lib/dev/libActon.a lib/rel/libActon.a lib/libActonDeps-$(PLATFORM).a lib/libactongc-$(PLATFORM).a
 
 DIST_BINS=$(ACTONC) dist/bin/actondb dist/bin/runacton
 DIST_HFILES=\
@@ -295,7 +295,7 @@ DEPS_SUM=$(shell echo $(DEPS_REFS) | sha256sum | cut -d' ' -f1)
 show-deps-sum:
 	@echo $(DEPS_SUM)
 
-build-deps: $(DEPSA)
+build-deps: $(DEPSA) lib/libactongc-$(PLATFORM).a
 
 lib/libActonDeps-$(PLATFORM).a: $(DEP_LIBS) dist/zig
 	mkdir -p lib_deps
@@ -306,7 +306,7 @@ lib/libActonDeps-$(PLATFORM).a: $(DEP_LIBS) dist/zig
 	done
 	cd lib_deps && ar -qc ../lib/libActonDeps-$(PLATFORM).a */*.o
 
-lib/libactongc.a: deps/instdir/lib/libgc.a
+lib/libactongc-$(PLATFORM).a: deps/instdir/lib/libgc.a dist/zig
 	cp $< $@
 
 .PHONY: clean-deps

--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -791,7 +791,7 @@ buildExecutable env opts paths binTask
         buildF              = joinPath [projPath paths, "build.sh"]
         outbase             = outBase paths mn
         rootFile            = outbase ++ ".root.c"
-        libFiles            = " -lActonProject -lActon -lActonDB -lActonDeps-" ++ platform ++ " -lactongc -lpthread -lm -ldl "
+        libFiles            = " -lActonProject -lActon -lActonDB -lActonDeps-" ++ platform ++ " -lactongc-" ++ platform ++ " -lpthread -lm -ldl "
         libPaths            = " -L " ++ sysPath paths ++ "/lib -L" ++ sysLib paths ++ " -L" ++ projLib paths
         binFile             = joinPath [binDir paths, (binName binTask)]
         srcbase             = srcFile paths mn


### PR DESCRIPTION
Just like we did for libActonDeps, libactongc now includes the platform name in the archive name, like libactongc-x86_64-linux.a, so we can easily differentiate multiple versions of it, which in turn makes it simpler to do caching and perhaps eventually cross-compilation.