### PR TITLE
Publish release on actonlang/libactondeps

### DIFF
--- a/.github/workflows/deps-builds.yml
+++ b/.github/workflows/deps-builds.yml
@@ -84,7 +84,8 @@ jobs:
           allowUpdates: true
           artifacts: "libActonDeps-*"
           body: "libActonDeps"
-          token: ${{ secrets.GITHUB_TOKEN }}
-          replacesArtifacts: true
           makeLatest: false
           prerelease: true
+          replacesArtifacts: true
+          repo: "libactondeps"
+          token: ${{ secrets.ACTBOT_PAT }}


### PR DESCRIPTION
To avoid littering the actonlang/acton repo with deps-* releases, we move them to a separate repository!