### PR TITLE
Revamp deps build & use deps dl as cache

### DIFF
--- a/.github/workflows/deps-builds.yml
+++ b/.github/workflows/deps-builds.yml
@@ -29,8 +29,7 @@ jobs:
         with:
           name: deps-x86_64-macos
           path: |
-            ${{ github.workspace }}/lib/libActonDeps-x86_64-macos.a
-            ${{ github.workspace }}/lib/libactongc-x86_64-macos.a
+            ${{ github.workspace }}/deps-*.tar.bz2
 
   build-linux:
     strategy:
@@ -54,14 +53,13 @@ jobs:
           apt-get install -qy automake autopoint bison bzip2 curl git libtool make pkg-config procps python3
           apt-get install -qy libprotobuf-c-dev zlib1g-dev
       - name: "Build Acton deps"
-        run: make -j2 -C ${GITHUB_WORKSPACE} build-deps
+        run: make -C ${GITHUB_WORKSPACE} build-deps
       - name: "Upload deps artifact"
         uses: actions/upload-artifact@v3
         with:
           name: deps-x86_64-linux
           path: |
-            ${{ github.workspace }}/lib/libActonDeps-x86_64-linux.a
-            ${{ github.workspace }}/lib/libactongc-x86_64-linux.a
+            ${{ github.workspace }}/deps-*.tar.bz2
 
   # Release job, only run for version tagged releases.
   upload-deps:
@@ -84,7 +82,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           allowUpdates: true
-          artifacts: "libActonDeps-*,libactongc-*"
+          artifacts: "deps-*.tar.bz2"
           body: "libActonDeps"
           makeLatest: false
           prerelease: true

--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -701,7 +701,7 @@ runRestPasses opts paths env0 parsed stubMode = do
                                        " -Werror=return-type " ++ pedantArg ++
                                        (if (C.dev opts) then " -Og -g " else " -O3 ") ++
                                        " -c " ++
-                                       " -isystem " ++ sysPath paths ++ "/include" ++
+                                       " -isystem " ++ sysPath paths ++ "/inc" ++
                                        " -I" ++ wd ++
                                        " -I" ++ wd ++ "/out" ++
                                        " -I" ++ sysPath paths ++
@@ -799,7 +799,7 @@ buildExecutable env opts paths binTask
         ccCmd               = (cc paths opts ++
                                pedantArg ++
                                (if (C.dev opts) then " -Og -g " else " -O3 ") ++
-                               " -isystem " ++ sysPath paths ++ "/include" ++
+                               " -isystem " ++ sysPath paths ++ "/inc" ++
                                " -I" ++ projOut paths ++
                                " -I" ++ sysPath paths ++
                                " " ++ rootFile ++

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -1,6 +1,6 @@
 TD:=$(shell dirname $(realpath ../$(firstword $(MAKEFILE_LIST))))
 CC=$(TD)/dist/zig/zig cc
-CFLAGS+= -L$(TD)/deps/instdir/lib -I$(TD)/deps/instdir/include -fno-common -I.. -I../dist -I../dist/include -L../lib -Wno-int-to-pointer-cast -Wno-pointer-to-int-cast -Wformat -Werror=format-security
+CFLAGS+= -L$(TD)/dist/lib -I$(TD)/dist/inc -fno-common -I.. -I../dist -I../dist/inc -L../lib -Wno-int-to-pointer-cast -Wno-pointer-to-int-cast -Wformat -Werror=format-security
 CFLAGS_REL= -O3 -DREL
 CFLAGS_DEV= -g -DDEV
 


### PR DESCRIPTION
This revamps building deps so we now produce a single tar.bz2 ball containing relevant libraries and headers. Makes it easier to handle rather than multiple independent files.

There is now some support, though relatively untested, for also downloading an existing tar ball, extracting it and using those files. It is possible to override by setting ALWAYS_BUILD=true, which means we will not download and force local build. This should also be idempotent, so we do not attempt to download the deps archive multiple times, thus even without internet connectivity, we won't attempt to run curl (which would fail).