### PR TITLE
rm segfault workaround in example

### DIFF
--- a/docs/acton-by-example/src/actors.md
+++ b/docs/acton-by-example/src/actors.md
@@ -14,10 +14,6 @@ actor Act(name):
     def hello():
         # We can directly access actor arguments, like `name`
         print("Hello world from " + name)
-        # TODO: remove 'return True' as it should not be necessary, but with the
-        # default (returning None), we get a segfault when we do await async on 
-        # this method.
-        return True
 
 actor main(env):
     # Create an actor instance a of Act


### PR DESCRIPTION
The comment in the first actors example mentions that a dummy return was needed to avoid a segfault with "await async". This doesn't seem to be true anymore -- at least, the example doesn't segfault and produces the same output for me either way (running on Pop!_OS 22.04 Linux).