### PR TITLE
Build builder for x86_64 with ReleaseSafe

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,6 +143,10 @@ jobs:
     container:
       image: debian:bullseye
     steps:
+      - name: "Show platform and environment"
+        run: |
+          env
+          cat /proc/cpuinfo
       - name: "Set BUILD_RELEASE when we are building for a version tag"
         run: |
           echo "BUILD_RELEASE=1" >> $GITHUB_ENV
@@ -329,6 +333,10 @@ jobs:
       image: ${{ matrix.os }}:${{ matrix.version }}
       options: --privileged --ulimit core=-1 --security-opt seccomp=unconfined
     steps:
+      - name: "Show platform and environment"
+        run: |
+          env
+          cat /proc/cpuinfo
       - name: "Download .deb files"
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -338,6 +338,7 @@ jobs:
           apt update
           apt install -y ./deb/acton_*.deb
           actonc --version
+          sha256sum /usr/lib/acton/builder
       - name: "Enable dumping core files to /tmp/core..."
         run: |
           apt install -qy procps

--- a/Makefile
+++ b/Makefile
@@ -227,6 +227,7 @@ builder/builder: builder/build.zig $(ZIG)
 	cd builder \
 		&& ../$(ZIG)/zig build -Doptimize=Debug -Dcpu=$(ARCH) \
 		&& find zig-cache -name build -exec cp {} builder \;
+	sha256sum $@
 
 # /builtin ----------------------------------------------
 builtin/__builtin__.c builtin/__builtin__.h: builtin/ty/out/types/__builtin__.ty

--- a/Makefile
+++ b/Makefile
@@ -224,7 +224,9 @@ backend/test/skiplist_test: backend/test/skiplist_test.c backend/skiplist.c
 
 builder/builder: builder/build.zig $(ZIG)
 	rm -rf builder/zig-cache builder/zig-out
-	cd builder && ../$(ZIG)/zig build && find zig-cache -name build -exec cp {} builder \;
+	cd builder \
+		&& ../$(ZIG)/zig build -Doptimize=Debug -Dcpu=$(ARCH) \
+		&& find zig-cache -name build -exec cp {} builder \;
 
 # /builtin ----------------------------------------------
 builtin/__builtin__.c builtin/__builtin__.h: builtin/ty/out/types/__builtin__.ty

--- a/debian/rules
+++ b/debian/rules
@@ -19,6 +19,9 @@ export DH_VERBOSE = 1
 override_dh_auto_test:
 	@echo "Skipping tests"
 
+override_dh_strip:
+	dh_strip --exclude=builder
+
 # dh_make generated override targets
 # This is example for Cmake (See https://bugs.debian.org/641051 )
 #override_dh_auto_configure:


### PR DESCRIPTION
We have problems with builder dying with SIGILL. Could it be because it's built on some newer CPU and then run on an older CPU that doesn't have some CPU feature? Setting -Dcpu=$(ARCH) should fix this by only enabling the base CPU feature set.