### PR TITLE
Build a portable builder!

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
         os: [macos-11, macos-12, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: "Print env"
+      - name: "Show env"
         run: env
       - name: "Set BUILD_RELEASE when we are building for a version tag"
         run: |
@@ -97,8 +97,10 @@ jobs:
     container:
       image: ${{ matrix.os }}:${{ matrix.version }}
     steps:
-      - name: "Print env"
-        run: env
+      - name: "Show platform and environment"
+        run: |
+          env
+          cat /proc/cpuinfo
       - name: "Set BUILD_RELEASE when we are building for a version tag"
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
@@ -143,6 +145,10 @@ jobs:
     container:
       image: debian:bullseye
     steps:
+      - name: "Show platform and environment"
+        run: |
+          env
+          cat /proc/cpuinfo
       - name: "Set BUILD_RELEASE when we are building for a version tag"
         run: |
           echo "BUILD_RELEASE=1" >> $GITHUB_ENV
@@ -198,7 +204,7 @@ jobs:
     #if: ${{ startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/release-') }}
     runs-on: macos-12
     steps:
-      - name: "Print env"
+      - name: "Show environment"
         run: env
       - name: "Set BUILD_RELEASE when we are building for a version tag"
         run: |
@@ -329,6 +335,10 @@ jobs:
       image: ${{ matrix.os }}:${{ matrix.version }}
       options: --privileged --ulimit core=-1 --security-opt seccomp=unconfined
     steps:
+      - name: "Show platform and environment"
+        run: |
+          env
+          cat /proc/cpuinfo
       - name: "Download .deb files"
         uses: actions/download-artifact@v3
         with:

--- a/Makefile
+++ b/Makefile
@@ -224,7 +224,8 @@ backend/test/skiplist_test: backend/test/skiplist_test.c backend/skiplist.c
 
 builder/builder: builder/build.zig $(ZIG)
 	rm -rf builder/zig-cache builder/zig-out
-	cd builder && ../$(ZIG)/zig build && find zig-cache -name build -exec cp {} builder \;
+	(echo 'const root = @import("build.zig");'; tail -n +2 deps/zig/lib/build_runner.zig) > builder/build_runner.zig
+	cd builder && ../$(ZIG)/zig build-exe build_runner.zig -femit-bin=builder -mcpu=$(ARCH)
 
 # /builtin ----------------------------------------------
 builtin/__builtin__.c builtin/__builtin__.h: builtin/ty/out/types/__builtin__.ty
@@ -687,7 +688,7 @@ test-stdlib:
 
 .PHONY: clean clean-all clean-backend clean-rts
 clean: clean-distribution clean-backend clean-rts
-	rm -rf builder/builder builder/zig-cache builder/zig-out
+	rm -rf builder/build_runner* builder/builder* builder/zig-cache builder/zig-out
 
 clean-all: clean clean-compiler clean-deps
 	rm -rf lib_deps lib/*

--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -444,10 +444,7 @@ filterMainActor env opts paths binTask
         (sc,_)              = Acton.QuickType.schemaOf env (A.eQVar qn)
 
 useZigBuild opts paths =
-  -- Default to NOT use zig build, unless the user explicitly asks for it
-  C.zigbuild opts
-  -- TODO: enable zig build by default when it's ready
-  --not (C.zigbuild opts)
+  not (C.nozigbuild opts)
 
 importsOf :: CompileTask -> [A.ModName]
 importsOf t = A.importsOf (atree t)


### PR DESCRIPTION
One pin down the rabbit hole! Switched from using the `zig build` frontend, which under the hood just builds the builder program based on our build.zig. It's really build_runner.zig, which in turn imports build.zig. We now do that step manually and are then able to inject our own compilation arguments, like which arch to compile for and should thus get a portable executable that is built for the base CPU feature set without all the bells and whistles of the native CPU of the build machine!

Default to use the zig build!

Fixes #1305.