### PR TITLE
Only force base CPU feature set on x86_64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,10 +230,13 @@ backend/test/skiplist_test: backend/test/skiplist_test.c backend/skiplist.c
 	$(CC) -o$@ $^ $(CFLAGS_DB) -Ibackend \
 		$(LDLIBS)
 
+ifeq ($(ARCH),x86_64)
+ZIG_ARCH_ARG=-mcpu=x86_64
+endif
 builder/builder: builder/build.zig $(ZIG)
 	rm -rf builder/zig-cache builder/zig-out
 	(echo 'const root = @import("build.zig");'; tail -n +2 deps/zig/lib/build_runner.zig) > builder/build_runner.zig
-	cd builder && ../$(ZIG)/zig build-exe build_runner.zig -femit-bin=builder -mcpu=$(ARCH)
+	cd builder && ../$(ZIG)/zig build-exe build_runner.zig -femit-bin=builder $(ZIG_ARCH_ARG)
 
 # /compiler ----------------------------------------------
 ACTONC_ALL_HS=$(wildcard compiler/*.hs compiler/**/*.hs)


### PR DESCRIPTION
Per default zig compiles a super optimized binary using all the CPU features avilable on the build machine. This isn't very portable. On x86_64 we tell zig to compile for the base CPU spec by doing -mcpu=x86_64 which disables all extra features. I figured it was the same for all architectures but apparently not on aarch64, so now we will only specify -mcpu=$(ARCH) on x86_64.

Portable binaries are mostly important when we do releases. We don't have any aarch64 builds, thus this is only used for locally built Acton systems and will thus probably work just fine. Will be interesting to see if an M2 will produce a binary compatible with an M1 though!

Fixes #1310