### PR TITLE
Remove failing brew-macos job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -183,110 +183,6 @@ jobs:
           if-no-files-found: error
 
 
-  # This job test builds the Homebrew Formula in this repo. We'd really like to
-  # use brew test-bot for this, but it's a little too opinionated and rigid
-  # about how things should workd. It assumes that it is running in our
-  # actonlang/homebrew-acton repository. We made initial attempts to fake that
-  # environment by overwriting GITHUB_REPOSITORY and overwriting the formula
-  # with the formula in this (actonlang/acton) repo but it is ultimately futile
-  # as the test-bot actually pulls down the real actonlang/homebrew-acton repo,
-  # so we cannot get it to test local files.
-  # In order to get it to test our Formula that is unreleased, we rewrite the
-  # Formula so that the head/revision matches the current git commit sha and run
-  # all brew commands with --HEAD. Some commands for verification do not support
-  # --HEAD, so we skip them, but they are later run in the homebrew-acton repo
-  # anyway. The point is mostly to validate as much as possible of the Formula
-  # here, before we push it to homebrew-acton.
-  # We only run on macos-12 as it is faster than macos-11 for some weird reason.
-  # The Formula will be tested on all current versions of macos + one Linux once
-  # its pushed to the homebrew-acton repository.
-  brew-macos:
-    #if: ${{ startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/release-') }}
-    runs-on: macos-13
-    steps:
-      - name: "Show environment"
-        run: env
-      - name: "Set BUILD_RELEASE when we are building for a version tag"
-        run: |
-          echo "BUILD_RELEASE=1" >> $GITHUB_ENV
-        if: startsWith(github.ref, 'refs/tags/v')
-      - name: "Enable dumping core files"
-        run: |
-          sudo sysctl kern.corefile=core.%P
-          ulimit -c unlimited
-      - name: "Check out repository code"
-        uses: actions/checkout@v3
-      - name: "Get the version"
-        id: get_version
-        run: echo "version=$(grep VERSION= common.mk | cut -d = -f 2)" >> $GITHUB_OUTPUT
-      - name: "Hacky hacky homebrew formula"
-        # NOTE: brew --prefix gives us path to Homebrew installation directory,
-        #       which differs between Intel and M1 mac. However, on Intel the
-        #       path is one deeper, which is why we use sed to rewrite
-        #       /usr/local to /usr/local/Homebrew so we can find
-        #       /usr/local/Homewbrew/Library while on M1 it is in
-        #       /opt/homebrew/Library.
-        # COMMIT_SHA is either the SHA from the pull request or read directly
-        # from GITHUB_SHA. It is needed because GITHUB_SHA, which works
-        # correctly for a push event, does not work for pull_request events as
-        # GITHUB_SHA points to a PR merge commit or something like that... it's
-        # weird and doesn't work.
-        run: |
-          mkdir -p $(brew --prefix | sed -e 's,^/usr/local,/usr/local/Homebrew,')/Library/Taps/actonlang/
-          sed -i -e 's,^  url.*,  url "https://github.com/actonlang/acton/archive/refs/tags/v${{ steps.get_version.outputs.version }}.tar.gz",' homebrew/Formula/acton.rb
-          export PR_SHA=${{github.event.pull_request.head.sha}}
-          export COMMIT_SHA=${PR_SHA:-${GITHUB_SHA}}
-          export PR_REMOTE=${{ github.event.pull_request.head.repo.clone_url }}
-          export BASE_REMOTE=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git
-          export GIT_REPO=${PR_REMOTE:-${BASE_REMOTE}}
-          sed -i -e "s#^\(  head.*,\) branch.*#  head \"${GIT_REPO}\", revision: \"${COMMIT_SHA}\"#" homebrew/Formula/acton.rb
-          cat homebrew/Formula/acton.rb
-          git diff homebrew/Formula/acton.rb
-          cp -av homebrew $(brew --prefix | sed -e 's,^/usr/local,/usr/local/Homebrew,')/Library/Taps/actonlang/homebrew-acton
-          cat $(brew --prefix | sed -e 's,^/usr/local,/usr/local/Homebrew,')/Library/Taps/actonlang/homebrew-acton/Formula/acton.rb
-      - name: "brew test-bot --only-tap-syntax"
-        run: |
-          brew readall --aliases actonlang/acton
-          brew style actonlang/acton
-          brew audit --tap=actonlang/acton
-      - name: "brew test-bot --only-formulae"
-        run: |
-          brew audit --strict --only=gcc_dependency actonlang/acton/acton
-          brew deps --tree --annotate --include-build --include-test actonlang/acton/acton
-          brew fetch --HEAD --retry actonlang/acton/acton --build-bottle --force
-          brew install --HEAD --only-dependencies --verbose --build-bottle actonlang/acton/acton
-          brew install --HEAD --verbose --build-bottle actonlang/acton/acton
-          brew linkage actonlang/acton/acton
-          brew linkage --test --strict actonlang/acton/acton
-          brew test --verbose actonlang/acton/acton
-          # Cannot run on --HEAD
-          #brew audit actonlang/acton/acton --online --git --skip-style
-      - name: "Test compile acton program"
-        run: |
-          echo '#!/usr/bin/env runacton'   > test-runtime.act
-          echo 'actor main(env):'          >> test-runtime.act
-          echo '    print("Hello, world")' >> test-runtime.act
-          echo '    env.exit(0)'           >> test-runtime.act
-          chmod a+x test-runtime.act
-          ./test-runtime.act
-          ./test-runtime.act | grep "Hello, world"
-      - name: "Get the actonc version"
-        id: get_actonc_version
-        run: echo "version=$(actonc --numeric-version)" >> $GITHUB_OUTPUT
-      - name: "brew bottle"
-        run: |
-          brew bottle acton
-          ls
-          export BOTTLE_NAME=$(ls | grep "acton.*bottle" | sed -E -e 's/acton--[^.]+(\..*.bottle.tar.gz)/acton-v${{ steps.get_actonc_version.outputs.version }}\1/')
-          echo "Moving bottle to ${BOTTLE_NAME}"
-          mv acton*bottle.tar.gz ${BOTTLE_NAME}
-      - name: "Upload bottles as artifact"
-        uses: actions/upload-artifact@main
-        with:
-          name: bottles
-          path: '*.bottle.*'
-
-
   run-macos:
     needs: test-macos
     strategy:
@@ -390,7 +286,7 @@ jobs:
     # Only run on the main branch
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    needs: [test-macos, test-linux, build-debs, brew-macos]
+    needs: [test-macos, test-linux, build-debs]
     steps:
       - name: "Delete current tip release & tag"
         uses: dev-drprasad/delete-tag-and-release@v0.2.1
@@ -462,7 +358,7 @@ jobs:
   release:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
-    needs: [test-macos, test-linux, build-debs, brew-macos]
+    needs: [test-macos, test-linux, build-debs]
     steps:
       - name: "Check out repository code"
         uses: actions/checkout@v3
@@ -500,7 +396,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: debian:bullseye
-    needs: [test-macos, test-linux, build-debs, brew-macos]
+    needs: [test-macos, test-linux, build-debs]
     steps:
       - name: Install build prerequisites
         run: |
@@ -542,7 +438,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     # Depend on all test jobs so we don't update brew repo in case anything fails
-    needs: [test-macos, test-linux, build-debs, brew-macos]
+    needs: [test-macos, test-linux, build-debs]
     steps:
       - name: "Check out code of main acton repo"
         uses: actions/checkout@v3


### PR DESCRIPTION
The brew-macos job is failing more times than not. I don't have the time or energy to fix it now, so option to remove as all failures are becoming a nuisance.

I originally added the brew-macos job as we had failures once we pushed a new release to the homebrew-acton repo. With rather few releases and far between, the brew build problems only dawned on us once we made a release. Having the Formula committed locally and testing it continuously was an attempt in increasing the likelihood of finding problems earlier so we could fix them. It did work well and did catch a bunch of problems but something is different now, presumable in brew itself, so that our local test no longer works. It was quite hacked up and not a "supported mode of operation" in / by brew.

In the longer term I think we should add this job back, but I simply don't have the energy to try and figure this stuff out now.

There is one big difference now compared to before when we had lots of problems with brew builds (and which this test helped find), which is related to dependencies. Before we had a number of external library dependencies added as brew dependencies, so we let brew install static libraries that we then copied into our distribution. Whenever we added or removed a dependency, the brew Formula had to stay in sync (and we often forget!). Now we do not have any externl dependencies like that, instead we download and build external libs from source, so the risk to run out of sync in this way is 0. There are some other build dependencies and other parts of the Formula that might cause problems of course, but the historically biggest contributor to problems is now, by design, gone forever!

I left the Formula itself in this repo. No point in removing it...