### PR TITLE
Allow 'native' target

### DIFF
--- a/compiler/Acton/CommandLineParser.hs
+++ b/compiler/Acton/CommandLineParser.hs
@@ -8,7 +8,7 @@ defTarget = "aarch64-macos-none"
 #elif defined(darwin_HOST_OS) && defined(x86_64_HOST_ARCH)
 defTarget = "x86_64-macos-none"
 #elif defined(linux_HOST_OS) && defined(x86_64_HOST_ARCH)
-defTarget = "x86_64-linux-gnu.2.28"
+defTarget = "x86_64-linux-gnu.2.27"
 #else
 #error "Unsupported platform"
 #endif

--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -68,10 +68,11 @@ import Text.Printf
 import qualified Data.ByteString.Char8 as B
 
 archOs t = case t of
+  "native" -> archOs C.defTarget
   "aarch64-macos-none" -> "aarch64-macos"
   "x86_64-macos-none"  -> "x86_64-macos"
   "x86_64-linux-none"  -> "x86_64-linux"
-  "x86_64-linux-gnu.2.28"  -> "x86_64-linux"
+  "x86_64-linux-gnu.2.27"  -> "x86_64-linux"
   _ -> error $ "Unsupported target: " ++ t
 
 
@@ -871,8 +872,8 @@ zigBuild env opts paths tasks binTasks = do
                  " -Dsyspath_include=" ++ joinPath [ sysPath paths, "inc" ] ++
                  " -Dsyspath_lib=" ++ joinPath [ sysPath paths, "lib" ] ++
                  " -Dsyspath_libreldev=" ++ joinPath [ sysPath paths, "lib", reldev ] ++
-                 " -Dlibactondeps=ActonDeps-" ++ archOs (C.target opts) ++
-                 " -Dlibactongc=actongc-" ++ archOs (C.target opts) ++
+                 " -Dlibactondeps=ActonDeps-" ++ (if use_prebuilt then archOs (C.target opts) else "") ++
+                 " -Dlibactongc=actongc-" ++ (if use_prebuilt then archOs (C.target opts) else "") ++
                  if use_prebuilt then " -Duse_prebuilt" else ""
 
     runZig opts zigCmd (Just (projPath paths))


### PR DESCRIPTION
This will target the native machine, i.e. the machine we are currently compiling, by using the current libc and all available CPU features. It usually gives a faster binary at the cost of portability.