### PR TITLE
Remove old dependencies from debian & homebrew

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,9 +6,7 @@ Build-Depends:
  bash-completion,
  debhelper-compat (= 13),
  haskell-stack,
- libprotobuf-c-dev,
- make,
- pkg-config
+ make
 Standards-Version: 4.6.0
 Homepage: http://www.acton-lang.org
 Rules-Requires-Root: no

--- a/docs/development_workflow.md
+++ b/docs/development_workflow.md
@@ -52,12 +52,12 @@ There are two types of releases, "version releases" and the `tip` release.
 
 # Dependencies
 
+## Run time
+- GMP
+  - actonc is written in Haskell which uses GMP for big integers
+    - for releases on Linux, we build a static binary so GMP is linked in and
+      thus not a dependency
+    - for non-releases or MacOS, we need gmp as a shared library
+
 ## Build time
-- automake, autopoint, bison, libtool, pkg-config
-  - required by external library dependencies
-- libprotobuf-c-dev
-  - required by libprotobuf-c, this is all very complicated
-- gcc
-  - required by ghc
-- zlib1g-dev
-  - required by ghc
+- ghc

--- a/homebrew/Formula/acton.rb
+++ b/homebrew/Formula/acton.rb
@@ -6,20 +6,14 @@ class Acton < Formula
   license "BSD-3-Clause"
   head "https://github.com/actonlang/acton.git", branch: "main"
 
-  depends_on "autoconf" => :build
-  depends_on "automake" => :build
+  # TODO: can gettext be removed? it was likely necessary when we built deps
+  # using autoconf, but might not be needed now that we use build.zig?
   depends_on "gettext" => :build
   depends_on "ghc@8.10" => :build
   depends_on "haskell-stack" => :build
-  depends_on "libtool" => :build
-  depends_on "pkg-config" => :build
-  depends_on "protobuf-c" => :build
 
   on_linux do
-    depends_on "libbsd" => :build
-    depends_on "gcc"
     depends_on "gmp"
-    depends_on "util-linux"
   end
 
   def install


### PR DESCRIPTION
Now that we are building all the external library dependencies from source using build.zig, we do not need the whole autoconf suite of tools.