### PR TITLE
Remove unused programs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,7 +123,7 @@ jobs:
         run: |
           export DEBIAN_FRONTEND=noninteractive
           apt-get update
-          apt-get install -qy bzip2 curl git haskell-stack make procps python3 zlib1g-dev
+          apt-get install -qy bzip2 curl haskell-stack make procps zlib1g-dev
       - name: "Upgrade stack on old distributions"
         if: ${{ (matrix.os == 'ubuntu') && (matrix.version == '20.04') }}
         run: |
@@ -170,7 +170,7 @@ jobs:
       - name: "Install build prerequisites"
         run: |
           apt-get update
-          apt-get install -qy bzip2 curl git haskell-stack make procps python3 zlib1g-dev
+          apt-get install -qy bzip2 curl haskell-stack make procps zlib1g-dev
           apt-get install -qy bash-completion build-essential debhelper devscripts
       - name: "Build Debian packages"
         run: |


### PR DESCRIPTION
git was used to clone dependencies, we now pull tar balls via http using curl instead.

python3 was used for the database test harness, but that is now implemented in an acton program.