### PR TITLE
Remove testing on Ubuntu 20.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,8 +91,6 @@ jobs:
           - os: "debian"
             version: "11"
           - os: "ubuntu"
-            version: "20.04"
-          - os: "ubuntu"
             version: "22.04"
           - os: "ubuntu"
             version: "22.10"


### PR DESCRIPTION
There appears to be build problems with Ubuntu 20.04. We can't download the latest stack for Haskell. Removing the job for now.