### PR TITLE
Ditch libActonDeps, minimize dist

### DIFF
--- a/builder/build.zig
+++ b/builder/build.zig
@@ -58,8 +58,6 @@ pub fn build(b: *std.build.Builder) void {
     const syspath_include = b.option([]const u8, "syspath_include", "") orelse "";
     const syspath_lib = b.option([]const u8, "syspath_lib", "") orelse "";
     const syspath_libreldev = b.option([]const u8, "syspath_libreldev", "") orelse "";
-    const libactondeps = b.option([]const u8, "libactondeps", "") orelse "";
-    const libactongc = b.option([]const u8, "libactongc", "") orelse "";
     const wd = b.option([]const u8, "wd", "") orelse "";
 
     const libactondb_dep = b.anonymousDependency(syspath_backend, @import("backendbuild.zig"), .{
@@ -254,9 +252,18 @@ pub fn build(b: *std.build.Builder) void {
 
         if (use_prebuilt) {
             executable.linkSystemLibraryName("Acton");
-            executable.linkSystemLibraryName(libactondeps);
+            executable.linkSystemLibraryName("argp");
+            executable.linkSystemLibraryName("bsdnt");
+            executable.linkSystemLibraryName("netstring");
+            executable.linkSystemLibraryName("pcre2");
+            executable.linkSystemLibraryName("protobuf-c");
+            executable.linkSystemLibraryName("utf8proc");
+            executable.linkSystemLibraryName("uuid");
+            executable.linkSystemLibraryName("uv");
+            executable.linkSystemLibraryName("xml2");
+            executable.linkSystemLibraryName("yyjson");
             executable.linkSystemLibraryName("ActonDB");
-            executable.linkSystemLibraryName(libactongc);
+            executable.linkSystemLibraryName("actongc");
         } else {
             executable.linkLibrary(actonbase_dep.artifact("Acton"));
             executable.linkLibrary(libactondb_dep.artifact("ActonDB"));


### PR DESCRIPTION
In order to simplify compilation and decouple the compiler from the list of C libraries, we bunched them all up in one large archive called libActonDeps.a. Recently it was moved to include the platform name, like libActonDeps-x86_64-linux.a.

With the move towards using zig build and how the entire build process, both what's called from actonc as well as how we put together the Acton distribution itself, the need for having libActonDeps is smaller. We accept the list of libraries in multiple places. Since our dist building step now naturally installs the .o files in dist/depsout, we make use of them directly, so also building libActonDeps is just unnecessary. It has now been removed.

The classic C compilation (not using zig) has also been fixed to use the correct paths.

dist/builtin is gone since it is already in dist/base/builtin

dist/zig is now stripped of docs, libcxx and windows headers which reduces it's size by over 100MB.