### PR TITLE
Avoid using acton.rts.sleep() in example

### DIFF
--- a/docs/acton-by-example/src/modules.md
+++ b/docs/acton-by-example/src/modules.md
@@ -9,18 +9,18 @@ Use `from` .. `import` to import a single function from a module.
 Functions and modules can be aliased using the `as` keyword.
 
 ```python
-import acton.rts
-import acton.rts as arts
-from acton.rts import sleep
-from acton.rts import sleep as sleepy
+import time
+import time as timmy
+from time import now
+from time import now as rightnow
 
 actor main(env):
-    acton.rts.sleep(0)   # using the fully qualified name
-    arts.sleep(0)        # using aliased module name
-    sleep(0)             # using the directly imported function
-    sleepy(0)            # using function alias
+    time.now()         # using the fully qualified name
+    timmy.now()        # using aliased module name
+    now()              # using the directly imported function
+    rightnow()         # using function alias
 
     await async env.exit(0)
 ```
 
-Remember, all state in an Acton program must be held by actors. There can be no mutable variables in an Acton module, only constants!
+Remember, all state in an Acton program must be held by actors. There can be no mutable variables in an Acton module, only constants! Similarly, there can be no global instantiation code in a module.


### PR DESCRIPTION
sleep() as a concept, i.e. actively waiting, is not something that exists in Acton. This particular module is a hack to allow RTS debugging. We shouldn't promote or even talk about it since it might lead users into thinking it should be used.