### PR TITLE
temporary fix to hashing bigints

### DIFF
--- a/base/builtin/int.c
+++ b/base/builtin/int.c
@@ -454,7 +454,13 @@ B_bool B_HashableD_intD___ne__(B_HashableD_int wit, B_int a, B_int b) {
 }
 
 B_int B_HashableD_intD___hash__(B_HashableD_int wit, B_int a) {
-    return to$int(B_i64D_hash(toB_i64(from$int(a))));
+    long sz = a->val.size;
+    if (sz==0) return toB_i64(sz);
+    unsigned long res = a->val.n[0];
+    if (res > LONG_MAX || labs(sz) > 1) 
+        return to$int(B_i64D_hash(toB_i64((long)res & LONG_MAX)));
+    else
+        return to$int(B_i64D_hash(toB_i64(sz<0 ? -res : res)));
 }
  
 long from$int(B_int n) { 

--- a/test/builtins_auto/int.act
+++ b/test/builtins_auto/int.act
@@ -23,4 +23,6 @@ actor main(env):
         raise ValueError("round(-123456789, -10) != -1234567890000000000")
     if int('123') != 123:
         raise ValueError("int('123') != 123")
+    if hash(2**131) >= 2**64:
+        raise ValueError("hash(2**131) too big")        
     await async env.exit(0)

--- a/test/builtins_auto/set_test.act
+++ b/test/builtins_auto/set_test.act
@@ -9,12 +9,14 @@ actor main(env):
     for k in range(0,1000,1):
         if k in s: n += 1
     if n != 18:
+        raise ValueError("n is" + str(n) + ", not 18")
+
         env.exit(1)
     s2 = {1}
     for i in range(0,500,1):
         s2.add(i*i*i*i)
     if len(s) != 985 or len(s2) != 500:
-        env.exit(1)
+        raise ValueError("set length error 1")
     if len(s & s2) != 27 or len(s | s2) != 1458 or len(s ^ s2) != 1431:  
-        env.exit(1) 
+        raise ValueError("set length error 2")
     env.exit(0)


### PR DESCRIPTION
This avoids crashing when hashing big integers, but is not a long-term solution. We need to decide on a new general-purpose hash function and simplify creating hashes for user-defined types, possibly following Swift's design.