### PR TITLE
Use xz instead of bzip2 compression

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -210,7 +210,7 @@ jobs:
           name: acton-macos-11
       - name: "Extract acton"
         run: |
-          tar jxvf $(ls acton-darwin*.tar.bz2 | tail -n1)
+          tar Jxvf $(ls acton-darwin*.tar.xz | tail -n1)
       - name: "Compile acton program"
         run: |
           echo '#!/usr/bin/env runacton'   > test-runtime.act
@@ -346,9 +346,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           replacesArtifacts: true
       - name: "Remove version number from darwin tar ball"
-        run: mv $(ls acton-darwin*.tar.bz2 | tail -n1) acton-darwin-x86_64.tar.bz2
+        run: mv $(ls acton-darwin*.tar.xz | tail -n1) acton-darwin-x86_64.tar.xz
       - name: "Remove version number from linux tar ball"
-        run: mv $(ls acton-linux-x86_64*.tar.bz2 | tail -n1) acton-linux-x86_64.tar.bz2
+        run: mv $(ls acton-linux-x86_64*.tar.xz | tail -n1) acton-linux-x86_64.tar.xz
       - name: "Remove version number from debian package"
         run: mv $(ls deb/acton_*.deb | tail -n1) deb/acton_tip_amd64.deb
       - name: "List files for debug"

--- a/Makefile
+++ b/Makefile
@@ -486,13 +486,13 @@ endif
 # Do grep to only get a version number. If there's an error, we get an empty
 # string which is better than getting the error message itself.
 ACTONC_VERSION=$(shell $(ACTONC) --numeric-version 2>/dev/null | grep -E "^[0-9.]+$$")
-.PHONY: acton-$(PLATARCH)-$(ACTONC_VERSION).tar.bz2
-acton-$(PLATARCH)-$(ACTONC_VERSION).tar.bz2:
-	tar jcvf $@ $(TAR_TRANSFORM_OPT) --exclude .gitignore dist
+.PHONY: acton-$(PLATARCH)-$(ACTONC_VERSION).tar.xz
+acton-$(PLATARCH)-$(ACTONC_VERSION).tar.xz:
+	tar cv $(TAR_TRANSFORM_OPT) --exclude .gitignore dist | xz -z -0 --threads=0 > $@
 
 .PHONY: release
 release: distribution
-	$(MAKE) acton-$(PLATARCH)-$(ACTONC_VERSION).tar.bz2
+	$(MAKE) acton-$(PLATARCH)-$(ACTONC_VERSION).tar.xz
 
 .PHONY: install
 install:


### PR DESCRIPTION
xz is faster and better than bzip2. Here we tell it to use lowest level of compression (-0) and thus the fastest mode. --threads=0 enables using multiple threads to compress data.

Despite being the faster level and thus worst compression, it beats bzip2 standard settings. The current release tar ball turns in bz2 & xz:

- bz2: 66061362
- xz:  65009672

On an AMD 5950X (16 cores / 32 threads) with an NVMe drive, it takes ~16 seconds to produce the bz2 while producing the xz takes just over 1 second. It might just be the increased parallelism or a combination with xz being faster overall.

There are plenty of CI runs where it takes just as long to build Acton, like coming in just over 2 minutes (with a zig build cache), as it does to produce the release tar ball (just under 2 minutes). Hopefully this can minimize that time.