### PR TITLE
musl compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
+            ~/.cache/acton/
             ~/.stack
             ~/zig-cache
           key: ${{ matrix.os }}
@@ -116,6 +117,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
+            ~/.cache/acton/
             ~/.stack
             ~/zig-cache
           key: ${{ matrix.os }}-${{ matrix.version }}
@@ -166,6 +168,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
+            ~/.cache/acton/
             ~/.stack
             ~/zig-cache
           key: build-debs

--- a/Makefile
+++ b/Makefile
@@ -213,7 +213,7 @@ dist/depsout/lib/libbsdnt.a: dist/deps/libbsdnt $(DIST_ZIG)
 	cd $< && $(ZIG) build $(ZIG_TARGET) --prefix $(TD)/dist/depsout
 
 # /deps/libgc --------------------------------------------
-LIBGC_REF=8ee0dc25da0a4572dc3ba706b3d26983f1928d21
+LIBGC_REF=6f729399e329de5373f8f117f85f03181ec64d58
 deps-download/$(LIBGC_REF).tar.gz:
 	mkdir -p deps-download
 	curl -f -L -o $@ https://github.com/actonlang/bdwgc/archive/$(LIBGC_REF).tar.gz

--- a/base/src/time.ext.c
+++ b/base/src/time.ext.c
@@ -31,7 +31,11 @@ unsigned long time__uuid_to_ulong(const char* uuid) {
 
 
 void time__get_clock_data_cb(uv_timer_t *ev) {
+#ifdef __linux__
+    time__realclock_status = adjtimex(&time__realclock_tx);
+#else
     time__realclock_status = ntp_adjtime(&time__realclock_tx);
+#endif
 }
 
 void timeQ___ext_init__() {

--- a/compiler/Acton/CommandLineParser.hs
+++ b/compiler/Acton/CommandLineParser.hs
@@ -63,6 +63,7 @@ data CompileOptions   = CompileOptions {
                          syspath     :: String,
                          cc          :: String,
                          target      :: String,
+                         cachedir    :: String,
                          zigbuild    :: Bool,
                          nozigbuild  :: Bool
                      } deriving Show
@@ -78,6 +79,7 @@ data BuildOptions = BuildOptions {
                          timingB     :: Bool,
                          ccB         :: String,
                          targetB     :: String,
+                         cachedirB   :: String,
                          zigbuildB   :: Bool,
                          nozigbuildB :: Bool
                      } deriving Show
@@ -149,6 +151,7 @@ compileOptions = CompileOptions
         <*> strOption (long "syspath"   <> metavar "TARGETDIR" <>  value "" <> help "Set syspath")
         <*> strOption (long "cc"        <> metavar "PATH" <>  value "" <> help "CC")
         <*> strOption (long "target"    <> metavar "TARGET" <>  value defTarget <> help "Target, e.g. x86_64-linux-gnu.2.28")
+        <*> strOption (long "cache"     <> metavar "CACHEDIR" <>  value "" <> help "Cache directory")
         <*> switch (long "zigbuild"     <> help "Use zig build")
         <*> switch (long "no-zigbuild"  <> help "Don't use zig build")
 
@@ -164,6 +167,7 @@ buildCommand          = Build <$> (
         <*> switch (long "timing"       <> help "Print timing information")
         <*> strOption (long "cc"        <> metavar "PATH" <>  value "" <> help "CC")
         <*> strOption (long "target"    <> metavar "TARGET" <>  value defTarget <> help "Target, e.g. x86_64-linux-gnu.2.28")
+        <*> strOption (long "cache"     <> metavar "CACHEDIR" <>  value "" <> help "Cache directory")
         <*> switch (long "zigbuild"     <> help "Use zig build")
         <*> switch (long "no-zigbuild"  <> help "Don't use zig build")
     )

--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -71,14 +71,28 @@ main                     =  do arg <- C.parseCmdLine
                                case arg of
                                    C.VersionOpt opts       -> printVersion opts
                                    C.CmdOpt (C.New opts)   -> createProject (C.file opts)
-                                   C.CmdOpt (C.Build opts) -> buildProject $ defaultOpts {C.alwaysbuild = C.alwaysB opts, C.autostub = C.autostubB opts, C.debug = C.debugB opts, C.dev = C.devB opts, C.root = C.rootB opts, C.ccmd = C.ccmdB opts, C.quiet = C.quietB opts, C.timing = C.timingB opts, C.cc = C.ccB opts, C.target = C.targetB opts, C.zigbuild = C.zigbuildB opts, C.nozigbuild = C.nozigbuildB opts}
+                                   C.CmdOpt (C.Build opts) -> buildProject $ defaultOpts {
+                                     C.alwaysbuild = C.alwaysB opts,
+                                     C.autostub = C.autostubB opts,
+                                     C.debug = C.debugB opts,
+                                     C.dev = C.devB opts,
+                                     C.root = C.rootB opts,
+                                     C.ccmd = C.ccmdB opts,
+                                     C.quiet = C.quietB opts,
+                                     C.timing = C.timingB opts,
+                                     C.cc = C.ccB opts,
+                                     C.target = C.targetB opts,
+                                     C.cachedir = C.cachedirB opts,
+                                     C.zigbuild = C.zigbuildB opts,
+                                     C.nozigbuild = C.nozigbuildB opts
+                                     }
                                    C.CmdOpt (C.Cloud opts) -> undefined
                                    C.CmdOpt (C.Doc opts)   -> printDocs opts
                                    C.CompileOpt nms opts   -> compileFiles opts (catMaybes $ map filterActFile nms)
 
 defaultOpts   = C.CompileOptions False False False False False False False False False False False
                                  False False False False False False False False False "" "" "" ""
-                                 C.defTarget False False
+                                 C.defTarget "" False False
 
 
 -- Auxiliary functions ---------------------------------------------------------------------------------------
@@ -831,7 +845,7 @@ zigBuild env opts paths tasks binTasks = do
     -- custom build.zig ?
     buildZigExists <- doesFileExist $ projPath paths ++ "/build.zig"
     homeDir <- getHomeDirectory
-    let cache_dir = joinPath [ projPath paths, "build-cache" ]
+    let cache_dir = if (not $ null $ C.cachedir opts) then (C.cachedir opts) else joinPath [ projPath paths, "build-cache" ]
         global_cache_dir = joinPath [ homeDir, ".cache", "acton", "build-cache" ]
         use_prebuilt = C.defTarget == C.target opts
     let zigCmdBase =

--- a/compiler/test.hs
+++ b/compiler/test.hs
@@ -55,7 +55,7 @@ main = do
       , stdlibTests
       ]
   where timeout :: Timeout
-        timeout = mkTimeout (60*1000000) -- 60 second timeout
+        timeout = mkTimeout (3*60*1000000) -- 3 minutes timeout
 
 coreLangTests =
   testGroup "Core language"
@@ -78,6 +78,14 @@ compilerTests =
         (returnCode, cmdOut, cmdErr) <- readCreateProcessWithExitCode (shell $ "rm -rf ../test/compiler/rebuild-import/out") ""
         testBuild "" ExitSuccess False "../test/compiler/rebuild-import/"
         testBuild "" ExitSuccess False "../test/compiler/rebuild-import/"
+  , testCase "build hello --target aarch64-macos-none" $ do
+        testBuild "--target aarch64-macos-none" ExitSuccess False "../test/compiler/hello/"
+  , testCase "build hello --target x86_64-macos-none" $ do
+        testBuild "--target x86_64-macos-none" ExitSuccess False "../test/compiler/hello/"
+  , testCase "build hello --target x86_64-linux-gnu.2.27" $ do
+        testBuild "--target x86_64-linux-gnu.2.27" ExitSuccess False "../test/compiler/hello/"
+  , testCase "build hello --target x86_64-linux-musl" $ do
+        testBuild "--target x86_64-linux-musl" ExitSuccess False "../test/compiler/hello/"
   ]
 
 actoncProjTests =

--- a/compiler/test.hs
+++ b/compiler/test.hs
@@ -289,7 +289,7 @@ buildThing opts thing = do
     projPath <- canonicalizePath thing
     curDir <- getCurrentDirectory
     let wd = if proj then projPath else curDir
-    let actCmd    = (id actonc) ++ " " ++ (if proj then "build " else thing) ++ " --always-build " ++ opts
+    let actCmd    = (id actonc) ++ " " ++ (if proj then "build " else thing) ++ " --always-build --cache ~/.cache/acton/test-build-cache " ++ opts
     (returnCode, cmdOut, cmdErr) <- readCreateProcessWithExitCode (shell $ actCmd){ cwd = Just wd } ""
     return (returnCode, cmdOut, cmdErr)
 

--- a/docs/acton-by-example/src/compilation.md
+++ b/docs/acton-by-example/src/compilation.md
@@ -8,6 +8,48 @@ The default target is somewhat conservative to ensure a reasonable amount of com
 
 To compile an executable optimized for the local computer, use `--target native`. In many cases it can lead to a significant faster program, often running 30% to 100% faster.
 
+## Statically linked executables using musl for portability
+
+On Linux, executable programs can be statically linked using the Musl C library, which maximizes portability as there are no runtime dependencies at all.
+
+To compile an executable optimized for portability using musl on x86_64, use `--target x86_64-linux-musl`.
+
+A default compiled program is dynamically linked with GNU libc & friends
+```
+$ actonc helloworld.act
+Building file helloworld.act
+  Compiling helloworld.act for release
+   Finished compilation in   0.013 s
+  Final compilation step
+   Finished final compilation step in   0.224 s
+$ ldd helloworld
+        linux-vdso.so.1 (0x00007fff2975b000)
+        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f11f472a000)
+        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f11f4725000)
+        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f11f4544000)
+        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f11f453f000)
+        /lib64/ld-linux-x86-64.so.2 (0x00007f11f4827000)
+$
+```
+
+A program linked statically towards Musl has no run time dependencies:
+
+```
+$ actonc helloworld.act --target x86_64-linux-musl
+Building file helloworld.act
+  Compiling helloworld.act for release
+   Finished compilation in   0.013 s
+  Final compilation step
+   Finished final compilation step in   0.224 s
+$ ldd helloworld
+        not a dynamic executable
+$
+```
+
+Although untested, static linking with musl should work on other CPU architectures.
+
+MacOS does not support static compilation.
+
 ## Cross-compilation
 
 Acton supports cross-compilation, which means that it is possible to run develop on one computer, say a Linux computer with an x86-64 CPU but build an executable binary that can run on a MacOS computer.

--- a/test/compiler/hello/.gitignore
+++ b/test/compiler/hello/.gitignore
@@ -1,0 +1,5 @@
+.actonc.lock
+build.sh
+out
+zig-cache
+zig-out

--- a/test/compiler/hello/src/hello.act
+++ b/test/compiler/hello/src/hello.act
@@ -1,0 +1,6 @@
+#
+#
+
+actor main(env):
+    print("Hello World!")
+    await async env.exit(0)


### PR DESCRIPTION
Musl libc doesn't expose ntp_adjtime, only adjtimex. However, adjtimex is apparently just an older name for ntp_adjtime() and ntp_adjtime() is the pereferred one and available on many systems. Somewhat unclear on why musl picks the older name, but regardless, by picking adjtimex() for Linux systemes, we are compatible with both GNU libc and musl, while for others, like Macos we keep the call to ntp_adjtime().

Switch libgc to a newer version of its build.zit that will set options correctly for musl, which comes down to setting NO_GETCONTEXT.