### PR TITLE
Bump zig

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ export ZIG_LOCAL_CACHE_DIR
 
 ACTONC=dist/bin/actonc
 ACTC=dist/bin/actonc
-ZIG_VERSION:=0.11.0-dev.3384+00ff65357
+ZIG_VERSION:=0.11.0-dev.3739+939e4d81e
 ZIG=$(TD)/dist/zig/zig
 AR=$(ZIG) ar
 CC=$(ZIG) cc


### PR DESCRIPTION
This includes a commit that likely fixed the problems we've seen with spurious "File not found" errors from zig, see
https://github.com/ziglang/zig/issues/13515. Although, since switching to using zig more natively with build.zig, I don't think I've seen those errors. Doesn't hurt upgrading though.