### PR TITLE
Add .close() for TCP client actor

### DIFF
--- a/base/build.zig
+++ b/base/build.zig
@@ -112,6 +112,15 @@ pub fn build(b: *std.build.Builder) void {
     var flags = std.ArrayList([]const u8).init(b.allocator);
     defer flags.deinit();
 
+    var file_prefix_map = std.ArrayList(u8).init(b.allocator);
+    defer file_prefix_map.deinit();
+    const file_prefix_path = b.build_root.handle.openDir("..", .{}) catch unreachable;
+    const file_prefix_path_path = file_prefix_path.realpathAlloc(b.allocator, ".") catch unreachable;
+    file_prefix_map.appendSlice("-ffile-prefix-map=") catch unreachable;
+    file_prefix_map.appendSlice(file_prefix_path_path) catch unreachable;
+    file_prefix_map.appendSlice("/=") catch unreachable;
+    flags.append(file_prefix_map.items) catch unreachable;
+
     if (optimize == .Debug) {
         print("Debug build\n", .{});
         flags.appendSlice(&.{

--- a/base/rts/rts.c
+++ b/base/rts/rts.c
@@ -234,6 +234,12 @@ void pin_actor_affinity() {
     a->$affinity = i;
 }
 
+void set_actor_affinity(int wthread_id) {
+    $Actor a = ($Actor)pthread_getspecific(self_key);
+    log_debug("Setting affinity for %s actor %ld to WT %d", a->$class->$GCINFO, a->$globkey, wthread_id);
+    a->$affinity = wthread_id;
+}
+
 void wake_wt(int wtid) {
     // We are sometimes optimistically called, i.e. the caller sometimes does
     // not really know whether there is new work or not. We check and if there

--- a/base/rts/rts.c
+++ b/base/rts/rts.c
@@ -244,9 +244,9 @@ void wake_wt(int wtid) {
     // wake up corresponding worker threads....
     if (wtid == 0) {
         // global queue
-        for (int j = 0; j < num_wthreads; j++) {
-            if (wt_stats[j].state == WT_Idle) {
-                uv_async_send(&wake_ev[j]);
+        for (int i = 1; i < num_wthreads+1; i++) {
+            if (wt_stats[i].state == WT_Idle) {
+                uv_async_send(&wake_ev[i]);
                 return;
             }
         }

--- a/base/rts/rts.c
+++ b/base/rts/rts.c
@@ -1426,6 +1426,7 @@ void BOOTSTRAP(int argc, char *argv[]) {
         wit->$class->append(wit,args,to$str(argv[i]));
 
     env_actor = B_EnvG_newactor(B_WorldAuthG_new(), args);
+    env_actor->nr_wthreads = to$int(num_wthreads);
 
     root_actor = $ROOT();                           // Assumed to return $NEWACTOR(X) for the selected root actor X
     time_t now = current_time();

--- a/base/rts/rts.h
+++ b/base/rts/rts.h
@@ -159,6 +159,7 @@ void handle_timeout();
 void rts_shutdown();
 
 void pin_actor_affinity();
+void set_actor_affinity(int wthread_id);
 
 //typedef B_int B_Env;
 

--- a/base/src/__builtin__.act
+++ b/base/src/__builtin__.act
@@ -872,6 +872,7 @@ class WorldAuth():
 actor Env (token: WorldAuth, args: list[str]):
     auth = token
     argv = args
+    nr_wthreads: int = 0
 
     action def stdout_write(s: str) -> None:
         NotImplemented

--- a/base/src/__builtin__.ext.c
+++ b/base/src/__builtin__.ext.c
@@ -1,4 +1,4 @@
-#include "../rts/rts.c"
+#include "rts/rts.c"
 
 void B___ext_init__() {
 

--- a/base/src/acton/rts.act
+++ b/base/src/acton/rts.act
@@ -21,6 +21,31 @@ def rss(auth: WorldAuth) -> int:
     """Get Resident Set Size"""
     NotImplemented
 
-def io_handles(auth: WorldAuth) -> dict[u64, (typ: str, act: u64)]:
+def _io_handles(auth: WorldAuth) -> dict[u64, (typ: str, act: u64)]:
     """Return all I/O handles and their type for the current worker thread"""
     NotImplemented
+
+actor WThreadMonitor(env: Env, arg_wthread_id: int):
+    wthread_id = arg_wthread_id
+
+    def io_handles():
+        return _io_handles(env.auth)
+
+    proc def _init():
+        """Implementation internal"""
+        NotImplemented
+    _init()
+
+actor Monitor(env: Env):
+    tms: dict[int, WThreadMonitor] = {}
+
+    for wthread_id in range(1, env.nr_wthreads+1, 1):
+        tm = WThreadMonitor(env, wthread_id)
+        tms[wthread_id] = tm
+
+    def io_handles():
+        res = {}
+        for wthread_id, tm in tms.items():
+            res[wthread_id] = tm.io_handles()
+        return res
+

--- a/base/src/acton/rts.act
+++ b/base/src/acton/rts.act
@@ -1,3 +1,5 @@
+# TODO: replace WorldAuth with SysAuth here for reading information and
+# SysAuthBAD or something for write operations
 
 def gc() -> None:
     NotImplemented
@@ -17,4 +19,8 @@ def sleep(duration: float) -> None:
 
 def rss(auth: WorldAuth) -> int:
     """Get Resident Set Size"""
+    NotImplemented
+
+def io_handles(auth: WorldAuth) -> dict[u64, (typ: str, act: u64)]:
+    """Return all I/O handles and their type for the current worker thread"""
     NotImplemented

--- a/base/src/acton/rts.ext.c
+++ b/base/src/acton/rts.ext.c
@@ -69,7 +69,7 @@ void actonQ_rtsQ_io_handles_walk_cb (uv_handle_t *handle, void *arg) {
     B_dictD_setitem(walk_res->d, walk_res->wit, toB_u64((long)handle), val);
 }
 
-B_dict actonQ_rtsQ_io_handles (B_WorldAuth auth) {
+B_dict actonQ_rtsQ__io_handles (B_WorldAuth auth) {
     B_Hashable wit = (B_Hashable)B_HashableD_u64G_witness;
     B_dict d = $NEW(B_dict, wit, NULL, NULL);
 
@@ -79,4 +79,9 @@ B_dict actonQ_rtsQ_io_handles (B_WorldAuth auth) {
     uv_walk(get_uv_loop(), actonQ_rtsQ_io_handles_walk_cb, (void *)&walk_res);
 
     return d;
+}
+
+$R actonQ_rtsQ_WThreadMonitorD__init (actonQ_rtsQ_WThreadMonitor self, $Cont C_cont) {
+    set_actor_affinity(from$int(self->wthread_id));
+    return $RU_CONT(C_cont, B_None);
 }

--- a/base/src/net.act
+++ b/base/src/net.act
@@ -55,6 +55,9 @@ actor TCPIPConnection(auth: TCPConnectAuth, address: str, port: int, on_connect:
         """Close the connection"""
         NotImplemented
 
+    def reconnect():
+        close(_connect)
+
     action def write(data: bytes) -> None:
         """Write data to remote"""
         NotImplemented
@@ -64,7 +67,11 @@ actor TCPIPConnection(auth: TCPConnectAuth, address: str, port: int, on_connect:
 
     proc def _init():
         NotImplemented
+
+    proc def _connect(c):
+        NotImplemented
     _init()
+    _connect(self)
 
 actor TCPListenConnection(auth: _TCPListenConnectAuth, server_client: int):
     """TCP Listener Connection"""

--- a/base/src/net.act
+++ b/base/src/net.act
@@ -51,6 +51,10 @@ actor TCPIPConnection(auth: TCPConnectAuth, address: str, port: int, on_connect:
     """TCP IP Connection"""
     _socket = -1
 
+    action def close(on_close: action(TCPIPConnection) -> None) -> None:
+        """Close the connection"""
+        NotImplemented
+
     action def write(data: bytes) -> None:
         """Write data to remote"""
         NotImplemented

--- a/base/src/net.ext.c
+++ b/base/src/net.ext.c
@@ -200,6 +200,10 @@ void on_connect(uv_connect_t *connect_req, int status) {
 
 $R netQ_TCPIPConnectionD__init (netQ_TCPIPConnection self, $Cont c$cont) {
     pin_actor_affinity();
+    return $R_CONT(c$cont, B_None);
+}
+
+$R netQ_TCPIPConnectionD__connect (netQ_TCPIPConnection self, $Cont c$cont, netQ_TCPIPConnection c) {
     uv_tcp_t* socket = (uv_tcp_t*)malloc(sizeof(uv_tcp_t));
     uv_tcp_init(get_uv_loop(), socket);
     self->_socket = to$int((long)socket);

--- a/builder/build.zig
+++ b/builder/build.zig
@@ -58,7 +58,6 @@ pub fn build(b: *std.build.Builder) void {
     const syspath_include = b.option([]const u8, "syspath_include", "") orelse "";
     const syspath_lib = b.option([]const u8, "syspath_lib", "") orelse "";
     const syspath_libreldev = b.option([]const u8, "syspath_libreldev", "") orelse "";
-    const wd = b.option([]const u8, "wd", "") orelse "";
 
     const libactondb_dep = b.anonymousDependency(syspath_backend, @import("backendbuild.zig"), .{
         .target = target,
@@ -208,11 +207,21 @@ pub fn build(b: *std.build.Builder) void {
         .target = target,
         .optimize = optimize,
     });
-    const cflags = [_][]const u8{
-        wd
-    };
+    var flags = std.ArrayList([]const u8).init(b.allocator);
+    defer flags.deinit();
+
+    if (optimize == .Debug) {
+        print("Debug build\n", .{});
+        flags.appendSlice(&.{
+            "-DDEV",
+        }) catch |err| {
+            std.log.err("Error appending flags: {}", .{err});
+            std.os.exit(1);
+        };
+    }
+
     for (c_files.items) |entry| {
-        libActonProject.addCSourceFile(entry, &cflags);
+        libActonProject.addCSourceFile(entry, flags.items);
     }
 
     libActonProject.addIncludePath(projpath);
@@ -241,7 +250,7 @@ pub fn build(b: *std.build.Builder) void {
             .optimize = optimize,
         });
         //_ = syspath;
-        executable.addCSourceFile(entry.full_path, &[_][]const u8{});
+        executable.addCSourceFile(entry.full_path, flags.items);
         executable.addIncludePath(projpath);
         executable.addIncludePath(syspath_base);
         executable.addIncludePath(syspath_include);

--- a/builder/build.zig
+++ b/builder/build.zig
@@ -210,6 +210,15 @@ pub fn build(b: *std.build.Builder) void {
     var flags = std.ArrayList([]const u8).init(b.allocator);
     defer flags.deinit();
 
+    var file_prefix_map = std.ArrayList(u8).init(b.allocator);
+    defer file_prefix_map.deinit();
+    const file_prefix_path = b.build_root.handle.openDir("..", .{}) catch unreachable;
+    const file_prefix_path_path = file_prefix_path.realpathAlloc(b.allocator, ".") catch unreachable;
+    file_prefix_map.appendSlice("-ffile-prefix-map=") catch unreachable;
+    file_prefix_map.appendSlice(file_prefix_path_path) catch unreachable;
+    file_prefix_map.appendSlice("/=") catch unreachable;
+    flags.append(file_prefix_map.items) catch unreachable;
+
     if (optimize == .Debug) {
         print("Debug build\n", .{});
         flags.appendSlice(&.{

--- a/test/stdlib_auto/acton_rts_io.act
+++ b/test/stdlib_auto/acton_rts_io.act
@@ -1,0 +1,10 @@
+
+import acton.rts
+
+actor main(env):
+    rts_monitor = acton.rts.Monitor(env)
+    for k,v in rts_monitor.io_handles().items():
+        print("Worker", k)
+        for hid, handle in v.items():
+            print("  %d:" % int(hid), handle)
+    await async env.exit(0)

--- a/test/stdlib_auto/test_net_tcp.act
+++ b/test/stdlib_auto/test_net_tcp.act
@@ -37,6 +37,9 @@ actor Client(env: Env, port: int):
         print("Client RECV", data)
         if data == b"PONG":
             print("Got PONG, all good, yay")
+            # Test idempotency / that we don't break anything by double-closing
+            c.close()
+            c.close()
             after 0.1: _exit()
         else:
             print("Got bad response, exiting with error..")

--- a/test/stdlib_auto/test_net_tcp.act
+++ b/test/stdlib_auto/test_net_tcp.act
@@ -2,8 +2,17 @@
 # and then creating a TCP client connection which connects to the server, sends
 # a message and expects a reply. This exercices both ends of the TCP connection.
 
+import acton.rts
 import net
 import random
+
+
+def filter_tcp_handles(handles: dict[u64, (typ: str, act: u64)]):
+    res = {}
+    for k, v in handles.items():
+        if v.typ == "tcp" and v.act != u64(0):
+            res[k] = v
+    return res
 
 actor Server(conn):
     def on_receive(c, data):
@@ -29,18 +38,39 @@ actor Listener(env, port):
 
 
 actor Client(env: Env, port: int):
+    var connection = 0
     def on_connect(c):
-        print("Client established connection")
+        connection += 1
+        print("Client connected, TCP handles", filter_tcp_handles(acton.rts.io_handles(env.auth)))
         await async c.write(b"PING")
+
+    def on_close(c):
+        print("closed connection", connection)
+        if connection == 2:
+            after 0.001: check_io()
+
+    def check_io():
+        tcp_handles = filter_tcp_handles(acton.rts.io_handles(env.auth))
+        print("IO check...", tcp_handles)
+        if len(tcp_handles) < 2:
+            # Only TCP listening socket left...
+            print("TCP client properly cleaned from IO loop, exiting...")
+            await async env.exit(0)
+        else:
+            print("TCP client not properly cleaned from IO loop, waiting...")
+            after 0.8: check_io()
 
     def on_receive(c, data):
         print("Client RECV", data)
         if data == b"PONG":
             print("Got PONG, all good, yay")
-            # Test idempotency / that we don't break anything by double-closing
-            c.close()
-            c.close()
-            after 0.1: _exit()
+            if connection == 1:
+                print("Conn 1: reconnecting")
+                c.reconnect()
+            else:
+                # Test idempotency / that we don't break anything by double-closing
+                c.close(on_close)
+                await async c.close(on_close)
         else:
             print("Got bad response, exiting with error..")
             await async env.exit(1)
@@ -49,6 +79,8 @@ actor Client(env: Env, port: int):
         print("Client ERR", msg)
 
     def _exit():
+        print("exiting..")
+        print(acton.rts.io_handles(env.auth))
         await async env.exit(0)
 
     connect_auth = net.TCPConnectAuth(net.TCPAuth(net.NetAuth(env.auth)))
@@ -56,6 +88,7 @@ actor Client(env: Env, port: int):
 
 
 actor main(env):
+    init_io_handles = acton.rts.io_handles(env.auth)
     def timeout_error():
         print("Timeout reached, exiting with error...")
         await async env.exit(1)
@@ -66,4 +99,3 @@ actor main(env):
     print("Using port", port)
     l = Listener(env, port)
     c = Client(env, port)
-

--- a/test/stdlib_auto/test_net_tcp.act
+++ b/test/stdlib_auto/test_net_tcp.act
@@ -7,11 +7,13 @@ import net
 import random
 
 
-def filter_tcp_handles(handles: dict[u64, (typ: str, act: u64)]):
+def get_tcp_handles(m):
+    tcp_handles = m.io_handles()
     res = {}
-    for k, v in handles.items():
-        if v.typ == "tcp" and v.act != u64(0):
-            res[k] = v
+    for wthread_id, handles in tcp_handles.items():
+        for k, v in handles.items():
+            if v.typ == "tcp" and v.act != u64(0):
+                res[k] = v
     return res
 
 actor Server(conn):
@@ -37,11 +39,11 @@ actor Listener(env, port):
     server = net.TCPListener(listen_auth, "0.0.0.0", port, on_lsock_error, on_server_accept)
 
 
-actor Client(env: Env, port: int):
+actor Client(rts_monitor, env: Env, port: int):
     var connection = 0
     def on_connect(c):
         connection += 1
-        print("Client connected, TCP handles", filter_tcp_handles(acton.rts.io_handles(env.auth)))
+        print("Client connected, TCP handles", get_tcp_handles(rts_monitor))
         await async c.write(b"PING")
 
     def on_close(c):
@@ -50,7 +52,7 @@ actor Client(env: Env, port: int):
             after 0.001: check_io()
 
     def check_io():
-        tcp_handles = filter_tcp_handles(acton.rts.io_handles(env.auth))
+        tcp_handles = get_tcp_handles(rts_monitor)
         print("IO check...", tcp_handles)
         if len(tcp_handles) < 2:
             # Only TCP listening socket left...
@@ -80,7 +82,6 @@ actor Client(env: Env, port: int):
 
     def _exit():
         print("exiting..")
-        print(acton.rts.io_handles(env.auth))
         await async env.exit(0)
 
     connect_auth = net.TCPConnectAuth(net.TCPAuth(net.NetAuth(env.auth)))
@@ -88,7 +89,6 @@ actor Client(env: Env, port: int):
 
 
 actor main(env):
-    init_io_handles = acton.rts.io_handles(env.auth)
     def timeout_error():
         print("Timeout reached, exiting with error...")
         await async env.exit(1)
@@ -97,5 +97,6 @@ actor main(env):
 
     port = random.randint(10000, 20000)
     print("Using port", port)
+    rts_monitor = acton.rts.Monitor(env)
     l = Listener(env, port)
-    c = Client(env, port)
+    c = Client(rts_monitor, env, port)


### PR DESCRIPTION
This makes it possible to explicitly shut down a TCP client connection, which should clean up everything in the libuv loop.

If actors are garbage collected, there is likely remaining socket cruft left in the libuv loop which we do not currently have any means of cleaning up. At least this gives us the ability to explicitly shut things down cleanly from within the application.