### PR TITLE
Rename auth arg to cap & env.auth -> env.worldcap

### DIFF
--- a/base/builtin/env.c
+++ b/base/builtin/env.c
@@ -71,11 +71,11 @@ $R B_EnvD_exitG_local (B_Env self, $Cont c$cont, B_int n) {
 }
 
 
-B_Env B_EnvG_newactor(B_WorldCap token, B_list args) {
+B_Env B_EnvG_newactor(B_WorldCap wc, B_list args) {
     B_Env $tmp = $NEWACTOR(B_Env);
-    $tmp->token = token;
+    $tmp->cap = wc;
     $tmp->args = args;
-    $tmp->auth = $tmp->token;
+    $tmp->auth = $tmp->cap;
     $tmp->argv = $tmp->args;
     $tmp->$affinity = 0;
     serialize_state_shortcut(($Actor)$tmp);

--- a/base/src/__builtin__.act
+++ b/base/src/__builtin__.act
@@ -890,14 +890,17 @@ class WorldCap():
     """
     pass
 
-actor Env (token: WorldCap, args: list[str]):
-    auth = token
+actor Env (wc: WorldCap, args: list[str]):
+    cap = wc
+    auth = wc
     argv = args
     nr_wthreads: int = 0
 
     action def stdout_write(s: str) -> None:
         NotImplemented
+
     action def stdin_install(cb: action(str) -> None) -> None:
         NotImplemented
+
     action def exit(n: int):
         NotImplemented

--- a/base/src/acton/rts.act
+++ b/base/src/acton/rts.act
@@ -17,11 +17,11 @@ def sleep(duration: float) -> None:
     """Put RTS worker thread to sleep"""
     NotImplemented
 
-def rss(auth: WorldCap) -> int:
+def rss(cap: WorldCap) -> int:
     """Get Resident Set Size"""
     NotImplemented
 
-def _io_handles(auth: WorldCap) -> dict[u64, (typ: str, act: u64)]:
+def _io_handles(cap: WorldCap) -> dict[u64, (typ: str, act: u64)]:
     """Return all I/O handles and their type for the current worker thread"""
     NotImplemented
 
@@ -29,7 +29,7 @@ actor WThreadMonitor(env: Env, arg_wthread_id: int):
     wthread_id = arg_wthread_id
 
     def io_handles():
-        return _io_handles(env.auth)
+        return _io_handles(env.cap)
 
     proc def _init():
         """Implementation internal"""

--- a/base/src/file.act
+++ b/base/src/file.act
@@ -1,25 +1,25 @@
 
 class FileCap():
-    def __init__(self, auth: WorldCap):
+    def __init__(self, cap: WorldCap):
         pass
 
 class ReadFileCap():
-    def __init__(self, auth: FileCap):
+    def __init__(self, cap: FileCap):
         pass
 
 class WriteFileCap():
-    def __init__(self, auth: FileCap):
+    def __init__(self, cap: FileCap):
         pass
 
 
-actor FS(auth: FileCap):
+actor FS(cap: FileCap):
     """File system operations """
     action def mkdir(filename: str):
         """Make a directory"""
         pass
 
 
-actor ReadFile(auth: ReadFileCap, filename: str):
+actor ReadFile(cap: ReadFileCap, filename: str):
     """Read a file
     """
     var _fd = -1
@@ -38,7 +38,7 @@ actor ReadFile(auth: ReadFileCap, filename: str):
         NotImplemented
 
 
-actor WriteFile(auth: WriteFileCap, filename: str):
+actor WriteFile(cap: WriteFileCap, filename: str):
     """Write a file
     """
     var _fd = -1

--- a/base/src/net.act
+++ b/base/src/net.act
@@ -2,28 +2,28 @@
 """
 
 class NetCap():
-    """Token for general network access"""
-    def __init__(self, auth: WorldCap):
+    """Capability to access network"""
+    def __init__(self, cap: WorldCap):
         pass
 
 class DNSCap():
-    """Token for performing DNS queries"""
-    def __init__(self, auth: NetCap):
+    """Capability to perform DNS queries"""
+    def __init__(self, cap: NetCap):
         pass
 
 class TCPCap():
-    """Token for connecting or listening with TCP"""
-    def __init__(self, auth: NetCap):
+    """Capability to connect or listen with TCP"""
+    def __init__(self, cap: NetCap):
         pass
 
 class TCPConnectCap():
-    """Token to connect using TCP to a remote host"""
-    def __init__(self, auth: TCPCap):
+    """Capability to connect using TCP to a remote host"""
+    def __init__(self, cap: TCPCap):
         pass
 
 class TCPListenCap():
-    """Token for opening a TCP socket"""
-    def __init__(self, auth: TCPCap):
+    """Capability to listen with TCP"""
+    def __init__(self, cap: TCPCap):
         pass
 
 class _TCPListenConnectCap():
@@ -53,7 +53,7 @@ def lookup_aaaa(cap: DNSCap, name: str, on_resolve: action(list[str]) -> None, o
     _lookup_aaaa(name, on_resolve, on_error)
 
 
-actor TCPIPConnection(auth: TCPConnectCap, address: str, port: int, on_connect: action(TCPIPConnection) -> None, on_receive: action(TCPIPConnection, bytes) -> None, on_error: action(TCPIPConnection, str) -> None):
+actor TCPIPConnection(cap: TCPConnectCap, address: str, port: int, on_connect: action(TCPIPConnection) -> None, on_receive: action(TCPIPConnection, bytes) -> None, on_error: action(TCPIPConnection, str) -> None):
     """TCP IP Connection"""
     _socket = -1
 
@@ -79,7 +79,7 @@ actor TCPIPConnection(auth: TCPConnectCap, address: str, port: int, on_connect: 
     _init()
     _connect(self)
 
-actor TCPListenConnection(auth: _TCPListenConnectCap, server_client: int):
+actor TCPListenConnection(cap: _TCPListenConnectCap, server_client: int):
     """TCP Listener Connection"""
     var client: int = -1
     var on_receive: ?action(TCPListenConnection, bytes) -> None = None
@@ -114,12 +114,12 @@ actor TCPListenConnection(auth: _TCPListenConnectCap, server_client: int):
         NotImplemented
     _init()
 
-actor TCPListener(auth: TCPListenCap, address: str, port: int, on_error: action(TCPListener, str) -> None, on_accept: action(TCPListenConnection) -> None):
+actor TCPListener(cap: TCPListenCap, address: str, port: int, on_error: action(TCPListener, str) -> None, on_accept: action(TCPListenConnection) -> None):
     """TCP Listener"""
     _stream = -1
-    def create_tcp_listen_connection(auth: _TCPListenConnectCap, client: int):
+    def create_tcp_listen_connection(cap: _TCPListenConnectCap, client: int):
         """Implementation internal"""
-        c = TCPListenConnection(auth, client)
+        c = TCPListenConnection(cap, client)
         on_accept(c)
 
     mut def __resume__() -> None:

--- a/base/src/process.act
+++ b/base/src/process.act
@@ -2,12 +2,13 @@
 """
 
 class ProcessCap():
-    def __init__(self, auth: WorldCap):
+    """Capability to start processes"""
+    def __init__(self, cap: WorldCap):
         pass
 
-actor Process(auth: ProcessCap, cmd: list[str], workdir: ?str, env: ?dict[str, str], on_stdout: action(Process, bytes) -> None, on_stderr: action(Process, bytes) -> None, on_exit: action(Process, int, int) -> None, on_error: action(Process,str) -> None):
+actor Process(cap: ProcessCap, cmd: list[str], workdir: ?str, env: ?dict[str, str], on_stdout: action(Process, bytes) -> None, on_stderr: action(Process, bytes) -> None, on_exit: action(Process, int, int) -> None, on_error: action(Process,str) -> None):
     """A process
-    - auth: authentication token
+    - cap: capability to start processes
     - cmd: the command to run
     - workdir: working directory, use None for current directory
     - env: environment for process, use None to inherit current environment

--- a/examples/client.act
+++ b/examples/client.act
@@ -19,5 +19,5 @@ actor main(env):
         print("usage: client [HOST] [PORT]")
         await async env.exit(-1)
 
-    connect_cap = net.TCPConnectCap(net.TCPCap(net.NetCap(env.auth)))
+    connect_cap = net.TCPConnectCap(net.TCPCap(net.NetCap(env.cap)))
     client = net.TCPIPConnection(connect_cap, env.argv[1], int(env.argv[2]), on_connect, on_receive, on_error)

--- a/examples/files.act
+++ b/examples/files.act
@@ -2,7 +2,7 @@ import file
 
 actor main(env):
     # Get a reference to capability to read a file, by refining from WorldCap
-    f_cap = file.ReadFileCap(file.FileCap(env.auth))
+    f_cap = file.ReadFileCap(file.FileCap(env.cap))
     f = file.ReadFile(f_cap, env.argv[1])
     data = f.read()
     print(data.decode())

--- a/examples/server.act
+++ b/examples/server.act
@@ -24,7 +24,7 @@ actor Listener(listen_cap, port):
 actor main(env):
     port = 12345
 
-    # Set up specific auth token
-    listen_cap = net.TCPListenCap(net.TCPCap(net.NetCap(env.auth)))
+    # Set up capability for listening with TCP
+    listen_cap = net.TCPListenCap(net.TCPCap(net.NetCap(env.cap)))
 
     l = Listener(listen_cap, port)

--- a/test/perf/ring.act
+++ b/test/perf/ring.act
@@ -50,12 +50,12 @@ actor main(env):
             count += c
         print("In total across all actors:", count)
         print("Total messages per second:", int(float(count)/stop_at))
-        print("RSS:", acton.rts.rss(env.auth))
+        print("RSS:", acton.rts.rss(env.cap))
         await async env.exit(0)
 
     var alive = 0
     def report():
-        print("RSS at second", alive, ":", acton.rts.rss(env.auth) / (1024*1024), "MB")
+        print("RSS at second", alive, ":", acton.rts.rss(env.cap) / (1024*1024), "MB")
         alive += 1
         after 1: report()
 

--- a/test/rts_db/ddb_test_client.act
+++ b/test/rts_db/ddb_test_client.act
@@ -27,7 +27,7 @@ actor main(env):
 
     def connect():
         attempts += 1
-        connect_cap = net.TCPConnectCap(net.TCPCap(net.NetCap(env.auth)))
+        connect_cap = net.TCPConnectCap(net.TCPCap(net.NetCap(env.cap)))
         client = net.TCPIPConnection(connect_cap, "127.0.0.1", port, on_connect, on_receive, on_error)
 
     connect()

--- a/test/rts_db/ddb_test_server.act
+++ b/test/rts_db/ddb_test_server.act
@@ -31,7 +31,7 @@ actor Tester(env, port):
         print("There was an error:", error, " from:", c)
 
     def init_listen():
-        listen_cap = net.TCPListenCap(net.TCPCap(net.NetCap(env.auth)))
+        listen_cap = net.TCPListenCap(net.TCPCap(net.NetCap(env.cap)))
         print("Starting to listen...")
         s = net.TCPListener(listen_cap, "0.0.0.0", port, on_listen_error, on_server_accept)
         print("NOW LISTENING ON", str(port))

--- a/test/rts_db/test_db_app.act
+++ b/test/rts_db/test_db_app.act
@@ -22,7 +22,7 @@ PORT_CHUNK_MAX=30000
 
 
 actor Tester(env, verbose, port_chunk):
-    process_cap = process.ProcessCap(env.auth)
+    process_cap = process.ProcessCap(env.cap)
     var ps = []
     var psp: dict[int, str] = {}
     var combined_output = ""

--- a/test/rts_db/test_tcp_client.act
+++ b/test/rts_db/test_tcp_client.act
@@ -42,7 +42,7 @@ actor Client(connect_auth, port: int):
 
 
 actor Tester(env, verbose, port_chunk):
-    process_cap = process.ProcessCap(env.auth)
+    process_cap = process.ProcessCap(env.cap)
     var ps = []
     var psp: dict[int, str] = {}
     var combined_output = ""
@@ -149,7 +149,7 @@ actor Tester(env, verbose, port_chunk):
         # 3. terminate TCP client app
         # 4. connect using our TCP client to TCP server and send INC to increase counter to 1
         # 5. start TCP client app, which will connect to TCP server & fetch current value, which will be 1 / correct and we exit 0
-        connect_auth = net.TCPConnectCap(net.TCPCap(net.NetCap(env.auth)))
+        connect_auth = net.TCPConnectCap(net.TCPCap(net.NetCap(env.cap)))
         port = port_chunk+199
         cmd_srv = ["./rts_db/ddb_test_server", str(port), "--rts-verbose"]
         p_srv = None

--- a/test/rts_db/test_tcp_server.act
+++ b/test/rts_db/test_tcp_server.act
@@ -42,7 +42,7 @@ actor Client(connect_cap, port: int):
 
 
 actor Tester(env, verbose, port_chunk):
-    process_cap = process.ProcessCap(env.auth)
+    process_cap = process.ProcessCap(env.cap)
     var ps = []
     var psp: dict[int, str] = {}
     var combined_output = ""
@@ -136,7 +136,7 @@ actor Tester(env, verbose, port_chunk):
 
 
     def test_ddb_server():
-        connect_cap = net.TCPConnectCap(net.TCPCap(net.NetCap(env.auth)))
+        connect_cap = net.TCPConnectCap(net.TCPCap(net.NetCap(env.cap)))
         port = port_chunk+199
         cmd = ["./rts_db/ddb_test_server", str(port), "--rts-verbose"] + db_args(port_chunk, 3)
         p = None

--- a/test/stdlib_auto/test_file.act
+++ b/test/stdlib_auto/test_file.act
@@ -6,7 +6,7 @@ actor main(env):
         filename = "test-file"
         test_data = b"test-data\n"
 
-        fc = file.FileCap(env.auth)
+        fc = file.FileCap(env.cap)
         wfc = file.WriteFileCap(fc)
         wf = file.WriteFile(wfc, filename)
         await async wf.write(test_data)

--- a/test/stdlib_auto/test_net_dns.act
+++ b/test/stdlib_auto/test_net_dns.act
@@ -26,7 +26,7 @@ actor main(env):
             env.exit(1)
 
         print("== DNS test")
-        dc = net.DNSCap(net.NetCap(env.auth))
+        dc = net.DNSCap(net.NetCap(env.cap))
         net.lookup_a(dc, "localhost", on_resolved, on_error)
         net.lookup_aaaa(dc, "localhost", on_resolved, on_error)
 

--- a/test/stdlib_auto/test_net_tcp.act
+++ b/test/stdlib_auto/test_net_tcp.act
@@ -35,7 +35,7 @@ actor Listener(env, port):
         s = Server(c)
         c.cb_install(s.on_receive, s.on_error)
 
-    listen_cap = net.TCPListenCap(net.TCPCap(net.NetCap(env.auth)))
+    listen_cap = net.TCPListenCap(net.TCPCap(net.NetCap(env.cap)))
     server = net.TCPListener(listen_cap, "0.0.0.0", port, on_lsock_error, on_server_accept)
 
 
@@ -84,7 +84,7 @@ actor Client(rts_monitor, env: Env, port: int):
         print("exiting..")
         await async env.exit(0)
 
-    connect_cap = net.TCPConnectCap(net.TCPCap(net.NetCap(env.auth)))
+    connect_cap = net.TCPConnectCap(net.TCPCap(net.NetCap(env.cap)))
     client = net.TCPIPConnection(connect_cap, "127.0.0.1", port, on_connect, on_receive, on_error)
 
 

--- a/test/stdlib_auto/test_process.act
+++ b/test/stdlib_auto/test_process.act
@@ -24,7 +24,7 @@ actor main(env):
 
     def test():
         print("Starting process..")
-        pc = process.ProcessCap(env.auth)
+        pc = process.ProcessCap(env.cap)
         p = process.Process(pc, ["echo", "HELLO"], None, None, on_stdout, on_stderr, on_exit, on_error)
 
     def ex():

--- a/test/stdlib_auto/test_process_env.act
+++ b/test/stdlib_auto/test_process_env.act
@@ -27,7 +27,7 @@ actor main(env):
 
     def test():
         print("Starting process..")
-        pc = process.ProcessCap(env.auth)
+        pc = process.ProcessCap(env.cap)
         p = process.Process(pc, ["env"], None, {"FOO": "BAR"}, on_stdout, on_stderr, on_exit, on_error)
 
     def ex():

--- a/test/stdlib_auto/test_process_pid.act
+++ b/test/stdlib_auto/test_process_pid.act
@@ -27,7 +27,7 @@ actor main(env):
 
     def test():
         print("Starting process..")
-        pc = process.ProcessCap(env.auth)
+        pc = process.ProcessCap(env.cap)
         p = process.Process(pc, ["sleep", "2"], None, None, on_stdout, on_stderr, on_exit, on_error)
         pid = p.pid()
 

--- a/test/stdlib_auto/test_process_wdir.act
+++ b/test/stdlib_auto/test_process_wdir.act
@@ -27,7 +27,7 @@ actor main(env):
 
     def test():
         print("Starting process..")
-        pc = process.ProcessCap(env.auth)
+        pc = process.ProcessCap(env.cap)
         p = process.Process(pc, ["pwd"], "/", None, on_stdout, on_stderr, on_exit, on_error)
 
     def ex():

--- a/test/stdlib_auto/test_process_write.act
+++ b/test/stdlib_auto/test_process_write.act
@@ -31,7 +31,7 @@ actor main(env):
 
     def test():
         print("Starting process..")
-        pc = process.ProcessCap(env.auth)
+        pc = process.ProcessCap(env.cap)
         p = process.Process(pc, ["cat"], None, None, on_stdout, on_stderr, on_exit, on_error)
         p.write(b"hejsan\n")
 


### PR DESCRIPTION
All actors that take a capability ref argument, now has the argument renamed from 'auth' to 'cap' to better align with the capability intuition.

WorldCap is now available as env.worldcap, which should be used rather than env.auth. env.auth will be removed in a future version.

Fixes #1178