### PR TITLE
Remove outdated out files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@
     mode, thus suppressing various progress messages which interferred with the
     alternate output
   - Avoid errors when compiling files without a root actor
+- Clean up old generated output files [#1411]
+  - When the source files is moved or removed, also remove the corresponding
+    output files
 
 
 ## [0.16.0] (2023-07-03)


### PR DESCRIPTION
Remove files from the out/ directory that do not have a corresponding source file in the src/ directory. This can happen if we have compiled a project and then rename a source file. The old generate .c and .h files would remain and the low level builder would find them and attempt to compile them. This way we clean out such files without having to resort to something akin of 'make clean'.

Fixes #1411.