### PR TITLE
Add SysCap

### DIFF
--- a/base/builtin/env.c
+++ b/base/builtin/env.c
@@ -71,16 +71,30 @@ $R B_EnvD_exitG_local (B_Env self, $Cont c$cont, B_int n) {
 }
 
 
-B_Env B_EnvG_newactor(B_WorldCap wc, B_list args) {
+B_Env B_EnvG_newactor(B_WorldCap wc, B_SysCap sc, B_list args) {
     B_Env $tmp = $NEWACTOR(B_Env);
     $tmp->cap = wc;
     $tmp->args = args;
+    $tmp->syscap = sc;
     $tmp->auth = $tmp->cap;
     $tmp->argv = $tmp->args;
     $tmp->$affinity = 0;
     serialize_state_shortcut(($Actor)$tmp);
     return $tmp;
 }
+
+
+B_SysCap B_SysCapG_new() {
+    B_SysCap $tmp = malloc(sizeof(struct B_SysCap));
+    $tmp->$class = &B_SysCapG_methods;
+    //   B_SysCapG_methods.__init__($tmp);
+    return $tmp;
+}
+
+B_NoneType B_SysCapD___init__ (B_SysCap self) {
+    return B_None;
+}
+
 
 B_WorldCap B_WorldCapG_new() {
     B_WorldCap $tmp = malloc(sizeof(struct B_WorldCap));

--- a/base/builtin/env.h
+++ b/base/builtin/env.h
@@ -1,6 +1,9 @@
 #pragma once
 
-B_Env B_EnvG_newactor (B_WorldCap, B_list);
+B_Env B_EnvG_newactor (B_WorldCap, B_SysCap, B_list);
+
+B_SysCap B_SysCapG_new();
+B_NoneType B_SysCapD___init__ (B_SysCap self);
 
 B_WorldCap B_WorldCapG_new();
 B_NoneType B_WorldCapD___init__ (B_WorldCap self);

--- a/base/rts/rts.c
+++ b/base/rts/rts.c
@@ -1431,7 +1431,7 @@ void BOOTSTRAP(int argc, char *argv[]) {
     for (int i=0; i< argc; i++)
         wit->$class->append(wit,args,to$str(argv[i]));
 
-    env_actor = B_EnvG_newactor(B_WorldCapG_new(), args);
+    env_actor = B_EnvG_newactor(B_WorldCapG_new(), B_SysCapG_new(), args);
     env_actor->nr_wthreads = to$int(num_wthreads);
 
     root_actor = $ROOT();                           // Assumed to return $NEWACTOR(X) for the selected root actor X

--- a/base/src/__builtin__.act
+++ b/base/src/__builtin__.act
@@ -890,9 +890,15 @@ class WorldCap():
     """
     pass
 
-actor Env (wc: WorldCap, args: list[str]):
+class SysCap():
+    """SysCap has the capability to access the internals of the Acton RTS system
+    """
+    pass
+
+actor Env (wc: WorldCap, sc: SysCap, args: list[str]):
     cap = wc
     auth = wc
+    syscap = sc
     argv = args
     nr_wthreads: int = 0
 

--- a/base/src/acton/rts.act
+++ b/base/src/acton/rts.act
@@ -1,7 +1,4 @@
-# TODO: replace WorldCap with SysCap here for reading information and
-# SysCapBAD or something for write operations
-
-def gc() -> None:
+def gc(cap: SysCap) -> None:
     NotImplemented
 
 # sleep is sort of dangerous - it will actually put the RTS thread executing the
@@ -13,15 +10,15 @@ def gc() -> None:
 # in a benchmark we can pretend some actors are doing relatively heavy work, yet
 # our CPU usage will be lower, so this is like laptop airplane mode friendly
 # (consumes less battery).
-def sleep(duration: float) -> None:
+def sleep(cap: SysCap, duration: float) -> None:
     """Put RTS worker thread to sleep"""
     NotImplemented
 
-def rss(cap: WorldCap) -> int:
+def rss(cap: SysCap) -> int:
     """Get Resident Set Size"""
     NotImplemented
 
-def _io_handles(cap: WorldCap) -> dict[u64, (typ: str, act: u64)]:
+def _io_handles(cap: SysCap) -> dict[u64, (typ: str, act: u64)]:
     """Return all I/O handles and their type for the current worker thread"""
     NotImplemented
 
@@ -29,7 +26,7 @@ actor WThreadMonitor(env: Env, arg_wthread_id: int):
     wthread_id = arg_wthread_id
 
     def io_handles():
-        return _io_handles(env.cap)
+        return _io_handles(env.syscap)
 
     proc def _init():
         """Implementation internal"""

--- a/base/src/acton/rts.ext.c
+++ b/base/src/acton/rts.ext.c
@@ -11,12 +11,12 @@ void actonQ_rtsQ___ext_init__() {
     // NOP
 }
 
-B_NoneType actonQ_rtsQ_gc () {
+B_NoneType actonQ_rtsQ_gc (B_SysCap cap) {
     GC_gcollect();
     return B_None;
 }
 
-B_NoneType actonQ_rtsQ_sleep (B_float sleep_time) {
+B_NoneType actonQ_rtsQ_sleep (B_SysCap cap, B_float sleep_time) {
     double st = fromB_float(sleep_time);
     struct timespec ts;
     ts.tv_sec = (int)st;
@@ -39,7 +39,7 @@ B_NoneType actonQ_rtsQ_sleep (B_float sleep_time) {
     return B_None;
 }
 
-B_int actonQ_rtsQ_rss (B_WorldCap auth) {
+B_int actonQ_rtsQ_rss (B_SysCap cap) {
     size_t rsm;
     int r = uv_resident_set_memory(&rsm);
     return to$int(rsm);
@@ -69,7 +69,7 @@ void actonQ_rtsQ_io_handles_walk_cb (uv_handle_t *handle, void *arg) {
     B_dictD_setitem(walk_res->d, walk_res->wit, toB_u64((long)handle), val);
 }
 
-B_dict actonQ_rtsQ__io_handles (B_WorldCap auth) {
+B_dict actonQ_rtsQ__io_handles (B_SysCap cap) {
     B_Hashable wit = (B_Hashable)B_HashableD_u64G_witness;
     B_dict d = $NEW(B_dict, wit, NULL, NULL);
 

--- a/test/regression_auto/125-async-actor-method-call.act
+++ b/test/regression_auto/125-async-actor-method-call.act
@@ -1,14 +1,14 @@
 import acton.rts
 import time
 
-actor sleeper():
+actor sleeper(cap):
     def sleep(sleep_time):
-        acton.rts.sleep(sleep_time)
+        acton.rts.sleep(cap, sleep_time)
 
 actor main(env):
     def work():
-        s1 = sleeper()
-        s2 = sleeper()
+        s1 = sleeper(env.syscap)
+        s2 = sleeper(env.syscap)
         s = time.Stopwatch()
         # this is not an assignment, so sleep() should run async and thus take
         # like 0 time

--- a/test/stdlib_auto/test_acton_rts_sleep.act
+++ b/test/stdlib_auto/test_acton_rts_sleep.act
@@ -1,16 +1,16 @@
 import acton.rts
 import time
 
-actor Interruptor():
+actor Interruptor(cap):
     def interrupt():
-        acton.rts.gc()
+        acton.rts.gc(cap)
         after 0.001: interrupt()
     interrupt()
 
 actor main(env):
     def test():
         s = time.Stopwatch()
-        acton.rts.sleep(0.1)
+        acton.rts.sleep(env.syscap, 0.1)
         d = s.elapsed()
         if d.to_float() < 0.1:
             print("Sleep seems to have been below 1 second :(")
@@ -18,6 +18,6 @@ actor main(env):
         else:
             return 0
 
-#    i = Interruptor()
+#    i = Interruptor(env.syscap)
     r = test()
     env.exit(r)


### PR DESCRIPTION
This splits up so that functions related to the Acton RTS system internals now take a special SysCap capability. This is not part of the WorldCap chain of capabilities and so it must be more explicitly passed around.

Fixes #1388 