### PR TITLE
Upgrade to zig v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,16 @@
       as well.
   - All `*Auth` objects now have a `Cap` suffix
   - All `auth` args are renamed to `cap`
+- `SysCap` is a new capability for functions related to Acton RTS System
+  internals [#1388]
+  - `SysCap` is available from `env.syscap`
+  - `SysCap` is separate from the normal capability hierarchy where `WorldCap`
+    is the root
+    - This is to promote the aspiration to restrict access to RTS internal
+    - While `WorldCap` shouldn't be passed around frivolously either,
+      capabilities should restricted and delegated, it is still fairly normal to
+      pass `WorldCap` while the vast majority of programs should not even need
+      `SysCap`
 - The `msg` of exceptions is now optional [#1422]
 
 ### Fixed
@@ -38,6 +48,7 @@
 - Fix return value of int hashable [#1415]
 - Fix module import check [#1420]
 - Avoid segfault when exception `error_message` is not set [#1422]
+- Bump Zig version to v0.11.0 [#1421]
 
 
 ## [0.16.0] (2023-07-03)

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ export ZIG_LOCAL_CACHE_DIR
 
 ACTONC=dist/bin/actonc
 ACTC=dist/bin/actonc
-ZIG_VERSION:=0.11.0-dev.3739+939e4d81e
+ZIG_VERSION:=0.11.0
 ZIG=$(TD)/dist/zig/zig
 AR=$(ZIG) ar
 CC=$(ZIG) cc
@@ -184,7 +184,7 @@ clean-downloads:
 	rm -rf deps-download
 
 # /deps/libargp --------------------------------------------
-LIBARGP_REF=a2b750b4439099c223fd0fb70c902df396791fb1
+LIBARGP_REF=ba179f83370d91ed6bc8fc5da87f6863ab2e2613
 deps-download/$(LIBARGP_REF).tar.gz:
 	mkdir -p deps-download
 	curl -f -L -o $@ https://github.com/actonlang/argp-standalone/archive/$(LIBARGP_REF).tar.gz
@@ -199,7 +199,7 @@ dist/depsout/lib/libargp.a: dist/deps/libargp $(DIST_ZIG)
 	cd $< && $(ZIG) build $(ZIG_TARGET) --prefix $(TD)/dist/depsout
 
 # /deps/libbsdnt --------------------------------------------
-LIBBSDNT_REF=20c727a5f390d1d4d2c22a3c5bfabb5276d34757
+LIBBSDNT_REF=1c02c76995905aedcfb74125e3191ff7c180fe9e
 deps-download/$(LIBBSDNT_REF).tar.gz:
 	mkdir -p deps-download
 	curl -f -L -o $@ https://github.com/actonlang/bsdnt/archive/$(LIBBSDNT_REF).tar.gz
@@ -213,7 +213,7 @@ dist/depsout/lib/libbsdnt.a: dist/deps/libbsdnt $(DIST_ZIG)
 	cd $< && $(ZIG) build $(ZIG_TARGET) --prefix $(TD)/dist/depsout
 
 # /deps/libgc --------------------------------------------
-LIBGC_REF=66ed03b9283b56a530717f1aa7d1ed4cf1e65741
+LIBGC_REF=ead2119801a6659d1d78406563d5acc6df4d94e3
 deps-download/$(LIBGC_REF).tar.gz:
 	mkdir -p deps-download
 	curl -f -L -o $@ https://github.com/actonlang/bdwgc/archive/$(LIBGC_REF).tar.gz
@@ -265,7 +265,7 @@ dist/depsout/lib/libuuid.a: dist/deps/libuuid $(DIST_ZIG)
 	cd $< && $(ZIG) build $(ZIG_TARGET) --prefix $(TD)/dist/depsout
 
 # /deps/libuv --------------------------------------------
-LIBUV_REF=53b7649fc83f8cee6f0170b335222a759c0a26f0
+LIBUV_REF=5e5a6bd6850ef5ec3e9c74520093392020c4caa7
 deps-download/$(LIBUV_REF).tar.gz:
 	mkdir -p deps-download
 	curl -f -L -o $@ https://github.com/actonlang/libuv/archive/$(LIBUV_REF).tar.gz
@@ -279,7 +279,7 @@ dist/depsout/lib/libuv.a: dist/deps/libuv $(DIST_ZIG)
 	cd $< && $(ZIG) build $(ZIG_TARGET) --prefix $(TD)/dist/depsout
 
 # /deps/libxml2 ------------------------------------------
-LIBXML2_REF=8459e725c3294d8d637317036f9d8b10860195dc
+LIBXML2_REF=ee7863427393b9fa9c55e1c03fa40289429d7b29
 deps-download/$(LIBXML2_REF).tar.gz:
 	mkdir -p deps-download
 	curl -f -L -o $@ https://github.com/actonlang/libxml2/archive/$(LIBXML2_REF).tar.gz
@@ -294,7 +294,7 @@ dist/depsout/lib/libxml2.a: dist/deps/libxml2 $(DIST_ZIG)
 	cd $< && $(ZIG) build $(ZIG_TARGET) --prefix $(TD)/dist/depsout
 
 # /deps/pcre2 --------------------------------------------
-LIBPCRE2_REF=ece17affd4f1d57eb148af9a39c64c1bb19b0e51
+LIBPCRE2_REF=d9ddcd6e986d894385408818942524549080ba46
 deps-download/$(LIBPCRE2_REF).tar.gz:
 	mkdir -p deps-download
 	curl -f -L -o $@ https://github.com/actonlang/pcre2/archive/$(LIBPCRE2_REF).tar.gz

--- a/backend/build.zig
+++ b/backend/build.zig
@@ -71,7 +71,7 @@ pub fn build(b: *std.build.Builder) void {
     });
     libactondb.addCSourceFiles(&libactondb_sources, flags.items);
     libactondb.defineCMacro("LOG_USER_COLOR", "");
-    libactondb.addIncludePath(syspath_include);
+    libactondb.addIncludePath(.{ .path = syspath_include });
     libactondb.linkLibC();
     b.installArtifact(libactondb);
 
@@ -80,12 +80,12 @@ pub fn build(b: *std.build.Builder) void {
         .target = target,
         .optimize = optimize,
     });
-    actondb.addCSourceFile("actondb.c", &[_][]const u8{
+    actondb.addCSourceFile(.{ .file = .{ .path = "actondb.c" }, .flags = &[_][]const u8{
         "-fno-sanitize=undefined",
-    });
-    actondb.addCSourceFile("log.c", flags.items);
-    actondb.addIncludePath(syspath_include);
-    actondb.addLibraryPath("../lib");
+    }});
+    actondb.addCSourceFile(.{ .file = .{ .path = "log.c" }, .flags = flags.items });
+    actondb.addIncludePath(.{ .path = syspath_include });
+    actondb.addLibraryPath(.{ .path = "../lib" });
     actondb.linkLibrary(libactondb);
     actondb.linkLibrary(dep_libargp.artifact("argp"));
     actondb.linkLibrary(dep_libnetstring.artifact("netstring"));

--- a/base/build.zig
+++ b/base/build.zig
@@ -137,14 +137,14 @@ pub fn build(b: *std.build.Builder) void {
         .optimize = optimize,
     });
     for (c_files.items) |entry| {
-        libActon.addCSourceFile(entry, flags.items);
+        libActon.addCSourceFile(.{ .file = .{ .path = entry }, .flags = flags.items });
     }
 
-    libActon.addIncludePath(projpath);
-    libActon.addIncludePath(syspath_base);
-    libActon.addIncludePath(syspath_include);
-    libActon.addIncludePath("../inc"); // hack hack for stdlib TODO: sort out
-    libActon.addIncludePath("../deps/instdir/include"); // hack hack for stdlib TODO: sort out
+    libActon.addIncludePath(.{ .path = projpath });
+    libActon.addIncludePath(.{ .path = syspath_base });
+    libActon.addIncludePath(.{ .path = syspath_include });
+    libActon.addIncludePath(.{ .path = "../inc" }); // hack hack for stdlib TODO: sort out
+    libActon.addIncludePath(.{ .path = "../deps/instdir/include" }); // hack hack for stdlib TODO: sort out
     libActon.linkLibC();
     b.installArtifact(libActon);
 }

--- a/builder/build.zig
+++ b/builder/build.zig
@@ -230,12 +230,12 @@ pub fn build(b: *std.build.Builder) void {
     }
 
     for (c_files.items) |entry| {
-        libActonProject.addCSourceFile(entry, flags.items);
+        libActonProject.addCSourceFile(.{ .file = .{ .path = entry }, .flags = flags.items });
     }
 
-    libActonProject.addIncludePath(projpath);
-    libActonProject.addIncludePath(syspath_base);
-    libActonProject.addIncludePath(syspath_include);
+    libActonProject.addIncludePath(.{ .path = projpath });
+    libActonProject.addIncludePath(.{ .path = syspath_base });
+    libActonProject.addIncludePath(.{ .path = syspath_include });
     libActonProject.linkLibC();
     b.installArtifact(libActonProject);
 
@@ -259,13 +259,13 @@ pub fn build(b: *std.build.Builder) void {
             .optimize = optimize,
         });
         //_ = syspath;
-        executable.addCSourceFile(entry.full_path, flags.items);
-        executable.addIncludePath(projpath);
-        executable.addIncludePath(syspath_base);
-        executable.addIncludePath(syspath_include);
-        executable.addLibraryPath("out/rel/lib/");
-        executable.addLibraryPath(syspath_libreldev);
-        executable.addLibraryPath(syspath_lib);
+        executable.addCSourceFile(.{ .file = .{ .path = entry.full_path }, .flags = flags.items });
+        executable.addIncludePath(.{ .path = projpath });
+        executable.addIncludePath(.{ .path = syspath_base });
+        executable.addIncludePath(.{ .path = syspath_include });
+        executable.addLibraryPath(.{ .path = "out/rel/lib/" });
+        executable.addLibraryPath(.{ .path = syspath_libreldev });
+        executable.addLibraryPath(.{ .path = syspath_lib });
         executable.linkLibrary(libActonProject);
 
         if (use_prebuilt) {

--- a/deps/libuuid/build.zig
+++ b/deps/libuuid/build.zig
@@ -34,7 +34,7 @@ pub fn build(b: *std.build.Builder) void {
         "-DHAVE_SYS_FILE_H",
         "-DUSLEEP",
     });
-    lib.addIncludePath("include");
+    lib.addIncludePath(.{ .path = "include" });
     lib.linkLibC();
     b.installFile("src/uuid.h", "include/uuid/uuid.h");
     b.installArtifact(lib);


### PR DESCRIPTION
More changes to the build.zig syntax which we've now updated. All dependencies are updated as necessary, thus the bumped REFs.

Fixes #1421 