### PR TITLE
Generate wrappers for hidden funcs

### DIFF
--- a/base/src/acton/rts.ext.c
+++ b/base/src/acton/rts.ext.c
@@ -81,7 +81,7 @@ B_dict actonQ_rtsQ__io_handles (B_SysCap cap) {
     return d;
 }
 
-$R actonQ_rtsQ_WThreadMonitorD__init (actonQ_rtsQ_WThreadMonitor self, $Cont C_cont) {
+$R actonQ_rtsQ_WThreadMonitorD__initG_local (actonQ_rtsQ_WThreadMonitor self, $Cont C_cont) {
     set_actor_affinity(from$int(self->wthread_id));
     return $RU_CONT(C_cont, B_None);
 }

--- a/base/src/file.ext.c
+++ b/base/src/file.ext.c
@@ -11,7 +11,7 @@ void fileQ___ext_init__() {
 
 }
 
-$R fileQ_ReadFileD__open_file (fileQ_ReadFile self, $Cont c$cont) {
+$R fileQ_ReadFileD__open_fileG_local (fileQ_ReadFile self, $Cont c$cont) {
     pin_actor_affinity();
     uv_fs_t *req = (uv_fs_t *)calloc(1, sizeof(uv_fs_t));
     int r = uv_fs_open(get_uv_loop(), req, (char *)fromB_str(self->filename), UV_FS_O_RDONLY, 0, NULL);
@@ -64,7 +64,7 @@ $R fileQ_ReadFileD_readG_local (fileQ_ReadFile self, $Cont c$cont) {
 }
 
 
-$R fileQ_WriteFileD__open_file (fileQ_WriteFile self, $Cont c$cont) {
+$R fileQ_WriteFileD__open_fileG_local (fileQ_WriteFile self, $Cont c$cont) {
     pin_actor_affinity();
     uv_fs_t *req = (uv_fs_t *)calloc(1, sizeof(uv_fs_t));
     int r = uv_fs_open(get_uv_loop(), req, (char *)fromB_str(self->filename),  UV_FS_O_RDWR | UV_FS_O_CREAT, S_IWUSR|S_IRUSR|S_IRGRP|S_IROTH, NULL);

--- a/base/src/net.act
+++ b/base/src/net.act
@@ -190,11 +190,6 @@ actor TCPConnection(cap: TCPConnectCap, address: str, port: int, on_connect: act
                 bytes_in=_bytes_in,
                 bytes_out=_bytes_out)
 
-    # TODO: is it possible to directly call e.g. _on_connect4 from a non-CPSed C function? how?
-    var _fun_oncon4: action() -> None = _on_connect4
-    var _fun_oncon6: action() -> None = _on_connect6
-    var _fun_on_tcp_error: action(int, int, str) -> None = _on_tcp_error
-
     _connect(self)
 
 

--- a/base/src/net.ext.c
+++ b/base/src/net.ext.c
@@ -182,7 +182,7 @@ void netQ_TCPConnection__on_receive(uv_stream_t *stream, ssize_t nread, const uv
 }
 
 
-$R netQ_TCPConnectionD__pin_affinity (netQ_TCPConnection self, $Cont c$cont) {
+$R netQ_TCPConnectionD__pin_affinityG_local (netQ_TCPConnection self, $Cont c$cont) {
     pin_actor_affinity();
     return $R_CONT(c$cont, B_None);
 }
@@ -194,13 +194,10 @@ void on_connect4(uv_connect_t *connect_req, int status) {
         char errmsg[1024] = "Error in TCP connect over IPv4: ";
         uv_strerror_r(status, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
         log_warn(errmsg);
-        $action3 f = self->_fun_on_tcp_error;
-        f->$class->__asyn__(f, to$int(4), to$int(status), to$str(errmsg));
+        self->$class->_on_tcp_error(self, to$int(4), to$int(status), to$str(errmsg));
         return;
     }
-    $action f = self->_fun_oncon4;
-    //$action f = self->$class->_on_connect4;
-    f->$class->__asyn__(f, self);
+    self->$class->_on_connect4(self);
 }
 
 void on_connect6(uv_connect_t *connect_req, int status) {
@@ -210,15 +207,13 @@ void on_connect6(uv_connect_t *connect_req, int status) {
         char errmsg[1024] = "Error in TCP connect over IPv6: ";
         uv_strerror_r(status, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
         log_warn(errmsg);
-        $action3 f = self->_fun_on_tcp_error;
-        f->$class->__asyn__(f, to$int(6), to$int(status), to$str(errmsg));
+        self->$class->_on_tcp_error(self, to$int(4), to$int(status), to$str(errmsg));
         return;
     }
-    $action f = self->_fun_oncon6;
-    f->$class->__asyn__(f, self);
+    self->$class->_on_connect6(self);
 }
 
-$R netQ_TCPConnectionD__connect4 (netQ_TCPConnection self, $Cont c$cont, B_str ip_address) {
+$R netQ_TCPConnectionD__connect4G_local (netQ_TCPConnection self, $Cont c$cont, B_str ip_address) {
     log_debug("TCP connecting over IPv4 to %s", fromB_str(ip_address));
     uv_tcp_t* socket = (uv_tcp_t*)malloc(sizeof(uv_tcp_t));
     uv_tcp_init(get_uv_loop(), socket);
@@ -235,7 +230,7 @@ $R netQ_TCPConnectionD__connect4 (netQ_TCPConnection self, $Cont c$cont, B_str i
     return $R_CONT(c$cont, B_None);
 }
 
-$R netQ_TCPConnectionD__connect6 (netQ_TCPConnection self, $Cont c$cont, B_str ip_address) {
+$R netQ_TCPConnectionD__connect6G_local (netQ_TCPConnection self, $Cont c$cont, B_str ip_address) {
     log_debug("TCP connecting over IPv6 to %s", fromB_str(ip_address));
     uv_tcp_t* socket = (uv_tcp_t*)malloc(sizeof(uv_tcp_t));
     uv_tcp_init(get_uv_loop(), socket);
@@ -252,7 +247,7 @@ $R netQ_TCPConnectionD__connect6 (netQ_TCPConnection self, $Cont c$cont, B_str i
     return $R_CONT(c$cont, B_None);
 }
 
-$R netQ_TCPConnectionD__read_start (netQ_TCPConnection self, $Cont c$cont) {
+$R netQ_TCPConnectionD__read_startG_local (netQ_TCPConnection self, $Cont c$cont) {
     uv_tcp_t* socket = (uv_tcp_t *)from$int(self->_sock);
     socket->data = self;
     int r = uv_read_start(socket, alloc_buffer, netQ_TCPConnection__on_receive);
@@ -427,7 +422,7 @@ void on_new_connection(uv_stream_t *server, int status) {
 }
 
 
-$R netQ_TCPListenerD__init (netQ_TCPListener self, $Cont c$cont) {
+$R netQ_TCPListenerD__initG_local (netQ_TCPListener self, $Cont c$cont) {
     pin_actor_affinity();
 
     uv_tcp_t *server = (uv_tcp_t *)malloc(sizeof(uv_tcp_t));
@@ -495,7 +490,7 @@ B_NoneType netQ_TCPListenerD___resume__ (netQ_TCPListener self) {
     return B_None;
 }
 
-$R netQ_TCPListenConnectionD__init (netQ_TCPListenConnection self, $Cont c$cont) {
+$R netQ_TCPListenConnectionD__initG_local (netQ_TCPListenConnection self, $Cont c$cont) {
     pin_actor_affinity();
 
     uv_stream_t *client = (uv_tcp_t *)from$int(self->server_client);
@@ -527,7 +522,7 @@ void netQ_TCPListenConnection__on_receive(uv_stream_t *stream, ssize_t nread, co
     //    free(buf->base);
 }
 
-$R netQ_TCPListenConnectionD__read_start (netQ_TCPListenConnection self, $Cont c$cont) {
+$R netQ_TCPListenConnectionD__read_startG_local (netQ_TCPListenConnection self, $Cont c$cont) {
     uv_stream_t *client = (uv_stream_t *)from$int(self->client);
     client->data = self;
     int r = uv_read_start(client, alloc_buffer, netQ_TCPListenConnection__on_receive);

--- a/base/src/process.ext.c
+++ b/base/src/process.ext.c
@@ -71,7 +71,7 @@ $R processQ_ProcessD_aidG_local (processQ_Process self, $Cont c$cont) {
     return $R_CONT(c$cont, to$int(self->$globkey));
 }
 
-$R processQ_ProcessD__create_process (processQ_Process self, $Cont c$cont) {
+$R processQ_ProcessD__create_processG_local (processQ_Process self, $Cont c$cont) {
     pin_actor_affinity();
     struct process_data *process_data = calloc(1, sizeof(struct process_data));
     process_data->process = self;

--- a/compiler/Acton/Deactorizer.hs
+++ b/compiler/Acton/Deactorizer.hs
@@ -144,7 +144,7 @@ instance Deact Decl where
               | otherwise           = bound params `intersect` fvs ++ [ n | n <- dom $ envOf inits, not (isHidden n) || n `elem` fvs ]
             locals                  = nub $ live_vars ++ bound decls
             wrapped                 = bound wrapdefs
-            wrapdefs                = [ d | Decl _ ds <- decls, d@Def{dname=n, dfx=fx} <- ds, fx == fxProc && not (isHidden n) || fx == fxAction ]
+            wrapdefs                = [ d | Decl _ ds <- decls, d@Def{dname=n, dfx=fx} <- ds, fx == fxProc || fx == fxAction ]
 
             propsigs                = [ Signature l0 [n] (monotype t) Property | (n,t) <- concat $ props' params : map props inits ]
 


### PR DESCRIPTION
Private actor methods are hidden and wouldn't get nice C wrapper functions generated. This is now changed so that we can easily call actor methods from outside of CPS context.

Through this change in actonc, we can use this and directly call the relevant methods in TCPConnection. This let's us get rid of some ugly hacky variables.

Fixes #1432.