### PR TITLE
Bump test timeout to 5 minutes for cross-compile

### DIFF
--- a/compiler/test.hs
+++ b/compiler/test.hs
@@ -55,7 +55,10 @@ main = do
       , stdlibTests
       ]
   where timeout :: Timeout
-        timeout = mkTimeout (3*60*1000000) -- 3 minutes timeout
+        timeout = mkTimeout (5*60*1000000) -- 5 minutes timeout
+        -- this normally doesn't take long on a local machine but in GitHub
+        -- Actions CI, in particular the MacOS workers can be really slow so it
+        -- has taken longer than 3 minutes, thus the rather lengthy timeout
 
 coreLangTests =
   testGroup "Core language"


### PR DESCRIPTION
The cross-compilation tests can take a really long time, in particular when run in GitHub Actions on the MacOS runners, which are likely quite strained. 5 minutes should be enough!