### PR TITLE
Add acton.rts.rts_stats()

### DIFF
--- a/base/rts/rts.c
+++ b/base/rts/rts.c
@@ -76,44 +76,6 @@ int mon_log_period = 30;
 char *mon_socket_path = NULL;
 
 
-struct wt_stat {
-    unsigned int idx;          // worker thread index
-    char key[10];              // thread index as string for convenience
-    unsigned int state;        // current thread state
-    unsigned long long sleeps; // number of times thread slept
-    // Executing actor continuations is the primary work of the RTS, we measure
-    // the execution time of each and count to buckets to get a rough idea of
-    // how long it takes
-    unsigned long long conts_count; // number of executed continuations
-    unsigned long long conts_sum;   // nanoseconds spent running continuations
-    unsigned long long conts_100ns; // bucket for <100ns
-    unsigned long long conts_1us;   // bucket for <1us
-    unsigned long long conts_10us;  // bucket for <10us
-    unsigned long long conts_100us; // bucket for <100us
-    unsigned long long conts_1ms;   // bucket for <1ms
-    unsigned long long conts_10ms;  // bucket for <10ms
-    unsigned long long conts_100ms; // bucket for <100ms
-    unsigned long long conts_1s;     // bucket for <1s
-    unsigned long long conts_10s;    // bucket for <10s
-    unsigned long long conts_100s;   // bucket for <100s
-    unsigned long long conts_inf;   // bucket for <+Inf
-    // Bookkeeping is all the other work we do not directly related to running
-    // actor continuations, like taking locks, committing information, talking
-    // to the database etc
-    unsigned long long bkeep_count; // number of bookkeeping rounds
-    unsigned long long bkeep_sum;   // nanoseconds spent bookkeeping
-    unsigned long long bkeep_100ns; // bucket for <100ns
-    unsigned long long bkeep_1us;   // bucket for <1us
-    unsigned long long bkeep_10us;  // bucket for <10us
-    unsigned long long bkeep_100us; // bucket for <100us
-    unsigned long long bkeep_1ms;   // bucket for <1ms
-    unsigned long long bkeep_10ms;  // bucket for <10ms
-    unsigned long long bkeep_100ms; // bucket for <100ms
-    unsigned long long bkeep_1s;     // bucket for <1s
-    unsigned long long bkeep_10s;    // bucket for <10s
-    unsigned long long bkeep_100s;   // bucket for <100s
-    unsigned long long bkeep_inf;   // bucket for <+Inf
-};
 struct wt_stat wt_stats[MAX_WTHREADS];
 
 // Conveys current thread status, like what is it doing?

--- a/base/rts/rts.h
+++ b/base/rts/rts.h
@@ -18,6 +18,48 @@
 #define MAX_WTHREADS 256
 
 extern long num_wthreads;
+struct wt_stat {
+    unsigned int idx;          // worker thread index
+    char key[10];              // thread index as string for convenience
+    unsigned int state;        // current thread state
+    unsigned long long sleeps; // number of times thread slept
+
+    // Executing actor continuations is the primary work of the RTS, we measure
+    // the execution time of each and count to buckets to get a rough idea of
+    // how long it takes
+    unsigned long long conts_count; // number of executed continuations
+    unsigned long long conts_sum;   // nanoseconds spent running continuations
+    unsigned long long conts_100ns; // bucket for <100ns
+    unsigned long long conts_1us;   // bucket for <1us
+    unsigned long long conts_10us;  // bucket for <10us
+    unsigned long long conts_100us; // bucket for <100us
+    unsigned long long conts_1ms;   // bucket for <1ms
+    unsigned long long conts_10ms;  // bucket for <10ms
+    unsigned long long conts_100ms; // bucket for <100ms
+    unsigned long long conts_1s;     // bucket for <1s
+    unsigned long long conts_10s;    // bucket for <10s
+    unsigned long long conts_100s;   // bucket for <100s
+    unsigned long long conts_inf;   // bucket for <+Inf
+    // Bookkeeping is all the other work we do not directly related to running
+    // actor continuations, like taking locks, committing information, talking
+    // to the database etc
+    unsigned long long bkeep_count; // number of bookkeeping rounds
+    unsigned long long bkeep_sum;   // nanoseconds spent bookkeeping
+    unsigned long long bkeep_100ns; // bucket for <100ns
+    unsigned long long bkeep_1us;   // bucket for <1us
+    unsigned long long bkeep_10us;  // bucket for <10us
+    unsigned long long bkeep_100us; // bucket for <100us
+    unsigned long long bkeep_1ms;   // bucket for <1ms
+    unsigned long long bkeep_10ms;  // bucket for <10ms
+    unsigned long long bkeep_100ms; // bucket for <100ms
+    unsigned long long bkeep_1s;     // bucket for <1s
+    unsigned long long bkeep_10s;    // bucket for <10s
+    unsigned long long bkeep_100s;   // bucket for <100s
+    unsigned long long bkeep_inf;   // bucket for <+Inf
+    // Avoid cache trashing by aligning on cache line size (64!?)
+    char padding[56];
+};
+extern struct wt_stat wt_stats[MAX_WTHREADS];
 
 extern pthread_key_t pkey_wtid;
 extern pthread_key_t pkey_uv_loop;

--- a/base/src/acton/rts.act
+++ b/base/src/acton/rts.act
@@ -22,6 +22,10 @@ def _io_handles(cap: SysCap) -> dict[u64, (typ: str, act: u64)]:
     """Return all I/O handles and their type for the current worker thread"""
     NotImplemented
 
+def rts_stats(cap: SysCap) -> dict[u64, (state: str, work_entered: u64, no_work: u64, yield_to_io: u64, sleeps: u64, conts_count: u64, conts_sum: u64, conts_100ns: u64, conts_1us: u64, conts_10us: u64, conts_100us: u64, conts_1ms: u64, conts_10ms: u64, conts_100ms: u64, conts_1s: u64, conts_10s: u64, conts_100s: u64, conts_inf: u64, bkeep_count: u64, bkeep_sum: u64, bkeep_100ns: u64, bkeep_1us: u64, bkeep_10us: u64, bkeep_100us: u64, bkeep_1ms: u64, bkeep_10ms: u64, bkeep_100ms: u64, bkeep_1s: u64, bkeep_10s: u64, bkeep_100s: u64, bkeep_inf: u64)]:
+    """Return all I/O handles and their type for the current worker thread"""
+    NotImplemented
+
 actor WThreadMonitor(env: Env, arg_wthread_id: int):
     wthread_id = arg_wthread_id
 

--- a/base/src/acton/rts.ext.c
+++ b/base/src/acton/rts.ext.c
@@ -81,6 +81,45 @@ B_dict actonQ_rtsQ__io_handles (B_SysCap cap) {
     return d;
 }
 
+B_dict actonQ_rtsQ_rts_stats (B_SysCap cap) {
+    B_Hashable wit = (B_Hashable)B_HashableD_u64G_witness;
+    B_dict d = $NEW(B_dict, wit, NULL, NULL);
+    for (int i; i <= num_wthreads; i++) {
+        B_tuple stats = $NEWTUPLE(28,
+                            to$str("TODO"), // state
+                            toB_u64(wt_stats[i].sleeps),
+                            toB_u64(wt_stats[i].conts_count),
+                            toB_u64(wt_stats[i].conts_sum),
+                            toB_u64(wt_stats[i].conts_100ns),
+                            toB_u64(wt_stats[i].conts_1us),
+                            toB_u64(wt_stats[i].conts_10us),
+                            toB_u64(wt_stats[i].conts_100us),
+                            toB_u64(wt_stats[i].conts_1ms),
+                            toB_u64(wt_stats[i].conts_10ms),
+                            toB_u64(wt_stats[i].conts_100ms),
+                            toB_u64(wt_stats[i].conts_1s),
+                            toB_u64(wt_stats[i].conts_10s),
+                            toB_u64(wt_stats[i].conts_100s),
+                            toB_u64(wt_stats[i].conts_inf),
+                            toB_u64(wt_stats[i].bkeep_count),
+                            toB_u64(wt_stats[i].bkeep_sum),
+                            toB_u64(wt_stats[i].bkeep_100ns),
+                            toB_u64(wt_stats[i].bkeep_1us),
+                            toB_u64(wt_stats[i].bkeep_10us),
+                            toB_u64(wt_stats[i].bkeep_100us),
+                            toB_u64(wt_stats[i].bkeep_1ms),
+                            toB_u64(wt_stats[i].bkeep_10ms),
+                            toB_u64(wt_stats[i].bkeep_100ms),
+                            toB_u64(wt_stats[i].bkeep_1s),
+                            toB_u64(wt_stats[i].bkeep_10s),
+                            toB_u64(wt_stats[i].bkeep_100s),
+                            toB_u64(wt_stats[i].bkeep_inf)
+                            );
+        B_dictD_setitem(d, wit, toB_u64(i), stats);
+    }
+    return d;
+}
+
 $R actonQ_rtsQ_WThreadMonitorD__initG_local (actonQ_rtsQ_WThreadMonitor self, $Cont C_cont) {
     set_actor_affinity(from$int(self->wthread_id));
     return $RU_CONT(C_cont, B_None);


### PR DESCRIPTION
This returns the RTS stats from within Acton! A first step to replacing the RTS mon functionality written in C in the RTS with similar functionality that we can instaed build in Acton! It's monitoring Acton from within Acton!

Part of #1430.