### PR TITLE
Fix i64 eq/ne/etc comparisons

### DIFF
--- a/base/builtin/i64.h
+++ b/base/builtin/i64.h
@@ -12,9 +12,9 @@ B_i64 B_i64G_new(B_atom a);
 // only called with e>=0.
 long longpow(long a, long e); // used also for ndarrays
 
-#define ORD_B_i64__eq__(a,b)  (&a->val == &b->val)
-#define ORD_B_i64__ne__(a,b)  (&a->val != &b->val)
-#define ORD_B_i64__lt__(a,b)  (&a->val < &b->val) 
-#define ORD_B_i64__le__(a,b)  (&a->val <= &b->val)
-#define ORD_B_i64__gt__(a,b)  (&a->val > &b->val)
-#define ORD_B_i64__ge__(a,b)  (&a->val >= &b->val)
+#define ORD_B_i64__eq__(a,b)  (a->val == b->val)
+#define ORD_B_i64__ne__(a,b)  (a->val != b->val)
+#define ORD_B_i64__lt__(a,b)  (a->val < b->val)
+#define ORD_B_i64__le__(a,b)  (a->val <= b->val)
+#define ORD_B_i64__gt__(a,b)  (a->val > b->val)
+#define ORD_B_i64__ge__(a,b)  (a->val >= b->val)

--- a/test/builtins_auto/int.act
+++ b/test/builtins_auto/int.act
@@ -1,3 +1,12 @@
+def test_i64():
+    x: i64 = 0
+    if (bool(x != 0)):
+       raise ValueError("unexpected: bool(x) != 0")
+    if x != 0:
+       raise ValueError("unexpected: x != 0")
+    return True
+
+
 actor main(env):
     if (141234567898765434567654345678765456787654 << 12) != 578496790113343219989112199900223311002230784:
         raise ValueError("left shift of positive int broken")
@@ -24,5 +33,8 @@ actor main(env):
     if int('123') != 123:
         raise ValueError("int('123') != 123")
     if hash(2**131) >= 2**64:
-        raise ValueError("hash(2**131) too big")        
+        raise ValueError("hash(2**131) too big")
+    if not test_i64():
+        await async env.exit(1)
+
     await async env.exit(0)


### PR DESCRIPTION
val is not a pointer. I suspect this was erroneously copied from our int implementation where val is a pointer to a bsdnt struct. Now fixed!

Fixes #1459 