### PR TITLE
Fix list add for empty list input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,11 @@
 - Fix `reversed([])` which would `SIGILL` in dev mode [#1455]
 - Fix `reversed([1,2,3])` which now returns reversed result [#1455]
   - Previous code did the reversal but returned the original value :P
+- Fix `i64` comparisons like eq/ne/etc [#1459]
+  - Would just return the wrong results, like `i64(0) == i64(0)` would not
+    return `True`. Now works as they should!
+- Fix list add with empty list input, like `[1]+[]` [#1461]
+  - Used to segfault, now works as intended
 
 
 ## [0.16.0] (2023-07-03)

--- a/base/builtin/list.c
+++ b/base/builtin/list.c
@@ -37,6 +37,7 @@ static void shrink(B_list lst) {
         $WORD old = lst->data;
         lst->data = malloc(newcapacity * sizeof($WORD));
         lst->capacity = newcapacity;
+        assert(old != NULL);
         memcpy(lst->data, old, newcapacity * sizeof($WORD));
     }
 }
@@ -154,6 +155,7 @@ B_NoneType B_listD_clear(B_list lst) {
 
 B_NoneType B_listD_extend(B_list lst, B_list other) {
     expand(lst, other->length);
+    assert(other->data != NULL);
     memcpy(lst->data + lst->length, other->data, other->length * sizeof($WORD));
     lst->length += other->length;
     return B_None;
@@ -236,8 +238,10 @@ B_list B_TimesD_SequenceD_listD___add__ (B_TimesD_SequenceD_list wit, B_list lst
     int otherlen = other->length;
     int reslen = lstlen + otherlen;
     B_list res = B_listD_new(reslen);
-    memcpy(res->data,lst->data,lstlen*sizeof($WORD));
-    memcpy(res->data+lstlen,other->data,otherlen*sizeof($WORD));
+    if (lstlen > 0)
+        memcpy(res->data,lst->data,lstlen*sizeof($WORD));
+    if (otherlen > 0)
+        memcpy(res->data+lstlen,other->data,otherlen*sizeof($WORD));
     res->length = reslen;
     return res;
 }

--- a/test/builtins_auto/list.act
+++ b/test/builtins_auto/list.act
@@ -96,5 +96,15 @@ actor main(env):
     if len(l) != 10 or l[4] != 4:
         print("Unexpected shrinking of list")
         await async env.exit(1)
-    
+
+    print([1] + [])
+    if [1] + [2] != [1,2]:
+        raise ValueError("unexpected: [1] + [2] != [1,2]")
+
+    if [1] + [] != [1]:
+        raise ValueError("unexpected: [1] + [] != [1]")
+
+    if [] + [2] != [2]:
+        raise ValueError("unexpected: [] + [2] != [2]")
+
     await async env.exit(0)


### PR DESCRIPTION
It's that damn memcpy again! I have now also skimmed the other uses of memcpy in this module and I think they are OK but added asserts to check at least the source argument.

Fixes #1461 