### PR TITLE
Add mbedtls & tlsuv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,12 +159,14 @@ clean-compiler:
 	rm -f compiler/actonc compiler/package.yaml compiler/acton.cabal
 
 # /deps --------------------------------------------------
+DEPS_DIRS += dist/deps/mbedtls
 DEPS_DIRS += dist/deps/libargp
 DEPS_DIRS += dist/deps/libbsdnt
 DEPS_DIRS += dist/deps/libgc
 DEPS_DIRS += dist/deps/libnetstring
 DEPS_DIRS += dist/deps/pcre2
 DEPS_DIRS += dist/deps/libprotobuf_c
+DEPS_DIRS += dist/deps/tlsuv
 DEPS_DIRS += dist/deps/libutf8proc
 DEPS_DIRS += dist/deps/libuuid
 DEPS_DIRS += dist/deps/libuv
@@ -174,8 +176,12 @@ DEPS_DIRS += dist/deps/libyyjson
 DEPS += dist/depsout/lib/libactongc.a
 DEPS += dist/depsout/lib/libargp.a
 DEPS += dist/depsout/lib/libbsdnt.a
+DEPS += dist/depsout/lib/libmbedcrypto.a
+DEPS += dist/depsout/lib/libmbedtls.a
+DEPS += dist/depsout/lib/libmbedx509.a
 DEPS += dist/depsout/lib/libpcre2.a
 DEPS += dist/depsout/lib/libprotobuf-c.a
+DEPS += dist/depsout/lib/libtlsuv.a
 DEPS += dist/depsout/lib/libutf8proc.a
 DEPS += dist/depsout/lib/libuuid.a
 DEPS += dist/depsout/lib/libuv.a
@@ -232,6 +238,22 @@ dist/depsout/lib/libactongc.a: dist/deps/libgc $(DIST_ZIG)
 	cd $< && $(ZIG) build $(ZIG_TARGET) --prefix $(TD)/dist/depsout
 	mv dist/depsout/lib/libgc.a $@
 
+# /deps/libmbedtls --------------------------------------------
+LIBMBEDTLS_REF=c820d300e8d2129a4b79eb45a14ac42e85882732
+deps-download/$(LIBMBEDTLS_REF).tar.gz:
+	mkdir -p deps-download
+	curl -f -L -o $@ https://github.com/actonlang/mbedtls/archive/$(LIBMBEDTLS_REF).tar.gz
+
+dist/deps/mbedtls: deps-download/$(LIBMBEDTLS_REF).tar.gz
+	mkdir -p $@
+	cd $@ && tar zx --strip-components=1 -f $(TD)/$<
+	touch $(TD)/$@
+
+dist/depsout/lib/libmbedtls.a: dist/deps/mbedtls $(DIST_ZIG)
+	cd $< && $(ZIG) build $(ZIG_TARGET) --prefix $(TD)/dist/depsout
+dist/depsout/lib/libmbedcrypto.a: dist/depsout/lib/libmbedtls.a
+dist/depsout/lib/libmbedx509.a: dist/depsout/lib/libmbedtls.a
+
 # /deps/libprotobuf_c --------------------------------------------
 LIBPROTOBUF_C_REF=5499f774396953c2ef63e725e2f03a5c0bdeff73
 deps-download/$(LIBPROTOBUF_C_REF).tar.gz:
@@ -245,6 +267,20 @@ dist/deps/libprotobuf_c: deps-download/$(LIBPROTOBUF_C_REF).tar.gz
 
 dist/depsout/lib/libprotobuf-c.a: dist/deps/libprotobuf_c $(DIST_ZIG)
 	cd $< && $(ZIG) build $(ZIG_TARGET) --prefix $(TD)/dist/depsout
+
+# /deps/tlsuv ---------------------------------------------
+TLSUV_REF=e8f5a74a88e8943b24ece11a0bb9b9deaa373467
+deps-download/$(TLSUV_REF).tar.gz:
+	mkdir -p deps-download
+	curl -f -L -o $@ https://github.com/actonlang/tlsuv/archive/$(TLSUV_REF).tar.gz
+
+dist/deps/tlsuv: deps-download/$(TLSUV_REF).tar.gz
+	mkdir -p $@
+	cd $@ && tar zx --strip-components=1 -f $(TD)/$<
+	touch $(TD)/$@
+
+dist/depsout/lib/libtlsuv.a: dist/deps/tlsuv $(DIST_ZIG) dist/depsout/lib/libmbedtls.a dist/depsout/lib/libuv.a
+	cd $< && $(ZIG) build $(ZIG_TARGET) --prefix $(TD)/dist/depsout --search-prefix $(TD)/dist/depsout
 
 # /deps/libutf8proc --------------------------------------
 LIBUTF8PROC_REF=3c489aea1a497b98f6cc28ea5b218181b84769e6

--- a/builder/build.zig
+++ b/builder/build.zig
@@ -88,6 +88,11 @@ pub fn build(b: *std.build.Builder) void {
         .optimize = optimize,
     });
 
+    const dep_libmbedtls = b.anonymousDependency(joinPath(b.allocator, dots_to_root, syspath, "deps/mbedtls"), @import("deps/mbedtls/build.zig"), .{
+        .target = target,
+        .optimize = optimize,
+    });
+
     const dep_libnetstring = b.anonymousDependency(joinPath(b.allocator, dots_to_root, syspath, "deps/libnetstring"), @import("deps/libnetstring/build.zig"), .{
         .target = target,
         .optimize = optimize,
@@ -99,6 +104,11 @@ pub fn build(b: *std.build.Builder) void {
     });
 
     const dep_libprotobuf_c = b.anonymousDependency(joinPath(b.allocator, dots_to_root, syspath, "deps/libprotobuf_c"), @import("deps/libprotobuf_c/build.zig"), .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const dep_libtlsuv = b.anonymousDependency(joinPath(b.allocator, dots_to_root, syspath, "deps/tlsuv"), @import("deps/tlsuv/build.zig"), .{
         .target = target,
         .optimize = optimize,
     });
@@ -275,6 +285,10 @@ pub fn build(b: *std.build.Builder) void {
             executable.linkSystemLibraryName("netstring");
             executable.linkSystemLibraryName("pcre2");
             executable.linkSystemLibraryName("protobuf-c");
+            executable.linkSystemLibraryName("tlsuv");
+            executable.linkSystemLibraryName("mbedtls");
+            executable.linkSystemLibraryName("mbedcrypto");
+            executable.linkSystemLibraryName("mbedx509");
             executable.linkSystemLibraryName("utf8proc");
             executable.linkSystemLibraryName("uuid");
             executable.linkSystemLibraryName("uv");
@@ -291,6 +305,8 @@ pub fn build(b: *std.build.Builder) void {
             executable.linkLibrary(dep_libnetstring.artifact("netstring"));
             executable.linkLibrary(dep_libpcre2.artifact("pcre2"));
             executable.linkLibrary(dep_libprotobuf_c.artifact("protobuf-c"));
+            executable.linkLibrary(dep_libtlsuv.artifact("tlsuv"));
+            executable.linkLibrary(dep_libmbedtls.artifact("libtls"));
             executable.linkLibrary(dep_libutf8proc.artifact("utf8proc"));
             executable.linkLibrary(dep_libuuid.artifact("uuid"));
             executable.linkLibrary(dep_libuv.artifact("uv"));


### PR DESCRIPTION
tlsuv is a library that marries TLS with libuv, which is really something we need since building TLS support on top of libuv directly is non-trivial. For the TLS part it relies on an existing TLS library, either OpenSSL or MbedTLS. I picked MbedTLS in this case since I could get it to build with zig.

I did make an attempt at building OpenSSL based on a build.zig file I found on the Internetz but it was incomplete and adding the missing files that we need didn't really work as they in turn relied on some bespoke build tool with a custom code generator in the OpenSSL repo. Way too much yak shaving!

MbedTLS should be fine for now. Not quite sure how well it supports TLS 1.3 but there should be some basic support and they seem to be working on it. Longer term I'd like to use the crypto stuff in zigs stdlib. BoringSSL could be another alternative.