### PR TITLE
Add net.TLSConnection()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,12 +159,14 @@ clean-compiler:
 	rm -f compiler/actonc compiler/package.yaml compiler/acton.cabal
 
 # /deps --------------------------------------------------
+DEPS_DIRS += dist/deps/mbedtls
 DEPS_DIRS += dist/deps/libargp
 DEPS_DIRS += dist/deps/libbsdnt
 DEPS_DIRS += dist/deps/libgc
 DEPS_DIRS += dist/deps/libnetstring
 DEPS_DIRS += dist/deps/pcre2
 DEPS_DIRS += dist/deps/libprotobuf_c
+DEPS_DIRS += dist/deps/tlsuv
 DEPS_DIRS += dist/deps/libutf8proc
 DEPS_DIRS += dist/deps/libuuid
 DEPS_DIRS += dist/deps/libuv
@@ -174,8 +176,12 @@ DEPS_DIRS += dist/deps/libyyjson
 DEPS += dist/depsout/lib/libactongc.a
 DEPS += dist/depsout/lib/libargp.a
 DEPS += dist/depsout/lib/libbsdnt.a
+DEPS += dist/depsout/lib/libmbedcrypto.a
+DEPS += dist/depsout/lib/libmbedtls.a
+DEPS += dist/depsout/lib/libmbedx509.a
 DEPS += dist/depsout/lib/libpcre2.a
 DEPS += dist/depsout/lib/libprotobuf-c.a
+DEPS += dist/depsout/lib/libtlsuv.a
 DEPS += dist/depsout/lib/libutf8proc.a
 DEPS += dist/depsout/lib/libuuid.a
 DEPS += dist/depsout/lib/libuv.a
@@ -232,6 +238,22 @@ dist/depsout/lib/libactongc.a: dist/deps/libgc $(DIST_ZIG)
 	cd $< && $(ZIG) build $(ZIG_TARGET) --prefix $(TD)/dist/depsout
 	mv dist/depsout/lib/libgc.a $@
 
+# /deps/libmbedtls --------------------------------------------
+LIBMBEDTLS_REF=c820d300e8d2129a4b79eb45a14ac42e85882732
+deps-download/$(LIBMBEDTLS_REF).tar.gz:
+	mkdir -p deps-download
+	curl -f -L -o $@ https://github.com/actonlang/mbedtls/archive/$(LIBMBEDTLS_REF).tar.gz
+
+dist/deps/mbedtls: deps-download/$(LIBMBEDTLS_REF).tar.gz
+	mkdir -p $@
+	cd $@ && tar zx --strip-components=1 -f $(TD)/$<
+	touch $(TD)/$@
+
+dist/depsout/lib/libmbedtls.a: dist/deps/mbedtls $(DIST_ZIG)
+	cd $< && $(ZIG) build $(ZIG_TARGET) --prefix $(TD)/dist/depsout
+dist/depsout/lib/libmbedcrypto.a: dist/depsout/lib/libmbedtls.a
+dist/depsout/lib/libmbedx509.a: dist/depsout/lib/libmbedtls.a
+
 # /deps/libprotobuf_c --------------------------------------------
 LIBPROTOBUF_C_REF=5499f774396953c2ef63e725e2f03a5c0bdeff73
 deps-download/$(LIBPROTOBUF_C_REF).tar.gz:
@@ -245,6 +267,20 @@ dist/deps/libprotobuf_c: deps-download/$(LIBPROTOBUF_C_REF).tar.gz
 
 dist/depsout/lib/libprotobuf-c.a: dist/deps/libprotobuf_c $(DIST_ZIG)
 	cd $< && $(ZIG) build $(ZIG_TARGET) --prefix $(TD)/dist/depsout
+
+# /deps/tlsuv ---------------------------------------------
+TLSUV_REF=e8707d82f626ee2636cff0e2de116be7067fd1a6
+deps-download/$(TLSUV_REF).tar.gz:
+	mkdir -p deps-download
+	curl -f -L -o $@ https://github.com/actonlang/tlsuv/archive/$(TLSUV_REF).tar.gz
+
+dist/deps/tlsuv: deps-download/$(TLSUV_REF).tar.gz
+	mkdir -p $@
+	cd $@ && tar zx --strip-components=1 -f $(TD)/$<
+	touch $(TD)/$@
+
+dist/depsout/lib/libtlsuv.a: dist/deps/tlsuv $(DIST_ZIG) dist/depsout/lib/libmbedtls.a dist/depsout/lib/libuv.a
+	cd $< && $(ZIG) build $(ZIG_TARGET) --prefix $(TD)/dist/depsout --search-prefix $(TD)/dist/depsout
 
 # /deps/libutf8proc --------------------------------------
 LIBUTF8PROC_REF=3c489aea1a497b98f6cc28ea5b218181b84769e6

--- a/base/src/net.act
+++ b/base/src/net.act
@@ -264,3 +264,51 @@ actor TCPListener(cap: TCPListenCap, address: str, port: int, on_error: action(T
         """Implementation internal"""
         NotImplemented
     _init()
+
+actor TLSConnection(cap: TCPConnectCap, address: str, port: int, on_connect: action(TLSConnection) -> None, on_receive: action(TLSConnection, bytes) -> None, on_error: action(TLSConnection, str) -> None):
+    # TODO: support disabling certificate verification
+    # TODO: support hostname/CN mismatch, good when connecting with IP address?
+    # TODO: do DNS lookup in Acton
+    # TODO: support ALPN
+    # TODO: support SNI
+    # TODO: support client certificates
+    # TODO: implement state machine
+    # TODO: support timeout
+    # TODO: do Happy Eyeballs
+    var _stream = -1
+
+    var _on_close: ?action(TLSConnection) -> None = None
+
+    var _connections = 0
+    var _consecutive_connect_errors = 0
+    var _bytes_in: u64 = 0
+    var _bytes_out: u64 = 0
+
+    proc def _pin_affinity() -> None:
+        NotImplemented
+    _pin_affinity()
+
+    action def _on_tls_connect():
+        _connections += 1
+        on_connect(self)
+
+    action def _on_tls_error(sockfamily: int, err: int, errmsg: str):
+        on_error(self, errmsg)
+
+    action def close(on_close: action(TLSConnection) -> None) -> None:
+        """Close the connection"""
+        NotImplemented
+
+    action def write(data: bytes) -> None:
+        """Write data to remote"""
+        NotImplemented
+
+    def reconnect():
+        close(_connect)
+
+    proc def _connect_tls():
+        NotImplemented
+
+    proc def _connect(c):
+        _connect_tls()
+    _connect(self)

--- a/builder/build.zig
+++ b/builder/build.zig
@@ -88,6 +88,11 @@ pub fn build(b: *std.build.Builder) void {
         .optimize = optimize,
     });
 
+    const dep_libmbedtls = b.anonymousDependency(joinPath(b.allocator, dots_to_root, syspath, "deps/mbedtls"), @import("deps/mbedtls/build.zig"), .{
+        .target = target,
+        .optimize = optimize,
+    });
+
     const dep_libnetstring = b.anonymousDependency(joinPath(b.allocator, dots_to_root, syspath, "deps/libnetstring"), @import("deps/libnetstring/build.zig"), .{
         .target = target,
         .optimize = optimize,
@@ -99,6 +104,11 @@ pub fn build(b: *std.build.Builder) void {
     });
 
     const dep_libprotobuf_c = b.anonymousDependency(joinPath(b.allocator, dots_to_root, syspath, "deps/libprotobuf_c"), @import("deps/libprotobuf_c/build.zig"), .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const dep_libtlsuv = b.anonymousDependency(joinPath(b.allocator, dots_to_root, syspath, "deps/tlsuv"), @import("deps/tlsuv/build.zig"), .{
         .target = target,
         .optimize = optimize,
     });
@@ -275,6 +285,10 @@ pub fn build(b: *std.build.Builder) void {
             executable.linkSystemLibraryName("netstring");
             executable.linkSystemLibraryName("pcre2");
             executable.linkSystemLibraryName("protobuf-c");
+            executable.linkSystemLibraryName("tlsuv");
+            executable.linkSystemLibraryName("mbedtls");
+            executable.linkSystemLibraryName("mbedcrypto");
+            executable.linkSystemLibraryName("mbedx509");
             executable.linkSystemLibraryName("utf8proc");
             executable.linkSystemLibraryName("uuid");
             executable.linkSystemLibraryName("uv");
@@ -291,6 +305,8 @@ pub fn build(b: *std.build.Builder) void {
             executable.linkLibrary(dep_libnetstring.artifact("netstring"));
             executable.linkLibrary(dep_libpcre2.artifact("pcre2"));
             executable.linkLibrary(dep_libprotobuf_c.artifact("protobuf-c"));
+            executable.linkLibrary(dep_libtlsuv.artifact("tlsuv"));
+            executable.linkLibrary(dep_libmbedtls.artifact("mbedtls"));
             executable.linkLibrary(dep_libutf8proc.artifact("utf8proc"));
             executable.linkLibrary(dep_libuuid.artifact("uuid"));
             executable.linkLibrary(dep_libuv.artifact("uv"));

--- a/test/stdlib/test_net_tls.act
+++ b/test/stdlib/test_net_tls.act
@@ -1,0 +1,142 @@
+# Test stdlib net module by first starting a server which listens to a TCP port
+# and then creating a TCP client connection which connects to the server, sends
+# a message and expects a reply. This exercices both ends of the TCP connection.
+
+import acton.rts
+import net
+import random
+
+
+def get_tcp_handles(m):
+    tcp_handles = m.io_handles()
+    res = {}
+    for wthread_id, handles in tcp_handles.items():
+        for k, v in handles.items():
+            if v.typ == "tcp" and v.act != u64(0):
+                res[k] = v
+    return res
+
+actor Server(conn):
+    def on_receive(c, data):
+        print("Server received some data:", data, " from:", c)
+        if data == b"PING":
+            c.write(b"PONG")
+            c.close()
+
+    def on_error(c, error):
+        print("There was an error:", error, " from:", c)
+
+
+actor Listener(env, address, port):
+    def on_lsock_error(l, error):
+        print("There was an error with the TCPListener socket:", error)
+
+    def on_server_accept(c):
+        s = Server(c)
+        c.cb_install(s.on_receive, s.on_error)
+
+    listen_cap = net.TCPListenCap(net.TCPCap(net.NetCap(env.cap)))
+    server = net.TCPListener(listen_cap, address, port, on_lsock_error, on_server_accept)
+
+http_req = (b"GET / HTTP/1.0\r\n"
+          + b"\r\n")
+actor Client(name, rts_monitor, env: Env, port: int, on_success):
+    var connection = 0
+    def on_connect(c):
+        connection += 1
+        print("Client connected", connection)
+        #print("Client %s connected to %s:%d, TCP handles: %s" % (name, c.remote_address(), port, str(get_tcp_handles(rts_monitor))))
+        #await async c.write(b"PING")
+        await async c.write(http_req)
+
+    def on_close(c):
+        print("closed connection", connection)
+        if connection == 2:
+            on_success()
+
+    def on_receive(c, data):
+        print("Client RECV", data)
+        # NOTE: True here, so we accept any data since we don't have our own TLS
+        # server side yet, thus testing against like google.com or similar
+        if True or data == b"PONG":
+            print("Got PONG, all good, yay")
+            if connection == 1:
+                print("Conn 1: reconnecting")
+                c.reconnect()
+            else:
+                # Test idempotency / that we don't break anything by double-closing
+                c.close(on_close)
+                await async c.close(on_close)
+        else:
+            print("Got bad response, exiting with error..")
+            await async env.exit(1)
+
+    def on_error(c, msg):
+        print("Client ERR", msg)
+
+    def _exit():
+        print("exiting..")
+        await async env.exit(0)
+
+    connect_cap = net.TCPConnectCap(net.TCPCap(net.NetCap(env.cap)))
+    #client = net.TLSConnection(connect_cap, "localhost", port, on_connect, on_receive, on_error)
+    client = net.TLSConnection(connect_cap, "www.google.com", 443, on_connect, on_receive, on_error)
+    #client = net.TLSConnection(connect_cap, "142.250.74.132", 443, on_connect, on_receive, on_error)
+
+
+actor main(env):
+    def timeout_error():
+        print("Timeout reached, exiting with error...")
+        await async env.exit(1)
+
+    #after 2: timeout_error()
+
+    rts_monitor = acton.rts.Monitor(env)
+
+    port4 = random.randint(10000, 20000)
+    port6 = port4+1
+    print("Using ports, IPv4: %d  IPv6: %d" % (port4, port6))
+
+    require_v4 = True
+    require_v6 = False
+
+    if require_v4:
+        l4 = Listener(env, "127.0.0.1", port4)
+    if require_v6:
+        l6 = Listener(env, "::1", port6)
+
+    var v4_connected = False
+    var v6_connected = False
+    var ds_connected = False
+
+    def _on_v4_connect():
+        v4_connected = True
+        if not require_v6 or v6_connected:
+            after 0.1: check_io()
+
+    def _on_v6_connect():
+        print("v6 connected")
+        v6_connected = True
+        if not require_v4 or v4_connected:
+            after 0.1: check_io()
+
+    def check_io():
+        tcp_handles = get_tcp_handles(rts_monitor)
+        print("IO check...", tcp_handles)
+        expected_tcp_handles = 0
+        if require_v4:
+            expected_tcp_handles += 1
+        if require_v6:
+            expected_tcp_handles += 1
+        if len(tcp_handles) <= expected_tcp_handles:
+            # Only TCP listening sockets left...
+            print("TCP client properly cleaned from IO loop, exiting...")
+            await async env.exit(0)
+        else:
+            print("TCP client not properly cleaned from IO loop, waiting...")
+            after 0.8: check_io()
+
+    if require_v4:
+        c4 = Client("c4", rts_monitor, env, port4, _on_v4_connect)
+    if require_v6:
+        c6 = Client("c6", rts_monitor, env, port6, _on_v6_connect)


### PR DESCRIPTION
This adds a TLS client connection actor. It's interface is rather similar to the TCPConnection actor.

Under the hood, we are using tlsuv and mbedtls for the TLS functionality and integration with libuv. It is quite integrated so for example, at this point it has name resolution integrated. That's a part I'd like to lift out so we can do it in Acton (and one day avoid relying on getaddrinfo entirely) but it's there for now out of simplicity. There's more important issues to fix on this TLSConnection first, like disabling certification verification (useful for testing).

Longer term I'd also like to see the ability to bundle CA certs in the application itself so that we don't rely on anything external, think of a WASM app or on a freestanding target.

There's a simple test application that tests our TLS client against www.google.com. Since we don't have a TLS server and I don't want to rely on external tools, like Python with some SSL module, this is sort of the best we can do. As we don't want tests that rely on Internet connectivity, this test is not run automatically.

Fixes #1038