### PR TITLE
Allow disabling TLS certificate verification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -269,7 +269,7 @@ dist/depsout/lib/libprotobuf-c.a: dist/deps/libprotobuf_c $(DIST_ZIG)
 	cd $< && $(ZIG) build $(ZIG_TARGET) --prefix $(TD)/dist/depsout
 
 # /deps/tlsuv ---------------------------------------------
-TLSUV_REF=e8707d82f626ee2636cff0e2de116be7067fd1a6
+TLSUV_REF=686f38a8e6cc537134335dd314358cfdf51c442d
 deps-download/$(TLSUV_REF).tar.gz:
 	mkdir -p deps-download
 	curl -f -L -o $@ https://github.com/actonlang/tlsuv/archive/$(TLSUV_REF).tar.gz

--- a/base/src/net.act
+++ b/base/src/net.act
@@ -265,8 +265,8 @@ actor TCPListener(cap: TCPListenCap, address: str, port: int, on_error: action(T
         NotImplemented
     _init()
 
-actor TLSConnection(cap: TCPConnectCap, address: str, port: int, on_connect: action(TLSConnection) -> None, on_receive: action(TLSConnection, bytes) -> None, on_error: action(TLSConnection, str) -> None):
-    # TODO: support disabling certificate verification
+# TODO default: verify_tls=True
+actor TLSConnection(cap: TCPConnectCap, address: str, port: int, on_connect: action(TLSConnection) -> None, on_receive: action(TLSConnection, bytes) -> None, on_error: action(TLSConnection, str) -> None, verify_tls: bool):
     # TODO: support hostname/CN mismatch, good when connecting with IP address?
     # TODO: do DNS lookup in Acton
     # TODO: support ALPN

--- a/base/src/net.ext.c
+++ b/base/src/net.ext.c
@@ -723,9 +723,6 @@ $R netQ_TLSConnectionD__connect_tlsG_local (netQ_TLSConnection self, $Cont c$con
     //const char *alpn[] = { "http/1.1" };
     //tlsuv_stream_set_protocols(stream, 1, alpn);
     // No ALPN for now.
-    // TODO: This feels like it should really go into tlsuv_stream_init since
-    // otherweise we get a segfault? Upstream?
-    tlsuv_stream_set_protocols(stream, 0, NULL);
     // TODO: take SNI as input to TLSConnection actor
     stream->data = (void *)self;
 

--- a/base/src/net.ext.c
+++ b/base/src/net.ext.c
@@ -712,6 +712,13 @@ $R netQ_TLSConnectionD__connect_tlsG_local (netQ_TLSConnection self, $Cont c$con
     //tlsuv_set_debug(5, tlsuv_logger);
     tlsuv_stream_t *stream = (tlsuv_stream_t *)malloc(sizeof(tlsuv_stream_t));
     tlsuv_stream_init(get_uv_loop(), stream, NULL);
+
+    // Default is to verify TLS certificate. Should we disable verification?
+    if (fromB_bool(self->verify_tls) == false) {
+        log_debug("TLS certificate verification disabled");
+        stream->authmode = 0; // 0=none, 2=require (mbedtls specific)
+    }
+
     // TODO: take ALPN as input to TLSConnection actor
     //const char *alpn[] = { "http/1.1" };
     //tlsuv_stream_set_protocols(stream, 1, alpn);

--- a/test/stdlib/test_net_tls.act
+++ b/test/stdlib/test_net_tls.act
@@ -79,9 +79,9 @@ actor Client(name, rts_monitor, env: Env, port: int, on_success):
         await async env.exit(0)
 
     connect_cap = net.TCPConnectCap(net.TCPCap(net.NetCap(env.cap)))
-    #client = net.TLSConnection(connect_cap, "localhost", port, on_connect, on_receive, on_error)
-    client = net.TLSConnection(connect_cap, "www.google.com", 443, on_connect, on_receive, on_error)
-    #client = net.TLSConnection(connect_cap, "142.250.74.132", 443, on_connect, on_receive, on_error)
+    #client = net.TLSConnection(connect_cap, "localhost", port, on_connect, on_receive, on_error, True)
+    client = net.TLSConnection(connect_cap, "www.google.com", 443, on_connect, on_receive, on_error, True)
+    #client = net.TLSConnection(connect_cap, "142.250.74.132", 443, on_connect, on_receive, on_error, False)
 
 
 actor main(env):


### PR DESCRIPTION
This is obviously not a good security practice but for the sake of testing or similar it is very useful to be able to disable the verification of TLS certificates.

Most of the changes went into the tlsuv library where I had to add new options for this. I'm not all too pleased with that solution but it works.

I have verified that this works by connecting to google.com but through an IP address so we get a mismatch between the address and certificate name. It normally fails but once we disable verification the connection is established.

Fixes #1471