### PR TITLE
Print unhandled exceptions

### DIFF
--- a/base/rts/rts.c
+++ b/base/rts/rts.c
@@ -1448,6 +1448,35 @@ void wt_wake_cb(uv_async_t *ev) {
     // work is run later when wt_work_cb is called as part of the "check" phase.
 }
 
+char *unmangle_name(char *input) {
+    // Check for NULL input
+    if (input == NULL) {
+        return NULL;
+    }
+    char *output = malloc(strlen(input) + 1);
+    // Check for allocation failure
+    if (output == NULL) {
+        return NULL;
+    }
+
+    // Check if string starts with "B_"
+    if (strncmp(input, "B_", 2) == 0) {
+        // Copy string without "B_"
+        strcpy(output, input + 2);
+    } else {
+        // Copy string as is
+        strcpy(output, input);
+    }
+    // Handle "Q_" mangling for nested modules
+    char *pos;
+    while ((pos = strstr(output, "Q_")) != NULL) {
+        *pos = '.';
+        memmove(pos + 1, pos + 2, strlen(pos + 2) + 1);
+    }
+
+    return output;
+}
+
 void wt_work_cb(uv_check_t *ev) {
     volatile JumpBuf jump0 = NULL;
     pthread_setspecific(jump_top, NULL);
@@ -1544,7 +1573,7 @@ void wt_work_cb(uv_check_t *ev) {
             } else {                            // An unhandled exception
                 save_actor_state(current, m);
                 B_BaseException ex = (B_BaseException)r.value;
-                rtsd_printf("## UNHANDLED EXCEPTION %s in actor %ld : %s", ex->$class->$GCINFO, current->$globkey, current->$class->$GCINFO);
+                fprintf(stderr, "Unhandled exception in actor: %s[%ld]]:\n  %s: %s\n", unmangle_name(current->$class->$GCINFO), current->$globkey, unmangle_name(ex->$class->$GCINFO), fromB_str(ex->error_message));
                 m->value = r.value;                                 // m->value holds the raised exception,
                 $Actor b = FREEZE_waiting(m, MARK_EXCEPTION);       // so mark this and stop further m->waiting additions
                 while (b) {


### PR DESCRIPTION
Rather than hiding them away in the RTS debug output, we print them to stderr per default.

Also added a very simple version of name unmangling to get at least the most basic of examples working with better readability.

With this PR this code:
```python
actor main(env):
    raise ValueError("foo")
    env.exit(0)
```
Looks like:
```
Unhandled exception in actor: -12[foo.main]:
  ValueError: foo
```

The indentation of the exception itself is intentional. I was thinking we would make it easier to parse these tracebacks, which are log multi-line log messages, by indenting the subsequent lines.

Fixes #1475 