### PR TITLE
AbE: fix bool field in tuple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
     HTTPS using TLS on port 443
   - `http.Listener` / `http.Server` is a HTTP server component that currently
     only supports unencrypted HTTP (due to lack of a `net.TLSListener`)
+  - Supports chunked transfer-encoding [#1510]
 - New `logging` module [#1483]
   - Provides logging functionality in an actor centric world
 - New `argparse` module [#1499]
@@ -113,6 +114,8 @@
 ### Fixed
 - Fix control flow bug for `continue` in `for` loop [#1265]
 - Fix control flow bug for `return` in `while loop` [#1194]
+- Fix comparison of optional types [#1186] [#1506]
+- Fix necessary casts for bool checks on tuple field [#1500] [#1504]
 - Throw exceptions for unimplemented builtins [#1010]
   - Previously printed to stderr and did `exit(1)`
   - Now throws a `NotImplemetedError` instead!

--- a/docs/acton-by-example/src/primitives/tuples.md
+++ b/docs/acton-by-example/src/primitives/tuples.md
@@ -17,8 +17,7 @@ actor main(env):
     print(nt.b)
     
     r = foo()
-    # TODO: bool() should not be necessary
-    if bool(r.b):
+    if r.b:
         print(r.c)
 
     await async env.exit(0)

--- a/docs/run-example.py
+++ b/docs/run-example.py
@@ -26,7 +26,7 @@ def run(source):
             sf = open(sfn, "w")
             sf.write(source)
             sf.close()
-            subprocess.run(["actonc", sfn, "--root", "main"])
+            subprocess.run(["../../dist/bin/actonc", sfn])
             os.chmod(sfe, 0o755)
             output = subprocess.check_output([sfe]).decode("utf-8")
         except Exception as exc:

--- a/test/core_lang_auto/return-tuple-with-bool.act
+++ b/test/core_lang_auto/return-tuple-with-bool.act
@@ -1,0 +1,10 @@
+def foo() -> (a: str, b: bool, c: int):
+    return (a="hello", b=True, c=123)
+
+actor main(env):
+    r = foo()
+    print(r.b)
+
+    if r.b:
+        print("r.b is True")
+    env.exit(0)


### PR DESCRIPTION
Move run-example.py so it can be reused for multiple books, not just AbE.

Fix tuple example to directly check bool type as a bool. We fixed this bug but I couldn't get the example to work, which turned out to be because I was using the system installed actonc rather than the one locally built in the repo, and so I ended up with an older one that didn't have the fix.

I changed the path to actonc in run-example so we get the locally built one which is probably what we want!?

Now also have a test on this type of bool check on a field in a returned tuple.

Fixes #1500. Really fixed by #1504, but this adds tests etc too :)