### PR TITLE
Upgrade to Stack LTS 21.13 & GHC 9.4, build on Debian 12 and always do static compilation for Linux

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -183,7 +183,7 @@ jobs:
       - name: "Build Debian packages"
         run: |
           export ZIG_LOCAL_CACHE_DIR=~/zig-cache
-          make -C ${GITHUB_WORKSPACE} debs BUILD_RELEASE=${{ env.BUILD_RELEASE }} STATIC_ACTONC=true
+          make -C ${GITHUB_WORKSPACE} debs BUILD_RELEASE=${{ env.BUILD_RELEASE }}
       - name: "Compute variables"
         id: vars
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,7 +150,7 @@ jobs:
   build-debs:
     runs-on: ubuntu-latest
     container:
-      image: debian:bullseye
+      image: debian:12
     steps:
       - name: "Show platform and environment"
         run: |
@@ -326,10 +326,10 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: acton-macos-11
-      - name: "Download artifacts for Linux, built on Debian:11"
+      - name: "Download artifacts for Linux, built on Debian:12"
         uses: actions/download-artifact@v3
         with:
-          name: acton-debian-11
+          name: acton-debian-12
       - name: "Download artifacts for Debian Linux"
         uses: actions/download-artifact@v3
         with:
@@ -391,10 +391,10 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: acton-macos-11
-      - name: "Download artifacts for Linux, built on Debian:11"
+      - name: "Download artifacts for Linux, built on Debian:12"
         uses: actions/download-artifact@v3
         with:
-          name: acton-debian-11
+          name: acton-debian-12
       - name: "Download artifacts for Debian Linux"
         uses: actions/download-artifact@v3
         with:
@@ -420,7 +420,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     container:
-      image: debian:bullseye
+      image: debian:12
     needs: [test-macos, test-linux, build-debs]
     steps:
       - name: Install build prerequisites
@@ -445,7 +445,7 @@ jobs:
       - name: "Include new deb in Apt repository"
         run: |
           cd apt
-          reprepro include bullseye ../deb/*.changes
+          reprepro include bookworm ../deb/*.changes
       - name: "Push updates to git repository for apt.acton-lang.io"
         run: |
           cd apt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,9 +125,9 @@ jobs:
         run: |
           export DEBIAN_FRONTEND=noninteractive
           apt-get update
-          apt-get install -qy bzip2 curl haskell-stack make procps zlib1g-dev
+          apt-get install -qy bzip2 curl g++ haskell-stack make procps zlib1g-dev
       - name: "Upgrade stack on old distributions"
-        if: ${{ (matrix.os == 'ubuntu') && (matrix.version == '20.04') }}
+        if: ${{ (matrix.os == 'ubuntu' && (matrix.version == '20.04' || matrix.version == '22.04')) || (matrix.os == 'debian' && matrix.version == '11') }}
         run: |
           stack upgrade
           echo "PATH=~/.local/bin:$PATH" >> $GITHUB_ENV
@@ -173,8 +173,13 @@ jobs:
       - name: "Install build prerequisites"
         run: |
           apt-get update
-          apt-get install -qy bzip2 curl haskell-stack make procps zlib1g-dev
+          apt-get install -qy bzip2 curl g++ haskell-stack make procps zlib1g-dev
           apt-get install -qy bash-completion build-essential debhelper devscripts
+      - name: "Upgrade stack on old distributions"
+        if: ${{ (matrix.os == 'ubuntu' && (matrix.version == '20.04' || matrix.version == '22.04')) || (matrix.os == 'debian' && matrix.version == '11') }}
+        run: |
+          stack upgrade
+          echo "PATH=~/.local/bin:$PATH" >> $GITHUB_ENV
       - name: "Build Debian packages"
         run: |
           export ZIG_LOCAL_CACHE_DIR=~/zig-cache

--- a/Makefile
+++ b/Makefile
@@ -140,17 +140,12 @@ test-backend: $(BACKEND_TESTS)
 ACTONC_ALL_HS=$(wildcard compiler/*.hs compiler/**/*.hs)
 ACTONC_TEST_HS=$(wildcard compiler/tests/*.hs)
 ACTONC_HS=$(filter-out $(ACTONC_TEST_HS),$(ACTONC_ALL_HS))
-# Set STATIC_ACTONC=true to build a static actonc binary. This works on Debian
-# 11 and distributions of similar age while it seems to fail on newer versions.
-ifeq ($(STATIC_ACTONC),true)
-ACTC_GHC_OPTS=-optl-static
-endif
-# NOTE: we're unsetting CC to avoid using zig cc for stack / ghc, which doesn't
-# seem to work properly
+# NOTE: we're unsetting CC & CXX to avoid using zig cc & zig c++ for stack /
+# ghc, which doesn't seem to work properly
 compiler/actonc: compiler/package.yaml.in compiler/stack.yaml dist/builder $(ACTONC_HS)
 	cd compiler && unset CC && unset CXX && unset CFLAGS && stack build --dry-run 2>&1 | grep "Nothing to build" || \
 		(sed 's,^version:.*,version:      "$(VERSION_INFO)",' < package.yaml.in > package.yaml \
-		&& stack build --ghc-options='-j4 $(ACTC_GHC_OPTS)' \
+		&& stack build $(STACK_OPTS) --ghc-options='-j4 $(ACTC_GHC_OPTS)' \
 		&& stack --local-bin-path=. install 2>/dev/null)
 
 .PHONY: clean-compiler
@@ -548,4 +543,4 @@ debian/changelog: debian/changelog.in CHANGELOG.md
 
 .PHONY: debs
 debs: debian/changelog
-	debuild --preserve-envvar VERSION_INFO --preserve-envvar STATIC_ACTONC -i -us -uc -b
+	debuild --preserve-envvar VERSION_INFO -i -us -uc -b

--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ endif
 # NOTE: we're unsetting CC to avoid using zig cc for stack / ghc, which doesn't
 # seem to work properly
 compiler/actonc: compiler/package.yaml.in compiler/stack.yaml dist/builder $(ACTONC_HS)
-	cd compiler && unset CC && unset CFLAGS && stack build --dry-run 2>&1 | grep "Nothing to build" || \
+	cd compiler && unset CC && unset CXX && unset CFLAGS && stack build --dry-run 2>&1 | grep "Nothing to build" || \
 		(sed 's,^version:.*,version:      "$(VERSION_INFO)",' < package.yaml.in > package.yaml \
 		&& stack build --ghc-options='-j4 $(ACTC_GHC_OPTS)' \
 		&& stack --local-bin-path=. install 2>/dev/null)

--- a/compiler/package.yaml.in
+++ b/compiler/package.yaml.in
@@ -50,8 +50,10 @@ executables:
       - unix
       - utf8-string
       - zlib
-    ghc-options:
-      - -threaded
+    when:
+    - condition: os(linux)
+      ld-options:
+        - -static
 
 tests:
   test_actonc:

--- a/compiler/package.yaml.in
+++ b/compiler/package.yaml.in
@@ -25,7 +25,7 @@ executables:
     dependencies:
       - array
       - async
-      - base >= 4.7 && < 5
+      - base
       - binary
       - bytestring
       - clock
@@ -36,7 +36,7 @@ executables:
       - filelock
       - filepath
       - hashable
-      - megaparsec >= 9
+      - megaparsec
       - mtl
       - optparse-applicative
       - parser-combinators
@@ -59,7 +59,7 @@ tests:
     dependencies:
       - base
       - dir-traverse
-      - directory >= 1.3.1
+      - directory
       - filepath
       - process
       - split

--- a/compiler/stack.yaml
+++ b/compiler/stack.yaml
@@ -4,7 +4,7 @@
 
 # NOTE: do not forget to update homebrew/Formula/acton.rb with the version of
 # GHC that corresponds to the stack LTS release, like lts-18.28 -> ghc@8.10
-resolver: lts-18.28
+resolver: lts-21.13
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -29,7 +29,7 @@ packages:
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
 # extra-deps: []
-extra-deps: [dir-traverse-0.2.3.0]
+extra-deps: [Cabal-3.10.1.0,Cabal-syntax-3.10.1.0,dir-traverse-0.2.3.0,directory-1.3.8.1,filepath-1.4.100.4,process-1.6.18.0,unix-2.8.2.1]
 # Override default flag values for local packages and extra-deps
 # flags: {}
 

--- a/compiler/stack.yaml
+++ b/compiler/stack.yaml
@@ -41,3 +41,6 @@ extra-deps: [Cabal-3.10.1.0,Cabal-syntax-3.10.1.0,dir-traverse-0.2.3.0,directory
 # we rewrite this in our Homebrew recipe to use the system GHC. Do NOT remove
 # this line, regexp replace matches on it!
 # system-ghc: true
+
+ghc-options:
+  "unix": -fPIC

--- a/compiler/stack.yaml.lock
+++ b/compiler/stack.yaml.lock
@@ -5,15 +5,57 @@
 
 packages:
 - completed:
+    hackage: Cabal-3.10.1.0@sha256:6d11adf7847d9734e7b02785ff831b5a0d11536bfbcefd6634b2b08411c63c94,12316
+    pantry-tree:
+      sha256: 3d175ab2e29f17494599bf5844d0037d01fd04287ac5d50c5c788b0633a8ee6f
+      size: 9223
+  original:
+    hackage: Cabal-3.10.1.0
+- completed:
+    hackage: Cabal-syntax-3.10.1.0@sha256:bb835ebab577fd0f9c11dab96210dbb8d68ffc62652576f4b092563c345930e7,7434
+    pantry-tree:
+      sha256: bb1e418f0eb0976bbf4f50491ef4f2b737121bb866e22d07cff1de91f199db7e
+      size: 11052
+  original:
+    hackage: Cabal-syntax-3.10.1.0
+- completed:
     hackage: dir-traverse-0.2.3.0@sha256:adcc128f201ff95131b15ffe41365dc99c50dc3fa3a910f021521dc734013bfa,2137
     pantry-tree:
       sha256: b19f0562746dfd0f8f21eccab6584592f55fb781ca3e043da9132cc23d8a5b99
       size: 389
   original:
     hackage: dir-traverse-0.2.3.0
+- completed:
+    hackage: directory-1.3.8.1@sha256:e384a4831b0ac0f8908a1d99d14ce44bf9c5fe2092eec5b2c47ea072d477a493,2942
+    pantry-tree:
+      sha256: 5265dc75d29245961933e91bbae05b5f7630da84489b6e157a44d95d4c097618
+      size: 3519
+  original:
+    hackage: directory-1.3.8.1
+- completed:
+    hackage: filepath-1.4.100.4@sha256:2de84756d3907308230e34fcc7c1917a73f218f6d53838618b7d5b95dd33e2c3,5536
+    pantry-tree:
+      sha256: 3f8869f574ea76933efe77ed3c6e4e5a646317b38e8962970c8d0d092266f230
+      size: 3346
+  original:
+    hackage: filepath-1.4.100.4
+- completed:
+    hackage: process-1.6.18.0@sha256:cd0a3e0376b5a8525983d3131a31e52f9ffefc278ce635eec45a9d3987b8be3e,3025
+    pantry-tree:
+      sha256: 3f9fef1f9a6ed1a6923578ada0bc8c16d016344cc67614473384524334463cc2
+      size: 1675
+  original:
+    hackage: process-1.6.18.0
+- completed:
+    hackage: unix-2.8.2.1@sha256:433396e6087bbe6433ea4a743600bddd29d0e6cd701ea688d6d637ebae7b7bac,9318
+    pantry-tree:
+      sha256: 1be1c56da093b0db76374ed0692109a8ebb7a0e5a44b660d186ac759e2b5bd94
+      size: 5752
+  original:
+    hackage: unix-2.8.2.1
 snapshots:
 - completed:
-    sha256: 428ec8d5ce932190d3cbe266b9eb3c175cd81e984babf876b64019e2cbe4ea68
-    size: 590100
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/28.yaml
-  original: lts-18.28
+    sha256: 8017c7970c2a8a9510c60cc70ac245d59e0c34eb932b91d37af09fe59855d854
+    size: 640038
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/21/13.yaml
+  original: lts-21.13

--- a/debian/control
+++ b/debian/control
@@ -5,6 +5,7 @@ Maintainer: Kristian Larsson <kristian@spritelink.net>
 Build-Depends:
  bash-completion,
  debhelper-compat (= 13),
+ g++,
  haskell-stack,
  make
 Standards-Version: 4.6.0

--- a/homebrew/Formula/acton.rb
+++ b/homebrew/Formula/acton.rb
@@ -6,15 +6,8 @@ class Acton < Formula
   license "BSD-3-Clause"
   head "https://github.com/actonlang/acton.git", branch: "main"
 
-  # TODO: can gettext be removed? it was likely necessary when we built deps
-  # using autoconf, but might not be needed now that we use build.zig?
-  depends_on "gettext" => :build
-  depends_on "ghc@8.10" => :build
+  depends_on "ghc@9.4" => :build
   depends_on "haskell-stack" => :build
-
-  on_linux do
-    depends_on "gmp"
-  end
 
   def install
     # Fix up stack config to not install project local GHC


### PR DESCRIPTION
It's been awhile since we upgraded and it would be nice to move to a fresher version of ghc, so here we go.

Now doing CI .deb builds using Debian 12 / bookworm. Since our newer Stack LTS requires a newer version of Stack, we have to upgrade stack on Debian 11 and Ubuntu 20.04 and 22.04. It's a little nasty but I think it's ok to say that people who want to develop Acton itself needs to use a relatively recent platform.

The LTS & GHC upgrade gives a good speed increase. Compiling a certain relatively large project now runs ~25% faster or so.

I managed to put together so we can now do static compilation on Linux even when building on other distributions than Debian 11.

Fixes #1512.