### PR TITLE
Add __str__() method to Exceptions

### DIFF
--- a/base/rts/rts.c
+++ b/base/rts/rts.c
@@ -817,8 +817,6 @@ void $DROP() {
 }
 
 void $RAISE(B_BaseException e) {
-    //fprintf(stderr, "%s: %s\n", e->$class->$GCINFO, e->error_message ? fromB_str(e->error_message) : "");
-    //exit(1);
     JumpBuf jump = (JumpBuf)pthread_getspecific(jump_top);
     jump->xval = e;
     longjmp(jump->buf, 1);
@@ -1576,7 +1574,7 @@ void wt_work_cb(uv_check_t *ev) {
             } else {                            // An unhandled exception
                 save_actor_state(current, m);
                 B_BaseException ex = (B_BaseException)r.value;
-                fprintf(stderr, "Unhandled exception in actor: %s[%ld]]:\n  %s: %s\n", unmangle_name(current->$class->$GCINFO), current->$globkey, unmangle_name(ex->$class->$GCINFO), fromB_str(ex->error_message));
+                fprintf(stderr, "Unhandled exception in actor: %s[%ld]]:\n  %s\n", unmangle_name(current->$class->$GCINFO), current->$globkey, fromB_str(ex->$class->__str__(ex)));
                 m->value = r.value;                                 // m->value holds the raised exception,
                 $Actor b = FREEZE_waiting(m, MARK_EXCEPTION);       // so mark this and stop further m->waiting additions
                 while (b) {

--- a/base/src/__builtin__.act
+++ b/base/src/__builtin__.act
@@ -311,6 +311,12 @@ class BaseException (value):
     def __init__(self, msg: str) -> None:
         self.error_message = msg
 
+    def __str__(self):
+        return "%s: %s" % (self._name(), self.error_message)
+
+    def _name(self) -> str:
+        NotImplemented
+
 class SystemExit (BaseException):
     pass
 

--- a/base/src/__builtin__.ext.c
+++ b/base/src/__builtin__.ext.c
@@ -17,3 +17,7 @@ void B___ext_init__() {
     B_ContainerD_listG_methods.__fromiter__ = (B_list (*)(B_ContainerD_list, B_Iterable, $WORD))B_CollectionD_SequenceD_listD___fromiter__;
     B_ContainerD_listG_methods.__iter__ = (B_Iterator (*)(B_ContainerD_list, B_list))B_CollectionD_SequenceD_listD___iter__;
 }
+
+B_str B_BaseExceptionD__name (B_BaseException self) {
+    return to$str(unmangle_name(self->$class->$GCINFO));
+}


### PR DESCRIPTION
The base exception now has a __str__() method that formats the exception. This is very useful for more advanced exception types where we want to be able to include more dynamic data but not carry the cost of doing up front string formatting. Now we can always provide extra data but only string formt it when necessary for printing. More complex exception types need to implement their own __str__().

_name() returns the name of the exception type.

Now we can standardize on calling this __str__() function when printing exceptions too!