### PR TITLE
Fix error handling in TCPConnection

### DIFF
--- a/base/src/net.ext.c
+++ b/base/src/net.ext.c
@@ -207,7 +207,7 @@ void on_connect6(uv_connect_t *connect_req, int status) {
         char errmsg[1024] = "Error in TCP connect over IPv6: ";
         uv_strerror_r(status, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
         log_warn(errmsg);
-        self->$class->_on_tcp_error(self, to$int(4), to$int(status), to$str(errmsg));
+        self->$class->_on_tcp_error(self, to$int(6), to$int(status), to$str(errmsg));
         return;
     }
     self->$class->_on_connect6(self);


### PR DESCRIPTION
We are waiting for an error both on IPv4 and IPv6 but since we incorrectly reported IPv6 errors as IPv4, we never got both and thus never propagated errors to the calling code via the on_error callback.

This only deals properly with dual stack connections. For IPv4-only or IPv6-only cases we need more code paths...