### PR TITLE
Remove exception for float /0

### DIFF
--- a/base/builtin/float.c
+++ b/base/builtin/float.c
@@ -174,8 +174,6 @@ B_float B_MinusD_RealFloatD_floatD___sub__(B_MinusD_RealFloatD_float wit,  B_flo
 // B_DivD_float  ////////////////////////////////////////////////////////////////////////////////////////
 
 B_float B_DivD_floatD___truediv__(B_DivD_float wit, B_float a, B_float b) {
-    if (b->val == to$float(0.0)->val)
-        $RAISE((B_BaseException)$NEW(B_ZeroDivisionError, to$str("float division by zero")));
     return to$float(fromB_float(a) / fromB_float(b));
 }  
 


### PR DESCRIPTION
We opt to diverge from Python and join the bunch of languages that follow the IEEE float convention of returning infinity for divide by zero instead of throwing an exception.

Fixes #1521.