### PR TITLE
Change JSON encode/decode to free functions

### DIFF
--- a/base/src/json.act
+++ b/base/src/json.act
@@ -1,23 +1,28 @@
-# TODO: flip around Json actor with free encode/decode functions, i.e. we want
-# the free encode/decode functions to actually do the work, which can be called
-# as json.encode() or json.decode() and will run as procs, i.e. synchronous
-# whereas if you want to run them async, you can use the Json actor. The Json
-# actor should just wrap the free functions. Now it's the other way around (only
-# way it works with compiler currently due to some bug), which means that every
-# invocation of encode / decode will also allocate a new actor.
-
 actor Json():
+    """JSON actor for distributed async processing
+
+    This actor can be used to process JSON data in a asynchronous distributed
+    fashion. The `encode` and `decode` methods are identical to the free
+    `encode` and `decode` functions in this module but by being wrapped in an
+    actor, they can be:
+    - called asynchronously
+    - the Json actor can be run by a different worker
+    Thus, by using one or multiple Json actors, the work of encoding or decoding
+    JSON can be distributed across multiple actors / workers / CPUs.
+    """
     action def decode(data: str) -> dict[str, value]:
-        NotImplemented
+        return decode(data)
 
     action def encode(data: dict[str, value]) -> str:
-        NotImplemented
+        return encode(data)
 
 
-def decode(data: str) -> dict[str, value]:
-    j = Json()
-    return j.decode(data)
+mut def decode(data: str) -> dict[str, value]:
+    """Decode a JSON string into a dictionary of values
+    """
+    NotImplemented
 
-def encode(data: dict[str, value]) -> str:
-    j = Json()
-    return j.encode(data)
+mut def encode(data: dict[str, value]) -> str:
+    """Encode a dictionary into a JSON string
+    """
+    NotImplemented

--- a/base/src/json.ext.c
+++ b/base/src/json.ext.c
@@ -94,20 +94,6 @@ void jsonQ_encode_list(yyjson_mut_doc *doc, yyjson_mut_val *node, B_list data) {
     }
 }
 
-$R jsonQ_JsonD_encodeG_local (jsonQ_Json self, $Cont c$cont, B_dict data) {
-    // Create JSON document
-    yyjson_mut_doc *doc = yyjson_mut_doc_new(NULL);
-    yyjson_mut_val *root = yyjson_mut_obj(doc);
-    yyjson_mut_doc_set_root(doc, root);
-
-    // TODO: do the thing
-    jsonQ_encode_dict(doc, root, data);
-
-    char *json = yyjson_mut_write(doc, 0, NULL);
-    //yyjson_doc_free(doc);
-    return $R_CONT(c$cont, to$str(json));
-}
-
 B_list jsonQ_decode_arr(yyjson_val *);
 
 B_dict jsonQ_decode_obj(yyjson_val *obj) {
@@ -211,7 +197,7 @@ B_list jsonQ_decode_arr(yyjson_val *arr) {
     return res;
 }
 
-$R jsonQ_JsonD_decodeG_local (jsonQ_Json self, $Cont c$cont, B_str data) {
+B_dict jsonQ_decode (B_str data) {
     // Read JSON and get root
     yyjson_read_err err;
     yyjson_doc *doc = yyjson_read_opts(fromB_str(data), strlen(fromB_str(data)), 0, NULL, &err);
@@ -229,5 +215,18 @@ $R jsonQ_JsonD_decodeG_local (jsonQ_Json self, $Cont c$cont, B_str data) {
     }
 
     yyjson_doc_free(doc);
-    return $R_CONT(c$cont, res);
+    return res;
+}
+
+B_str jsonQ_encode (B_dict data) {
+    // Create JSON document
+    yyjson_mut_doc *doc = yyjson_mut_doc_new(NULL);
+    yyjson_mut_val *root = yyjson_mut_obj(doc);
+    yyjson_mut_doc_set_root(doc, root);
+
+    jsonQ_encode_dict(doc, root, data);
+
+    char *json = yyjson_mut_write(doc, 0, NULL);
+    //yyjson_doc_free(doc);
+    return to$str(json);
 }

--- a/test/stdlib_auto/test_json.act
+++ b/test/stdlib_auto/test_json.act
@@ -1,31 +1,7 @@
-
 import json
+import testing
 
-actor main(env):
-
-    print("Testing: data -> JSON str -> data")
-    test_data = [
-        {"a": True, "b": False},
-        {"a": "1", "b": 2, "c": 3.1},
-        {"a": {"b": 1, "c": 2, "d": [1, 2], "e": [1.1, 2.2]}},
-        {"a": [1, 2, 3], "b": [1.1, 2.2, 3.3]},
-        {"a": [[1, 2, 3], [1, 2, 3]]},
-        {"a": [{"b": 1, "c": 2, "d": [1, 2]}, {"b": 1, "c": 2, "d": [1, 2]}]},
-    ]
-    for s in test_data:
-        print(s)
-        e = json.encode(s)
-        print(e)
-        d = json.decode(e)
-        print(d)
-#       This fails due to a compiler bug, see https://github.com/actonlang/acton/issues/841
-#        if s is not None and d is not None and s != d:
-#            print("MISMATCH")
-#            await async env.exit(1)
-
-        print()
-
-    print("Testing: JSON str -> data -> JSON str")
+def _test_json():
     test_json = [
         """{"a":true,"b":false}""",
         """{"a":"1","b":2,"c":3.1}""",
@@ -36,14 +12,18 @@ actor main(env):
         """{"a":[{"b":"1","c":2,"d":[1,2]},{"b":"1","c":2,"d":[1,2]}]}""",
     ]
     for s in test_json:
-        print(s)
+        #log.debug("Input string", {"json_str": s})
         d = json.decode(s)
-        print(d)
+        #log.debug("Decoded JSON string to dict", {"dict": d})
+        testing.assertIsNotNone(d, "Failed to decode JSON")
         e = json.encode(d)
-        if s is not None and e is not None and s != e:
-            print("MISMATCH")
-            await async env.exit(1)
+        #log.debug("Encoded to JSON", {"encoded": s})
+        testing.assertIsNotNone(e, "Failed to encode to JSON")
+        testing.assertEqual(s, e, "Input output via JSON round trip does not match")
 
-        print()
+__unit_tests: dict[str, testing.UnitTest] = {
+    "_test_json": testing.UnitTest(_test_json, "json", "Decode JSON [str, bool]"),
+}
 
-    await async env.exit(0)
+actor main(env):
+    testing.unit_test_runner(env, __unit_tests)


### PR DESCRIPTION
The JSON encode and decode functions were implemented as methods on an Actor due to an actonc bug where NotImplemented simply wasn't recognized for free functions. This design was never the intended one but a side effect of this actonc limitation. The json.encode() function instantiated the Json actor and called Json.encode() so the functionality of calling the encode function was possible just that it involved creating an actor and so required quite a bit of extra overhead than necessary.

Another consequence was that the encode() function got the effect proc, since it creates an actor, and of course any calling could would be CPS split. The unit testing functionality offered by the testing module requires mut() effect so we can't use it to test JSON encoding or test any function that in turn deals with JSON.

So, now I've finally swapped these around so the real encode/decode happens in the free functions encode() & decode() in the module. The Json ator still remains but now act as a thin outer shell for doing async style processing of JSON.