### PR TITLE
Do -fPIC for all deps

### DIFF
--- a/compiler/stack.yaml
+++ b/compiler/stack.yaml
@@ -43,4 +43,4 @@ extra-deps: [Cabal-3.10.1.0,Cabal-syntax-3.10.1.0,dir-traverse-0.2.3.0,directory
 # system-ghc: true
 
 ghc-options:
-  "unix": -fPIC
+  "*": -fPIC


### PR DESCRIPTION
Not that I've seen any direct issues on this branch, there were build issues on Ubuntu with LTS 20.26 that might be due to inconsistency compilation flags. It's probably best to keep consistent compilation options for all dependencies.