### PR TITLE
Revert "Use per-thread malloc"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -218,7 +218,7 @@ dist/depsout/lib/libbsdnt.a: dist/deps/libbsdnt $(DIST_ZIG)
 	cd $< && $(ZIG) build $(ZIG_TARGET) --prefix $(TD)/dist/depsout
 
 # /deps/libgc --------------------------------------------
-LIBGC_REF=6d884227b4db1f5bd3e09a86e65a1caed32f3174
+LIBGC_REF=ead2119801a6659d1d78406563d5acc6df4d94e3
 deps-download/$(LIBGC_REF).tar.gz:
 	mkdir -p deps-download
 	curl -f -L -o $@ https://github.com/actonlang/bdwgc/archive/$(LIBGC_REF).tar.gz


### PR DESCRIPTION
This reverts commit 1f7fcf3db5bf17ce988803edd29cfff585c12927.

The per thread malloc seems to cause hangs, so we need to disable it for now and bring it back in in an order fashion.

I've been running the rts_db/test_tcp_client application repeatedly and it keeps hanging in about 25% of cases with per thread malloc whereas it always works without it.