### PR TITLE
Avoid DNS lookup in testing

### DIFF
--- a/test/rts_db/ddb_test_client.act
+++ b/test/rts_db/ddb_test_client.act
@@ -28,6 +28,6 @@ actor main(env):
     def connect():
         attempts += 1
         connect_cap = net.TCPConnectCap(net.TCPCap(net.NetCap(env.cap)))
-        client = net.TCPConnection(connect_cap, "localhost", port, on_connect, on_receive, on_error)
+        client = net.TCPConnection(connect_cap, "127.0.0.1", port, on_connect, on_receive, on_error)
 
     connect()

--- a/test/rts_db/test_tcp_client.act
+++ b/test/rts_db/test_tcp_client.act
@@ -35,7 +35,7 @@ actor Client(connect_auth, port: int):
     def on_error(c, msg):
         print("Client ERR", msg)
 
-    client = net.TCPConnection(connect_auth, "localhost", port, on_connect, on_receive, on_error)
+    client = net.TCPConnection(connect_auth, "127.0.0.1", port, on_connect, on_receive, on_error)
 
     def write(data: bytes):
         client.write(data)
@@ -229,7 +229,7 @@ actor Tester(env, verbose, port_chunk):
                 log("TCP client app exited, doing our TCP client to increase counter...")
                 if exit_code == 0 and term_signal == 0:
                     state = 2
-                    tcp_client = net.TCPConnection(connect_auth, "localhost", port, tcpc_on_connect, tcpc_on_receive, tcpc_on_error)
+                    tcp_client = net.TCPConnection(connect_auth, "127.0.0.1", port, tcpc_on_connect, tcpc_on_receive, tcpc_on_error)
 
             if state == 4:
                 if exit_code == 0 and term_signal == 0:


### PR DESCRIPTION
I suspect a bug related to DNS lookups that hits us on MacOS. We already have stdlib_auto/test_net_dns.act that does DNS lookups and that seems to work just fine, but continuously running test/rts_db/test_tcp_client results in a lot of SIGILL and SIGSEGV on MacOS. We are doing DNS lookups both in the program under test, ddb_test_client, but also in the test_tcp_client app test orchestrator itself, which seem to account for most of the failures and since it's the app test runner, its crashing have weird effects and cannot be easily handled. I don't know why but it somehow seems to be hanging, so running it in a bash for loop, I still need to ctrl+c it and in CI we hit the timeout in GitHub Actions (6 hours) rather than it just failing.

I've looked quickly at the backtrace and it seems we crash in _lookup_a__on_resolve. The DNS query has failed with status -3008 and error message "DNS lookup error: unknown node or service". Now obviously a failed DNS lookup shouldn't lead to a crash, but it seems like the on_error callbak that we store in the data struct passed via the libuv DNS query struct is NULL. I don't see how can that be, since it is unconditionally set when we send in the request. Perhaps a bug in libuv? Maybe add some asserts here? Annoying that we have to guard against bugs in these APIs, I'd expect them to be fairly mature by now.

Switching to an IP address works around the issue by avoiding the DNS lookup. We obviously want a proper fix but in the meantime it's better with working CI etc.