### PR TITLE
Use -tip as version number

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -356,9 +356,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           replacesArtifacts: true
       - name: "Remove version number from darwin tar ball"
-        run: mv $(ls acton-darwin*.tar.xz | tail -n1) acton-darwin-x86_64.tar.xz
+        run: mv $(ls acton-darwin*.tar.xz | tail -n1) acton-darwin-x86_64-tip.tar.xz
       - name: "Remove version number from linux tar ball"
-        run: mv $(ls acton-linux-x86_64*.tar.xz | tail -n1) acton-linux-x86_64.tar.xz
+        run: mv $(ls acton-linux-x86_64*.tar.xz | tail -n1) acton-linux-x86_64-tip.tar.xz
       - name: "Remove version number from debian package"
         run: mv $(ls deb/acton_*.deb | tail -n1) deb/acton_tip_amd64.deb
       - name: "List files for debug"


### PR DESCRIPTION
To keep a consistent style, add in -tip where we would normally have the version number. For example:

 https://github.com/actonlang/acton/releases/download/v0.17.0/acton-linux-x86_64-0.17.0.tar.xz
 https://github.com/actonlang/acton/releases/download/tip/acton-linux-x86_64-tip.tar.xz

Whereas we used to have

 https://github.com/actonlang/acton/releases/download/tip/acton-linux-x86_64.tar.xz