### PR TITLE
Improve DNS error handling

### DIFF
--- a/base/src/net.act
+++ b/base/src/net.act
@@ -101,7 +101,8 @@ actor TCPConnection(cap: TCPConnectCap, address: str, port: int, on_connect: act
         _connect4(result[0])
 
     def _on_dns_a_error(name, msg):
-        _lookup_a(address, _on_dns_a_resolve, _on_dns_a_error)
+        if _state == STATE_RESOLVING:
+            after 0.1: _lookup_a(address, _on_dns_a_resolve, _on_dns_a_error)
 
     # DNS AAAA
     def _on_dns_aaaa_resolve(result):
@@ -111,7 +112,8 @@ actor TCPConnection(cap: TCPConnectCap, address: str, port: int, on_connect: act
         _connect6(result[0])
 
     def _on_dns_aaaa_error(name, msg):
-        _lookup_aaaa(address, _on_dns_aaaa_resolve, _on_dns_aaaa_error)
+        if _state == STATE_RESOLVING:
+            after 0.1: _lookup_aaaa(address, _on_dns_aaaa_resolve, _on_dns_aaaa_error)
 
     action def _on_tcp_error(sockfamily: int, err: int, errmsg: str):
         if sockfamily == 4:


### PR DESCRIPTION
If we get a DNS resolution error, we now check if we are still in the resolving state. If not, like if we have already connected or are in some other state where this is not relevant any longer, we don't do anything. If we are still in the resolving state, we retry the DNS lookup after 0.1 seconds.

Previously we would just retry immediately, which would lead to loads of busy work. For example, if there is no AAAA record at all, we would just continue retrying the AAAA lookup for all future, so even when the IPv4 connection has established and TCP is working properly, the TCP actor would just retry the AAAA lookup. This could consume 50% - 75% of a CPU core!