### PR TITLE
Improve http.Client connection handling

### DIFF
--- a/base/builtin/registration.c
+++ b/base/builtin/registration.c
@@ -79,6 +79,7 @@ void $register_builtin() {
   $register_force(MEMORYERROR_ID,&B_MemoryErrorG_methods);
   $register_force(OSERROR_ID,&B_OSErrorG_methods);
   $register_force(RUNTIMEERROR_ID,&B_RuntimeErrorG_methods);
+  $register_force(CONNECTIONERROR_ID,&B_ConnectionErrorG_methods);
   $register_force(NOTIMPLEMENTEDERROR_ID,&B_NotImplementedErrorG_methods);
   $register_force(VALUEERROR_ID,&B_ValueErrorG_methods);
   //  $register_builtin_protocols();

--- a/base/builtin/registration.h
+++ b/base/builtin/registration.h
@@ -54,22 +54,23 @@
 #define             KEYERROR_ID                 39
 #define         MEMORYERROR_ID                  40
 #define         OSERROR_ID                      41
-#define         RUNTIMEERROR_ID                 42
-#define             NOTIMPLEMENTEDERROR_ID      43
-#define         VALUEERROR_ID                   44
+#define             CONNECTIONERROR_ID          42
+#define         RUNTIMEERROR_ID                 43
+#define             NOTIMPLEMENTEDERROR_ID      44
+#define         VALUEERROR_ID                   45
 
-#define PROC_ID 45
-#define ACTION_ID 46
-#define MUT_ID 47
-#define PURE_ID 48
+#define PROC_ID 46
+#define ACTION_ID 47
+#define MUT_ID 48
+#define PURE_ID 49
 
-#define SEQ_ID 49
-#define BRK_ID 50
-#define CNT_ID 51
-#define RET_ID 52
+#define SEQ_ID 50
+#define BRK_ID 51
+#define CNT_ID 52
+#define RET_ID 53
 
 
-#define PREASSIGNED 53
+#define PREASSIGNED 54
 
 
 /* 

--- a/base/src/__builtin__.act
+++ b/base/src/__builtin__.act
@@ -344,6 +344,9 @@ class MemoryError (Exception):
 class OSError (Exception):
     pass
 
+class ConnectionError (OSError):
+    pass
+
 class RuntimeError (Exception):
     pass
 

--- a/base/src/http.act
+++ b/base/src/http.act
@@ -513,6 +513,10 @@ actor Client(cap: net.TCPConnectCap, scheme: str, address: str, port: ?int, tls_
                 if "connection" in r.headers and r.headers["connection"] == "close":
                     # Is this really the right thing to do here? If the client
                     # does not make a new request we just reconnected for nothing!
+                    # TODO: inspect the _on_response queue to see if there are more requests
+                    # TODO: for HTTP/1.0 do not reconnect right after the first
+                    # request, wait until the 2nd query and then assume there
+                    # will be more.
                     _log.debug("Closing TCP connection due to header: Connection: close", None)
                     _conn_reconnect()
                 if len(_on_response) == 0:

--- a/base/src/http.act
+++ b/base/src/http.act
@@ -557,13 +557,10 @@ actor Client(cap: net.TCPConnectCap, scheme: str, address: str, port: ?int, tls_
                 await async tcp_conn.write(data)
             elif tls_conn is not None:
                 await async tls_conn.write(data)
-        except RuntimeError as exc:
+        except ConnectionError as exc:
             # HTTP/1.0 servers close the connection after each request by default
-            if "bad file descriptor" in str(exc) or "bad stream" in str(exc):
-                _log.debug("TCP connection closed, reconnecting", {"error": str(exc)})
-                _conn_reconnect()
-            else:
-                _on_con_error(str(exc))
+            _log.debug("TCP connection closed, reconnecting", {"error": str(exc)})
+            _conn_reconnect()
 
     # HTTP methods
     def get(path: str, headers: dict[str, str], on_response: action(Client, Response) -> None):

--- a/base/src/http.act
+++ b/base/src/http.act
@@ -447,6 +447,7 @@ actor Listener(cap: net.TCPListenCap, address: str, port: int, on_listen_error: 
 # TODO: default schema="https"
 # TODO: default port=None
 # TODO: default tls_verify=True
+# TODO: add arguments for configuring request buffering (size) and reconnection attempts and timeouts
 actor Client(cap: net.TCPConnectCap, scheme: str, address: str, port: ?int, tls_verify: bool, on_connect: action(Client) -> None, on_error: action(Client, str) -> None, log_handler: ?logging.Handler):
     """HTTP(S) Client
 
@@ -457,9 +458,10 @@ actor Client(cap: net.TCPConnectCap, scheme: str, address: str, port: ?int, tls_
     var _on_response: list[(bytes, action(Client, Response) -> None)] = []
     var version: ?bytes = None
     var buf = b""
-    var close_connection: bool = True
     var tcp_conn: ?net.TCPConnection = None
     var tls_conn: ?net.TLSConnection = None
+
+    var connecting: bool = True
 
     def _connect():
         if scheme == "http":
@@ -475,9 +477,18 @@ actor Client(cap: net.TCPConnectCap, scheme: str, address: str, port: ?int, tls_
 
     def _on_conn_connect():
         # If there are outstanding requests, it probably means we were
+        # disconnected or have not connected yet
+        # TODO: do not flush entire buffer if we know the server will close the
+        # connection. If the latency is so big that we're able to send the
+        # entire buffer before the server closes the connection we're just
+        # wasting resources.
         for r in _on_response:
+            _log.trace("Sending outstanding request", {"request": r.0})
             _conn_write(r.0)
-        await async on_connect(self)
+        if connecting:
+            # Dispatch the on_connect callback on first connect but not for reconnects
+            await async on_connect(self)
+            connecting = False
 
     def _on_tcp_connect(conn: net.TCPConnection) -> None:
         _on_conn_connect()
@@ -500,10 +511,10 @@ actor Client(cap: net.TCPConnectCap, scheme: str, address: str, port: ?int, tls_
             r, buf = parse_response(buf, _log)
             if r is not None:
                 if "connection" in r.headers and r.headers["connection"] == "close":
-                    close_connection = True
-                    _conn_close()
+                    # Is this really the right thing to do here? If the client
+                    # does not make a new request we just reconnected for nothing!
                     _log.debug("Closing TCP connection due to header: Connection: close", None)
-                    _connect()
+                    _conn_reconnect()
                 if len(_on_response) == 0:
                     _log.notice("Data received with no on_response callback set", None)
                     break
@@ -524,22 +535,31 @@ actor Client(cap: net.TCPConnectCap, scheme: str, address: str, port: ?int, tls_
     def _on_con_error(error: str) -> None:
         on_error(self, error)
 
-    def _conn_close() -> None:
+    def _conn_reconnect() -> None:
         if tcp_conn is not None:
-            def _noop(c):
-                pass
-            tcp_conn.close(_noop)
+            tcp_conn.reconnect()
         elif tls_conn is not None:
-            def _noop(c):
-                pass
-            tls_conn.close(_noop)
+            tls_conn.reconnect()
 
     def _conn_write(data: bytes) -> None:
-        _log.trace("Sending data", {"data": data})
-        if tcp_conn is not None:
-            tcp_conn.write(data)
-        elif tls_conn is not None:
-            tls_conn.write(data)
+        try:
+            _log.trace("Sending data", {"data": data})
+            # We call the write method on the TCP or TLS connection actor
+            # synchronously because we want to be able to catch exceptions
+            # signaling the socket was closed. Note that this is *not* waiting
+            # for network I/O, just waiting on system I/O for writing to the
+            # local socket buffer.
+            if tcp_conn is not None:
+                await async tcp_conn.write(data)
+            elif tls_conn is not None:
+                await async tls_conn.write(data)
+        except RuntimeError as exc:
+            # HTTP/1.0 servers close the connection after each request by default
+            if "bad file descriptor" in str(exc) or "bad stream" in str(exc):
+                _log.debug("TCP connection closed, reconnecting", {"error": str(exc)})
+                _conn_reconnect()
+            else:
+                _on_con_error(str(exc))
 
     # HTTP methods
     def get(path: str, headers: dict[str, str], on_response: action(Client, Response) -> None):


### PR DESCRIPTION
If the (HTTPS) server closes the socket on us after a response, the stream becomes invalid. Let's communicate that to the user (http.Client) by ~~calling on_error~~. The user (http.Client) can automatically reconnect and resend the failed requests without any intervention from the actors further up the stack.

The HTTP(S) server closing the socket is perfectly valid behavior for HTTP/1.0. Users of http.Client do not have to do anything, they just get the response as expected.