### PR TITLE
Only print truly unhandled exceptions

### DIFF
--- a/base/rts/rts.c
+++ b/base/rts/rts.c
@@ -1574,9 +1574,15 @@ void wt_work_cb(uv_check_t *ev) {
             } else {                            // An unhandled exception
                 save_actor_state(current, m);
                 B_BaseException ex = (B_BaseException)r.value;
-                fprintf(stderr, "Unhandled exception in actor: %s[%ld]]:\n  %s\n", unmangle_name(current->$class->$GCINFO), current->$globkey, fromB_str(ex->$class->__str__(ex)));
                 m->value = r.value;                                 // m->value holds the raised exception,
                 $Actor b = FREEZE_waiting(m, MARK_EXCEPTION);       // so mark this and stop further m->waiting additions
+                // If any other actor is waiting for our result / exception,
+                // then we consider the exception handled and we can avoid
+                // printing the exception both in the originating actor and in
+                // the waiting actor. Thus we only print Unhandled exception in
+                // the originating actor when there is no one waiting for us.
+                if (!b)
+                    fprintf(stderr, "Unhandled exception in actor: %s[%ld]]:\n  %s\n", unmangle_name(current->$class->$GCINFO), current->$globkey, fromB_str(ex->$class->__str__(ex)));
                 while (b) {
                     b->B_Msg->$cont = &$Fail$instance;
                     b->B_Msg->value = r.value;


### PR DESCRIPTION
Previously unhandled exceptions would bubble up and be printed both in the actor where the exception was raised as well as in another actor that called the method raising the exception. Given this program:

    actor Foo():
        def foo():
            print("FOO")
            raise ValueError("FOO")

    actor main(env):
        f = Foo()
        a = f.foo()

We would see:

    FOO
    Unhandled exception in actor: foo.Foo[-14]]:
      ValueError: FOO
    Unhandled exception in actor: foo.main[-12]]:
      ValueError: FOO

Since the Foo.foo() method is actually "returning" the exception back to the main actor (the return value is assigned in the main actor), it should not be considered "unhandled" in the Foo actor where it is raised.

We now check if there are other actors waiting for us, in which case we consider the exception handled since we propagate it back. Thus, the output for the above program is now:

    FOO
    Unhandled exception in actor: foo.main[-12]]:
      ValueError: FOO

And a proper program should obviously try/except that exception.

There are sneaky cases where we would still print the unhandled exception in the originating actor, like if the program looks like this:

    actor Foo():
        def foo():
            print("FOO")
            raise ValueError("FOO")

    actor main(env):
        f = Foo()
        m = async f.foo()

        def blargh():
            # This function is called later
            await m

We could potentially find out through slightly more analysis in the compiler. For the time being though, it is what it is. It's rather unlikely someone would write this by mistake though and thus missing an exception by mistake.