### PR TITLE
Add type()

### DIFF
--- a/base/src/__builtin__.act
+++ b/base/src/__builtin__.act
@@ -884,6 +884,17 @@ def gcd(a : int, b : int) -> int:
 def xgcd(a : int, b : int) -> (int, int, int):
     NotImplemented
 
+def type(a: value) -> str:
+    """Get the name of the type of something as a string
+
+    Do not use this for meta-programming. Use isinstance().
+
+    This is only meant for development use as an alternative to letting actonc
+    print inferred types and similar. It will be removed in a future version
+    when there are better ways to debug types.
+    """
+    NotImplemented
+
 ## Environment ################################################
 
 class WorldCap():

--- a/base/src/__builtin__.ext.c
+++ b/base/src/__builtin__.ext.c
@@ -21,3 +21,7 @@ void B___ext_init__() {
 B_str B_BaseExceptionD__name (B_BaseException self) {
     return to$str(unmangle_name(self->$class->$GCINFO));
 }
+
+B_str B_type(B_value a) {
+    return to$str(unmangle_name(a->$class->$GCINFO));
+}


### PR DESCRIPTION
Johan Nordlander hates type() - it should not be used for metaprogramming... but I find it damn helpful as a debug tool. I print types and work with that :) Maybe a "print_type" could fix this, which directly prints to stdout instead of returning a str, that way it's impossible to use for metaprogramming but anyhow, let's go for this. We'll try to remove it in the future when we have other better means of debugging types, like a language server or similar.