### PR TITLE
Support no-threads RTS mode

### DIFF
--- a/backend/build.zig
+++ b/backend/build.zig
@@ -5,6 +5,7 @@ const ArrayList = std.ArrayList;
 pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
+    const no_threads = b.option(bool, "no_threads", "") orelse false;
     const syspath_include = b.option([]const u8, "syspath_include", "") orelse "";
 
     const dep_libargp = b.anonymousDependency("deps/libargp", @import("deps/libargp/build.zig"), .{
@@ -63,6 +64,18 @@ pub fn build(b: *std.Build) void {
     file_prefix_map.appendSlice(file_prefix_path_path) catch unreachable;
     file_prefix_map.appendSlice("/=") catch unreachable;
     flags.append(file_prefix_map.items) catch unreachable;
+
+    if (no_threads) {
+        print("No threads\n", .{});
+    } else {
+        print("Threads enabled\n", .{});
+        flags.appendSlice(&.{
+            "-DACTON_THREADS",
+        }) catch |err| {
+            std.log.err("Error appending flags: {}", .{err});
+            std.os.exit(1);
+        };
+    }
 
     const libactondb = b.addStaticLibrary(.{
         .name = "ActonDB",

--- a/backend/client_api.c
+++ b/backend/client_api.c
@@ -181,7 +181,11 @@ remote_db_t * get_remote_db(int replication_factor, int rack_id, int dc_id, char
     db->stop_comm = 0;
     int r = pipe(db->wakeup_pipe);
 
+#ifdef ACTON_THREADS
     assert(pthread_create(&(db->comm_thread), NULL, comm_thread_loop, db) == 0);
+#else
+    assert(1==0 && "DB client API not supported in single-threaded mode!");
+#endif
 
     db->my_lc = init_empty_vc();
     db->current_view_id = NULL;
@@ -1089,7 +1093,9 @@ int update_lc_protected(remote_db_t * db, vector_clock * vc_in)
 int close_remote_db(remote_db_t * db)
 {
     db->stop_comm = 1;
+#ifdef ACTON_THREADS
     pthread_join(db->comm_thread, NULL);
+#endif
 
     for(snode_t * crt = HEAD(db->servers); crt!=NULL; crt = NEXT(crt))
     {

--- a/base/build.zig
+++ b/base/build.zig
@@ -57,6 +57,7 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const cpedantic = b.option(bool, "cpedantic", "") orelse false;
     const use_db = b.option(bool, "db", "") orelse false;
+    const no_threads = b.option(bool, "no_threads", "") orelse false;
     const syspath = b.option([]const u8, "syspath", "") orelse "";
     const libactondeps = b.option([]const u8, "libactondeps", "") orelse "";
     const libactongc = b.option([]const u8, "libactongc", "") orelse "";
@@ -172,6 +173,18 @@ pub fn build(b: *std.Build) void {
     if (use_db) {
         print("Building with DB backend support\n", .{});
         flags.append("-DACTON_DB") catch unreachable;
+    }
+
+    if (no_threads) {
+        print("No threads\n", .{});
+    } else {
+        print("Threads enabled\n", .{});
+        flags.appendSlice(&.{
+            "-DACTON_THREADS",
+        }) catch |err| {
+            std.log.err("Error appending flags: {}", .{err});
+            std.os.exit(1);
+        };
     }
 
     const libActon = b.addStaticLibrary(.{

--- a/base/rts/io.c
+++ b/base/rts/io.c
@@ -1,4 +1,6 @@
+#ifdef ACTON_THREADS
 #define GC_THREADS 1
+#endif
 #include <gc.h>
 
 #include "io.h"
@@ -12,7 +14,7 @@
 extern char rts_exit;
 
 uv_loop_t *get_uv_loop() {
-    WorkerCtx wctx = (WorkerCtx)pthread_getspecific(pkey_wctx);
+    WorkerCtx wctx = GET_WCTX();
     return (uv_loop_t *)wctx->uv_loop;
 }
 

--- a/base/rts/log.c
+++ b/base/rts/log.c
@@ -20,10 +20,16 @@
  * IN THE SOFTWARE.
  */
 
+#ifdef ACTON_THREADS
+#include <pthread.h>
+#endif
+
 #include "log.h"
 
 #define MAX_CALLBACKS 32
+#ifdef ACTON_THREADS
 static pthread_mutex_t l_mutex;
+#endif
 
 typedef struct {
   log_LogFn fn;
@@ -52,8 +58,10 @@ static const char *level_colors[] = {
 
 static void stdout_callback(log_Event *ev) {
   // Get a short thread name
-  char tname[16];
+  char tname[16] = "";
+#ifdef ACTON_THREADS
   pthread_getname_np(pthread_self(), tname, 16);
+#endif
   if (strncmp(tname, "IO", 6) == 0) {
   } else if (strncmp(tname, "Worker", 6) == 0) {
     strncpy(tname, &tname[7], 4);
@@ -83,7 +91,9 @@ static void stdout_callback(log_Event *ev) {
 static void file_callback(log_Event *ev) {
   // Get a short thread name
   char tname[16];
+#ifdef ACTON_THREADS
   pthread_getname_np(pthread_self(), tname, 16);
+#endif
   if (strncmp(tname, "IO", 6) == 0) {
   } else if (strncmp(tname, "Worker", 6) == 0) {
     strncpy(tname, &tname[7], 4);
@@ -104,12 +114,16 @@ static void file_callback(log_Event *ev) {
 
 
 static void lock(void)   {
+#ifdef ACTON_THREADS
   pthread_mutex_lock(&l_mutex);
+#endif
 }
 
 
 static void unlock(void) {
+#ifdef ACTON_THREADS
   pthread_mutex_unlock(&l_mutex);
+#endif
 }
 
 

--- a/base/rts/log.h
+++ b/base/rts/log.h
@@ -14,7 +14,6 @@
 #endif
 #endif
 
-#include <pthread.h>
 #include <stdio.h>
 #include <stdarg.h>
 #include <stdbool.h>
@@ -23,8 +22,6 @@
 #include "../rts/rts.h"
 
 #define LOG_VERSION "0.1.0"
-
-extern pthread_key_t self_key;
 
 typedef struct {
   va_list ap;

--- a/base/rts/q.c
+++ b/base/rts/q.c
@@ -29,7 +29,7 @@ int ENQ_ready($Actor a) {
     rqs[i].count++;
     spinlock_unlock(&rqs[i].lock);
     // If we enqueue to someone who is not us, immediately wake them up...
-    WorkerCtx wctx = (WorkerCtx)pthread_getspecific(pkey_wctx);
+    WorkerCtx wctx = GET_WCTX();
     if (wctx != NULL) {
         long our_wtid = wctx->id;
         if (our_wtid != i)
@@ -52,7 +52,7 @@ int ENQ_ready($Actor a) {
     a->$next = NULL;
     spinlock_unlock(&rqs[i].lock);
     // If we enqueue to someone who is not us, immediately wake them up...
-    WorkerCtx wctx = (WorkerCtx)pthread_getspecific(pkey_wctx);
+    WorkerCtx wctx = GET_WCTX();
     if (wctx != NULL) {
         long our_wtid = wctx->id;
         if (our_wtid != i)

--- a/base/rts/q.h
+++ b/base/rts/q.h
@@ -22,4 +22,4 @@ struct mpmcq {
 };
 #endif
 
-extern struct mpmcq rqs[MAX_WTHREADS+1];
+extern struct mpmcq rqs[NUM_RQS];

--- a/base/src/logging.ext.c
+++ b/base/src/logging.ext.c
@@ -4,11 +4,11 @@ void loggingQ___ext_init__() {
 }
 
 B_int loggingQ_MessageD__get_actor_id (loggingQ_Message self) {
-    $Actor actor_self = ($Actor)pthread_getspecific(self_key);
+    $Actor actor_self = GET_SELF();
     return to$int(actor_self->$globkey);
 }
 
 B_str loggingQ_MessageD__get_actor_class (loggingQ_Message self) {
-    $Actor actor_self = ($Actor)pthread_getspecific(self_key);
+    $Actor actor_self = GET_SELF();
     return to$str(actor_self->$class->$GCINFO);
 }

--- a/compiler/Acton/CommandLineParser.hs
+++ b/compiler/Acton/CommandLineParser.hs
@@ -62,6 +62,7 @@ data CompileOptions   = CompileOptions {
                          dev         :: Bool,
                          only_build  :: Bool,
                          skip_build  :: Bool,
+                         no_threads  :: Bool,
                          root        :: String,
                          tempdir     :: String,
                          syspath     :: String,
@@ -75,6 +76,7 @@ data BuildOptions = BuildOptions {
                          alwaysB     :: Bool,
                          cpedanticB  :: Bool,
                          dbB         :: Bool,
+                         no_threadsB :: Bool,
                          debugB      :: Bool,
                          devB        :: Bool,
                          only_buildB :: Bool,
@@ -156,6 +158,7 @@ compileOptions = CompileOptions
         <*> switch (long "dev"          <> help "Development mode; include debug symbols etc")
         <*> switch (long "only-build"   <> help "Only perform final build of .c files, do not compile .act files")
         <*> switch (long "skip-build"   <> help "Skip final bulid of .c files")
+        <*> switch (long "no-threads"   <> help "Don't use threads")
         <*> strOption (long "root"      <> metavar "ROOTACTOR" <> value "" <> help "Set root actor")
         <*> strOption (long "tempdir"   <> metavar "TEMPDIR" <> value "" <> help "Set directory for build files")
         <*> strOption (long "syspath"   <> metavar "TARGETDIR" <> value "" <> help "Set syspath")
@@ -169,6 +172,7 @@ buildCommand          = Build <$> (
         <$> switch (long "always-build" <> help "Development mode; include debug symbols etc")
         <*> switch (long "cpedantic"    <> help "Pedantic C compilation with -Werror")
         <*> switch (long "db"           <> help "Enable DB backend")
+        <*> switch (long "no-threads"   <> help "Don't use threads")
         <*> switch (long "debug"        <> help "Print debug stuff")
         <*> switch (long "dev"          <> help "Development mode; include debug symbols etc")
         <*> switch (long "only-build"   <> help "Only perform final build of .c files, do not compile .act files")

--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -84,6 +84,7 @@ main = do
           C.db = C.dbB opts,
           C.only_build = C.only_buildB opts,
           C.skip_build = C.skip_buildB opts,
+          C.no_threads = C.no_threadsB opts,
           C.root = C.rootB opts,
           C.ccmd = C.ccmdB opts,
           C.quiet = C.quietB opts,
@@ -101,7 +102,7 @@ main = do
 
 defaultOpts   = C.CompileOptions False False False False False False False False False False False False
                                  False False False False False False False False False False False False
-                                 "" "" "" "" C.defTarget "" False
+                                 False "" "" "" "" C.defTarget "" False
 
 
 -- Auxiliary functions ---------------------------------------------------------------------------------------
@@ -844,6 +845,7 @@ zigBuild env opts paths tasks binTasks = do
                  " -Ddeps_path=" ++ (C.deppath opts) ++
                  " -Doptimize=" ++ (if (C.dev opts) then "Debug" else "ReleaseFast") ++
                  (if (C.db opts) then " -Ddb " else " ") ++
+                 (if (C.no_threads opts) then " -Dno_threads " else " ") ++
                  (if (C.cpedantic opts) then " -Dcpedantic " else " ") ++
                  " -Dsyspath=" ++ sysPath paths
 


### PR DESCRIPTION
This adds a mode for running the RTS without threads. It can be useful on platforms that do not have POSIX threads available, such as WASM.

Since one of the goals is to remove the need for pthreads, this must be chosen at compile time rather than run time. Use the --no-threads flag:

  actonc --no-threads foo.act