### PR TITLE
Improve typeerrormsgs 4

### DIFF
--- a/compiler/Acton/Env.hs
+++ b/compiler/Acton/Env.hs
@@ -490,6 +490,12 @@ findSigLoc n env            = findSL (names env)
              | otherwise          = findSL ps
           findSL []               = Nothing
 
+findDefLoc n env            = findSL (names env)
+    where findSL ((n',t):ps)
+             | NDef{} <- t, n==n' = Just (loc n')
+             | otherwise          = findSL ps
+          findSL []               = Nothing
+
 findName n env              = findQName (NoQ n) env
 
 findAllName n env           = look (names env)
@@ -1215,4 +1221,71 @@ err2 xs s                           = err (loc $ head xs) (s ++ " " ++ prstrs xs
 err3 l xs s                         = err l (s ++ " " ++ prstrs xs)
 
 notYetExpr e                        = notYet (loc e) e
+
+stripQual q                             = [ Quant v [] | Quant v us <- q ]
+
+
+class Simp a where
+    simp                            :: EnvF x -> a -> a
+
+instance (Simp a) => Simp [a] where
+    simp env                        = map (simp env)
+
+instance Simp TSchema where
+    simp env (TSchema l q t)        = TSchema l q' (substIteratively s $ simp env' t)
+      where (q', s)                 = simpQuant env (simp env' q) (tyfree t)
+            env'                    = defineTVars (stripQual q) env
+
+simpQuant env q vs0                 = (subst s [ Quant v ps | Quant v ps <- q2, not $ null ps ], s)
+  where (q1,q2)                     = partition isEX q
+        isEX (Quant v [p])          = length (filter (==v) vs) == 1
+        isEX _                      = False
+        vs                          = concat [ tyfree ps | Quant v ps <- q ] ++ vs0
+        s                           = s1 ++ s2
+        s1                          = [ (v, tCon p) | Quant v [p] <- q1 ]                       -- Inline existentials
+        s2                          = univars `zip` beautyvars                                  -- Beautify univars
+        univars                     = filter univar $ qbound q2
+        beautyvars                  = map tVar $ tvarSupply \\ tvarScope env
+
+instance Simp QBind where
+    simp env (Quant v ps)           = Quant v (simp env ps)
+
+instance Simp WTCon where
+    simp env (w, c)                 = (w, simp env c)
+
+instance Simp (Name, NameInfo) where
+    simp env (n, NSig sc dec)       = (n, NSig (simp env sc) dec)
+    simp env (n, NDef sc dec)       = (n, NDef (simp env sc) dec)
+    simp env (n, NVar t)            = (n, NVar (simp env t))
+    simp env (n, NSVar t)           = (n, NSVar (simp env t))
+    simp env (n, NClass q us te)    = (n, NClass (simp env' q) (simp env' us) (simp env' te))
+      where env'                    = defineTVars (stripQual q) env
+    simp env (n, NProto q us te)    = (n, NProto (simp env' q) (simp env' us) (simp env' te))
+      where env'                    = defineTVars (stripQual q) env
+    simp env (n, NExt q c us te)    = (n, NExt q' (subst s $ simp env' c) (subst s $ simp env' us) (subst s $ simp env' te))
+      where (q', s)                 = simpQuant env (simp env' q) (tyfree c ++ tyfree us ++ tyfree te)
+            env'                    = defineTVars (stripQual q) env
+    simp env (n, NAct q p k te)     = (n, NAct (simp env' q) (simp env' p) (simp env' k) (simp env' te))
+      where env'                    = defineTVars (stripQual q) env
+    simp env (n, i)                 = (n, i)
+
+instance Simp Type where
+    simp env (TCon l c)             = TCon l (simp env c)
+    simp env (TFun l fx p k t)      = TFun l (simp env fx) (simp env p) (simp env k) (simp env t)
+    simp env (TTuple l p k)         = TTuple l (simp env p) (simp env k)
+    simp env (TOpt l t)             = TOpt l (simp env t)
+    simp env (TRow l k n t r)       = TRow l k n (simp env t) (simp env r)
+    simp env t                      = t
+
+instance Simp TCon where
+    simp env (TC n ts)              = TC (simp env n) (simp env ts)
+
+instance Simp QName where
+    simp env (GName m n)
+      | inBuiltin env               = NoQ n
+      | Just m == thismod env       = NoQ n
+    simp env n
+      | not $ null aliases          = NoQ $ head aliases
+      | otherwise                   = n
+      where aliases                 = [ n1 | (n1, NAlias n2) <- names env, n2 == n ]
 

--- a/compiler/Acton/Env.hs
+++ b/compiler/Acton/Env.hs
@@ -484,6 +484,11 @@ findQName (GName m n) env
                                     Nothing -> noItem m n -- error ("## Failed lookup of " ++ prstr n ++ " in module " ++ prstr m)
                                 Nothing -> noModule m -- error ("## Failed lookup of module " ++ prstr m)
 
+findSigLoc n env            = findSL (names env)
+    where findSL ((n',t):ps)
+             | NSig{} <- t, n==n' = Just (loc n')
+             | otherwise          = findSL ps
+          findSL []               = Nothing
 
 findName n env              = findQName (NoQ n) env
 

--- a/compiler/Acton/Syntax.hs
+++ b/compiler/Acton/Syntax.hs
@@ -253,9 +253,9 @@ data Constraint = Cast  {info :: ErrInfo, type1 :: Type, type2 :: Type}
 
 type Constraints = [Constraint] 
 
-data ErrInfo    = DfltInfo {errloc :: SrcLoc, ident :: Int, iexpr :: Maybe Expr, typings :: [(Name,TSchema,Type)]}
-                | DeclInfo {errloc :: SrcLoc, otherloc :: SrcLoc, idecl :: Decl, itype :: Type, imsg :: String}
-                | Simple {errloc ::SrcLoc, imsg :: String}
+data ErrInfo    = DfltInfo {errloc :: SrcLoc, errno :: Int, errexpr :: Maybe Expr, errinsts :: [(QName,TSchema,Type)]}
+                | DeclInfo {errloc :: SrcLoc, errloc2 :: SrcLoc, errname :: Name, errschema :: TSchema, errmsg :: String}
+                | Simple {errloc ::SrcLoc, errmsg :: String}
                 deriving (Eq,Show,Read,Generic,NFData)
                 
 type WPath      = [Either QName QName]

--- a/compiler/Acton/Syntax.hs
+++ b/compiler/Acton/Syntax.hs
@@ -589,12 +589,12 @@ instance HasLoc ErrInfo where
       loc (DeclInfo l _ _ _ _) = l
       
 instance HasLoc PosArg where
-      loc (PosArg e p) = loc e
+      loc (PosArg e p) = loc e  `upto` loc p
       loc (PosStar e)  = loc e
       loc PosNil       = NoLoc
 
 instance HasLoc KwdArg where
-      loc (KwdArg n e p) = loc n `upto` loc e
+      loc (KwdArg n e k) = loc n `upto` loc k
       loc (KwdStar e)    = loc e
       loc KwdNil         = NoLoc
 

--- a/compiler/Acton/TypeM.hs
+++ b/compiler/Acton/TypeM.hs
@@ -169,9 +169,9 @@ explainRequirement b c                = case info c of
                                           DfltInfo l n mbe ts ->
                                              (if ts /= []
                                               then text (concatMap (\(n,s,t) -> Pretty.print n ++ " has had its polymorphic type "
-                                                            ++  Pretty.print s ++ " instantiated to " ++ Pretty.print t) ts++", so")  
+                                                            ++  Pretty.print s ++ " instantiated to " ++ Pretty.print t) ts++", so ")  
                                                                     
-                                              else empty) $+$ 
+                                              else empty) Pretty.<> 
                                                (case c of
                                                    Cast _ t1 t2 -> intro b t1 mbe <+> text "must be a subclass of" <+> pretty t2
                                                    Sub i _ t1 t2 -> intro b t1 mbe <+> text "must be a subtype of" <+> pretty t2 
@@ -239,5 +239,9 @@ noRed c                             = throwError $ NoRed c
 noSolve mbt vs cs                   = throwError $ NoSolve mbt vs cs
 noUnify info t1 t2                  = throwError $ NoUnify info t1 t2
 
-posElemNotFound True info n         = throwError $ PosElemNotFound info "Too few positional elements"
-posElemNotFound False info n        = throwError $ PosElemNotFound info "Too many positional elements"
+posElemNotFound True c n            = case info c of
+                                        DeclInfo{} -> throwError $ NoRed (c{info = (info c){errmsg = errmsg(info c)++" (too few arguments in call)"}})
+                                        info          -> throwError $ PosElemNotFound info "Too few positional elements"
+posElemNotFound False c n           = case info c of
+                                        DeclInfo{} -> throwError $ NoRed  (c{info = (info c){errmsg = errmsg(info c)++" (too many arguments in call)"}})
+                                        info          -> throwError $ PosElemNotFound info "Too many positional elements"

--- a/compiler/Acton/TypeM.hs
+++ b/compiler/Acton/TypeM.hs
@@ -162,14 +162,14 @@ explainViolation c                   = case info c of
                                                   Impl _ _ t p -> intro False t mbe <+> text "does not implement" <+> pretty p
                                                   Sel _ _ t n t0 -> intro False t mbe <+> text "does not have an attribute" <+> pretty n <+> text "with type" <+> pretty t0
                                                   _ -> pretty c <+> text "does not hold") 
-                                          DeclInfo _ _ _ t msg -> text msg $+$ text "Function inferred to have type"<+> pretty t
+                                          DeclInfo _ _ n sc msg -> text msg $+$ pretty n <+> text "is inferred to have a type of the form"<+> pretty sc
 
 explainRequirement b c                = case info c of
                                           Simple l s -> text s
                                           DfltInfo l n mbe ts ->
                                              (if ts /= []
                                               then text (concatMap (\(n,s,t) -> Pretty.print n ++ " has had its polymorphic type "
-                                                            ++  Pretty.print s ++ " instantiated to " ++ Pretty.print t) ts++", so")  -- s is printed with internal typevars, not A, B...
+                                                            ++  Pretty.print s ++ " instantiated to " ++ Pretty.print t) ts++", so")  
                                                                     
                                               else empty) $+$ 
                                                (case c of
@@ -179,7 +179,7 @@ explainRequirement b c                = case info c of
                                                    Sel _ _ t n t0 -> intro b t mbe <+> text "must have an attribute" <+> pretty n <+> text "with type" <+> pretty t0
                                                                           Pretty.<> text "; no such type is known."
                                                    _ -> pretty c <+> text "must hold")  
-                                          DeclInfo _ _ _ t msg -> text msg  $+$ text "Function inferred to have type"<+> pretty t
+                                          DeclInfo _ _ n sc msg -> text msg  $+$ pretty n <+> text "is inferred to have a type of the form"<+> pretty sc
 
 
 
@@ -208,17 +208,15 @@ typeError (NoMut n)                  = [(loc n, render (text "Non @property attr
 typeError (LackSig n)                = [(loc n, render (text "Declaration lacks accompanying signature"))]
 typeError (LackDef n)                = [(loc n, render (text "Signature lacks accompanying definition"))]
 typeError (NoRed c)
-    | DeclInfo l1 l2 _ t _ <- info c = [(l1,""), (l2,render (explainViolation c))]
+    | DeclInfo l1 l2 _ _ _ <- info c = [(l1,""), (l2,render (explainViolation c))]
     | otherwise                      = [(loc c, render (explainViolation c))]
 typeError (NoSolve mbt vs cs)        = case length cs of
                                            0 -> [(NoLoc, "Unable to give good error message: please report example")]
                                            1 ->  (NoLoc, "Cannot satisfy the following constraint:\n") : map (mkReq False) cs
                                            _ ->  (NoLoc, "Cannot satisfy the following simultaneous constraints for the unknown "
                                                          ++ (if length vs==1 then "type " else "types ") ++ render(commaList vs)  ++":\n")
-                                                : map (mkReq True) (cs2++cs1)
-         where mkReq b c             = (newLoc c, render (explainRequirement b c))
-               (cs1,cs2)             = partition (\c -> null $ typings(info c)) cs
-               newLoc c              = if null (typings (info c)) then loc c else loc(fst3(head(typings (info c))))
+                                                : map (mkReq True) cs
+         where mkReq b c             = (loc c, render (explainRequirement b c))
                fst3 (a,_,_)          = a
 
 typeError (NoUnify info t1 t2)       = case (loc t1, loc t2) of

--- a/compiler/Utils.hs
+++ b/compiler/Utils.hs
@@ -28,7 +28,9 @@ import Prelude hiding((<>))
 
 data SrcLoc                     = Loc Int Int | NoLoc deriving (Eq,Ord,Show,Read,Generic,NFData)
 
-instance Data.Binary.Binary SrcLoc 
+instance Data.Binary.Binary SrcLoc -- where
+--    put _ = return ()
+--    get   = return NoLoc
 
 instance Pretty SrcLoc where
     pretty (Loc l r)            = pretty l <> text "-" <> pretty r
@@ -127,7 +129,7 @@ errReport ((SpanPoint file row col,msg) : ps) src
         line2                   = replicate (length rowstr+1) ' '++"|"
         line3                   = rowstr ++ " |" ++ lines src!!!(row-1)
         line4                   = replicate (length rowstr+1) ' '++"|"++replicate (col-1) ' '++"^"
-errReport ((SpanEmpty,msg) : ps) src = msg ++ errReport ps src
+errReport ((SpanEmpty,msg) : ps) src = '\n' : msg ++ errReport ps src
 errReport [] _                  = errSep
 
 lst !!! ix | ix >= length lst   = lst !! 0

--- a/test/typeerrors/ex1.golden
+++ b/test/typeerrors/ex1.golden
@@ -6,7 +6,13 @@ ERROR: Error when compiling ex1 module: Type error
   |
 4 |a = f(3)
   |    ^^^^
-Too few positional elements
+
+
+  |
+1 |def f(x,y):
+  |    ^
+Type incompatibility between definition of and call of f (too few arguments in call)
+f is inferred to have a type of the form [A(Plus)] => _(A, A) -> A
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 

--- a/test/typeerrors/ex11.golden
+++ b/test/typeerrors/ex11.golden
@@ -6,7 +6,13 @@ ERROR: Error when compiling ex11 module: Type error
   |
 4 |a = f([8])
   |    ^^^^^^
-The type of f([8]) is not a subclass of __builtin__.str
+
+
+  |
+1 |def f(s):
+  |    ^
+Type incompatibility between definition of and call of f
+f is inferred to have a type of the form _(__builtin__.str) -> __builtin__.str
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 

--- a/test/typeerrors/ex12.golden
+++ b/test/typeerrors/ex12.golden
@@ -2,6 +2,7 @@ Building file ../test/typeerrors/ex12.act
   Compiling ex12.act for release
 
 ERROR: Error when compiling ex12 module: Type error
+
 Cannot satisfy the following constraint:
 
   |

--- a/test/typeerrors/ex14.golden
+++ b/test/typeerrors/ex14.golden
@@ -6,7 +6,13 @@ ERROR: Error when compiling ex14 module: Type error
   |
 2 |    return g(x)
   |           ^^^^
-Too few positional elements
+
+
+  |
+4 |def g(x,y):
+  |    ^
+Type incompatibility between definition of and call of g (too few arguments in call)
+g is inferred to have a type of the form _(_, _) -> _
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 

--- a/test/typeerrors/ex15.golden
+++ b/test/typeerrors/ex15.golden
@@ -2,6 +2,7 @@ Building file ../test/typeerrors/ex15.act
   Compiling ex15.act for release
 
 ERROR: Error when compiling ex15 module: Type error
+
 Cannot satisfy the following simultaneous constraints for the unknown types t0, t1:
 
   |

--- a/test/typeerrors/ex17.golden
+++ b/test/typeerrors/ex17.golden
@@ -2,13 +2,8 @@ Building file ../test/typeerrors/ex17.act
   Compiling ex17.act for release
 
 ERROR: Error when compiling ex17 module: Type error
-Cannot satisfy the following simultaneous constraints for the unknown types t0, t1:
 
-  |
-2 |a = pow(3,"hej")
-  |    ^^^
-pow has had its polymorphic type [A(Number)] => (A, A) -> A instantiated to (t0, t0) -> t0, so
-t0 must implement __builtin__.Number
+Cannot satisfy the following simultaneous constraints for the unknown types t0, t1:
 
   |
 2 |a = pow(3,"hej")
@@ -19,6 +14,11 @@ The type of pow(3, "hej") ( __builtin__.str) must be a subclass of t0
 2 |a = pow(3,"hej")
   |    ^^^^^^^^^^^^
 The type of pow(3, "hej") (which we call t1) must be a subtype of t0
+
+  |
+2 |a = pow(3,"hej")
+  |    ^^^
+pow has had its polymorphic type [A(Number)] => (A, A) -> A instantiated to (t0, t0) -> t0, so t0 must implement __builtin__.Number
 
   |
 2 |a = pow(3,"hej")

--- a/test/typeerrors/ex18.golden
+++ b/test/typeerrors/ex18.golden
@@ -2,7 +2,9 @@ Building file ../test/typeerrors/ex18.act
   Compiling ex18.act for release
 
 ERROR: Error when compiling ex18 module: Type error
+
 Cannot satisfy the following simultaneous constraints for the unknown type t0:
+
 __builtin__.atom must be a subclass of t0
   |
 2 |    return len(ls) + "hej"

--- a/test/typeerrors/ex19.golden
+++ b/test/typeerrors/ex19.golden
@@ -2,19 +2,8 @@ Building file ../test/typeerrors/ex19.act
   Compiling ex19.act for release
 
 ERROR: Error when compiling ex19 module: Type error
+
 Cannot satisfy the following simultaneous constraints for the unknown types t0, t1:
-
-  |
-7 |a = f(3,"hej")
-  |    ^
-f has had its polymorphic type [A(Plus, Ord)] => (A, A) -> A instantiated to (t1, t1) -> t1, so
-t1 must implement __builtin__.Ord
-
-  |
-7 |a = f(3,"hej")
-  |    ^
-f has had its polymorphic type [A(Plus, Ord)] => (A, A) -> A instantiated to (t1, t1) -> t1, so
-t1 must implement __builtin__.Plus
 
   |
 7 |a = f(3,"hej")
@@ -23,13 +12,25 @@ The type of 3 (which we call t0) must implement __builtin__.Number
 
   |
 7 |a = f(3,"hej")
-  |    ^^^^^^^^^^
-The type of f(3, "hej") (which we call t0) must be a subtype of t1
+  |    ^
+f has had its polymorphic type [A(Plus, Ord)] => (A, A) -> A instantiated to (t1, t1) -> t1, so t1 must implement __builtin__.Ord
+
+  |
+7 |a = f(3,"hej")
+  |    ^
+f has had its polymorphic type [A(Plus, Ord)] => (A, A) -> A instantiated to (t1, t1) -> t1, so t1 must implement __builtin__.Plus
 
   |
 7 |a = f(3,"hej")
   |    ^^^^^^^^^^
-The type of f(3, "hej") ( __builtin__.str) must be a subclass of t1
+Type incompatibility between definition of and call of f
+f is inferred to have a type of the form [T_2(__builtin__.Plus, __builtin__.Ord)] => (T_2, T_2) -> T_2
+
+  |
+7 |a = f(3,"hej")
+  |    ^^^^^^^^^^
+Type incompatibility between definition of and call of f
+f is inferred to have a type of the form [T_2(__builtin__.Plus, __builtin__.Ord)] => (T_2, T_2) -> T_2
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 

--- a/test/typeerrors/ex2.golden
+++ b/test/typeerrors/ex2.golden
@@ -6,7 +6,13 @@ ERROR: Error when compiling ex2 module: Type error
   |
 4 |a = f(3,4,5)
   |    ^^^^^^^^
-Too many positional elements
+
+
+  |
+1 |def f(x,y):
+  |    ^
+Type incompatibility between definition of and call of f (too many arguments in call)
+f is inferred to have a type of the form [A(Plus)] => _(A, A) -> A
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 

--- a/test/typeerrors/ex20.golden
+++ b/test/typeerrors/ex20.golden
@@ -11,8 +11,8 @@ ERROR: Error when compiling ex20 module: Type error
 3 |def f(s : str, a):
 4 |    return s * a
   |
-Type incompatibility between signature and function definition
-Function inferred to have type _(__builtin__.str, __builtin__.int) -> __builtin__.str
+Type incompatibility between signature for and definition of f
+f is inferred to have a type of the form _(__builtin__.str, __builtin__.int) -> __builtin__.str
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 

--- a/test/typeerrors/ex21.act
+++ b/test/typeerrors/ex21.act
@@ -1,0 +1,6 @@
+import math
+
+actor main(env):
+   print(math.sin("hej"))
+   env.exit(0)
+   

--- a/test/typeerrors/ex21.golden
+++ b/test/typeerrors/ex21.golden
@@ -1,0 +1,19 @@
+Building file ../test/typeerrors/ex21.act
+  Compiling ex21.act for release
+
+ERROR: Error when compiling ex21 module: Type error
+
+Cannot satisfy the following simultaneous constraints for the unknown type t0:
+
+  |
+4 |   print(math.sin("hej"))
+  |         ^^^^^^^^
+__builtin__.str must be a subclass of t0
+
+  |
+4 |   print(math.sin("hej"))
+  |         ^^^^^^^^
+math.sin has had its polymorphic type [A(math.RealFuns)] => (A) -> A instantiated to (t0) -> t0, so t0 must implement math.RealFuns
+
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+

--- a/test/typeerrors/ex22.act
+++ b/test/typeerrors/ex22.act
@@ -1,0 +1,4 @@
+f : [A(Plus)] => (A) -> A
+
+def f(x,y):
+    return x

--- a/test/typeerrors/ex22.golden
+++ b/test/typeerrors/ex22.golden
@@ -1,0 +1,18 @@
+Building file ../test/typeerrors/ex22.act
+  Compiling ex22.act for release
+
+ERROR: Error when compiling ex22 module: Type error
+
+  |
+1 |f : [A(Plus)] => (A) -> A
+  |^
+
+  |
+3 |def f(x,y):
+4 |    return x
+  |
+Type incompatibility between signature for and definition of f (too few arguments in call)
+f is inferred to have a type of the form _(_, _) -> _
+
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+

--- a/test/typeerrors/ex23.act
+++ b/test/typeerrors/ex23.act
@@ -1,0 +1,27 @@
+def f(x,s : str):
+    if s==7:
+       return x
+    else:
+       return x+x
+
+'''
+This gives a misleading error message; the last constraint is
+
+
+  |
+2 |    if s==7:
+  |       ^^^^
+The type of s == 7 (which we call t1) must implement __builtin__.Eq
+
+
+Instead of "The type of s == 7" one wants "a common supertype of s and 7" (?)
+
+Fix should be done in the 
+
+    infer env e@(CompOp l e1 [OpArg op e2])
+
+case in Types.hs.
+
+
+Similar problems show up for other binary operators.
+'''

--- a/test/typeerrors/ex23.golden
+++ b/test/typeerrors/ex23.golden
@@ -1,0 +1,29 @@
+Building file ../test/typeerrors/ex23.act
+  Compiling ex23.act for release
+
+ERROR: Error when compiling ex23 module: Type error
+
+Cannot satisfy the following simultaneous constraints for the unknown types t0, t1:
+
+  |
+2 |    if s==7:
+  |          ^
+The type of 7 (which we call t0) must implement __builtin__.Number
+
+  |
+2 |    if s==7:
+  |          ^
+The type of 7 (which we call t0) must be a subtype of t1
+
+  |
+2 |    if s==7:
+  |       ^
+The type of s ( __builtin__.str) must be a subclass of t1
+
+  |
+2 |    if s==7:
+  |       ^^^^
+The type of s == 7 (which we call t1) must implement __builtin__.Eq
+
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+

--- a/test/typeerrors/ex4.golden
+++ b/test/typeerrors/ex4.golden
@@ -6,7 +6,13 @@ ERROR: Error when compiling ex4 module: Type error
   |
 5 |    print("a".center(f(3)))
   |                     ^^^^
-Too few positional elements
+
+
+  |
+1 |def f(x,y):
+  |    ^
+Type incompatibility between definition of and call of f (too few arguments in call)
+f is inferred to have a type of the form [A(Plus)] => _(A, A) -> A
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 

--- a/test/typeerrors/ex5.golden
+++ b/test/typeerrors/ex5.golden
@@ -6,7 +6,13 @@ ERROR: Error when compiling ex5 module: Type error
   |
 7 |a = apply(f,3)
   |    ^^^^^^^^^^
-Too few positional elements
+
+
+  |
+4 |def apply(g,x):
+  |    ^^^^^
+Type incompatibility between definition of and call of apply (too few arguments in call)
+apply is inferred to have a type of the form _(_(A) -> B, A) -> B
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 

--- a/test/typeerrors/ex8.golden
+++ b/test/typeerrors/ex8.golden
@@ -2,6 +2,7 @@ Building file ../test/typeerrors/ex8.act
   Compiling ex8.act for release
 
 ERROR: Error when compiling ex8 module: Type error
+
 Cannot satisfy the following simultaneous constraints for the unknown type t0:
 
   |

--- a/test/typeerrors/ex9.golden
+++ b/test/typeerrors/ex9.golden
@@ -2,13 +2,8 @@ Building file ../test/typeerrors/ex9.act
   Compiling ex9.act for release
 
 ERROR: Error when compiling ex9 module: Type error
-Cannot satisfy the following simultaneous constraints for the unknown types t0, t1:
 
-  |
-4 |a = f(3,"hej")
-  |    ^
-f has had its polymorphic type [A(Plus)] => (A, A) -> A instantiated to (t1, t1) -> t1, so
-t1 must implement __builtin__.Plus
+Cannot satisfy the following simultaneous constraints for the unknown types t0, t1:
 
   |
 4 |a = f(3,"hej")
@@ -17,13 +12,20 @@ The type of 3 (which we call t0) must implement __builtin__.Number
 
   |
 4 |a = f(3,"hej")
-  |    ^^^^^^^^^^
-The type of f(3, "hej") (which we call t0) must be a subtype of t1
+  |    ^
+f has had its polymorphic type [A(Plus)] => (A, A) -> A instantiated to (t1, t1) -> t1, so t1 must implement __builtin__.Plus
 
   |
 4 |a = f(3,"hej")
   |    ^^^^^^^^^^
-The type of f(3, "hej") ( __builtin__.str) must be a subclass of t1
+Type incompatibility between definition of and call of f
+f is inferred to have a type of the form [T_6w(__builtin__.Plus)] => (T_6w, T_6w) -> T_6w
+
+  |
+4 |a = f(3,"hej")
+  |    ^^^^^^^^^^
+Type incompatibility between definition of and call of f
+f is inferred to have a type of the form [T_6w(__builtin__.Plus)] => (T_6w, T_6w) -> T_6w
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 


### PR DESCRIPTION
Small further improvements to type error messages, in particular some changes to avoid assigning blame. Example, test/typeerrors/ex1.act:

```
def f(x,y):
    return x+y

a = f(3)
```

Error message is now
```
ERROR: Error when compiling ex1 module: Type error

  |
4 |a = f(3)
  |    ^^^^


  |
1 |def f(x,y):
  |    ^
Type incompatibility between definition of and call of f (too few arguments in call)
f is inferred to have a type of the form [A(Plus)] => _(A, A) -> A

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
```
This avoids the previous blaming of the call for being wrong, just noting that the call and the function definirion are incompatible.

Note: I made one restructurintg change, by moving class Simp and its instances from Types.hs to Env.hs (so I could use it in Solver.hs).

This is still only a little bit of the way to good type error messages...
