### PR TITLE
Stop testing on MacOS 11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11, macos-12, macos-13]
+        os: [macos-12, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Show env"
@@ -214,10 +214,10 @@ jobs:
         os: [macos-11, macos-12, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: "Download artifacts for Macos, built on macos-11"
+      - name: "Download artifacts for Macos, built on macos-12"
         uses: actions/download-artifact@v3
         with:
-          name: acton-macos-11
+          name: acton-macos-12
       - name: "Extract acton"
         run: |
           tar Jxvf $(ls acton-darwin*.tar.xz | tail -n1)
@@ -326,10 +326,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: "Check out repository code"
         uses: actions/checkout@v3
-      - name: "Download artifacts for Macos, built on macos-11"
+      - name: "Download artifacts for Macos, built on macos-12"
         uses: actions/download-artifact@v3
         with:
-          name: acton-macos-11
+          name: acton-macos-12
       - name: "Download artifacts for Linux, built on Debian:12"
         uses: actions/download-artifact@v3
         with:
@@ -391,10 +391,10 @@ jobs:
     steps:
       - name: "Check out repository code"
         uses: actions/checkout@v3
-      - name: "Download artifacts for Macos, built on macos-11"
+      - name: "Download artifacts for Macos, built on macos-12"
         uses: actions/download-artifact@v3
         with:
-          name: acton-macos-11
+          name: acton-macos-12
       - name: "Download artifacts for Linux, built on Debian:12"
         uses: actions/download-artifact@v3
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Testing / CI
+- Stop testing on MacOS 11 [#1600]
+  - Homebrew has dropped support for MacOS 11 so the CI job had to build stuff
+    from source making it super slow and fragile, thus dropping it.
+
 ## [0.18.3] (2023-11-21)
 
 ### Added


### PR DESCRIPTION
Seems Homebrew has dropped support for MacOS 11 and with it pre-built binary versions of stuff, so in order to avoid building everything from source, we drop MacOS 11 from CI.