### PR TITLE
deb: use stable as codename

### DIFF
--- a/debian/changelog.in
+++ b/debian/changelog.in
@@ -1,4 +1,4 @@
-acton (VERSION) bullseye; urgency=medium
+acton (VERSION) stable; urgency=medium
 
   * See CHANGELOG.md
 


### PR DESCRIPTION
Get rid of idea of targetting a particular Debian release like bullseye, instead use "stable". actonc is statically compiled, so it should work across a very large range of Debian and Ubuntu releases (and anything else supporting .deb). The binaries that actonc produces target GNU libc 2.27 per default, which is really quite old. We just call it "stable" for lack of a better name.