### PR TITLE
Store multiple versions in apt repo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -424,13 +424,14 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     container:
-      image: debian:12
+      image: debian:experimental
     needs: [test-macos, test-linux, build-debs]
     steps:
       - name: Install build prerequisites
         run: |
           apt-get update
-          apt-get install -qy git gnupg reprepro
+          apt-get install -qy -t experimental reprepro
+          apt-get install -qy git gnupg
       - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v4
@@ -446,6 +447,10 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: acton-debs
+      - name: "Get the version"
+        id: get_version
+        run: |
+          echo ::set-output name=version::$(ls ../deb/*.changes | sed -e 's/.*acton_//' -e 's/_amd64.*//')
       - name: "Include new deb in Apt repository"
         run: |
           cd apt
@@ -458,7 +463,7 @@ jobs:
           git add .
           git status
           git diff
-          git commit -a -m "Updated apt package index"
+          git commit -a -m "Add Acton v${{steps.get_version.outputs.version}}"
           git push
 
 


### PR DESCRIPTION
Rather than overwrite the acton package in the repo with a new one, we now keep all versions. Since this is a new feature in reprepro, we've also moved to using a fresher container etc.

Now also using the Acton package name in the git commit message.