### PR TITLE
Use defaults args for range()

### DIFF
--- a/base/src/acton/rts.act
+++ b/base/src/acton/rts.act
@@ -72,7 +72,7 @@ actor WThreadMonitor(env: Env, arg_wthread_id: int):
 actor Monitor(env: Env):
     tms: dict[int, WThreadMonitor] = {}
 
-    for wthread_id in range(1, env.nr_wthreads+1, 1):
+    for wthread_id in range(1, env.nr_wthreads+1):
         tm = WThreadMonitor(env, wthread_id)
         tms[wthread_id] = tm
 

--- a/base/src/argparse.act
+++ b/base/src/argparse.act
@@ -196,7 +196,7 @@ class Parser(object):
 
         posargs = []
         skip = 0
-        for i in range(0, len(argv), 1):
+        for i in range(len(argv)):
             p = i + skip
             if p >= len(argv):
                 break
@@ -254,7 +254,7 @@ class Parser(object):
                 else:
                     posargs.append(arg)
 
-        for i in range(0, len(posargs), 1):
+        for i in range(len(posargs)):
             arg = posargs[i]
             if len(self.args) == 0:
                 rest.append(arg)

--- a/base/src/http.act
+++ b/base/src/http.act
@@ -76,7 +76,7 @@ def hex_to_decimal(hex_str: str) -> int:
                '8': 8, '9': 9, 'A': 10, 'B': 11, 'C': 12, 'D': 13, 'E': 14, 'F': 15}
     decimal_value = 0
     try:
-        for i in range(0, len(hex_str), 1):
+        for i in range(len(hex_str)):
             j = len(hex_str)-i
             digit = hex_str[j-1].upper()
             decimal_value += hex_map[digit] * (16 ** i)

--- a/base/src/random.act
+++ b/base/src/random.act
@@ -27,11 +27,11 @@ def sample[T](population: list[T], k: int) -> list[T]:
         raise ValueError("Sample larger than population or is negative")
 
     result = []
-    indices = list(range(0, len(population), 1))
-    for _ in range(0, k, 1):
+    indices = list(range(len(population)))
+    for _ in range(k):
         idx_to_pop = choice(indices)
         idx = 0
-        for i in range(0, len(indices), 1):
+        for i in range(len(indices)):
             if indices[i] == idx_to_pop:
                 idx = i
                 break

--- a/base/src/re.act
+++ b/base/src/re.act
@@ -9,7 +9,7 @@
 #    def __str__(self):
 #        res = "("
 #        l = len(self.p)
-#        for i in range(0, l, 1):
+#        for i in range(l):
 #            res += str(self.p[i])
 #            if i < l-1:
 #                res += "|"

--- a/base/src/testing.act
+++ b/base/src/testing.act
@@ -520,7 +520,7 @@ actor test_runner(env: Env, unit_tests: dict[str, UnitTest], sync_actor_tests: d
                     print()
                     env.exit(0)
 
-        for i in range(0, env.nr_wthreads, 1):
+        for i in range(env.nr_wthreads):
             unit_test_runner(i, get_test, report_result)
 
     proc def _run_sync_actor_tests(args):
@@ -583,7 +583,7 @@ actor test_runner(env: Env, unit_tests: dict[str, UnitTest], sync_actor_tests: d
         for ut in unit_tests.values():
             test_res = []
             try:
-                for iteration in range(0, args.get_int("iterations"), 1):
+                for iteration in range(args.get_int("iterations")):
                     acton.rts.gc(env.syscap) # explicit GC collection
                     mem_before = acton.rts.get_mem_usage(env.syscap)
                     sw = time.Stopwatch()

--- a/examples/reprtest.act
+++ b/examples/reprtest.act
@@ -6,7 +6,7 @@ actor main(env):
   s.add("def")
   print(s)
   d = {}
-  for i in range(0,10,1):
+  for i in range(10):
       d[i] = str(i)
   print(d)
   env.exit(0)

--- a/examples/sieve.act
+++ b/examples/sieve.act
@@ -3,7 +3,7 @@ import math
 def sieve(n):
     isPrime = [True] * n
     isPrime[0] = False; isPrime[1] = False
-    for i in range(2,int(math.sqrt(float(n)))+1,1):
+    for i in range(2, int(math.sqrt(float(n)))+1):
         if isPrime[i]:
             for k in range(i*i,n,i): isPrime[k] = False
 
@@ -20,7 +20,7 @@ def count(bs):
 def primesTo(n):
     res = []
     isPrime = sieve(n)
-    for i in range(2,n,1):
+    for i in range(2, n):
         if isPrime[i]: res.append(i)
     return res
 

--- a/examples/sumto2.act
+++ b/examples/sumto2.act
@@ -2,7 +2,7 @@ import numpy
 import math
 
 def sumto(n):
-    a = numpy.arange(0,n,1)
+    a = numpy.arange(0, n)
     return numpy.sum(a,None)
     
 actor main(env):

--- a/test/builtins_auto/builtin_functions_test.act
+++ b/test/builtins_auto/builtin_functions_test.act
@@ -1,4 +1,4 @@
-lst = list(range(10, 15, 1))
+lst = list(range(10, 15))
 
 def even(n):
     return n % 2 == 0

--- a/test/builtins_auto/bytearray_test.act
+++ b/test/builtins_auto/bytearray_test.act
@@ -4,17 +4,17 @@ actor main(env):
 # TODO: fix all this?
 #    b = bytearray(lst0)
 #    print(b.center(25,None))
-#    lst2 = list(range(65,91,1))
+#    lst2 = list(range(65, 91))
 #    b2 = bytearray(lst2)
 #    print(b2)
-#    b3 = bytearray(list(range(75,77,1)))
+#    b3 = bytearray(list(range(75, 77)))
 #    n = b2.find(b3,0,-1);
 #    print(b3,"occurs in",b2,"at pos",n)
 #    b4 = bytearray(10)
 #    print("bytearray(10) gives",b4)
 #    b4 = b.center(20,None)
 #    print(b.lstrip(b4))
-#    sep = bytearray(list(range(70,72,1)))
+#    sep = bytearray(list(range(70, 72)))
 #    print(b2.split(sep,None))
 #    b5 = bytearray("line 1\nline 2\r\n\nBjörn")
 #    print(b5)
@@ -22,7 +22,7 @@ actor main(env):
 #    print(b5.splitlines(True))
 #    lst = list(b2)
 #    print(lst[1:20:2])
-#    for i in range(0,1000,1):
+#    for i in range(1000):
 #      b2.append(65+i%26)     #add repeated copies of upper case alphabet
 #    for i in range(26,1,-1):
 #      del b2[0:10000:i]      # delete everything except the Z's

--- a/test/builtins_auto/container_test.act
+++ b/test/builtins_auto/container_test.act
@@ -1,5 +1,5 @@
 actor main(env):
-    lst = list(range(1,100,1))
+    lst = list(range(1, 100))
     if 17 not in lst or 171 in lst or 100 in lst:
         env.exit(1)
     env.exit(0)

--- a/test/builtins_auto/dict_test2.act
+++ b/test/builtins_auto/dict_test2.act
@@ -1,18 +1,18 @@
 actor main(env):
     dict = {}
     other = {}
-    for i in range(1,1000,1):
+    for i in range(1, 1000):
         dict[str(i)] = str(i+1)
     r = 17
     s = 0
-    for j in range(1,200,1):
+    for j in range(1, 200):
        r = r*r % 1000
        s += int(dict[str(r)])
     if s != 99446:
         env.exit(1)
     if str(678) not in dict:
         env.exit(1)
-    for i in range(1,1000,1):
+    for i in range(1, 1000):
         if i%10 > 0:
             del dict[str(i)]
     if len(dict) != 99:

--- a/test/builtins_auto/list.act
+++ b/test/builtins_auto/list.act
@@ -90,8 +90,8 @@ actor main(env):
         await async env.exit(1)
 
 #shrinking
-    l = list(range(0,30,1))
-    for i in range(0,20,1):
+    l = list(range(30))
+    for i in range(20):
         l.pop(-1)
     if len(l) != 10 or l[4] != 4:
         print("Unexpected shrinking of list")

--- a/test/builtins_auto/protocol_test.act
+++ b/test/builtins_auto/protocol_test.act
@@ -7,8 +7,8 @@ def concat(seq, zero):
 
 actor main(env):
     var lst = []
-    for i in range(1,10,1):
-        lst.append(list(range(i,2*i,1)))
+    for i in range(1, 10):
+        lst.append(list(range(i, 2*i)))
         
     lst2 = concat(lst, [])
     print(lst2)

--- a/test/builtins_auto/set_test.act
+++ b/test/builtins_auto/set_test.act
@@ -1,19 +1,19 @@
 actor main(env):
     s = {400}
-    for i in range(13,1000,1):
+    for i in range(13, 1000):
         s.add(i*i)
     s.discard(64)
     s.discard(225)
     s.discard(10000)
     n = 0
-    for k in range(0,1000,1):
+    for k in range(1000):
         if k in s: n += 1
     if n != 18:
         raise ValueError("n is" + str(n) + ", not 18")
 
         env.exit(1)
     s2 = {1}
-    for i in range(0,500,1):
+    for i in range(500):
         s2.add(i*i*i*i)
     if len(s) != 985 or len(s2) != 500:
         raise ValueError("set length error 1")

--- a/test/builtins_auto/slice_test.act
+++ b/test/builtins_auto/slice_test.act
@@ -1,8 +1,8 @@
 actor main(env):
-    lst = list(range(0,100,1))
+    lst = list(range(100))
     lst2 = lst[-1:0:-2]
-    lst2[10:30:2] = range(100,110,1)
-    lst4 = list(range(0,1000,1))
+    lst2[10:30:2] = range(100, 110)
+    lst4 = list(range(1000))
     for i in range(100,1,-1):
         del lst4[1:1000:i]
     if sum(lst4,0) != 4500:

--- a/test/perf-benchgames/edigits/1.act
+++ b/test/perf-benchgames/edigits/1.act
@@ -49,7 +49,7 @@ actor main(env):
             print(s[i:i+10] + "\t:" + str(i+10))
         else:
             spaces = ""
-            for j in range(0, (10-(len(str(s[i:])))), 1):
+            for j in range(10-len(str(s[i:]))):
                 spaces += " "
             print(s[i:] + spaces + "\t:" + str(n))
             #print(f'{s[i:]}{" "*(10-n%10)}\t:{n}')

--- a/test/perf-benchgames/spectral-norm/1.act
+++ b/test/perf-benchgames/spectral-norm/1.act
@@ -7,13 +7,13 @@ def eval_A(i, j):
 
 def eval_A_times_u(u):
     res = []
-    for i in range(0, len(u), 1):
+    for i in range(len(u)):
         res.append(part_A_times_u(i,u))
     return res
 
 def eval_At_times_u(u):
     res = []
-    for i in range(0, len(u), 1):
+    for i in range(len(u)):
         res.append(part_At_times_u(i,u))
     return res
 
@@ -36,13 +36,13 @@ actor main(env):
     var u = [1] * int(env.argv[1])
     var v = []
 
-    for dummy in range(0, 10, 1):
+    for dummy in range(10):
         v = eval_AtA_times_u(u)
         u = eval_AtA_times_u(v)
 
     vBv = vv = 0
 
-    for i in range(0, len(u), 1):
+    for i in range(len(u)):
         ue = u[i]
         ve = v[i]
         vBv += ue * ve

--- a/test/perf/src/pairs.act
+++ b/test/perf/src/pairs.act
@@ -44,7 +44,7 @@ actor Node(name: str, _affinity: int):
         counter += 1
         tokens += 1
         if not _stop and tokens > 0 and partner is not None:
-            for i in range(0, 1000, 1):
+            for i in range(1000):
                 if tokens == 0:
                     return
                 tokens -= 1
@@ -58,12 +58,12 @@ actor Pairs(wthreads, num_pairs):
     nodes = []
     var count = 0
 
-    for i in range(0, num_pairs*2, 1):
+    for i in range(num_pairs*2):
         affinity = int(i // 2) % wthreads
         n = Node(str(i), affinity+1)
         nodes.append(n)
 
-#    for i in range(0, num_pairs, 1):
+#    for i in range(num_pairs):
 #        affinity = i % wthreads
 #        n1 = Node(str(i), affinity+1)
 #        n2 = Node(str(i+1), affinity+1)
@@ -81,7 +81,7 @@ actor Pairs(wthreads, num_pairs):
 
     def get_count():
         count = 0
-        for i in range(0, num_pairs*2, 1):
+        for i in range(num_pairs*2):
             c = nodes[i].get_count()
             print("Actor %d:" % i, c)
             count += c
@@ -89,11 +89,11 @@ actor Pairs(wthreads, num_pairs):
 
     def start():
 #        print("Starting...")
-        for i in range(0, num_pairs*2, 1):
+        for i in range(num_pairs*2):
             nodes[i].ping()
 
     def stop():
-        for i in range(0, num_pairs*2, 1):
+        for i in range(num_pairs*2):
             nodes[i].stop()
 
 

--- a/test/perf/src/ring.act
+++ b/test/perf/src/ring.act
@@ -34,17 +34,17 @@ actor main(env):
     stop_at = float(env.argv[2])
 
     nodes = []
-    for i in range(0, num_nodes, 1):
+    for i in range(num_nodes):
         n = Node(i)
         nodes.append(n)
-    for i in range(0, num_nodes-1, 1):
+    for i in range(num_nodes-1):
         nodes[i].set_next(nodes[i+1])
     nodes[-1].set_next(nodes[0])
     a = nodes[0].ping()
 
     var count = 0
     def stop():
-        for i in range(0, num_nodes, 1):
+        for i in range(num_nodes):
             c = nodes[i].get_count()
             print("Actor %d:" % i, c)
             count += c

--- a/test/regression_auto/signature_with_typeargs.act
+++ b/test/regression_auto/signature_with_typeargs.act
@@ -1,5 +1,5 @@
 lst : list[int]
-lst = list(range(10,14,1))
+lst = list(range(10, 14))
 
 actor main(env):
    print(lst==[10,11,12,13])

--- a/test/rts_db/test_db_app.act
+++ b/test/rts_db/test_db_app.act
@@ -103,7 +103,7 @@ actor Tester(env, verbose, port_chunk):
         are_we_done()
 
     def dbc_start():
-        for i in range(0, 3, 1):
+        for i in range(3):
             port = port_chunk + (2*i)
             cmd = ["../dist/bin/actondb", "-p", str(port)]
             p = process.Process(process_cap, cmd, None, None, on_stdout, on_stderr, db_on_exit, on_error)
@@ -113,9 +113,9 @@ actor Tester(env, verbose, port_chunk):
             psp[paid] = "db%d" % i
 
     def db_args(start_port, replication_factor) -> list[str]:
-        #a = ["127.0.0.1:" for idx in range(0, replication_factor, 1)]
+        #a = ["127.0.0.1:" for idx in range(replication_factor)]
         args = ["--rts-ddb-replication", str(replication_factor)]
-        for idx in range(0, replication_factor, 1):
+        for idx in range(replication_factor):
             args.append("--rts-ddb-host")
             args.append("127.0.0.1:" + str(start_port + idx*2))
         return args

--- a/test/rts_db/test_tcp_client.act
+++ b/test/rts_db/test_tcp_client.act
@@ -124,7 +124,7 @@ actor Tester(env, verbose, port_chunk):
         are_we_done()
 
     def dbc_start():
-        for i in range(0, 3, 1):
+        for i in range(3):
             port = port_chunk + (2*i)
             cmd = ["../dist/bin/actondb", "-p", str(port)]
             p = process.Process(process_cap, cmd, None, None, on_stdout, on_stderr, db_on_exit, on_error)
@@ -134,9 +134,9 @@ actor Tester(env, verbose, port_chunk):
             psp[paid] = "db%d" % i
 
     def db_args(start_port, replication_factor) -> list[str]:
-        #a = ["127.0.0.1:" for idx in range(0, replication_factor, 1)]
+        #a = ["127.0.0.1:" for idx in range(replication_factor)]
         args = ["--rts-ddb-replication", str(replication_factor)]
-        for idx in range(0, replication_factor, 1):
+        for idx in range(replication_factor):
             args.append("--rts-ddb-host")
             args.append("127.0.0.1:" + str(start_port + idx*2))
         return args
@@ -164,7 +164,7 @@ actor Tester(env, verbose, port_chunk):
             log("Server app exited in state %d with exit code %d and termination signal %d" % (state, exit_code, term_signal))
             p_alive -= 1
             paid = p.aid()
-            for i in range(0, len(ps), 1):
+            for i in range(len(ps)):
                 ps_aid = ps[i].aid()
                 if ps_aid == paid:
                     del ps[i]
@@ -219,7 +219,7 @@ actor Tester(env, verbose, port_chunk):
             log("App exited in state %d with exit code %d and termination signal %d" % (state, exit_code, term_signal))
             p_alive -= 1
             paid = p.aid()
-            for i in range(0, len(ps), 1):
+            for i in range(len(ps)):
                 ps_aid = ps[i].aid()
                 if ps_aid == paid:
                     del ps[i]

--- a/test/rts_db/test_tcp_server.act
+++ b/test/rts_db/test_tcp_server.act
@@ -117,7 +117,7 @@ actor Tester(env, verbose, port_chunk):
         are_we_done()
 
     def dbc_start():
-        for i in range(0, 3, 1):
+        for i in range(3):
             port = port_chunk + (2*i)
             cmd = ["../dist/bin/actondb", "-p", str(port), "-s", "127.0.0.1:" + str(port_chunk+1)]
             p = process.Process(process_cap, cmd, None, None, on_stdout, on_stderr, db_on_exit, on_error)
@@ -127,9 +127,9 @@ actor Tester(env, verbose, port_chunk):
             psp[paid] = "db%d" % i
 
     def db_args(start_port, replication_factor) -> list[str]:
-        #a = ["127.0.0.1:" for idx in range(0, replication_factor, 1)]
+        #a = ["127.0.0.1:" for idx in range(replication_factor)]
         args = ["--rts-ddb-replication", str(replication_factor)]
-        for idx in range(0, replication_factor, 1):
+        for idx in range(replication_factor):
             args.append("--rts-ddb-host")
             args.append("127.0.0.1:" + str(start_port + idx*2))
         return args
@@ -209,7 +209,7 @@ actor Tester(env, verbose, port_chunk):
             log("App exited in state %d with exit code %d and termination signal %d" % (state, exit_code, term_signal))
             p_alive -= 1
             paid = p.aid()
-            for i in range(0, len(ps), 1):
+            for i in range(len(ps)):
                 ps_aid = ps[i].aid()
                 if ps_aid == paid:
                     del ps[i]

--- a/test/stdlib/test_http.act
+++ b/test/stdlib/test_http.act
@@ -9,7 +9,7 @@ import net
 #    var reconnects = 0
 #
 #    def request_some(conn, n):
-#        for i in range(0, n, 1):
+#        for i in range(n):
 #            conn.get("/" + str(i), on_response)
 #            outstanding += 1
 #
@@ -44,7 +44,7 @@ actor main(env):
 #    def test_http_request_parser(query, parsed) -> bool:
 #        # Go through query byte by byte, and feed it to the parser one more
 #        # byte at a time until we get a complete request
-#        for i in range(0, len(query), 1):
+#        for i in range(len(query)):
 #            partial_request = query[0:i+1]
 #            req, rest = http.parse_request(partial_request)
 #            if req is not None:
@@ -75,7 +75,7 @@ actor main(env):
     tcpccap = net.TCPConnectCap(net.TCPCap(net.NetCap(env.cap)))
 ##
 ##    var workers = []
-##    for i in range(0, 1, 1):
+##    for i in range(1):
 ##        print("Starting worker " + str(i))
 ##        workers.append(HttpGetter(connect_auth, host, 20))
 ##

--- a/test/stdlib_auto/test_http.act
+++ b/test/stdlib_auto/test_http.act
@@ -6,7 +6,7 @@ def test_http_parser(log):
     def partializer(testfun, query, parsed) -> bool:
         # Go through query byte by byte, and feed it to the parser one more
         # byte at a time until we get a complete request
-        for i in range(0, len(query), 1):
+        for i in range(len(query)):
             partial_request = query[0:i+1]
             req, rest = http.parse_request(partial_request, log)
             if req is not None:
@@ -44,7 +44,7 @@ def test_http_parser(log):
 
 
         # Parse request byte by byte
-        for i in range(0, len(t.query), 1):
+        for i in range(len(t.query)):
             partial_request = t.query[0:i+1]
             req, rest = http.parse_request(partial_request, log)
             if req is not None:

--- a/test/stdlib_auto/test_random.act
+++ b/test/stdlib_auto/test_random.act
@@ -4,7 +4,7 @@ import testing
 # choice()
 def _test_choice_basic_functionality():
     lst = [1, 2, 3, 4, 5]
-    for _ in range(0, 1000, 1):  # Repeat many times to ensure randomness
+    for _ in range(1000):  # Repeat many times to ensure randomness
         testing.assertIn(random.choice(lst), lst, "random.choice() returned a value not in the list")
 
 def _test_choice_empty_sequence():
@@ -20,7 +20,7 @@ def _test_choice_single_element():
 def _test_choice_repeatability():
     lst = [1, 2, 3, 4, 5]
     results = set(None)
-    for _ in range(0, 1000, 1):
+    for _ in range(1000):
         results.add(random.choice(lst))
     testing.assertTrue(bool(len(results) > 1), "Expected multiple unique results for repeated calls")
 
@@ -58,7 +58,7 @@ def _test_sample_repeatability() -> None:
     lst = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     sample_1 = random.sample(lst, 2)
 
-    for _ in range(0, 1000, 1):
+    for _ in range(1000):
         sample_2 = random.sample(lst, 2)
         if sample_1 != sample_2:
             return None
@@ -82,7 +82,7 @@ def _test_random_distribution():
     total = 1000000
     num_range = high - low
     stats = {}
-    for i in range(0, total, 1):
+    for i in range(total):
         r = random.randint(low, high)
         if r not in stats:
             stats[r] = 0
@@ -100,12 +100,12 @@ def _test_random_distribution():
             #print("n", n, " outside of expected range (", (expected_count*0.9), "-", (expected_count*1.1), "):", stats[n])
 
 def _test_random1():
-    for i in range(0, 100000, 1):
+    for i in range(100000):
         r = random.randint(0, 1234)
         testing.assertTrue(r >= 0 and r <= 1234, "random.randint() returned a value outside of the range")
 
 def _test_random2():
-    for i in range(0, 100000, 1):
+    for i in range(100000):
         r = random.randint(1293862, 97309358)
         testing.assertTrue(r >= 1293862 and r <= 97309358, "random.randint() returned a value outside of the range")
 

--- a/workspace/misc-examples/divtest.act
+++ b/workspace/misc-examples/divtest.act
@@ -4,7 +4,7 @@ import math
 actor main(env):
   print(3/5)
   print(3.2/1.6)
-  a = np.arange(1,10,1)
+  a = np.arange(1, 10)
   b = np.full(a.shape,2)
   print(a/b)
   c = np.linspace(0,5,5)

--- a/workspace/misc-examples/loess_smoother.act
+++ b/workspace/misc-examples/loess_smoother.act
@@ -20,7 +20,7 @@ def sample():
     y = numpy.unirandfloat(1.0, 3.0, 101) + math.sin(x)
     z = loess(x, y, x, 40)
     print("clear\n$data <<EOD");
-    for i in range(0, 101, 1):
+    for i in range(101):
        print(x[i],y[i],z[i])
     print("EOD")
     print("plot [0:10][0:5] \'$data\' using 1:2 with points title \"raw data\", \\")

--- a/workspace/misc-examples/loess_smoother3.act
+++ b/workspace/misc-examples/loess_smoother3.act
@@ -33,7 +33,7 @@ def sample(t0, n, n0, w):
 
     smooth = loess(time,observation,time,w)
     print("clear\n$data <<EOD")
-    for i in range(0, n, 1):
+    for i in range(n):
        print(time[i],observation[i],smooth[i])
     print("EOD")
     print("plot [",t0,":",t1,"][0:5] \'$data\' using 1:2 with lines title \"raw data\", \\")

--- a/workspace/misc-examples/loess_smoother4.act
+++ b/workspace/misc-examples/loess_smoother4.act
@@ -52,7 +52,7 @@ actor analyzer(sample_size, loess_win_size):
        observation = numpy.concatenate(ysamples)
        smooth      = loess(time,observation,time,loess_win_size)
        print("clear\n$data <<EOD")
-       for i in range(0, 8*sample_size, 1):
+       for i in range(8*sample_size):
            print(time[i],observation[i],smooth[i])
        print("EOD")
        t0 = numpy.scalar(time[0])

--- a/workspace/misc-examples/loess_smoother5.act
+++ b/workspace/misc-examples/loess_smoother5.act
@@ -44,7 +44,7 @@ actor analyzer(window_size, loess_win_size):
        observation = numpy.concatenate([observation[len(y):],y])
        trend, seasonal, resid, periodic, phase = decompose(observation, time, 52, 0.6)
        print("clear\n$data <<EOD")
-       for i in range(0, window_size, 1):
+       for i in range(window_size):
            print(time[i], observation[i], trend[i], seasonal[i], resid[i])
        print("EOD")
        t0 = numpy.scalar(time[0])

--- a/workspace/misc-examples/numpyfns.act
+++ b/workspace/misc-examples/numpyfns.act
@@ -2,7 +2,7 @@ import numpy
 import math
 
 actor main(env):
-  a = numpy.arange(0,20,1)
+  a = numpy.arange(20)
   b = numpy.tile(a,3)
   print(b)
   c = numpy.roll(a,-7)


### PR DESCRIPTION
Since we haven't previously supported default arguments values, all calls to range() have been of the explicit 3 arg kind. Now that we do support default arguments we opt to use the more concise 1 and 2 arg call of range where we rely on the default values, i.e.:
```
  range(0, foo, 1)
```
becomes:
```
  range(foo)
```
and:
```
  range(1, bar, 1)
```
becomes:
```
  range(1, bar)
```