### PR TITLE
Upgrade to Stack 21.25 / GHC 9.4.8

### DIFF
--- a/compiler/stack.yaml
+++ b/compiler/stack.yaml
@@ -4,7 +4,7 @@
 
 # NOTE: do not forget to update homebrew/Formula/acton.rb with the version of
 # GHC that corresponds to the stack LTS release, like lts-18.28 -> ghc@8.10
-resolver: lts-21.13
+resolver: lts-21.25
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
Homebrew is based on GHC 9.4.8 currently so this should help align there and get a working version!