### PR TITLE
argparse: Support optional arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 ## Unreleased
 
+### Added
+- `argparse` now supports optional positional arguments
+  - like so: `p.add_arg("foo", "Foo thing", required=False, nargs="?")`
+
 ### Fixed
-- Homebrew Formula now somewhat decoupled from Stack version
+- Homebrew Formula now somewhat decoupled from Stack version [#1627]
   - Idiomatic Homebrew Formulas use system-ghc, i.e. a GHC version installed by
     Homebrew itself and not from Stack. Since we specify a Stack LTS resolver,
     which is a coupled to a particular version of GHC, there is room for a

--- a/base/src/argparse.act
+++ b/base/src/argparse.act
@@ -79,7 +79,7 @@ class Args(object):
 
 class Parser(object):
     opts: dict[str, (name: str, type: str, nargs: str, default: ?value, help: str)]
-    args: list[(name: str, help: str, nargs: str, left: int)]
+    args: list[(name: str, help: str, required: bool, nargs: str, left: int)]
     cmds: dict[str, (help: str, parser: Parser, fn: proc(Args) -> None)]
     prog: str
 
@@ -99,12 +99,12 @@ class Parser(object):
             raise ArgumentError("Invalid option type '%s'" % type)
         self.opts[name] = (name=name, type=type, nargs=nargs, default=default, help="")
 
-    def add_arg(self, name: str, help: str = "", nargs: str = "?"):
+    def add_arg(self, name: str, help: str="", required: bool=True, nargs: str="?"):
         if nargs == "+" or nargs == "*":
             for arg in self.args:
                 if arg.nargs == "+" or arg.nargs == "*":
                     raise ArgumentError("Only one positional argument with multiple values allowed")
-        self.args.append((name=name, help=help, nargs=nargs, left=1))
+        self.args.append((name=name, help=help, required=required, nargs=nargs, left=1))
 
     def add_cmd(self, name: str, help: str, fn: proc(Args) -> None):
         p = Parser()
@@ -171,7 +171,7 @@ class Parser(object):
         if args.get_bool("help"):
             raise PrintUsage(self.get_usage())
         for arg in self.args:
-            if arg.name not in args.options:
+            if arg.required and arg.name not in args.options:
                 raise ArgumentError("Missing positional argument: %s" % arg.name)
         if cmd_parser is not None:
             args = cmd_parser._parse(rest, args)

--- a/test/stdlib_auto/test_argparse.act
+++ b/test/stdlib_auto/test_argparse.act
@@ -45,8 +45,8 @@ def test_opts_nargs():
 
 def test_posarg():
     p = argparse.Parser()
-    p.add_arg("infile", "input file", "?")
-    p.add_arg("outfile", "output file", "?")
+    p.add_arg("infile", "input file", True, "?")
+    p.add_arg("outfile", "output file", True, "?")
 
     args = p.parse(["./app", "foo", "bar"])
     if args.get_str("infile") != "foo":
@@ -56,8 +56,8 @@ def test_posarg():
 
 def test_posarg_nargs1():
     p = argparse.Parser()
-    p.add_arg("infile", "input file", "+")
-    p.add_arg("outfile", "output file", "?")
+    p.add_arg("infile", "input file", True, "+")
+    p.add_arg("outfile", "output file", True, "?")
 
     args = p.parse(["./app", "in1", "in2", "bar"])
     if args.get_strlist("infile") != ["in1", "in2"]:
@@ -67,8 +67,8 @@ def test_posarg_nargs1():
 
 def test_posarg_nargs2():
     p = argparse.Parser()
-    p.add_arg("infile", "input file", "?")
-    p.add_arg("outfile", "output file", "+")
+    p.add_arg("infile", "input file", True, "?")
+    p.add_arg("outfile", "output file", True, "+")
 
     args = p.parse(["./app", "in1", "out1", "out2"])
     if args.get_str("infile") != "in1":
@@ -79,22 +79,46 @@ def test_posarg_nargs2():
 
 def test_posarg_nargs_invalid():
     p = argparse.Parser()
-    p.add_arg("infile", "input file", "+")
+    p.add_arg("infile", "input file", True, "+")
     try:
-        p.add_arg("outfile", "output file", "+")
+        p.add_arg("outfile", "output file", True, "+")
     except argparse.ArgumentError:
         return
     raise ValueError("Expected ArgumentError since multiple nargs=+ args is invalid (ambiguous)")
 
 def test_posarg_missing():
     p = argparse.Parser()
-    p.add_arg("infile", "input file", "?")
+    p.add_arg("infile", "input file", True, "?")
 
     try:
         p.parse(["./app"])
     except argparse.ArgumentError:
         return
     raise ValueError("Expected ArgumentError since positional argument is missing")
+
+def test_posarg_not_required1():
+    p = argparse.Parser()
+    p.add_arg("infile", "input file", False, "?")
+    p.add_arg("outfile", "output file", False, "?")
+
+    args = p.parse(["./app", "foo", "bar"])
+    if args.get_str("infile") != "foo":
+        raise ValueError("pos arg infile != foo")
+    if args.get_str("outfile") != "bar":
+        raise ValueError("pos arg outfile != bar")
+
+def test_posarg_not_required2():
+    p = argparse.Parser()
+    p.add_arg("infile", "input file", False, "?")
+
+    # These should both work fine
+    args = p.parse(["./app"])
+    try:
+        args.get_str("infile")
+    except argparse.ArgumentError:
+        return
+    raise ValueError("Expected ArgumentError since optional positional argument is missing")
+
 
 actor Foo():
     def foo():
@@ -161,6 +185,8 @@ actor main(env):
         test_posarg_nargs1()
         test_posarg_nargs2()
         test_posarg_missing()
+        test_posarg_not_required1()
+        test_posarg_not_required2()
         test_cmd()
         #test_cmd_nested()
         test_help()


### PR DESCRIPTION
This makes it possible to support optional positional arguments. It's a little weird but can work out alright in combination with commands, like when either a positional argument or a command is expected.