### PR TITLE
Add sep, end, stderr & flush args to print()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@
 ### Added
 - `argparse` now supports optional positional arguments
   - like so: `p.add_arg("foo", "Foo thing", required=False, nargs="?")`
+- `print()` now takes multiple new input arguments:
+  - `print(*vals, sep=" ", end="", stderr=False, flush=False)`
+  - `sep` is the separation character between values, default " "
+  - `end` is the line ending character, default "\n"
+  - Output is written to stdout per default, set `stderr=True` to write to
+    stderr instead
+  - set `flush=True` to flush the output
+
+### Changed
+- `print()` now formats to a temporary buffer before printing to reduce
+  interleaving multiple outputs
+- `printn()` has been removed in preference of using `print(foo, end="")`
 
 ### Fixed
 - Homebrew Formula now somewhat decoupled from Stack version [#1627]

--- a/base/builtin/builtin_functions.c
+++ b/base/builtin/builtin_functions.c
@@ -46,32 +46,45 @@ B_str __str__(B_value x) {
         return x->$class->__str__(x);
 }
 
-B_NoneType B_print(B_tuple t) {
-    if (t->size > 0) {
-        B_value elem = (B_value)t->components[0];
-        fputs((const char*)__str__(elem)->str, stdout);
+B_NoneType B_print(B_tuple t, B_str sep_arg, B_str end_arg, B_bool stderr_arg, B_bool flush_arg) {
+    FILE *outfd = stdout;
+    if (stderr_arg && stderr_arg->val) {
+        outfd = stderr;
     }
-    for (int i=1; i<t->size; i++) {
-        putchar(' ');
-        B_value elem = (B_value)t->components[i];
-        fputs((const char*)__str__(elem)->str, stdout);
-    }
-    putchar('\n');
-    return B_None;
-}
+    B_str sep = to$str(" ");
+    if (sep_arg)
+        sep = sep_arg;
+    B_str end = to$str("\n");
+    if (end_arg)
+        end = end_arg;
 
-B_NoneType B_printn(B_tuple t) {
-    if (t->size > 0) {
-        B_value elem = (B_value)t->components[0];
-        char *s = elem->$class->__str__(elem);
-        fputs((const char*)__str__(elem)->str, stdout);
-    }
-    for (int i=1; i<t->size; i++) {
-        putchar(' ');
+    // Write to temporary buffer first, making us much less prone to interleaved
+    // output from multiple threads. It costs a malloc and some copies but print
+    // should not be used in performance critical code.
+    int tlen = 0;
+    for (int i=0; i<t->size; i++) {
         B_value elem = (B_value)t->components[i];
-        fputs((const char*)__str__(elem)->str, stdout);
+        tlen += __str__(elem)->nbytes + sep->nbytes;
     }
-    fflush(stdout);
+    tlen += end->nbytes;
+    char *s = malloc(tlen+1);
+    int pos = 0;
+    for (int i=0; i<t->size; i++) {
+        if (i > 0) {
+            memcpy(s+pos, sep->str, sep->nbytes);
+            pos += sep->nbytes;
+        }
+        B_value elem = (B_value)t->components[i];
+        memcpy(s+pos, __str__(elem)->str, __str__(elem)->nbytes);
+        pos += __str__(elem)->nbytes;
+    }
+    memcpy(s+pos, end->str, end->nbytes);
+    pos += end->nbytes;
+    s[pos] = '\0';
+    fputs(s, outfd);
+
+    if (flush_arg && flush_arg->val)
+        fflush(outfd);
     return B_None;
 }
 

--- a/base/src/__builtin__.act
+++ b/base/src/__builtin__.act
@@ -857,17 +857,18 @@ def ord(c: str) -> int:
 def pow [A(Number)] (a : A, b : A) -> A:
     return Number.__pow__(a,b)
 
-def print(*args) -> None:
-    """Print to stdout with ending newline"""
-    NotImplemented
+def print(*args, sep: str=" ", end: str="\n", stderr: bool=False, flush: bool=False) -> None:
+    """Prints values
 
-def printn(*args) -> None:
-    """Print to stdout without newline & flushing
+    Values are printed per default to stdout, but can be printed to stderr by
+    setting stderr=True. Multiple values are separated by the sep argument, a
+    space per default. Each invocation will per default add a new line character
+    at the end, which can be overridden through the end argument. Output can be
+    flushed by setting flush=True.
 
-    This is useful to print progress information and similar where we want to
-    overwrite the current line.
+    It is not possible to write to arbitrary file descriptors. Use the file IO
+    functionality to write to files.
     """
-    # TODO: fold this into print
     NotImplemented
 
 def repr(x : value):

--- a/base/src/testing.act
+++ b/base/src/testing.act
@@ -379,13 +379,13 @@ actor test_runner(env: Env, unit_tests: dict[str, UnitTest], sync_actor_tests: d
                 complete = False
                 d += " "
         d += "]"
-        printn("\r")
-        printn(d)
+        print("\r", end="")
+        print(d, end="")
 
         errors = 0
         failures = 0
         if complete:
-            printn(term.clearline + term.up() + term.clearline)
+            print(term.clearline + term.up() + term.clearline, end="")
             print("\nTests")
             tname_width = 20
             for tname, t in results.items():
@@ -466,13 +466,13 @@ actor test_runner(env: Env, unit_tests: dict[str, UnitTest], sync_actor_tests: d
                     complete = False
                     d += " "
             d += "]"
-            printn("\r")
-            printn(d)
+            print("\r", end="")
+            print(d, end="")
 
             errors = 0
             failures = 0
             if complete:
-                printn(term.clearline + term.up() + term.clearline)
+                print(term.clearline + term.up() + term.clearline, end="")
                 print("\nTests")
                 tname_width = 20
                 for tname, t in results.items():


### PR DESCRIPTION
Also remove printn() since it is superceded by print(foo, end="").

Fixes #112.