### PR TITLE
Include actual key in KeyError.__str__()

### DIFF
--- a/base/builtin/dict.c
+++ b/base/builtin/dict.c
@@ -621,7 +621,7 @@ $WORD B_IndexedD_MappingD_dictD___getitem__(B_IndexedD_MappingD_dict wit, B_dict
     $WORD res;
     int ix = $lookdict(dict,hashwit,hash,key,&res);
     if (ix < 0)  {
-        $RAISE((B_BaseException)$NEW(B_KeyError, to$str("getitem: key not in dictionary")));
+        $RAISE((B_BaseException)$NEW(B_KeyError, to$str("getitem: key not in dictionary"), key));
     }      
     return res;
 }
@@ -637,14 +637,14 @@ B_NoneType B_IndexedD_MappingD_dictD___delitem__ (B_IndexedD_MappingD_dict wit, 
     int ix = $lookdict(dict,hashwit,hash,key,&res);
     $table table = dict->table;
     if (ix < 0)  {
-        $RAISE((B_BaseException)$NEW(B_KeyError,to$str("getitem: key not in dictionary")));
+        $RAISE((B_BaseException)$NEW(B_KeyError, to$str("getitem: key not in dictionary"), key));
     }      
     $entry_t entry = &TB_ENTRIES(table)[ix];
     int i = $lookdict_index(table,hash,ix);
     table->tb_indices[i] = DKIX_DUMMY;
     res = entry->value;
     if (res == NULL) {
-        $RAISE((B_BaseException)$NEW(B_KeyError,to$str("delitem: key not in dictionary")));
+        $RAISE((B_BaseException)$NEW(B_KeyError, to$str("delitem: key not in dictionary"), key));
     }
     entry->value = NULL;
     dict->numelements--;
@@ -746,7 +746,7 @@ struct B_OrdD_dictG_class B_OrdD_dictG_methods = {
 void B_dictD_setitem(B_dict dict, B_Hashable hashwit, $WORD key, $WORD value) {
     long hash = from$int(hashwit->$class->__hash__(hashwit,key));
     if (insertdict(dict, hashwit, hash, key, value)<0) {
-        $RAISE((B_BaseException)$NEW(B_KeyError,to$str("setitem: key not in dictionary")));
+        $RAISE((B_BaseException)$NEW(B_KeyError, to$str("setitem: key not in dictionary"), key));
     }      
 }
 

--- a/base/src/__builtin__.act
+++ b/base/src/__builtin__.act
@@ -336,7 +336,12 @@ class IndexError (LookupError):
     pass
 
 class KeyError (LookupError):
-    pass
+    def __init__(self, msg: str, key: value):
+        self.error_message = msg
+        self.key = key
+
+    def __str__(self):
+        return "%s: %s, key: %s" % (self._name(), self.error_message, str(self.key))
 
 class MemoryError (Exception):
     pass


### PR DESCRIPTION
Now that exceptions are always string formatted by __str__ we can actually include the key in the KeyError exception. It's only included as an object attribute so it doesn't cost much. The actual string formatting is only performed if the exception is actually printed.

Fixes #1564.