### PR TITLE
Remove git LFS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -506,8 +506,6 @@ jobs:
       - name: Install build prerequisites
         run: |
           apt-get update
-          apt-get install -qy git-lfs
-          git lfs install
           apt-get install -qy -t experimental reprepro
           apt-get install -qy git gnupg
       - name: Check out code of aptip.acton-lang.io repo


### PR DESCRIPTION
GitHub caps it at 1GB. Weird, because surely it must be easier & cheaper to produce than regular git access. Anyway, ditching LFS since we want to stay in the free...

Part of #1569 