### PR TITLE
added support for different bases in string argument to integer type …

### DIFF
--- a/base/builtin/i16.c
+++ b/base/builtin/i16.c
@@ -24,63 +24,20 @@ short shortpow(short a, short e) {
 
 // General methods ///////////////////////////////////////////////////////////////////////
 
-B_i16 B_i16G_new(B_atom a) {
-    if ($ISINSTANCE(a,B_int)->val){
-        zz_struct n = ((B_int)a)-> val;
-        if (n.n[0] > SHRT_MAX || (labs(n.size))>1) {
-            $RAISE((B_BaseException)$NEW(B_ValueError,to$str("i16(): int argument out of range")));
-        }
-        return toB_i16(n.size*n.n[0]);
+B_i16 B_i16G_new(B_atom a, B_int base) {
+    B_int b = B_intG_new(a, base);
+    unsigned long n = b->val.n[0];
+    long sz = b->val.size;
+    if (labs(sz) > 1 || (sz==1 && n > SHRT_MAX) || sz == -1 && n > labs(SHRT_MIN)) {
+        char errmsg[1024];
+        snprintf(errmsg, sizeof(errmsg), "i16(): value %s out of range for type i16",get_str(&b->val));
+        $RAISE((B_BaseException)$NEW(B_ValueError,to$str(errmsg)));
     }
-    if ($ISINSTANCE(a,B_i64)->val) {
-        long x = ((B_i64)a)->val;
-        if (x > SHRT_MAX || x < SHRT_MIN) 
-            $RAISE((B_BaseException)$NEW(B_ValueError,to$str("i16(): i64 argument out of range")));
-        return toB_i16((short)x);
-    }
-
-    if ($ISINSTANCE(a,B_i32)->val) {
-        int x = ((B_i32)a)->val;
-        if (x > SHRT_MAX || x < SHRT_MIN) 
-            $RAISE((B_BaseException)$NEW(B_ValueError,to$str("i16(): i32 argument out of range")));
-        return toB_i16((short)x);
-    }
-    if ($ISINSTANCE(a,B_i16)->val) return (B_i16)a;
-    if ($ISINSTANCE(a,B_u64)->val) {
-        unsigned long x = ((B_u64)a)->val;
-        if (x > SHRT_MAX) 
-            $RAISE((B_BaseException)$NEW(B_ValueError,to$str("i16(): u64 argument out of range")));
-        return toB_i16((short)x);
-    }
-    if ($ISINSTANCE(a,B_u32)->val) {
-        unsigned int x = ((B_u32)a)->val;
-        if (x > SHRT_MAX) 
-            $RAISE((B_BaseException)$NEW(B_ValueError,to$str("i16(): u32 argument out of range")));
-        return toB_i16((short)x);
-    }
-    if ($ISINSTANCE(a,B_u16)->val) {
-        unsigned short x = ((B_u16)a)->val;
-        if (x > SHRT_MAX) 
-            $RAISE((B_BaseException)$NEW(B_ValueError,to$str("i16(): u16 argument out of range")));
-        return toB_i16((short)x);
-    }
-    if ($ISINSTANCE(a,B_float)->val) return toB_i16(round(((B_float)a)->val));
-    if ($ISINSTANCE(a,B_bool)->val) return toB_i16(((B_bool)a)->val);
-    if ($ISINSTANCE(a,B_str)->val) {
-        short x;
-        int c;
-        sscanf((char *)((B_str)a)->str,"%hd%n",&x,&c);
-        if (c==((B_str)a)->nbytes)
-            return toB_i16(x);
-        else 
-            $RAISE((B_BaseException)$NEW(B_ValueError,to$str("int(): invalid str value for type int")));
-    }
-    fprintf(stderr,"internal error: B_i16G_new: argument not of atomic type");
-    exit(-1);
+    return toB_i16(n);
 }
 
-B_NoneType B_i16D___init__(B_i16 self, B_atom a){
-    self->val = B_i16G_new(a)->val;
+B_NoneType B_i16D___init__(B_i16 self, B_atom a, B_int base){
+    self->val = B_i16G_new(a,base)->val;
     return B_None;
 }
 
@@ -133,7 +90,7 @@ B_complex B_IntegralD_i16D___complex__(B_IntegralD_i16 wit, B_i16 a) {
 }
 
 B_i16 B_IntegralD_i16D___fromatom__(B_IntegralD_i16 wit, B_atom a) {
-    return B_i16G_new(a);
+    return B_i16G_new(a,NULL);
 }
 
 B_i16 B_IntegralD_i16D___mul__(B_IntegralD_i16 wit,  B_i16 a, B_i16 b) {
@@ -211,11 +168,11 @@ $WORD B_IntegralD_i16D_denominator (B_IntegralD_i16 wit, B_i16 n, B_Integral wit
 }
   
 B_int B_IntegralD_i16D___int__ (B_IntegralD_i16 wit, B_i16 n) {
-    return B_intG_new((B_atom)n);
+    return B_intG_new((B_atom)n,NULL);
 }
 
 B_int B_IntegralD_i16D___index__(B_IntegralD_i16 wit, B_i16 n) {
-    return B_intG_new((B_atom)n);
+    return B_intG_new((B_atom)n,NULL);
 }
 
 B_tuple B_IntegralD_i16D___divmod__(B_IntegralD_i16 wit, B_i16 a, B_i16 b) {

--- a/base/builtin/i16.h
+++ b/base/builtin/i16.h
@@ -7,5 +7,5 @@ struct B_i16 {
 B_i16 toB_i16(short n);
 short fromB_i16(B_i16 n);
 
-B_i16 B_i16G_new(B_atom a);
+B_i16 B_i16G_new(B_atom a, B_int base);
  

--- a/base/builtin/i32.c
+++ b/base/builtin/i32.c
@@ -24,53 +24,21 @@ int intpow(int a, int e) {
 
 // General methods ///////////////////////////////////////////////////////////////////////
 
-B_i32 B_i32G_new(B_atom a) {
-    if ($ISINSTANCE(a,B_int)->val){
-        zz_struct n = ((B_int)a)-> val;
-        if (n.n[0] > INT_MAX || (labs(n.size))>1) {
-            $RAISE((B_BaseException)$NEW(B_ValueError,to$str("i32(): int argument out of range")));
-        }
-        return toB_i32(n.size*n.n[0]);
+B_i32 B_i32G_new(B_atom a, B_int base) {
+    B_int b = B_intG_new(a, base);
+    unsigned long n = b->val.n[0];
+    long sz = b->val.size;
+    if (labs(sz) > 1 || (sz==1 && n > INT_MAX) || sz == -1 && n > labs(INT_MIN)) {
+        char errmsg[1024];
+        snprintf(errmsg, sizeof(errmsg), "i32(): value %s out of range for type i32",get_str(&b->val));
+        $RAISE((B_BaseException)$NEW(B_ValueError,to$str(errmsg)));
     }
-    if ($ISINSTANCE(a,B_i64)->val) {
-        long x = ((B_i64)a)->val;
-        if (x > INT_MAX || x < INT_MIN) 
-            $RAISE((B_BaseException)$NEW(B_ValueError,to$str("i32(): i64 argument out of range")));
-        return toB_i32((long)x);
-    }
-
-    if ($ISINSTANCE(a,B_i32)->val) return (B_i32)a;
-    if ($ISINSTANCE(a,B_i16)->val) return toB_i32((int)((B_i16)a)->val);
-    if ($ISINSTANCE(a,B_u64)->val) {
-        unsigned long x = ((B_u64)a)->val;
-        if (x > INT_MAX) 
-            $RAISE((B_BaseException)$NEW(B_ValueError,to$str("i32(): u64 argument out of range")));
-        return toB_i32((int)x);
-    }
-    if ($ISINSTANCE(a,B_u32)->val) {
-        unsigned int x = ((B_u32)a)->val;
-        if (x > INT_MAX) 
-            $RAISE((B_BaseException)$NEW(B_ValueError,to$str("i32(): u32 argument out of range")));
-        return toB_i32((int)x);
-    }
-    if ($ISINSTANCE(a,B_u16)->val) return toB_i32((int)((B_u16)a)->val);
-    if ($ISINSTANCE(a,B_float)->val) return toB_i32(round(((B_float)a)->val));
-    if ($ISINSTANCE(a,B_bool)->val) return toB_i32(((B_bool)a)->val);
-    if ($ISINSTANCE(a,B_str)->val) {
-        int x;
-        int c;
-        sscanf((char *)((B_str)a)->str,"%d%n",&x,&c);
-        if (c==((B_str)a)->nbytes)
-            return toB_i32(x);
-        else 
-            $RAISE((B_BaseException)$NEW(B_ValueError,to$str("int(): invalid str value for type int")));
-    }
-    fprintf(stderr,"internal error: B_i32G_new: argument not of atomic type");
-    exit(-1);
+    return toB_i32(n);
 }
 
-B_NoneType B_i32D___init__(B_i32 self, B_atom a){
-    self->val = B_i32G_new(a)->val;
+
+B_NoneType B_i32D___init__(B_i32 self, B_atom a, B_int base){
+    self->val = B_i32G_new(a,base)->val;
     return B_None;
 }
 
@@ -123,7 +91,7 @@ B_complex B_IntegralD_i32D___complex__(B_IntegralD_i32 wit, B_i32 a) {
 }
 
 B_i32 B_IntegralD_i32D___fromatom__(B_IntegralD_i32 wit, B_atom a) {
-    return B_i32G_new(a);
+    return B_i32G_new(a,NULL);
 }
 
 B_i32 B_IntegralD_i32D___mul__(B_IntegralD_i32 wit,  B_i32 a, B_i32 b) {
@@ -201,11 +169,11 @@ $WORD B_IntegralD_i32D_denominator (B_IntegralD_i32 wit, B_i32 n, B_Integral wit
 }
   
 B_int B_IntegralD_i32D___int__ (B_IntegralD_i32 wit, B_i32 n) {
-    return B_intG_new((B_atom)n);
+    return B_intG_new((B_atom)n,NULL);
 }
 
 B_int B_IntegralD_i32D___index__(B_IntegralD_i32 wit, B_i32 n) {
-    return B_intG_new((B_atom)n);
+    return B_intG_new((B_atom)n,NULL);
 }
 
 B_tuple B_IntegralD_i32D___divmod__(B_IntegralD_i32 wit, B_i32 a, B_i32 b) {

--- a/base/builtin/i32.h
+++ b/base/builtin/i32.h
@@ -7,5 +7,5 @@ struct B_i32 {
 B_i32 toB_i32(int n);
 int fromB_i32(B_i32 n);
 
-B_i32 B_i32G_new(B_atom a);
+B_i32 B_i32G_new(B_atom a, B_int base);
 

--- a/base/builtin/i64.c
+++ b/base/builtin/i64.c
@@ -24,42 +24,20 @@ long longpow(long a, long e) {
 
 // General methods ///////////////////////////////////////////////////////////////////////
 
-B_i64 B_i64G_new(B_atom a) {
-    if ($ISINSTANCE0(a,B_int)){
-        zz_struct n = ((B_int)a)-> val;
-        if (n.n[0] > LONG_MAX || (labs(n.size))>1) {
-            $RAISE((B_BaseException)$NEW(B_ValueError,to$str("i64(): int argument out of range")));
-        }
-        return toB_i64(n.size*n.n[0]);
+B_i64 B_i64G_new(B_atom a, B_int base) {
+    B_int b = B_intG_new(a, base);
+    unsigned long n = b->val.n[0];
+    long sz = b->val.size;
+    if (labs(sz) > 1 || (sz==1 && n > LONG_MAX) || sz == -1 && n > labs(LONG_MIN)) {
+        char errmsg[1024];
+        snprintf(errmsg, sizeof(errmsg), "i64(): value %s out of range for type i64",get_str(&b->val));
+        $RAISE((B_BaseException)$NEW(B_ValueError,to$str(errmsg)));
     }
-    if ($ISINSTANCE0(a,B_i64)) return (B_i64)a;
-    if ($ISINSTANCE0(a,B_i32)) return toB_i64((long)((B_i32)a)->val);
-    if ($ISINSTANCE0(a,B_i16)) return toB_i64((long)((B_i16)a)->val);
-    if ($ISINSTANCE0(a,B_u64)) {
-        unsigned long x = ((B_u64)a)->val;
-        if (x > LONG_MAX) 
-            $RAISE((B_BaseException)$NEW(B_ValueError,to$str("i64(): u64 argument out of range")));
-        return toB_i64((long)x);
-    }
-    if ($ISINSTANCE0(a,B_u32)) return toB_i64((long)((B_u32)a)->val);
-    if ($ISINSTANCE0(a,B_u16)) return toB_i64((long)((B_u16)a)->val);
-    if ($ISINSTANCE0(a,B_float)) return toB_i64(round(((B_float)a)->val));
-    if ($ISINSTANCE0(a,B_bool)) return toB_i64(((B_bool)a)->val);
-    if ($ISINSTANCE0(a,B_str)) {
-        long x;
-        int c;
-        sscanf((char *)((B_str)a)->str,"%ld%n",&x,&c);
-        if (c==((B_str)a)->nbytes)
-            return toB_i64(x);
-        else 
-            $RAISE((B_BaseException)$NEW(B_ValueError,to$str("int(): invalid str value for type int")));
-    }
-    fprintf(stderr,"internal error: B_i64G_new: argument not of atomic type");
-    exit(-1);
+    return toB_i64(n);
 }
-
-B_NoneType B_i64D___init__(B_i64 self, B_atom a){
-    self->val = B_i64G_new(a)->val;
+ 
+B_NoneType B_i64D___init__(B_i64 self, B_atom a, B_int base){
+    self->val = B_i64G_new(a,base)->val;
     return B_None;
 }
 
@@ -112,7 +90,7 @@ B_complex B_IntegralD_i64D___complex__(B_IntegralD_i64 wit, B_i64 a) {
 }
 
 B_i64 B_IntegralD_i64D___fromatom__(B_IntegralD_i64 wit, B_atom a) {
-    return B_i64G_new(a);
+    return B_i64G_new(a,NULL);
 }
 
 B_i64 B_IntegralD_i64D___mul__(B_IntegralD_i64 wit,  B_i64 a, B_i64 b) {
@@ -190,11 +168,11 @@ $WORD B_IntegralD_i64D_denominator (B_IntegralD_i64 wit, B_i64 n, B_Integral wit
 }
   
 B_int B_IntegralD_i64D___int__ (B_IntegralD_i64 wit, B_i64 n) {
-    return B_intG_new((B_atom)n);
+    return B_intG_new((B_atom)n,NULL);
 }
 
 B_int B_IntegralD_i64D___index__(B_IntegralD_i64 wit, B_i64 n) {
-    return B_intG_new((B_atom)n);
+    return B_intG_new((B_atom)n,NULL);
 }
 
 B_tuple B_IntegralD_i64D___divmod__(B_IntegralD_i64 wit, B_i64 a, B_i64 b) {

--- a/base/builtin/i64.h
+++ b/base/builtin/i64.h
@@ -7,7 +7,7 @@ struct B_i64 {
 B_i64 toB_i64(long n);
 long fromB_i64(B_i64 n);
 
-B_i64 B_i64G_new(B_atom a);
+B_i64 B_i64G_new(B_atom a, B_int base);
 
 // only called with e>=0.
 long longpow(long a, long e); // used also for ndarrays

--- a/base/builtin/int.h
+++ b/base/builtin/int.h
@@ -11,7 +11,9 @@ long from$int(B_int n);
 B_int to$int(long n);
 B_int to$int2(char *str);
 
-B_int B_intG_new(B_atom a);
+char *get_str(zz_ptr n);
+
+B_int B_intG_new(B_atom a, B_int base);
 
 B_int $gcd(B_int, B_int);
 B_tuple $xgcd(B_int, B_int);

--- a/base/builtin/u16.c
+++ b/base/builtin/u16.c
@@ -24,68 +24,20 @@ unsigned short ushortpow(unsigned short a, unsigned short e) {
 
 // General methods ///////////////////////////////////////////////////////////////////////
 
-B_u16 B_u16G_new(B_atom a) {
-    if ($ISINSTANCE(a,B_int)->val){
-        zz_struct n = ((B_int)a)-> val;
-        if (n.size < 0 || n.size > 1) {
-            $RAISE((B_BaseException)$NEW(B_ValueError,to$str("u16(): int argument out of range")));
-        }
-        return toB_u16(n.size*n.n[0]);
+B_u16 B_u16G_new(B_atom a, B_int base) {
+    B_int b = B_intG_new(a, base);
+    unsigned long n = b->val.n[0];
+    long sz = b->val.size;
+    if (sz > 1 || sz < 0 || n > USHRT_MAX) {
+        char errmsg[1024];
+        snprintf(errmsg, sizeof(errmsg), "u16(): value %s out of range for type u16",get_str(&b->val));
+        $RAISE((B_BaseException)$NEW(B_ValueError,to$str(errmsg)));
     }
-    if ($ISINSTANCE(a,B_i64)->val) {
-        long x = ((B_i64)a)->val;
-        if (x < 0 || x > USHRT_MAX) 
-            $RAISE((B_BaseException)$NEW(B_ValueError,to$str("u16(): i64 argument out of range")));
-        return toB_u16((unsigned short)x);
-    }
-    if ($ISINSTANCE(a,B_i32)->val) {
-        int x = ((B_i32)a)->val;
-        if (x < 0 || x > USHRT_MAX) 
-            $RAISE((B_BaseException)$NEW(B_ValueError,to$str("u16(): i32 argument out of range")));
-        return toB_u16((unsigned short)x);
-    }
-    if ($ISINSTANCE(a,B_i16)->val) {
-        short x = ((B_i16)a)->val;
-        if (x < 0) 
-            $RAISE((B_BaseException)$NEW(B_ValueError,to$str("u16(): i16 argument out of range")));
-        return toB_u16((unsigned short)x);
-    }
-    if ($ISINSTANCE(a,B_u64)->val) {
-        unsigned long x = ((B_u64)a)->val;
-        if (x > USHRT_MAX) 
-            $RAISE((B_BaseException)$NEW(B_ValueError,to$str("u16(): u64 argument out of range")));
-        return toB_u16((unsigned short)x);
-    }
-    if ($ISINSTANCE(a,B_u32)->val) {
-        unsigned int x = ((B_u32)a)->val;
-        if (x > USHRT_MAX) 
-            $RAISE((B_BaseException)$NEW(B_ValueError,to$str("u16(): u32 argument out of range")));
-        return toB_u16((unsigned short)x);
-    }
-    if ($ISINSTANCE(a,B_u16)->val)return (B_u16)a;
-    if ($ISINSTANCE(a,B_float)->val) {
-        short x = round(((B_float)a)->val);
-        if (x<0)
-           $RAISE((B_BaseException)$NEW(B_ValueError,to$str("u16(): negative float argument")));
-        else
-            return toB_u16((unsigned short)x);
-    }
-    if ($ISINSTANCE(a,B_bool)->val) return toB_u16((unsigned short)((B_bool)a)->val);
-    if ($ISINSTANCE(a,B_str)->val) {
-        unsigned short x;
-        int c;
-        sscanf((char *)((B_str)a)->str,"%hu%n",&x,&c);
-        if (c==((B_str)a)->nbytes)
-            return toB_u16(x);
-        else 
-            $RAISE((B_BaseException)$NEW(B_ValueError,to$str("u16(): invalid str value for type u16")));
-    }
-    fprintf(stderr,"internal error: B_u16G_new: argument not of atomic type");
-    exit(-1);
+    return toB_u16(n);
 }
 
-B_NoneType B_u16D___init__(B_u16 self, B_atom a){
-    self->val = B_u16G_new(a)->val;
+B_NoneType B_u16D___init__(B_u16 self, B_atom a, B_int base){
+    self->val = B_u16G_new(a,base)->val;
     return B_None;
 }
 
@@ -138,7 +90,7 @@ B_complex B_IntegralD_u16D___complex__(B_IntegralD_u16 wit, B_u16 a) {
 }
 
 B_u16 B_IntegralD_u16D___fromatom__(B_IntegralD_u16 wit, B_atom a) {
-    return B_u16G_new(a);
+    return B_u16G_new(a,NULL);
 }
 
 B_u16 B_IntegralD_u16D___mul__(B_IntegralD_u16 wit,  B_u16 a, B_u16 b) {
@@ -212,11 +164,11 @@ $WORD B_IntegralD_u16D_denominator (B_IntegralD_u16 wit, B_u16 n, B_Integral wit
 }
   
 B_int B_IntegralD_u16D___int__ (B_IntegralD_u16 wit, B_u16 n) {
-    return B_intG_new((B_atom)n);
+    return B_intG_new((B_atom)n,NULL);
 }
 
 B_int B_IntegralD_u16D___index__(B_IntegralD_u16 wit, B_u16 n) {
-    return B_intG_new((B_atom)n);
+    return B_intG_new((B_atom)n,NULL);
 }
 
 B_tuple B_IntegralD_u16D___divmod__(B_IntegralD_u16 wit, B_u16 a, B_u16 b) {

--- a/base/builtin/u16.h
+++ b/base/builtin/u16.h
@@ -6,5 +6,5 @@ struct B_u16 {
 B_u16 toB_u16(unsigned short n);
 unsigned short fromB_u16(B_u16 n);
 
-B_u16 B_u16G_new(B_atom a);
+B_u16 B_u16G_new(B_atom a, B_int base);
 

--- a/base/builtin/u32.c
+++ b/base/builtin/u32.c
@@ -24,63 +24,20 @@ unsigned int uintpow(unsigned int a, unsigned int e) {
 
 // General methods ///////////////////////////////////////////////////////////////////////
 
-B_u32 B_u32G_new(B_atom a) {
-    if ($ISINSTANCE(a,B_int)->val){
-        zz_struct n = ((B_int)a)-> val;
-        if (n.size < 0 || n.size > 1) {
-            $RAISE((B_BaseException)$NEW(B_ValueError,to$str("u32(): int argument out of range")));
-        }
-        return toB_u32(n.size*n.n[0]);
-    }
-    if ($ISINSTANCE(a,B_i64)->val) {
-        long x = ((B_i64)a)->val;
-        if (x < 0 || x > UINT_MAX) 
-            $RAISE((B_BaseException)$NEW(B_ValueError,to$str("u32(): i64 argument out of range")));
-        return toB_u32((unsigned int)x);
-    }
-    if ($ISINSTANCE(a,B_i32)->val) {
-        int x = ((B_i32)a)->val;
-        if (x < 0) 
-            $RAISE((B_BaseException)$NEW(B_ValueError,to$str("u32(): i32 argument out of range")));
-        return toB_u32((unsigned int)x);
-    }
-    if ($ISINSTANCE(a,B_i16)->val) {
-        short x = ((B_i16)a)->val;
-        if (x < 0) 
-            $RAISE((B_BaseException)$NEW(B_ValueError,to$str("u32(): i16 argument out of range")));
-        return toB_u32((unsigned int)x);
-    }
-    if ($ISINSTANCE(a,B_u64)->val) {
-        unsigned long x = ((B_u64)a)->val;
-        if (x > UINT_MAX) 
-            $RAISE((B_BaseException)$NEW(B_ValueError,to$str("u32(): u64 argument out of range")));
-        return toB_u32((unsigned int)x);
-    }
-    if ($ISINSTANCE(a,B_u32)->val)return (B_u32)a;
-    if ($ISINSTANCE(a,B_u16)->val) return toB_u32((unsigned int)((B_u16)a)->val);
-    if ($ISINSTANCE(a,B_float)->val) {
-        int x = round(((B_float)a)->val);
-        if (x<0)
-           $RAISE((B_BaseException)$NEW(B_ValueError,to$str("u32(): negative float argument")));
-        else
-            return toB_u32((unsigned int)x);
-    }
-    if ($ISINSTANCE(a,B_bool)->val) return toB_u32((unsigned int)((B_bool)a)->val);
-    if ($ISINSTANCE(a,B_str)->val) {
-        unsigned int x;
-        int c;
-        sscanf((char *)((B_str)a)->str,"%u%n",&x,&c);
-        if (c==((B_str)a)->nbytes)
-            return toB_u32(x);
-        else 
-            $RAISE((B_BaseException)$NEW(B_ValueError,to$str("u32(): invalid str value for type u32")));
-    }
-    fprintf(stderr,"internal error: B_u32G_new: argument not of atomic type");
-    exit(-1);
+B_u32 B_u32G_new(B_atom a, B_int base) {
+    B_int b = B_intG_new(a, base);
+    unsigned long n = b->val.n[0];
+    long sz = b->val.size;
+    if (sz > 1 || sz < 0 || n > UINT_MAX) {
+        char errmsg[1024];
+        snprintf(errmsg, sizeof(errmsg), "u32(): value %s out of range for type u32",get_str(&b->val));
+        $RAISE((B_BaseException)$NEW(B_ValueError,to$str(errmsg)));
+    } 
+    return toB_u32(n);
 }
 
-B_NoneType B_u32D___init__(B_u32 self, B_atom a){
-    self->val = B_u32G_new(a)->val;
+B_NoneType B_u32D___init__(B_u32 self, B_atom a, B_int base){
+    self->val = B_u32G_new(a,base)->val;
     return B_None;
 }
 
@@ -133,7 +90,7 @@ B_complex B_IntegralD_u32D___complex__(B_IntegralD_u32 wit, B_u32 a) {
 }
 
 B_u32 B_IntegralD_u32D___fromatom__(B_IntegralD_u32 wit, B_atom a) {
-    return B_u32G_new(a);
+    return B_u32G_new(a,NULL);
 }
 
 B_u32 B_IntegralD_u32D___mul__(B_IntegralD_u32 wit,  B_u32 a, B_u32 b) {
@@ -207,11 +164,11 @@ $WORD B_IntegralD_u32D_denominator (B_IntegralD_u32 wit, B_u32 n, B_Integral wit
 }
   
 B_int B_IntegralD_u32D___int__ (B_IntegralD_u32 wit, B_u32 n) {
-    return B_intG_new((B_atom)n);
+    return B_intG_new((B_atom)n,NULL);
 }
 
 B_int B_IntegralD_u32D___index__(B_IntegralD_u32 wit, B_u32 n) {
-    return B_intG_new((B_atom)n);
+    return B_intG_new((B_atom)n,NULL);
 }
 
 B_tuple B_IntegralD_u32D___divmod__(B_IntegralD_u32 wit, B_u32 a, B_u32 b) {

--- a/base/builtin/u32.h
+++ b/base/builtin/u32.h
@@ -6,5 +6,5 @@ struct B_u32 {
 B_u32 toB_u32(unsigned int n);
 unsigned int fromB_u32(B_u32 n);
 
-B_u32 B_u32G_new(B_atom a);
+B_u32 B_u32G_new(B_atom a, B_int base);
 

--- a/base/builtin/u64.c
+++ b/base/builtin/u64.c
@@ -24,58 +24,20 @@ unsigned long ulongpow(unsigned long a, unsigned long e) {
 
 // General methods ///////////////////////////////////////////////////////////////////////
 
-B_u64 B_u64G_new(B_atom a) {
-    if ($ISINSTANCE(a,B_int)->val){
-        zz_struct n = ((B_int)a)-> val;
-        if (n.size < 0 || n.size > 1) {
-            $RAISE((B_BaseException)$NEW(B_ValueError,to$str("u64(): int argument out of range")));
-        }
-        return toB_u64(n.size*n.n[0]);
+B_u64 B_u64G_new(B_atom a, B_int base) {
+    B_int b = B_intG_new(a, base);
+    unsigned long n = b->val.n[0];
+    long sz = b->val.size;
+    if (sz > 1 || sz < 0) {
+        char errmsg[1024];
+        snprintf(errmsg, sizeof(errmsg), "u64(): value %s out of range for type u64",get_str(&b->val));
+        $RAISE((B_BaseException)$NEW(B_ValueError,to$str(errmsg)));
     }
-    if ($ISINSTANCE(a,B_i64)->val) {
-        long x = ((B_i64)a)->val;
-        if (x < 0) 
-            $RAISE((B_BaseException)$NEW(B_ValueError,to$str("u64(): i64 argument out of range")));
-        return toB_u64((unsigned long)x);
-    }
-    if ($ISINSTANCE(a,B_i32)->val) {
-        int x = ((B_i32)a)->val;
-        if (x < 0) 
-            $RAISE((B_BaseException)$NEW(B_ValueError,to$str("u64(): i32 argument out of range")));
-        return toB_u64((unsigned long)x);
-    }
-    if ($ISINSTANCE(a,B_i16)->val) {
-        short x = ((B_i16)a)->val;
-        if (x < 0) 
-            $RAISE((B_BaseException)$NEW(B_ValueError,to$str("u64(): i16 argument out of range")));
-        return toB_u64((unsigned long)x);
-    }
-    if ($ISINSTANCE(a,B_u64)->val) return (B_u64)a;
-    if ($ISINSTANCE(a,B_u32)->val) return toB_u64((unsigned long)((B_u32)a)->val);
-    if ($ISINSTANCE(a,B_u16)->val) return toB_u64((unsigned long)((B_u16)a)->val);
-    if ($ISINSTANCE(a,B_float)->val) {
-        long x = round(((B_float)a)->val);
-        if (x<0)
-           $RAISE((B_BaseException)$NEW(B_ValueError,to$str("u64(): negative float argument")));
-        else
-            return toB_u64((unsigned long)x);
-    }
-    if ($ISINSTANCE(a,B_bool)->val) return toB_u64((unsigned long)((B_bool)a)->val);
-    if ($ISINSTANCE(a,B_str)->val) {
-        unsigned long x;
-        int c;
-        sscanf((char *)((B_str)a)->str,"%lu%n",&x,&c);
-        if (c==((B_str)a)->nbytes)
-            return toB_u64(x);
-        else 
-            $RAISE((B_BaseException)$NEW(B_ValueError,to$str("u64(): invalid str value for type u64")));
-    }
-    fprintf(stderr,"internal error: B_u64G_new: argument not of atomic type");
-    exit(-1);
+    return toB_u64(n);
 }
-
-B_NoneType B_u64D___init__(B_u64 self, B_atom a){
-    self->val = B_u64G_new(a)->val;
+ 
+B_NoneType B_u64D___init__(B_u64 self, B_atom a, B_int base){
+    self->val = B_u64G_new(a,base)->val;
     return B_None;
 }
 
@@ -128,7 +90,7 @@ B_complex B_IntegralD_u64D___complex__(B_IntegralD_u64 wit, B_u64 a) {
 }
 
 B_u64 B_IntegralD_u64D___fromatom__(B_IntegralD_u64 wit, B_atom a) {
-    return B_u64G_new(a);
+    return B_u64G_new(a,NULL);
 }
 
 B_u64 B_IntegralD_u64D___mul__(B_IntegralD_u64 wit,  B_u64 a, B_u64 b) {
@@ -202,11 +164,11 @@ $WORD B_IntegralD_u64D_denominator (B_IntegralD_u64 wit, B_u64 n, B_Integral wit
 }
   
 B_int B_IntegralD_u64D___int__ (B_IntegralD_u64 wit, B_u64 n) {
-    return B_intG_new((B_atom)n);
+    return B_intG_new((B_atom)n,NULL);
 }
 
 B_int B_IntegralD_u64D___index__(B_IntegralD_u64 wit, B_u64 n) {
-    return B_intG_new((B_atom)n);
+    return B_intG_new((B_atom)n,NULL);
 }
 
 B_tuple B_IntegralD_u64D___divmod__(B_IntegralD_u64 wit, B_u64 a, B_u64 b) {

--- a/base/builtin/u64.h
+++ b/base/builtin/u64.h
@@ -6,5 +6,5 @@ struct B_u64 {
 B_u64 toB_u64(unsigned long n);
 unsigned long fromB_u64(B_u64 n);
 
-B_u64 B_u64G_new(B_atom a);
+B_u64 B_u64G_new(B_atom a, B_int base);
 

--- a/base/src/__builtin__.act
+++ b/base/src/__builtin__.act
@@ -29,31 +29,31 @@ class atom (value):
     pass
 
 class int (atom):
-    def __init__(self, val: atom) -> None:
+    def __init__(self, val: atom, base: ?int) -> None:
         NotImplemented
 
 class i64 (atom):
-    def __init__(self, val: atom) -> None:
+    def __init__(self, val: atom, base: ?int) -> None:
         NotImplemented
 
 class i32 (atom):
-    def __init__(self, val: atom) -> None:
+    def __init__(self, val: atom, base: ?int) -> None:
         NotImplemented
 
 class i16 (atom):
-    def __init__(self, val: atom) -> None:
+    def __init__(self, val: atom, base: ?int) -> None:
         NotImplemented
 
 class u64 (atom):
-    def __init__(self, val: atom) -> None:
+    def __init__(self, val: atom, base: ?int) -> None:
         NotImplemented
 
 class u32 (atom):
-    def __init__(self, val: atom) -> None:
+    def __init__(self, val: atom, base: ?int) -> None:
         NotImplemented
 
 class u16 (atom):
-    def __init__(self, val: atom) -> None:
+    def __init__(self, val: atom, base: ?int) -> None:
         NotImplemented
 
 class float (atom):

--- a/test/builtins_auto/int.act
+++ b/test/builtins_auto/int.act
@@ -81,6 +81,16 @@ def test_i16():
     if x != 0:
        raise ValueError("unexpected: x != 0")
     return True
+    if i16("1234") != 1234:
+        raise ValueError('i16("1234") gives wrong result')
+    if i16("0x1234") != 4660:
+        raise ValueError('i16("0x1234") gives wrong result')
+    if i16("0o1234") != 668:
+        raise ValueError('i16("0o1234") gives wrong result')
+    if i16("0b1111") != 15:
+        raise ValueError('i16("0b1111") gives wrong result')
+    if i16("1234",7) != 466:
+        raise ValueError('i16("1234",7) gives wrong result')
 
 def test_i32():
     test_i32_divzero()
@@ -126,6 +136,16 @@ def test_u64():
     if x != 0:
        raise ValueError("unexpected: x != 0")
     return True
+    if u64("1234") != 1234:
+        raise ValueError('u64("1234") gives wrong result')
+    if u64("0x1234") != 4660:
+        raise ValueError('u64("0x1234") gives wrong result')
+    if u64("0o1234") != 668:
+        raise ValueError('u64("0o1234") gives wrong result')
+    if u64("0b1111") != 15:
+        raise ValueError('u64("0b1111") gives wrong result')
+    if u64("1234",7) != 466:
+        raise ValueError('u64("1234",7) gives wrong result')
 
 
 
@@ -156,6 +176,26 @@ def test_int():
         raise ValueError("int('123') != 123")
     if hash(2**131) >= 2**64:
         raise ValueError("hash(2**131) too big")
+    if int("1234") != 1234:
+        raise ValueError('int("1234") gives wrong result')
+    if int("0x1234") != 4660:
+        raise ValueError('int("0x1234") gives wrong result')
+    if int("0o1234") != 668:
+        raise ValueError('int("0o1234") gives wrong result')
+    if int("0b1111") != 15:
+        raise ValueError('int("0b1111") gives wrong result')
+    if int("1234",7) != 466:
+        raise ValueError('int("1234",7) gives wrong result')
+    if int(" -0x34ac53ba0976ae3345A4E8765CCD2345",16) != -70014629019847787457594182942686257989:
+        raise ValueError('int(" -0x34ac53ba0976ae3345A4E8765CCD2345",16) gives wrong result')
+    if int("123rtgvhu7654erfghjuyt54567ujhgfrtyujhgvfc3456ytyhgt54edf",36) != 1505279714924572685646656049328765658872190236487877560661160764208141566553212677331651:
+        raise ValueError('int("123rtgvhu7654erfghjuyt54567ujhgfrtyujhgvfc3456ytyhgt54edf",36) gives wrong result')
+    if int("0") != 0:
+        raise ValueError('int("0")  gives wrong result')
+    if int("1234567890abcdef" * 100,16) != 0x1234567890abcdef * (2**6400)//(2**64-1):
+        raise ValueError('int("1234567890abcdef" * 100,16) gives wrong result')
+    if int('1'* 10000,2) != 2**10000 - 1:
+        raise ValueError("int('1'* 10000,2) gives wrong result")
 
 actor main(env):
     try:


### PR DESCRIPTION
This request adds an optional second parameter 'base' to the constructors of the integer types. This can only be used when the first parameter is of type str. In this case it adds support for using another base (radix) than 10. Bases between 2 and 36 are supported, with decimal digits and letters used as digits as needed. (in base 36 all digits and letters are used; in base 16 0-9 and a-f, and in base 5 0-4 etc). 

In base 2, 8 and 16 the str itself may contain a prefix '0b', '0o' and '0x' respectively. If present the base parameter need not be given. Contradictory base indication in the two arguments (e.g. i64('0x123',8)) is a ValueError.

The conversion from string to integer  values does for the moment not use the linear algoritm that is possible when the base is a power of two.

Tests are in test/builtin_auto/int.act.