### PR TITLE
fixes #1659

### DIFF
--- a/base/src/__builtin__.act
+++ b/base/src/__builtin__.act
@@ -477,6 +477,11 @@ class complex (value):
 class dict[A(Hashable),B] (object):
     def __init__(self, iterable: ?Iterable[(A,B)]) -> None:
         NotImplemented
+# Code generation for calls to copy and clear becomes wrong, so we omit them for now
+#    def clear(self) -> None:
+#        NotImplemented
+#    def copy(self) -> dict[A,B]:
+#        NotImplemented
 
 class set[A(Hashable)] (object):
     def __init__(self, iterable: ?Iterable[A]) -> None:
@@ -722,7 +727,7 @@ protocol Mapping[A(Eq),B] (Container[A], Indexed[A,B]):
     items       : () -> Iterator[(A,B)]
     update      : mut(Iterable[(A,B)]) -> None
     popitem     : () -> (A,B)
-    setdefault  : mut(A,B) -> None
+    setdefault  : mut(A,B) -> ?B
 
 
 

--- a/test/builtins_auto/dict.act
+++ b/test/builtins_auto/dict.act
@@ -28,6 +28,7 @@ actor main(env):
         print("Unexpected result of del dict[\"b\"]:", d)
         await async env.exit(1)
 
+#    pop is a merhod of protocol Set, so for Mapping we have chosen name popitem...
 #    d["pop"] = 123
 #    p = d.pop("pop")
 #    if p != 123:
@@ -45,27 +46,33 @@ actor main(env):
         print("Unexpected result of d.get(\"a\"):", g)
         await async env.exit(1)
 
-# TODO: fix, seemingly broken?
-#    d.update({"c": "C"})
-#    if d != {"a": "A", "c": "C"}:
-#        print("Unexpected result of dict.update():", d)
-#        await async env.exit(1)
+    d.update({"c": "C"}.items())
+    if d != {"a": "A", "c": "C"}:
+        print("Unexpected result of dict.update():", d)
+        await async env.exit(1)
 
-#    sd = d.setdefault("setdef", "a")
-#    print(d)
-#    if sd is not None and sd.0 is not None and sd.0 != "setdef":
-#        print("Unexpected result of d.setdefault(\"setdef\", 1):", str(sd))
-#        await async env.exit(1)
+    sd = d.setdefault("setdef", "a")
+    if sd is None or (sd is not None and sd != "a") or d != {'a':'A', 'c':'C', 'setdef':'a'}:
+        print("Unexpected result of d.setdefault(\"setdef\", \"a\")")
+        await async env.exit(1)
 
+#    Code generation for calls of copy is wrong; the hashwit needed is not supplied.
+#    d = {'a' : 'A', 'b' : 'B'}
 #    d2 = d.copy()
-#    if d2 != {"a": 1}:
+#    if d2 !=  {'a' : 'A', 'b' : 'B'}:
 #        print("Unexpected result of d.copy():", d2)
 #        await async env.exit(1)
 
+#    d3 = d
 #    d.clear()
-#    if d != {}:
-#        print("Unexpected result of d.clear():", d)
-#        await async env.exit(1)
+#    if d != {} or d3 !=  {}: 
+#       print("Unexpected result of d.clear():", d)
+#       await async env.exit(1)
 
+    d1 : dict[str,?str] = {"a":"A", "b" : None, "c" : "C"}
+    del d1["a"]
+    if d1 != {"b" : None, "c" : "C"}:
+        print("Unexpected result with None value:", d1)
+        await async env.exit(1)
 
     await async env.exit(0)


### PR DESCRIPTION
This does the change described in #1659. It also fixes a bug in setdefault.

I also tried to add copy and clear as methods to  dict, but code generation  for calls in client code fails. The type signatures in __builtin__.c have a Hashable witness as 2nd parameter (and so did my implementation), but code generated for calls got only one argument (the dict). Leaving it for now.