### PR TITLE
More support for ty files

### DIFF
--- a/compiler/Acton/CommandLineParser.hs
+++ b/compiler/Acton/CommandLineParser.hs
@@ -50,6 +50,7 @@ data CompileOptions   = CompileOptions {
                          hgen        :: Bool,
                          cgen        :: Bool,
                          ccmd        :: Bool,
+                         ty          :: Bool,
                          timing      :: Bool,
                          autostub    :: Bool,
                          stub        :: Bool,
@@ -140,6 +141,7 @@ compileOptions = CompileOptions
         <*> switch (long "hgen"         <> help "Show the generated .h header")
         <*> switch (long "cgen"         <> help "Show the generated .c code")
         <*> switch (long "ccmd"         <> help "Show CC / LD commands")
+        <*> switch (long "ty"           <> help "Write .ty file to src file directory")
         <*> switch (long "timing"       <> help "Print timing information")
         <*> switch (long "auto-stub"    <> help "Allow automatic stub detection")
         <*> switch (long "stub"         <> help "Stub (.ty) file generation only")

--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -92,10 +92,12 @@ main = do
           }
         C.CmdOpt (C.Cloud opts) -> undefined
         C.CmdOpt (C.Doc opts)   -> printDocs opts
-        C.CompileOpt nms opts   -> compileFiles opts (catMaybes $ map filterActFile nms)
+        C.CompileOpt nms opts   -> if length nms == 1 && takeExtension (head nms) == ".ty"
+                                    then printDocs (C.DocOptions (head nms) "")
+                                    else compileFiles opts (catMaybes $ map filterActFile nms)
 
 defaultOpts   = C.CompileOptions False False False False False False False False False False False
-                                 False False False False False False False False "" "" "" ""
+                                 False False False False False False False False False "" "" "" ""
                                  C.defTarget "" False False False
 
 
@@ -740,6 +742,9 @@ runRestPasses opts paths env0 parsed stubMode = do
 
                           writeFile hFile h
                           writeFile cFile c
+                          let tyFileName =  modNameToString(modName paths) ++ ".ty"
+                          iff (C.ty opts) $
+                               copyFileWithMetadata (joinPath [projTypes paths, tyFileName]) (joinPath [srcDir paths, tyFileName])
 
                           timeCodeWrite <- getTime Monotonic
                           iff (C.timing opts) $ putStrLn("    Pass: Writing code    : " ++ fmtTime (timeCodeWrite - timeCodeGen))


### PR DESCRIPTION
This pull request adds two things:
- actonc  can take one file argument with suffix .ty; if the file exists, its contents is prettyprinted on stdout.
- one more Boolean CompileOption --ty is added; this causes copying of the .ty file from the temporary  project dir to the source file directory before the temporary dir is erased.