### PR TITLE
removed SrcLoc info from .ty files

### DIFF
--- a/compiler/Utils.hs
+++ b/compiler/Utils.hs
@@ -28,9 +28,9 @@ import Prelude hiding((<>))
 
 data SrcLoc                     = Loc Int Int | NoLoc deriving (Eq,Ord,Show,Read,Generic,NFData)
 
-instance Data.Binary.Binary SrcLoc -- where
---    put _ = return ()
---    get   = return NoLoc
+instance Data.Binary.Binary SrcLoc where
+    put _ = return ()
+    get   = return NoLoc
 
 instance Pretty SrcLoc where
     pretty (Loc l r)            = pretty l <> text "-" <> pretty r


### PR DESCRIPTION
This pull request removes all SrcLoc info in .ty files. When these are read all SrcLoc entries become NoLoc.

After pulling, do 'make clean'. 

All existing .ty files become invalid and the corresponding source files must be recompiled. The symptom is an error report from Data.Binary.Get.runGet.

Fixes #1592