### PR TITLE
Place data from initialization in non-GC heap

### DIFF
--- a/base/builtin/bool.c
+++ b/base/builtin/bool.c
@@ -52,7 +52,7 @@ B_bool B_boolG_new(B_value s) {
 }
 
 B_bool toB_bool(long b) {
-    B_bool res = malloc(sizeof(struct B_bool));
+    B_bool res = acton_malloc(sizeof(struct B_bool));
     res->$class = &B_boolG_methods;
     res->val = b;
     return res;

--- a/base/builtin/builtin.h
+++ b/base/builtin/builtin.h
@@ -14,6 +14,7 @@
 #include <ctype.h>
 #include <stdatomic.h>
 
+#include "../rts/common.h"
 #include "common.h"
 
 struct B_NoneType;

--- a/base/builtin/builtin_functions.c
+++ b/base/builtin/builtin_functions.c
@@ -67,7 +67,7 @@ B_NoneType B_print(B_tuple t, B_str sep_arg, B_str end_arg, B_bool stderr_arg, B
         tlen += __str__(elem)->nbytes + sep->nbytes;
     }
     tlen += end->nbytes;
-    char *s = malloc(tlen+1);
+    char *s = acton_malloc(tlen+1);
     int pos = 0;
     for (int i=0; i<t->size; i++) {
         if (i > 0) {

--- a/base/builtin/common.h
+++ b/base/builtin/common.h
@@ -11,16 +11,16 @@ void $default__init__($WORD);
 // void B_printobj(char *mess,$WORD obj);
 
 
-#define $NEW($T, ...)       ({ $T $t = malloc(sizeof(struct $T)); \
+#define $NEW($T, ...)       ({ $T $t = acton_malloc(sizeof(struct $T)); \
                                $t->$class = &$T ## G_methods; \
                                $t->$class->__init__($t, ##__VA_ARGS__); \
                                $t; })
 
-#define $NEWCC($X, $c, ...) ({ $X $x = malloc(sizeof(struct $X)); \
+#define $NEWCC($X, $c, ...) ({ $X $x = acton_malloc(sizeof(struct $X)); \
                                $x->$class = &$X ## G_methods; \
                                $x->$class->__init__($x, ##__VA_ARGS__, $CONSTCONT($x,$c)); })
 
-#define $DNEW($T, $state)   ({ $T $t = malloc(sizeof(struct $T)); \
+#define $DNEW($T, $state)   ({ $T $t = acton_malloc(sizeof(struct $T)); \
                                $t->$class = &$T ## G_methods;                                     \
                                B_dictD_setitem($state->done,(B_Hashable)B_HashableD_intG_witness,to$int($state->row_no-1),$t); \
                                $t; })

--- a/base/builtin/complex.c
+++ b/base/builtin/complex.c
@@ -13,7 +13,7 @@
  */
 
 B_complex toB_complex(complex double c) {
-    B_complex res = malloc(sizeof(struct B_complex));
+    B_complex res = acton_malloc(sizeof(struct B_complex));
     res->$class = &B_complexG_methods;
     res->val = c;
     return res;

--- a/base/builtin/dict.c
+++ b/base/builtin/dict.c
@@ -79,7 +79,7 @@ static int dictresize(B_dict d) {
       }
     */
     /* Allocate a new table. */
-    $table newtable =  malloc(sizeof(char*) + 3*sizeof(long) + newsize*sizeof(int) + (2*newsize/3)*sizeof(struct $entry_struct));
+    $table newtable =  acton_malloc(sizeof(char*) + 3*sizeof(long) + newsize*sizeof(int) + (2*newsize/3)*sizeof(struct $entry_struct));
     newtable->tb_size = newsize;
     newtable->tb_usable = 2*newsize/3-numelements;
     newtable->tb_nentries = numelements;
@@ -97,7 +97,7 @@ static int dictresize(B_dict d) {
         }
     }
     d->table = newtable;
-    free(oldtable);
+    acton_free(oldtable);
     build_indices(newtable, newentries, numelements);
     return 0;
 }
@@ -202,7 +202,7 @@ B_dict B_dictG_new(B_Hashable hashwit, B_Iterable wit, $WORD iterable) {
 
 B_NoneType B_dictD___init__(B_dict dict, B_Hashable hashwit, B_Iterable wit, $WORD iterable) {
     dict->numelements = 0;
-    dict->table = malloc(sizeof(char*)+3*sizeof(long) + 8*sizeof(int) + 5*sizeof(struct $entry_struct));
+    dict->table = acton_malloc(sizeof(char*)+3*sizeof(long) + 8*sizeof(int) + 5*sizeof(struct $entry_struct));
     dict->table->tb_size = 8;
     dict->table->tb_usable = 5;
     dict->table->tb_nentries = 0;
@@ -232,11 +232,11 @@ B_str B_dictD___str__(B_dict self) {
         B_value value = ((B_value)item->components[1]);
         B_str keystr = key->$class->__repr__(key);
         B_str valuestr = value->$class->__repr__(value);
-        B_str elem = malloc(sizeof(struct B_str));
+        B_str elem = acton_malloc(sizeof(struct B_str));
         elem->$class = &B_strG_methods;
         elem->nbytes = keystr->nbytes+valuestr->nbytes+1;
         elem->nchars = keystr->nchars+valuestr->nchars+1;
-        elem->str = malloc(elem->nbytes+1);
+        elem->str = acton_malloc(elem->nbytes+1);
         memcpy(elem->str,keystr->str,keystr->nbytes);
         elem->str[keystr->nbytes] = ':';
         memcpy(&elem->str[keystr->nbytes+1],valuestr->str,valuestr->nbytes);
@@ -281,12 +281,12 @@ B_dict B_dictD___deserialize__(B_dict res, $Serial$state state) {
         return B_dictD_get(state->done,(B_Hashable)B_HashableD_intG_witness,to$int((long)this->blob[0]),NULL);
     } else {
         if (!res)
-            res = malloc(sizeof(struct B_dict));
+            res = acton_malloc(sizeof(struct B_dict));
         B_dictD_setitem(state->done,(B_Hashable)B_HashableD_intG_witness,to$int(state->row_no-1),res);
         res->$class = &B_dictG_methods;
         res->numelements = (long)this->blob[0];
         long tb_size = (long)this->blob[1];
-        res->table = malloc(sizeof(char*) + 3*sizeof(long) + tb_size*sizeof(int) + (2*tb_size/3)*sizeof(struct $entry_struct));
+        res->table = acton_malloc(sizeof(char*) + 3*sizeof(long) + tb_size*sizeof(int) + (2*tb_size/3)*sizeof(struct $entry_struct));
         res->table->tb_size = tb_size;
         res->table->tb_usable = (long)this->blob[2];
         res->table->tb_nentries = (long)this->blob[3];
@@ -412,7 +412,7 @@ B_dict B_MappingD_dictD___fromiter__ (B_MappingD_dict wit, B_Iterable wit2, $WOR
     B_Hashable hashwit = wit->W_HashableD_AD_MappingD_dict;
     B_dict dict = $NEW(B_dict,hashwit,NULL,NULL);
     dict->numelements = 0;
-    dict->table = malloc(sizeof(char*)+3*sizeof(long) + 8*sizeof(int) + 5*sizeof(struct $entry_struct));
+    dict->table = acton_malloc(sizeof(char*)+3*sizeof(long) + 8*sizeof(int) + 5*sizeof(struct $entry_struct));
     dict->table->tb_size = 8;
     dict->table->tb_usable = 5;
     dict->table->tb_nentries = 0;

--- a/base/builtin/env.c
+++ b/base/builtin/env.c
@@ -52,13 +52,13 @@ void read_stdin(uv_stream_t *stream, ssize_t nread, const uv_buf_t *buf) {
     }
 
     if (buf->base)
-        free(buf->base);
+        acton_free(buf->base);
 }
 $R B_EnvD_stdin_installG_local (B_Env self, $Cont c$cont, $action cb) {
     // This should be the only call in env that does IO stuff, so it is safe to
     // pin affinity here (and not earlier)..
     pin_actor_affinity();
-    uv_tty_t *tty = malloc(sizeof(uv_tty_t));
+    uv_tty_t *tty = acton_malloc(sizeof(uv_tty_t));
     uv_tty_init(get_uv_loop(), tty, 0, 1);
     tty->data = cb;
     uv_read_start((uv_stream_t*)tty, alloc_buffer, read_stdin);
@@ -85,7 +85,7 @@ B_Env B_EnvG_newactor(B_WorldCap wc, B_SysCap sc, B_list args) {
 
 
 B_SysCap B_SysCapG_new() {
-    B_SysCap $tmp = malloc(sizeof(struct B_SysCap));
+    B_SysCap $tmp = acton_malloc(sizeof(struct B_SysCap));
     $tmp->$class = &B_SysCapG_methods;
     //   B_SysCapG_methods.__init__($tmp);
     return $tmp;
@@ -97,7 +97,7 @@ B_NoneType B_SysCapD___init__ (B_SysCap self) {
 
 
 B_WorldCap B_WorldCapG_new() {
-    B_WorldCap $tmp = malloc(sizeof(struct B_WorldCap));
+    B_WorldCap $tmp = acton_malloc(sizeof(struct B_WorldCap));
     $tmp->$class = &B_WorldCapG_methods;
     //   B_WorldCapG_methods.__init__($tmp);
     return $tmp;

--- a/base/builtin/exceptions.c
+++ b/base/builtin/exceptions.c
@@ -25,7 +25,7 @@ B_NoneType $SEQD___init__ ($SEQ self) {
 $SEQ $SEQD___deserialize__ ($SEQ self, $Serial$state state) {
     if (!self) {
         if (!state) {
-            self = malloc(sizeof(struct $SEQ));
+            self = acton_malloc(sizeof(struct $SEQ));
             self->$class = &$SEQG_methods;
             return self;
         }
@@ -35,7 +35,7 @@ $SEQ $SEQD___deserialize__ ($SEQ self, $Serial$state state) {
     return self;
 }
 $SEQ $SEQG_new() {
-    $SEQ $tmp = malloc(sizeof(struct $SEQ));
+    $SEQ $tmp = acton_malloc(sizeof(struct $SEQ));
     $tmp->$class = &$SEQG_methods;
     $SEQG_methods.__init__($tmp);
     return $tmp;
@@ -55,7 +55,7 @@ struct $SEQG_class $SEQG_methods = {
 $BRK $BRKD___deserialize__ ($BRK self, $Serial$state state) {
     if (!self) {
         if (!state) {
-            self = malloc(sizeof(struct $BRK));
+            self = acton_malloc(sizeof(struct $BRK));
             self->$class = &$BRKG_methods;
             return self;
         }
@@ -65,7 +65,7 @@ $BRK $BRKD___deserialize__ ($BRK self, $Serial$state state) {
     return self;
 }
 $BRK $BRKG_new() {
-    $BRK $tmp = malloc(sizeof(struct $BRK));
+    $BRK $tmp = acton_malloc(sizeof(struct $BRK));
     $tmp->$class = &$BRKG_methods;
     $BRKG_methods.__init__($tmp);
     return $tmp;
@@ -85,7 +85,7 @@ struct $BRKG_class $BRKG_methods = {
 $CNT $CNTD___deserialize__ ($CNT self, $Serial$state state) {
     if (!self) {
         if (!state) {
-            self = malloc(sizeof(struct $CNT));
+            self = acton_malloc(sizeof(struct $CNT));
             self->$class = &$CNTG_methods;
             return self;
         }
@@ -95,7 +95,7 @@ $CNT $CNTD___deserialize__ ($CNT self, $Serial$state state) {
     return self;
 }
 $CNT $CNTG_new() {
-    $CNT $tmp = malloc(sizeof(struct $CNT));
+    $CNT $tmp = acton_malloc(sizeof(struct $CNT));
     $tmp->$class = &$CNTG_methods;
     $CNTG_methods.__init__($tmp);
     return $tmp;
@@ -123,7 +123,7 @@ void $RETD___serialize__ ($RET self, $Serial$state state) {
 $RET $RETD___deserialize__ ($RET self, $Serial$state state) {
     if (!self) {
         if (!state) {
-            self = malloc(sizeof(struct $RET));
+            self = acton_malloc(sizeof(struct $RET));
             self->$class = &$RETG_methods;
             return self;
         }
@@ -134,7 +134,7 @@ $RET $RETD___deserialize__ ($RET self, $Serial$state state) {
     return self;
 }
 $RET $RETG_new(B_value G_1) {
-    $RET $tmp = malloc(sizeof(struct $RET));
+    $RET $tmp = acton_malloc(sizeof(struct $RET));
     $tmp->$class = &$RETG_methods;
     $RETG_methods.__init__($tmp, G_1);
     return $tmp;

--- a/base/builtin/float.c
+++ b/base/builtin/float.c
@@ -86,7 +86,7 @@ B_str B_floatD___repr__(B_float x) {
 }
 
 B_float to$float(double x) {
-    B_float res = malloc(sizeof(struct B_float));
+    B_float res = acton_malloc(sizeof(struct B_float));
     res->$class = &B_floatG_methods;
     res->val = x;
     return res;

--- a/base/builtin/i16.c
+++ b/base/builtin/i16.c
@@ -66,7 +66,7 @@ B_str B_i16D___repr__(B_i16 n) {
 }
 
 B_i16 toB_i16(short i) {
-    B_i16 res = malloc(sizeof(struct B_i16));
+    B_i16 res = acton_malloc(sizeof(struct B_i16));
     res->$class = &B_i16G_methods;
     res->val = i;
     return res;

--- a/base/builtin/i32.c
+++ b/base/builtin/i32.c
@@ -67,7 +67,7 @@ B_str B_i32D___repr__(B_i32 n) {
 }
 
 B_i32 toB_i32(int i) {
-    B_i32 res = malloc(sizeof(struct B_i32));
+    B_i32 res = acton_malloc(sizeof(struct B_i32));
     res->$class = &B_i32G_methods;
     res->val = i;
     return res;

--- a/base/builtin/i64.c
+++ b/base/builtin/i64.c
@@ -66,7 +66,7 @@ B_str B_i64D___repr__(B_i64 n) {
 }
 
 B_i64 toB_i64(long i) {
-    B_i64 res = malloc(sizeof(struct B_i64));
+    B_i64 res = acton_malloc(sizeof(struct B_i64));
     res->$class = &B_i64G_methods;
     res->val = i;
     return res;

--- a/base/builtin/list.c
+++ b/base/builtin/list.c
@@ -22,8 +22,8 @@ static void expand(B_list lst,int n) {
     while (newcapacity < lst->length+n)
         newcapacity <<= 1;
     $WORD* newptr = lst->data==NULL
-        ? malloc(newcapacity*sizeof($WORD))
-        : realloc(lst->data,newcapacity*sizeof($WORD));
+        ? acton_malloc(newcapacity*sizeof($WORD))
+        : acton_realloc(lst->data,newcapacity*sizeof($WORD));
     if (newptr == NULL) {
         $RAISE((B_BaseException)$NEW(B_MemoryError,to$str("memory allocation failed")));
     }
@@ -35,7 +35,7 @@ static void shrink(B_list lst) {
     if (lst->capacity > 20 && 2*lst->length < lst->capacity) {
         int newcapacity = lst->length;
         $WORD old = lst->data;
-        lst->data = malloc(newcapacity * sizeof($WORD));
+        lst->data = acton_malloc(newcapacity * sizeof($WORD));
         lst->capacity = newcapacity;
         assert(old != NULL);
         memcpy(lst->data, old, newcapacity * sizeof($WORD));
@@ -48,12 +48,12 @@ B_list B_listD_new(int capacity) {
         fprintf(stderr,"Internal error list_new: negative capacity");
         exit(-1);
     } 
-    B_list lst = malloc(sizeof(struct B_list));
+    B_list lst = acton_malloc(sizeof(struct B_list));
     if (lst == NULL) {
         $RAISE((B_BaseException)$NEW(B_MemoryError,to$str("memory allocation failed")));
     }
     if (capacity>0) {
-        lst->data = malloc(capacity*sizeof($WORD));
+        lst->data = acton_malloc(capacity*sizeof($WORD));
         if (lst->data == NULL) {
             $RAISE((B_BaseException)$NEW(B_MemoryError,to$str("memory allocation failed")));
         }

--- a/base/builtin/range.c
+++ b/base/builtin/range.c
@@ -66,7 +66,7 @@ B_range B_rangeD___deserialize__(B_range self, $Serial$state state) {
     $ROW this = state->row;
     state->row = this->next;
     state->row_no++;
-    B_range res = malloc(sizeof(struct B_range));
+    B_range res = acton_malloc(sizeof(struct B_range));
     res->$class = &B_rangeG_methods;
     res->start = (long)this->blob[0];
     res->stop = (long)this->blob[1];

--- a/base/builtin/serialize.c
+++ b/base/builtin/serialize.c
@@ -74,7 +74,7 @@ struct B_HashableD_WORD *B_HashableD_WORDG_witness = &B_HashableD_WORD_instance;
 // small-step functions for (de)serializing the next object /////////////////////////////////////////////////
 
 $ROW $add_header(int class_id, int blob_size, $Serial$state state) {
-    $ROW res = malloc(2 * sizeof(int) + (1+blob_size)*sizeof($WORD));
+    $ROW res = acton_malloc(2 * sizeof(int) + (1+blob_size)*sizeof($WORD));
     res->class_id = class_id;
     state->row_no++;
     res->blob_size = blob_size;
@@ -183,7 +183,7 @@ void $write_serialized($ROW row, char *file) {
 }
  
 $ROW $serialize($Serializable s, $WORD (*globmap)($WORD)) {
-    $Serial$state state = malloc(sizeof(struct $Serial$state));
+    $Serial$state state = acton_malloc(sizeof(struct $Serial$state));
     state->done = $NEW(B_dict,(B_Hashable)B_HashableD_WORDG_witness,NULL,NULL);
     state->globmap = globmap;
     state->row_no=0;
@@ -194,7 +194,7 @@ $ROW $serialize($Serializable s, $WORD (*globmap)($WORD)) {
 }
 
 $ROW $glob_serialize($Serializable self, $WORD (*globmap)($WORD)) {
-    $Serial$state state = malloc(sizeof(struct $Serial$state));
+    $Serial$state state = acton_malloc(sizeof(struct $Serial$state));
     state->done = $NEW(B_dict,(B_Hashable)B_HashableD_WORDG_witness,NULL,NULL);
     state->globmap = globmap;
     state->row_no=0;
@@ -210,7 +210,7 @@ void $serialize_file($Serializable s, char *file) {
 }
 
 $Serializable $deserialize($ROW row, $WORD (*globmap)($WORD)) {
-    $Serial$state state = malloc(sizeof(struct $Serial$state));
+    $Serial$state state = acton_malloc(sizeof(struct $Serial$state));
     state->done = $NEW(B_dict,(B_Hashable)B_HashableD_intG_witness,NULL,NULL);
     state->globmap = globmap;
     state->row_no=0;
@@ -220,7 +220,7 @@ $Serializable $deserialize($ROW row, $WORD (*globmap)($WORD)) {
 }
 
 $Serializable $glob_deserialize($Serializable self, $ROW row, $WORD (*globmap)($WORD)) {
-    $Serial$state state = malloc(sizeof(struct $Serial$state));
+    $Serial$state state = acton_malloc(sizeof(struct $Serial$state));
     state->done = $NEW(B_dict,(B_Hashable)B_HashableD_intG_witness,NULL,NULL);
     state->globmap = globmap;
     state->row_no=1;
@@ -254,7 +254,7 @@ $ROW $read_serialized(char *file) {
         }
         memcpy(start,p,chunk_size);
         p+=chunk_size;
-        $ROW row = malloc(2*sizeof(int) + (init[1]+1) * sizeof($WORD));
+        $ROW row = acton_malloc(2*sizeof(int) + (init[1]+1) * sizeof($WORD));
         memcpy(row,init,2*sizeof(int));//4
         row->next = NULL;
         chunk_size =  (init[1]) * sizeof($WORD);

--- a/base/builtin/set.c
+++ b/base/builtin/set.c
@@ -56,7 +56,7 @@ static int B_set_table_resize(B_set so, int minsize) {
     /* Get space for a new table. */
     oldtable = so->table;
 
-    newtable = malloc(sizeof(B_setentry) * newsize);
+    newtable = acton_malloc(sizeof(B_setentry) * newsize);
     if (newtable == NULL) {
         return -1;
     }
@@ -84,7 +84,7 @@ static int B_set_table_resize(B_set so, int minsize) {
         }
     }
 
-    free(oldtable);
+    acton_free(oldtable);
     return 0;
 }
 
@@ -178,9 +178,9 @@ void B_set_add_entry(B_set set, B_Hashable hashwit, $WORD key, long hash) {
 
 
 B_set B_set_copy(B_set set, B_Hashable hashwit) {
-    B_set res = malloc(sizeof(struct B_set));
+    B_set res = acton_malloc(sizeof(struct B_set));
     memcpy(res,set,sizeof(struct B_set));
-    res->table = malloc((set->mask+1)*sizeof(B_setentry));
+    res->table = acton_malloc((set->mask+1)*sizeof(B_setentry));
     memcpy(res->table,set->table,(set->mask+1)*sizeof(B_setentry));
     return res;
 }
@@ -207,7 +207,7 @@ B_NoneType B_setD___init__(B_set set, B_Hashable hashwit, B_Iterable wit, $WORD 
     set->fill = 0;
     set->mask = MIN_SIZE-1;
     set->finger = 0;
-    set->table = malloc(MIN_SIZE*sizeof(B_setentry));
+    set->table = acton_malloc(MIN_SIZE*sizeof(B_setentry));
     memset(set->table,0,MIN_SIZE*sizeof(B_setentry));
     if (wit && iterable) {
         B_Iterator it = wit->$class->__iter__(wit,iterable);
@@ -267,14 +267,14 @@ B_set B_setD___deserialize__ (B_set res, $Serial$state state) {
         return B_dictD_get(state->done,(B_Hashable)B_HashableD_intG_witness,to$int((long)this->blob[0]),NULL);
     } else {
         if (!res)
-            res = malloc(sizeof(struct B_set));
+            res = acton_malloc(sizeof(struct B_set));
         B_dictD_setitem(state->done,(B_Hashable)B_HashableD_intG_witness,to$int(state->row_no-1),res);
         res->$class = &B_setG_methods;
         res->numelements = (long)this->blob[0];
         res->fill = (long)this->blob[1];
         res->mask = (long)this->blob[2];
         res->finger = (long)this->blob[3];
-        res->table = malloc((res->mask+1)*sizeof(B_setentry));
+        res->table = acton_malloc((res->mask+1)*sizeof(B_setentry));
         memset(res->table,0,(res->mask+1)*sizeof(B_setentry));
         for (int i=0; i<=res->mask;i++) {
             B_setentry *entry = &res->table[i];
@@ -308,8 +308,8 @@ static $WORD B_IteratorD_set_next_entry(B_IteratorD_set self) {
 }
 
 static B_Iterator B_set_iter_entry(B_set set) {
-    B_IteratorD_set iter =  malloc(sizeof(struct B_IteratorD_set));
-    struct B_IteratorD_setG_class *methods = malloc(sizeof(struct B_IteratorD_setG_class));
+    B_IteratorD_set iter =  acton_malloc(sizeof(struct B_IteratorD_set));
+    struct B_IteratorD_setG_class *methods = acton_malloc(sizeof(struct B_IteratorD_setG_class));
     iter->$class = methods;
     methods->__next__ =  B_IteratorD_set_next_entry;
     iter->src = set;
@@ -379,7 +379,7 @@ B_set B_SetD_setD___fromiter__(B_SetD_set wit, B_Iterable wit2, $WORD iter) {
     res->fill = 0;
     res->mask = MIN_SIZE-1;
     res->finger = 0;
-    res->table = malloc(MIN_SIZE*sizeof(B_setentry));
+    res->table = acton_malloc(MIN_SIZE*sizeof(B_setentry));
     memset(res->table,0,MIN_SIZE*sizeof(B_setentry));
     $WORD nxt;
     while((nxt = it->$class->__next__(it))) {

--- a/base/builtin/slice.c
+++ b/base/builtin/slice.c
@@ -60,17 +60,17 @@ B_slice B_sliceG_new(B_int start,B_int stop,B_int step) {
 
 B_NoneType B_sliceD___init__(B_slice s, B_int start, B_int stop, B_int step) {
     if (start) {
-        s->start = malloc(sizeof(long));
+        s->start = acton_malloc(sizeof(long));
         *s->start = from$int(start);
     } else
         s->start = NULL;
     if (stop) {
-        s->stop = malloc(sizeof(long));
+        s->stop = acton_malloc(sizeof(long));
         *s->stop = from$int(stop);
     } else
         s->stop = NULL;
     if (step) {
-        s->step = malloc(sizeof(long));
+        s->step = acton_malloc(sizeof(long));
         *s->step = from$int(step);
     } else
         s->step = NULL;
@@ -87,11 +87,11 @@ B_slice B_sliceD___deserialize__ (B_slice self, $Serial$state state) {
     $ROW this = state->row;
     state->row = this->next;
     state->row_no++;
-    B_slice res = malloc(sizeof(struct B_slice));
+    B_slice res = acton_malloc(sizeof(struct B_slice));
     res->$class = &B_sliceG_methods;
-    res->start = malloc(sizeof(long));
-    res->stop = malloc(sizeof(long));
-    res->step = malloc(sizeof(long));
+    res->start = acton_malloc(sizeof(long));
+    res->stop = acton_malloc(sizeof(long));
+    res->step = acton_malloc(sizeof(long));
     *res->start = (long)this->blob[0];
     *res->stop = (long)this->blob[1];
     *res->step = (long)this->blob[2];

--- a/base/builtin/str.c
+++ b/base/builtin/str.c
@@ -40,26 +40,26 @@ static struct B_str whitespace_struct = {&B_strG_methods,6,6,(unsigned char *)" 
 static B_str whitespace_str = &whitespace_struct;
 
 #define NEW_UNFILLED_STR(nm,nchrs,nbtes)        \
-    nm = malloc(sizeof(struct B_str));           \
+    nm = acton_malloc(sizeof(struct B_str));           \
     (nm)->$class = &B_strG_methods;               \
     (nm)->nchars = nchrs;                       \
     (nm)->nbytes = nbtes;                       \
-    (nm)->str = GC_MALLOC_ATOMIC(nbtes + 1);       \
+    (nm)->str = acton_malloc_atomic(nbtes + 1);       \
     (nm)->str[nbtes] = 0
 
 #define NEW_UNFILLED_BYTEARRAY(nm,nbtes)        \
-    nm = malloc(sizeof(struct B_bytearray));     \
+    nm = acton_malloc(sizeof(struct B_bytearray));     \
     (nm)->$class = &B_bytearrayG_methods;         \
     (nm)->nbytes = nbtes;                       \
     (nm)->capacity = nbtes;                     \
-    (nm)->str = GC_MALLOC_ATOMIC(nbtes + 1);       \
+    (nm)->str = acton_malloc_atomic(nbtes + 1);       \
     (nm)->str[nbtes] = 0
 
 #define NEW_UNFILLED_BYTES(nm,nbtes)            \
-    nm = malloc(sizeof(struct B_bytes));         \
+    nm = acton_malloc(sizeof(struct B_bytes));         \
     (nm)->$class = &B_bytesG_methods;             \
     (nm)->nbytes = nbtes;                       \
-    (nm)->str = GC_MALLOC_ATOMIC(nbtes + 1);              \
+    (nm)->str = acton_malloc_atomic(nbtes + 1);              \
     (nm)->str[nbtes] = 0
 
 // Conversion to and from C strings
@@ -201,7 +201,7 @@ static int get_index(int i, int nchars) {
 
 static int fix_start_end(int nchars, B_int *start, B_int *end) {
     if (*start==NULL) {
-        *start = malloc(sizeof(struct B_int));
+        *start = acton_malloc(sizeof(struct B_int));
         *start = to$int(0);
     } else {
         int st = from$int(*start);
@@ -213,7 +213,7 @@ static int fix_start_end(int nchars, B_int *start, B_int *end) {
         *start = to$int(st);
     }
     if (*end==NULL) {
-        *end = malloc(sizeof(struct B_int));
+        *end = acton_malloc(sizeof(struct B_int));
         *end = to$int(nchars);
     } else {
         int en = from$int(*end);
@@ -429,7 +429,7 @@ B_str B_strD___deserialize__(B_str self, $Serial$state state) {
     $ROW this = state->row;
     state->row =this->next;
     state->row_no++;
-    B_str res = malloc(sizeof(struct B_str));
+    B_str res = acton_malloc(sizeof(struct B_str));
     long nbytes;
     memcpy(&nbytes,this->blob,sizeof($WORD));
     res->$class = &B_strG_methods;
@@ -437,7 +437,7 @@ B_str B_strD___deserialize__(B_str self, $Serial$state state) {
     long nchars;
     memcpy(&nchars,this->blob+1,sizeof($WORD));
     res->nchars = (int)nchars;
-    res->str = GC_MALLOC_ATOMIC(nbytes+1);
+    res->str = acton_malloc_atomic(nbytes+1);
     memcpy(res->str,this->blob+2,nbytes+1);
     return res;
 }
@@ -1369,8 +1369,8 @@ static void expand_bytearray(B_bytearray b,int n) {
     while (newcapacity < b->nbytes+n)
         newcapacity <<= 1;
     unsigned char *newstr = b->str==NULL
-        ? GC_MALLOC_ATOMIC(newcapacity+1)
-        : realloc(b->str,newcapacity+1);
+        ? acton_malloc_atomic(newcapacity+1)
+        : acton_realloc(b->str,newcapacity+1);
     if (newstr == NULL) {
         $RAISE((B_BaseException)$NEW(B_MemoryError,to$str("memory allocation failed")));
     }
@@ -1397,7 +1397,7 @@ B_NoneType B_bytearrayD___init__(B_bytearray self, B_bytes b) {
     int len = b->nbytes;
     self->nbytes = len;
     self->capacity = len;
-    self->str = GC_MALLOC_ATOMIC(len+1);
+    self->str = acton_malloc_atomic(len+1);
     memcpy(self->str,b->str,len+1);
     return B_None;
 }
@@ -1442,12 +1442,12 @@ B_bytearray B_bytearrayD___deserialize__(B_bytearray res, $Serial$state state) {
     state->row =this->next;
     state->row_no++;
     if(!res)
-        res = malloc(sizeof(struct B_bytearray));
+        res = acton_malloc(sizeof(struct B_bytearray));
     long nbytes;
     memcpy(&nbytes,this->blob,sizeof($WORD));
     res->$class = &B_bytearrayG_methods;
     res->nbytes = (long)nbytes;
-    res->str = GC_MALLOC_ATOMIC(nbytes+1);
+    res->str = acton_malloc_atomic(nbytes+1);
     memcpy(res->str,this->blob+1,nbytes+1);
     return res;
 }
@@ -2380,7 +2380,7 @@ B_NoneType B_bytesD___init__(B_bytes self, B_Iterable wit, $WORD iter) {
     B_list lst = wit2->$class->__fromiter__(wit2,wit,iter);
     int len = lst->length;
     self->nbytes = len;
-    self->str = GC_MALLOC_ATOMIC(len+1);
+    self->str = acton_malloc_atomic(len+1);
     self->str[len] = 0;
     for (int i=0; i< len; i++) {
         int n = from$int((B_int)lst->data[i]);
@@ -2430,12 +2430,12 @@ B_bytes B_bytesD___deserialize__(B_bytes self, $Serial$state state) {
     $ROW this = state->row;
     state->row =this->next;
     state->row_no++;
-    B_bytes res = malloc(sizeof(struct B_bytes));
+    B_bytes res = acton_malloc(sizeof(struct B_bytes));
     long nbytes;
     memcpy(&nbytes,this->blob,sizeof($WORD));
     res->$class = &B_bytesG_methods;
     res->nbytes = (long)nbytes;
-    res->str = GC_MALLOC_ATOMIC(nbytes+1);
+    res->str = acton_malloc_atomic(nbytes+1);
     memcpy(res->str,this->blob+2,nbytes+1);
     return res;
 }

--- a/base/builtin/timsort.c
+++ b/base/builtin/timsort.c
@@ -364,7 +364,7 @@ typedef struct {
 
 static void TIM_SORT_RESIZE(TEMP_STORAGE_T *store, const size_t new_size) {
   if (store->alloc < new_size) {
-    SORT_TYPE *tempstore = (SORT_TYPE *)realloc(store->storage, new_size * sizeof(SORT_TYPE));
+    SORT_TYPE *tempstore = (SORT_TYPE *)acton_realloc(store->storage, new_size * sizeof(SORT_TYPE));
 
     if (tempstore == NULL) {
       fprintf(stderr, "Error allocating temporary storage for tim sort: need %lu bytes",
@@ -528,7 +528,7 @@ static __inline int PUSH_NEXT(B_Ord w,
     }
 
     if (store->storage != NULL) {
-      free(store->storage);
+      acton_free(store->storage);
       store->storage = NULL;
     }
 

--- a/base/builtin/tuple.c
+++ b/base/builtin/tuple.c
@@ -18,7 +18,7 @@ B_NoneType B_tupleD___init__(B_tuple self,int size ,...) {
     va_list args;
     va_start(args,size);
     self->size = size;
-    self->components = malloc(size*sizeof($WORD));
+    self->components = acton_malloc(size*sizeof($WORD));
     for (int i=0; i<size; i++)
         self->components[i] = va_arg(args,$WORD);
     va_end(args);
@@ -62,9 +62,9 @@ B_tuple B_tupleD___deserialize__(B_tuple self, $Serial$state state) {
         return (B_tuple)B_dictD_get(state->done,(B_Hashable)B_HashableD_intG_witness,to$int((long)this->blob[0]),NULL);
     } else {
         int len = (int)(long)this->blob[0];
-        B_tuple res = malloc(sizeof(struct B_tuple));
+        B_tuple res = acton_malloc(sizeof(struct B_tuple));
         B_dictD_setitem(state->done,(B_Hashable)B_HashableD_intG_witness,to$int(state->row_no-1),res);
-        res->components = malloc(len * sizeof($WORD));
+        res->components = acton_malloc(len * sizeof($WORD));
         res->$class = &B_tupleG_methods;
         res->size = len;
         for (int i = 0; i < len; i++) 
@@ -196,10 +196,10 @@ B_tuple B_SliceableD_tupleD___getslice__ (B_SliceableD_tuple wit, B_tuple self, 
     normalize_slice(slc, size, &slen, &start, &stop, &step);
     //slice notation have been eliminated and default values applied.
     // slen now is the length of the slice
-    B_tuple res = malloc(sizeof(struct B_tuple));
+    B_tuple res = acton_malloc(sizeof(struct B_tuple));
     res->$class = self->$class;
     res->size = slen;
-    res->components = malloc(slen * sizeof($WORD));
+    res->components = acton_malloc(slen * sizeof($WORD));
     int t = start;
     for (int i=0; i<slen; i++) {
         res->components[i] = self->components[t];

--- a/base/builtin/tuple.h
+++ b/base/builtin/tuple.h
@@ -19,12 +19,12 @@ struct B_tuple {
 extern struct B_tupleG_class B_tupleG_methods;
 B_tuple B_tupleG_new(int,...);
 
-#define $NEWTUPLE(B_len, ...)  ({ B_tuple $t = malloc(sizeof(struct B_tuple)+B_len*sizeof($WORD)); \
+#define $NEWTUPLE(B_len, ...)  ({ B_tuple $t = acton_malloc(sizeof(struct B_tuple)+B_len*sizeof($WORD)); \
             $t->$class = &B_tupleG_methods;                               \
             $t->$class->__init__($t, B_len, __VA_ARGS__);                \
             $t; })
 
-#define $NEWTUPLE0  ({ B_tuple $t = malloc(sizeof(struct B_tuple));       \
+#define $NEWTUPLE0  ({ B_tuple $t = acton_malloc(sizeof(struct B_tuple));       \
             $t->$class = &B_tupleG_methods;                               \
             $t->$class->__init__($t,0);                                  \
             $t; })

--- a/base/builtin/u16.c
+++ b/base/builtin/u16.c
@@ -66,7 +66,7 @@ B_str B_u16D___repr__(B_u16 n) {
 }
 
 B_u16 toB_u16(unsigned short i) {
-    B_u16 res = malloc(sizeof(struct B_u16));
+    B_u16 res = acton_malloc(sizeof(struct B_u16));
     res->$class = &B_u16G_methods;
     res->val = i;
     return res;

--- a/base/builtin/u32.c
+++ b/base/builtin/u32.c
@@ -66,7 +66,7 @@ B_str B_u32D___repr__(B_u32 n) {
 }
 
 B_u32 toB_u32(unsigned int i) {
-    B_u32 res = malloc(sizeof(struct B_u32));
+    B_u32 res = acton_malloc(sizeof(struct B_u32));
     res->$class = &B_u32G_methods;
     res->val = i;
     return res;

--- a/base/builtin/u64.c
+++ b/base/builtin/u64.c
@@ -66,7 +66,7 @@ B_str B_u64D___repr__(B_u64 n) {
 }
 
 B_u64 toB_u64(unsigned long i) {
-    B_u64 res = malloc(sizeof(struct B_u64));
+    B_u64 res = acton_malloc(sizeof(struct B_u64));
     res->$class = &B_u64G_methods;
     res->val = i;
     return res;

--- a/base/rts/common.c
+++ b/base/rts/common.c
@@ -1,0 +1,126 @@
+#include <stdlib.h>
+#include <errno.h>
+
+void *(*real_malloc)(size_t) = NULL;
+void *(*real_realloc)(void *, size_t) = NULL;
+void *(*real_calloc)(size_t, size_t) = NULL;
+void (*real_free)(void *) = NULL;
+char *(*real_strdup)(const char *) = NULL;
+char *(*real_strndup)(const char *, size_t) = NULL;
+
+int resolve_real_malloc() {
+    real_malloc = dlsym(RTLD_NEXT, "malloc");
+    if (!real_malloc) {
+        fprintf(stderr, "Error in `dlsym`: %s\n", dlerror());
+        return 0;
+    }
+    real_realloc = dlsym(RTLD_NEXT, "realloc");
+    if (!real_realloc) {
+        fprintf(stderr, "Error in `dlsym`: %s\n", dlerror());
+        return 0;
+    }
+    real_calloc = dlsym(RTLD_NEXT, "calloc");
+    if (!real_calloc) {
+        fprintf(stderr, "Error in `dlsym`: %s\n", dlerror());
+        return 0;
+    }
+    real_free = dlsym(RTLD_NEXT, "free");
+    if (!real_free) {
+        fprintf(stderr, "Error in `dlsym`: %s\n", dlerror());
+        return 0;
+    }
+    real_strdup = dlsym(RTLD_NEXT, "strdup");
+    if (!real_strdup) {
+        fprintf(stderr, "Error in `dlsym`: %s\n", dlerror());
+        return 0;
+    }
+    real_strndup = dlsym(RTLD_NEXT, "strndup");
+    if (!real_strndup) {
+        fprintf(stderr, "Error in `dlsym`: %s\n", dlerror());
+        return 0;
+    }
+    return 1;
+}
+
+typedef struct {
+    acton_malloc_func malloc;
+    acton_malloc_func malloc_atomic;
+    acton_realloc_func realloc;
+    acton_calloc_func calloc;
+    acton_free_func free;
+    acton_strdup_func strdup;
+    acton_strndup_func strndup;
+} acton__allocator_t;
+
+static acton__allocator_t acton__allocator = {
+    malloc,
+    malloc,
+    realloc,
+    calloc,
+    free,
+    strdup,
+    strndup
+};
+
+int acton_replace_allocator(acton_malloc_func malloc_func,
+                            acton_malloc_func malloc_atomic_func,
+                            acton_realloc_func realloc_func,
+                            acton_calloc_func calloc_func,
+                            acton_free_func free_func,
+                            acton_strdup_func strdup_func,
+                            acton_strndup_func strndup_func) {
+    if (malloc_func == NULL || malloc_atomic_func == NULL ||
+        realloc_func == NULL || calloc_func == NULL ||
+        free_func == NULL || strdup_func == NULL ||
+        strndup_func == NULL
+        ) {
+        return -1;
+    }
+
+    acton__allocator.malloc = malloc_func;
+    acton__allocator.malloc_atomic = malloc_atomic_func;
+    acton__allocator.realloc = realloc_func;
+    acton__allocator.calloc = calloc_func;
+    acton__allocator.free = free_func;
+    acton__allocator.strdup = strdup_func;
+    acton__allocator.strndup = strndup_func;
+
+    return 0;
+}
+
+void* acton_malloc(size_t size) {
+    return acton__allocator.calloc(1, size);
+}
+
+void* acton_malloc_atomic(size_t size) {
+    return acton__allocator.malloc_atomic(size);
+}
+
+
+void* acton_realloc(void* ptr, size_t size) {
+    return acton__allocator.realloc(ptr, size);
+}
+
+
+void* acton_calloc(size_t count, size_t size) {
+    return acton__allocator.calloc(count, size);
+}
+
+void acton_free(void* ptr) {
+    int saved_errno;
+
+    /* The system allocator the assumption that errno is not modified but custom
+     * allocators may not be so careful.
+     */
+    saved_errno = errno;
+    acton__allocator.free(ptr);
+    errno = saved_errno;
+}
+
+char *acton_strdup(const char *s) {
+    return acton__allocator.strdup(s);
+}
+
+char *acton_strndup(const char *s, size_t n) {
+    return acton__allocator.strndup(s, n);
+}

--- a/base/rts/common.h
+++ b/base/rts/common.h
@@ -1,0 +1,38 @@
+#pragma once
+#include <dlfcn.h>
+#include <stddef.h>
+#include <stdlib.h>
+
+extern void *(*real_malloc)(size_t);
+extern void *(*real_malloc_atomic)(size_t);
+extern void *(*real_realloc)(void *, size_t);
+extern void *(*real_calloc)(size_t, size_t);
+extern void (*real_free)(void *);
+extern char *(*real_strdup)(const char *);
+extern char *(*real_strndup)(const char *, size_t);
+int resolve_real_malloc();
+
+typedef void *(*acton_malloc_func)(size_t size);
+typedef void *(*acton_malloc_func)(size_t size);
+typedef void *(*acton_realloc_func)(void* ptr, size_t size);
+typedef void *(*acton_calloc_func)(size_t count, size_t size);
+typedef void (*acton_free_func)(void* ptr);
+typedef char *(*acton_strdup_func)(const char* s);
+typedef char *(*acton_strndup_func)(const char* s, size_t n);
+
+int acton_replace_allocator(acton_malloc_func malloc_func,
+                            acton_malloc_func malloc_atomic_func,
+                            acton_realloc_func realloc_func,
+                            acton_calloc_func calloc_func,
+                            acton_free_func free_func,
+                            acton_strdup_func strdup_func,
+                            acton_strndup_func strndup_func);
+
+
+void *acton_malloc(size_t size);
+void *acton_malloc_atomic(size_t size);
+void *acton_realloc(void* ptr, size_t size);
+void *acton_calloc(size_t count, size_t size);
+void acton_free(void* ptr);
+char *acton_strdup(const char *s);
+char *acton_strndup(const char *s, size_t n);

--- a/base/rts/io.c
+++ b/base/rts/io.c
@@ -16,5 +16,5 @@ uv_loop_t *get_uv_loop() {
 }
 
 void alloc_buffer(uv_handle_t *handle, size_t size, uv_buf_t *buf) {
-    *buf = uv_buf_init((char*) GC_MALLOC_ATOMIC(size), size);
+    *buf = uv_buf_init((char*) acton_malloc_atomic(size), size);
 }

--- a/base/rts/rts.c
+++ b/base/rts/rts.c
@@ -39,6 +39,10 @@
 #ifdef __linux__
 #include <sys/prctl.h>
 #endif
+
+#include "common.h"
+#include "common.c"
+
 #include "yyjson.h"
 #include "rts.h"
 
@@ -278,7 +282,7 @@ void B_MsgD___init__(B_Msg m, $Actor to, $Cont cont, time_t baseline, $WORD valu
 */
 
 B_Msg B_MsgG_newXX( $Actor to, $Cont cont, time_t baseline, $WORD value) {
-    B_Msg m = malloc(sizeof(struct B_Msg));
+    B_Msg m = acton_malloc(sizeof(struct B_Msg));
     m->$class = &B_MsgG_methods;
     m->$next = NULL;
     m->$to = to;
@@ -456,7 +460,7 @@ $R $ConstContD___call__($ConstCont $this, $WORD _ignore) {
 }
 
 $Cont $CONSTCONT($WORD val, $Cont cont){
-    $ConstCont obj = malloc(sizeof(struct $ConstCont));
+    $ConstCont obj = acton_malloc(sizeof(struct $ConstCont));
     obj->$class = &$ConstContG_methods;
     $ConstContG_methods.__init__(obj, val, cont);
     return ($Cont)obj;
@@ -2100,7 +2104,7 @@ void launch_debugger(int signum) {
         fprintf(stderr, "\nERROR: illegal instruction\n");
     if (signum == SIGSEGV)
         fprintf(stderr, "\nERROR: segmentation fault\n");
-    fprintf(stderr, "Starting interactive debugger...\n", pthread_self());
+    fprintf(stderr, "Starting interactive debugger...\n");
     char pid_buf[30];
     sprintf(pid_buf, "%d", getpid());
     char name_buf[512];
@@ -2638,7 +2642,7 @@ int main(int argc, char **argv) {
     // RTS Monitor Log
     pthread_t mon_log_thread;
     if (mon_log_path) {
-        pthread_create(&mon_log_thread, NULL, $mon_log_loop, (void *)mon_log_period);
+        pthread_create(&mon_log_thread, NULL, $mon_log_loop, (void *)(intptr_t)mon_log_period);
         if (cpu_pin) {
             CPU_ZERO(&cpu_set);
             CPU_SET(0, &cpu_set);
@@ -2661,7 +2665,7 @@ int main(int argc, char **argv) {
     pthread_t threads[1 + num_wthreads];
 
     for(int idx = 1; idx < num_wthreads+1; idx++) {
-        pthread_create(&threads[idx], NULL, main_loop, (void*)idx);
+        pthread_create(&threads[idx], NULL, main_loop, (void*)(intptr_t)idx);
         // Index start at 1 and we pin wthreads to CPU 1...n
         // We use CPU 0 for misc threads, like IO / mon etc
         if (cpu_pin) {

--- a/base/rts/rts.h
+++ b/base/rts/rts.h
@@ -14,6 +14,7 @@
     #define IS_MACOS
 #endif
 
+#include "common.h"
 #include "../builtin/builtin.h"
 
 #define MSGQ 2


### PR DESCRIPTION
We now make use of the non-GC malloc, i.e. the normal malloc from libc on startup of Acton up to and including the module initialization. Since Acton only allows for constants at the module top level, we know all such values are immutable and static, thus we do not have to place them in GCed memory. To avoid the GC, since we are doing link time redirection, we dig out the real malloc using dlsym. This will only work on platforms where libc is dynamically loaded. It should be possible to rework this so that we can work in statically linked environments too.

This change makes it a viable path forward to place large but relatively static data as module constants since it can drastically reduce the GC heap and thus improve the performance of the program.

Fixes #1493 