### PR TITLE
Make DB backend optional

### DIFF
--- a/base/build.zig
+++ b/base/build.zig
@@ -18,6 +18,7 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
     const cpedantic = b.option(bool, "cpedantic", "") orelse false;
+    const use_db = b.option(bool, "db", "") orelse false;
     const use_prebuilt = b.option(bool, "use_prebuilt", "") orelse false;
     const projpath = b.option([]const u8, "projpath", "") orelse "";
     const projpath_outtypes = b.option([]const u8, "projpath_outtypes", "") orelse "";
@@ -135,6 +136,11 @@ pub fn build(b: *std.Build) void {
             std.log.err("Error appending flags: {}", .{err});
             std.os.exit(1);
         };
+    }
+
+    if (use_db) {
+        print("Building with DB backend support\n", .{});
+        flags.append("-DACTON_DB") catch unreachable;
     }
 
     const libActon = b.addStaticLibrary(.{

--- a/base/rts/rts.h
+++ b/base/rts/rts.h
@@ -186,12 +186,20 @@ void init_db_queue(long);
 void register_actor(long key);
 void serialize_state_shortcut($Actor);
 
+#ifdef ACTON_DB
+#define INIT_DB_QUEUE(key) init_db_queue(key)
+#define REGISTER_ACTOR(key) register_actor(key)
+#else
+#define INIT_DB_QUEUE(key)
+#define REGISTER_ACTOR(key)
+#endif
+
 #define $NEWACTOR($T)       ({ $T $t = malloc(sizeof(struct $T)); \
                                $t->$class = &$T ## G_methods; \
                                $ActorG_methods.__init__(($Actor)$t); \
                                $t->$affinity = 0; \
-                               init_db_queue($t->$globkey); \
-                               register_actor($t->$globkey); \
+                               INIT_DB_QUEUE($t->$globkey); \
+                               REGISTER_ACTOR($t->$globkey); \
                                $t; })
 
 $R $PUSH_C($Cont);

--- a/compiler/Acton/CommandLineParser.hs
+++ b/compiler/Acton/CommandLineParser.hs
@@ -39,6 +39,7 @@ data NewOptions     = NewOptions {
 
 data CompileOptions   = CompileOptions {
                          alwaysbuild :: Bool,
+                         db          :: Bool,
                          parse       :: Bool,
                          kinds       :: Bool,
                          types       :: Bool,
@@ -72,6 +73,7 @@ data CompileOptions   = CompileOptions {
 data BuildOptions = BuildOptions {
                          alwaysB     :: Bool,
                          cpedanticB  :: Bool,
+                         dbB         :: Bool,
                          debugB      :: Bool,
                          devB        :: Bool,
                          autostubB   :: Bool,
@@ -130,6 +132,7 @@ newCommand = New <$> (NewOptions <$> argument (str :: ReadM String) (metavar "PR
 
 compileOptions = CompileOptions
         <$> switch (long "always-build" <> help "Show the result of parsing")
+        <*> switch (long "db"           <> help "Enable DB backend")
         <*> switch (long "parse"        <> help "Show the result of parsing")
         <*> switch (long "kinds"        <> help "Show all the result after kind-checking")
         <*> switch (long "types"        <> help "Show all inferred expression types")
@@ -163,6 +166,7 @@ buildCommand          = Build <$> (
     BuildOptions
         <$> switch (long "always-build" <> help "Development mode; include debug symbols etc")
         <*> switch (long "cpedantic"    <> help "Pedantic C compilation with -Werror")
+        <*> switch (long "db"           <> help "Enable DB backend")
         <*> switch (long "debug"        <> help "Print debug stuff")
         <*> switch (long "dev"          <> help "Development mode; include debug symbols etc")
         <*> switch (long "auto-stub"    <> help "Allow automatic stub detection")

--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -79,6 +79,7 @@ main = do
           C.cpedantic = C.cpedanticB opts,
           C.debug = C.debugB opts,
           C.dev = C.devB opts,
+          C.db = C.dbB opts,
           C.root = C.rootB opts,
           C.ccmd = C.ccmdB opts,
           C.quiet = C.quietB opts,
@@ -96,7 +97,7 @@ main = do
                                     then printDocs (C.DocOptions (head nms) "")
                                     else compileFiles opts (catMaybes $ map filterActFile nms)
 
-defaultOpts   = C.CompileOptions False False False False False False False False False False False
+defaultOpts   = C.CompileOptions False False False False False False False False False False False False
                                  False False False False False False False False False "" "" "" ""
                                  C.defTarget "" False False False
 
@@ -900,7 +901,9 @@ zigBuild env opts paths tasks binTasks = do
     homeDir <- getHomeDirectory
     let cache_dir = if (not $ null $ C.cachedir opts) then (C.cachedir opts) else joinPath [ projPath paths, "build-cache" ]
         global_cache_dir = joinPath [ homeDir, ".cache", "acton", "build-cache" ]
-        use_prebuilt = C.defTarget == C.target opts
+        use_prebuilt = if isTmp paths
+                         then C.defTarget == C.target opts
+                         else if C.db opts then False else C.defTarget == C.target opts
     let zigCmdBase =
           if buildZigExists
             then zig paths ++ " build " ++
@@ -919,6 +922,7 @@ zigBuild env opts paths tasks binTasks = do
                  (if (C.debug opts) then " --verbose " else "") ++
                  " -Dtarget=" ++ (C.target opts) ++
                  " -Doptimize=" ++ (if (C.dev opts) then "Debug" else "ReleaseFast") ++
+                 (if (C.db opts) then " -Ddb " else " ") ++
                  (if (C.cpedantic opts) then " -Dcpedantic " else " ") ++
                  " -Dprojpath=" ++ projPath paths ++
                  " -Dprojpath_outtypes=" ++ joinPath [ projPath paths, "out", "types" ] ++

--- a/test/Makefile
+++ b/test/Makefile
@@ -17,19 +17,19 @@ DDB_TESTS=test_db_app test_db_resume_tcp_server test_db_resume_tcp_client
 # a simple app. We do not really verify that the RTS uses the database - we
 # assume it does and would fail catastrohpically if it encounters an error.
 test_db_app:
-	$(ACTONC) --dev rts_db/ddb_test_app.act
-	$(ACTONC) --dev rts_db/test_db_app.act
+	$(ACTONC) --db --dev rts_db/ddb_test_app.act
+	$(ACTONC) --db --dev rts_db/test_db_app.act
 	rts_db/test_db_app
 
 test_db_resume_tcp_server:
-	$(ACTONC) --dev rts_db/ddb_test_server.act
-	$(ACTONC) --dev rts_db/test_tcp_server.act
+	$(ACTONC) --db --dev rts_db/ddb_test_server.act
+	$(ACTONC) --db --dev rts_db/test_tcp_server.act
 	rts_db/test_tcp_server
 
 test_db_resume_tcp_client:
-	$(ACTONC) --dev rts_db/ddb_test_server.act
-	$(ACTONC) --dev rts_db/ddb_test_client.act
-	$(ACTONC) --dev rts_db/test_tcp_client.act
+	$(ACTONC) --db --dev rts_db/ddb_test_server.act
+	$(ACTONC) --db --dev rts_db/ddb_test_client.act
+	$(ACTONC) --db --dev rts_db/test_tcp_client.act
 	rts_db/test_tcp_client
 
 


### PR DESCRIPTION
It's now possible to build Acton programs without the DB backend support. In fact, it is the new default, since the DB backend is still a rather esoteric feature and not very mature, so anyone that wants it can easily add in the --db flag.