### PR TITLE
Support custom malloc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ dist/depsout/lib/libargp.a: dist/deps/libargp $(DIST_ZIG)
 	cd $< && $(ZIG) build $(ZIG_TARGET) $(ZIG_CPU) --prefix $(TD)/dist/depsout
 
 # /deps/libbsdnt --------------------------------------------
-LIBBSDNT_REF=a0af240bf32eacf5ad56a847b9a7f507c950aa53
+LIBBSDNT_REF=1f31f6903378022fec8f09a3b3f3446e961eacbc
 deps-download/$(LIBBSDNT_REF).tar.gz:
 	mkdir -p deps-download
 	curl -f -L -o $@ https://github.com/actonlang/bsdnt/archive/$(LIBBSDNT_REF).tar.gz
@@ -211,7 +211,7 @@ dist/depsout/lib/libactongc.a: dist/deps/libgc $(DIST_ZIG)
 	mv dist/depsout/lib/libgc.a $@
 
 # /deps/libmbedtls --------------------------------------------
-LIBMBEDTLS_REF=9351929a2f776e1073cdbac7963f622e77226a60
+LIBMBEDTLS_REF=9009ebc3d89f4acc43267280b7db637c4a4c7c51
 deps-download/$(LIBMBEDTLS_REF).tar.gz:
 	mkdir -p deps-download
 	curl -f -L -o $@ https://github.com/actonlang/mbedtls/archive/$(LIBMBEDTLS_REF).tar.gz
@@ -241,7 +241,7 @@ dist/depsout/lib/libprotobuf-c.a: dist/deps/libprotobuf_c $(DIST_ZIG)
 	cd $< && $(ZIG) build $(ZIG_TARGET) $(ZIG_CPU) --prefix $(TD)/dist/depsout
 
 # /deps/tlsuv ---------------------------------------------
-TLSUV_REF=c71a1980b07d1c7967b306e81cd7ba904c614dd2
+TLSUV_REF=f30ff355c06616b050002a12889b2cde4beccb19
 deps-download/$(TLSUV_REF).tar.gz:
 	mkdir -p deps-download
 	curl -f -L -o $@ https://github.com/actonlang/tlsuv/archive/$(TLSUV_REF).tar.gz

--- a/base/builtin/int.c
+++ b/base/builtin/int.c
@@ -226,10 +226,12 @@ B_int B_IntegralD_intD___pos__(B_IntegralD_int wit,  B_int a) {
 
 $WORD B_IntegralD_intD_real(B_IntegralD_int wit, B_int a, B_Real wit2) {
     $RAISE((B_BaseException)$NEW(B_NotImplementedError,to$str("Number.__real__ not implemented for int")));
+    return B_None; // Silence compiler warning, remove when implemented
 }
 
 $WORD B_IntegralD_intD_imag(B_IntegralD_int wit, B_int a, B_Real wit2) {
     $RAISE((B_BaseException)$NEW(B_NotImplementedError,to$str("Number.__imag__ not implemented for int")));
+    return B_None; // Silence compiler warning, remove when implemented
 }
 
 $WORD B_IntegralD_intD___abs__(B_IntegralD_int wit, B_int a, B_Real wit2) {
@@ -383,6 +385,7 @@ B_int B_IntegralD_intD___rshift__(B_IntegralD_int wit,  B_int a, B_int b) {
 B_int B_IntegralD_intD___invert__(B_IntegralD_int wit,  B_int a) {
     //return toB_i64(~a->val);
     $RAISE((B_BaseException)$NEW(B_NotImplementedError,to$str("Number.__invert__ not implemented for int")));
+    return to$int(-1); // Silence compiler warning, remove when implemented
 }
 
 
@@ -391,6 +394,7 @@ B_int B_IntegralD_intD___invert__(B_IntegralD_int wit,  B_int a) {
 B_int B_LogicalD_IntegralD_intD___and__(B_LogicalD_IntegralD_int wit,  B_int a, B_int b) {
     // return toB_i64(a->val & b->val);
     $RAISE((B_BaseException)$NEW(B_NotImplementedError,to$str("Protocol Logical not implemented for int; use i64\n")));
+    return to$int(-1); // Silence compiler warning, remove when implemented
 }
                                                  
 B_int B_LogicalD_IntegralD_intD___or__(B_LogicalD_IntegralD_int wit,  B_int a, B_int b) {
@@ -402,6 +406,7 @@ B_int B_LogicalD_IntegralD_intD___or__(B_LogicalD_IntegralD_int wit,  B_int a, B
 B_int B_LogicalD_IntegralD_intD___xor__(B_LogicalD_IntegralD_int wit,  B_int a, B_int b) {
     // return toB_i64(a->val ^ b->val);
     $RAISE((B_BaseException)$NEW(B_NotImplementedError,to$str("Protocol Logical not implemented for int; use i64\n")));
+    return to$int(-1); // Silence compiler warning, remove when implemented
 }
  
 // B_MinusD_IntegralD_int  ////////////////////////////////////////////////////////////////////////////////////////

--- a/base/rts/common.h
+++ b/base/rts/common.h
@@ -20,6 +20,8 @@ typedef void (*acton_free_func)(void* ptr);
 typedef char *(*acton_strdup_func)(const char* s);
 typedef char *(*acton_strndup_func)(const char* s, size_t n);
 
+void acton_init_malloc();
+
 int acton_replace_allocator(acton_malloc_func malloc_func,
                             acton_malloc_func malloc_atomic_func,
                             acton_realloc_func realloc_func,

--- a/base/rts/rts.c
+++ b/base/rts/rts.c
@@ -2222,6 +2222,7 @@ int main(int argc, char **argv) {
     // Init garbage collector and suppress warnings
     GC_INIT();
     GC_set_warn_proc(DaveNull);
+    acton_init_alloc();
     // Everything up to and including module init is static stuff, in particular
     // module constants which are created during module init are static and do
     // not need to be scanned. We therefore use the real_malloc (not GC_malloc)

--- a/base/src/re.ext.c
+++ b/base/src/re.ext.c
@@ -2,8 +2,26 @@
 
 #include <pcre2.h>
 
+static void *pcre2_malloc(size_t size, void *data) {
+    (void)data;
+    return acton_malloc(size);
+}
+
+static void pcre2_free(void *ptr, void *data) {
+    (void)data;
+    acton_free(ptr);
+}
+
+pcre2_general_context *general_context;
+
 void reQ___ext_init__() {
     // Nothing to do
+    general_context = pcre2_general_context_create(pcre2_malloc, pcre2_free, NULL);
+    if (general_context == NULL) {
+        // Handle error
+        assert(0);
+    }
+
 }
 
 
@@ -41,7 +59,7 @@ reQ_Match reQ__match (B_str arg_pattern, B_str arg_text, B_int arg_start_pos) {
                        0,                     /* default options */
                        &errornumber,          /* for error number */
                        &erroroffset,          /* for error offset */
-                       NULL);                 /* use default compile context */
+                       general_context);      /* use default compile context */
 
 
     /* Compilation failed: print the error message and exit. */

--- a/test/builtins_auto/modinit_large_int.act
+++ b/test/builtins_auto/modinit_large_int.act
@@ -1,0 +1,15 @@
+# This creates a large integer which tests that our malloc stuff works properly.
+# The initial B_int struct is malloced from builtin/int.c which uses
+# acton_malloc() which, during module initialization, points to real_malloc().
+# As we try to assign a large value, the int will be expanded, which happens
+# inside of zz_fit() in zz.c and it calls bsdnt_realloc(). bsdnt_realloc() must
+# at that time, point to real_realloc and not GC_realloc(). Before we had
+# custom allocator support in BSDNT, it would call realloc() which is link time
+# redirected to GC_realloc() and that would crash since GC_realloc() expects a
+# GC header and the initial allocation done in malloc_int() used acton_malloc()
+# -> real_malloc().
+
+a = pow(2, 127) - 1
+
+actor main(env):
+    env.exit(0)


### PR DESCRIPTION
We have thus far relied on link time redirection of malloc and friends. It's a little cleaner and more flexible to explicitly call GC_malloc or whichever malloc we want. That way we can still use the classic malloc if we want to and mix and match between different allocators.

acton_replace_allocator will now also change the allocator in all relevant C libraries we make use of in stdlib and similar. libuv and tlsuv are not affected, they always use GC_malloc, set from acton_init_alloc() since nothing in module initialization that is constant should come from these libraries and we want all libuv stuff to be GC_malloced, so that all things in the IO loops can be properly traced from the root set.

We're still doing link time redirection but this patch should put the necessary changes in place to actually stop redirecting malloc. We need to verify with testing before we flip the switch though.

Further, this patch actually fixes bugs, like for our int where the initial allocation is done in int.c using malloc_int. During module initialization, this points to real_malloc but if such an integer grows beyond a single limb, it is reallocated from within the BSDNT zz.c file which previously was hard-coded to use malloc, which is redirected to GC_malloc(). Since the initial malloc was done using real_malloc(), the object lacks the GC header and the subsequent GC_realloc() crashes. Now with this patch, we actively set the BSDNT realloc function to point to real_realloc during module initialization so it works.

Fixes #1685 