### PR TITLE
Fix test discovery to catch proper type signature

### DIFF
--- a/compiler/Acton/Types.hs
+++ b/compiler/Acton/Types.hs
@@ -1735,7 +1735,7 @@ testType (NDef (TSchema _ []  (TFun _ fx (TNil _ PRow) k res)) _)
           isGoodAction t@(TFun _ fx p (TNil _ KRow) res)
              | fx == fxAction
                && res == tNone  = case row2list p of
-                                    [t1,t2] -> (t1 == tBool || t1 == tNone) && (t2 == tNone || t2 == tException)
+                                    [t1,t2] -> (t1 == tOpt tBool || t1 == tBool || t1 == tNone) && (t2 == tOpt tException || t2 == tException || t2 == tNone)
                                     _       -> False
           isGoodAction t        = False
 testType _                      = Nothing


### PR DESCRIPTION
Somewhat funny, the test_testing module gets type inferred to the wron types, which is sort of expected in a way I guess, because since it is test discovery, there are no explicit calls from test_runner to these functions yet... if there were, then we would infer the right types. Not sure what the best solution but at the very least it should be possible to explicitly type out the full type signature for test functions... but that was broken, it would find report_result function which took either a bool or None as first argument, but the correct type is a maybe bool. It now accepts this. Not sure if we should still continue matching on just bool and None as well, but I guess it doesn't hurt since some test functions that have inferred type signatures might get those types!?