### PR TITLE
Revert "Make exception msg optional"

### DIFF
--- a/base/src/__builtin__.act
+++ b/base/src/__builtin__.act
@@ -318,15 +318,11 @@ class Msg[A] (value):
 ## Exceptions ##################################################################################
 
 class BaseException (value):
-    def __init__(self, msg: ?str) -> None:
+    def __init__(self, msg: str) -> None:
         self.error_message = msg
 
     def __str__(self):
-        res = self._name()
-        err = self.error_message
-        if err is not None:
-            res += ": " + err
-        return res
+        return "%s: %s" % (self._name(), self.error_message)
 
     def _name(self) -> str:
         NotImplemented
@@ -350,17 +346,12 @@ class IndexError (LookupError):
     pass
 
 class KeyError (LookupError):
-    def __init__(self, msg: ?str, key: value):
+    def __init__(self, msg: str, key: value):
         self.error_message = msg
         self.key = key
 
     def __str__(self):
-        res = self._name()
-        err = self.error_message
-        if err is not None:
-            res += ": " + err
-        res += ", key: " + str(self.key)
-        return res
+        return "%s: %s, key: %s" % (self._name(), self.error_message, str(self.key))
 
 class MemoryError (Exception):
     pass


### PR DESCRIPTION
This reverts commit 0089ed927ff3dffb96469a844e96cdc59a2d69cc.

Making the exception message optional has unexpected consequences for Telemetrify so I'm reverting this now. It's not a very important change. We'll try to bring it in at a later point in time.