### PR TITLE
Print build progress / result

### DIFF
--- a/cli/src/acton.act
+++ b/cli/src/acton.act
@@ -69,31 +69,40 @@ actor TestModule(process_cap, modname, report_result):
     def on_error(p, error):
         print("Error from process:", error)
 
-    print("Running test for module", modname)
     cmd = ["out/rel/bin/.test_" + modname, "--json", "test"]
     p = process.Process(process_cap, cmd, None, None, on_stdout, on_stderr, on_exit, on_error)
 
 actor RunTest(process_cap, env, args):
     _test_modules: list[str] = []
     modtests = {}
+    var stdout_buf = b""
+    var stderr_buf = b""
+    var stdout_tests = False
 
     def _on_build_done():
-        print("Build done")
+        print("Build done, running tests for modules:")
         results = testing.TestDisplayStatus(env)
         results.expected_modules = set(_test_modules)
 
         for modname in _test_modules:
+            print(" -", modname)
             def _on_test_result(module, test_def, test_result):
                 results.update(test_def, test_result, module)
             t = TestModule(process_cap, modname, _on_test_result)
             modtests[modname] = t
 
     cmdargs = build_cmd_args(args)
-    cmd = ["actonc"] + cmdargs + ["build", "--test", "--quiet"]
+    cmd = ["actonc"] + cmdargs + ["build", "--test"]
 
     def on_actbuild_stdout(p, data):
         for line in data.decode().splitlines(False):
-            _test_modules.append(line)
+            if line == "Test executables:":
+                stdout_tests = True
+            else:
+                if stdout_tests:
+                    _test_modules.append(line)
+                else:
+                    print(line)
 
     def on_actbuild_stderr(p, data):
         print(data.decode(), end="", stderr=True)
@@ -102,7 +111,6 @@ actor RunTest(process_cap, env, args):
         if exit_code == 0:
             _on_build_done()
         else:
-            print("actonc exited with code: ", exit_code, " terminated with signal:", term_signal)
             await async env.exit(exit_code)
 
     def on_actbuild_error(p, error):

--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -319,6 +319,7 @@ compileFiles opts srcFiles = do
     if C.test opts
       then do
         compileBins opts paths env tasks testBinTasks
+        putStrLn "Test executables:"
         mapM_ (\t -> putStrLn (binName t)) testBinTasks
       else do
         compileBins opts paths env tasks preBinTasks


### PR DESCRIPTION
When running acton test we implicitly build the project to ensure all tests are up to date before actually running the tests. actonc was invoked with --quiet and we wouldn't print any progress which meant for larger projects it felt like the program just hung. Now we print the normal build output in real time.

Similarly if there is an compilation error the output from the compiler is printed so it's clear what the problem is.