### PR TITLE
Accept larger time diff in test_time

### DIFF
--- a/test/stdlib/test_time.act
+++ b/test/stdlib/test_time.act
@@ -6,7 +6,7 @@ actor main(env):
     d = n.since(et)
     print("duration:", d)
 
-    if abs(d.second) > 5:
+    if abs(d.second) > 15:
         print("ERROR: diff seems too large, time.time*() should be roughly same as provided UNIX timestamp input")
         await async env.exit(1)
 


### PR DESCRIPTION
Bump up the accepted diff. It has started failing quite a lot in CI lately, with the diff being like 7 seconds. I think it's because of how we run the program from test.hs. We first get the time then build and run the test program. Presumably the build takes a little time and that leads to the larger diff. Maybe our builds are slightly slower now (after linking libc++??) or the CI runners are slightly slower.

If there's an actual problem with the time function it's likely to be off by much more.