### PR TITLE
Bump up test timeout

### DIFF
--- a/compiler/test.hs
+++ b/compiler/test.hs
@@ -59,7 +59,7 @@ main = do
       , typeErrorAutoTests
       ]
   where timeout :: Timeout
-        timeout = mkTimeout (5*60*1000000) -- 5 minutes timeout
+        timeout = mkTimeout (10*60*1000000)
         -- this normally doesn't take long on a local machine but in GitHub
         -- Actions CI, in particular the MacOS workers can be really slow so it
         -- has taken longer than 3 minutes, thus the rather lengthy timeout


### PR DESCRIPTION
Should really find a better way for expressing these tests. The cross-compilation tests all run in the same Acton project, for which actonc takes a lock, so only one test job at a time will run. That should be reflected here. Even if we have multiple repos, it woul might not be faster because zig / clang would ue all CPU cores per compilation so doing multiple compilations in parallel might not improve anything.