### PR TITLE
Fixo required since self is now parsed as a kwd param.

### DIFF
--- a/compiler/Acton/Subst.hs
+++ b/compiler/Acton/Subst.hs
@@ -35,10 +35,11 @@ dropSelf (TFun l x p k t) NoDec
   | TRow _ _ _ _ k' <- k                = TFun l x p k' t
 dropSelf t _                            = t
 
-selfType                                :: PosPar -> Deco -> Type
-selfType p NoDec
+selfType                                :: PosPar -> KwdPar -> Deco -> Type
+selfType p k NoDec
   | TRow _ _ _ t _ <- prowOf p          = t
-selfType _ _                            = tSelf
+  | TRow _ _ _ t _ <- krowOf k          = t
+selfType _ _ _                          = tSelf
 
 
 closeDepVars vs cs

--- a/compiler/Acton/Types.hs
+++ b/compiler/Acton/Types.hs
@@ -749,7 +749,7 @@ instance Check Decl where
                                              wellformed env1 q
                                              wellformed env1 a
                                              when (inClass env) $ do
-                                                 unify (DfltInfo l 600 Nothing []) tSelf $ selfType p dec
+                                                 unify (DfltInfo l 600 Nothing []) tSelf $ selfType p k dec
                                              (csp,te0,p') <- infEnv env1 p
                                              (csk,te1,k') <- infEnv (define te0 env1) k
                                              (csb,_,b') <- infDefBody (define te1 (define te0 env1)) n p' k' b

--- a/workspace/Semantics.txt
+++ b/workspace/Semantics.txt
@@ -258,15 +258,6 @@ Recent decisions:
 - Class inheritance is single ancestor only (all other types of mix-ins are expressed as protocol adoption)
 - Classes are the only nominal types, and only these support the 'isinstance' primitive
 - Narrowing of the option type is done through ==None and !=None comparisons
-- Narrowing of the primitive union type is done through built-ins 'isint', 'isfloat', 'isbool' and 'isstr'
-- Subtyping, as defined by class inheritance + structural rules, is ubiquitous
-- Class terms are subtypes of the function type (to allow for instantiation)
-- Type parameters to named types are written within brackets, as in List[int], dict[str,A]
-- Brackets also introduce type parameters in class declarations, as in class Bepa[T] (Apa[T]): ... 
-- And brackets introduce type parameters in explicitly polymorphic function/method declarations, as in def swap[A,B]((A,B)) -> (B,A): ...
-- Class names are also type names
-- Base class expressions are *type* expressions
-- Local classes are supported but all references to their names must be absent from the return type or env when their scope ends
 
 
 =========================================================================================================


### PR DESCRIPTION
Resolves #1598 