### PR TITLE
Testing: list tests, name filter & fixes

### DIFF
--- a/base/src/testing.act
+++ b/base/src/testing.act
@@ -441,6 +441,16 @@ class TestDisplay(object):
         self.sw = time.Stopwatch()
         self.expected_modules = set([''])
 
+    def set_expected(self, tests: dict[str, Test], modname: str=""):
+        for test_name, test in tests.items():
+            if modname not in self.results:
+                self.results[modname] = {}
+            self.results[modname][test_name] = (test=test, result=None)
+
+    def update_module(self, module_name: str, test_results: dict[str, (test: Test, result: ?TestResult)]):
+        self.results[module_name] = test_results
+        self.show()
+
     def update(self, test: Test, test_result: ?TestResult, modname: str=""):
         """Will return an integer when all tests are complete, otherwise None
         The returned integer is the suggested exit code.
@@ -450,6 +460,26 @@ class TestDisplay(object):
         self.results[modname][test.name] = (test=test, result=test_result)
         if test_result is not None:
             self.show()
+
+    def num_tests(self):
+        cnt = 0
+        for module_name in self.results:
+            cnt += len(self.results[module_name])
+        return cnt
+
+    def skip_show(self):
+        if len(self.expected_modules) > 0 and set(self.results.keys()) != self.expected_modules:
+            return True
+        return False
+
+    def is_test_done(self, modname, name):
+        if modname in self.results and name in self.results[modname]:
+            test_res = self.results[modname][name]
+            if test_res is not None:
+                test_res_result = test_res.result
+                if test_res_result is not None:
+                    return True
+        return False
 
     def show(self):
         pass
@@ -475,6 +505,8 @@ class TestDisplayJSON(TestDisplay):
 
 class TestDisplayStatus(TestDisplay):
     def show(self):
+        if self.skip_show():
+            return
         d = "["
         complete = True
         if set(self.results.keys()) != self.expected_modules:
@@ -518,7 +550,8 @@ class TestDisplayStatus(TestDisplay):
                 if modname == "":
                     print("\nTests")
                 else:
-                    print("\nTests - module %s:" % modname)
+                    if len(self.results[modname]) > 0:
+                        print("\nTests - module %s:" % modname)
                 for tname, t in self.results[modname].items():
                     r = t.result
                     if r is not None:
@@ -544,19 +577,19 @@ class TestDisplayStatus(TestDisplay):
                             print(prefix + term.green + "OK (%sms)" % (time) + term.normal)
             print("")
             if errors > 0 and failures > 0:
-                print(term.bold + term.red + "%d error and %d failure out of %d tests (%ss)" % (errors, failures, len(self.results), self.sw.elapsed().str_ms()) + term.normal)
+                print(term.bold + term.red + "%d error and %d failure out of %d tests (%ss)" % (errors, failures, self.num_tests(), self.sw.elapsed().str_ms()) + term.normal)
                 print()
                 self._env.exit(2)
             elif errors > 0:
-                print(term.bold + term.red + "%d out of %d tests errored (%ss)" % (errors, len(self.results), self.sw.elapsed().str_ms()) + term.normal)
+                print(term.bold + term.red + "%d out of %d tests errored (%ss)" % (errors, self.num_tests(), self.sw.elapsed().str_ms()) + term.normal)
                 print()
                 self._env.exit(2)
             elif failures > 0:
-                print(term.bold + term.red + "%d out of %d tests failed (%ss)" % (failures, len(self.results), self.sw.elapsed().str_ms()) + term.normal)
+                print(term.bold + term.red + "%d out of %d tests failed (%ss)" % (failures, self.num_tests(), self.sw.elapsed().str_ms()) + term.normal)
                 print()
                 self._env.exit(1)
             else:
-                print(term.green + "All %d tests passed (%ss)" % (len(self.results), self.sw.elapsed().str_ms()) + term.normal)
+                print(term.green + "All %d tests passed (%ss)" % (self.num_tests(), self.sw.elapsed().str_ms()) + term.normal)
                 print()
                 self._env.exit(0)
 
@@ -594,8 +627,9 @@ actor test_runner(env: Env, unit_tests: dict[str, UnitTest], sync_actor_tests: d
         if test_names == set():
             return tests
 
+        TEST_PREFIX_LEN = len("_test_")
         for name, t in tests.items():
-            if name[len("_test_"):] in test_names:
+            if name[TEST_PREFIX_LEN:] in test_names:
                 res[name] = t
         return res
 
@@ -605,7 +639,13 @@ actor test_runner(env: Env, unit_tests: dict[str, UnitTest], sync_actor_tests: d
         for modname in results.results.keys():
             for t in results.results[modname].keys():
                 tests.append(modname + "." + t)
-        print(json.encode({"tests": tests}))
+        if args.get_bool("json"):
+            print(json.encode({"tests": tests}), stderr=True)
+        else:
+            print("Tests:")
+            for test in tests:
+                print(" - " + test)
+        env.exit(0)
 
     proc def _run_tests(args):
         _init_results(args)
@@ -614,18 +654,24 @@ actor test_runner(env: Env, unit_tests: dict[str, UnitTest], sync_actor_tests: d
         _run_unit_tests(args)
 
     proc def _run_unit_tests(args):
-        hand_out = _filter_tests(unit_tests, args)
+        my_tests = _filter_tests(unit_tests, args)
+        handed_out = set()
 
-        def get_test():
-            r = hand_out.popitem()
-            if r is not None:
-                return r.1
+        def get_test() -> ?UnitTest:
+            remaining = list(set(my_tests.keys()) - handed_out)
+            if len(remaining) > 0:
+                test_name = remaining[0]
+                handed_out.add(test_name)
+                test = my_tests[test_name]
+                return test
 
         def check_complete():
-            if len(hand_out) == 0:
-                _run_sync_actor_tests(args)
-                return True
-            return False
+            for test in my_tests.values():
+                if not results.is_test_done("", test.name):
+                    return False
+
+            _run_sync_actor_tests(args)
+            return True
 
         def report_result(t, test_result: TestResult):
             results.update(t, test_result)
@@ -636,18 +682,24 @@ actor test_runner(env: Env, unit_tests: dict[str, UnitTest], sync_actor_tests: d
                 unit_test_runner(i, get_test, report_result)
 
     proc def _run_sync_actor_tests(args):
-        hand_out = _filter_tests(sync_actor_tests, args)
+        my_tests = _filter_tests(sync_actor_tests, args)
+        handed_out = set()
 
         def get_test() -> ?SyncActorTest:
-            r = hand_out.popitem()
-            if r is not None:
-                return r.1
+            remaining = list(set(my_tests.keys()) - handed_out)
+            if len(remaining) > 0:
+                test_name = remaining[0]
+                handed_out.add(test_name)
+                test = my_tests[test_name]
+                return test
 
         def check_complete():
-            if len(hand_out) == 0:
-                _run_async_actor_tests(args)
-                return True
-            return False
+            for test in my_tests.values():
+                if not results.is_test_done("", test.name):
+                    return False
+
+            _run_async_actor_tests(args)
+            return True
 
         def report_result(t, test_result: TestResult):
             results.update(t, test_result)
@@ -658,18 +710,24 @@ actor test_runner(env: Env, unit_tests: dict[str, UnitTest], sync_actor_tests: d
                 sync_actor_test_runner(get_test, report_result)
 
     proc def _run_async_actor_tests(args):
-        hand_out = _filter_tests(async_actor_tests, args)
+        my_tests = _filter_tests(async_actor_tests, args)
+        handed_out = set()
 
         def get_test() -> ?AsyncActorTest:
-            r = hand_out.popitem()
-            if r is not None:
-                return r.1
+            remaining = list(set(my_tests.keys()) - handed_out)
+            if len(remaining) > 0:
+                test_name = remaining[0]
+                handed_out.add(test_name)
+                test = my_tests[test_name]
+                return test
 
         def check_complete():
-            if len(hand_out) == 0:
-                _run_env_tests(args)
-                return True
-            return False
+            for test in my_tests.values():
+                if not results.is_test_done("", test.name):
+                    return False
+
+            _run_env_tests(args)
+            return True
 
         def report_result(t, test_result: TestResult):
             results.update(t, test_result)
@@ -680,18 +738,24 @@ actor test_runner(env: Env, unit_tests: dict[str, UnitTest], sync_actor_tests: d
                 async_actor_test_runner(get_test, report_result)
 
     proc def _run_env_tests(args):
-        hand_out = _filter_tests(env_tests, args)
+        my_tests = _filter_tests(env_tests, args)
+        handed_out = set()
 
         def get_test() -> ?EnvTest:
-            r = hand_out.popitem()
-            if r is not None:
-                return r.1
+            remaining = list(set(my_tests.keys()) - handed_out)
+            if len(remaining) > 0:
+                test_name = remaining[0]
+                handed_out.add(test_name)
+                test = my_tests[test_name]
+                return test
 
         def check_complete():
-            if len(hand_out) == 0:
-                # TODO: exit immediately or somethnig?
-                return True
-            return False
+            for test in my_tests.values():
+                if not results.is_test_done("", test.name):
+                    return False
+
+            env.exit(0)
+            return True
 
         def report_result(t, test_result: TestResult):
             results.update(t, test_result)
@@ -779,8 +843,8 @@ actor test_runner(env: Env, unit_tests: dict[str, UnitTest], sync_actor_tests: d
     try:
         _parse_args()
     except argparse.PrintUsage as exc:
-        print(exc)
+        print(exc.error_message)
         env.exit(0)
     except argparse.ArgumentError as exc:
-        print(exc)
+        print(exc.error_message)
         env.exit(1)

--- a/cli/src/acton.act
+++ b/cli/src/acton.act
@@ -27,7 +27,7 @@ actor CompilerRunner(process_cap, env, args):
     p = process.Process(process_cap, cmd, None, None, on_stdout, on_stderr, on_exit, on_error)
 
 
-actor TestModule(process_cap, modname, report_result):
+actor RunModuleTest(process_cap, modname, test_cmd, on_json_output):
     var stdout_buf = b""
     var stderr_buf = b""
 
@@ -47,22 +47,7 @@ actor TestModule(process_cap, modname, report_result):
                     print("Invalid json:", line)
                     continue
                 else:
-                    for tname, t in upd.items():
-                        if isinstance(t, dict):
-                            tdef = t["test"]
-                            tres = t["result"]
-                            test = testing.Test(tdef["name"], tdef["desc"])
-                            test_result = None
-                            if tres is not None and tres != {}:
-                                tr_success: ?bool = None
-                                tr_success_val = tres["success"]
-                                if tr_success_val is not None:
-                                    tr_success = bool(tr_success_val)
-                                test_result = testing.TestResult(
-                                    tr_success,
-                                    tres["exception"],
-                                    float(tres["duration"]))
-                            report_result(modname, test, test_result)
+                    on_json_output(upd)
             else:
                 # incomplete line
                 _stderr_buf = line
@@ -76,27 +61,54 @@ actor TestModule(process_cap, modname, report_result):
     def on_error(p, error):
         print("Error from process:", error)
 
-    cmd = ["out/rel/bin/.test_" + modname, "--json", "test"]
+    cmd = ["out/rel/bin/.test_" + modname, "--json"] + test_cmd
     p = process.Process(process_cap, cmd, None, None, on_stdout, on_stderr, on_exit, on_error)
 
-actor RunTest(process_cap, env, args):
+
+def parse_json_test_result(module_name, j) -> dict[str, (test: testing.Test, result: ?testing.TestResult)]:
+    res = {}
+    for tname, t in j.items():
+        if isinstance(t, dict):
+            tdef = t["test"]
+            tres = t["result"]
+            test_def = testing.Test(tdef["name"], tdef["desc"])
+            test_result = None
+            if tres is not None and tres != {}:
+                tr_success: ?bool = None
+                tr_success_val = tres["success"]
+                if tr_success_val is not None:
+                    tr_success = bool(tr_success_val)
+                test_result = testing.TestResult(
+                    tr_success,
+                    tres["exception"],
+                    float(tres["duration"]))
+            res[module_name + tname] = (test_def, test_result)
+        else:
+            raise ValueError("Invalid json: " + str(j))
+    return res
+
+def parse_test_list_json_output(j, modname):
+    res = []
+    if isinstance(j, dict):
+        for test_name in j["tests"]:
+            res.append(modname + test_name)
+    else:
+        raise ValueError("Invalid json: " + str(j))
+    return res
+
+actor BuildProjectTests(process_cap, env, args, on_build_success, on_build_failure):
+    """Build the project test
+
+    This actor builds the project tests using `actonc build --test`. It calls
+    on_build_success with a list of the test modules if the build was
+    successful, and on_build_failure with the exit code, term signal if the
+    build failed.
+    """
     _test_modules: list[str] = []
     modtests = {}
     var stdout_buf = b""
     var stderr_buf = b""
     var stdout_tests = False
-
-    def _on_build_done():
-        print("Build done, running tests for modules:")
-        results = testing.TestDisplayStatus(env)
-        results.expected_modules = set(_test_modules)
-
-        for modname in _test_modules:
-            print(" -", modname)
-            def _on_test_result(module, test_def, test_result):
-                results.update(test_def, test_result, module)
-            t = TestModule(process_cap, modname, _on_test_result)
-            modtests[modname] = t
 
     cmdargs = build_cmd_args(args)
     fs = file.FS(file.FileCap(env.cap))
@@ -115,20 +127,91 @@ actor RunTest(process_cap, env, args):
                     print(line)
 
     def on_actbuild_stderr(p, data):
-        print(data.decode(), end="", stderr=True)
+        stderr_buf += data
 
     def on_actbuild_exit(p, exit_code, term_signal):
         if exit_code == 0:
-            _on_build_done()
+            on_build_success(_test_modules)
         else:
-            await async env.exit(exit_code)
+            on_build_failure(exit_code, term_signal, stderr_buf)
 
     def on_actbuild_error(p, error):
-        print("Error from process:", error)
-        await async env.exit(1)
+        on_build_failure(-999, -999, error)
 
     p = process.Process(process_cap, cmd, None, None, on_actbuild_stdout, on_actbuild_stderr, on_actbuild_exit, on_actbuild_error)
 
+actor RunTestList(process_cap, env, args):
+    """Print list of module tests
+
+    Will run the project module test binaries with 'list --json' to get all
+    module tests, collect the output and print a list of all project tests.
+    """
+    var _expected_modules: set[str] = set()
+    var _module_tests = {}
+
+    def print_module_tests():
+        for mn in _module_tests.keys():
+            print("Module %s:" % mn)
+            for module_test_name in _module_tests[mn]:
+                print(" ", module_test_name)
+            print()
+
+    def _on_json_output(module_name, update):
+        if module_name in _module_tests:
+            raise ValueError("Duplicate list of tests from module: " + module_name)
+        if isinstance(update, dict):
+            _module_tests[module_name] = []
+            for test_name in update["tests"]:
+                _module_tests[module_name].append(module_name + test_name)
+        else:
+            raise ValueError("Unexpected JSON data from module test: " + module_name)
+
+        if set(_module_tests.keys()) == _expected_modules:
+            print_module_tests()
+            env.exit(0)
+
+    def _run_tests(module_names: list[str]):
+        _expected_modules = set(module_names)
+
+        for module_name in module_names:
+            t = RunModuleTest(process_cap, module_name, ["list"], lambda x: _on_json_output(module_name, x))
+
+    def _on_build_failure(exit_code, term_signal, stderr_buf):
+        print("Failed to build project tests")
+        print("actonc exited with code %d / %d" %(exit_code, term_signal))
+        print("stderr:", stderr_buf)
+        env.exit(1)
+
+    project_builder = BuildProjectTests(process_cap, env, args, _run_tests, _on_build_failure)
+
+
+actor RunTestTest(process_cap, env, args):
+    var _module_tests = {}
+    results = testing.TestDisplayStatus(env)
+
+    def _on_json_output(module_name, update):
+        if isinstance(update, dict):
+            parsed_update = parse_json_test_result(module_name, update)
+            results.update_module(module_name, parsed_update)
+        else:
+            raise ValueError("Unexpected JSON data from module test: " + module_name)
+
+    def _run_tests(module_names: list[str]):
+        results.expected_modules = set(module_names)
+
+        test_cmd = ["test"]
+        for name_filter in args.get_strlist("name"):
+            test_cmd.extend(["--name", name_filter])
+        for module_name in module_names:
+            t = RunModuleTest(process_cap, module_name, test_cmd, lambda x: _on_json_output(module_name, x))
+
+    def _on_build_failure(exit_code, term_signal, stderr_buf):
+        print("Failed to build project tests")
+        print("actonc exited with code %d / %d" %(exit_code, term_signal))
+        print("stderr:", stderr_buf)
+        env.exit(1)
+
+    project_builder = BuildProjectTests(process_cap, env, args, _run_tests, _on_build_failure)
 
 def build_cmd_args(args):
     cmdargs = []
@@ -169,7 +252,10 @@ actor main(env):
         env.exit(0)
 
     def _cmd_test(args):
-        RunTest(process_cap, env, args)
+        run_tests = RunTestTest(process_cap, env, args)
+
+    def _cmd_list_test(args):
+        run_tests = RunTestList(process_cap, env, args)
 
     def _parse_args():
         p = argparse.Parser()
@@ -208,6 +294,8 @@ actor main(env):
         newp = p.add_cmd("new", "New project", _cmd_new)
         newp.add_arg("projectdir", "Project directory", True, "?")
         testp = p.add_cmd("test", "Test", _cmd_test)
+        testp.add_option("name", "strlist", "+", [], "Filter on test name")
+        testp = testp.add_cmd("list", "List tests", _cmd_list_test)
         return p.parse(env.argv)
 
     try:
@@ -220,8 +308,12 @@ actor main(env):
             pass
         if _cmd is not None:
             if _file is not None:
-                # TODO: print to stderr
-                print("Error: cannot specify both a command and an .act file")
+                if _file.endswith(".act"):
+                    print("Error: cannot specify both a command and an .act file", stderr=True)
+                elif _file.endswith(".ty"):
+                    print("Error: cannot specify both a command and an .ty file", stderr=True)
+                else:
+                    print("Unknown argument:", _file, stderr=True)
                 await async env.exit(1)
             _cmd(_args)
         else:
@@ -230,8 +322,8 @@ actor main(env):
             else:
                 env.exit(0)
     except argparse.PrintUsage as exc:
-        print(exc)
+        print(exc.error_message)
         env.exit(0)
     except argparse.ArgumentError as exc:
-        print(exc)
+        print(exc.error_message)
         env.exit(1)


### PR DESCRIPTION
`acton test list` will list all the test names in a project and it can take --json. It's possible to use --name to filter which tests to run, e.g. `acton test --name foo --name bar`.

The reported test count in the result summary was wrong, it counted modules when it should have counted tests. We now wait showing output until we've received the initial list of tests from each module.