### PR TITLE
Revamp testing

### DIFF
--- a/base/src/testing.act
+++ b/base/src/testing.act
@@ -247,7 +247,7 @@ def assertNotIn(a, b, msg: ?str):
 class TestLogger(logging.Logger):
     pass
 
-class Test (object):
+class Test(object):
     name: str
     desc: str
 
@@ -261,6 +261,14 @@ class Test (object):
             "desc": self.desc,
         }
 
+    @staticmethod
+    def from_json(data: dict[str, str]):
+        name = data["name"]
+        desc = data["desc"]
+        if isinstance(name, str) and isinstance(desc, str):
+            return Test(name, desc)
+        else:
+            raise ValueError("Invalid Test JSON")
 
 class UnitTest(Test):
     def __init__(self, fn: mut() -> None, name: str, desc: str):
@@ -298,7 +306,7 @@ class TestResult(object):
       - for asynchronous actor & env tests, the report_result callback was called with TestResult(success=False, exception=AssertionError)
     - error: the test was unable to run to completion, encountering some other error in test setup or similar
       - for unit tests & synchronous actor tests, an Exception (or child thereof) was raised, but not an AssertionError
-      - for asynchronous actor & env tests, the report_result callback was called with TestResult(success=, exception=AssertionError)
+      - for asynchronous actor & env tests, the report_result callback was called with TestResult(success=None, exception=AssertionError)
     """
     success: ?bool
     exception: ?str
@@ -316,150 +324,359 @@ class TestResult(object):
             "duration": self.duration,
         }
 
+    @staticmethod
+    def from_json(data: dict[str, str]) -> TestResult:
+        success = data["success"]
+        exception = data["exception"]
+        duration = data["duration"]
+        if (isinstance(success, bool)
+            and isinstance(exception, str)
+            and isinstance(duration, float)
+            ):
+            return TestResult(success, exception, duration)
+        raise ValueError("Invalid TestResult JSON")
+
+
+class TestInfo(object):
+    definition: Test
+    complete: bool
+    success: ?bool
+    exception: ?str
+    flaky: bool
+    min_duration: float
+    max_duration: float
+    avg_duration: float
+    total_duration: float
+    num_iterations: int
+    num_failures: int
+    num_errors: int
+    results: list[TestResult]
+
+    def __init__(self, definition: Test, complete: bool=False, success: ?bool=None, exception: ?str=None, flaky: bool=False, min_duration: float=-1.0, max_duration: float=-1.0, avg_duration: float=-1.0, total_duration: float=-1.0, num_iterations: int=-1, num_failures: int=-1, num_errors: int=-1, results: list[TestResult]=[]):
+        self.definition = definition
+        self.complete = complete
+        self.success = success
+        self.exception = exception
+        self.flaky = flaky
+        self.min_duration = min_duration
+        self.max_duration = max_duration
+        self.avg_duration = avg_duration
+        self.total_duration = total_duration
+        self.num_iterations = num_iterations
+        self.num_failures = num_failures
+        self.num_errors = num_errors
+        self.results = results
+
+    def update(self, complete, result: TestResult):
+        self.complete = complete
+        self.results.append(result)
+        exc = result.exception
+        if exc is not None:
+            self.exception = exc
+
+        self.flaky = False
+        self.min_duration = -1.0
+        self.max_duration = -1.0
+        self.avg_duration = -1.0
+        self.total_duration = 0.0
+        self.num_iterations = len(self.results)
+        self.num_failures = 0
+        self.num_errors = 0
+        for result in self.results:
+            res_success = result.success
+            if res_success == False:
+                self.num_failures += 1
+            elif res_success is None:
+                self.num_errors += 1
+
+            if result.duration < self.min_duration or self.min_duration < 0.0:
+                self.min_duration = result.duration
+            if result.duration > self.max_duration or self.max_duration < 0.0:
+                self.max_duration = result.duration
+            self.total_duration += result.duration
+
+        self.avg_duration = self.total_duration / float(self.num_iterations)
+        if self.num_failures > 0:
+            self.success = False
+        elif self.num_errors > 0:
+            self.success = None
+        if (self.num_failures == 0 and self.num_errors == 0) or self.num_failures == self.num_iterations or self.num_errors == self.num_iterations:
+            self.flaky = False
+        else:
+            self.flaky = True
+
+    def to_json(self):
+        return {
+            "definition": self.definition.to_json(),
+            "complete": self.complete,
+            "success": self.success,
+            "exception": self.exception,
+            "flaky": self.flaky,
+            "min_duration": self.min_duration,
+            "max_duration": self.max_duration,
+            "avg_duration": self.avg_duration,
+            "total_duration": self.total_duration,
+            "num_iterations": self.num_iterations,
+            "num_failures": self.num_failures,
+            "num_errors": self.num_errors,
+            #"results": [r.to_json() for r in self.results],
+        }
+
+    @staticmethod
+    def from_json(json_data):
+        definition = Test.from_json(json_data["definition"])
+        complete = json_data["complete"]
+        success = json_data["success"]
+        exc = json_data["exception"]
+        flaky = json_data["flaky"]
+        min_duration = json_data["min_duration"]
+        max_duration = json_data["max_duration"]
+        avg_duration = json_data["avg_duration"]
+        total_duration = json_data["total_duration"]
+        num_iterations = json_data["num_iterations"]
+        num_failures = json_data["num_failures"]
+        num_errors = json_data["num_errors"]
+        results: list[TestResult] = []
+        json_data_results = json_data["results"]
+        if isinstance(json_data_results, list):
+            for r in json_data_results:
+                r_success = r["success"]
+                r_exception = r["exception"]
+                r_duration = r["duration"]
+                if (isinstance(r_success, bool)
+                    and isinstance(r_exception, str)
+                    and isinstance(r_duration, float)
+                    ):
+                    results.append(TestResult(r_success, r_exception, r_duration))
+                else:
+                    raise ValueError("Invalid TestResult JSON")
+        exception: ?str = None
+        if isinstance(exc, str):
+            exception = exc
+        if (isinstance(complete, bool)
+            and isinstance(success, bool)
+            and isinstance(flaky, bool)
+            and isinstance(min_duration, float)
+            and isinstance(max_duration, float)
+            and isinstance(avg_duration, float)
+            and isinstance(total_duration, float)
+            and isinstance(num_iterations, int)
+            and isinstance(num_failures, int)
+            and isinstance(num_errors, int)
+            ):
+            return TestInfo(definition, complete, success, exception, flaky, min_duration, max_duration, avg_duration, total_duration, num_iterations, num_failures, num_errors, results)
+        else:
+            raise ValueError("Invalid TestInfo JSON")
+
+# TODO: make this configurable
+# It doesn't seem to work well bumping up this value much beyond a few ms.
+# Probably because we are sending a test_result update for each test run which
+# becomes excessively chatty. Should probably summarize results and send the
+# summary at a lower frequency.
+MIN_TEST_DURATION = 1.0
+
 actor unit_test_runner(i, get_test, report_result):
     """Test runner for unit tests
     """
+    def _run_fn(f):
+        sw = time.Stopwatch()
+        try:
+            f()
+            dur = sw.elapsed().to_float() * 1000.0
+            return TestResult(True, None, dur)
+        except AssertionError as e:
+            dur = sw.elapsed().to_float() * 1000.0
+            return TestResult(False, str(e), dur)
+        except Exception as e:
+            dur = sw.elapsed().to_float() * 1000.0
+            return TestResult(None, str(e), dur)
+
     def _run():
         while True:
             t = get_test()
             if t is not None:
-                sw = time.Stopwatch()
                 f = t.fn
-                try:
-                    f()
-                    dur = sw.elapsed().to_float() * 1000.0
-                    report_result(t, TestResult(True, None, dur))
-                except AssertionError as e:
-                    dur = sw.elapsed().to_float() * 1000.0
-                    report_result(t, TestResult(None, str(e), dur))
-                except Exception as e:
-                    dur = sw.elapsed().to_float() * 1000.0
-                    report_result(t, TestResult(False, str(e), dur))
+                total_dur = 0.0
+                complete = False
+                while True:
+                    test_result = _run_fn(f)
+                    total_dur += test_result.duration
+                    if total_dur > MIN_TEST_DURATION:
+                        complete = True
+                    report_result(t, complete, test_result)
+                    if complete:
+                        break
             else:
                 return None
 
     after 0: _run()
 
 
+# TODO: collapse this and the above unit_test_runner, since both are sync tests
+# and the only difference is the type of test, so I think this should be
+# possible
+# TODO: investigate if we can turn this into async style, which would open up
+# for collapsing this with the async_actor_test_runner and env_test_runner
 actor sync_actor_test_runner(get_test: action() -> ?SyncActorTest, report_result):
     """Test runner for sync actor tests
     """
     log_handler = logging.Handler("TestRunner")
+
+    def _run_fn(f):
+        sw = time.Stopwatch()
+        try:
+            f(log_handler)
+            dur = sw.elapsed().to_float() * 1000.0
+            return TestResult(True, None, dur)
+        except AssertionError as e:
+            dur = sw.elapsed().to_float() * 1000.0
+            return TestResult(False, str(e), dur)
+        except Exception as e:
+            dur = sw.elapsed().to_float() * 1000.0
+            return TestResult(None, str(e), dur)
+
     def _run():
         while True:
             t = get_test()
             if t is not None:
-                sw = time.Stopwatch()
                 f = t.fn
-                try:
-                    f(log_handler)
-                    dur = sw.elapsed().to_float() * 1000.0
-                    report_result(t, TestResult(True, None, dur))
-                except AssertionError as e:
-                    dur = sw.elapsed().to_float() * 1000.0
-                    report_result(t, TestResult(None, str(e), dur))
-                except Exception as e:
-                    dur = sw.elapsed().to_float() * 1000.0
-                    report_result(t, TestResult(False, str(e), dur))
+                total_dur = 0.0
+                complete = False
+                while True:
+                    test_result = _run_fn(f)
+                    total_dur += test_result.duration
+                    if total_dur > MIN_TEST_DURATION:
+                        complete = True
+                    report_result(t, complete, test_result)
+                    if complete:
+                        break
             else:
                 return None
 
     after 0: _run()
 
 
+# TODO: add a timeout to this
 actor async_actor_test_runner(get_test: action() -> ?AsyncActorTest, report_result):
     """Test runner for async actor tests
     """
     log_handler = logging.Handler("TestRunner")
+    var total_duration = 0.0
 
     action def _report_result(test: AsyncActorTest, sw, success: ?bool, exception: ?Exception):
         dur = sw.elapsed().to_float() * 1000.0
+        total_duration += dur
+        complete = False
+        if total_duration > MIN_TEST_DURATION:
+            complete = True
         exc = None
         if exception is not None:
             exc = str(exception)
-        report_result(test, TestResult(success, exc, dur))
+        report_result(test, complete, TestResult(success, exc, dur))
+        if not complete:
+            _run_fn(test)
+        else:
+            _run_next()
 
-    def _run():
-        while True:
-            t = get_test()
-            if t is not None:
-                sw = time.Stopwatch()
-                f = t.fn
-                try:
-                    f(lambda s, e: _report_result(t, sw, s, e), log_handler)
-                except AssertionError as e:
-                    dur = sw.elapsed().to_float() * 1000.0
-                    report_result(t, TestResult(None, str(e), dur))
-                except Exception as e:
-                    dur = sw.elapsed().to_float() * 1000.0
-                    report_result(t, TestResult(False, str(e), dur))
-            else:
-                return None
+    def _run_fn(t):
+        sw = time.Stopwatch()
+        f = t.fn
+        try:
+            f(lambda s, e: _report_result(t, sw, s, e), log_handler)
+        except AssertionError as e:
+            _report_result(t, sw, False, e)
+        except Exception as e:
+            _report_result(t, sw, None, e)
 
-    after 0: _run()
+    def _run_next():
+        """Get the next available test and run it"""
+        total_duration = 0.0
+        t = get_test()
+        if t is not None:
+            _run_fn(t)
+
+    after 0: _run_next()
 
 
 actor env_test_runner(get_test: action() -> ?EnvTest, report_result, env):
     """Test runner for async actor tests
     """
     log_handler = logging.Handler("TestRunner")
+    var total_duration = 0.0
 
     action def _report_result(test: EnvTest, sw, success: ?bool, exception: ?Exception):
         dur = sw.elapsed().to_float() * 1000.0
+        total_duration += dur
+        complete = False
+        if total_duration > MIN_TEST_DURATION:
+            complete = True
         exc = None
         if exception is not None:
             exc = str(exception)
-        report_result(test, TestResult(success, exc, dur))
+        report_result(test, complete, TestResult(success, exc, dur))
+        if not complete:
+            _run_fn(test)
+        else:
+            _run_next()
 
-    def _run():
-        while True:
-            t = get_test()
-            if t is not None:
-                sw = time.Stopwatch()
-                f = t.fn
-                try:
-                    f(lambda s, e: _report_result(t, sw, s, e), env, log_handler)
-                except AssertionError as e:
-                    dur = sw.elapsed().to_float() * 1000.0
-                    report_result(t, TestResult(None, str(e), dur))
-                except Exception as e:
-                    dur = sw.elapsed().to_float() * 1000.0
-                    report_result(t, TestResult(False, str(e), dur))
-            else:
-                return None
+    def _run_fn(t):
+        sw = time.Stopwatch()
+        f = t.fn
+        try:
+            f(lambda s, e: _report_result(t, sw, s, e), env, log_handler)
+        except AssertionError as e:
+            _report_result(t, sw, False, e)
+        except Exception as e:
+            _report_result(t, sw, None, e)
 
-    after 0: _run()
+    def _run_next():
+        """Get the next available test and run it"""
+        total_duration = 0.0
+        t = get_test()
+        if t is not None:
+            _run_fn(t)
+
+    after 0: _run_next()
 
 
-class TestDisplay(object):
-    results: dict[str, dict[str, (test: Test, result: ?TestResult)]]
+class ProjectTestResults(object):
+    _env: Env
+    results: dict[str, dict[str, TestInfo]]
+    sw: time.Stopwatch
     expected_modules: set[str]
+    printed_lines: int
+    last_print: time.Instant
 
     def __init__(self, env):
         self._env = env
         self.results = {}
         self.sw = time.Stopwatch()
         self.expected_modules = set([''])
+        self.printed_lines = 0
+        self.last_print = time.monotonic()
+        self.last_print.second -= 1
 
     def set_expected(self, tests: dict[str, Test], modname: str=""):
         for test_name, test in tests.items():
             if modname not in self.results:
                 self.results[modname] = {}
-            self.results[modname][test_name] = (test=test, result=None)
+            self.results[modname][test_name] = TestInfo(test)
 
-    def update_module(self, module_name: str, test_results: dict[str, (test: Test, result: ?TestResult)]):
-        self.results[module_name] = test_results
-        self.show()
-
-    def update(self, test: Test, test_result: ?TestResult, modname: str=""):
-        """Will return an integer when all tests are complete, otherwise None
-        The returned integer is the suggested exit code.
+    def update_module(self, module_name: str, test_results: dict[str, TestInfo]):
+        """Update test results for all tests in a module
         """
-        if modname not in self.results:
-            self.results[modname] = {}
-        self.results[modname][test.name] = (test=test, result=test_result)
+        self.results[module_name] = test_results
+
+    def update(self, module_name: str, test: Test, complete: bool, test_result: TestResult):
+        """Update result for individual test
+        """
+        if module_name not in self.results:
+            self.results[module_name] = {}
+        if test.name not in self.results[module_name]:
+            self.results[module_name][test.name] = TestInfo(test)
+        tres = self.results[module_name][test.name]
         if test_result is not None:
-            self.show()
+            tres.update(complete, test_result)
 
     def num_tests(self):
         cnt = 0
@@ -474,107 +691,85 @@ class TestDisplay(object):
 
     def is_test_done(self, modname, name):
         if modname in self.results and name in self.results[modname]:
-            test_res = self.results[modname][name]
-            if test_res is not None:
-                test_res_result = test_res.result
-                if test_res_result is not None:
-                    return True
+            test_info = self.results[modname][name]
+            return test_info.complete
         return False
 
-    def show(self):
+    def show_updated(self, test, complete, test_result, modname):
         pass
 
-class TestDisplayJSON(TestDisplay):
-#    def update_from_json(self, json_update: str):
-#        update = json.decode(json_update)
-
-    def show(self):
-        res = {}
-        for modname in self.results:
-            #if modname not in res:
-            #    res[modname] = {}
-            for tname, t in self.results[modname].items():
-                tres = {}
-                r = t.result
-                if r is not None:
-                    tres = r.to_json()
-                #res[modname][tname] = {"test": t.test.to_json(), "result": tres}
-                res[modname + "." + tname] = {"test": t.test.to_json(), "result": tres}
-        print(json.encode(res), stderr=True)
-
-
-class TestDisplayStatus(TestDisplay):
     def show(self):
         if self.skip_show():
             return
-        d = "["
+
         complete = True
         if set(self.results.keys()) != self.expected_modules:
             complete = False
+        for module_name in self.results:
+            for test_name, test_info in self.results[module_name].items():
+                if not test_info.complete:
+                    complete = False
 
-        for modname in self.results:
-            if modname is not None:
-                for tname, t in self.results[modname].items():
-                    r = t.result
-                    if r is None:
-                        complete = False
-            else:
-                complete = False
-
-        for modname in self.results:
-            if modname is not None:
-                for tname, t in self.results[modname].items():
-                    r = t.result
-                    if r is not None:
-                        success = r.success
-                        if r:
-                            d += "."
-                        else:
-                            d += "!"
-                    else:
-                        d += " "
-        d += "]"
-        print("\r", end="", flush=True)
-        print(d, end="", flush=True)
+        now = time.monotonic()
+        if now.since(self.last_print).to_float() < 0.05:
+            return
+        self.last_print = now
 
         errors = 0
         failures = 0
-        if complete:
-            print(term.clearline + term.up() + term.clearline, end="")
-            tname_width = 20
-            for modname in self.results:
-                for tname, t in self.results[modname].items():
-                    tname_width = max([tname_width, len(t.test.name)], None)
 
-            for modname in self.results:
-                if modname == "":
-                    print("\nTests")
+        for i in range(self.printed_lines):
+            print(term.clearline + term.up() + term.clearline, end="")
+        self.printed_lines = 0
+        tname_width = 20
+        for modname in self.results:
+            for tname, tinfo in self.results[modname].items():
+                tname_width = max([tname_width, len(tinfo.definition.name)])
+        tname_width += 5
+
+        for modname in self.results:
+            if modname == "":
+                print("\nTests")
+                self.printed_lines += 2
+            elif len(self.results[modname]) > 0:
+                print("\nTests - module %s:" % modname)
+                self.printed_lines += 2
+            for tname, tinfo in self.results[modname].items():
+                prefix = "  " + tinfo.definition.name + ": "
+                prefix += " " * (tname_width - len(prefix))
+                success = tinfo.success
+                exc = tinfo.exception
+                if tinfo.complete:
+                    if exc is not None:
+                        flaky_info = "("
+                        msg = ""
+                        if tinfo.flaky:
+                            msg = "FLAKY "
+                        if tinfo.num_errors > 0:
+                            msg += "ERROR"
+                            errors += 1
+                            flaky_info += "%d errors" % tinfo.num_errors
+                        if tinfo.num_errors > 0 and tinfo.num_failures > 0:
+                            msg += "/"
+                            flaky_info += " and "
+                        if tinfo.num_failures > 0:
+                            msg += "FAIL"
+                            failures += 1
+                            flaky_info += "%d failures" % tinfo.num_failures
+                        flaky_info += " out of %d runs in %3.3fms)" % (tinfo.num_iterations, tinfo.total_duration)
+
+                        print(prefix + term.bold + term.red + msg + " " + flaky_info + term.normal)
+                        self.printed_lines += 1
+                        for line in str(exc).splitlines(None):
+                            print(term.red + "    %s" % (line) + term.normal)
+                            self.printed_lines += 1
+                    else:
+                        print(prefix + term.green + "OK (%3d runs in %-3.3fms)" % (tinfo.num_iterations, tinfo.total_duration) + term.normal)
+                        self.printed_lines += 1
                 else:
-                    if len(self.results[modname]) > 0:
-                        print("\nTests - module %s:" % modname)
-                for tname, t in self.results[modname].items():
-                    r = t.result
-                    if r is not None:
-                        prefix = "  " + t.test.name + ": "
-                        prefix += " " * (tname_width - len(prefix))
-                        success = r.success
-                        exc = r.exception
-                        if exc is not None:
-                            if success is not None:
-                                failures += 1
-                                print(prefix + term.bold + term.red + "FAIL (%fms)" % r.duration + term.normal)
-                                for line in str(exc).splitlines(None):
-                                    print(term.red + "    %s" % (line) + term.normal)
-                            else:
-                                errors += 1
-                                print(prefix + term.bold + term.red + "ERROR (%fms)" % r.duration + term.normal)
-                                for line in str(exc).splitlines(None):
-                                    print(term.red + "    %s" % (line) + term.normal)
-                        else:
-                            time = "N/A"
-                            if r.duration >= 0:
-                                time = "%f" % (r.duration)
-                            print(prefix + term.green + "OK (%sms)" % (time) + term.normal)
+                    print(prefix + term.bold + term.yellow + "RUNNING (%3d runs in %.3fms)" % (tinfo.num_iterations, tinfo.total_duration) + term.normal)
+                    self.printed_lines += 1
+        if complete:
             print("")
             if errors > 0 and failures > 0:
                 print(term.bold + term.red + "%d error and %d failure out of %d tests (%ss)" % (errors, failures, self.num_tests(), self.sw.elapsed().str_ms()) + term.normal)
@@ -593,13 +788,42 @@ class TestDisplayStatus(TestDisplay):
                 print()
                 self._env.exit(0)
 
+class ModuleTestResults(object):
+    tests: dict[str, TestInfo]
+
+    def __init__(self):
+        self.tests = {}
+
+    def set_tests(self, tests: dict[str, TestInfo]):
+        self.tests = tests
+
+    def update(self, test: Test, complete: bool, test_result: TestResult):
+        if test.name not in self.tests:
+            self.tests[test.name] = TestInfo(test)
+        self.tests[test.name].update(complete, test_result)
+        print(json.encode({"test": test.to_json(), "complete": complete, "result": test_result.to_json()}), stderr=True)
+
+    def is_test_done(self, name):
+        if name in self.tests:
+            return self.tests[name].complete
+        return False
+
+    def show(self):
+        res = {}
+        for test in self.tests.values():
+            res[test.definition.name] = test.definition.to_json()
+        print(json.encode({"tests": res}), stderr=True)
+
+    def show_updated(self, test, complete, test_result, modname):
+        print(json.encode({"test": test.to_json(), "complete": complete, "result": test_result.to_json()}), stderr=True)
+
+
+
 actor test_runner(env: Env, unit_tests: dict[str, UnitTest], sync_actor_tests: dict[str, SyncActorTest], async_actor_tests: dict[str, AsyncActorTest], env_tests: dict[str, EnvTest]):
     sw = time.Stopwatch()
-    var results = TestDisplayStatus(env)
+    var results = ModuleTestResults()
 
     def _init_results(args):
-        if args.get_bool("json"):
-            results = TestDisplayJSON(env)
 
         all_tests = {}
         for name, t in unit_tests.items():
@@ -613,8 +837,10 @@ actor test_runner(env: Env, unit_tests: dict[str, UnitTest], sync_actor_tests: d
 
         tests = _filter_tests(all_tests, args)
 
-        for name, t in tests.items():
-            results.update(t, None)
+        test_module_results = {}
+        for test_def in tests.values():
+            test_module_results[test_def.name] = TestInfo(test_def)
+        results.set_tests(test_module_results)
 
     def _filter_tests[T](tests: dict[str, T], args) -> dict[str, T]:
         res = {}
@@ -636,15 +862,9 @@ actor test_runner(env: Env, unit_tests: dict[str, UnitTest], sync_actor_tests: d
     proc def _list_tests(args):
         _init_results(args)
         tests = []
-        for modname in results.results.keys():
-            for t in results.results[modname].keys():
-                tests.append(modname + "." + t)
-        if args.get_bool("json"):
-            print(json.encode({"tests": tests}), stderr=True)
-        else:
-            print("Tests:")
-            for test in tests:
-                print(" - " + test)
+        for test in results.tests.values():
+            tests.append(test.definition.to_json())
+        print(json.encode({"tests": tests}), stderr=True)
         env.exit(0)
 
     proc def _run_tests(args):
@@ -667,14 +887,13 @@ actor test_runner(env: Env, unit_tests: dict[str, UnitTest], sync_actor_tests: d
 
         def check_complete():
             for test in my_tests.values():
-                if not results.is_test_done("", test.name):
+                if not results.is_test_done(test.name):
                     return False
-
             _run_sync_actor_tests(args)
             return True
 
-        def report_result(t, test_result: TestResult):
-            results.update(t, test_result)
+        def report_result(t, complete, test_result: TestResult):
+            results.update(t, complete, test_result)
             check_complete()
 
         if not check_complete():
@@ -695,14 +914,13 @@ actor test_runner(env: Env, unit_tests: dict[str, UnitTest], sync_actor_tests: d
 
         def check_complete():
             for test in my_tests.values():
-                if not results.is_test_done("", test.name):
+                if not results.is_test_done(test.name):
                     return False
-
             _run_async_actor_tests(args)
             return True
 
-        def report_result(t, test_result: TestResult):
-            results.update(t, test_result)
+        def report_result(t, complete, test_result: TestResult):
+            results.update(t, complete, test_result)
             check_complete()
 
         if not check_complete():
@@ -723,14 +941,13 @@ actor test_runner(env: Env, unit_tests: dict[str, UnitTest], sync_actor_tests: d
 
         def check_complete():
             for test in my_tests.values():
-                if not results.is_test_done("", test.name):
+                if not results.is_test_done(test.name):
                     return False
-
             _run_env_tests(args)
             return True
 
-        def report_result(t, test_result: TestResult):
-            results.update(t, test_result)
+        def report_result(t, complete, test_result: TestResult):
+            results.update(t, complete, test_result)
             check_complete()
 
         if not check_complete():
@@ -751,14 +968,14 @@ actor test_runner(env: Env, unit_tests: dict[str, UnitTest], sync_actor_tests: d
 
         def check_complete():
             for test in my_tests.values():
-                if not results.is_test_done("", test.name):
+                if not results.is_test_done(test.name):
                     return False
-
             env.exit(0)
             return True
 
-        def report_result(t, test_result: TestResult):
-            results.update(t, test_result)
+        def report_result(t, complete, test_result: TestResult):
+            results.update(t, complete, test_result)
+            check_complete()
 
         if not check_complete():
             for i in range(0, min([1, env.nr_wthreads // 4], None), 1):

--- a/base/src/time.act
+++ b/base/src/time.act
@@ -406,7 +406,7 @@ class DateTime(object):
 
 
 
-class Instant:
+class Instant(object):
     """A specific point in time as measured with a monotonically increasing
     clock. Only useful with ~Duration~ and ~Stopwatch~ to measure elapsed time.
 
@@ -497,7 +497,7 @@ extension Instant(Ord):
 
 
 
-class Duration:
+class Duration(object):
     """Duration represents elapsed time
 
     Stored using seconds and attoseconds.

--- a/cli/src/acton.act
+++ b/cli/src/acton.act
@@ -65,37 +65,6 @@ actor RunModuleTest(process_cap, modname, test_cmd, on_json_output):
     p = process.Process(process_cap, cmd, None, None, on_stdout, on_stderr, on_exit, on_error)
 
 
-def parse_json_test_result(module_name, j) -> dict[str, (test: testing.Test, result: ?testing.TestResult)]:
-    res = {}
-    for tname, t in j.items():
-        if isinstance(t, dict):
-            tdef = t["test"]
-            tres = t["result"]
-            test_def = testing.Test(tdef["name"], tdef["desc"])
-            test_result = None
-            if tres is not None and tres != {}:
-                tr_success: ?bool = None
-                tr_success_val = tres["success"]
-                if tr_success_val is not None:
-                    tr_success = bool(tr_success_val)
-                test_result = testing.TestResult(
-                    tr_success,
-                    tres["exception"],
-                    float(tres["duration"]))
-            res[module_name + tname] = (test_def, test_result)
-        else:
-            raise ValueError("Invalid json: " + str(j))
-    return res
-
-def parse_test_list_json_output(j, modname):
-    res = []
-    if isinstance(j, dict):
-        for test_name in j["tests"]:
-            res.append(modname + test_name)
-    else:
-        raise ValueError("Invalid json: " + str(j))
-    return res
-
 actor BuildProjectTests(process_cap, env, args, on_build_success, on_build_failure):
     """Build the project test
 
@@ -161,8 +130,8 @@ actor RunTestList(process_cap, env, args):
             raise ValueError("Duplicate list of tests from module: " + module_name)
         if isinstance(update, dict):
             _module_tests[module_name] = []
-            for test_name in update["tests"]:
-                _module_tests[module_name].append(module_name + test_name)
+            for test in update["tests"]:
+                _module_tests[module_name].append(test["name"])
         else:
             raise ValueError("Unexpected JSON data from module test: " + module_name)
 
@@ -185,20 +154,71 @@ actor RunTestList(process_cap, env, args):
     project_builder = BuildProjectTests(process_cap, env, args, _run_tests, _on_build_failure)
 
 
-actor RunTestTest(process_cap, env, args):
-    var _module_tests = {}
-    results = testing.TestDisplayStatus(env)
+def parse_json_tests(data):
+    tests: dict[str, testing.TestInfo] = {}
+    jdata_tests = data["tests"]
+    if isinstance(jdata_tests, dict):
+        for jdata_test in jdata_tests.values():
+            if isinstance(jdata_test, dict):
+                name = jdata_test["name"]
+                desc = jdata_test["desc"]
+                if isinstance(name, str) and isinstance(desc, str):
+                    test_def = testing.Test(name, desc)
+                    tests[name] = testing.TestInfo(test_def)
+                else:
+                    raise ValueError("Invalid test list JSON")
+    else:
+        raise ValueError("Invalid test list JSON")
+    return tests
 
-    def _on_json_output(module_name, update):
-        if isinstance(update, dict):
-            parsed_update = parse_json_test_result(module_name, update)
-            results.update_module(module_name, parsed_update)
+def parse_json_test_result(data):
+    data_test = data["test"]
+    if isinstance(data_test, dict):
+        name = data_test["name"]
+        desc = data_test["desc"]
+        complete = data["complete"]
+        result = data["result"]
+        if isinstance(result, dict):
+            success = result["success"]
+            exception = result["exception"]
+            duration = result["duration"]
+            if (isinstance(name, str)
+                and isinstance(desc, str)
+                and isinstance(complete, bool)
+                and (success is None or isinstance(success, bool))
+                and (exception is None or isinstance(exception, str))
+                and isinstance(duration, float)
+                ):
+                return testing.Test(name, desc), complete, testing.TestResult(success, exception, duration)
+            else:
+                raise ValueError("Invalid test result JSON")
+        else:
+            raise ValueError("Invalid test result JSON")
+    else:
+        raise ValueError("Invalid test result JSON")
+
+
+actor RunTestTest(process_cap, env: Env, args):
+    var _module_tests = {}
+    results = testing.ProjectTestResults(env)
+    def _periodic_show():
+        results.show()
+        after 0.05: _periodic_show()
+
+    def _on_json_output(module_name, data):
+        if isinstance(data, dict):
+            if "tests" in data:
+                tests = parse_json_tests(data)
+                results.update_module(module_name, tests)
+                _periodic_show()
+            elif "test" in data:
+                test_def, complete, test_result = parse_json_test_result(data)
+                results.update(module_name, test_def, complete, test_result)
         else:
             raise ValueError("Unexpected JSON data from module test: " + module_name)
 
     def _run_tests(module_names: list[str]):
         results.expected_modules = set(module_names)
-
         test_cmd = ["test"]
         for name_filter in args.get_strlist("name"):
             test_cmd.extend(["--name", name_filter])

--- a/test/stdlib_tests/src/test_testing.act
+++ b/test/stdlib_tests/src/test_testing.act
@@ -36,6 +36,7 @@ def _test_asyncact(report_result, log_handler: logging.Handler) -> None:
     s = AsyncTester(report_result, log_handler)
     s.test()
 
+# this doesn't work because actonc doesn't infer the right type signature
 def _test_envtest(report_result, env, log_handler: logging.Handler) -> None:
     s = EnvTester(report_result, env, log_handler)
     s.test()


### PR DESCRIPTION
Tests are now run multiple times for a minimum of
1ms (MIN_TEST_DURATION). Many small unit tests will run a bunch of times and we can thus get an average for performance numbers and we can detect flakiness. The whole display routine has been rewritten to be able to show such results. It also shows tests in progress in a more consistent manner.

Errors / failures were flipped. Now fixed.

Async actor test and env tests are now run properly. Previously we would actually start all such async tests at once, so they would run in parallel. The idea is that we should grab one test, let it run and once complete we move on to the next. This has now been corrected so it works as intended.

There's a bunch of to_json / from_json serialization functions but it doesn't work very well for some reason so I've had to go with separate more manual functions for now. Should look into this.

Split TestDisplay class to instead be one for the module test and one for the project test that assembles a summary view of tests in all modules. Makes for simpler code.

Avoid named tuples for keeping the test information since we have some type inference bugs. I wish I could find smaller reproduction cases for this but haven't had time. Using classes is more stable, thus TestInfo!