### PR TITLE
Default to apple_a15 for aarch64-macos

### DIFF
--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -949,10 +949,11 @@ zigBuild env opts paths tasks binTasks = do
         target_cpu = if (C.cpu opts /= "")
                        then C.cpu opts
                        else
-                         case (head $ splitOn "-" (C.target opts)) of
-                           "native"  -> ""
-                           "aarch64" -> if (C.target opts) == C.defTarget then "" else " -Dcpu=apple_a15 "
-                           "x86_64"  -> " -Dcpu=westmere "
+                         case (splitOn "-" (C.target opts)) of
+                           ("native":_:_)        -> ""
+                           ("aarch64":"macos":_) -> " -Dcpu=apple_a15 "
+                           ("x86_64":_:_)        -> " -Dcpu=westmere "
+                           (_:_:_)               -> ""
     let zigCmdBase =
           if buildZigExists
             then zig paths ++ " build " ++


### PR DESCRIPTION
I suppose aarch64-linux might be using some other CPU. We (or Zig?) should really have some better CPU detection going on I think but this should do it for now.