### PR TITLE
builder: correct path to dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- Correct dependency path computation in builder
+
+
 ## [0.21.0] (2024-03-13)
 
-## Added
+### Added
 - `acton test` testing has been revamped, now doing multiple test iterations
   - each test will be run for at least 1ms, for many smaller unit tests this
     means the test case run hundreds of times
@@ -67,7 +73,7 @@
   `actonc` is on the path
 - Add `--only-act` to only perform Acton compilation and skip C compilation
 
-## Changed
+### Changed
 - `acton test` will compile test functions in dev mode to get asserts
 - The `dev` and `rel` folders have been removed, e.g. `out/rel/bin` -> `out/bin`
 - Printing of compiler pass debug output from individual files, like `acton

--- a/builder/build.zig
+++ b/builder/build.zig
@@ -324,15 +324,15 @@ pub fn build(b: *std.Build) void {
             if (deps_dir) |dir| {
                 //defer dir.close();
                 var deps_walker = dir.iterate();
-                while (deps_walker.next() catch unreachable) |deps_entry| {
-                    if (deps_entry.kind == .directory) {
+                while (deps_walker.next() catch unreachable) |dep_entry| {
+                    if (dep_entry.kind == .directory) {
                         // Process sub-directory. For example, print its name.
-                        std.debug.print("Found sub-directory: {s}\n", .{deps_entry.name});
-                        const dep_path = joinPath(b.allocator, deps_path, deps_entry.name);
-                        //const dep_include = joinPath(b.allocator, dep_path, "out/types");
+                        std.debug.print("Found sub-directory: {s}\n", .{dep_entry.name});
+                        const dep_path = joinPath(b.allocator, deps_path, dep_entry.name);
                         libActonProject.addIncludePath(.{ .path = dep_path });
                         executable.addIncludePath(.{ .path = dep_path });
-                        const dep_dep = b.anonymousDependency("deps/dumbo", @import("build.zig"), .{
+                        const dep_path_rel = joinPath(b.allocator, "deps", dep_entry.name);
+                        const dep_dep = b.anonymousDependency(dep_path_rel, @import("build.zig"), .{
                             .target = target,
                             .optimize = optimize,
                             .only_lib = true,


### PR DESCRIPTION
Haha, how silly, I had a hard-coded path from the early hack attempts and since I did all my testing with a repo where the dependency is called "dumbo" it all worked. Now using a true dynamic path!