### PR TITLE
Reorder process args & add RunProcess

### DIFF
--- a/base/src/process.act
+++ b/base/src/process.act
@@ -6,12 +6,18 @@ class ProcessCap():
     def __init__(self, cap: WorldCap):
         pass
 
-actor Process(cap: ProcessCap, cmd: list[str], workdir: ?str, env: ?dict[str, str], on_stdout: action(Process, bytes) -> None, on_stderr: action(Process, bytes) -> None, on_exit: action(Process, int, int) -> None, on_error: action(Process, str) -> None):
+actor Process(cap: ProcessCap,
+              cmd: list[str],
+              on_stdout: action(Process, bytes) -> None,
+              on_stderr: action(Process, bytes) -> None,
+              on_exit: action(Process, int, int) -> None,
+              on_error: action(Process, str) -> None,
+              workdir: ?str=None,
+              env: ?dict[str, str]=None,
+              timeout: ?float=None):
     """A process
     - cap: capability to start processes
     - cmd: the command to run
-    - workdir: working directory, use None for current directory
-    - env: environment for process, use None to inherit current environment
     - on_stdout: stdout callback actor method
     - on_stderr: stderr callback actor method
     - on_exit: exit callback
@@ -19,6 +25,9 @@ actor Process(cap: ProcessCap, cmd: list[str], workdir: ?str, env: ?dict[str, st
       - exit code
       - signal that caused program to exit
     - on_error: error callback
+    - workdir: working directory, use None for current directory
+    - env: environment for process, use None to inherit current environment
+    - timeout: time in seconds before process is stopped
     """
     _p = 0
 
@@ -76,6 +85,56 @@ actor Process(cap: ProcessCap, cmd: list[str], workdir: ?str, env: ?dict[str, st
         stopped.
         """
         terminate()
-        after 1: kill()
+        after 1.0: kill()
 
     _create_process()
+
+    if timeout is not None:
+        after timeout: stop()
+
+
+actor RunProcess(cap: ProcessCap,
+                 cmd: list[str],
+                 on_exit: action(Process, int, int, bytes, bytes) -> None,
+                 on_error: action(Process, str) -> None,
+                 workdir: ?str,
+                 env: ?dict[str, str],
+                 timeout: ?float=None):
+    """Run a process and wait for it to finish
+    """
+    var out_buf = b""
+    var err_buf = b""
+
+    def _on_stdout(p: Process, data: bytes):
+        out_buf += data
+
+    def _on_stderr(p: Process, data: bytes):
+        err_buf += data
+
+    def _on_exit(p: Process, exit_code: int, signal: int):
+        on_exit(p, exit_code, signal, out_buf, err_buf)
+
+    p = Process(cap, cmd, _on_stdout, _on_stderr, _on_exit, on_error, workdir, env, timeout)
+
+    def signal(sig: int):
+        """Send signal to process"""
+        p.signal(sig)
+
+    def kill():
+        """Abrubtly kill process by sending SIGKILL
+        """
+        p.kill()
+
+    def terminate():
+        """Stop process by sending SIGTERM
+        """
+        p.terminate()
+
+    def stop():
+        """Stop process
+
+        Attempts to stop process using normal means, which means SIGTERM on a
+        Unix system. After kill_after seconds (defaults to 1), SIGKILL is sent
+        to ensure the process is stopped.
+        """
+        p.stop()

--- a/cli/src/acton.act
+++ b/cli/src/acton.act
@@ -39,7 +39,7 @@ actor CompilerRunner(process_cap, env, args, wdir=None):
     # We find the path to actonc by looking at the executable path of the
     # current process. Since we are called 'acton', we just add a 'c'.
     cmd = [fs.exepath() + "c"] + args
-    p = process.Process(process_cap, cmd, wdir, None, on_stdout, on_stderr, on_exit, on_error)
+    p = process.Process(process_cap, cmd, on_stdout, on_stderr, on_exit, on_error, wdir)
 
 
 actor CompilerBuildRunner(process_cap, env, args, wdir=None, on_success: action() -> None, on_error: action(str) -> None):
@@ -62,7 +62,7 @@ actor CompilerBuildRunner(process_cap, env, args, wdir=None, on_success: action(
     # We find the path to actonc by looking at the executable path of the
     # current process. Since we are called 'acton', we just add a 'c'.
     cmd = [fs.exepath() + "c", "build"] + args
-    p = process.Process(process_cap, cmd, wdir, None, on_actonc_stdout, on_actonc_stderr, on_actonc_exit, on_actonc_error)
+    p = process.Process(process_cap, cmd, on_actonc_stdout, on_actonc_stderr, on_actonc_exit, on_actonc_error, wdir)
 
 
 actor BuildProject(process_cap, env, args):
@@ -161,7 +161,7 @@ actor BuildProjectTests(process_cap, env, args, on_build_success, on_build_failu
 
     clean_buildcache(file.FileCap(env.cap))
 
-    p = process.Process(process_cap, cmd, None, None, on_actbuild_stdout, on_actbuild_stderr, on_actbuild_exit, on_actbuild_error)
+    p = process.Process(process_cap, cmd, on_actbuild_stdout, on_actbuild_stderr, on_actbuild_exit, on_actbuild_error)
 
 
 actor RunModuleTest(process_cap, modname, test_cmd, on_json_output):
@@ -199,7 +199,7 @@ actor RunModuleTest(process_cap, modname, test_cmd, on_json_output):
         print("Error from process:", error)
 
     cmd = ["out/bin/.test_" + modname, "--json"] + test_cmd
-    p = process.Process(process_cap, cmd, None, None, on_stdout, on_stderr, on_exit, on_error)
+    p = process.Process(process_cap, cmd, on_stdout, on_stderr, on_exit, on_error)
 
 
 actor RunTestList(process_cap, env, args):

--- a/test/rts_db/test_db_app.act
+++ b/test/rts_db/test_db_app.act
@@ -106,7 +106,7 @@ actor Tester(env, verbose, port_chunk):
         for i in range(3):
             port = port_chunk + (2*i)
             cmd = ["../dist/bin/actondb", "-p", str(port)]
-            p = process.Process(process_cap, cmd, None, None, on_stdout, on_stderr, db_on_exit, on_error)
+            p = process.Process(process_cap, cmd, on_stdout, on_stderr, db_on_exit, on_error)
             p_alive += 1
             ps.append(p)
             paid = p.aid()
@@ -125,7 +125,7 @@ actor Tester(env, verbose, port_chunk):
     def test_ddb_app():
         dbc_start()
         cmd = ["rts_db/ddb_test_app", "--rts-verbose"] + db_args(port_chunk, 3)
-        p = process.Process(process_cap, cmd, None, None, on_stdout, on_stderr, app_on_exit, on_error)
+        p = process.Process(process_cap, cmd, on_stdout, on_stderr, app_on_exit, on_error)
         p_alive += 1
         paid = p.aid()
         psp[paid] = "app"

--- a/test/rts_db/test_tcp_client.act
+++ b/test/rts_db/test_tcp_client.act
@@ -127,7 +127,7 @@ actor Tester(env, verbose, port_chunk):
         for i in range(3):
             port = port_chunk + (2*i)
             cmd = ["../dist/bin/actondb", "-p", str(port)]
-            p = process.Process(process_cap, cmd, None, None, on_stdout, on_stderr, db_on_exit, on_error)
+            p = process.Process(process_cap, cmd, on_stdout, on_stderr, db_on_exit, on_error)
             p_alive += 1
             ps.append(p)
             paid = p.aid()
@@ -171,7 +171,7 @@ actor Tester(env, verbose, port_chunk):
                     break
             are_we_done()
 
-        p_srv = process.Process(process_cap, cmd_srv, None, None, app_server_on_stdout, on_stderr, app_server_on_exit, on_error)
+        p_srv = process.Process(process_cap, cmd_srv, app_server_on_stdout, on_stderr, app_server_on_exit, on_error)
         p_alive += 1
         if p_srv is not None:
             ps.append(p_srv)
@@ -192,7 +192,7 @@ actor Tester(env, verbose, port_chunk):
                     state = 4
                     tcp_expect += 1
                     log("state 2: Starting test tcp client app")
-                    p = process.Process(process_cap, cmd, None, None, app_client_on_stdout, on_stderr, app_client_on_exit, on_error)
+                    p = process.Process(process_cap, cmd, app_client_on_stdout, on_stderr, app_client_on_exit, on_error)
                     p_alive += 1
                     if p is not None:
                         ps.append(p)
@@ -240,7 +240,7 @@ actor Tester(env, verbose, port_chunk):
         log("Running TCP client test")
         dbc_start()
         log("Starting TCP client app: " + " ".join(cmd))
-        p = process.Process(process_cap, cmd, None, None, app_client_on_stdout, on_stderr, app_client_on_exit, on_error)
+        p = process.Process(process_cap, cmd, app_client_on_stdout, on_stderr, app_client_on_exit, on_error)
         p_alive += 1
         if p is not None:
             ps.append(p)

--- a/test/rts_db/test_tcp_server.act
+++ b/test/rts_db/test_tcp_server.act
@@ -121,7 +121,7 @@ actor Tester(env, verbose, port_chunk, app_wthreads=4):
         for i in range(3):
             port = port_chunk + (2*i)
             cmd = ["../dist/bin/actondb", "-p", str(port), "-s", "127.0.0.1:" + str(port_chunk+1)]
-            p = process.Process(process_cap, cmd, None, None, on_stdout, on_stderr, db_on_exit, on_error)
+            p = process.Process(process_cap, cmd, on_stdout, on_stderr, db_on_exit, on_error)
             p_alive += 1
             ps.append(p)
             paid = p.aid()
@@ -219,7 +219,7 @@ actor Tester(env, verbose, port_chunk, app_wthreads=4):
                 if exit_code == 0 and term_signal == 0:
                     log("App successfully exited in state %d with exit code %d and termination signal %d" % (state, exit_code, term_signal))
                     state = 6
-                    p = process.Process(process_cap, cmd, None, None, app_server_on_stdout, on_stderr, app_server_on_exit, on_error)
+                    p = process.Process(process_cap, cmd, app_server_on_stdout, on_stderr, app_server_on_exit, on_error)
                     ps.append(p)
                     p_alive += 1
                     if p is not None:
@@ -244,7 +244,7 @@ actor Tester(env, verbose, port_chunk, app_wthreads=4):
 
 
         # Start server
-        p = process.Process(process_cap, cmd, None, None, app_server_on_stdout, on_stderr, app_server_on_exit, on_error)
+        p = process.Process(process_cap, cmd, app_server_on_stdout, on_stderr, app_server_on_exit, on_error)
         p_alive += 1
         if p is not None:
             app_pid = p.pid()

--- a/test/stdlib_auto/test_process.act
+++ b/test/stdlib_auto/test_process.act
@@ -25,7 +25,7 @@ actor main(env):
     def test():
         print("Starting process..")
         pc = process.ProcessCap(env.cap)
-        p = process.Process(pc, ["echo", "HELLO"], None, None, on_stdout, on_stderr, on_exit, on_error)
+        p = process.Process(pc, ["echo", "HELLO"], on_stdout, on_stderr, on_exit, on_error)
 
     def ex():
         print("Test timeout, should exit with error but not now... disabled due to faulty error")

--- a/test/stdlib_auto/test_process_env.act
+++ b/test/stdlib_auto/test_process_env.act
@@ -28,7 +28,7 @@ actor main(env):
     def test():
         print("Starting process..")
         pc = process.ProcessCap(env.cap)
-        p = process.Process(pc, ["env"], None, {"FOO": "BAR"}, on_stdout, on_stderr, on_exit, on_error)
+        p = process.Process(pc, ["env"], on_stdout, on_stderr, on_exit, on_error, env={"FOO": "BAR"})
 
     def ex():
         print("Test timeout, exiting with error")

--- a/test/stdlib_auto/test_process_pid.act
+++ b/test/stdlib_auto/test_process_pid.act
@@ -28,7 +28,7 @@ actor main(env):
     def test():
         print("Starting process..")
         pc = process.ProcessCap(env.cap)
-        p = process.Process(pc, ["sleep", "2"], None, None, on_stdout, on_stderr, on_exit, on_error)
+        p = process.Process(pc, ["sleep", "2"], on_stdout, on_stderr, on_exit, on_error)
         pid = p.pid()
 
         print("PID:", pid)

--- a/test/stdlib_auto/test_process_wdir.act
+++ b/test/stdlib_auto/test_process_wdir.act
@@ -28,7 +28,7 @@ actor main(env):
     def test():
         print("Starting process..")
         pc = process.ProcessCap(env.cap)
-        p = process.Process(pc, ["pwd"], "/", None, on_stdout, on_stderr, on_exit, on_error)
+        p = process.Process(pc, ["pwd"], on_stdout, on_stderr, on_exit, on_error, "/")
 
     def ex():
         print("Test timeout, exiting with error")

--- a/test/stdlib_auto/test_process_write.act
+++ b/test/stdlib_auto/test_process_write.act
@@ -32,7 +32,7 @@ actor main(env):
     def test():
         print("Starting process..")
         pc = process.ProcessCap(env.cap)
-        p = process.Process(pc, ["cat"], None, None, on_stdout, on_stderr, on_exit, on_error)
+        p = process.Process(pc, ["cat"], on_stdout, on_stderr, on_exit, on_error)
         p.write(b"hejsan\n")
 
     def ex():


### PR DESCRIPTION
Move workdir & env to end of list and make them optional. Nicer interface!

Add an optional timeout argument so we can say we want to terminate a program after some timeout period.

Added a new RunProcess which buffers stdout & stderr while waiting for the program to exit after which a callback is called. This is a much simpler interface for the scenario when we want to await a process to finish and then read the output.