### PR TITLE
file.WriteFile: Truncate file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 - `actonc` no longer supports explicit `--stub` compilation, use `--auto-stub`
 
 ### Fixed
+- `file.WriteFile.write()` now truncates file to avoid leftover tail of old
+  content
 - Correct dependency path computation in builder
 - Makefile now more idempotent to avoid building when nothing has changed
 

--- a/base/src/file.ext.c
+++ b/base/src/file.ext.c
@@ -285,7 +285,7 @@ $R fileQ_ReadFileD_readG_local (fileQ_ReadFile self, $Cont c$cont) {
 $R fileQ_WriteFileD__open_fileG_local (fileQ_WriteFile self, $Cont c$cont) {
     pin_actor_affinity();
     uv_fs_t *req = (uv_fs_t *)acton_malloc(sizeof(uv_fs_t));
-    int r = uv_fs_open(get_uv_loop(), req, (char *)fromB_str(self->filename),  UV_FS_O_RDWR | UV_FS_O_CREAT, S_IWUSR|S_IRUSR|S_IRGRP|S_IROTH, NULL);
+    int r = uv_fs_open(get_uv_loop(), req, (char *)fromB_str(self->filename),  UV_FS_O_RDWR | UV_FS_O_CREAT | UV_FS_O_TRUNC, S_IWUSR|S_IRUSR|S_IRGRP|S_IROTH, NULL);
     if (r < 0) {
         char errmsg[1024] = "Error opening file for writing: ";
         uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));


### PR DESCRIPTION
Since WriteFile.write() writes the whole content of the file (not append) we should truncate the file when opening it so we don't get the tail of the old file if our new content is shorter.