### PR TITLE
Stop redirecting malloc & friends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@
   C source by hand and still leverage the low level builder to perform the build.
 - `file.FS.cwd()` to get current working directory
 - `file.join_path()` to join path components
+- Link time redirection of malloc & friends is now removed. All malloc calls are
+  instead explicit, either directly to `GC_MALLOC` or via `acton_malloc` which
+  is our own malloc function which is runtime reconfigurable. While there is no
+  usage of malloc directly from our code, that is now possible to do manual
+  memory management mixed with GC managed memory.
+  - As before, module constants are placed in the regular heap, so that the GC
+    does not have to scan it.
 
 ### Changed
 - Rename `--only-act` to `--skip-build`

--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,7 @@ dist/deps/libgc: deps-download/$(LIBGC_REF).tar.gz
 	touch $(TD)/$@
 
 dist/depsout/lib/libactongc.a: dist/deps/libgc $(DIST_ZIG)
-	cd $< && $(ZIG) build $(ZIG_TARGET) $(ZIG_CPU) --prefix $(TD)/dist/depsout -DBUILD_SHARED_LIBS=false -Denable_redirect_malloc -Denable_ignore_free -Denable_large_config -Denable_mmap
+	cd $< && $(ZIG) build $(ZIG_TARGET) $(ZIG_CPU) --prefix $(TD)/dist/depsout -DBUILD_SHARED_LIBS=false -Denable_large_config -Denable_mmap
 	mv dist/depsout/lib/libgc.a $@
 
 # /deps/libmbedtls --------------------------------------------

--- a/base/builtin/common.c
+++ b/base/builtin/common.c
@@ -28,7 +28,7 @@ char *unmangle_name(char *input) {
     if (input == NULL) {
         return NULL;
     }
-    char *output = malloc(strlen(input) + 1);
+    char *output = GC_malloc(strlen(input) + 1);
     // Check for allocation failure
     if (output == NULL) {
         return NULL;

--- a/base/builtin/dict.c
+++ b/base/builtin/dict.c
@@ -255,7 +255,7 @@ B_str B_dictD___str__(B_dict self) {
         B_value value = ((B_value)item->components[1]);
         B_str keystr = key->$class->__repr__(key);
         B_str valuestr = value ? value->$class->__repr__(value) : to$str("None");
-        B_str elem = malloc(sizeof(struct B_str));
+        B_str elem = acton_malloc(sizeof(struct B_str));
         elem->$class = &B_strG_methods;
         elem->nbytes = keystr->nbytes+valuestr->nbytes+1;
         elem->nchars = keystr->nchars+valuestr->nchars+1;

--- a/base/rts/common.c
+++ b/base/rts/common.c
@@ -5,46 +5,7 @@
 #include <libxml/xmlmemory.h>
 #include <tlsuv/tlsuv.h>
 
-void *(*real_malloc)(size_t) = NULL;
-void *(*real_realloc)(void *, size_t) = NULL;
-void *(*real_calloc)(size_t, size_t) = NULL;
-void (*real_free)(void *) = NULL;
-char *(*real_strdup)(const char *) = NULL;
-char *(*real_strndup)(const char *, size_t) = NULL;
-
-int resolve_real_malloc() {
-    real_malloc = dlsym(RTLD_NEXT, "malloc");
-    if (!real_malloc) {
-        fprintf(stderr, "Error in `dlsym`: %s\n", dlerror());
-        return 0;
-    }
-    real_realloc = dlsym(RTLD_NEXT, "realloc");
-    if (!real_realloc) {
-        fprintf(stderr, "Error in `dlsym`: %s\n", dlerror());
-        return 0;
-    }
-    real_calloc = dlsym(RTLD_NEXT, "calloc");
-    if (!real_calloc) {
-        fprintf(stderr, "Error in `dlsym`: %s\n", dlerror());
-        return 0;
-    }
-    real_free = dlsym(RTLD_NEXT, "free");
-    if (!real_free) {
-        fprintf(stderr, "Error in `dlsym`: %s\n", dlerror());
-        return 0;
-    }
-    real_strdup = dlsym(RTLD_NEXT, "strdup");
-    if (!real_strdup) {
-        fprintf(stderr, "Error in `dlsym`: %s\n", dlerror());
-        return 0;
-    }
-    real_strndup = dlsym(RTLD_NEXT, "strndup");
-    if (!real_strndup) {
-        fprintf(stderr, "Error in `dlsym`: %s\n", dlerror());
-        return 0;
-    }
-    return 1;
-}
+#include "rts/common.h"
 
 typedef struct {
     acton_malloc_func malloc;

--- a/base/rts/common.h
+++ b/base/rts/common.h
@@ -3,14 +3,8 @@
 #include <stddef.h>
 #include <stdlib.h>
 
-extern void *(*real_malloc)(size_t);
-extern void *(*real_malloc_atomic)(size_t);
-extern void *(*real_realloc)(void *, size_t);
-extern void *(*real_calloc)(size_t, size_t);
-extern void (*real_free)(void *);
-extern char *(*real_strdup)(const char *);
-extern char *(*real_strndup)(const char *, size_t);
-int resolve_real_malloc();
+#define GC_THREADS 1
+#include <gc.h>
 
 typedef void *(*acton_malloc_func)(size_t size);
 typedef void *(*acton_malloc_func)(size_t size);

--- a/base/rts/netstring.c
+++ b/base/rts/netstring.c
@@ -136,12 +136,12 @@ size_t netstring_add_ex(char **netstring, char *data, size_t len) {
   size_next = num_len + len + 2;
 
   if (*netstring == 0) {
-    ptr = malloc(size_next + 1);
+    ptr = acton_malloc(size_next + 1);
     if (ptr == 0) return 0;
     *netstring = ptr;
   } else {
     size_prev = strlen(*netstring);
-    ptr = realloc(*netstring, size_prev + size_next + 1);
+    ptr = acton_realloc(*netstring, size_prev + size_next + 1);
     if (ptr == 0) return 0;
     *netstring = ptr;
     ptr += size_prev;

--- a/base/rts/rts.h
+++ b/base/rts/rts.h
@@ -198,7 +198,7 @@ void serialize_state_shortcut($Actor);
 #define REGISTER_ACTOR(key)
 #endif
 
-#define $NEWACTOR($T)       ({ $T $t = malloc(sizeof(struct $T)); \
+#define $NEWACTOR($T)       ({ $T $t = GC_malloc(sizeof(struct $T)); \
                                $t->$class = &$T ## G_methods; \
                                $ActorG_methods.__init__(($Actor)$t); \
                                $t->$affinity = SHARED_RQ; \

--- a/base/src/file.ext.c
+++ b/base/src/file.ext.c
@@ -218,7 +218,7 @@ $R fileQ_FSD_statG_local (fileQ_FS self, $Cont C_cont, B_str filename) {
 
 $R fileQ_FSD_tmpdirG_local (fileQ_FS self, $Cont C_cont) {
     size_t size = 1024; // Initial buffer size for the tmp directory path
-    char *buffer = (char*)malloc(size);
+    char *buffer = (char*)acton_malloc(size);
     int r = uv_os_tmpdir(buffer, &size);
     if (r < 0) {
         char errmsg[1024] = "Error getting temporary directory: ";

--- a/base/src/net.ext.c
+++ b/base/src/net.ext.c
@@ -72,19 +72,19 @@ static void _lookup_a__on_resolve (uv_getaddrinfo_t *req, int status, struct add
 }
 
 B_NoneType netQ__lookup_a (B_str name, $action on_resolve, $action on_error) {
-    struct addrinfo *hints = (struct addrinfo *)malloc(sizeof(struct addrinfo));
+    struct addrinfo *hints = (struct addrinfo *)acton_malloc(sizeof(struct addrinfo));
     hints->ai_family = PF_INET;
     hints->ai_socktype = SOCK_STREAM;
     hints->ai_protocol = IPPROTO_TCP;
     hints->ai_flags = 0;
 
-    struct dns_cb_data *cb_data = (struct dns_cb_data *)malloc(sizeof(struct dns_cb_data));
+    struct dns_cb_data *cb_data = (struct dns_cb_data *)acton_malloc(sizeof(struct dns_cb_data));
     cb_data->hints = hints;
     cb_data->hostname = (char *)fromB_str(name);
     cb_data->on_resolve = on_resolve;
     cb_data->on_error = ($action2) on_error;
 
-    uv_getaddrinfo_t *req = (uv_getaddrinfo_t*)malloc(sizeof(uv_getaddrinfo_t));
+    uv_getaddrinfo_t *req = (uv_getaddrinfo_t*)acton_malloc(sizeof(uv_getaddrinfo_t));
     req->data = cb_data;
 
     int r = uv_getaddrinfo(get_uv_loop(), req, _lookup_a__on_resolve, (const char *)fromB_str(name), NULL, hints);
@@ -137,19 +137,19 @@ static void _lookup_aaaa__on_resolve (uv_getaddrinfo_t *req, int status, struct 
 }
 
 B_NoneType netQ__lookup_aaaa (B_str name, $action on_resolve, $action on_error) {
-    struct addrinfo *hints = (struct addrinfo *)malloc(sizeof(struct addrinfo));
+    struct addrinfo *hints = (struct addrinfo *)acton_malloc(sizeof(struct addrinfo));
     hints->ai_family = PF_INET6;
     hints->ai_socktype = SOCK_STREAM;
     hints->ai_protocol = IPPROTO_TCP;
     hints->ai_flags = 0;
 
-    struct dns_cb_data *cb_data = (struct dns_cb_data *)malloc(sizeof(struct dns_cb_data));
+    struct dns_cb_data *cb_data = (struct dns_cb_data *)acton_malloc(sizeof(struct dns_cb_data));
     cb_data->hints = hints;
     cb_data->hostname = (char *)fromB_str(name);
     cb_data->on_resolve = on_resolve;
     cb_data->on_error = ($action2)on_error;
 
-    uv_getaddrinfo_t *req = (uv_getaddrinfo_t*)malloc(sizeof(uv_getaddrinfo_t));
+    uv_getaddrinfo_t *req = (uv_getaddrinfo_t*)acton_malloc(sizeof(uv_getaddrinfo_t));
     req->data = cb_data;
 
     int r = uv_getaddrinfo(get_uv_loop(), req, _lookup_aaaa__on_resolve, (const char *)fromB_str(name), NULL, hints);
@@ -215,11 +215,11 @@ void on_connect6(uv_connect_t *connect_req, int status) {
 
 $R netQ_TCPConnectionD__connect4G_local (netQ_TCPConnection self, $Cont c$cont, B_str ip_address) {
     log_debug("TCP connecting over IPv4 to %s", fromB_str(ip_address));
-    uv_tcp_t* socket = (uv_tcp_t*)malloc(sizeof(uv_tcp_t));
+    uv_tcp_t* socket = (uv_tcp_t*)acton_malloc(sizeof(uv_tcp_t));
     uv_tcp_init(get_uv_loop(), socket);
     self->_sock4 = to$int((long)socket);
 
-    uv_connect_t* connect_req = (uv_connect_t*)malloc(sizeof(uv_connect_t));
+    uv_connect_t* connect_req = (uv_connect_t*)acton_malloc(sizeof(uv_connect_t));
     connect_req->data = (void *)self;
 
     struct sockaddr_in dest;
@@ -232,11 +232,11 @@ $R netQ_TCPConnectionD__connect4G_local (netQ_TCPConnection self, $Cont c$cont, 
 
 $R netQ_TCPConnectionD__connect6G_local (netQ_TCPConnection self, $Cont c$cont, B_str ip_address) {
     log_debug("TCP connecting over IPv6 to %s", fromB_str(ip_address));
-    uv_tcp_t* socket = (uv_tcp_t*)malloc(sizeof(uv_tcp_t));
+    uv_tcp_t* socket = (uv_tcp_t*)acton_malloc(sizeof(uv_tcp_t));
     uv_tcp_init(get_uv_loop(), socket);
     self->_sock6 = to$int((long)socket);
 
-    uv_connect_t* connect_req = (uv_connect_t*)malloc(sizeof(uv_connect_t));
+    uv_connect_t* connect_req = (uv_connect_t*)acton_malloc(sizeof(uv_connect_t));
     connect_req->data = (void *)self;
 
     struct sockaddr_in6 dest;
@@ -269,7 +269,7 @@ $R netQ_TCPConnectionD_writeG_local (netQ_TCPConnection self, $Cont c$cont, B_by
     if ((long int)stream == -1)
         return $R_CONT(c$cont, B_None);
 
-    uv_write_t *req = (uv_write_t *)malloc(sizeof(uv_write_t));
+    uv_write_t *req = (uv_write_t *)acton_malloc(sizeof(uv_write_t));
     uv_buf_t buf = uv_buf_init((char *)data->str, data->nbytes);
     int r = uv_write(req, stream, &buf, 1, NULL);
     if (r < 0) {
@@ -314,10 +314,10 @@ $R netQ_TCPConnectionD_closeG_local (netQ_TCPConnection self, $Cont c$cont, $act
         return $R_CONT(c$cont, B_None);
 
     log_debug("Closing TCP connection");
-    struct close_cb_data *cb_data = (struct close_cb_data *)malloc(sizeof(struct close_cb_data));
+    struct close_cb_data *cb_data = (struct close_cb_data *)acton_malloc(sizeof(struct close_cb_data));
     cb_data->self = self;
     cb_data->on_close = on_close;
-    uv_shutdown_t *req = (uv_shutdown_t *)malloc(sizeof(uv_shutdown_t));
+    uv_shutdown_t *req = (uv_shutdown_t *)acton_malloc(sizeof(uv_shutdown_t));
     req->data = (void *)cb_data;
     int r = uv_shutdown(req, stream, after_shutdown);
     self->_sock = to$int(-1);
@@ -404,7 +404,7 @@ void on_new_connection(uv_stream_t *server, int status) {
         return;
     }
 
-    uv_tcp_t *client = (uv_tcp_t*) malloc(sizeof(uv_tcp_t));
+    uv_tcp_t *client = (uv_tcp_t*)acton_malloc(sizeof(uv_tcp_t));
     uv_tcp_init(get_uv_loop(), client);
     int r = uv_accept(server, (uv_stream_t *)client);
     if (r != 0) {
@@ -425,7 +425,7 @@ void on_new_connection(uv_stream_t *server, int status) {
 $R netQ_TCPListenerD__initG_local (netQ_TCPListener self, $Cont c$cont) {
     pin_actor_affinity();
 
-    uv_tcp_t *server = (uv_tcp_t *)malloc(sizeof(uv_tcp_t));
+    uv_tcp_t *server = (uv_tcp_t *)acton_malloc(sizeof(uv_tcp_t));
     uv_tcp_init(get_uv_loop(), server);
     server->data = (void *)self;
     int r;
@@ -496,7 +496,7 @@ $R netQ_TCPListenConnectionD__initG_local (netQ_TCPListenConnection self, $Cont 
     uv_stream_t *client = (uv_stream_t *)from$int(self->server_client);
     int fd;
     uv_fileno((uv_handle_t *)client, &fd);
-    uv_tcp_t* client_handle = (uv_tcp_t*) malloc(sizeof(uv_tcp_t));
+    uv_tcp_t* client_handle = (uv_tcp_t*)acton_malloc(sizeof(uv_tcp_t));
     uv_tcp_init(get_uv_loop(), client_handle);
     uv_tcp_open(client_handle, fd);
     self->client = to$int((long)client_handle);
@@ -544,7 +544,7 @@ $R netQ_TCPListenConnectionD_writeG_local (netQ_TCPListenConnection self, $Cont 
     if ((long int)stream == -1)
         return $R_CONT(c$cont, B_None);
 
-    uv_write_t *req = (uv_write_t *)malloc(sizeof(uv_write_t));
+    uv_write_t *req = (uv_write_t *)acton_malloc(sizeof(uv_write_t));
     uv_buf_t buf = uv_buf_init((char *)data->str, data->nbytes);
     int r = uv_write(req, stream, &buf, 1, NULL);
     if (r < 0) {
@@ -647,7 +647,7 @@ $R netQ_TLSConnectionD_writeG_local (netQ_TLSConnection self, $Cont c$cont, B_by
     if ((long int)stream == -1)
         return $R_CONT(c$cont, B_None);
 
-    uv_write_t *wreq = (uv_write_t *)malloc(sizeof(uv_write_t));
+    uv_write_t *wreq = (uv_write_t *)acton_malloc(sizeof(uv_write_t));
     wreq->data = self;
     uv_buf_t buf = uv_buf_init((char *)data->str, data->nbytes);
     int r = tlsuv_stream_write(wreq, stream, &buf, tls_write_cb);
@@ -704,11 +704,11 @@ void tlsuv_logger(int level, const char *file, unsigned int line, const char *ms
 }
 
 $R netQ_TLSConnectionD__connect_tlsG_local (netQ_TLSConnection self, $Cont c$cont) {
-    uv_connect_t* connect_req = (uv_connect_t*)calloc(1, sizeof(uv_connect_t));
+    uv_connect_t* connect_req = (uv_connect_t*)acton_calloc(1, sizeof(uv_connect_t));
     connect_req->data = (void *)self;
 
     //tlsuv_set_debug(5, tlsuv_logger);
-    tlsuv_stream_t *stream = (tlsuv_stream_t *)malloc(sizeof(tlsuv_stream_t));
+    tlsuv_stream_t *stream = (tlsuv_stream_t *)acton_malloc(sizeof(tlsuv_stream_t));
     tlsuv_stream_init(get_uv_loop(), stream, NULL);
 
     // Default is to verify TLS certificate. Should we disable verification?

--- a/base/src/re.ext.c
+++ b/base/src/re.ext.c
@@ -115,7 +115,7 @@ reQ_Match reQ__match (B_str arg_pattern, B_str arg_text, B_int arg_start_pos) {
         PCRE2_SPTR substring_start = text + ovector[2*i];
         size_t substring_length = ovector[2*i+1] - ovector[2*i];
         // TODO: get rid of extra copy, need to$str that takes a length
-        char *substring = malloc(substring_length + 1);
+        char *substring = acton_malloc(substring_length + 1);
         memcpy(substring, substring_start, substring_length);
         swit->$class->append(swit, groups, to$str(substring));
         end_pos = ovector[2*i+1];
@@ -157,11 +157,11 @@ reQ_Match reQ__match (B_str arg_pattern, B_str arg_text, B_int arg_start_pos) {
 
             // Offset of name in name table is 2 bytes after the number of the substring it refers to (n) and 2 bytes after the length of the name string (which is held in the first two bytes of the entry). The name string is not necessarily zero-terminated, so we have to use memcpy() to copy it to a buffer and add a terminating zero.
             // TODO: get rid of extra copy, need to$str that takes a length
-            char *group_name = malloc(name_entry_size - (2 + 1));
+            char *group_name = acton_malloc(name_entry_size - (2 + 1));
             memcpy(group_name, tabptr + 2, name_entry_size - (2 + 1));
             group_name[name_entry_size - (2 + 1)] = '\0';
 
-            char *substring = malloc(substring_length + 1);
+            char *substring = acton_malloc(substring_length + 1);
             memcpy(substring, substring_start, substring_length);
             substring[substring_length] = '\0';
 

--- a/base/src/snappy.ext.c
+++ b/base/src/snappy.ext.c
@@ -19,7 +19,7 @@ B_bytes snappyQ_compress (B_bytes data) {
     input_len = (size_t)data->nbytes;
 
     compressed_len = snappy_max_compressed_length(input_len);
-    compressed = malloc(compressed_len);
+    compressed = acton_malloc(compressed_len);
     status = snappy_compress(input, input_len, compressed, &compressed_len);
 
     if (SNAPPY_OK == status) {
@@ -51,7 +51,7 @@ B_bytes snappyQ_decompress (B_bytes data) {
         $RAISE((B_BaseException)$NEW(B_ValueError, to$str(errmsg)));
     }
 
-    uncompressed = malloc(uncompressed_len);
+    uncompressed = acton_malloc(uncompressed_len);
     snappy_uncompress(input, input_len, uncompressed, &uncompressed_len);
 
     if (SNAPPY_OK == status) {

--- a/base/src/time.ext.c
+++ b/base/src/time.ext.c
@@ -87,7 +87,7 @@ void timeQ___ext_init__() {
     //   clock_gettime operations per second: 56995674.769229
     // We don't want to slow down our programs like that, getting the time
     // should be cheap, which is why we do this somewhat elaborate dance.
-    uv_timer_t *time__get_clock_data_ev = malloc(sizeof(uv_timer_t));
+    uv_timer_t *time__get_clock_data_ev = acton_malloc(sizeof(uv_timer_t));
     uv_timer_init(aux_uv_loop, time__get_clock_data_ev);
     uv_timer_start(time__get_clock_data_ev, time__get_clock_data_cb, 10000, 10000);
     time__get_clock_data_cb(NULL);

--- a/base/src/xml.ext.c
+++ b/base/src/xml.ext.c
@@ -1,13 +1,13 @@
 #include <libxml/xmlmemory.h>
 #include <libxml/parser.h>
 
-// The macro below is from builtin/str.c. We should not duplicate it...
+// TODO: The macro below is from builtin/str.c. We should not duplicate it...
 #define NEW_UNFILLED_STR(nm, nchrs, nbtes)      \
-    nm = malloc(sizeof(struct B_str));           \
+    nm = acton_malloc(sizeof(struct B_str));           \
     (nm)->$class = &B_strG_methods;               \
     (nm)->nchars = nchrs;                       \
     (nm)->nbytes = nbtes;                       \
-    (nm)->str = malloc((nm)->nbytes + 1);       \
+    (nm)->str = acton_malloc_atomic((nm)->nbytes + 1);       \
     (nm)->str[(nm)->nbytes] = 0
 
 

--- a/base/stdlib/numpy/ndarray.c
+++ b/base/stdlib/numpy/ndarray.c
@@ -30,7 +30,7 @@ B_int numpyQ_newaxis;
 // res->offset gets default value 0 (may be unsuitable when allocate_data = false)
 
 static numpyQ_ndarray G_newarray(enum ElemType typ, long ndim, B_int size, B_list shape, B_list strides, bool allocate_data) {
-    numpyQ_ndarray res = malloc(sizeof(struct numpyQ_ndarray));
+    numpyQ_ndarray res = acton_malloc(sizeof(struct numpyQ_ndarray));
     res->$class = &numpyQ_ndarrayG_methods;
     res->elem_type = typ;
     res->ndim = ndim;
@@ -38,7 +38,7 @@ static numpyQ_ndarray G_newarray(enum ElemType typ, long ndim, B_int size, B_lis
     res->offset = 0;
     res->shape = shape;
     res->strides = strides;
-    if (allocate_data) res->data = malloc(from$int(size) * $elem_size(typ) * sizeof(union $Bytes8));
+    if (allocate_data) res->data = acton_malloc(from$int(size) * $elem_size(typ) * sizeof(union $Bytes8));
     return res;
 }
 

--- a/base/stdlib/numpy/ndselect.c
+++ b/base/stdlib/numpy/ndselect.c
@@ -37,7 +37,7 @@ struct numpyQ_ndselectG_class numpyQ_ndselectG_methods = {
 };
 
 numpyQ_ndselect numpyQ_ndselectG_new() {
-    numpyQ_ndselect $tmp = malloc(sizeof(struct numpyQ_ndselect));
+    numpyQ_ndselect $tmp = acton_malloc(sizeof(struct numpyQ_ndselect));
     $tmp->$class = &numpyQ_ndselectG_methods;
     numpyQ_ndselectG_methods.__init__($tmp);
     return $tmp;

--- a/builder/build.zig
+++ b/builder/build.zig
@@ -226,8 +226,6 @@ pub fn build(b: *std.Build) void {
             .target = target,
             .optimize = optimize,
             .BUILD_SHARED_LIBS = false,
-            .enable_redirect_malloc = true,
-            .enable_ignore_free = true,
             .enable_large_config = true,
             .enable_mmap = true,
         });


### PR DESCRIPTION
Since the introduction of the GC, we have been making use of link time redirection of malloc and friends in order to catch all invocations of these calls. It works but is less flexible as we are forced to use the GC-heap for everything. We would like to be able to mix GC-managed memory with manual memory management and thus we want to avoid doing link time redirection of malloc.

For a period of time, we've used a sort of hack where we dig out the real malloc through dlsym shenanigans, but that only works when malloc is in a libc that is dynamically linked. It won't work when statically linking libc. We do this so we can run with manual malloc during module init and avoid placing module constants on the GC-heap.

To disable link time redirection, we must make sure that all mallocs that we want to be on the GC-heap must be explicit calls to GC_malloc. Some time ago I patched all our external C library dependencies to support pluggable malloc and we thus support this.

This commit now disables link time redirection. I have replaced all remaining calls to malloc & friends with either acton_malloc() or GC_malloc for cases when we always want to use the GC-heap. It should now be possible to do manual memory management selectively, although we don't have any real uses cases for it just yet.

Fixes #1673 