### PR TITLE
Fix GC deadlock & uv_spawn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -281,7 +281,7 @@ dist/depsout/lib/libuuid.a: dist/deps/libuuid $(DIST_ZIG)
 	cd $< && $(ZIG) build $(ZIG_TARGET) $(ZIG_CPU) --prefix $(TD)/dist/depsout
 
 # /deps/libuv --------------------------------------------
-LIBUV_REF=f85e52114e5149a3108123a601061d65e9c209be
+LIBUV_REF=5cd49cfde1ecb19d564b7cc7752ea3b98c86ffe7
 deps-download/$(LIBUV_REF).tar.gz:
 	mkdir -p deps-download
 	curl -f -L -o $@ https://github.com/actonlang/libuv/archive/$(LIBUV_REF).tar.gz

--- a/test/stdlib_auto/test_process_many.act
+++ b/test/stdlib_auto/test_process_many.act
@@ -1,0 +1,35 @@
+import acton.rts
+import process
+
+NUM=1000
+
+actor GC(env):
+    def _tihi():
+        acton.rts.gc(env.syscap)
+        after 0.0001: _tihi()
+
+    after 0: _tihi()
+
+
+actor main(env):
+    var exited = 0
+    def on_exit(p, exit_code, term_signal, stdout_buf, stderr_buf):
+        exited += 1
+        print("Process exited with code: ", exit_code, " terminated with signal:", term_signal, "  exited:", exited)
+        if exited == NUM:
+            print("Enough...")
+            env.exit(0)
+
+    def on_error(p, error):
+        print("Error from process:", error)
+        await async env.exit(1)
+
+    def test():
+        print("Starting process..")
+        pc = process.ProcessCap(env.cap)
+        p = process.RunProcess(pc, ["echo", "HELLO"], on_exit, on_error)
+
+    gc = GC(env)
+
+    for i in range(NUM):
+        test()


### PR DESCRIPTION
libuv blocks most signals when it forks in the uv_spawn() call. I guess because signal handling can get messy around a fork.

The GC uses SIGPWR & SIGXCPU to pause & resume threads. We must not ignore those signals since it leads to a deadlock. When one thread initiates GC stop-the-world it will wait for all other threads to comply and if they ignore signals, they will never comply.

Also add a test program that runs lots of subprocesses so we get to exercise this code. I can reproduce the bug on like the 4th process down and we run 1000 so I'm quite confident in this fix working well.