### PR TITLE
Place jump0 in wctx

### DIFF
--- a/base/rts/rts.h
+++ b/base/rts/rts.h
@@ -231,6 +231,7 @@ struct WorkerCtx {
     long id;
     uv_loop_t *uv_loop;
     volatile JumpBuf jump_top;
+    volatile JumpBuf jump0;
 };
 
 JumpBuf $PUSH_BUF();


### PR DESCRIPTION
We just want to initialize jump0 once per worker thread which we now achieve by placing jump0 in our worker context wctx. Previous to this, we would rerun the $PUSH every time we entered wt_work_cb, and thus actually push a new exception jump point to the stack - effectively a memory "leak" with run-away memory consumption as a consequence.