### PR TITLE
Reduce test run repeats

### DIFF
--- a/compiler/test.hs
+++ b/compiler/test.hs
@@ -213,7 +213,7 @@ createAutoTest file = do
                       else (head fileParts) ++ " (" ++testExp ++ ")"
         testFunc  = case testExp of
                         "bf" -> testBuild ""
-                        _    -> testBuildAndRunRepeat "" "" 100
+                        _    -> testBuildAndRunRepeat "" "" 2
         expRet    = case testExp of
                         "bf" -> (ExitFailure 1)
                         "rf" -> (ExitFailure 1)


### PR DESCRIPTION
The idea was to get better test coverage of like stress testing but I don't think it meets this since we still just have very short lived programs. What we really want is for a program to run for a longer period of time. The extra time it takes to run through the tests is slightly annoying, so I'm tuning it down to 2. Still keeping the basic support for running repeat tests so we can easily ramp it up again.