### PR TITLE
Increase randomness

### DIFF
--- a/base/rts/rts.h
+++ b/base/rts/rts.h
@@ -241,6 +241,7 @@ void $RAISE(B_BaseException e);
 #define $PUSH()             (!setjmp($PUSH_BUF()->buf))
 #define $PUSHF $PUSH
 
+extern pid_t pid;
 extern B_Msg timerQ;
 
 void wake_wt(int wtid);

--- a/base/src/random.ext.c
+++ b/base/src/random.ext.c
@@ -1,7 +1,11 @@
 #include <stdlib.h>
 
 void randomQ___ext_init__() {
-    srand(time(NULL));
+    // seed the random number generator with nanoseconds since the epoch and our
+    // PID
+    uv_timespec64_t ts;
+    uv_clock_gettime(UV_CLOCK_MONOTONIC, &ts);
+    srand(ts.tv_nsec ^ pid);
 }
 
 // NOTE: the standard srand / rand functions are not thread safe, but what does


### PR DESCRIPTION
Rather than seed our PRNG with time() which is second-granularity, we now feed in nanoseconds.

Running the test suite over and over would result in flakiness as we'd get the same random values and that in turn affects some of the file tests where it creates temp files (which would be the same due to random being the same). This fixes that.