### PR TITLE
Limit test perf concurrency to 1

### DIFF
--- a/base/src/testing.act
+++ b/base/src/testing.act
@@ -563,7 +563,7 @@ class TestInfo(object):
                 test_definition = jd["definition"]
                 if isinstance(test_definition, dict):
                     return Test.from_json(test_definition)
-            raise ValueError("Invalid Test JSON")
+            raise ValueError("Invalid Test JSON: " + str(jd))
         definition: Test = take_definition(json_data)
         complete = json_data["complete"]
         suc = json_data["success"]
@@ -814,6 +814,13 @@ class ProjectTestResults(object):
             return test_info.complete
         return False
 
+    def is_module_done(self, modname):
+        if modname in self.results:
+            for tname, test_info in self.results[modname].items():
+                if not test_info.complete:
+                    return False
+        return True
+
     def to_json(self):
         """Return JSON encoded results that can be saved to a file
         """
@@ -826,7 +833,7 @@ class ProjectTestResults(object):
             res[modname] = modres
         return json.encode(res)
 
-    def show(self, only_show_complete=False):
+    def show(self, only_show_complete=False, perf_mem=True):
 
         def format_diff(new, old, unit=""):
             diff = float(new) - float(old)
@@ -943,7 +950,7 @@ class ProjectTestResults(object):
                 l += run_info + term.normal
                 print(l)
                 self.printed_lines += 1
-                if self.perf_mode:
+                if self.perf_mode and perf_mem:
                     indent = " " * 10
                     diffs = tinfo.diff(last_tinfo)
                     print(indent + "Memory usag      : %6dKB %s" % (tinfo.mem_usage_delta_avg // 1024, diffs.mem_usage_delta_avg))
@@ -1013,8 +1020,8 @@ class ModuleTestResults(object):
 
     def show(self):
         res = {}
-        for test in self.tests.values():
-            res[test.definition.name] = test.definition.to_json()
+        for test_name, test_info in self.tests.items():
+            res[test_name] = test_info.to_json()
         print(json.encode({"tests": res}), err=True)
 
 
@@ -1065,10 +1072,7 @@ actor test_runner(env: Env,
 
     proc def _list_tests(args):
         _init_results(args)
-        tests = []
-        for test in results.tests.values():
-            tests.append(test.definition.to_json())
-        print(json.encode({"tests": tests}), err=True)
+        results.show()
         env.exit(0)
 
     proc def _run_tests(args, perf_mode: bool=False):
@@ -1076,8 +1080,6 @@ actor test_runner(env: Env,
         if config.perf_mode:
             acton.rts.start_gc_performance_measurement(env.syscap)
         _init_results(args)
-        if config.output_enabled:
-            results.show()
 
         test_concurrency = 1 if config.perf_mode else env.nr_wthreads
         my_tests = _filter_tests(all_tests, args)
@@ -1110,9 +1112,9 @@ actor test_runner(env: Env,
         p = argparse.Parser()
         p.add_bool("json", "Output results as JSON")
         p.add_bool("no_output", "No result output")
+        p.add_option("name", "strlist", nargs="+", default=[], help="Filter tests by name")
         lp = p.add_cmd("list", "list tests", _list_tests)
         tp = p.add_cmd("test", "Run tests", _run_tests)
-        tp.add_option("name", "strlist", nargs="+", default=[], help="Filter tests by name")
         pp = tp.add_cmd("perf", "Performance benchmark tests", _run_perf_tests)
         pp.add_option("iterations", "int", "?", 1, "Number of iterations to run")
         pp.add_option("min_time", "int", "?", 1000, "Minimum time to run a test in milliseconds")

--- a/cli/src/acton.act
+++ b/cli/src/acton.act
@@ -275,8 +275,15 @@ actor RunTestList(env, args):
 
 actor RunTestTest(env: Env, args, perf_mode: bool=False):
     process_cap = process.ProcessCap(env.cap)
+    var expected_modules_list: set[str] = set()
     var _module_tests = {}
+    var modules_to_test = set()
     var perf_data = "{}"
+
+    test_cmd_args = []
+    for name_filter in args.get_strlist("name"):
+        test_cmd_args.extend(["--name", name_filter])
+
     try:
         perf_file = file.ReadFile(file.ReadFileCap(file.FileCap(env.cap)), "perf_data")
         perf_data = perf_file.read().decode()
@@ -297,12 +304,28 @@ actor RunTestTest(env: Env, args, perf_mode: bool=False):
     def _on_json_output(module_name, data):
         if isinstance(data, dict):
             if "tests" in data:
-                tests = parse_json_tests(data)
+                data_tests = data["tests"]
+                tests = {}
+                for test_name, json_test_info in data_tests.items():
+                    if isinstance(json_test_info, dict):
+                        tests[test_name] = TestInfo.from_json(json_test_info)
+
                 ptr.update_module(module_name, tests)
-                _periodic_show()
+                expected_modules_list.discard(module_name)
+                if len(expected_modules_list) == 0:
+                    _periodic_show()
+                    if perf_mode:
+                        _run_module_tests()
+                    else:
+                        # Run all tests in parallel
+                        for module_name in modules_to_test:
+                            t = RunModuleTest(process_cap, module_name, ["test"] + test_cmd_args, lambda x: _on_json_output(module_name, x), lambda x, y, z: _on_test_error(module_name, x, y, z))
+
             elif "test_info" in data:
                 test_info = TestInfo.from_json(data["test_info"])
                 ptr.update(module_name, test_info.definition.name, test_info)
+                if ptr.is_module_done(module_name) and perf_mode:
+                    _run_module_tests()
         else:
             raise ValueError("Unexpected JSON data from module test: " + module_name)
 
@@ -315,19 +338,30 @@ actor RunTestTest(env: Env, args, perf_mode: bool=False):
         if module_name in ptr.results:
             moderr = testing.ModuleError(exit_code, term_signal, errout)
             ptr.update_module_error(module_name, moderr)
+        _run_module_tests()
 
     def _run_tests(module_names: list[str]):
+        expected_modules_list = set(module_names)
+        modules_to_test = set(module_names)
         ptr.expected_modules = set(module_names)
-        test_cmd = ["test"]
-        if perf_mode:
-            test_cmd.append("perf")
-        for name_filter in args.get_strlist("name"):
-            test_cmd.extend(["--name", name_filter])
         if len(module_names) == 0:
             print("No tests found")
             env.exit(0)
+
+        # List all tests first, which we can run in parallel. Once we have the
+        # list of all tests we can start running them one at a time in sequence.
         for module_name in module_names:
-            t = RunModuleTest(process_cap, module_name, test_cmd, lambda x: _on_json_output(module_name, x), lambda x, y, z: _on_test_error(module_name, x, y, z))
+            t = RunModuleTest(process_cap, module_name, ["list"] + test_cmd_args, lambda x: _on_json_output(module_name, x), lambda x, y, z: _on_test_error(module_name, x, y, z))
+
+    def _run_module_tests():
+        try:
+            module_name = modules_to_test.pop()
+            if module_name is not None:
+                t = RunModuleTest(process_cap, module_name, ["test", "perf"] + test_cmd_args, lambda x: _on_json_output(module_name, x), lambda x, y, z: _on_test_error(module_name, x, y, z))
+            else:
+                _periodic_show()
+        except:
+            pass
 
     def _on_build_failure(exit_code, term_signal, stderr_buf):
         print("Failed to build project tests")


### PR DESCRIPTION
While we have only run 1 concurrent test within a module when in perf mode, multiple modules have been executed at the same time, so we've gotten useless results. This fixes that by serializing the test modules to run one by one.

We still run in full concurrency when not in perf mode.