### PR TITLE
Include acton(c) binary in uptodate check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -512,7 +512,22 @@ endif
 distribution1: dist/base $(DIST_BACKEND_FILES) $(DEPSA) dist/builder $(DIST_INC) $(DIST_BINS) $(DIST_HFILES) $(DIST_ZIG)
 	$(MAKE) $(DIST_DEPS)
 
+#
+# Touch the acton(c) binary to ensure it has a timestamp that reflects the last
+# updated file in the distribution. The actonc compiler itself has an up-to-date
+# check which it uses to determine when an .act file should be recompiled. Since
+# we naturally want to recompile programs if the compiler has been changed, the
+# up-to-date check includes the actonc program itself as a "source file", so if
+# it is newer than the compiled output, a recompilation will be performed. Thus,
+# it is important that the actonc mtime reflects when it was actually modified
+# and it also acts as a sentinel of sort for the modification of the acton
+# distribution as a whole, which is why we copy over the timestamp of the last
+# modified file in the distribution to the acton binary. This way, when a file
+# in stdlib or builtins is modified, it updates the acton binary as well and in
+# turn will lead to recompilation of acton programs.
 distribution: dist/bin/acton
+    @latest_file=$$(find dist -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -d' ' -f2); \
+    touch -r "$$latest_file" dist/bin/acton
 
 clean-distribution:
 	rm -rf dist

--- a/Makefile
+++ b/Makefile
@@ -512,22 +512,7 @@ endif
 distribution1: dist/base $(DIST_BACKEND_FILES) $(DEPSA) dist/builder $(DIST_INC) $(DIST_BINS) $(DIST_HFILES) $(DIST_ZIG)
 	$(MAKE) $(DIST_DEPS)
 
-#
-# Touch the acton(c) binary to ensure it has a timestamp that reflects the last
-# updated file in the distribution. The actonc compiler itself has an up-to-date
-# check which it uses to determine when an .act file should be recompiled. Since
-# we naturally want to recompile programs if the compiler has been changed, the
-# up-to-date check includes the actonc program itself as a "source file", so if
-# it is newer than the compiled output, a recompilation will be performed. Thus,
-# it is important that the actonc mtime reflects when it was actually modified
-# and it also acts as a sentinel of sort for the modification of the acton
-# distribution as a whole, which is why we copy over the timestamp of the last
-# modified file in the distribution to the acton binary. This way, when a file
-# in stdlib or builtins is modified, it updates the acton binary as well and in
-# turn will lead to recompilation of acton programs.
 distribution: dist/bin/acton
-    @latest_file=$$(find dist -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -d' ' -f2); \
-    touch -r "$$latest_file" dist/bin/acton
 
 clean-distribution:
 	rm -rf dist

--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -616,6 +616,11 @@ doTask opts paths env t@(ActonTask mn src m stubMode) = do
 checkUptoDate :: C.CompileOptions -> Paths -> FilePath -> [FilePath] -> [A.ModName] -> IO Bool
 checkUptoDate opts paths actFile outFiles imps = do
     iff (C.debug opts) (putStrLn ("    Checking " ++ makeRelative (srcDir paths) actFile ++ " is up to date..."))
+    -- get the path to the actonc binary, i.e. ourself
+    actoncBin <- System.Environment.getExecutablePath
+    -- get path to `acton` which is the actonc binary without the `c` at the end
+    let actonBin = take (length actoncBin - 1) actoncBin
+    let potSrcFiles     = [actonBin, actoncBin, actFile, extCFile, srcCFile, srcHFile]
     srcFiles  <- filterM System.Directory.doesFileExist potSrcFiles
     outExists <- mapM System.Directory.doesFileExist outFiles
 
@@ -636,7 +641,6 @@ checkUptoDate opts paths actFile outFiles imps = do
         extCFile        = srcBase ++ ".ext.c"
         -- except for actFile, these are *potential* source files which might
         -- not actually exist...
-        potSrcFiles     = [actFile, extCFile, srcCFile, srcHFile]
         impOK iTime mn  = do
                              impFile <- findTyFile (searchPath paths) mn
                              case impFile of


### PR DESCRIPTION
Thus we can detect whether a program should be recompiled when the acton distribution itself has been modified.