### PR TITLE
Fix str.strip() to handle empty strings

### DIFF
--- a/base/builtin/str.c
+++ b/base/builtin/str.c
@@ -855,6 +855,7 @@ B_str B_strD_lower(B_str s) {
 
 
 B_str B_strD_lstrip(B_str s, B_str cs) {
+    if (s->nchars == 0) return s;
     if (cs==NULL) cs = whitespace_str;
     unsigned char *p = s->str;
     int i, k;
@@ -1107,6 +1108,7 @@ B_list B_strD_splitlines(B_str s, B_bool keepends) {
 } 
 
 B_str B_strD_rstrip(B_str s, B_str cs) {
+    if (s->nchars == 0) return s;
     if (cs==NULL) cs = whitespace_str;
     unsigned char *p = s->str + s->nbytes;
     int i, k;

--- a/test/builtins_auto/strings_and_bytes.act
+++ b/test/builtins_auto/strings_and_bytes.act
@@ -19,6 +19,12 @@ actor main(env):
         # library in Acton :/
         assertEqual("encoded & decoded == original", uniesc, ulim)
 
+    def test_strip():
+        s = ""
+        a = [s.strip()]
+        assertEqual("empty string", "['']", str(a))
+
     test_helloworld()
     test_limdef()
+    test_strip()
     env.exit(0)


### PR DESCRIPTION
The str.strip() method was not handling empty strings correctly. We would get back a \0 character instead of an empty string. Now fixed by returning input string if length is 0. I don't think it's an issue that you get back the actual string if you call strip on an empty string rather than a new string with the same value as you'd otherwise get.