### PR TITLE
Fix re groups for no match

### DIFF
--- a/base/src/re.act
+++ b/base/src/re.act
@@ -29,7 +29,7 @@
 
 
 class Match:
-    def __init__(self, pattern: str, string: str, start_pos: int, end_pos: int, group: list[str], named_group: dict[str, str]) -> None:
+    def __init__(self, pattern: str, string: str, start_pos: int, end_pos: int, group: list[?str], named_group: dict[str, ?str]) -> None:
         self.pattern = pattern
         self.string = string
         self.start_pos = start_pos

--- a/base/src/uri.act
+++ b/base/src/uri.act
@@ -5,7 +5,10 @@ def get_scheme(uri: str) -> (str, str):
     m = re.match("""(^[A-Za-z][A-Za-z0-9+\\-._@&!*",'$]*):(.*)""", uri)
 #    m = re.match("""^[a-zA-Z][a-zA-Z0]*:""", uri)
     if m is not None:
-        return (m.group[1], m.group[2])
+        g1 = m.group[1]
+        g2 = m.group[2]
+        if g1 is not None and g2 is not None:
+            return (g1, g2)
     raise ValueError("Invalid URI: " + uri)
 
 def parse_http(url: str) -> (str, str, int, str):
@@ -16,9 +19,18 @@ def parse_http(url: str) -> (str, str, int, str):
     # host can be a domain name or an IP address
     m = re.match("""^//(?P<host>[a-zA-Z0-9\\-._~%]+)(:(?P<port>[0-9]+))?(?P<path>/.*)?""", rest)
     if m is not None:
-        if m.named["port"] == "":
-            port = 80 if scheme == "http" else 443
+        gport = m.named["port"]
+        if gport is not None and gport != "":
+            port = int(gport)
         else:
-            port = int(m.named["port"])
-        return (scheme, m.named["host"], port, m.named["path"])
+            port = 80 if scheme == "http" else 443
+        host = ""
+        ghost = m.named["host"]
+        if ghost is not None:
+            host = ghost
+        path = ""
+        gpath = m.named["path"]
+        if gpath is not None:
+            path = gpath
+        return (scheme, host, port, path)
     raise ValueError("Invalid URI: " + url)

--- a/test/stdlib_tests/src/test_re.act
+++ b/test/stdlib_tests/src/test_re.act
@@ -11,15 +11,45 @@ def _test_basic():
 def _test_group():
     """Regexp matching with groups
     """
-    m = re.match("foo[a-z]+", "åbc123 foobar åbc123")
-    testing.assertIsNotNone(m, "basic regexp matching failed")
+    m = re.match("foo([a-z]+)", "åbc123 foobar åbc123")
+    testing.assertIsNotNone(m, "group matching failed")
     if m is not None:
-        testing.assertEqual(m.group[0], "foobar", "match failed")
+        testing.assertEqual(m.group[0], "foobar", "whole group match failed")
+        testing.assertEqual(m.group[1], "bar", "first group match failed")
+
+def _test_nested_group():
+    """Regexp matching with groups
+    """
+    m = re.match("foo((B)[A-Z]+)", "åbc123 fooBAR åbc123")
+    testing.assertIsNotNone(m, "group matching failed")
+    if m is not None:
+        testing.assertEqual(m.group[0], "fooBAR", "whole group match failed")
+        testing.assertEqual(m.group[1], "BAR", "first group match failed")
+        testing.assertEqual(m.group[2], "B", "second group match failed")
+
+def _test_nested_group_without_match():
+    """Regexp matching with groups
+    """
+    m = re.match("foo((Z?)[A-Z]+)", "åbc123 fooBAR åbc123")
+    testing.assertIsNotNone(m, "group matching failed")
+    if m is not None:
+        testing.assertEqual(m.group[0], "fooBAR", "whole group match failed")
+        testing.assertEqual(m.group[1], "BAR", "first group match failed")
+        testing.assertEqual(m.group[2], "", "second group match failed")
 
 def _test_named_groups():
     """Regexp matching with named groups
     """
     m = re.match("(?P<mypattern>foo[a-z]+)", "åbc123 foobar åbc123")
+    testing.assertIsNotNone(m, "regexp matching with named groups failed")
+    if m is not None:
+        testing.assertEqual(m.named["mypattern"], "foobar", "named group ('foobar') match failed")
+
+
+def _test_named_groups_without_match():
+    """Regexp matching with named groups but without a match on an inner group
+    """
+    m = re.match("(?P<mypattern>foo((?P<inner>AAA)|[a-z]+))", "åbc123 foobar åbc123")
     testing.assertIsNotNone(m, "regexp matching with named groups failed")
     if m is not None:
         testing.assertEqual(m.named["mypattern"], "foobar", "named group ('foobar') match failed")


### PR DESCRIPTION
It is possible to define a matching group in a regexp that does not match while the overall regexp does match, in which case the individual group should be None. As such, the type has been updated to be a list[?str] instead of list[str] for both group and named groups.

The code has been updated to avoid segfault since the string offsets are unset (-1) when a group has no match.

New test case to test this.