### PR TITLE
Fix str slice outside of range

### DIFF
--- a/base/builtin/str.c
+++ b/base/builtin/str.c
@@ -1360,6 +1360,9 @@ B_str B_SliceableD_strD___getslice__ (B_SliceableD_str wit, B_str s, B_slice slc
     int nbytes = 0;
     long start, stop, step, slen;
     normalize_slice(slc, nchars, &slen, &start, &stop, &step);
+    if (slen == 0) {
+        return to$str("");
+    }
     //slice notation have been eliminated and default values applied.
     unsigned char buffer[4*slen]; // very conservative buffer size.
     unsigned char *p = buffer;

--- a/test/builtins_auto/str_slice.act
+++ b/test/builtins_auto/str_slice.act
@@ -1,0 +1,18 @@
+
+def test_slice():
+    a = "asdf"
+    b = a[1]
+
+def test_slice_outside_of_range():
+    a = "asdf"
+    i = 7
+    b = a[i:]
+
+actor main(env):
+    try:
+        test_slice()
+        test_slice_outside_of_range()
+        env.exit(0)
+    except Exception as e:
+        print(e)
+        env.exit(1)


### PR DESCRIPTION
The problem is really that slice is 0 long and allocating an array that is 0 long and then doing operations on it becomes UB so we SIGILL in testing since we now run tests in --dev mode (which comes with all sorts of UBsan).