### PR TITLE
Temp fix (CI) build via zigballs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -503,7 +503,8 @@ dist/zig: deps-download/zig-$(OS)-$(ARCH)-$(ZIG_VERSION).tar.xz
 deps-download/zig-$(OS)-$(ARCH)-$(ZIG_VERSION).tar.xz:
 	mkdir -p deps-download
 ifeq ($(findstring -dev,$(ZIG_VERSION)),-dev)
-	curl -o $@ https://ziglang.org/builds/zig-$(OS)-$(ARCH)-$(ZIG_VERSION).tar.xz
+	curl -L -o $@ https://github.com/actonlang/zigballs/raw/main/zig-$(OS)-$(ARCH)-$(ZIG_VERSION).tar.xz
+#	curl -o $@ https://ziglang.org/builds/zig-$(OS)-$(ARCH)-$(ZIG_VERSION).tar.xz
 else
 	curl -o $@ https://ziglang.org/download/$(ZIG_VERSION)/zig-$(OS)-$(ARCH)-$(ZIG_VERSION).tar.xz
 endif


### PR DESCRIPTION
Official zig build download page has removed the particular zig build we used. We cannot directly go to zig v0.12 which is the closest release to what we need, since some stuff we use was deprecated.

Meanwhile, we fix this by uploading the missing .tar.xz file to our own little mirror of the zig builds and use that for our build.