### PR TITLE
Make set.pop() throw ValueError for empty set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
   - For example, `acton test --module foo` to only run tests in module foo
 - Improved printing of test results for test modules that crashed
   - The error is now printed for each individual test in the test module
+- Added `list.index(val, start=0, stop: ?int)` to get the first index of an
+  element in a list. It can be constrained through the start and stop
+  parameters.
 
 ## Changed
 - `re.match()` now returns `Match` object where the group is `list[?str]`. It
@@ -29,6 +32,7 @@
   - For example, consider `foo((123)|bar)` which matches either `foo123` or
     `foobar`. The inner `(123)` group is ORed and so it will have no match for
     `foobar`, thus we get the result `m.group = ["foobar", "bar", None]`
+- `set.pop()` now throws `ValueError` for an empty set
 
 ## Fixed
 - Fixed tuple type inference
@@ -47,6 +51,8 @@
     no character 23 and so the length of the slice is 0 which would trigger a
     `SIGILL` when compiled in `--dev` mode (which comes with lots of extra
     UBsan)
+- Fix dict corruption issue #1805
+- `set.pop()` now does not crash for an empty list (it threw NULL before)
 
 ### Testing / CI
 - Added performance test to CI
@@ -68,6 +74,10 @@
     - We do not currently inspect the results to give a pass / fail score,
       they're just printed in the CI output for a human to look at
     - Natural variance seems to hover around +-5%, which feels OK
+- Temporary fix of building Acton by using our own mirror for the Zig tar ball.
+  We are using a particular nightly v0.12.0 build that is no longer available
+  for download from ziglang.org and so we now mirror it ourselves. This affects
+  both builds in CI and local builds.
 
 
 ## [0.22.0] (2024-04-14)

--- a/base/builtin/set.c
+++ b/base/builtin/set.c
@@ -425,14 +425,14 @@ B_NoneType B_SetD_setD_discard (B_SetD_set wit, B_set set, $WORD elem) {
 }
 
 $WORD B_SetD_setD_pop (B_SetD_set wit, B_set set) {
+    if (set->numelements == 0)
+        $RAISE((B_BaseException)$NEW(B_ValueError, to$str("pop from an empty set")));
+
     $WORD res;
     // Make sure the search finger is in bounds 
     B_setentry *entry = set->table + (set->finger & set->mask);
     B_setentry *limit = set->table + set->mask;
 
-    if (set->numelements == 0) {
-        return NULL;
-    }
     while (entry->key == NULL || entry->key==dummy) {
         entry++;
         if (entry > limit)

--- a/test/builtins_auto/set_test.act
+++ b/test/builtins_auto/set_test.act
@@ -1,4 +1,26 @@
+
+def test_set_pop():
+    s = {1, 2, 3}
+    if s.pop() not in {1, 2, 3}:
+        raise ValueError("pop() returned an invalid value")
+    if len(s) != 2:
+        raise ValueError("pop() did not remove an element")
+    s.pop()
+    s.pop()
+    try:
+        s.pop()
+    except ValueError:
+        pass
+    else:
+        raise ValueError("pop() did not raise an exception when called on an empty set")
+
 actor main(env):
+    try:
+        test_set_pop()
+    except Exception as e:
+        print("Unexpected exception during testing:", e)
+        await async env.exit(1)
+
     s = {400}
     for i in range(13, 1000):
         s.add(i*i)


### PR DESCRIPTION
It previously returned NULL, which is just invalid in so many ways. The type signature says it should return something and thus throw an exception if something goes wrong. Now it does!

Fixes #1789 