### PR TITLE
Do not pass --record when building tests

### DIFF
--- a/cli/src/acton.act
+++ b/cli/src/acton.act
@@ -488,7 +488,7 @@ actor RunTestTest(env: Env, args, perf_mode: bool=False):
 def build_cmd_args(args):
     cmdargs = []
     for argname, arg in args.options.items():
-        if argname == "file":
+        if argname in {"file", "record"}:
             continue
         if arg.type == "bool":
             if args.get_bool(argname):


### PR DESCRIPTION
This is sort of a fine line to walk here. We currently use build_cmd_args to take all arguments to acton and pass them through to actonc. This works great since we don't have to manually specify all arguments that should actually be passed through but on the other hand it means that some arguments, which are not available on actonc, need to be stripped out. In this case, --record is one such argument.

Fixes #1865 