### PR TITLE
Revamp zig build caching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,12 @@ TD:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 CHANGELOG_VERSION=$(shell grep '^\#\# \[[0-9]' CHANGELOG.md | sed 's/\#\# \[\([^]]\{1,\}\)].*/\1/' | head -n1)
 GIT_VERSION_TAG=$(shell git tag --points-at HEAD 2>/dev/null | grep "v[0-9]" | sed -e 's/^v//')
 
+ifdef HOME
+ZIG_LOCAL_CACHE_DIR ?= $(HOME)/.cache/acton/zig-cache
+else
+# TODO: Windows?
 ZIG_LOCAL_CACHE_DIR ?= $(TD)/zig-cache
+endif
 export ZIG_LOCAL_CACHE_DIR
 
 ACTON=$(TD)/dist/bin/acton

--- a/cli/src/acton.act
+++ b/cli/src/acton.act
@@ -7,19 +7,66 @@ import testing
 from buildy import *
 from testing import TestInfo
 
+def get_zig_local_cache_dir(file_cap: file.FileCap):
+    fs = file.FS(file_cap)
+    return file.join_path([fs.homedir(), ".cache", "acton", "zig-cache"])
+
+def get_zig_global_cache_dir(file_cap: file.FileCap):
+    fs = file.FS(file_cap)
+    return file.join_path([fs.homedir(), ".cache", "acton", "zig-global-cache"])
+
 def base_path(file_cap: file.FileCap):
     fs = file.FS(file_cap)
     return fs.exepath()[0:-len("/bin/acton")]
 
-def clean_buildcache(cap: file.FileCap):
+def warn_on_large_zig_global_cache(cap: file.FileCap):
     fs = file.FS(cap)
-    cache_dir = fs.homedir() + "/.cache/acton"
-    #cache_dir = fs.join(fs.homedir(), ".cache", "acton")
+    last_warn_file = file.join_path([get_zig_global_cache_dir(cap), "last_warn"])
+    warn_level: int = 10 # start to warn at 10GB
+    try:
+        last_warn = int(file.ReadFile(file.ReadFileCap(cap), last_warn_file).read().decode())
+        warn_level = last_warn + 1 # warn in 1GB increments
+    except:
+        try:
+            f = file.WriteFile(file.WriteFileCap(cap), last_warn_file)
+            f.write(str(warn_level).encode())
+            f.close()
+        except:
+            # The cache dir probably doesn't exist, just ignore
+            pass
+
+    cache_dir = get_zig_global_cache_dir(cap)
+    total_size: int = 0
+    for f in fs.walk(cache_dir):
+        total_size += int(f.size)
+    gb = 1024 * 1024 * 1024
+    if total_size > warn_level * gb:
+        print("WARN: The Zig global cache has grown to %dMB" % (total_size // (1024*1024)))
+        print("HINT: You can clear the cache with with: rm -rf %s" % cache_dir)
+        print("INFO: Do NOT clear the cache if you are offline or have a slow connection.")
+        print("INFO: The global cache stores downloaded package dependencies as well as")
+        print("INFO: compiled artifacts for common libraries, like libc.")
+        print("INFO: Another warning will be issued when the cache grows by another 1GB.")
+        print("")
+        # write new warn level
+        try:
+            f = file.WriteFile(file.WriteFileCap(cap), last_warn_file)
+            f.write(str(total_size // gb).encode())
+            f.close()
+        except Exception as e:
+            print("WARN: Could not write new warn level to", last_warn_file)
+            print(e)
+
+def clean_zig_local_cache(cap: file.FileCap):
+    fs = file.FS(cap)
+    cache_dir = get_zig_local_cache_dir(cap)
     total_size = 0
     for f in fs.walk(cache_dir):
         total_size += f.size
-    if total_size > 15 * 1024 * 1024 * 1024: # 5GB
-        print("Build cache (", total_size // (1024*1024), "MB) over 5GB, cleaning it up.")
+    gb = 1024 * 1024 * 1024
+    limit = 5 * gb
+    if total_size > limit:
+        print("Build cache (", total_size // (1024*1024), "MB) over %dGB, cleaning it up." % (int(limit // gb)))
         fs.rmtree(cache_dir)
         total_size = 0
     if total_size == 0:
@@ -86,7 +133,6 @@ actor CompilerRunner(process_cap, env, args, wdir=None, on_exit: ?action(int, in
             print("Error from process:", error)
             env.exit(1)
 
-    clean_buildcache(file.FileCap(env.cap))
     fs = file.FS(file.FileCap(env.cap))
     # We find the path to actonc by looking at the executable path of the
     # current process. Since we are called 'acton', we just add a 'c'.
@@ -106,6 +152,7 @@ actor BuildProject(process_cap, env, args, on_build_success: action(str) -> None
     fs = file.FS(fcap)
     lock_file = None
     remaining_deps = {}
+    zig_global_cache_dir = get_zig_global_cache_dir(file.FileCap(env.cap))
     cmdargs = ["build"] + build_cmd_args(args)
     if build_tests:
         cmdargs.append("--dev")
@@ -128,7 +175,7 @@ actor BuildProject(process_cap, env, args, on_build_success: action(str) -> None
             hash = dep.hash
             path = dep.path
             if hash is not None:
-                search_paths.append(file.join_path([fs.homedir(), ".cache", "acton", "build-cache", "p", hash, "out", "types"]))
+                search_paths.append(file.join_path([zig_global_cache_dir, "p", hash, "out", "types"]))
             elif path is not None:
                 # deconstruct and put together to get OS independent path? i.e. flip / to \ on windows
                 # TODO: force relative path?
@@ -210,7 +257,7 @@ actor BuildProject(process_cap, env, args, on_build_success: action(str) -> None
                 if dep_name not in deps_dir:
                     print("Copying", dep_name, "from zig global cache")
                     fs.mkdir(file.join_path(["deps", dep_name]))
-                    src = file.join_path([fs.homedir(), ".cache", "acton", "build-cache", "p", hash])
+                    src = file.join_path([zig_global_cache_dir, "p", hash])
                     dst = file.join_path([fs.cwd(), "deps", dep_name])
                     print("Copying", src, "to", dst)
                     await async fs.copytree(src, dst)
@@ -256,6 +303,9 @@ actor BuildProject(process_cap, env, args, on_build_success: action(str) -> None
             print("Build lock exists, trying again soon...")
             after 1: get_lock()
 
+    # check cache size and warn or clean if necessary...
+    warn_on_large_zig_global_cache(file.FileCap(env.cap))
+    clean_zig_local_cache(file.FileCap(env.cap))
     # and off we go! Start by grabbing the project build lock
     get_lock()
 
@@ -549,10 +599,11 @@ actor ZigFetchDeps(env, build_config: BuildConfig, on_done: action() -> None, on
         # TODO: collect all errors before calling on_fetch_error?
         on_fetch_error(error)
 
+    zig_global_cache_dir = get_zig_global_cache_dir(file.FileCap(env.cap))
     for dep_name, dep in build_config.dependencies.items():
         dep_url = dep.url
         if dep_url is not None:
-            cmd = [zig, "fetch", "--global-cache-dir", file.join_path([fs.homedir(), ".cache", "acton", "build-cache"]), dep_url]
+            cmd = [zig, "fetch", "--global-cache-dir", zig_global_cache_dir, dep_url]
             p = process.RunProcess(
                 pcap,
                 cmd,
@@ -564,7 +615,7 @@ actor ZigFetchDeps(env, build_config: BuildConfig, on_done: action() -> None, on
         dep_url = dep.url
         if dep_url is not None:
 
-            cmd = [zig, "fetch", "--global-cache-dir", file.join_path([fs.homedir(), ".cache", "acton", "build-cache"]), dep_url]
+            cmd = [zig, "fetch", "--global-cache-dir", zig_global_cache_dir, dep_url]
             p = process.RunProcess(
                 pcap,
                 cmd,
@@ -617,13 +668,14 @@ actor CmdFetch(env, args):
         print("No dependencies to fetch")
         env.exit(0)
     else:
+        zig_global_cache_dir = get_zig_global_cache_dir(file.FileCap(env.cap))
         for dep_name, dep in build_config.dependencies.items():
             print("Checking", dep_name)
             dep_url = dep.url
             if dep_url is not None:
                 print("Fetching", dep_name, "from", dep_url)
 
-                cmd = [zig, "fetch", "--global-cache-dir", file.join_path([fs.homedir(), ".cache", "acton", "build-cache"]), dep_url]
+                cmd = [zig, "fetch", "--global-cache-dir", zig_global_cache_dir, dep_url]
                 p = process.RunProcess(
                     pcap,
                     cmd,
@@ -637,7 +689,7 @@ actor CmdFetch(env, args):
             if dep_url is not None:
                 print("Fetching", dep_name, "from", dep_url)
 
-                cmd = [zig, "fetch", "--global-cache-dir", file.join_path([fs.homedir(), ".cache", "acton", "build-cache"]), dep_url]
+                cmd = [zig, "fetch", "--global-cache-dir", zig_global_cache_dir, dep_url]
                 p = process.RunProcess(
                     pcap,
                     cmd,
@@ -703,7 +755,7 @@ actor CmdPkgAdd(env, args):
         print("Error fetching", error)
         env.exit(1)
 
-    cmd = [zig, "fetch", "--global-cache-dir", file.join_path([fs.homedir(), ".cache", "acton", "build-cache"]), args.get_str("url")]
+    cmd = [zig, "fetch", "--global-cache-dir", get_zig_global_cache_dir(file.FileCap(env.cap)), args.get_str("url")]
     process.RunProcess(
         pcap,
         cmd,
@@ -801,7 +853,7 @@ actor CmdZigPkgAdd(env, args):
         print("Error fetching", error)
         env.exit(1)
 
-    cmd = [zig, "fetch", "--global-cache-dir", file.join_path([fs.homedir(), ".cache", "acton", "build-cache"]), args.get_str("url")]
+    cmd = [zig, "fetch", "--global-cache-dir", get_zig_global_cache_dir(file.FileCap(env.cap)), args.get_str("url")]
     process.RunProcess(
         pcap,
         cmd,

--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -888,7 +888,8 @@ zigBuild env opts paths tasks binTasks = do
 
     -- custom build.zig ?
     homeDir <- getHomeDirectory
-    let global_cache_dir = joinPath [ homeDir, ".cache", "acton", "build-cache" ]
+    let local_cache_dir = joinPath [ homeDir, ".cache", "acton", "zig-local-cache" ]
+        global_cache_dir = joinPath [ homeDir, ".cache", "acton", "zig-global-cache" ]
         no_threads = if isWindowsOS (C.target opts) then True else C.no_threads opts
         target_cpu = if (C.cpu opts /= "")
                        then C.cpu opts
@@ -909,11 +910,6 @@ zigBuild env opts paths tasks binTasks = do
     removeDirectoryLink (joinPath [projPath paths, ".build", "sys"])
       `catch` handleNotExists
     createDirectoryLink (sysPath paths) (joinPath [projPath paths, ".build", "sys"])
-    -- symlink .build/cache to the global cache directory ~/.cache/acton
-    removeDirectoryLink (joinPath [projPath paths, ".build", "cache"])
-      `catch` handleNotExists
-    createDirectoryLink global_cache_dir (joinPath [projPath paths, ".build", "cache"])
-
 
     -- Write our build.zig and build.zig.zon files
     buildZigExists <- doesFileExist $ projPath paths ++ "/build.zig"
@@ -929,13 +925,13 @@ zigBuild env opts paths tasks binTasks = do
     let zigCmdBase =
           if buildZigExists
             then zig paths ++ " build " ++
-                 " --cache-dir " ++ global_cache_dir ++
+                 " --cache-dir " ++ local_cache_dir ++
                  " --global-cache-dir " ++ global_cache_dir ++
                  if (C.debug opts) then " --verbose " else ""
             else (joinPath [ sysPath paths, "builder", "builder" ]) ++ " " ++
                  (joinPath [ sysPath paths, "zig/zig" ]) ++ " " ++
                  projPath paths ++ " " ++
-                 global_cache_dir ++ " " ++
+                 local_cache_dir ++ " " ++
                  global_cache_dir
     let zigCmd = zigCmdBase ++
                  " --prefix " ++ projOut paths ++ " --prefix-exe-dir 'bin'" ++


### PR DESCRIPTION
Now split the cache into the zig global cache and the zig local cache. Zig had these separate from the beginning but as Zig didn't differentiate between them earlier, before the package manager, I didn't know what they were good for and so we ended up just using a single directory. Now that there is a package manager, we separate the global cache, which is used for downloaded packages, and the local cache which is used for built stuff.

The automatic clearing of the cache is kept but only applies for the local cache. The global cache is never automatically cleared, instead a warning is emitted once it crosses 10GB in size and for every additional 1GB in growth.

Fixes #1858 