### PR TITLE
Don't set worker thread CPU affinity

### DIFF
--- a/base/rts/rts.c
+++ b/base/rts/rts.c
@@ -2810,7 +2810,7 @@ int main(int argc, char **argv) {
         if (cpu_pin) {
             CPU_ZERO(&cpu_set);
             CPU_SET(idx, &cpu_set);
-            pthread_setaffinity_np(threads[idx-1], sizeof(cpu_set), &cpu_set);
+            //pthread_setaffinity_np(threads[idx-1], sizeof(cpu_set), &cpu_set);
         }
     }
 #endif


### PR DESCRIPTION
This is triggered right now by a problem with Zig build concurrency. Zig gets the number of parallel worker threads to run by inspecting its affinity. This is a great approach since it works in containers / cgroups, unlike when just inspecting /proc/cpuinfo or similar. However, zig is run as a subprocess to actonc which in turn is run as a subprocess to acton, which is an Acton program. The Acton RTS sets the thread affinity in order to pin each worker thread to a CPU core. This affinity is apparently inherited from the acton RTS worker threads to actonc and finally to zig, so it thinks it can only run on a single CPU and thus.. it's rather slow.

I have been pondering the thread affinity topic in general for quite some time. I don't have any hard evidence, but I think that pinning to cores might be a premature optimization. It certainly should work better for server workloads, but for desktop workloads, which frankly we are doing more of right now (in development), I wouldn't be surprised if it works better without affinity.

Anyway, turning it off isn't a biggie right now. Zig parallelism is the most important thing and no worker affinity is fine. Let's figure out how to move forward on this in the longer term.

I did look into getting libuv to set affinity for the new process etc but there's nothing like that in libuv 1.x. I tried upgrading to master but then tlsuv fails.

I also quickly tried to fiddle with thread affinity when I realized that we have our own pthread_setaffinity_np for macos.. and libuv has some thread affinity functions but I don't think they work on Macos. Until we sort this out, we disable thread affinity!

This should speed up our cross-compilation tests in CI by quite a bit!

Fixes #1880