### PR TITLE
Add Zig support in base for new base64 module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -429,10 +429,10 @@ dist/backend%: backend/%
 # We depend on __builtin__.ty because the base/out directory will be populated
 # as a result of building it, and we want to copy those files!
 .PHONY: dist/base
-dist/base: base base/.build base/build.zig base/build.zig.zon dist/base/out/types/__builtin__.ty
+dist/base: base base/.build base/__root.zig base/acton.zig base/build.zig base/build.zig.zon dist/base/out/types/__builtin__.ty base/acton.zig
 	mkdir -p $@ $@/.build $@/out
 	ln -sf ../../ dist/base/.build/sys || true
-	cp -a base/Acton.toml base/build.zig base/build.zig.zon base/builtin base/rts base/src base/stdlib dist/base/
+	cp -a base/__root.zig base/Acton.toml base/acton.zig base/build.zig base/build.zig.zon base/builtin base/rts base/src base/stdlib dist/base/
 	cp -a base/out/types dist/base/out/
 
 dist/bin/acton: bin/acton

--- a/base/__root.zig
+++ b/base/__root.zig
@@ -1,0 +1,40 @@
+const std = @import("std");
+
+const acton = @import("acton.zig");
+const gc = @import("rts/gc.zig");
+
+export fn base64Q_encode(data: *acton.str) callconv(.C) *acton.str {
+    const alloc = gc.allocator();
+    const encoder = std.base64.standard.Encoder;
+    const data_len: usize = @intCast(data.nchars);
+    const out_len = encoder.calcSize(data_len);
+    const buffer = alloc.alloc(u8, out_len) catch @panic("OOM");
+    const encoded = encoder.encode(buffer, std.mem.span(data.str));
+
+    const res = alloc.create(acton.str) catch @panic("OOM");
+    res.* = .{
+        .class = data.class,
+        .nbytes = @intCast(out_len),
+        .nchars = @intCast(out_len),
+        .str = @as([*:0]const u8, @ptrCast(encoded.ptr))
+    };
+    return res;
+}
+
+export fn base64Q_decode(data: *acton.str) callconv(.C) *acton.str {
+    const alloc = gc.allocator();
+    const decoder = std.base64.standard.Decoder;
+    const data_len: usize = @intCast(data.nchars);
+    const out_len = decoder.calcSizeUpperBound(data_len) catch unreachable;
+    const buffer = alloc.alloc(u8, out_len) catch @panic("OOM");
+    decoder.decode(buffer, std.mem.span(data.str)) catch unreachable;
+
+    const res = alloc.create(acton.str) catch @panic("OOM");
+    res.* = .{
+        .class = data.class,
+        .nbytes = @intCast(out_len),
+        .nchars = @intCast(out_len),
+        .str = @as([*:0]const u8, @ptrCast(buffer.ptr))
+    };
+    return res;
+}

--- a/base/acton.zig
+++ b/base/acton.zig
@@ -1,0 +1,50 @@
+const std = @import("std");
+const expect = std.testing.expect;
+const c_acton = @cImport({
+    @cInclude("builtin/builtin.h");
+});
+
+// B_str
+pub const str = extern struct {
+    class: usize,
+    nbytes: i32,              // length of str in bytes
+    nchars: i32,              // length of str in Unicode chars
+    str: [*:0]const u8            // str is UTF-8 encoded.
+};
+
+test "str struct" {
+    // Check that our struct is the same size as the C struct, by using @typeInfo
+    // B_str is a pointer to a C struct, so we need to "dereference" the pointer
+    // type to get to the struct type, then check the size of the nbytes field
+    switch (@typeInfo(c_acton.B_str)) {
+        .Pointer => |info| switch (info.size) {
+            .C => switch (@typeInfo(info.child)) {
+                .Struct => |child_info| {
+                    inline for (child_info.fields) |field| {
+                        //std.debug.print("struct B_str field: {s} size: {d}\n", .{field.name, @sizeOf(field.type)});
+                        if (std.mem.eql(u8, field.name, "nbytes")) {
+                            try expect(@sizeOf(field.type) == 4);
+                        }
+                        if (std.mem.eql(u8, field.name, "nchars")) {
+                            try expect(@sizeOf(field.type) == 4);
+                        }
+                    }
+                },
+                else => {
+                    @compileError("Unhandled type: {s}" ++ @typeName(info.child));
+                }
+            },
+            else => {
+                @compileError("Unhandled type:");
+            }
+        },
+        else =>
+            std.debug.print("unexpected type\n", .{}),
+    }
+    try expect(@sizeOf(str) == 24); // 8 + 4 + 4 + 8
+//    std.debug.print("size of str: {d}\n", .{ @sizeOf(str) });
+//    std.debug.print("size of B_str: {d}\n", .{ @sizeOf(B_str) });
+//    std.debug.print("size of imported c_acton.B_str: {d}\n", .{ @sizeOf(c_acton.B_str.*) });
+    //try expect(@sizeOf(c_acton.B_str) == 8);
+    //try expect(@sizeOf(str) == @sizeOf(c_acton.B_str));
+}

--- a/base/build.zig
+++ b/base/build.zig
@@ -223,6 +223,7 @@ pub fn build(b: *std.Build) void {
     const libActon = b.addStaticLibrary(.{
         .name = "Acton",
         .target = target,
+        .root_source_file = b.path("__root.zig"),
         .optimize = optimize,
     });
     for (c_files.items) |entry| {
@@ -268,4 +269,16 @@ pub fn build(b: *std.Build) void {
     libActon.linkLibC();
     libActon.linkLibCpp();
     b.installArtifact(libActon);
+
+    const base_tests = b.addTest(.{
+        .root_source_file = b.path("acton.zig"),
+        .optimize = optimize,
+    });
+    base_tests.addIncludePath(.{ .cwd_relative = buildroot_path });
+    base_tests.linkLibrary(dep_libbsdnt.artifact("bsdnt"));
+    base_tests.linkLibrary(dep_libgc.artifact("gc"));
+    base_tests.linkLibC();
+    const run_base_tests = b.addRunArtifact(base_tests);
+    const test_step = b.step("test", "Run tests");
+    test_step.dependOn(&run_base_tests.step);
 }

--- a/base/rts/gc.zig
+++ b/base/rts/gc.zig
@@ -1,0 +1,174 @@
+const std = @import("std");
+const assert = std.debug.assert;
+const testing = std.testing;
+const mem = std.mem;
+const Allocator = std.mem.Allocator;
+
+const gc = @cImport({
+    @cInclude("gc.h");
+});
+
+/// Returns the Allocator used for APIs in Zig
+pub fn allocator() Allocator {
+    // Initialize libgc
+    if (gc.GC_is_init_called() == 0) {
+        gc.GC_init();
+    }
+
+    return Allocator{
+        .ptr = undefined,
+        .vtable = &gc_allocator_vtable,
+    };
+}
+
+/// Enable or disable interior pointers.
+/// If used, this must be called before the first allocator() call.
+pub fn setAllInteriorPointers(enable_interior_pointers: bool) void {
+    gc.GC_set_all_interior_pointers(@intFromBool(enable_interior_pointers));
+}
+
+/// Returns the current heap size of used memory.
+pub fn getHeapSize() u64 {
+    return gc.GC_get_heap_size();
+}
+
+/// Disable garbage collection.
+pub fn disable() void {
+    gc.GC_disable();
+}
+
+/// Enables garbage collection. GC is enabled by default so this is
+/// only useful if you called disable earlier.
+pub fn enable() void {
+    gc.GC_enable();
+}
+
+// Performs a full, stop-the-world garbage collection. With leak detection
+// enabled this will output any leaks as well.
+pub fn collect() void {
+    gc.GC_gcollect();
+}
+
+/// Perform some garbage collection. Returns zero when work is done.
+pub fn collectLittle() u8 {
+    return @as(u8, @intCast(gc.GC_collect_a_little()));
+}
+
+/// Enables leak-finding mode. See the libgc docs for more details.
+pub fn setFindLeak(v: bool) void {
+    return gc.GC_set_find_leak(@intFromBool(v));
+}
+
+// TODO(mitchellh): there are so many more functions to add here
+// from gc.h, just add em as they're useful.
+
+/// GcAllocator is an implementation of std.mem.Allocator that uses
+/// libgc under the covers. This means that all memory allocated with
+/// this allocated doesn't need to be explicitly freed (but can be).
+///
+/// The GC is a singleton that is globally shared. Multiple GcAllocators
+/// do not allocate separate pages of memory; they share the same underlying
+/// pages.
+///
+// NOTE(mitchellh): this is basically just a copy of the standard CAllocator
+// since libgc has a malloc/free-style interface. There are very slight differences
+// due to API differences but overall the same.
+pub const GcAllocator = struct {
+    fn alloc(
+        _: *anyopaque,
+        len: usize,
+        log2_align: u8,
+        return_address: usize,
+    ) ?[*]u8 {
+        _ = return_address;
+        assert(len > 0);
+        return alignedAlloc(len, log2_align);
+    }
+
+    fn resize(
+        _: *anyopaque,
+        buf: []u8,
+        log2_buf_align: u8,
+        new_len: usize,
+        return_address: usize,
+    ) bool {
+        _ = log2_buf_align;
+        _ = return_address;
+        if (new_len <= buf.len) {
+            return true;
+        }
+
+        const full_len = alignedAllocSize(buf.ptr);
+        if (new_len <= full_len) {
+            return true;
+        }
+
+        return false;
+    }
+
+    fn free(
+        _: *anyopaque,
+        buf: []u8,
+        log2_buf_align: u8,
+        return_address: usize,
+    ) void {
+        _ = log2_buf_align;
+        _ = return_address;
+        alignedFree(buf.ptr);
+    }
+
+    fn getHeader(ptr: [*]u8) *[*]u8 {
+        return @as(*[*]u8, @ptrFromInt(@intFromPtr(ptr) - @sizeOf(usize)));
+    }
+
+    fn alignedAlloc(len: usize, log2_align: u8) ?[*]u8 {
+        const alignment = @as(usize, 1) << @as(Allocator.Log2Align, @intCast(log2_align));
+
+        // Thin wrapper around regular malloc, overallocate to account for
+        // alignment padding and store the orignal malloc()'ed pointer before
+        // the aligned address.
+        const unaligned_ptr = @as([*]u8, @ptrCast(gc.GC_malloc(len + alignment - 1 + @sizeOf(usize)) orelse return null));
+        const unaligned_addr = @intFromPtr(unaligned_ptr);
+        const aligned_addr = mem.alignForward(usize, unaligned_addr + @sizeOf(usize), alignment);
+        const aligned_ptr = unaligned_ptr + (aligned_addr - unaligned_addr);
+        getHeader(aligned_ptr).* = unaligned_ptr;
+
+        return aligned_ptr;
+    }
+
+    fn alignedFree(ptr: [*]u8) void {
+        const unaligned_ptr = getHeader(ptr).*;
+        gc.GC_free(unaligned_ptr);
+    }
+
+    fn alignedAllocSize(ptr: [*]u8) usize {
+        const unaligned_ptr = getHeader(ptr).*;
+        const delta = @intFromPtr(ptr) - @intFromPtr(unaligned_ptr);
+        return gc.GC_size(unaligned_ptr) - delta;
+    }
+};
+
+const gc_allocator_vtable = Allocator.VTable{
+    .alloc = GcAllocator.alloc,
+    .resize = GcAllocator.resize,
+    .free = GcAllocator.free,
+};
+
+test "GcAllocator" {
+    const alloc = allocator();
+
+    try std.heap.testAllocator(alloc);
+    try std.heap.testAllocatorAligned(alloc);
+    try std.heap.testAllocatorLargeAlignment(alloc);
+    try std.heap.testAllocatorAlignedShrink(alloc);
+}
+
+test "heap size" {
+    // No garbage so should be 0
+    try testing.expect(collectLittle() == 0);
+
+    // Force a collection should work
+    collect();
+
+    try testing.expect(getHeapSize() > 0);
+}

--- a/base/src/base64.act
+++ b/base/src/base64.act
@@ -1,0 +1,5 @@
+def encode(data: str) -> str:
+    NotImplemented
+
+def decode(data: str) -> str:
+    NotImplemented

--- a/base/src/base64.ext.c
+++ b/base/src/base64.ext.c
@@ -1,0 +1,1 @@
+void base64Q___ext_init__() {}

--- a/test/stdlib_tests/src/test_base64.act
+++ b/test/stdlib_tests/src/test_base64.act
@@ -1,0 +1,11 @@
+import base64
+
+import testing
+
+def _test_base64():
+    i = "foobar"
+    for a in range(1000):
+        e = base64.encode(i)
+        #testing.assertEqual(e, "Zm9vYmFy")
+        d = base64.decode(e)
+        testing.assertEqual(i, d)


### PR DESCRIPTION
This adds a new stdlib module called base64. It does exactly what you think it does. What's slightly cooler is the way it is implemented. Base now includes a __root.zig file, which is the root module of base. It defines two functions:

export fn base64Q_encode(data: *acton.str) callconv(.C) *acton.str {
export fn base64Q_decode(data: *acton.str) callconv(.C) *acton.str {

These are written in Zig but using the C ABI, 'export' saying they should be exported, having the C calling convention and taking input and output of the Zig type called `acton.str`. I have created this new acton module in Zig which is meant to contain acton related things. In this case some types, although so far I have only gotten to implement the B_str type. Unlike C, Zig has modules so we don't have to treat everything with a global name, that means acton.str can actually be acton.str and doesn't collide with anything else called str in some other module. Neat. Also, while Zig does expose a bunch of types that are guarantee to match the C ABI, like c_int matches int in C on each platform, I have opted to use more idiomatic Zig types since I think the end goal is not to keep our C structs but to convert to Zig. Using more Zig idiomatic types can save us some ugly intCasts. Obviously though, the size of the ints have to line up, so I check that now with a comptime test that inspects the type from Acton builtin (we import builtin.h) and the Zig defined acton.str. Now, in this particular code right now we still get an intCast, but this is because the C struct is used a int and maybe it would be more natural with a word sized int instead? I didn't want to change our builtins in this commit, so I left that for now, but by changing the B_str nbytes / nchars to like u64, we could get to use the very idiomatic usize in Zig which happens to map to what the Zig base64 functions take and produce!

It's quite a lot of boiler plate, wrapping things up in C.. but it works. Maybe we can find nicer patterns for how to do this or maybe automatically generate this binding code from the compiler? It would be pretty nice if we could just write a base64.ext.zig and in there have a

pub fn encode(data: *acton.str) *acton.str {

i.e. skip a lot of the C mumbo jumbo. I guess it's hard to avoid creating our box.

Also added in rts/gc.zig, which is a Zig module for the BDW GC that we are already using. I opted to inline this file instead of adding a dependency on yet another thing.  While zig can fetch stuff, it doesn't help us bundle that in the Acton distribution, so easier to inline. Plus, I'm hoping we can test out this interface and try to upstream it.

Fixes #1468 

Fixes #1469 