### PR TITLE
Let local dep path take precedence over URL

### DIFF
--- a/cli/src/acton.act
+++ b/cli/src/acton.act
@@ -266,7 +266,9 @@ actor BuildProject(process_cap, env, args, on_build_success: action(str) -> None
             # Does deps/X exist?
             hash = dep.hash
             path = dep.path
-            if hash is not None:
+            if path is not None:
+                pass
+            elif hash is not None:
                 if dep_name not in deps_dir:
                     print("Copying", dep_name, "from zig global cache")
                     try:
@@ -277,10 +279,8 @@ actor BuildProject(process_cap, env, args, on_build_success: action(str) -> None
                     dst = file.join_path([fs.cwd(), ".build", "deps", dep_name])
                     print("Copying", src, "to", dst)
                     await async fs.copytree(src, dst)
-            elif path is not None:
-                pass
             else:
-                raise ValueError("Dependency %s has no hash" % dep_name)
+                raise ValueError("Dependency %s has no hash or path set" % dep_name)
         build_deps()
 
     def on_zig_fetch_error(error):


### PR DESCRIPTION
If a dependency is available both remotely as well as locally via a path, the local path should take precedence. A common scenario would be that the dependency normally is available as a download from the Internet but the user decides to fork the dependency and make changes to it. After cloning the repo, we can use the dependency just by updating the build.act.json and set the path to the local clone.

Fixes #1907