### PR TITLE
Speed up CI run-linux by doing 1 iteration (not 50)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -361,14 +361,13 @@ jobs:
           ulimit -c unlimited
       - name: "Compile acton program"
         run: |
-          echo '#!/usr/bin/env runacton'   > test-runtime.act
-          echo 'actor main(env):'          >> test-runtime.act
-          echo '    print("Hello, world")' >> test-runtime.act
-          echo '    env.exit(0)'           >> test-runtime.act
-          chmod a+x test-runtime.act
-          ./test-runtime.act
-          ./test-runtime.act | grep "Hello, world"
-          for I in $(seq 50); do ./test-runtime.act || break; done
+          echo '#!/usr/bin/env runacton'   > acton-test.act
+          echo 'actor main(env):'          >> acton-test.act
+          echo '    print("Hello, world")' >> acton-test.act
+          echo '    env.exit(0)'           >> acton-test.act
+          chmod a+x acton-test.act
+          ./acton-test.act
+          ./acton-test.act | grep "Hello, world"
       - name: "ls core"
         if: failure()
         run: |


### PR DESCRIPTION
The iterations was meant at some point to catch errors but even with the error in mind (we had a problem at the time) we never saw this testing any errors, it's just too small and simple of a test. It's point and thus I'm removing it. I think it should also speed up the test execution by a bit since when we use the script style runacton execution, each invocation actually gets its own file, which means it's compiled anew and thus takes "some time". It feels in CI like this is 0.5~1s per iteration, so we're looking at 20-60 seconds of time for a whole test!?