### PR TITLE
Remove embedded Builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,6 @@ builder/builder
 builder/build_runner.zig
 builder/zig-cache
 
-compiler/Acton/Builder.hs
 compiler/actonc
 compiler/package.yaml
 compiler/tests/*.ty


### PR DESCRIPTION
Acton.Builder in the compiler was an embedding of the builder so that we could generate it, but this haswon been moved to the acton cli, so we can remove it from actonc entirely!