### PR TITLE
Allow naming overlap for hierarchical modules

### DIFF
--- a/compiler/Acton/Env.hs
+++ b/compiler/Acton/Env.hs
@@ -435,7 +435,7 @@ addMod                     :: ModName -> TEnv -> EnvF x -> EnvF x
 addMod m newte env          = env{ modules = addM ns (modules env) }
   where
     ModName ns              = m
-    addM [] te              = newte
+    addM [] te              = newte ++ te
     addM (n:ns) te          = update n ns te
     update n ns ((x,i):te)
       | n == x,


### PR DESCRIPTION
Having a module foo (src/foo.act) and a foo.bar (src/foo/bar.act) would previously "conflict" and lead to a compilation error. We now allow it. We should really have some more checks around this to ensure that there are no true conflicts, i.e. that the module foo does not define any "bar", since the foo.bar is now a module... but that's for later ;) Meanwhile, one needs to be careful :)

Fixes #1657 