### PR TITLE
Fix assert(Not)Equal & add tests

### DIFF
--- a/base/src/testing.act
+++ b/base/src/testing.act
@@ -181,11 +181,14 @@ class NotIsInstanceError(AssertionError):
 
 
 def assertEqual[T(Eq)](a: ?T, b: ?T, msg: ?str):
-    if a is not None and b is not None and not (a == b):
+    if ((a is None and b is not None)
+        or (a is not None and b is None)
+        or (a is not None and b is not None and not (a == b))):
         raise NotEqualError(a, b, msg)
 
-def assertNotEqual(a, b, msg: ?str):
-    if not (a != b):
+def assertNotEqual[T(Eq)](a: ?T, b: ?T, msg: ?str):
+    if ((a is None and b is None)
+        or (a is not None and b is not None and a == b)):
         raise EqualError(a, b, msg)
 
 def assertTrue(a, msg: ?str):

--- a/test/stdlib_tests/src/test_logging.act
+++ b/test/stdlib_tests/src/test_logging.act
@@ -65,12 +65,12 @@ actor MyApp(log_handler):
 actor LogTester(report_result: action(?bool, ?Exception) -> None, log_handler: logging.Handler):
 
     expected_logs = [
-        logging.Message(logging.INFO, [], "", "hej", None),
-        logging.Message(logging.INFO, [], "", "hello", None),
-        logging.Message(logging.DEBUG, [], "", "dello", None),
-        logging.Message(logging.INFO, ["MyApp"], "", "Starting up", None),
-        logging.Message(logging.INFO, ["MyApp"], "", "Doing some work", None),
-        logging.Message(logging.INFO, ["MyApp"], "", "Bidabopp", {"actor": "MyApp", "thing": "bopp", "number": 42}),
+        logging.Message(logging.INFO, [], None, "hej", None),
+        logging.Message(logging.INFO, [], None, "hello", None),
+        logging.Message(logging.DEBUG, [], None, "dello", None),
+        logging.Message(logging.INFO, ["MyApp"], None, "Starting up", None),
+        logging.Message(logging.INFO, ["MyApp"], None, "Doing some work", None),
+        logging.Message(logging.INFO, ["MyApp"], None, "Bidabopp", {"actor": "MyApp", "thing": "bopp", "number": 42}),
         logging.Message(logging.EMERGENCY, ["MyApp", "deepfun", "deepy"], "deepy", "deep emergency", None),
         logging.Message(logging.ALERT, ["MyApp", "deepfun", "deepy"], "deepy", "deep alert", None),
         logging.Message(logging.CRITICAL, ["MyApp", "deepfun", "deepy"], "deepy", "deep critical", None),

--- a/test/stdlib_tests/src/test_testing_asserts.act
+++ b/test/stdlib_tests/src/test_testing_asserts.act
@@ -1,0 +1,72 @@
+
+import testing
+from testing import NotEqualError
+
+def _test_assert_equal() -> None:
+    """Test assertEqual"""
+
+    # should raise NotEqualError because 1 != 2
+    try:
+        testing.assertEqual(1, 2)
+    except AssertionError as e:
+        pass
+    else:
+        raise Exception("assertEqual(1, 2) should have raised NotEqualError")
+
+    # should raise NotEqualError because 1 != None
+    try:
+        testing.assertEqual(1, None)
+    except AssertionError as e:
+        pass
+    else:
+        raise Exception("assertEqual(1, None) should have raised NotEqualError")
+
+    # should raise NotEqualError because None != 1
+    try:
+        testing.assertEqual(None, 1)
+    except AssertionError as e:
+        pass
+    else:
+        raise Exception("assertEqual(None, 1) should have raised NotEqualError")
+
+    # should not raise NotEqualError because None == None
+    try:
+        testing.assertEqual(None, None)
+    except AssertionError as e:
+        raise Exception("assertEqual(None, None) should not have raised NotEqual")
+
+def _test_assert_not_equal() -> None:
+    """Test assertNotEqual"""
+
+    # should not raise NotEqualError because 1 != 2
+    try:
+        testing.assertNotEqual(1, 2)
+    except AssertionError as e:
+        raise Exception("assertNotEqual(1, 2) should not have raised NotEqualError")
+
+    # should not raise NotEqualError because 1 != None
+    try:
+        testing.assertNotEqual(1, None)
+    except AssertionError as e:
+        raise Exception("assertNotEqual(1, None) should not have raised NotEqualError")
+
+    # should not raise NotEqualError because None != 1
+    try:
+        testing.assertNotEqual(None, 1)
+    except AssertionError as e:
+        raise Exception("assertNotEqual(None, 1) should not have raised NotEqualError")
+
+    # should raise NotEqualError because None == None
+    try:
+        testing.assertNotEqual(None, None)
+    except AssertionError as e:
+        pass
+    else:
+        raise Exception("assertNotEqual(None, None) should have raised NotEqual")
+
+    try:
+        testing.assertNotEqual(1, 1)
+    except AssertionError as e:
+        pass
+    else:
+        raise Exception("assertNotEqual(1, 1) should have raised NotEqual")


### PR DESCRIPTION
Now assertEqual & assertNotEqual actually work properly for None values. Previously they only compared correctly for non-None values.

Also added a test of these testing functions.