### PR TITLE
Test acton-yang project

### DIFF
--- a/.github/workflows/test-app.yml
+++ b/.github/workflows/test-app.yml
@@ -1,0 +1,33 @@
+
+on:
+  workflow_call:
+    inputs:
+      repo_url:
+        required: true
+        type: string
+jobs:
+  test-app:
+    runs-on: ubuntu-latest
+    container:
+      image: debian:experimental
+    steps:
+      - name: "Download .deb files"
+        uses: actions/download-artifact@v3
+        with:
+          name: acton-debs
+      - name: "Install acton from .deb"
+        run: |
+          apt update
+          apt install -y ./deb/acton_*.deb
+          acton --version
+      - name: "Clone app repo"
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.repo_url }}
+          path: app
+      - name: "Compile acton program"
+        run: |
+          cd app
+          acton build
+          acton test
+          acton test perf

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -485,6 +485,11 @@ jobs:
           make start
           make test
 
+  test-app-yang:
+    needs: build-debs
+    uses: "./.github/workflows/test-app.yml"
+    with:
+      repo_url: "orchestron-orchestrator/acton-yang"
 
   # If we are on the main branch, we'll create or update a pre-release called
   # 'tip' which holds the latest build output from the main branch!  We upload


### PR DESCRIPTION
Add a GitHub CI reusable workflow to test Acton projects by just providing a git repo URL. The first project we test is the acton-yang repo, the YANG module & compiler.