### PR TITLE
Fix so dependency "path" works

### DIFF
--- a/base/src/buildy.act
+++ b/base/src/buildy.act
@@ -101,11 +101,11 @@ class Dependency(object):
                 data_url = data["url"]
                 if isinstance(data_url, str):
                     dep_url = data_url
-            elif "hash" in data:
+            elif key == "hash":
                 data_hash = data["hash"]
                 if isinstance(data_hash, str):
                     dep_hash = data_hash
-            elif "path" in data:
+            elif key == "path":
                 data_path = data["path"]
                 if isinstance(data_path, str):
                     dep_path = data_path


### PR DESCRIPTION
I think this is the first bug that I have checked in that is probably written by Copilot. I usually spot such things immediately since I let it write just a few lines at a time but the pattern here was probably somehow close enough so that it "looked right". Blargh. Anyhow, now fixed!