### PR TITLE
Add test for actor with mut arg

### DIFF
--- a/test/builtins_auto/actor_mutarg.act
+++ b/test/builtins_auto/actor_mutarg.act
@@ -1,0 +1,5 @@
+actor Foo(cb: mut() -> None):
+    pass
+
+actor main(env):
+    env.exit(0)


### PR DESCRIPTION
The compiler currently complains about this, stating that mut leaks the actor seal, but I don't think that is right. I don't see how it is leaking...

kll@Kristians-MacBook-Air builtins_auto % acton actor_mutarg.act Building file actor_mutarg.act
  Compiling actor_mutarg.act for release

ERROR: Error when compiling actor_mutarg module: Type error

  |
2 |actor Foo(cb: mut() -> None):
  |              ^^^
Leaking actor seal: mut

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

kll@Kristians-MacBook-Air builtins_auto %