### PR TITLE
Fix hierarchical module import

### DIFF
--- a/compiler/Acton/Env.hs
+++ b/compiler/Acton/Env.hs
@@ -518,11 +518,16 @@ lookupMod                   :: ModName -> EnvF x -> Maybe TEnv
 lookupMod m env | inBuiltin env, m==mBuiltin
                             = Just (names env)
 lookupMod (ModName ns) env  = f ns (modules env)
-  where f [] te             = Just te
+  where f [] te
+          | not (all isNModule te) = Just te
+          | otherwise              = Nothing
         f (n:ns) te         = case lookup n te of
                                 Just (NModule te') -> f ns te'
                                 Just (NMAlias (ModName m)) -> lookupMod (ModName $ m++ns) env
                                 _ -> Nothing
+        isNModule (_, NModule{}) = True
+        isNModule _         = False
+
 
 isMod                       :: EnvF x -> [Name] -> Bool
 isMod env ns                = maybe False (const True) (findMod (ModName ns) env)

--- a/compiler/ActonCompiler.hs
+++ b/compiler/ActonCompiler.hs
@@ -523,7 +523,8 @@ data BinTask            = BinTask { isDefaultRoot :: Bool, binName :: String, ro
 
 -- return task where the specified root actor exists
 filterMainActor env opts paths binTask
-                         = case lookup n (fromJust (Acton.Env.lookupMod m env)) of
+                         = case Acton.Env.lookupMod m env of
+                             Just te -> case lookup n te of
                                Just (A.NAct [] A.TNil{} (A.TRow _ _ _ t A.TNil{}) _)
                                    | prstr t == "Env" || prstr t == "None"
                                       || prstr t == "__builtin__.Env"|| prstr t == "__builtin__.None"-> do   -- TODO: proper check of parameter type
@@ -531,6 +532,7 @@ filterMainActor env opts paths binTask
                                    | otherwise -> return Nothing
                                Just t -> return Nothing
                                Nothing -> return Nothing
+                             Nothing -> return Nothing
   where mn                  = A.mname qn
         qn@(A.GName m n)    = rootActor binTask
         (sc,_)              = Acton.QuickType.schemaOf env (A.eQVar qn)


### PR DESCRIPTION
We had some tricky cases where we got compilation errors due to imports not working properly. It has to do with hierarchical modules, so like when there is a foo.act and a foo/bar.act. If we import foo.bar first into our compilation environment, the foo module will just be an empty module, but it will exist and so if we later on import foo, the compiler thinks it is already imported, won't read the .ty file and then proceed to (likely at least) give some error about whatever we tried to access in the foo module does not exist.

We now check explicitly if the module is empty. If it is, we try to import it by reading .ty file. We cannot differentiate between an actually empty module and a module that is just a placeholder, i.e. have only been created to form the structure to a submodule, and so our only choice is to attempt to read the .ty file whenever we have an empty module. The caching we have here is useful but won't work for empty module, however, re-reading empty modules likely isn't very expensive and actually having empty modules is likely to be exceedingly rare in real life.