### PR TITLE
Proper class hierarchy for Dependency

### DIFF
--- a/base/src/buildy.act
+++ b/base/src/buildy.act
@@ -24,10 +24,10 @@ class BuildConfig(object):
     - zig_dependencies are dependencies on Zig projects, which could in turn be
       Zig, C or C++ libraries that get linked in with the project
     """
-    dependencies: dict[str, Dependency]
+    dependencies: dict[str, PkgDependency]
     zig_dependencies: dict[str, ZigDependency]
 
-    def __init__(self, dependencies: dict[str, Dependency]={}, zig_dependencies: dict[str, ZigDependency]={}):
+    def __init__(self, dependencies: dict[str, PkgDependency]={}, zig_dependencies: dict[str, ZigDependency]={}):
         self.dependencies = dependencies
         self.zig_dependencies = zig_dependencies
 
@@ -43,7 +43,7 @@ class BuildConfig(object):
                         if isinstance(value, dict):
                             for dep_name, dep_attrs in value.items():
                                 if isinstance(dep_name, str) and isinstance(dep_attrs, dict):
-                                    dep = Dependency.from_json(dep_name, dep_attrs)
+                                    dep = PkgDependency.from_json(dep_name, dep_attrs)
                                     new_dependencies[dep_name] = dep
                                 else:
                                     raise ValueError("Invalid build.act.json, dependencies should be a dict")
@@ -85,6 +85,8 @@ class Dependency(object):
     hash: ?str
     path: ?str
 
+class PkgDependency(Dependency):
+
     def __init__(self, name: str, url: ?str, hash: ?str, path: ?str):
         self.name = zig_safe_name(name)
         self.url = url
@@ -111,7 +113,7 @@ class Dependency(object):
                     dep_path = data_path
             else:
                 raise ValueError("Invalid build.act.json, unknown key '%s' in dependency '%s'" % (key, dep_name))
-        return Dependency(dep_name, dep_url, dep_hash, dep_path)
+        return PkgDependency(dep_name, dep_url, dep_hash, dep_path)
 
     def to_json(self) -> dict[str, str]:
         res = {}

--- a/cli/src/acton.act
+++ b/cli/src/acton.act
@@ -622,7 +622,7 @@ actor ZigFetchDeps(env, build_config: BuildConfig, on_done: action() -> None, on
                     on_fetch_error(errmsg)
                     return
 
-            if isinstance(dep, Dependency):
+            if isinstance(dep, PkgDependency):
                 del dep_processes[dep.name]
             elif isinstance(dep, ZigDependency):
                 del zig_processes[dep.name]
@@ -751,7 +751,7 @@ actor CmdPkgAdd(env, args):
                     bc_dep.hash = dep_hash
             else:
                 # Add the hash
-                build_config.dependencies[dep_name] = Dependency(dep_name, dep_url, dep_hash)
+                build_config.dependencies[dep_name] = PkgDependency(dep_name, dep_url, dep_hash)
                 print("Added new package dependency", dep_name, "with hash", dep_hash)
 
             baj_file = file.WriteFile(file.WriteFileCap(file.FileCap(env.cap)), "build.act.json")


### PR DESCRIPTION
We have to be able to separate the base type from the type for our pkg dependencies, so renamed the latter to PkgDependency.

Previously we got an error when downloading zig deps since in the fetch code we would check if it's a pkg dependency or zig dependency and then delete from the corresponding list of outstanding downloads, but an isinstance check on the pkg Dependency also matched the base type of ZigDependency, and so we would try to delete it from the wrong dict and get an error.