### PR TITLE
Idempotently fetch deps

### DIFF
--- a/cli/src/acton.act
+++ b/cli/src/acton.act
@@ -320,7 +320,7 @@ actor BuildProject(process_cap, env, args, on_build_success: action(str) -> None
             await async env.exit(1)
 
         write_buildzig(file.FileCap(env.cap), build_config)
-        zfd = ZigFetchDeps(env, build_config, check_deps, on_zig_fetch_error)
+        zfd = ZigFetchDeps(env, build_config, lambda x, y: check_deps(), on_zig_fetch_error)
 
     def get_lock():
         """Try to get the build lock for the project
@@ -595,7 +595,7 @@ def build_cmd_args(args):
     return cmdargs
 
 
-actor ZigFetchDeps(env, build_config: BuildConfig, on_done: action() -> None, on_fetch_error: action(str) -> None, print_output: bool=False):
+actor ZigFetchDeps(env, build_config: BuildConfig, on_done: action(int, int) -> None, on_fetch_error: action(str) -> None, print_output: bool=False):
     """Fetch dependencies and Zig dependencies
     """
     pcap = process.ProcessCap(env.cap)
@@ -606,12 +606,14 @@ actor ZigFetchDeps(env, build_config: BuildConfig, on_done: action() -> None, on
 
     dep_processes = {}
     zig_processes = {}
+    var total = 0
+    var fetched = 0
 
     def on_exit(dep: Dependency, p, exit_code, term_signal, stdout_buf, stderr_buf):
         if exit_code == 0:
             fetched_hash: str = stdout_buf.decode().strip()
             if print_output:
-                print("Fetched", fetched_hash, err=True)
+                print("Fetched dependency %s with hash %s" % (dep.name, fetched_hash), err=True)
 
             dep_hash = dep.hash
             if dep_hash is not None:
@@ -622,13 +624,14 @@ actor ZigFetchDeps(env, build_config: BuildConfig, on_done: action() -> None, on
                     on_fetch_error(errmsg)
                     return
 
+            fetched += 1
             if isinstance(dep, PkgDependency):
                 del dep_processes[dep.name]
             elif isinstance(dep, ZigDependency):
                 del zig_processes[dep.name]
 
             if len(dep_processes) == 0 and len(zig_processes) == 0:
-                on_done()
+                on_done(total, fetched)
         else:
             on_fetch_error(stderr_buf.decode())
 
@@ -638,8 +641,26 @@ actor ZigFetchDeps(env, build_config: BuildConfig, on_done: action() -> None, on
 
     zig_global_cache_dir = get_zig_global_cache_dir(file.FileCap(env.cap))
     for dep_name, dep in build_config.dependencies.items():
+        total += 1
+        dep_path = dep.path
+        if dep_path is not None:
+            if print_output:
+                print("Skip fetching dependency %s that uses local path (%s)" % (dep.name, dep_path))
+            continue
+
         dep_url = dep.url
+        dep_hash = dep.hash
         if dep_url is not None:
+            if dep_hash is not None:
+                dep_dir = file.join_path([zig_global_cache_dir, "p", dep_hash])
+                try:
+                    s = fs.stat(dep_dir)
+                    continue
+                except:
+                    pass
+            else:
+                on_fetch_error("dependency %s does not have a hash configured")
+
             cmd = [zig, "fetch", "--global-cache-dir", zig_global_cache_dir, dep_url]
             p = process.RunProcess(
                 pcap,
@@ -649,8 +670,25 @@ actor ZigFetchDeps(env, build_config: BuildConfig, on_done: action() -> None, on
             dep_processes[dep.name] = p
 
     for dep_name, dep in build_config.zig_dependencies.items():
+        total += 1
+        dep_path = dep.path
+        if dep_path is not None:
+            if print_output:
+                print("Skip fetching dependency %s that uses local path (%s)" % (dep.name, dep_path))
+            continue
+
         dep_url = dep.url
+        dep_hash = dep.hash
         if dep_url is not None:
+            if dep_hash is not None:
+                dep_dir = file.join_path([zig_global_cache_dir, "p", dep_hash])
+                try:
+                    s = fs.stat(dep_dir)
+                    continue
+                except:
+                    pass
+            else:
+                on_fetch_error("dependency %s does not have a hash configured")
 
             cmd = [zig, "fetch", "--global-cache-dir", zig_global_cache_dir, dep_url]
             p = process.RunProcess(
@@ -661,7 +699,7 @@ actor ZigFetchDeps(env, build_config: BuildConfig, on_done: action() -> None, on
             zig_processes[dep.name] = p
 
     if len(dep_processes) == 0 and len(zig_processes) == 0:
-        on_done()
+        on_done(total, fetched)
 
 
 actor CmdFetch(env, args):
@@ -685,20 +723,18 @@ actor CmdFetch(env, args):
     dep_processes = {}
     zig_processes = {}
 
-    def all_done():
-        print("All dependencies fetched", err=True)
+    def all_done(total, fetched):
+        if total == 0:
+            print("No dependencies to fetch", err=True)
+        else:
+            print("All dependencies up to date", err=True)
         env.exit(0)
 
     def on_zig_fetch_error(errmsg):
         print(errmsg, err=True)
         env.exit(1)
 
-    # TODO: call ZigFetchDeps instead!?
-    if len(build_config.dependencies) == 0 and len(build_config.zig_dependencies) == 0:
-        print("No dependencies to fetch")
-        env.exit(0)
-    else:
-        zfd = ZigFetchDeps(env, build_config, all_done, on_zig_fetch_error)
+    zfd = ZigFetchDeps(env, build_config, all_done, on_zig_fetch_error, print_output=True)
 
 
 actor CmdPkgAdd(env, args):


### PR DESCRIPTION
If we already have the deps, identified by their hash, on disk, we don't need to fetch them again!

Fixes #1952 