### PR TITLE
Install zstd before cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -255,6 +255,7 @@ jobs:
         with:
           path: |
             ./debian/.debhelper/
+            ~/.stack
           key: build-debs
       - name: "locale en_US.UTF-8"
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -243,6 +243,11 @@ jobs:
         run: |
           echo "BUILD_RELEASE=1" >> $GITHUB_ENV
         if: startsWith(github.ref, 'refs/tags/v')
+      - name: "Install build prerequisites"
+        run: |
+          apt-get update
+          apt-get install -qy bzip2 curl g++ haskell-stack make procps zlib1g-dev
+          apt-get install -qy bash-completion build-essential debhelper devscripts
       - name: "Check out repository code"
         uses: actions/checkout@v4
       - name: "Cache stuff"
@@ -251,11 +256,6 @@ jobs:
           path: |
             ./debian/.debhelper/
           key: build-debs
-      - name: "Install build prerequisites"
-        run: |
-          apt-get update
-          apt-get install -qy bzip2 curl g++ haskell-stack make procps zlib1g-dev
-          apt-get install -qy bash-completion build-essential debhelper devscripts
       - name: "locale en_US.UTF-8"
         run: |
           apt-get install -qy locales


### PR DESCRIPTION
The GitHub runner cache relies on zstd, so in order to provide a consistent environment, where both the pre and post cache steps run consistently, we move the installation of build stuff before the cache step.