### PR TITLE
Remove old deps discovery

### DIFF
--- a/builder/build.zig
+++ b/builder/build.zig
@@ -38,13 +38,10 @@ pub fn build(b: *std.Build) void {
     const db = b.option(bool, "db", "") orelse false;
     const only_lib = b.option(bool, "only_lib", "") orelse false;
     const no_threads = b.option(bool, "no_threads", "") orelse false;
-    const arg_deps_path = b.option([]const u8, "deps_path", "") orelse "";
-
-    const deps_path = if (arg_deps_path.len > 0) arg_deps_path else joinPath(b.allocator, buildroot_path, "deps");
 
     const projpath_outtypes = joinPath(b.allocator, buildroot_path, "out/types");
 
-    print("Acton Project Builder - building {s}\nDeps path: {s}\n", .{buildroot_path, deps_path});
+    print("Acton Project Builder - building {s}\n", .{buildroot_path});
 
     const actonbase_dep = b.dependency("base", .{
         .target = target,

--- a/cli/src/acton.act
+++ b/cli/src/acton.act
@@ -184,7 +184,9 @@ actor BuildProject(process_cap, env, args, on_build_success: action(str) -> None
                 else:
                     search_paths.append(file.join_path([fs.cwd(), path, "out", "types"]))
             elif hash is not None:
-                search_paths.append(file.join_path([zig_global_cache_dir, "p", hash, "out", "types"]))
+                # For dependencies with hashes, we have previously copied them
+                # from the Zig global cache to .build/deps/
+                search_paths.append(file.join_path([fs.cwd(), ".build", "deps", dep_name, "out", "types"]))
             else:
                 raise ValueError("Dependency %s has no hash" % dep_name)
         search_path_arg = []
@@ -199,7 +201,7 @@ actor BuildProject(process_cap, env, args, on_build_success: action(str) -> None
         if build_tests:
             cmdargs.append("--dev")
             cmdargs.append("--test")
-        cmd = cmdargs + ["--deppath", file.join_path([fs.cwd(), ".build", "deps"])] + search_path_arg
+        cmd = cmdargs + search_path_arg
         cr = CompilerRunner(
             process_cap,
             env,

--- a/compiler/Acton/CommandLineParser.hs
+++ b/compiler/Acton/CommandLineParser.hs
@@ -66,7 +66,6 @@ data CompileOptions   = CompileOptions {
                          root        :: String,
                          tempdir     :: String,
                          syspath     :: String,
-                         deppath     :: String,
                          target      :: String,
                          cpu         :: String,
                          test        :: Bool,
@@ -90,7 +89,6 @@ data BuildOptions = BuildOptions {
                          timingB     :: Bool,
                          targetB     :: String,
                          cpuB        :: String,
-                         deppathB    :: String,
                          testB       :: Bool,
                          keepbuildB  :: Bool,
                          searchpathB :: [String]
@@ -166,7 +164,6 @@ compileOptions = CompileOptions
         <*> strOption (long "root"      <> metavar "ROOTACTOR" <> value "" <> help "Set root actor")
         <*> strOption (long "tempdir"   <> metavar "TEMPDIR" <> value "" <> help "Set directory for build files")
         <*> strOption (long "syspath"   <> metavar "TARGETDIR" <> value "" <> help "Set syspath")
-        <*> strOption (long "deppath"   <> metavar "DIR" <> value "" <> help "Set deppath")
         <*> strOption (long "target"    <> metavar "TARGET" <> value defTarget <> help "Target, e.g. x86_64-linux-gnu.2.28")
         <*> strOption (long "cpu"       <> metavar "CPU" <> value "" <> help "CPU, e.g. skylake")
         <*> switch (long "test"         <> help "Build tests")
@@ -190,7 +187,6 @@ buildCommand          = Build <$> (
         <*> switch (long "timing"       <> help "Print timing information")
         <*> strOption (long "target"    <> metavar "TARGET" <> value defTarget <> help "Target, e.g. x86_64-linux-gnu.2.28")
         <*> strOption (long "cpu"       <> metavar "CPU" <> value "" <> help "CPU, e.g. skylake")
-        <*> strOption (long "deppath"   <> metavar "DIR" <> value "" <> help "Set deppath")
         <*> switch (long "test"         <> help "Build tests")
         <*> switch (long "keepbuild"    <> help "Keep build.zig")
         <*> many (strOption (long "searchpath" <> metavar "DIR" <> help "Add search path"))

--- a/compiler/Acton/Env.hs
+++ b/compiler/Acton/Env.hs
@@ -1109,6 +1109,7 @@ findTyFile spaths mn = go spaths
     go (p:ps) = do
       let fullPath = joinPath (p : modPath mn) ++ ".ty"
       exists <- doesFileExist fullPath
+      --traceM ("findTyFile: " ++ fullPath ++ " " ++ show exists)
       if exists
         then return (Just fullPath)
         else go ps


### PR DESCRIPTION
The initial implementation of dependencies relied on discovering dependencies through their location in the special directory deps/ in the project root. Since we have subsequently added support for reading the dependencies from our build.act.json configuration file, we can now get rid of the first crude method of dependency discovery and rely entirely on configured deps.

Fixes #1999 