### PR TITLE
top testing on Ubuntu 18.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -344,8 +344,6 @@ jobs:
           - os: "debian"
             version: "12"
           - os: "ubuntu"
-            version: "18.04"
-          - os: "ubuntu"
             version: "20.04"
           - os: "ubuntu"
             version: "22.04"


### PR DESCRIPTION
Seems our hacks for getting the GitHub Action artifact steps no longer work. Guess Ubuntu 18.04 is dead for real, so removing and moving on...