### PR TITLE
Separate caches in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,9 +90,15 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ~/.cache/acton/
             ~/.stack
           key: test-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.arch }}
+      - name: "Cache Acton"
+        if: matrix.cache == true
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/acton/
+          key: test-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.arch }}-acton
       - name: "Install build prerequisites"
         run: brew install haskell-stack
       - name: "Build Acton"
@@ -180,9 +186,15 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ~/.cache/acton/
             ~/.stack
           key: test-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.arch }}
+      - name: "Cache Acton"
+        if: matrix.cache == true
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/acton/
+          key: test-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.arch }}-acton
       - name: "chown our home dir to avoid stack complaining"
         run: chown -R root:root /github/home
       - name: "Install build prerequisites"


### PR DESCRIPTION
We have a lot of Acton (Zig) build cache related issues now so we need to clear the cache to get builds to work. It's quite annoying since the Haskell Stack install is so slow. Separating caches lets us only clear the problematic acton cache.