### PR TITLE
Reverse order of tests

### DIFF
--- a/compiler/Acton/Types.hs
+++ b/compiler/Acton/Types.hs
@@ -1717,7 +1717,7 @@ testFuns env ss                         = tF ss [] [] [] []
          tF (Decl l (d : ds) : ss) uts sats aats ets   = tF (Decl l ds : ss) uts sats aats ets
          tF (Decl l [] : ss) uts sats aats ets = tF ss uts sats aats ets
          tF (s : ss) uts sats aats ets   = tF ss uts sats aats ets
-         tF [] uts sats aats ets         = (uts, sats, aats, ets)
+         tF [] uts sats aats ets         = (reverse uts, reverse sats, reverse aats, reverse ets)
 
 isTestName n                             = take 6 (nstr n) == "_test_"
 


### PR DESCRIPTION
We construct the lists by prepending using :, which is more efficient O(1) in Haskell than appending O(n), but it ends up reversing the list of the tests and I think it's nice if we present the lists to the user in the same order in which they are defined in the source file. It is still grouped by test type, but at least there is some more semblence between list of tests and source file now.

Fixes #2019 