### PR TITLE
Do not let actonc depend on builder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ ACTONC_TEST_HS=$(wildcard compiler/tests/*.hs)
 ACTONC_HS=$(filter-out $(ACTONC_TEST_HS),$(ACTONC_ALL_HS))
 # NOTE: we're unsetting CC & CXX to avoid using zig cc & zig c++ for stack /
 # ghc, which doesn't seem to work properly
-compiler/actonc: compiler/package.yaml.in compiler/stack.yaml dist/builder $(ACTONC_HS)
+compiler/actonc: compiler/package.yaml.in compiler/stack.yaml $(ACTONC_HS)
 	cd compiler && unset CC && unset CXX && unset CFLAGS && stack build --dry-run 2>&1 | grep "Nothing to build" || \
 		(sed 's,^version:.*,version:      "$(VERSION_INFO)",' < package.yaml.in > package.yaml \
 		&& stack build $(STACK_OPTS) --ghc-options='-j4 $(ACTC_GHC_OPTS)' \


### PR DESCRIPTION
It's nice to be able to iterate on the compiler without getting the whole world rebuilt. I believe this dep was added when we embedded stuff early on in the compiler and thus needed the dep.