### PR TITLE
Revamp test running

### DIFF
--- a/base/src/testing.act
+++ b/base/src/testing.act
@@ -786,19 +786,8 @@ actor TestExecutor(syscap, config, get_test: () -> Test, report_complete, env):
     after 0: _run_next()
 
 
-class ModuleError(object):
-    exit_code: int
-    term_signal: int
-    errout: str
-
-    def __init__(self, exit_code: int, term_signal: int, err: str):
-        self.exit_code = exit_code
-        self.term_signal = term_signal
-        self.err = err
-
 class ProjectTestResults(object):
     results: dict[str, dict[str, TestInfo]]
-    module_error: dict[str, ModuleError]
     last_results: dict[str, dict[str, TestInfo]]
     sw: time.Stopwatch
     expected_modules: set[str]
@@ -808,7 +797,6 @@ class ProjectTestResults(object):
 
     def __init__(self, perf_data: str, perf_mode: bool=False):
         self.results = {}
-        self.module_error = {}
         self.last_results = self.parse_perf_data(perf_data)
         self.sw = time.Stopwatch()
         self.expected_modules = set([''])
@@ -833,18 +821,6 @@ class ProjectTestResults(object):
             print("Failed to parse performance data")
             return {}
 
-    def set_expected(self, tests: dict[str, Test], modname: str=""):
-        for test_name, test in tests.items():
-            if modname not in self.results:
-                self.results[modname] = {}
-            self.results[modname][test_name] = TestInfo(test)
-
-    def update_module(self, module_name: str, test_results: dict[str, TestInfo]):
-        """Update test results for all tests in a module
-        """
-        self.up_to_date = False
-        self.results[module_name] = test_results
-
     def update(self, module_name: str, test_name: str, test_info: TestInfo):
         """Update result for individual test
         """
@@ -852,21 +828,6 @@ class ProjectTestResults(object):
         if module_name not in self.results:
             self.results[module_name] = {}
         self.results[module_name][test_name] = test_info
-
-    def update_result(self, module_name: str, test: Test, complete: bool, test_result: TestResult):
-        """Update result for individual test
-        """
-        self.up_to_date = False
-        if module_name not in self.results:
-            self.results[module_name] = {}
-        if test.name not in self.results[module_name]:
-            self.results[module_name][test.name] = TestInfo(test)
-        tres = self.results[module_name][test.name]
-        if test_result is not None:
-            tres.update(complete, test_result)
-
-    def update_module_error(self, module_name: str, moderr: ModuleError):
-        self.module_error[module_name] = moderr
 
     def num_tests(self):
         cnt = 0
@@ -951,10 +912,6 @@ class ProjectTestResults(object):
         if set(self.results.keys()) != self.expected_modules:
             complete = False
         for module_name in self.results:
-            if module_name in self.module_error:
-                for test_name, test_info in self.results[module_name].items():
-                    errors += 1
-                continue
             for test_name, test_info in self.results[module_name].items():
                 if not test_info.complete:
                     complete = False
@@ -1013,9 +970,6 @@ class ProjectTestResults(object):
                     if self.perf_mode:
                         msg += format_timing(module_name, test_name) + " "
                     msg += "%4d runs in %3.3fms" % (tinfo.num_iterations, tinfo.test_duration) + term.normal
-                elif module_name in self.module_error:
-                    moderr = self.module_error[module_name]
-                    msg = term.red + "##: Test crash? Exit code: %d  term signal: %d" % (moderr.exit_code, moderr.term_signal) + term.normal
                 else:
                     msg = term.yellow + "**" + term.normal
 
@@ -1035,14 +989,6 @@ class ProjectTestResults(object):
                     for line in str(exc).splitlines(None):
                         print(term.red + "    %s" % (line) + term.normal)
                         self.printed_lines += 1
-
-            if module_name in self.module_error:
-                moderr = self.module_error[module_name]
-                if moderr.err != "":
-                    msg = term.red + "Error:\n" + term.normal
-                    msg += moderr.err
-                    print(msg)
-                    self.printed_lines += len(msg.splitlines())
 
         print("")
         if complete:

--- a/base/src/testing.act
+++ b/base/src/testing.act
@@ -696,9 +696,10 @@ class TestRunnerConfig(object):
         self.output_enabled = False if args.get_bool("no_output") else True
         self.min_test_duration = mtd
 
+class TimeoutError(Exception):
+    pass
 
-# TODO: add a timeout to this
-actor TestExecutor(syscap, config, get_test: () -> Test, report_complete, env):
+actor TestExecutor(syscap, config, get_test: action() -> Test, report_complete, env):
     """The actual executor of tests
     """
     log_handler = logging.Handler("TestRunner")
@@ -775,9 +776,9 @@ actor TestExecutor(syscap, config, get_test: () -> Test, report_complete, env):
 
     def _run_next():
         """Get the next available test and run it"""
-        test_sw = time.Stopwatch()
         try:
             t = get_test()
+            test_sw = time.Stopwatch()
             test_info = TestInfo(t)
             _run_fn(t)
         except Exception as e:
@@ -1043,24 +1044,52 @@ actor test_runner(env: Env,
         print(json.encode({"tests": res}), err=True)
         env.exit(0)
 
+
+
     proc def _run_tests(args, perf_mode: bool=False):
         config = TestRunnerConfig(perf_mode, args)
         if config.perf_mode:
             acton.rts.start_gc_performance_measurement(env.syscap)
+
+        test_concurrency = 1 if config.perf_mode else env.nr_wthreads
+        test_timeout = 3.0
 
         test_name = args.get_str("name")
         test_fun_name = "_test_" + test_name
         if test_fun_name not in all_tests:
             print("Test not found: %s" % test_fun_name)
             env.exit(1)
-        test_concurrency = 1 if config.perf_mode else env.nr_wthreads
-        my_tests = {test_name: all_tests[test_fun_name]}
+        my_tests = {test_fun_name: all_tests[test_fun_name]}
         to_hand_out = list(my_tests.keys())
         tests_complete = set()
+
+        def _check_timeout(test_id):
+            if test_id in tests_complete:
+                return
+            test_def = all_tests[test_id]
+            time_s = test_timeout * 1000.0
+            test_info = TestInfo(
+                test_def,
+                complete=True,
+                success=None,
+                exception="Test timeout",
+                min_duration=time_s,
+                max_duration=time_s,
+                avg_duration=time_s,
+                total_duration=time_s,
+                test_duration=time_s,
+                num_iterations=1,
+                num_failures=0,
+                num_errors=1
+                )
+            tests_complete.add(test_id)
+            print(json.encode({"test_info": test_info.to_json()}), err=True)
+            env.exit(0)
 
         def get_test():
             test_id = to_hand_out.pop()
             test = my_tests[test_id]
+            after test_timeout: _check_timeout(test_id)
             return test
 
         def check_complete():
@@ -1069,8 +1098,12 @@ actor test_runner(env: Env,
                 return True
             return False
 
-        def report_complete(t):
-            tests_complete.add("_test_" + t)
+        def report_complete(test_name):
+            test_id = "_test_" + test_name
+            if test_id in tests_complete:
+                # Report after we hit timeout
+                return
+            tests_complete.add(test_id)
             check_complete()
 
         test_executors = []

--- a/base/src/testing.act
+++ b/base/src/testing.act
@@ -274,6 +274,29 @@ class Test(object):
             return Test(name, desc, module)
         raise ValueError("Test: Invalid JSON")
 
+def safe_hash(h: int) -> int: # TODO: Remove when https://github.com/actonlang/acton/issues/1348 is fixed
+    limit = 2**63-1
+    sign = 1
+    if h < 0:
+        limit = 2**63
+        sign = -1
+        h = -h
+
+    while h > limit:
+        f = h // limit
+        h %= limit
+        h += f
+
+    return sign * h
+
+extension Test(Hashable):
+    def __eq__(self, other: Test) -> bool:
+        return self.module == other.module and self.name == other.name
+
+    def __hash__(self) -> int:
+        #return hash(self.data)
+        return safe_hash(2*hash(self.module) + 3*hash(self.name))
+
 class UnitTest(Test):
     def __init__(self, fn: mut() -> None, name: str, desc: str, module: str):
         self.fn = fn

--- a/base/src/testing.act
+++ b/base/src/testing.act
@@ -1017,45 +1017,6 @@ class ProjectTestResults(object):
             print()
         self.printed_lines += 3
 
-class ModuleTestResults(object):
-    tests: dict[str, TestInfo]
-    last_show: time.Instant
-
-    def __init__(self):
-        self.tests = {}
-        self.last_show = time.monotonic()
-        self.last_show.second -= 1
-
-    def set_tests(self, tests: dict[str, TestInfo]):
-        self.tests = tests
-
-    def update(self, test: Test, complete: bool, test_result: TestResult):
-        if test.name not in self.tests:
-            self.tests[test.name] = TestInfo(test)
-        tinfo = self.tests[test.name]
-        tinfo.update(complete, test_result)
-        self.show_test(test.name)
-
-    def is_test_done(self, name):
-        if name in self.tests:
-            return self.tests[name].complete
-        return False
-
-    def show_test(self, test_name: str):
-        tinfo = self.tests[test_name]
-        now = time.monotonic()
-        if tinfo.complete == False and now.since(self.last_show).to_float() < 0.05:
-            return
-        self.last_show = now
-        print(json.encode({"test_info": tinfo.to_json()}), err=True)
-
-    def show(self):
-        res = {}
-        for test_name, test_info in self.tests.items():
-            res[test_name] = test_info.to_json()
-        print(json.encode({"tests": res}), err=True)
-
-
 
 actor test_runner(env: Env,
                   unit_tests: dict[str, UnitTest],
@@ -1063,57 +1024,37 @@ actor test_runner(env: Env,
                   async_actor_tests: dict[str, AsyncActorTest],
                   env_tests: dict[str, EnvTest]):
     sw = time.Stopwatch()
-    var results = ModuleTestResults()
     var all_tests = {}
 
-    def _init_results(args):
+    for name, t in unit_tests.items():
+        all_tests[name] = t
+    for name, t in sync_actor_tests.items():
+        all_tests[name] = t
+    for name, t in async_actor_tests.items():
+        all_tests[name] = t
+    for name, t in env_tests.items():
+        all_tests[name] = t
 
-        for name, t in unit_tests.items():
-            all_tests[name] = t
-        for name, t in sync_actor_tests.items():
-            all_tests[name] = t
-        for name, t in async_actor_tests.items():
-            all_tests[name] = t
-        for name, t in env_tests.items():
-            all_tests[name] = t
-
-        tests = _filter_tests(all_tests, args)
-
-        test_module_results = {}
-        for test_def in tests.values():
-            test_module_results[test_def.name] = TestInfo(test_def)
-        results.set_tests(test_module_results)
-
-    def _filter_tests[T](tests: dict[str, T], args) -> dict[str, T]:
+    proc def _cmd_list(args):
         res = {}
-        name_filter = []
-        try:
-            name_filter = args.get_strlist("name")
-        except argparse.ArgumentError:
-            pass
-        test_names = set(name_filter)
-        if test_names == set():
-            return tests
-
-        TEST_PREFIX_LEN = len("_test_")
-        for name, t in tests.items():
-            if name[TEST_PREFIX_LEN:] in test_names:
-                res[name] = t
-        return res
-
-    proc def _list_tests(args):
-        _init_results(args)
-        results.show()
+        for test_name, test_def in all_tests.items():
+            test_info = TestInfo(test_def)
+            res[test_def.name] = test_info.to_json()
+        print(json.encode({"tests": res}), err=True)
         env.exit(0)
 
     proc def _run_tests(args, perf_mode: bool=False):
         config = TestRunnerConfig(perf_mode, args)
         if config.perf_mode:
             acton.rts.start_gc_performance_measurement(env.syscap)
-        _init_results(args)
 
+        test_name = args.get_str("name")
+        test_fun_name = "_test_" + test_name
+        if test_fun_name not in all_tests:
+            print("Test not found: %s" % test_fun_name)
+            env.exit(1)
         test_concurrency = 1 if config.perf_mode else env.nr_wthreads
-        my_tests = _filter_tests(all_tests, args)
+        my_tests = {test_name: all_tests[test_fun_name]}
         to_hand_out = list(my_tests.keys())
         tests_complete = set()
 
@@ -1145,9 +1086,9 @@ actor test_runner(env: Env,
         p = argparse.Parser()
         p.add_bool("json", "Output results as JSON")
         p.add_bool("no_output", "No result output")
-        p.add_option("name", "strlist", nargs="+", default=[], help="Filter tests by name")
-        lp = p.add_cmd("list", "list tests", _list_tests)
+        lp = p.add_cmd("list", "list tests", _cmd_list)
         tp = p.add_cmd("test", "Run tests", _run_tests)
+        tp.add_arg("name", "Name of the test to run")
         pp = tp.add_cmd("perf", "Performance benchmark tests", _run_perf_tests)
         pp.add_option("iterations", "int", "?", 1, "Number of iterations to run")
         pp.add_option("min_time", "int", "?", 1000, "Minimum time to run a test in milliseconds")

--- a/base/src/testing.act
+++ b/base/src/testing.act
@@ -727,6 +727,7 @@ actor TestExecutor(syscap, config, t: Test, report_complete, env):
     var test_sw = time.Stopwatch()
     var last_report = time.Stopwatch()
     var test_info = None
+    var iteration = 0
 
     def get_expected(module: str, test: str) -> ?str:
         filename = file.join_path([fs.cwd(), "test", "golden", module, test])
@@ -765,6 +766,8 @@ actor TestExecutor(syscap, config, t: Test, report_complete, env):
             report_complete(t)
 
     def _run_fn(t: Test):
+        print("\n== Running test, iteration:", iteration)
+        print("\n== Running test, iteration:", iteration, err=True)
         # Run GC to get accurate memory usage
         if config.perf_mode:
             acton.rts.gc(syscap)
@@ -790,6 +793,7 @@ actor TestExecutor(syscap, config, t: Test, report_complete, env):
             _report_result(t, sw, non_gc_mem_usage_before, gc_total_bytes_start, gc_time_start, False, e, None)
         except Exception as e:
             _report_result(t, sw, non_gc_mem_usage_before, gc_total_bytes_start, gc_time_start, None, e, None)
+        iteration += 1
 
     def _run_test():
         """Get the next available test and run it"""
@@ -1006,18 +1010,24 @@ class ProjectTestResults(object):
                             self.printed_lines += 1
                     # Print stdout/stderr if the test failed
                     if tinfo.num_failures > 0 or tinfo.num_errors > 0:
+                        def test_output(msgs: str):
+                            for line in msgs.splitlines():
+                                if not (line.startswith("== Running test,") or line == ""):
+                                    return True
+                            return False
+
                         stdout = tinfo.stdout
-                        if stdout != None and stdout != "":
+                        if stdout != None and test_output(stdout):
                             print("    STDOUT:")
                             self.printed_lines += 1
-                            for line in stdout.splitlines():
+                            for line in stdout.strip().splitlines():
                                 print("      " + line)
                                 self.printed_lines += 1
                         stderr = tinfo.stderr
-                        if stderr != None and stderr != "":
+                        if stderr != None and test_output(stderr):
                             print("    STDERR:")
                             self.printed_lines += 1
-                            for line in stderr.splitlines():
+                            for line in stderr.strip().splitlines():
                                 print("      " + line)
                                 self.printed_lines += 1
 

--- a/base/src/testing.act
+++ b/base/src/testing.act
@@ -431,8 +431,8 @@ class TestInfo(object):
     success: ?bool
     exception: ?str
     output: ?str
-    stdout: ?str
-    stderr: ?str
+    std_out: ?str
+    std_err: ?str
     flaky_output: bool
     flaky: bool
     leaky: bool
@@ -455,8 +455,8 @@ class TestInfo(object):
                  success: ?bool=None,
                  exception: ?str=None,
                  output: ?str=None,
-                 stdout: ?str=None,
-                 stderr: ?str=None,
+                 std_out: ?str=None,
+                 std_err: ?str=None,
                  flaky: bool=False,
                  min_duration: float=-1.0,
                  max_duration: float=-1.0,
@@ -475,8 +475,8 @@ class TestInfo(object):
         self.success = success
         self.exception = exception
         self.output = output
-        self.stdout = stdout
-        self.stderr = stderr
+        self.std_out = std_out
+        self.std_err = std_err
         self.flaky_output = False
         self.flaky = flaky
         self.leaky = False
@@ -599,8 +599,8 @@ class TestInfo(object):
             "success": self.success,
             "exception": self.exception,
             "output": self.output,
-            "stdout": self.stdout,
-            "stderr": self.stderr,
+            "std_out": self.std_out,
+            "std_err": self.std_err,
             "flaky": self.flaky,
             "min_duration": self.min_duration,
             "max_duration": self.max_duration,
@@ -638,14 +638,14 @@ class TestInfo(object):
         output: ?str = None
         if out is not None and isinstance(out, str):
             output = out
-        stdout_d = json_data["stdout"]
-        stdout: ?str = None
-        if stdout_d is not None and isinstance(stdout_d, str):
-            stdout = stdout_d
-        stderr_d = json_data["stderr"]
-        stderr: ?str = None
-        if stderr_d is not None and isinstance(stderr_d, str):
-            stderr = stderr_d
+        std_out_d = json_data["std_out"]
+        std_out: ?str = None
+        if std_out_d is not None and isinstance(std_out_d, str):
+            std_out = std_out_d
+        std_err_d = json_data["std_err"]
+        std_err: ?str = None
+        if std_err_d is not None and isinstance(std_err_d, str):
+            std_err = std_err_d
         flaky = json_data["flaky"]
         min_duration = json_data["min_duration"]
         max_duration = json_data["max_duration"]
@@ -681,8 +681,8 @@ class TestInfo(object):
                             success,
                             exception,
                             output,
-                            stdout,
-                            stderr,
+                            std_out,
+                            std_err,
                             flaky,
                             min_duration,
                             max_duration,
@@ -1008,7 +1008,7 @@ class ProjectTestResults(object):
                         for line in str(exc).splitlines(None):
                             print(term.red + "    %s" % (line) + term.normal)
                             self.printed_lines += 1
-                    # Print stdout/stderr if the test failed
+                    # Print std_out/std_err if the test failed
                     if tinfo.num_failures > 0 or tinfo.num_errors > 0:
                         def test_output(msgs: str):
                             for line in msgs.splitlines():
@@ -1016,18 +1016,18 @@ class ProjectTestResults(object):
                                     return True
                             return False
 
-                        stdout = tinfo.stdout
-                        if stdout != None and test_output(stdout):
-                            print("    STDOUT:")
+                        std_out = tinfo.std_out
+                        if std_out != None and test_output(std_out):
+                            print("    STD_OUT:")
                             self.printed_lines += 1
-                            for line in stdout.strip().splitlines():
+                            for line in std_out.strip().splitlines():
                                 print("      " + line)
                                 self.printed_lines += 1
-                        stderr = tinfo.stderr
-                        if stderr != None and test_output(stderr):
-                            print("    STDERR:")
+                        std_err = tinfo.std_err
+                        if std_err != None and test_output(std_err):
+                            print("    STD_ERR:")
                             self.printed_lines += 1
-                            for line in stderr.strip().splitlines():
+                            for line in std_err.strip().splitlines():
                                 print("      " + line)
                                 self.printed_lines += 1
 

--- a/base/src/testing.act
+++ b/base/src/testing.act
@@ -699,7 +699,7 @@ class TestRunnerConfig(object):
 class TimeoutError(Exception):
     pass
 
-actor TestExecutor(syscap, config, get_test: action() -> Test, report_complete, env):
+actor TestExecutor(syscap, config, t: Test, report_complete, env):
     """The actual executor of tests
     """
     log_handler = logging.Handler("TestRunner")
@@ -744,8 +744,7 @@ actor TestExecutor(syscap, config, get_test: action() -> Test, report_complete, 
         if not complete:
             _run_fn(test)
         else:
-            report_complete(test.name)
-            _run_next()
+            report_complete(t)
 
     def _run_fn(t: Test):
         # Run GC to get accurate memory usage
@@ -774,17 +773,13 @@ actor TestExecutor(syscap, config, get_test: action() -> Test, report_complete, 
         except Exception as e:
             _report_result(t, sw, non_gc_mem_usage_before, gc_total_bytes_start, gc_time_start, None, e, None)
 
-    def _run_next():
+    def _run_test():
         """Get the next available test and run it"""
-        try:
-            t = get_test()
-            test_sw = time.Stopwatch()
-            test_info = TestInfo(t)
-            _run_fn(t)
-        except Exception as e:
-            return None
+        test_sw = time.Stopwatch()
+        test_info = TestInfo(t)
+        _run_fn(t)
 
-    after 0: _run_next()
+    after 0: _run_test()
 
 
 class ProjectTestResults(object):
@@ -1057,16 +1052,14 @@ actor test_runner(env: Env,
         test_name = args.get_str("name")
         test_fun_name = "_test_" + test_name
         if test_fun_name not in all_tests:
-            print("Test not found: %s" % test_fun_name)
+            print("Test not found: %s" % test_name)
             env.exit(1)
-        my_tests = {test_fun_name: all_tests[test_fun_name]}
-        to_hand_out = list(my_tests.keys())
+        the_test = all_tests[test_fun_name]
         tests_complete = set()
 
-        def _check_timeout(test_id):
-            if test_id in tests_complete:
+        def _check_timeout(test_def):
+            if test_def in tests_complete:
                 return
-            test_def = all_tests[test_id]
             time_s = test_timeout * 1000.0
             test_info = TestInfo(
                 test_def,
@@ -1082,35 +1075,20 @@ actor test_runner(env: Env,
                 num_failures=0,
                 num_errors=1
                 )
-            tests_complete.add(test_id)
+            tests_complete.add(test_def)
             print(json.encode({"test_info": test_info.to_json()}), err=True)
             env.exit(0)
 
-        def get_test():
-            test_id = to_hand_out.pop()
-            test = my_tests[test_id]
-            after test_timeout: _check_timeout(test_id)
-            return test
-
-        def check_complete():
-            if tests_complete == set(my_tests.keys()):
-                env.exit(0)
-                return True
-            return False
-
-        def report_complete(test_name):
-            test_id = "_test_" + test_name
-            if test_id in tests_complete:
+        def report_complete(t):
+            if t in tests_complete:
                 # Report after we hit timeout
                 return
-            tests_complete.add(test_id)
-            check_complete()
+            tests_complete.add(t)
+            env.exit(0)
 
         test_executors = []
-        if not check_complete():
-            for i in range(test_concurrency):
-                te = TestExecutor(env.syscap, config, get_test, report_complete, env)
-                test_executors.append(te)
+        te = TestExecutor(env.syscap, config, the_test, report_complete, env)
+        after test_timeout: _check_timeout(the_test)
 
     proc def _run_perf_tests(args):
         _run_tests(args, perf_mode=True)

--- a/base/src/testing.act
+++ b/base/src/testing.act
@@ -431,6 +431,8 @@ class TestInfo(object):
     success: ?bool
     exception: ?str
     output: ?str
+    stdout: ?str
+    stderr: ?str
     flaky_output: bool
     flaky: bool
     leaky: bool
@@ -453,6 +455,8 @@ class TestInfo(object):
                  success: ?bool=None,
                  exception: ?str=None,
                  output: ?str=None,
+                 stdout: ?str=None,
+                 stderr: ?str=None,
                  flaky: bool=False,
                  min_duration: float=-1.0,
                  max_duration: float=-1.0,
@@ -471,6 +475,8 @@ class TestInfo(object):
         self.success = success
         self.exception = exception
         self.output = output
+        self.stdout = stdout
+        self.stderr = stderr
         self.flaky_output = False
         self.flaky = flaky
         self.leaky = False
@@ -593,6 +599,8 @@ class TestInfo(object):
             "success": self.success,
             "exception": self.exception,
             "output": self.output,
+            "stdout": self.stdout,
+            "stderr": self.stderr,
             "flaky": self.flaky,
             "min_duration": self.min_duration,
             "max_duration": self.max_duration,
@@ -630,6 +638,14 @@ class TestInfo(object):
         output: ?str = None
         if out is not None and isinstance(out, str):
             output = out
+        stdout_d = json_data["stdout"]
+        stdout: ?str = None
+        if stdout_d is not None and isinstance(stdout_d, str):
+            stdout = stdout_d
+        stderr_d = json_data["stderr"]
+        stderr: ?str = None
+        if stderr_d is not None and isinstance(stderr_d, str):
+            stderr = stderr_d
         flaky = json_data["flaky"]
         min_duration = json_data["min_duration"]
         max_duration = json_data["max_duration"]
@@ -665,6 +681,8 @@ class TestInfo(object):
                             success,
                             exception,
                             output,
+                            stdout,
+                            stderr,
                             flaky,
                             min_duration,
                             max_duration,
@@ -739,7 +757,7 @@ actor TestExecutor(syscap, config, t: Test, report_complete, env):
             test_info.update(complete, TestResult(success, exc, val, testiter_dur, mem_usage_delta, non_gc_mem_usage_delta), test_dur*1000.0)
         if last_report.elapsed().to_float() > 0.05 or complete:
             if test_info is not None and config.output_enabled:
-                print(json.encode({"test_info": test_info.to_json()}), err=True)
+                print("\n" + json.encode({"test_info": test_info.to_json()}), err=True)
             last_report.reset()
         if not complete:
             _run_fn(test)
@@ -981,10 +999,27 @@ class ProjectTestResults(object):
                                                                         tinfo.non_gc_mem_inc_count,
                                                                         tinfo.num_iterations))
                     self.printed_lines += 3
-                if tinfo.complete and exc is not None:
-                    for line in str(exc).splitlines(None):
-                        print(term.red + "    %s" % (line) + term.normal)
-                        self.printed_lines += 1
+                if tinfo.complete:
+                    if exc != None:
+                        for line in str(exc).splitlines(None):
+                            print(term.red + "    %s" % (line) + term.normal)
+                            self.printed_lines += 1
+                    # Print stdout/stderr if the test failed
+                    if tinfo.num_failures > 0 or tinfo.num_errors > 0:
+                        stdout = tinfo.stdout
+                        if stdout != None and stdout != "":
+                            print("    STDOUT:")
+                            self.printed_lines += 1
+                            for line in stdout.splitlines():
+                                print("      " + line)
+                                self.printed_lines += 1
+                        stderr = tinfo.stderr
+                        if stderr != None and stderr != "":
+                            print("    STDERR:")
+                            self.printed_lines += 1
+                            for line in stderr.splitlines():
+                                print("      " + line)
+                                self.printed_lines += 1
 
         print("")
         if complete:
@@ -1036,7 +1071,7 @@ actor test_runner(env: Env,
         for test_name, test_def in all_tests.items():
             test_info = TestInfo(test_def)
             res[test_def.name] = test_info.to_json()
-        print(json.encode({"tests": res}), err=True)
+        print("\n" + json.encode({"tests": res}), err=True)
         env.exit(0)
 
 
@@ -1076,7 +1111,7 @@ actor test_runner(env: Env,
                 num_errors=1
                 )
             tests_complete.add(test_def)
-            print(json.encode({"test_info": test_info.to_json()}), err=True)
+            print("\n" + json.encode({"test_info": test_info.to_json()}), err=True)
             env.exit(0)
 
         def report_complete(t):

--- a/base/src/testing.act
+++ b/base/src/testing.act
@@ -237,20 +237,14 @@ class TestLogger(logging.Logger):
     pass
 
 class Test(object):
-    module: ?str
+    module: str
     name: str
     desc: str
 
-    def __init__(self, name: str, desc: str):
+    def __init__(self, name: str, desc: str, module):
         self.name = name
         self.desc = desc
-        self.module = None
-
-    def get_module(self) -> str:
-        mod = self.module
-        if mod is not None:
-            return mod
-        raise ValueError("Test: Module not set")
+        self.module = module
 
     def run(self, report_result: action(?bool, ?Exception, ?str) -> None, env: Env, log_handler: logging.Handler):
         if isinstance(self, UnitTest):
@@ -266,16 +260,18 @@ class Test(object):
 
     def to_json(self):
         return {
+            "module": self.module,
             "name": self.name,
             "desc": self.desc,
         }
 
     @staticmethod
     def from_json(data: dict[str, ?value]):
+        module = data["module"]
         name = data["name"]
         desc = data["desc"]
-        if isinstance(name, str) and isinstance(desc, str):
-            return Test(name, desc)
+        if isinstance(module, str) and isinstance(name, str) and isinstance(desc, str):
+            return Test(name, desc, module)
         raise ValueError("Test: Invalid JSON")
 
 class UnitTest(Test):
@@ -740,7 +736,7 @@ actor TestExecutor(syscap, config, get_test: () -> Test, report_complete, env):
         def repres(s: ?bool, e: ?Exception, val: ?str) -> None:
             # Compare expected golden value
             if val is not None:
-                exp_val = get_expected(t.get_module(), t.name)
+                exp_val = get_expected(t.module, t.name)
                 if exp_val is None or exp_val is not None and val != exp_val:
                     exc = NotEqualError(val, exp_val, "Test output does not match expected golden value.\nActual  : %s\nExpected: %s" % (val, exp_val if exp_val is not None else "None"))
                     _report_result(t, sw, non_gc_mem_usage_before, gc_total_bytes_start, gc_time_start, False, exc, val)

--- a/cli/src/acton.act
+++ b/cli/src/acton.act
@@ -583,10 +583,7 @@ actor CmdTest(env: Env, args, perf_mode: bool=False):
 
     def _on_test_error(test: testing.Test, exit_code: int, term_signal: int, errout: str):
         errmsg = "Test error, exit_code %d and term signal %d, errout: " % (exit_code, term_signal)
-        try:
-            errmsg += errout
-        except IndexError:
-            pass
+        errmsg += errout
         # We construct our own TestInfo here since we didn't get one from the
         # test process, because it crashed...
         ptr.update(
@@ -646,15 +643,18 @@ actor CmdTest(env: Env, args, perf_mode: bool=False):
             env.exit(1)
             return
 
-        ptr.expected_modules = set(tests.keys())
 
+        expected_modules = set()
         name_filter = set(args.get_strlist("name"))
         for module_name in sorted(tests.keys()):
             module_tests = tests[module_name]
+            if len(module_tests) > 0:
+                expected_modules.add(module_name)
             for test_name, test_info in module_tests.items():
                 if len(name_filter) == 0 or test_name in name_filter:
                     ptr.update(module_name, test_name, test_info)
                     tests_to_run.append(test_info)
+        ptr.expected_modules = expected_modules
 
         _run_test()
 

--- a/cli/src/acton.act
+++ b/cli/src/acton.act
@@ -401,7 +401,7 @@ actor RunModuleTest(process_cap, modname, test_cmd, on_json_output, on_test_erro
                     except ValueError:
                         pass
                     else:
-                        on_json_output(upd)
+                        on_json_output(self, upd)
                 else:
                     # incomplete line
                     stderr_buf = line
@@ -420,6 +420,9 @@ actor RunModuleTest(process_cap, modname, test_cmd, on_json_output, on_test_erro
     # TODO: fs.join()
     cmd = ["out/bin/.test_" + modname, "--json"] + test_cmd
     p = process.Process(process_cap, cmd, on_stdout, on_stderr, on_exit, on_error)
+
+    def stop():
+        p.stop()
 
 
 actor CmdListTest(env, args):
@@ -570,12 +573,14 @@ actor CmdTest(env: Env, args, perf_mode: bool=False):
             return
         after 0.05: _periodic_show()
 
-    def _on_json_output(test, data):
+    def _on_json_output(rmt, test, data):
         if isinstance(data, dict):
             if "test_info" in data:
                 test_info = TestInfo.from_json(data["test_info"])
                 ptr.update(test_info.definition.module, test_info.definition.name, test_info)
                 if test_info.complete:
+                    if test_info.success == None and test_info.exception == "Test timeout":
+                        rmt.stop()
                     _run_test()
         else:
             raise ValueError("Unexpected JSON data from module test: " + test.module)
@@ -613,7 +618,7 @@ actor CmdTest(env: Env, args, perf_mode: bool=False):
                 process_cap,
                 test_info.definition.module,
                 cmd,
-                lambda x: _on_json_output(test_info.definition, x),
+                lambda rmt, x: _on_json_output(rmt, test_info.definition, x),
                 lambda x, y, z: _on_test_error(test_info.definition, x, y, z))
             running_tests[test_info.definition] = t
             if len(running_tests) < concurrency:

--- a/cli/src/acton.act
+++ b/cli/src/acton.act
@@ -422,47 +422,26 @@ actor RunModuleTest(process_cap, modname, test_cmd, on_json_output, on_test_erro
     p = process.Process(process_cap, cmd, on_stdout, on_stderr, on_exit, on_error)
 
 
-actor RunTestList(env, args):
+actor CmdListTest(env, args):
     """Print list of module tests
 
     Will run the project module test binaries with 'list --json' to get all
     module tests, collect the output and print a list of all project tests.
     """
     process_cap = process.ProcessCap(env.cap)
-    var _expected_modules: set[str] = set()
-    var _module_tests = {}
 
-    def print_module_tests():
-        for mn in _module_tests.keys():
-            print("Module %s:" % mn)
-            for module_test_name in _module_tests[mn]:
-                print(" ", module_test_name)
+    def print_module_tests(err, tests: dict[str, dict[str, testing.TestInfo]]={}):
+        if err != None:
+            print(err, err=True)
+            env.exit(1)
+            return
+
+        for module_name, module_tests in tests.items():
+            print("Module %s:" % module_name)
+            for test_name in module_tests:
+                print(" ", test_name)
             print()
-
-    def _on_json_output(module_name, update):
-        if module_name in _module_tests:
-            raise ValueError("Duplicate list of tests from module: " + module_name)
-        if isinstance(update, dict):
-            _module_tests[module_name] = []
-            update_tests = update["tests"]
-            if isinstance(update_tests, dict):
-                for test in update_tests.values():
-                    _module_tests[module_name].append(test["definition"]["name"])
-        else:
-            raise ValueError("Unexpected JSON data from module test: " + module_name)
-
-        if set(_module_tests.keys()) == _expected_modules:
-            print_module_tests()
-            env.exit(0)
-
-    def _on_test_error(exit_code, term_signal, stderr_buf):
-        pass
-
-    def _run_tests(module_names: list[str]):
-        _expected_modules = set(module_names)
-
-        for module_name in module_names:
-            t = RunModuleTest(process_cap, module_name, ["list"], lambda x: _on_json_output(module_name, x), _on_test_error)
+        env.exit(0)
 
     def _on_build_success(stdout_buf: str):
         test_modules = []
@@ -473,7 +452,7 @@ actor RunTestList(env, args):
             else:
                 if stdout_tests:
                     test_modules.append(line)
-        _run_tests(test_modules)
+        l = ListTests(process_cap, test_modules, print_module_tests)
 
     def _on_build_failure(exit_code, term_signal, stderr_buf: str):
         print("Failed to build project tests")
@@ -491,11 +470,59 @@ actor RunTestList(env, args):
     )
 
 
+actor ListTests(process_cap, test_modules: list[str], on_done: action(?str, ?dict[str, dict[str, testing.TestInfo]]) -> None):
+    """List all tests in project
+    """
+    remaining_mods = {}
+    tests: dict[str, dict[str, testing.TestInfo]] = {}
+
+    def _on_exit(module_name, p, exit_code, term_signal, stdout_buf, stderr_buf):
+        if exit_code == 0:
+            tests[module_name] = {}
+            try:
+                data = json.decode(stderr_buf.decode())
+                if isinstance(data, dict):
+                    if "tests" in data:
+                        for test_name, json_test_info in data["tests"].items():
+                            if isinstance(json_test_info, dict):
+                                tests[module_name][test_name] = TestInfo.from_json(json_test_info)
+                        del remaining_mods[module_name]
+                        if len(remaining_mods) == 0:
+                            on_done(None, tests)
+                    else:
+                        on_done("Error listing tests for module %s: no 'tests' key in JSON" % module_name)
+            except ValueError as e:
+                on_done("Error parsing JSON from module %s: %s" % (module_name, str(e)))
+        else:
+            on_done("Error listing tests for module %s, exited with code %d and term signal %d: %s" % (module_name, exit_code, term_signal, stderr_buf.decode()))
+
+    def _on_error(module_name, p, error):
+        err = "ERROR: Error listing tests for module %s: %s" % (module_name, error)
+        for op in remaining_mods.values():
+            op.stop()
+        on_done(err)
+
+    if len(test_modules) == 0:
+        on_done(None, {})
+
+    # List all tests by asking each module about its tests. This runs in
+    # parallel.
+    for module_name in test_modules:
+        cmd = [file.join_path(["out", "bin", ".test_" + module_name]), "list", "--json"]
+        p = process.RunProcess(
+            process_cap,
+            cmd,
+            lambda p, exit_code, term_signal, stdout_buf, stderr_buf: _on_exit(module_name, p, exit_code, term_signal, stdout_buf, stderr_buf),
+            lambda p, error: _on_error(module_name, p, error))
+        remaining_mods[module_name] = p
+
+
 actor RunTestTest(env: Env, args, perf_mode: bool=False):
+    """Run project tests, i.e. `acton test`
+    """
     process_cap = process.ProcessCap(env.cap)
-    var expected_modules_list: set[str] = set()
-    var _module_tests = {}
     var modules_to_test = set()
+    var tests = {}
     var perf_data = "{}"
     fs = file.FS(file.FileCap(env.cap))
 
@@ -541,24 +568,7 @@ actor RunTestTest(env: Env, args, perf_mode: bool=False):
 
     def _on_json_output(module_name, data):
         if isinstance(data, dict):
-            if "tests" in data:
-                data_tests = data["tests"]
-                tests = {}
-                for test_name, json_test_info in data_tests.items():
-                    if isinstance(json_test_info, dict):
-                        tests[test_name] = TestInfo.from_json(json_test_info)
-
-                ptr.update_module(module_name, tests)
-                expected_modules_list.discard(module_name)
-                if len(expected_modules_list) == 0:
-                    # We have received the test list from all modules, show
-                    # results to get empty skeleton and then run tests.
-                    # NOTE: in perf mode we run a single module at a time and
-                    # that module in turn limits concurrency to 1
-                    _periodic_show()
-                    _run_module_tests(run_all=not perf_mode)
-
-            elif "test_info" in data:
+            if "test_info" in data:
                 test_info = TestInfo.from_json(data["test_info"])
                 ptr.update(module_name, test_info.definition.name, test_info)
                 if ptr.is_module_done(module_name) and perf_mode:
@@ -577,26 +587,6 @@ actor RunTestTest(env: Env, args, perf_mode: bool=False):
             ptr.update_module_error(module_name, moderr)
         _run_module_tests()
 
-    def _run_tests(module_names: list[str]):
-        select_modules = set(args.get_strlist("module"))
-        if len(select_modules) > 0:
-            for module_name in module_names:
-                if module_name in select_modules:
-                    modules_to_test.add(module_name)
-        else:
-            modules_to_test = set(module_names)
-        expected_modules_list = set(modules_to_test)
-        ptr.expected_modules = set(modules_to_test)
-        if len(modules_to_test) == 0:
-            print("No tests found")
-            env.exit(0)
-            return
-
-        # List all tests first, which we can run in parallel. Once we have the
-        # list of all tests we can start running them one at a time in sequence.
-        for module_name in modules_to_test:
-            t = RunModuleTest(process_cap, module_name, ["list"] + test_cmd_args, lambda x: _on_json_output(module_name, x), lambda x, y, z: _on_test_error(module_name, x, y, z))
-
     def _run_module_tests(run_all=False):
         try:
             module_name = modules_to_test.pop()
@@ -611,6 +601,37 @@ actor RunTestTest(env: Env, args, perf_mode: bool=False):
         if run_all:
             _run_module_tests(run_all)
 
+    def _list_tests(built_modules: list[str]):
+        list_modules = []
+        select_modules = set(args.get_strlist("module"))
+        if len(select_modules) > 0:
+            for module_name in built_modules:
+                if module_name in select_modules:
+                    list_modules.append(module_name)
+        else:
+            list_modules = built_modules
+
+        if len(list_modules) == 0:
+            print("No tests found")
+            env.exit(0)
+            return
+
+        ListTests(process_cap, list_modules, _on_list_output)
+
+    def _on_list_output(err, tests: dict[str, dict[str, testing.TestInfo]]={}):
+        if err != None:
+            print(err, err=True)
+            env.exit(1)
+            return
+
+        modules_to_test = set(tests.keys())
+        ptr.expected_modules = set(modules_to_test)
+
+        tests = tests
+        for module_name, module_tests in tests.items():
+            ptr.update_module(module_name, module_tests)
+        _run_module_tests(run_all=not perf_mode)
+
     def _on_build_success(stdout_buf: str):
         print(term.clearline + term.up() + term.clearline, end="")
         test_modules = []
@@ -621,7 +642,7 @@ actor RunTestTest(env: Env, args, perf_mode: bool=False):
             else:
                 if stdout_tests:
                     test_modules.append(line)
-        _run_tests(test_modules)
+        _list_tests(test_modules)
 
     def _on_build_failure(exit_code, term_signal, stderr_buf: str):
         print("Failed to build project tests")
@@ -637,6 +658,7 @@ actor RunTestTest(env: Env, args, perf_mode: bool=False):
     dev = True
     print("Building project tests...")
     project_builder = BuildProject(process_cap, env, args, _on_build_success, _on_build_failure, build_tests=True)
+
 
 def build_cmd_args(args):
     cmdargs = []
@@ -673,7 +695,7 @@ actor ZigFetchDeps(env, build_config: BuildConfig, on_done: action(int, int) -> 
     var total = 0
     var fetched = 0
 
-    def on_exit(dep: Dependency, p, exit_code, term_signal, stdout_buf, stderr_buf):
+    def _on_exit(dep: Dependency, p, exit_code, term_signal, stdout_buf, stderr_buf):
         if exit_code == 0:
             fetched_hash: str = stdout_buf.decode().strip()
             if print_output:
@@ -699,7 +721,7 @@ actor ZigFetchDeps(env, build_config: BuildConfig, on_done: action(int, int) -> 
         else:
             on_fetch_error(stderr_buf.decode())
 
-    def on_error(dep, p, error):
+    def _on_error(dep, p, error):
         # TODO: collect all errors before calling on_fetch_error?
         on_fetch_error(error)
 
@@ -729,8 +751,8 @@ actor ZigFetchDeps(env, build_config: BuildConfig, on_done: action(int, int) -> 
             p = process.RunProcess(
                 pcap,
                 cmd,
-                lambda p, exit_code, term_signal, stdout_buf, stderr_buf: on_exit(dep, p, exit_code, term_signal, stdout_buf, stderr_buf),
-                lambda p, error: on_error(dep, p, error))
+                lambda p, exit_code, term_signal, stdout_buf, stderr_buf: _on_exit(dep, p, exit_code, term_signal, stdout_buf, stderr_buf),
+                lambda p, error: _on_error(dep, p, error))
             dep_processes[dep.name] = p
 
     for dep_name, dep in build_config.zig_dependencies.items():
@@ -758,8 +780,8 @@ actor ZigFetchDeps(env, build_config: BuildConfig, on_done: action(int, int) -> 
             p = process.RunProcess(
                 pcap,
                 cmd,
-                lambda p, exit_code, term_signal, stdout_buf, stderr_buf: on_exit(dep, p, exit_code, term_signal, stdout_buf, stderr_buf),
-                lambda p, error: on_error(dep, p, error))
+                lambda p, exit_code, term_signal, stdout_buf, stderr_buf: _on_exit(dep, p, exit_code, term_signal, stdout_buf, stderr_buf),
+                lambda p, error: _on_error(dep, p, error))
             zig_processes[dep.name] = p
 
     if len(dep_processes) == 0 and len(zig_processes) == 0:
@@ -1111,7 +1133,7 @@ actor main(env):
         run_tests = RunTestTest(env, args, perf_mode=True)
 
     def _cmd_list_test(args):
-        run_tests = RunTestList(env, args)
+        run_tests = CmdListTest(env, args)
 
     def _cmd_version(args):
         if args.get_bool("full"):

--- a/cli/src/acton.act
+++ b/cli/src/acton.act
@@ -377,42 +377,36 @@ actor BuildProject(process_cap, env, args, on_build_success: action(str) -> None
 
 
 actor RunModuleTest(process_cap, modname, test_cmd, on_json_output, on_test_error):
-    var stdout_buf = b""
+    var captured_stdout = b""
     var stderr_buf = b""
-    var errout = ""
-    var likely_json = False
+    var captured_stderr = b""
 
     def on_stdout(p, data: bytes):
-        stdout_buf += data
+        captured_stdout += data
 
     def on_stderr(p, data):
-        if not likely_json:
-            if data.startswith(b"{"):
-                likely_json = True
+        # TODO: we shouldn't sent test data in-band on stderr - should be separate pipe
         stderr_buf += data
         lines = stderr_buf.splitlines(True)
         stderr_buf = b""
-        for line in lines:
-            if likely_json:
-                if line.endswith(b"\n"):
-                    # valid line
-                    try:
-                        upd = json.decode(line.decode())
-                    except ValueError:
-                        pass
-                    else:
-                        on_json_output(self, upd)
-                else:
-                    # incomplete line
-                    stderr_buf = line
-                    break
-            if not likely_json:
-                errout += line.decode()
+        for i, line in enumerate(lines):
+            if not line.endswith(b"\n"):
+                stderr_buf = b"".join(lines[i:])
+                break
 
+            # We have a complete line, check if it is valid JSON
+            try:
+                upd = json.decode(line.decode())
+                # We have a complete JSON object, pass it to the callback
+                on_json_output(self, upd, captured_stdout, captured_stderr)
+            except ValueError:
+                # Not a complete JSON object, append to captured_stderr
+                if line != b"\n":
+                    captured_stderr += line
 
     def on_exit(p, exit_code, term_signal):
         if exit_code != 0 or term_signal != 0:
-            on_test_error(exit_code, term_signal, stdout_buf.decode() + errout)
+            on_test_error(exit_code, term_signal, captured_stdout.decode() + captured_stderr.decode())
 
     def on_error(p, error):
         on_test_error(-1, -1, error)
@@ -573,10 +567,12 @@ actor CmdTest(env: Env, args, perf_mode: bool=False):
             return
         after 0.05: _periodic_show()
 
-    def _on_json_output(rmt, test, data):
+    def _on_json_output(rmt, test, data, stdout_buf, stderr_buf):
         if isinstance(data, dict):
             if "test_info" in data:
                 test_info = TestInfo.from_json(data["test_info"])
+                test_info.stdout = stdout_buf.decode()
+                test_info.stderr = stderr_buf.decode()
                 ptr.update(test_info.definition.module, test_info.definition.name, test_info)
                 if test_info.complete:
                     if test_info.success == None and test_info.exception == "Test timeout":
@@ -618,7 +614,7 @@ actor CmdTest(env: Env, args, perf_mode: bool=False):
                 process_cap,
                 test_info.definition.module,
                 cmd,
-                lambda rmt, x: _on_json_output(rmt, test_info.definition, x),
+                lambda rmt, x, stdout_buf, stderr_buf: _on_json_output(rmt, test_info.definition, x, stdout_buf, stderr_buf),
                 lambda x, y, z: _on_test_error(test_info.definition, x, y, z))
             running_tests[test_info.definition] = t
             if len(running_tests) < concurrency:

--- a/cli/src/acton.act
+++ b/cli/src/acton.act
@@ -517,12 +517,16 @@ actor ListTests(process_cap, test_modules: list[str], on_done: action(?str, ?dic
         remaining_mods[module_name] = p
 
 
-actor RunTestTest(env: Env, args, perf_mode: bool=False):
+actor CmdTest(env: Env, args, perf_mode: bool=False):
     """Run project tests, i.e. `acton test`
     """
     process_cap = process.ProcessCap(env.cap)
-    var modules_to_test = set()
-    var tests = {}
+    # TODO: test concurrency should consider the type of test, so unit tests get
+    # 1 CPU while actor / env tests get more. This is a simple approximation for
+    # a start...
+    concurrency = env.nr_wthreads // 2
+    var running_tests = {}
+    var tests_to_run = []
     var perf_data = "{}"
     fs = file.FS(file.FileCap(env.cap))
 
@@ -566,40 +570,58 @@ actor RunTestTest(env: Env, args, perf_mode: bool=False):
             return
         after 0.05: _periodic_show()
 
-    def _on_json_output(module_name, data):
+    def _on_json_output(test, data):
         if isinstance(data, dict):
             if "test_info" in data:
                 test_info = TestInfo.from_json(data["test_info"])
-                ptr.update(module_name, test_info.definition.name, test_info)
-                if ptr.is_module_done(module_name) and perf_mode:
-                    _run_module_tests()
+                ptr.update(test_info.definition.module, test_info.definition.name, test_info)
+                if test_info.complete:
+                    _run_test()
         else:
-            raise ValueError("Unexpected JSON data from module test: " + module_name)
+            raise ValueError("Unexpected JSON data from module test: " + test.module)
 
-    def _on_test_error(module_name: str, exit_code: int, term_signal: int, errout: str):
-        errmsg = "Module test error, exit_code %d and term signal %d, errout: " % (exit_code, term_signal)
+    def _on_test_error(test: testing.Test, exit_code: int, term_signal: int, errout: str):
+        errmsg = "Test error, exit_code %d and term signal %d, errout: " % (exit_code, term_signal)
         try:
             errmsg += errout
         except IndexError:
             pass
-        if module_name in ptr.results:
-            moderr = testing.ModuleError(exit_code, term_signal, errout)
-            ptr.update_module_error(module_name, moderr)
-        _run_module_tests()
+        # We construct our own TestInfo here since we didn't get one from the
+        # test process, because it crashed...
+        ptr.update(
+            test.module,
+            test.name,
+            testing.TestInfo(
+                test,
+                complete=True,
+                success=None,
+                exception="Test crash, exit_code %d and term signal %d" % (exit_code, term_signal),
+                num_iterations=1,
+                num_failures=0,
+                num_errors=1
+            ))
+        _run_test()
 
-    def _run_module_tests(run_all=False):
+    def _run_test():
         try:
-            module_name = modules_to_test.pop()
+            test_info = tests_to_run.pop(0)
             cmd = ["test"]
             if perf_mode:
                 cmd += ["perf"]
+            cmd += ["--name", test_info.definition.name]
             cmd += test_cmd_args
-            t = RunModuleTest(process_cap, module_name, cmd, lambda x: _on_json_output(module_name, x), lambda x, y, z: _on_test_error(module_name, x, y, z))
-        except ValueError:
-            _periodic_show()
-            return
-        if run_all:
-            _run_module_tests(run_all)
+            t = RunModuleTest(
+                process_cap,
+                test_info.definition.module,
+                cmd,
+                lambda x: _on_json_output(test_info.definition, x),
+                lambda x, y, z: _on_test_error(test_info.definition, x, y, z))
+            running_tests[test_info.definition] = t
+            if len(running_tests) < concurrency:
+                _run_test()
+        except IndexError:
+            pass
+        _periodic_show()
 
     def _list_tests(built_modules: list[str]):
         list_modules = []
@@ -624,13 +646,14 @@ actor RunTestTest(env: Env, args, perf_mode: bool=False):
             env.exit(1)
             return
 
-        modules_to_test = set(tests.keys())
-        ptr.expected_modules = set(modules_to_test)
+        ptr.expected_modules = set(tests.keys())
 
-        tests = tests
         for module_name, module_tests in tests.items():
-            ptr.update_module(module_name, module_tests)
-        _run_module_tests(run_all=not perf_mode)
+            for test_name, test_info in module_tests.items():
+                ptr.update(module_name, test_name, test_info)
+                tests_to_run.append(test_info)
+
+        _run_test()
 
     def _on_build_success(stdout_buf: str):
         print(term.clearline + term.up() + term.clearline, end="")
@@ -1127,10 +1150,10 @@ actor main(env):
         env.exit(0)
 
     def _cmd_test(args):
-        run_tests = RunTestTest(env, args, perf_mode=False)
+        run_tests = CmdTest(env, args, perf_mode=False)
 
     def _cmd_test_perf(args):
-        run_tests = RunTestTest(env, args, perf_mode=True)
+        run_tests = CmdTest(env, args, perf_mode=True)
 
     def _cmd_list_test(args):
         run_tests = CmdListTest(env, args)

--- a/cli/src/acton.act
+++ b/cli/src/acton.act
@@ -108,22 +108,22 @@ actor CompilerRunner(process_cap, env, args, wdir=None, on_exit: ?action(int, in
     with an error message. Similarly, if actonc encounters an error, it will
     print the error message and exit.
     """
-    var stdout_buf = b""
-    var stderr_buf = b""
+    var std_out_buf = b""
+    var std_err_buf = b""
 
-    def on_actonc_stderr(p, data):
-        stderr_buf += data
+    def on_actonc_std_err(p, data):
+        std_err_buf += data
         if print_output:
             print(data.decode(), end="")
 
-    def on_actonc_stdout(p, data):
-        stdout_buf += data
+    def on_actonc_std_out(p, data):
+        std_out_buf += data
         if print_output:
             print(data.decode(), end="")
 
     def on_actonc_exit(p, exit_code, term_signal):
         if on_exit is not None:
-            on_exit(exit_code, term_signal, stdout_buf, stderr_buf)
+            on_exit(exit_code, term_signal, std_out_buf, std_err_buf)
         else:
             if exit_code != 0:
                 print("actonc exited with code: ", exit_code, " terminated with signal:", term_signal)
@@ -141,7 +141,7 @@ actor CompilerRunner(process_cap, env, args, wdir=None, on_exit: ?action(int, in
     # We find the path to actonc by looking at the executable path of the
     # current process. Since we are called 'acton', we just add a 'c'.
     cmd = [fs.exepath() + ("c" if exe == "actonc" else "")] + args
-    p = process.Process(process_cap, cmd, on_actonc_stdout, on_actonc_stderr, on_actonc_exit, on_actonc_error, wdir)
+    p = process.Process(process_cap, cmd, on_actonc_std_out, on_actonc_std_err, on_actonc_exit, on_actonc_error, wdir)
 
     def stop():
         p.stop()
@@ -172,11 +172,11 @@ actor BuildProject(process_cap, env, args, on_build_success: action(str) -> None
 
     var build_config = BuildConfig()
 
-    def _on_actonc_exit(exit_code, term_signal, stdout_buf, stderr_buf):
+    def _on_actonc_exit(exit_code, term_signal, std_out_buf, std_err_buf):
         if exit_code == 0:
-            on_build_success(stdout_buf.decode())
+            on_build_success(std_out_buf.decode())
         else:
-            on_build_failure(exit_code, term_signal, stdout_buf.decode() + stderr_buf.decode())
+            on_build_failure(exit_code, term_signal, std_out_buf.decode() + std_err_buf.decode())
 
     def _on_actonc_failure(error: str):
         on_build_failure(-999, -999, error)
@@ -224,7 +224,7 @@ actor BuildProject(process_cap, env, args, on_build_success: action(str) -> None
             print_output=not build_tests
         )
 
-    def _on_dep_actonc_exit(dep_name, exit_code, term_signal, stdout_buf, stderr_buf):
+    def _on_dep_actonc_exit(dep_name, exit_code, term_signal, std_out_buf, std_err_buf):
         if exit_code == 0:
             print("Dependency", dep_name, "built successfully")
             try:
@@ -272,7 +272,7 @@ actor BuildProject(process_cap, env, args, on_build_success: action(str) -> None
                     env,
                     cmd,
                     path,
-                    lambda exit_code, term_signal, stdout_buf, stderr_buf: _on_dep_actonc_exit(dep_name, exit_code, term_signal, stdout_buf, stderr_buf),
+                    lambda exit_code, term_signal, std_out_buf, std_err_buf: _on_dep_actonc_exit(dep_name, exit_code, term_signal, std_out_buf, std_err_buf),
                     lambda error_msg: on_dep_build_error(dep_name, error_msg),
                     exe="acton"
                 )
@@ -377,43 +377,43 @@ actor BuildProject(process_cap, env, args, on_build_success: action(str) -> None
 
 
 actor RunModuleTest(process_cap, modname, test_cmd, on_json_output, on_test_error):
-    var captured_stdout = b""
-    var stderr_buf = b""
-    var captured_stderr = b""
+    var captured_std_out = b""
+    var std_err_buf = b""
+    var captured_std_err = b""
 
-    def on_stdout(p, data: bytes):
-        captured_stdout += data
+    def on_std_out(p, data: bytes):
+        captured_std_out += data
 
-    def on_stderr(p, data):
-        # TODO: we shouldn't sent test data in-band on stderr - should be separate pipe
-        stderr_buf += data
-        lines = stderr_buf.splitlines(True)
-        stderr_buf = b""
+    def on_std_err(p, data):
+        # TODO: we shouldn't sent test data in-band on std_err - should be separate pipe
+        std_err_buf += data
+        lines = std_err_buf.splitlines(True)
+        std_err_buf = b""
         for i, line in enumerate(lines):
             if not line.endswith(b"\n"):
-                stderr_buf = b"".join(lines[i:])
+                std_err_buf = b"".join(lines[i:])
                 break
 
             # We have a complete line, check if it is valid JSON
             try:
                 upd = json.decode(line.decode())
                 # We have a complete JSON object, pass it to the callback
-                on_json_output(self, upd, captured_stdout, captured_stderr)
+                on_json_output(self, upd, captured_std_out, captured_std_err)
             except ValueError:
-                # Not a complete JSON object, append to captured_stderr
+                # Not a complete JSON object, append to captured_std_err
                 if line != b"\n":
-                    captured_stderr += line
+                    captured_std_err += line
 
     def on_exit(p, exit_code, term_signal):
         if exit_code != 0 or term_signal != 0:
-            on_test_error(exit_code, term_signal, captured_stdout.decode() + captured_stderr.decode())
+            on_test_error(exit_code, term_signal, captured_std_out.decode() + captured_std_err.decode())
 
     def on_error(p, error):
         on_test_error(-1, -1, error)
 
     # TODO: fs.join()
     cmd = ["out/bin/.test_" + modname, "--json"] + test_cmd
-    p = process.Process(process_cap, cmd, on_stdout, on_stderr, on_exit, on_error)
+    p = process.Process(process_cap, cmd, on_std_out, on_std_err, on_exit, on_error)
 
     def stop():
         p.stop()
@@ -440,21 +440,21 @@ actor CmdListTest(env, args):
             print()
         env.exit(0)
 
-    def _on_build_success(stdout_buf: str):
+    def _on_build_success(std_out_buf: str):
         test_modules = []
-        stdout_tests = False
-        for line in stdout_buf.splitlines(False):
+        std_out_tests = False
+        for line in std_out_buf.splitlines(False):
             if line.startswith("Test executables:"):
-                stdout_tests = True
+                std_out_tests = True
             else:
-                if stdout_tests:
+                if std_out_tests:
                     test_modules.append(line)
         l = ListTests(process_cap, test_modules, print_module_tests)
 
-    def _on_build_failure(exit_code, term_signal, stderr_buf: str):
+    def _on_build_failure(exit_code, term_signal, std_err_buf: str):
         print("Failed to build project tests")
         print("actonc exited with code %d / %d" % (exit_code, term_signal))
-        print("stderr:", stderr_buf)
+        print("std_err:", std_err_buf)
         env.exit(1)
 
     project_builder = BuildProject(
@@ -473,11 +473,11 @@ actor ListTests(process_cap, test_modules: list[str], on_done: action(?str, ?dic
     remaining_mods = {}
     tests: dict[str, dict[str, testing.TestInfo]] = {}
 
-    def _on_exit(module_name, p, exit_code, term_signal, stdout_buf, stderr_buf):
+    def _on_exit(module_name, p, exit_code, term_signal, std_out_buf, std_err_buf):
         if exit_code == 0:
             tests[module_name] = {}
             try:
-                data = json.decode(stderr_buf.decode())
+                data = json.decode(std_err_buf.decode())
                 if isinstance(data, dict):
                     if "tests" in data:
                         for test_name, json_test_info in data["tests"].items():
@@ -491,7 +491,7 @@ actor ListTests(process_cap, test_modules: list[str], on_done: action(?str, ?dic
             except ValueError as e:
                 on_done("Error parsing JSON from module %s: %s" % (module_name, str(e)))
         else:
-            on_done("Error listing tests for module %s, exited with code %d and term signal %d: %s" % (module_name, exit_code, term_signal, stderr_buf.decode()))
+            on_done("Error listing tests for module %s, exited with code %d and term signal %d: %s" % (module_name, exit_code, term_signal, std_err_buf.decode()))
 
     def _on_error(module_name, p, error):
         err = "ERROR: Error listing tests for module %s: %s" % (module_name, error)
@@ -509,7 +509,7 @@ actor ListTests(process_cap, test_modules: list[str], on_done: action(?str, ?dic
         p = process.RunProcess(
             process_cap,
             cmd,
-            lambda p, exit_code, term_signal, stdout_buf, stderr_buf: _on_exit(module_name, p, exit_code, term_signal, stdout_buf, stderr_buf),
+            lambda p, exit_code, term_signal, std_out_buf, std_err_buf: _on_exit(module_name, p, exit_code, term_signal, std_out_buf, std_err_buf),
             lambda p, error: _on_error(module_name, p, error))
         remaining_mods[module_name] = p
 
@@ -567,12 +567,12 @@ actor CmdTest(env: Env, args, perf_mode: bool=False):
             return
         after 0.05: _periodic_show()
 
-    def _on_json_output(rmt, test, data, stdout_buf, stderr_buf):
+    def _on_json_output(rmt, test, data, std_out_buf, std_err_buf):
         if isinstance(data, dict):
             if "test_info" in data:
                 test_info = TestInfo.from_json(data["test_info"])
-                test_info.stdout = stdout_buf.decode()
-                test_info.stderr = stderr_buf.decode()
+                test_info.std_out = std_out_buf.decode()
+                test_info.std_err = std_err_buf.decode()
                 ptr.update(test_info.definition.module, test_info.definition.name, test_info)
                 if test_info.complete:
                     if test_info.success == None and test_info.exception == "Test timeout":
@@ -614,7 +614,7 @@ actor CmdTest(env: Env, args, perf_mode: bool=False):
                 process_cap,
                 test_info.definition.module,
                 cmd,
-                lambda rmt, x, stdout_buf, stderr_buf: _on_json_output(rmt, test_info.definition, x, stdout_buf, stderr_buf),
+                lambda rmt, x, std_out_buf, std_err_buf: _on_json_output(rmt, test_info.definition, x, std_out_buf, std_err_buf),
                 lambda x, y, z: _on_test_error(test_info.definition, x, y, z))
             running_tests[test_info.definition] = t
             if len(running_tests) < concurrency:
@@ -658,22 +658,22 @@ actor CmdTest(env: Env, args, perf_mode: bool=False):
 
         _run_test()
 
-    def _on_build_success(stdout_buf: str):
+    def _on_build_success(std_out_buf: str):
         print(term.clearline + term.up() + term.clearline, end="")
         test_modules = []
-        stdout_tests = False
-        for line in stdout_buf.splitlines(False):
+        std_out_tests = False
+        for line in std_out_buf.splitlines(False):
             if line.startswith("Test executables:"):
-                stdout_tests = True
+                std_out_tests = True
             else:
-                if stdout_tests:
+                if std_out_tests:
                     test_modules.append(line)
         _list_tests(test_modules)
 
-    def _on_build_failure(exit_code, term_signal, stderr_buf: str):
+    def _on_build_failure(exit_code, term_signal, std_err_buf: str):
         print("Failed to build project tests")
         print("actonc exited with code %d / %d" % (exit_code, term_signal))
-        print("stderr:", stderr_buf)
+        print("std_err:", std_err_buf)
         env.exit(1)
 
     # TODO: let dev mode enable for normal test and disable, i.e. use release mode for perf tests
@@ -721,9 +721,9 @@ actor ZigFetchDeps(env, build_config: BuildConfig, on_done: action(int, int) -> 
     var total = 0
     var fetched = 0
 
-    def _on_exit(dep: Dependency, p, exit_code, term_signal, stdout_buf, stderr_buf):
+    def _on_exit(dep: Dependency, p, exit_code, term_signal, std_out_buf, std_err_buf):
         if exit_code == 0:
-            fetched_hash: str = stdout_buf.decode().strip()
+            fetched_hash: str = std_out_buf.decode().strip()
             if print_output:
                 print("Fetched dependency %s with hash %s" % (dep.name, fetched_hash), err=True)
 
@@ -745,7 +745,7 @@ actor ZigFetchDeps(env, build_config: BuildConfig, on_done: action(int, int) -> 
             if len(dep_processes) == 0 and len(zig_processes) == 0:
                 on_done(total, fetched)
         else:
-            on_fetch_error(stderr_buf.decode())
+            on_fetch_error(std_err_buf.decode())
 
     def _on_error(dep, p, error):
         # TODO: collect all errors before calling on_fetch_error?
@@ -777,7 +777,7 @@ actor ZigFetchDeps(env, build_config: BuildConfig, on_done: action(int, int) -> 
             p = process.RunProcess(
                 pcap,
                 cmd,
-                lambda p, exit_code, term_signal, stdout_buf, stderr_buf: _on_exit(dep, p, exit_code, term_signal, stdout_buf, stderr_buf),
+                lambda p, exit_code, term_signal, std_out_buf, std_err_buf: _on_exit(dep, p, exit_code, term_signal, std_out_buf, std_err_buf),
                 lambda p, error: _on_error(dep, p, error))
             dep_processes[dep.name] = p
 
@@ -806,7 +806,7 @@ actor ZigFetchDeps(env, build_config: BuildConfig, on_done: action(int, int) -> 
             p = process.RunProcess(
                 pcap,
                 cmd,
-                lambda p, exit_code, term_signal, stdout_buf, stderr_buf: _on_exit(dep, p, exit_code, term_signal, stdout_buf, stderr_buf),
+                lambda p, exit_code, term_signal, std_out_buf, std_err_buf: _on_exit(dep, p, exit_code, term_signal, std_out_buf, std_err_buf),
                 lambda p, error: _on_error(dep, p, error))
             zig_processes[dep.name] = p
 
@@ -892,9 +892,9 @@ actor CmdPkgAdd(env, args):
 
     build_config = get_build_config()
 
-    def on_exit(p, exit_code, term_signal, stdout_buf, stderr_buf):
+    def on_exit(p, exit_code, term_signal, std_out_buf, std_err_buf):
         if exit_code == 0:
-            dep_hash = stdout_buf.decode().strip()
+            dep_hash = std_out_buf.decode().strip()
 
             if dep_name in build_config.dependencies:
                 bc_dep = build_config.dependencies[dep_name]
@@ -917,7 +917,7 @@ actor CmdPkgAdd(env, args):
 
             env.exit(0)
         else:
-            print("Error fetching", stderr_buf.decode())
+            print("Error fetching", std_err_buf.decode())
             env.exit(1)
 
     def on_error(p, error):
@@ -1012,9 +1012,9 @@ actor CmdZigPkgAdd(env, args):
 
     build_config = get_build_config()
 
-    def on_exit(p, exit_code, term_signal, stdout_buf, stderr_buf):
+    def on_exit(p, exit_code, term_signal, std_out_buf, std_err_buf):
         if exit_code == 0:
-            dep_hash = stdout_buf.decode().strip()
+            dep_hash = std_out_buf.decode().strip()
 
             if dep_name in build_config.zig_dependencies:
                 if build_config.zig_dependencies[dep_name].url != dep_url:
@@ -1037,7 +1037,7 @@ actor CmdZigPkgAdd(env, args):
 
             env.exit(0)
         else:
-            print("Error fetching", stderr_buf.decode())
+            print("Error fetching", std_err_buf.decode())
             env.exit(1)
 
     def on_error(p, error):
@@ -1111,11 +1111,11 @@ actor main(env):
 
     def _compilefile(_file, args):
         if in_project(_file):
-            def on_build_success(stdout_buf):
+            def on_build_success(std_out_buf):
                 env.exit(0)
 
-            def on_build_failure(exit_code: int,  term_signal: int, stderr_buf: str):
-                print("Error building project", stderr_buf)
+            def on_build_failure(exit_code: int,  term_signal: int, std_err_buf: str):
+                print("Error building project", std_err_buf)
                 env.exit(1)
 
             BuildProject(process_cap, env, args, on_build_success, on_build_failure, build_tests=False, files=[_file])
@@ -1124,11 +1124,11 @@ actor main(env):
             cr = CompilerRunner(process_cap, env, [_file] + cmdargs)
 
     def _cmd_build(args):
-        def on_build_success(stdout_buf):
+        def on_build_success(std_out_buf):
             env.exit(0)
 
-        def on_build_failure(exit_code: int,  term_signal: int, stderr_buf: str):
-            print("Error building project", stderr_buf)
+        def on_build_failure(exit_code: int,  term_signal: int, std_err_buf: str):
+            print("Error building project", std_err_buf)
             env.exit(1)
 
         BuildProject(process_cap, env, args, on_build_success, on_build_failure, build_tests=False)

--- a/cli/src/acton.act
+++ b/cli/src/acton.act
@@ -605,10 +605,9 @@ actor CmdTest(env: Env, args, perf_mode: bool=False):
     def _run_test():
         try:
             test_info = tests_to_run.pop(0)
-            cmd = ["test"]
+            cmd = ["test", test_info.definition.name]
             if perf_mode:
                 cmd += ["perf"]
-            cmd += ["--name", test_info.definition.name]
             cmd += test_cmd_args
             t = RunModuleTest(
                 process_cap,
@@ -648,10 +647,13 @@ actor CmdTest(env: Env, args, perf_mode: bool=False):
 
         ptr.expected_modules = set(tests.keys())
 
-        for module_name, module_tests in tests.items():
+        name_filter = set(args.get_strlist("name"))
+        for module_name in sorted(tests.keys()):
+            module_tests = tests[module_name]
             for test_name, test_info in module_tests.items():
-                ptr.update(module_name, test_name, test_info)
-                tests_to_run.append(test_info)
+                if len(name_filter) == 0 or test_name in name_filter:
+                    ptr.update(module_name, test_name, test_info)
+                    tests_to_run.append(test_info)
 
         _run_test()
 


### PR DESCRIPTION
Run tests in individual processes
- crashes now only affect the single test, not others
- we can now capture stdout / stderr from tests
  - these are printed if the test fails
- simplified logic in many places

Fixes #2048 

Fixes #1987