### PR TITLE
Always call on_close in TCPConnection.close()

### DIFF
--- a/base/src/net.ext.c
+++ b/base/src/net.ext.c
@@ -319,8 +319,10 @@ static void after_shutdown(uv_shutdown_t* req, int status) {
 $R netQ_TCPConnectionD_closeG_local (netQ_TCPConnection self, $Cont c$cont, $action on_close) {
     uv_stream_t *stream = (uv_stream_t *)from$int(self->_sock);
     // fd == -1 means invalid FD and can happen after __resume__
-    if ((long int)stream == -1)
+    if ((long int)stream == -1) {
+        on_close->$class->__asyn__(on_close, self);
         return $R_CONT(c$cont, B_None);
+    }
 
     log_debug("Closing TCP connection");
     struct close_cb_data *cb_data = (struct close_cb_data *)acton_malloc(sizeof(struct close_cb_data));

--- a/test/stdlib_auto/test_net_tcp.act
+++ b/test/stdlib_auto/test_net_tcp.act
@@ -28,15 +28,18 @@ actor Server(conn):
 
 
 actor Listener(env, address, port):
-    def on_lsock_error(l, error):
-        print("There was an error with the TCPListener socket:", error)
+    def on_listen(l, error):
+        if error != None:
+            print("There was an error with the TCPListener socket:", error)
+        else:
+            print("Successfully established listening socket on %s:%d" % (address, port))
 
     def on_server_accept(c):
         s = Server(c)
         c.cb_install(s.on_receive, s.on_error)
 
     listen_cap = net.TCPListenCap(net.TCPCap(net.NetCap(env.cap)))
-    server = net.TCPListener(listen_cap, address, port, on_lsock_error, on_server_accept)
+    server = net.TCPListener(listen_cap, address, port, on_listen, on_server_accept)
 
 
 actor Client(name, rts_monitor, env: Env, port: int, on_success):


### PR DESCRIPTION
Also realign some test code on newer behavior of on_listen callback!

Fixes #2072.