### PR TITLE
Update acton-by-example documentation with latest APT key guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Check out the [installation guide](https://www.acton-lang.org/install) for more 
 sudo install -m 0755 -d /etc/apt/keyrings
 sudo wget -q -O /etc/apt/keyrings/acton.asc https://apt.acton-lang.io/acton.gpg
 sudo chmod a+r /etc/apt/keyrings/acton.asc
-echo "deb [signed-by=/etc/apt/keyrings/acton.asc arch=amd64] http://apt.acton-lang.io/ stable main" | sudo tee /etc/apt/sources.list.d/acton.list
+echo "deb [signed-by=/etc/apt/keyrings/acton.asc arch=amd64] http://apt.acton-lang.io/ stable main" | sudo tee -a /etc/apt/sources.list.d/acton.list
 sudo apt-get update
 sudo apt-get install -qy acton
 ```

--- a/README.md
+++ b/README.md
@@ -36,8 +36,10 @@ Check out the [installation guide](https://www.acton-lang.org/install) for more 
 
 ### Debian / Ubuntu
 ```sh
-wget -q -O - https://apt.acton-lang.io/acton.gpg | sudo apt-key add -
-echo "deb [arch=amd64] http://apt.acton-lang.io/ bullseye main" | sudo tee /etc/apt/sources.list.d/acton.list
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo wget -q -O /etc/apt/keyrings/acton.asc https://apt.acton-lang.io/acton.gpg
+sudo chmod a+r /etc/apt/keyrings/acton.asc
+echo "deb [signed-by=/etc/apt/keyrings/acton.asc arch=amd64] http://apt.acton-lang.io/ stable main" | sudo tee /etc/apt/sources.list.d/acton.list
 sudo apt-get update
 sudo apt-get install -qy acton
 ```

--- a/docs/acton-by-example/src/install.md
+++ b/docs/acton-by-example/src/install.md
@@ -4,8 +4,10 @@
 {{#tab name="Debian / Ubuntu" }}
 For Debian derivative distributions that use .dpkg and the APT ecosystem. Add the Acton APT repo and install from there:
 ```console
-wget -q -O - https://apt.acton-lang.io/acton.gpg | sudo apt-key add -
-echo "deb [arch=amd64] http://apt.acton-lang.io/ stable main" | sudo tee /etc/apt/sources.list.d/acton.list
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo wget -q -O /etc/apt/keyrings/acton.asc https://apt.acton-lang.io/acton.gpg
+sudo chmod a+r /etc/apt/keyrings/acton.asc
+echo "deb [signed-by=/etc/apt/keyrings/acton.asc arch=amd64] http://apt.acton-lang.io/ stable main" | sudo tee /etc/apt/sources.list.d/acton.list
 sudo apt-get update
 sudo apt-get install -qy acton
 ```

--- a/docs/acton-by-example/src/install.md
+++ b/docs/acton-by-example/src/install.md
@@ -7,7 +7,7 @@ For Debian derivative distributions that use .dpkg and the APT ecosystem. Add th
 sudo install -m 0755 -d /etc/apt/keyrings
 sudo wget -q -O /etc/apt/keyrings/acton.asc https://apt.acton-lang.io/acton.gpg
 sudo chmod a+r /etc/apt/keyrings/acton.asc
-echo "deb [signed-by=/etc/apt/keyrings/acton.asc arch=amd64] http://apt.acton-lang.io/ stable main" | sudo tee /etc/apt/sources.list.d/acton.list
+echo "deb [signed-by=/etc/apt/keyrings/acton.asc arch=amd64] http://apt.acton-lang.io/ stable main" | sudo tee -a /etc/apt/sources.list.d/acton.list
 sudo apt-get update
 sudo apt-get install -qy acton
 ```

--- a/docs/acton-by-example/src/install_tip.md
+++ b/docs/acton-by-example/src/install_tip.md
@@ -9,7 +9,7 @@ For Debian derivative distributions that use .dpkg and the APT ecosystem. Add th
 sudo install -m 0755 -d /etc/apt/keyrings
 sudo wget -q -O /etc/apt/keyrings/acton.asc https://apt.acton-lang.io/acton.gpg
 sudo chmod a+r /etc/apt/keyrings/acton.asc
-echo "deb [signed-by=/etc/apt/keyrings/acton.asc arch=amd64] http://aptip.acton-lang.io/ tip main" | sudo tee /etc/apt/sources.list.d/acton.list
+echo "deb [signed-by=/etc/apt/keyrings/acton.asc arch=amd64] http://aptip.acton-lang.io/ tip main" | sudo tee -a /etc/apt/sources.list.d/acton.list
 sudo apt-get update
 sudo apt-get install -qy acton
 ```

--- a/docs/acton-by-example/src/install_tip.md
+++ b/docs/acton-by-example/src/install_tip.md
@@ -6,8 +6,10 @@ Tip releases are built from the latest commit on the acton git repo main branch.
 {{#tab name="Debian / Ubuntu x86_64" }}
 For Debian derivative distributions that use .dpkg and the APT ecosystem. Add the Acton APT tip repo and install from there:
 ```console
-wget -q -O - https://apt.acton-lang.io/acton.gpg | sudo apt-key add -
-echo "deb [arch=amd64] http://aptip.acton-lang.io/ tip main" | sudo tee /etc/apt/sources.list.d/acton.list
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo wget -q -O /etc/apt/keyrings/acton.asc https://apt.acton-lang.io/acton.gpg
+sudo chmod a+r /etc/apt/keyrings/acton.asc
+echo "deb [signed-by=/etc/apt/keyrings/acton.asc arch=amd64] http://aptip.acton-lang.io/ tip main" | sudo tee /etc/apt/sources.list.d/acton.list
 sudo apt-get update
 sudo apt-get install -qy acton
 ```


### PR DESCRIPTION
Update the acton-by-example documentation with the latest guidelines for APT package repository signing keys.  Change the distro to stable from bullseye.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/actonlang/acton/pull/2080?shareId=df46971a-c4a2-4867-a79f-e32406fc7d9b).