### PR TITLE
Avoid ** in Makefile wildcard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ test-backend: $(BACKEND_TESTS)
 	./backend/test/skiplist_test
 
 # /compiler ----------------------------------------------
-ACTONC_HS=$(wildcard compiler/lib/src/*.hs compiler/lib/src/**/*.hs compiler/actonc/Main.hs)
+ACTONC_HS=$(wildcard compiler/lib/src/*.hs compiler/lib/src/*/*.hs compiler/actonc/Main.hs)
 # NOTE: we're unsetting CC & CXX to avoid using zig cc & zig c++ for stack /
 # ghc, which doesn't seem to work properly
 dist/bin/actonc: compiler/lib/package.yaml.in compiler/actonc/package.yaml.in compiler/lsp-server/package.yaml.in compiler/stack.yaml $(ACTONC_HS) common.mk


### PR DESCRIPTION
** doesn't seem to be supported by Makefile at all. Other systems treat it a recursive wildcards, but I can't find support for that in Makefile, so probably my mistake to use that to begin with. Now using known-length path with wildcards to find all relevant source files for lib / actonc.