### PR TITLE
Ensure fresh build.zig.zon for cli build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -354,7 +354,7 @@ clean-base:
 	rm -rf base/out
 
 cli/out/bin/acton: distribution1
-	cd cli && $(ACTC) build $(ACTONC_TARGET)
+	cd cli && rm -f build.zig build.zig.zon && $(ACTC) build $(ACTONC_TARGET)
 
 # == DIST ==
 #


### PR DESCRIPTION
The building of the CLI is special. It's an Acton project which we normally compile with the acton cli, but that's obviously cyclic here, so we need to compile with actonc. It is normally acton that does some initialization of build.zig.zon, but since we're invoking actonc directly here we can't do the same. actonc normaly receives a build.zig.zon written to disk by acton, which it then rewrites a bit. Unless build.zig.zon doesn't exist, in which actonc will also place the file there. There is no acton to write it for us, so by removing the file first, we get actonc to write it for us.