### PR TITLE
Misc fix

### DIFF
--- a/base/builtin/builtin_functions.c
+++ b/base/builtin/builtin_functions.c
@@ -564,3 +564,10 @@ $WORD B_round (B_Real W_395, $WORD x, B_int n) {
     return W_395->$class->__round__(W_395, x, n);
 }
 */
+
+$WORD $ASSERT(B_bool test, B_str msg) {
+    if (!test->val) {
+        $RAISE(msg);
+    }
+    return B_None;
+}

--- a/base/builtin/builtin_functions.h
+++ b/base/builtin/builtin_functions.h
@@ -195,3 +195,5 @@ B_Iterator B_reversed (B_Sequence, $WORD);
 $WORD B_round (B_Real, $WORD, B_int);
 $WORD B_sum(B_Plus, B_Iterable, $WORD, $WORD);
 */
+
+$WORD $ASSERT(B_bool, B_str);

--- a/compiler/lib/src/Acton/CodeGen.hs
+++ b/compiler/lib/src/Acton/CodeGen.hs
@@ -661,7 +661,7 @@ genCall env [t] (Var _ n) PosNil
 -- TODO: would be even better to determine this in the compiler and not emit
 -- this line rather than inspect the method table at run time
 genCall env [TCon _ tc] (Var _ n) p
-  | n == primGCfinalizer            = text "if" <+> parens (gen env p <> text "->" <> gen env classKW <> text "->" <> gen env cleanupKW <+> text "!= $ActorD___cleanup__") <+> gen env n <> parens (gen env p <> comma <+> genTopName env (methodname (noq $ tcname tc) (name "_GC_finalizer")))
+  | n == primGCfinalizer            = text "if" <+> parens (text "(void*)" <> gen env p <> text "->" <> gen env classKW <> text "->" <> gen env cleanupKW <+> text "!= (void*)$ActorD___cleanup__") <+> gen env n <> parens (gen env p <> comma <+> genTopName env (methodname (noq $ tcname tc) (name "_GC_finalizer")))
 genCall env ts e@(Var _ n) p
   | NClass{} <- info                = genNew env n p
   | NDef{} <- info                  = (instCast env ts e $ gen env e) <> parens (gen env p)

--- a/compiler/lib/src/Acton/Solver.hs
+++ b/compiler/lib/src/Acton/Solver.hs
@@ -495,7 +495,7 @@ reduce' env eq (Seal info t@(TCon _ tc))
   | otherwise                               = reduce env eq (map (Seal info) $ tcargs tc)
 reduce' env eq (Seal _ t@(TFX _ fx))
 --  | fx `elem` [FXMut,FXProc]                = tyerr t "Leaking actor seal:"
-  | fx `elem` [FXProc]                      = tyerr t "Leaking actor seal:"
+--  | fx `elem` [FXProc]                      = tyerr t "Leaking actor seal:"
   | otherwise                               = return eq
 reduce' env eq (Seal info t)                = reduce env eq (map (Seal info) ts)
   where ts                                  = leaves t

--- a/compiler/lib/src/Acton/Types.hs
+++ b/compiler/lib/src/Acton/Types.hs
@@ -619,8 +619,8 @@ checkNoEscape l env vs                  = do fvs <- tyfree <$> msubst env
                                              let escaped = vs `intersect` fvs
                                              when (not $ null escaped) $ do
                                                  env1 <- msubst env
-                                                 --traceM ("####### env:\n" ++ prstr env1)
-                                                 err l "Escaping type variable"
+                                                 traceM ("####### env:\n" ++ prstr env1)
+                                                 err l ("Escaping type variables: " ++ prstrs escaped)
 
 
 wellformed                              :: (WellFormed a) => Env -> a -> TypeM ()


### PR DESCRIPTION
Turn off escaping proc checking, will turn on again once we support actor inheritance and no longer depend on proc parameters as a workaround. Also add C-level support for 'assert'.