### PR TITLE
Let iN overflow

### DIFF
--- a/base/build.zig
+++ b/base/build.zig
@@ -220,6 +220,10 @@ pub fn build(b: *std.Build) void {
         };
     }
 
+    flags.appendSlice(&.{
+        "-fno-sanitize=signed-integer-overflow",
+    }) catch unreachable;
+
     const libActon = b.addStaticLibrary(.{
         .name = "Acton",
         .target = target,

--- a/builder/build.zig
+++ b/builder/build.zig
@@ -168,6 +168,10 @@ pub fn build(b: *std.Build) void {
         };
     }
 
+    flags.appendSlice(&.{
+        "-fno-sanitize=signed-integer-overflow",
+    }) catch unreachable;
+
     for (c_files.items) |entry| {
         libActonProject.addCSourceFile(.{ .file = .{ .cwd_relative = entry }, .flags = flags.items });
     }

--- a/test/builtins_auto/int.act
+++ b/test/builtins_auto/int.act
@@ -96,6 +96,8 @@ def test_i16():
         raise ValueError('i16("0b1111") gives wrong result')
     if i16("1234",7) != 466:
         raise ValueError('i16("1234",7) gives wrong result')
+    #if i16(2**15-1) + 1 != -2**15:
+    #    raise ValueError("i16 wraparound failed")
     return True
 
 def test_i32():
@@ -117,6 +119,8 @@ def test_i32():
         raise ValueError('i32("1234",7) gives wrong result')
     if int(x) != 0:
         raise ValueError("unexpected: int(x) != 0")
+    if i32(2**31-1) + 1 != -2**31:
+        raise ValueError("i32 wraparound failed")
     return True
 
 def test_i64():
@@ -138,6 +142,8 @@ def test_i64():
         raise ValueError('i64("1234",7) gives wrong result')
     if int(x) != 0:
         raise ValueError("unexpected: int(x) != 0")
+    if i64(2**63-1) + 1 != -2**63:
+        raise ValueError("i64 wraparound failed")
     return True
 
 def test_u16():
@@ -159,6 +165,8 @@ def test_u16():
         raise ValueError('u16("1234",7) gives wrong result')
     if int(x) != 0:
         raise ValueError("unexpected: int(x) != 0")
+    #if u16(2**16-1) + 1 != 0:
+    #    raise ValueError("u16 wraparound failed")
     return True
 
 def test_u32():
@@ -180,6 +188,8 @@ def test_u32():
         raise ValueError('u32("1234",7) gives wrong result')
     if int(x) != 0:
         raise ValueError("unexpected: int(x) != 0")
+    if u32(2**32-1) + 1 != 0:
+        raise ValueError("u32 wraparound failed")
     return True
 
 def test_u64():
@@ -201,6 +211,8 @@ def test_u64():
         raise ValueError('u64("1234",7) gives wrong result')
     if int(x) != 0:
         raise ValueError("unexpected: int(x) != 0")
+    if u64(2**64-1) + 1 != 0:
+        raise ValueError("u64 wraparound failed")
     return True
 
 


### PR DESCRIPTION
Our signed integer types are now allowed to overflow. We use the straight C types and in the C specification, signed integer overflow is undefined behavior. Most C compilers are quite lax and don't enforce it in any way per default. We use Zig to compile and per default it enables all sorts of UBsan, and so we have inherited that behavior.

However, in Acton we think the sane behavior is for integer operations to be well defined and not change with compilation flags, plus we want decent performance and so overflow is the most sane behavior. That is now the case!

Some simple test cases are added to verify overflow works. u16 / i16 does not work, likely since the underpinning type is actually not 16 bits.

Fixes #2079 