### PR TITLE
Allow dep path OR url in build config

### DIFF
--- a/base/src/buildy.act
+++ b/base/src/buildy.act
@@ -88,6 +88,8 @@ class Dependency(object):
 class PkgDependency(Dependency):
 
     def __init__(self, name: str, url: ?str, hash: ?str, path: ?str):
+        if path != None and url != None:
+            raise ValueError("Dependency '%s' has both path and url set. Set only path or url. You can override path for a dep, e.g.: acton build --dep %s=%s" % (name, name, path))
         self.name = zig_safe_name(name)
         self.url = url
         self.hash = hash

--- a/docs/acton-by-example/src/SUMMARY.md
+++ b/docs/acton-by-example/src/SUMMARY.md
@@ -66,6 +66,7 @@
 - [Package Management](package_management.md)
   - [Add Dependency](pkg/add_dependency.md)
   - [Local Dependencies](pkg/local_dependencies.md)
+  - [Override Dependency](pkg/override_dependency.md)
   - [Remove Dependency](pkg/remove_dependency.md)
   - [Fetch Deps (Airplane mode)](pkg/fetch_dependencies.md)
   - [Zig / C / C++ dependencies](zig_dependencies.md)

--- a/docs/acton-by-example/src/pkg/local_dependencies.md
+++ b/docs/acton-by-example/src/pkg/local_dependencies.md
@@ -16,7 +16,7 @@ It is possible to use dependencies available via a local file system path by set
 }
 ```
 
-These are best used for dependencies located within the same git repository or similar. All users need to have the same relative path to the dependency so if the paths stretch over multiple repositories, the used needs to keep the paths aligned.
+These are best used for dependencies located within the same git repository or similar. All users need to have the same relative path to the dependency so if the paths stretch over multiple repositories, the user needs to keep the paths aligned.
 
 ```admonish
 You can temporarily override the path to a dependency through the `--dep` argument, e.g. `acton build --dep foo=../foo`. This can be useful to fork a library and make local modifications to it before submitting them back upstream.

--- a/docs/acton-by-example/src/pkg/local_dependencies.md
+++ b/docs/acton-by-example/src/pkg/local_dependencies.md
@@ -1,13 +1,11 @@
 # Local Dependencies
 
-It is possible to use dependencies available via a local file system path by setting the `path` attribute. Edit `build.act.json` and add or modify an existing dependency. Set the `path` attribute to a relative path on the local file system, e.g.:
+It is possible to use dependencies available via a local file system path by setting the `path` attribute. Edit `build.act.json` and add or modify an existing dependency. Set the `path` attribute to a relative path, e.g.:
 
 ```json
 {
     "dependencies": {
         "foo": {
-            "url": "https://github.com/actonlang/foo/archive/refs/heads/main.zip",
-            "hash": "1220cd47344f8a1e7fe86741c7b0257a63567b4c17ad583bddf690eedd672032abdd",
             "path": "../foo"
         },
         "local_lib": {
@@ -18,6 +16,8 @@ It is possible to use dependencies available via a local file system path by set
 }
 ```
 
+These are best used for dependencies located within the same git repository or similar. All users need to have the same relative path to the dependency so if the paths stretch over multiple repositories, the used needs to keep the paths aligned.
+
 ```admonish
-Setting a local `path` will take priority over a remote `url`. This can be useful to fork a library and make local modifications to it before submitting them back upstream.
+You can temporarily override the path to a dependency through the `--dep` argument, e.g. `acton build --dep foo=../foo`. This can be useful to fork a library and make local modifications to it before submitting them back upstream.
 ```

--- a/docs/acton-by-example/src/pkg/override_dependency.md
+++ b/docs/acton-by-example/src/pkg/override_dependency.md
@@ -1,0 +1,19 @@
+# Override the path to a dependency
+
+The configuration in `build.act.json` sets the path or url that is normally used for a dependency. It is possible to temporarily override the path through the `--dep` argument to `acton build`.
+
+Let's say we have the following configuration:
+
+```json
+{
+    "dependencies": {
+        "foo": {
+            "url": "https://github.com/actonlang/foo/archive/refs/tags/v1.0.zip",
+            "hash": "1220cd47344f8a1e7fe86741c7b0257a63567b4c17ad583bddf690eedd672032abdd"
+        }
+    },
+    "zig_dependencies": {}
+}
+```
+
+Now we want to make some modifications to the `foo` library, so we clone it to a local path. We can now build our project using `acton build --dep foo=../foo` to temporarily override the `foo` dependency to use the path `../foo` instead of the url in the configuration.


### PR DESCRIPTION
We used to allow path and url, in which case the path would override the url and this was useful to override with like a local fork of a dependency when doing development across multiple projects simultaneously. However, it's bad changing checked in files like build.act.json and so we added acton build --dep to override deps. It also has the benefit of being propagated to the build of dependencies, so if we have a main project that depends on foo and bar. In turn, foo depends on bar, so if we now override the path to bar, the same override is passed to the build of foo as to the main project.

Given that we have --dep, the old way of manually overriding the path in the configuration file is deprecated. We now block and require that only path OR url is set. Otherwise the user gets an error. We hint about the --dep argument and this is also based on the config the user has in their configuration file, e.g.:

  kll@Kristians-MacBook-Air test_deps % cat build.act.json
  {
      "dependencies": {
          "a_b": {
              "path": "deps/a-b",
              "url": "https://github.com/asdf/fnafna/refs/heads/main.zip"
          }
      }
  }
  kll@Kristians-MacBook-Air test_deps % acton build
  ERROR: Dependency 'a_b' has both path and url set. Set only path or url. You can override path for a dep, e.g.: acton build --dep a_b=deps/a-b
  kll@Kristians-MacBook-Air test_deps %

Fixes #2106 