### PR TITLE
Restructure actonc main, file build & locking

### DIFF
--- a/compiler/lib/src/Acton/CommandLineParser.hs
+++ b/compiler/lib/src/Acton/CommandLineParser.hs
@@ -62,6 +62,7 @@ data CompileOptions   = CompileOptions {
                          debug       :: Bool,
                          dev         :: Bool,
                          listimports :: Bool,
+                         sub         :: Bool,
                          only_build  :: Bool,
                          skip_build  :: Bool,
                          no_threads  :: Bool,
@@ -114,14 +115,14 @@ data DocOptions     = DocOptions {
 -- Internal stuff
 
 cmdLineParser       :: Parser CmdLineOptions
-cmdLineParser       =  (VersionOpt <$> versionOptions)
-                      <|> (CmdOpt <$> hsubparser 
+cmdLineParser       = (CmdOpt <$> hsubparser
                         (  command "new"   (info newCommand (progDesc "Create a new Acton project"))
                         <> command "build" (info buildCommand (progDesc "Build an Acton project"))
                         <> command "cloud" (info cloudCommand (progDesc "Run an Acton project in the cloud"))
                         <> command "doc"   (info docCommand (progDesc "Show type and docstring info"))
-                      ))              
-                     <|> (CompileOpt <$> (some $ argument (str :: ReadM String) (metavar "ACTONFILENAMES" <> help "Compile Acton files" <> completer (bashCompleter "file -X '!*.act' -o plusdirs"))) <*> compileOptions)
+                      ))
+                     <|> (CompileOpt <$> (fmap (:[]) $ argument str (metavar "ACTONFILE" <> help "Compile Acton file" <> completer (bashCompleter "file -X '!*.act' -o plusdirs"))) <*> compileOptions)
+                     <|> (VersionOpt <$> versionOptions)
 
 versionOptions         = VersionOptions <$>
                                          switch (long "version"         <> help "Show version information")
@@ -162,6 +163,7 @@ compileOptions = CompileOptions
         <*> switch (long "debug"        <> help "Print debug stuff")
         <*> switch (long "dev"          <> help "Development mode; include debug symbols etc")
         <*> switch (long "list-imports" <> help "List module imports")
+        <*> switch (long "sub")
         <*> switch (long "only-build"   <> help "Only perform final build of .c files, do not compile .act files")
         <*> switch (long "skip-build"   <> help "Skip final bulid of .c files")
         <*> switch (long "no-threads"   <> help "Don't use threads")


### PR DESCRIPTION
This restructure the top level main function in actonc a bit.

- we now accept a single file argument, not a list like before
  - makes code simpler and I don't think we will use option to send in multiple files
- new --sub argument which instructs actonc it is running as a sub-compiler, from which we can infer certain behavior. We don't really use this much yet, but I think it will expand
  - we do not take locks on single file compilation in --sub mode, so that we can run multiple concurrent actonc as a subprocesses to a parent acton compiler
- locking is more consistently handled
- improved detection if we are in a project or not and act accordingly
- cleaner main function

Related to #620 through non-locking under --sub