### PR TITLE
Fix acton test --name

### DIFF
--- a/cli/src/acton.act
+++ b/cli/src/acton.act
@@ -661,12 +661,11 @@ actor CmdTest(env: Env, args, perf_mode: bool=False):
         name_filter = set(args.get_strlist("name"))
         for module_name in sorted(tests.keys()):
             module_tests = tests[module_name]
-            if len(module_tests) > 0:
-                expected_modules.add(module_name)
             for test_name, test_info in module_tests.items():
                 if len(name_filter) == 0 or test_name in name_filter:
                     ptr.update(module_name, test_name, test_info)
                     tests_to_run.append(test_info)
+                    expected_modules.add(module_name)
         ptr.expected_modules = expected_modules
 
         _run_test()


### PR DESCRIPTION
We only expect results from modules that contain a test with the provided name. Before this fix, acton test --name foo hangs if there are multiple modules where the name filter only matched on a test in one module. We would still expect output from the other modules, which would never come and thus we'd hang.