### PR TITLE
Reintroduce --tempdir

### DIFF
--- a/compiler/actonc/test/syntaxerrors/err1.golden
+++ b/compiler/actonc/test/syntaxerrors/err1.golden
@@ -1,4 +1,4 @@
-Building file test/syntaxerrors/err1.act
+Building file test/syntaxerrors/err1.act using temporary scratch directory
 
 ERROR: Error when compiling err1 module: Syntax error
 

--- a/compiler/actonc/test/syntaxerrors/err2.golden
+++ b/compiler/actonc/test/syntaxerrors/err2.golden
@@ -1,4 +1,4 @@
-Building file test/syntaxerrors/err2.act
+Building file test/syntaxerrors/err2.act using temporary scratch directory
 
 ERROR: Error when compiling err2 module: Context error
 

--- a/compiler/actonc/test/syntaxerrors/err3.golden
+++ b/compiler/actonc/test/syntaxerrors/err3.golden
@@ -1,4 +1,4 @@
-Building file test/syntaxerrors/err3.act
+Building file test/syntaxerrors/err3.act using temporary scratch directory
 
 ERROR: Error when compiling err3 module: Syntax error
 

--- a/compiler/actonc/test/syntaxerrors/err4.golden
+++ b/compiler/actonc/test/syntaxerrors/err4.golden
@@ -1,4 +1,4 @@
-Building file test/syntaxerrors/err4.act
+Building file test/syntaxerrors/err4.act using temporary scratch directory
 
 ERROR: Error when compiling err4 module: Syntax error
 

--- a/compiler/actonc/test/syntaxerrors/err5.golden
+++ b/compiler/actonc/test/syntaxerrors/err5.golden
@@ -1,4 +1,4 @@
-Building file test/syntaxerrors/err5.act
+Building file test/syntaxerrors/err5.act using temporary scratch directory
 
 ERROR: Error when compiling err5 module: Syntax error
 

--- a/compiler/actonc/test/syntaxerrors/err6.golden
+++ b/compiler/actonc/test/syntaxerrors/err6.golden
@@ -1,4 +1,4 @@
-Building file test/syntaxerrors/err6.act
+Building file test/syntaxerrors/err6.act using temporary scratch directory
 
 ERROR: Error when compiling err6 module: Syntax error
 

--- a/compiler/actonc/test/syntaxerrors/err7.golden
+++ b/compiler/actonc/test/syntaxerrors/err7.golden
@@ -1,4 +1,4 @@
-Building file test/syntaxerrors/err7.act
+Building file test/syntaxerrors/err7.act using temporary scratch directory
 
 ERROR: Error when compiling err7 module: Syntax error
 

--- a/compiler/actonc/test/syntaxerrors/err8.golden
+++ b/compiler/actonc/test/syntaxerrors/err8.golden
@@ -1,4 +1,4 @@
-Building file test/syntaxerrors/err8.act
+Building file test/syntaxerrors/err8.act using temporary scratch directory
 
 ERROR: Error when compiling err8 module: Indentation error
    |

--- a/compiler/actonc/test/syntaxerrors/err9.golden
+++ b/compiler/actonc/test/syntaxerrors/err9.golden
@@ -1,4 +1,4 @@
-Building file test/syntaxerrors/err9.act
+Building file test/syntaxerrors/err9.act using temporary scratch directory
 
 ERROR: Error when compiling err9 module: Syntax error
 

--- a/compiler/actonc/test/typeerrors/ex1.golden
+++ b/compiler/actonc/test/typeerrors/ex1.golden
@@ -1,4 +1,4 @@
-Building file test/typeerrors/ex1.act
+Building file test/typeerrors/ex1.act using temporary scratch directory
   Compiling ex1.act for development
 [error]: Incompatible types
      +--> ex1@4:5-4:9

--- a/compiler/actonc/test/typeerrors/ex10.golden
+++ b/compiler/actonc/test/typeerrors/ex10.golden
@@ -1,4 +1,4 @@
-Building file test/typeerrors/ex10.act
+Building file test/typeerrors/ex10.act using temporary scratch directory
   Compiling ex10.act for development
 [error]: Constraint violation
      +--> ex10@4:5-4:15

--- a/compiler/actonc/test/typeerrors/ex11.golden
+++ b/compiler/actonc/test/typeerrors/ex11.golden
@@ -1,4 +1,4 @@
-Building file test/typeerrors/ex11.act
+Building file test/typeerrors/ex11.act using temporary scratch directory
   Compiling ex11.act for development
 [error]: Constraint violation
      +--> ex11@4:5-4:11

--- a/compiler/actonc/test/typeerrors/ex13.golden
+++ b/compiler/actonc/test/typeerrors/ex13.golden
@@ -1,4 +1,4 @@
-Building file test/typeerrors/ex13.act
+Building file test/typeerrors/ex13.act using temporary scratch directory
   Compiling ex13.act for development
 [error]: Incompatible types
      +--> ex13@2:7-2:13

--- a/compiler/actonc/test/typeerrors/ex14.golden
+++ b/compiler/actonc/test/typeerrors/ex14.golden
@@ -1,4 +1,4 @@
-Building file test/typeerrors/ex14.act
+Building file test/typeerrors/ex14.act using temporary scratch directory
   Compiling ex14.act for development
 [error]: Incompatible types
      +--> ex14@2:12-2:16

--- a/compiler/actonc/test/typeerrors/ex15.golden
+++ b/compiler/actonc/test/typeerrors/ex15.golden
@@ -1,4 +1,4 @@
-Building file test/typeerrors/ex15.act
+Building file test/typeerrors/ex15.act using temporary scratch directory
   Compiling ex15.act for development
 [error]: Cannot satisfy the following simultaneous constraints for the unknown types
      +--> ex15@2:9-2:10

--- a/compiler/actonc/test/typeerrors/ex16.golden
+++ b/compiler/actonc/test/typeerrors/ex16.golden
@@ -1,4 +1,4 @@
-Building file test/typeerrors/ex16.act
+Building file test/typeerrors/ex16.act using temporary scratch directory
   Compiling ex16.act for development
 [error]: Constraint violation
      +--> ex16@6:9-6:19

--- a/compiler/actonc/test/typeerrors/ex17.golden
+++ b/compiler/actonc/test/typeerrors/ex17.golden
@@ -1,4 +1,4 @@
-Building file test/typeerrors/ex17.act
+Building file test/typeerrors/ex17.act using temporary scratch directory
   Compiling ex17.act for development
 [error]: Cannot satisfy the following simultaneous constraints for the unknown types
      +--> ex17@2:5-2:17

--- a/compiler/actonc/test/typeerrors/ex18.golden
+++ b/compiler/actonc/test/typeerrors/ex18.golden
@@ -1,4 +1,4 @@
-Building file test/typeerrors/ex18.act
+Building file test/typeerrors/ex18.act using temporary scratch directory
   Compiling ex18.act for development
 [error]: Cannot satisfy the following simultaneous constraints for the unknown type t0
      +--> ex18@2:12-2:27

--- a/compiler/actonc/test/typeerrors/ex19.golden
+++ b/compiler/actonc/test/typeerrors/ex19.golden
@@ -1,4 +1,4 @@
-Building file test/typeerrors/ex19.act
+Building file test/typeerrors/ex19.act using temporary scratch directory
   Compiling ex19.act for development
 [error]: Cannot satisfy the following simultaneous constraints for the unknown types
      +--> ex19@1:5-1:6

--- a/compiler/actonc/test/typeerrors/ex2.golden
+++ b/compiler/actonc/test/typeerrors/ex2.golden
@@ -1,4 +1,4 @@
-Building file test/typeerrors/ex2.act
+Building file test/typeerrors/ex2.act using temporary scratch directory
   Compiling ex2.act for development
 [error]: Incompatible types
      +--> ex2@4:5-4:13

--- a/compiler/actonc/test/typeerrors/ex20.golden
+++ b/compiler/actonc/test/typeerrors/ex20.golden
@@ -1,4 +1,4 @@
-Building file test/typeerrors/ex20.act
+Building file test/typeerrors/ex20.act using temporary scratch directory
   Compiling ex20.act for development
 [error]: Constraint violation
      +--> ex20@1:1-1:2

--- a/compiler/actonc/test/typeerrors/ex21.golden
+++ b/compiler/actonc/test/typeerrors/ex21.golden
@@ -1,4 +1,4 @@
-Building file test/typeerrors/ex21.act
+Building file test/typeerrors/ex21.act using temporary scratch directory
   Compiling ex21.act for development
 [error]: Constraint violation
      +--> ex21@4:10-4:25

--- a/compiler/actonc/test/typeerrors/ex22.golden
+++ b/compiler/actonc/test/typeerrors/ex22.golden
@@ -1,4 +1,4 @@
-Building file test/typeerrors/ex22.act
+Building file test/typeerrors/ex22.act using temporary scratch directory
   Compiling ex22.act for development
 [error]: Incompatible types
      +--> ex22@1:1-1:2

--- a/compiler/actonc/test/typeerrors/ex23.golden
+++ b/compiler/actonc/test/typeerrors/ex23.golden
@@ -1,4 +1,4 @@
-Building file test/typeerrors/ex23.act
+Building file test/typeerrors/ex23.act using temporary scratch directory
   Compiling ex23.act for development
 [error]: Cannot satisfy the following simultaneous constraints for the unknown types
      +--> ex23@2:11-2:12

--- a/compiler/actonc/test/typeerrors/ex24.golden
+++ b/compiler/actonc/test/typeerrors/ex24.golden
@@ -1,4 +1,4 @@
-Building file test/typeerrors/ex24.act
+Building file test/typeerrors/ex24.act using temporary scratch directory
   Compiling ex24.act for development
 [error]: Constraint violation
      +--> ex24@4:9-4:14

--- a/compiler/actonc/test/typeerrors/ex4.golden
+++ b/compiler/actonc/test/typeerrors/ex4.golden
@@ -1,4 +1,4 @@
-Building file test/typeerrors/ex4.act
+Building file test/typeerrors/ex4.act using temporary scratch directory
   Compiling ex4.act for development
 [error]: Incompatible types
      +--> ex4@5:22-5:26

--- a/compiler/actonc/test/typeerrors/ex5.golden
+++ b/compiler/actonc/test/typeerrors/ex5.golden
@@ -1,4 +1,4 @@
-Building file test/typeerrors/ex5.act
+Building file test/typeerrors/ex5.act using temporary scratch directory
   Compiling ex5.act for development
 [error]: Incompatible types
      +--> ex5@7:5-7:15

--- a/compiler/actonc/test/typeerrors/ex6.golden
+++ b/compiler/actonc/test/typeerrors/ex6.golden
@@ -1,4 +1,4 @@
-Building file test/typeerrors/ex6.act
+Building file test/typeerrors/ex6.act using temporary scratch directory
   Compiling ex6.act for development
 [error]: Incompatible types
      +--> ex6@1:9-1:16

--- a/compiler/actonc/test/typeerrors/ex7.golden
+++ b/compiler/actonc/test/typeerrors/ex7.golden
@@ -1,4 +1,4 @@
-Building file test/typeerrors/ex7.act
+Building file test/typeerrors/ex7.act using temporary scratch directory
   Compiling ex7.act for development
 [error]: Constraint violation
      +--> ex7@4:16-4:17

--- a/compiler/actonc/test/typeerrors/ex8.golden
+++ b/compiler/actonc/test/typeerrors/ex8.golden
@@ -1,4 +1,4 @@
-Building file test/typeerrors/ex8.act
+Building file test/typeerrors/ex8.act using temporary scratch directory
   Compiling ex8.act for development
 [error]: Cannot satisfy the following simultaneous constraints for the unknown type t0
      +--> ex8@3:14-3:15

--- a/compiler/actonc/test/typeerrors/ex9.golden
+++ b/compiler/actonc/test/typeerrors/ex9.golden
@@ -1,4 +1,4 @@
-Building file test/typeerrors/ex9.act
+Building file test/typeerrors/ex9.act using temporary scratch directory
   Compiling ex9.act for development
 [error]: Cannot satisfy the following simultaneous constraints for the unknown types
      +--> ex9@1:5-1:6

--- a/compiler/actonc/test/typeerrors/funargs1.golden
+++ b/compiler/actonc/test/typeerrors/funargs1.golden
@@ -1,4 +1,4 @@
-Building file test/typeerrors/funargs1.act
+Building file test/typeerrors/funargs1.act using temporary scratch directory
   Compiling funargs1.act for development
 [error]: Unexpected keyword argument
      +--> funargs1@4:9-4:10

--- a/compiler/actonc/test/typeerrors/funargs2.golden
+++ b/compiler/actonc/test/typeerrors/funargs2.golden
@@ -1,4 +1,4 @@
-Building file test/typeerrors/funargs2.act
+Building file test/typeerrors/funargs2.act using temporary scratch directory
   Compiling funargs2.act for development
 [error]: Unexpected keyword argument
      +--> funargs2@4:9-4:10

--- a/compiler/actonc/test/typeerrors/funargs3.golden
+++ b/compiler/actonc/test/typeerrors/funargs3.golden
@@ -1,4 +1,4 @@
-Building file test/typeerrors/funargs3.act
+Building file test/typeerrors/funargs3.act using temporary scratch directory
 
 ERROR: Error when compiling funargs3 module: Syntax error
 

--- a/compiler/actonc/test/typeerrors/funargs4.golden
+++ b/compiler/actonc/test/typeerrors/funargs4.golden
@@ -1,4 +1,4 @@
-Building file test/typeerrors/funargs4.act
+Building file test/typeerrors/funargs4.act using temporary scratch directory
   Compiling funargs4.act for development
 [error]: Unexpected keyword argument
      +--> funargs4@4:9-4:10

--- a/compiler/actonc/test/typeerrors/funargs5.golden
+++ b/compiler/actonc/test/typeerrors/funargs5.golden
@@ -1,4 +1,4 @@
-Building file test/typeerrors/funargs5.act
+Building file test/typeerrors/funargs5.act using temporary scratch directory
   Compiling funargs5.act for development
 [error]: Incompatible types
      +--> funargs5@4:5-4:15

--- a/compiler/actonc/test/typeerrors/funargs6.golden
+++ b/compiler/actonc/test/typeerrors/funargs6.golden
@@ -1,4 +1,4 @@
-Building file test/typeerrors/funargs6.act
+Building file test/typeerrors/funargs6.act using temporary scratch directory
   Compiling funargs6.act for development
 [error]: Incompatible types
      +--> funargs6@4:5-4:13


### PR DESCRIPTION
I sort of removed the function of --tempdir when I restructured single file compilation to use scratch directories. Figured no one was really using it so it was dead code. I was wrong. Now it's back.

Since we don't have any real temporary directories now, we never need to clean up after us. Instead for scratch dir compilation, we clean before to ensure there's no crap to inject noise into our compilation.