### PR TITLE
Await cache cleaning

### DIFF
--- a/cli/src/acton.act
+++ b/cli/src/acton.act
@@ -70,7 +70,7 @@ def clean_zig_local_cache(cap: file.FileCap):
     limit = 5 * gb
     if total_size > limit:
         print("Build cache (", total_size // (1024*1024), "MB) over %dGB, cleaning it up." % (int(limit // gb)))
-        fs.rmtree(cache_dir)
+        await async fs.rmtree(cache_dir)
         total_size = 0
     if total_size == 0:
         print("INFO: Acton local cache is empty: rebuilding Acton base which will take some time...")


### PR DESCRIPTION
Recursively removing the cache dir can actually take some time so we risk concurrent access from our cleaning code and zig, which is bad. I also suspect zig might hang because of this.