### PR TITLE
Add 'acton pkg upgrade'

### DIFF
--- a/base/src/buildy.act
+++ b/base/src/buildy.act
@@ -85,22 +85,28 @@ class Dependency(object):
     url: ?str
     hash: ?str
     path: ?str
+    repo_url: ?str
+    repo_ref: ?str
 
 class PkgDependency(Dependency):
 
-    def __init__(self, name: str, url: ?str, hash: ?str, path: ?str):
+    def __init__(self, name: str, url: ?str, hash: ?str, path: ?str, repo_url: ?str, repo_ref: ?str):
         if path != None and url != None:
             raise ValueError("Dependency '%s' has both path and url set. Set only path or url. You can override path for a dep, e.g.: acton build --dep %s=%s" % (name, name, path))
         self.name = zig_safe_name(name)
         self.url = url
         self.hash = hash
         self.path = path
+        self.repo_url = repo_url
+        self.repo_ref = repo_ref
 
     @staticmethod
     def from_json(dep_name, data: dict[str, str]):
         dep_url = None
         dep_hash = None
         dep_path = None
+        dep_repo_url = None
+        dep_repo_ref = None
         for key, value in data.items():
             if key == "url":
                 data_url = data["url"]
@@ -114,20 +120,34 @@ class PkgDependency(Dependency):
                 data_path = data["path"]
                 if isinstance(data_path, str):
                     dep_path = data_path
+            elif key == "repo_url":
+                data_repo_url = data["repo_url"]
+                if isinstance(data_repo_url, str):
+                    dep_repo_url = data_repo_url
+            elif key == "repo_ref":
+                data_repo_ref = data["repo_ref"]
+                if isinstance(data_repo_ref, str):
+                    dep_repo_ref = data_repo_ref
             else:
                 raise ValueError("Invalid build.act.json, unknown key '%s' in dependency '%s'" % (key, dep_name))
-        return PkgDependency(dep_name, dep_url, dep_hash, dep_path)
+        return PkgDependency(dep_name, dep_url, dep_hash, dep_path, dep_repo_url, dep_repo_ref)
 
     def to_json(self) -> dict[str, str]:
         res = {}
+        repo_url = self.repo_url
+        if repo_url != None:
+            res["repo_url"] = repo_url
+        repo_ref = self.repo_ref
+        if repo_ref != None:
+            res["repo_ref"] = repo_ref
         url = self.url
-        if url is not None:
+        if url != None:
             res["url"] = url
         hash = self.hash
-        if hash is not None:
+        if hash != None:
             res["hash"] = hash
         path = self.path
-        if path is not None:
+        if path != None:
             res["path"] = path
         return res
 

--- a/cli/src/acton.act
+++ b/cli/src/acton.act
@@ -1,12 +1,15 @@
 import argparse
 import file
 import json
+import net
 import process
 import term
 import testing
 
 from buildy import *
 from testing import TestInfo
+
+import acton_cli.github as cli_gh
 
 def get_zig_local_cache_dir(file_cap: file.FileCap):
     fs = file.FS(file_cap)
@@ -964,6 +967,143 @@ actor CmdPkgAdd(env, args):
         on_exit,
         on_error)
 
+actor ZigFetch(on_dl: action(?str, ?str) -> None, env, dep_name: str, dep_url: str):
+    """zig fetch
+
+    Calls zig fetch to fetch a dependency and get the hash of the fetched dependency
+
+    Args:
+        on_dl: action(err: ?str, hash: ?str) - callback when download is done
+        env: Env - the environment
+        dep_name: str - the name of the dependency
+        dep_url: str - the URL to fetch the dependency from
+    """
+    pcap = process.ProcessCap(env.cap)
+    fs = file.FS(file.FileCap(env.cap))
+
+    zig = file.join_path([base_path(file.FileCap(env.cap)), "zig", "zig"])
+
+    def on_exit(p, exit_code, term_signal, std_out_buf, std_err_buf):
+        if exit_code == 0:
+            dep_hash = std_out_buf.decode().strip()
+            on_dl(None, dep_hash)
+        else:
+            error = "Error fetching: %s" % std_err_buf.decode()
+            on_dl(error, None)
+
+    def on_error(p, error):
+        on_dl(error, None)
+
+    cmd = [zig, "fetch", "--global-cache-dir", get_zig_global_cache_dir(file.FileCap(env.cap)), dep_url]
+    process.RunProcess(
+        pcap,
+        cmd,
+        on_exit,
+        on_error)
+
+
+actor CmdPkgUpgrade(env, args):
+    """Upgrade (or downgrade) a package dependency
+    """
+    tcpc_cap = net.TCPConnectCap(net.TCPCap(net.NetCap(env.cap)))
+    pcap = process.ProcessCap(env.cap)
+    fs = file.FS(file.FileCap(env.cap))
+
+    zig = file.join_path([base_path(file.FileCap(env.cap)), "zig", "zig"])
+
+    # What arguments do we need?
+    # - the name of the dependency (e.g. "foo", used in the build.act.json config file)
+    # - the URL to fetch it from
+
+    # We need to fetch the dependency and get the (content) hash of the fetched
+    # dependency and store it in the build.act.json file. If the dependency is
+    # already in the build.act.json file, we need to check if the hash is the
+    # same as the one we just fetched. If it is, we do nothing. If it is not,
+
+    def get_build_config():
+        try:
+            return BuildConfig.from_json(file.ReadFile(file.ReadFileCap(file.FileCap(env.cap)), "build.act.json").read().decode())
+        except FileNotFoundError:
+            # Ignore, we create a new file
+            pass
+        except ValueError as e:
+            print("ERROR:", e.error_message)
+            await async env.exit(1)
+        return BuildConfig()
+
+    build_config = get_build_config()
+
+    remaining_fetch_ref = {}
+    remaining_zig_fetch = {}
+    new_pkg_urls = {}
+    new_pkg_hashes = {}
+
+    def _on_zig_fetch(dep_name: str, err: ?str, hash: ?str):
+        del remaining_zig_fetch[dep_name]
+        if hash != None:
+            new_pkg_hashes[dep_name] = hash
+        if err != None:
+            print("Error fetching updated hash for", dep_name, err)
+        if len(remaining_zig_fetch) == 0:
+            _update_build_config()
+
+    def _zig_fetch():
+        for dep_name, new_url in new_pkg_urls.items():
+            bc_dep = build_config.dependencies[dep_name]
+            if bc_dep.url != new_url:
+                remaining_zig_fetch[dep_name] = True
+                ZigFetch(lambda x, y: _on_zig_fetch(dep_name, x, y), env, dep_name, new_url)
+        if len(remaining_zig_fetch) == 0:
+            print("No dependencies to upgrade")
+            env.exit(0)
+
+    def _update_build_config():
+        updated = False
+        for dep_name, dep in build_config.dependencies.items():
+            new_url = new_pkg_urls.get_def(dep_name, dep.url)
+            new_hash = new_pkg_hashes.get_def(dep_name, dep.hash)
+            if new_url != dep.url or new_hash != dep.hash:
+                print("Updated dependency", dep_name, "with\n  - new URL", new_url, "\n  - new hash", new_hash)
+                dep.url = new_url
+                dep.hash = new_hash
+                updated = True
+
+        if updated:
+            baj_file = file.WriteFile(file.WriteFileCap(file.FileCap(env.cap)), "build.act.json")
+            baj_file.write(build_config.to_json().encode()+b"\n")
+            await async baj_file.close()
+            print("Wrote changes to build.act.json")
+        else:
+            print("No changes to build.act.json")
+        env.exit(0)
+
+    def _onPkgFetchRef(dep_name: str, err: ?Exception, url: ?str):
+        del remaining_fetch_ref[dep_name]
+        if url != None:
+            new_pkg_urls[dep_name] = url
+        if err != None:
+            print("Error fetching ref for", dep_name, err)
+        if len(remaining_fetch_ref) == 0:
+            _zig_fetch()
+
+    def _go():
+        for dep_name, dep in build_config.dependencies.items():
+            dep_repo_url = dep.repo_url
+            if dep_repo_url != None:
+                if dep_repo_url.startswith("https://github.com"):
+                    print(dep_name, "- fetching ref from", dep_repo_url)
+                    remaining_fetch_ref[dep_name] = dep
+                    cli_gh.FetchRef(lambda x, y: _onPkgFetchRef(dep_name, x, y), url=dep_repo_url, tcpc_cap=tcpc_cap, ref=dep.repo_ref)
+                else:
+                    print(dep_name, "- skipping upgrade: Unsupported git forge URL for", dep_name, ":", dep_repo_url, "only https://github.com is supported", err=True)
+            else:
+                print(dep_name, "- skipping upgrade: repo_url not set", err=True)
+
+        if len(remaining_fetch_ref) == 0:
+            print("No dependencies to upgrade")
+            env.exit(0)
+    _go()
+
 
 actor CmdPkgRemove(env, args):
     """Remove a package dependency from the project
@@ -1176,6 +1316,9 @@ actor main(env):
     def _cmd_pkg_add(args):
         c = CmdPkgAdd(env, args)
 
+    def _cmd_pkg_upgrade(args):
+        c = CmdPkgUpgrade(env, args)
+
     def _cmd_pkg_rm(args):
         c = CmdPkgRemove(env, args)
 
@@ -1250,6 +1393,9 @@ actor main(env):
 
         p_pkg_rm = p_pkg.add_cmd("remove", "Remove package dependency", _cmd_pkg_rm)
         p_pkg_rm.add_arg("name", "Name of dependency", True, "?")
+
+        p_pkg_upgrade = p_pkg.add_cmd("upgrade", "Upgrade (or downgrade) package dependency", _cmd_pkg_upgrade)
+        #p_pkg_upgrade.add_option("name", "str", "?", help="Dependency name")
 
         docp = p.add_cmd("doc", "Show documentation", _cmd_doc)
 

--- a/cli/src/acton_cli/github.act
+++ b/cli/src/acton_cli/github.act
@@ -1,0 +1,200 @@
+import json
+import http
+import net
+import re
+import uri
+
+import testing
+
+class RepoUrl(object):
+    """A GitHub repository URL
+    """
+    scheme: str
+    host: str
+    owner: str
+    repo: str
+    ref: ?str
+
+    def __init__(self, scheme: str, host: str, owner: str, repo: str, ref: ?str=None):
+        self.scheme = scheme
+        self.host = host
+        self.owner = owner
+        self.repo = repo
+        self.ref = ref
+
+    @staticmethod
+    def from_url(url: str):
+        u = uri.URI(url)
+        uscheme = u.scheme
+        scheme = uscheme if uscheme != None else "https"
+        uhost = u.host
+        host = uhost if uhost != None else "github.com"
+
+        def get_owner_repo(path: ?str) -> (str, str):
+            if path == None:
+                raise ValueError("No path in URL")
+            if path != None:
+                if path.startswith("/"):
+                    path = path[1:]
+                if path.endswith(".git"):
+                    path = path[:-4]
+                # Lacking .rsplit() we reverse the result
+                parts = path[::-1].split("/", 1)
+                if len(parts) == 2:
+                    # ... and reverse the parts again
+                    return parts[1][::-1], parts[0][::-1]
+            raise ValueError()
+
+        uowner, urepo = get_owner_repo(u.path)
+        owner = uowner
+        repo = urepo
+        return RepoUrl(scheme=scheme, host=host, owner=owner, repo=repo, ref=u.fragment)
+
+    def copy(self) -> RepoUrl:
+        return RepoUrl(
+            scheme=self.scheme,
+            host=self.host,
+            owner=self.owner,
+            repo=self.repo,
+            ref=self.ref
+        )
+
+    def archive_url(self) -> str:
+        self_ref = self.ref
+        ref = self_ref if self_ref != None else "XXX"
+        return self.scheme + "://" + self.host + "/" + self.owner + "/" + self.repo + "/archive/" + ref + ".zip"
+
+actor GetQuery(on_done: action(?str, ?http.Response) -> None, tcpc_cap: net.TCPConnectCap, url: str):
+    def parseUrl(url: str):
+        u = uri.URI(url)
+        uscheme = u.scheme
+        scheme = uscheme if uscheme != None else "https"
+        if scheme not in ["http", "https"]:
+            raise ValueError("Unsupported scheme: " + scheme)
+        uhost = u.host
+        host = uhost if uhost != None else ""
+        if host == "":
+            raise ValueError("No host in URL")
+        uport = u.port
+        port = uport if uport != None else (80 if scheme == "http" else 443)
+        upath = u.path
+        path = upath if upath != None else "/"
+        return (scheme=scheme, host=host, port=port, path=path)
+
+    urlp = parseUrl(url)
+
+    def _onHttpReceive(c, res):
+        on_done(None, res)
+
+    def _onHttpConnect(c):
+        c.get(urlp.path, _onHttpReceive, headers={"Accept": "application/vnd.github.v3+json"})
+
+    def _onHttpError(c, errmsg):
+        print(errmsg)
+
+    client = http.Client(tcpc_cap, urlp.host, _onHttpConnect, _onHttpError, scheme=urlp.scheme, port=urlp.port)
+
+
+actor FetchDefaultBranch(on_done: action(?str, ?str) -> None, url: str, tcpc_cap: net.TCPConnectCap, ref: ?str=None):
+    def _onQueryDone(err: ?str, res: ?http.Response):
+        if err != None:
+            on_done(err, None)
+            return
+        if res != None:
+            b = res.body.decode()
+            j = json.decode(b)
+            jdb = j.get("default_branch")
+            if isinstance(jdb, str):
+                if jdb != None:
+                    on_done(None, jdb)
+                else:
+                    on_done("No default branch", None)
+            return
+
+    def computeApiUrl(url: str):
+        ru = RepoUrl.from_url(url)
+        owner = ru.owner
+        repo = ru.repo
+        ruref = ru.ref
+        ref = ("/" + ruref) if ruref != None else ""
+        if owner != None and repo != None:
+            return "https://api.github.com/repos/" + owner + "/" + repo
+        else:
+            raise ValueError("Invalid URL")
+
+    api_url = computeApiUrl(url)
+    GetQuery(on_done=_onQueryDone, tcpc_cap=tcpc_cap, url=api_url)
+
+actor FetchRef(on_done: action(?Exception, ?str) -> None, url: str, tcpc_cap: net.TCPConnectCap, ref: ?str=None):
+    """Resolves a git reference, like a branch or tag, to a commit SHA"""
+    repo_url = RepoUrl.from_url(url)
+
+    def _onQueryDone(err: ?str, res: ?http.Response):
+        if err != None:
+            on_done(ValueError(err), None)
+            return
+        if res != None:
+            b = res.body.decode()
+            j = json.decode(b)
+            ref_obj = j.get("object")
+            if isinstance(ref_obj, dict):
+                sha = ref_obj.get("sha")
+                if isinstance(sha, str):
+                    if sha != None:
+                        new_url = repo_url.copy()
+                        new_url.ref = sha
+                        on_done(None, new_url.archive_url())
+                        return
+                on_done(ValueError("No SHA"), None)
+            else:
+                on_done(ValueError("No object"), None)
+            return
+
+    def computeApiUrl(url: str):
+        ru = RepoUrl.from_url(url)
+        owner = ru.owner
+        repo = ru.repo
+        ruref = ru.ref
+        ref_str = ""
+        if ref != None:
+            ref_str = ref
+        else:
+            if ruref != None:
+                ref_str = ruref
+
+        repo_ref = ref if ref != None else ruref if ruref != None else "main"
+        if owner != None and repo != None:
+            return "https://api.github.com/repos/" + owner + "/" + repo + "/git/refs/heads/" + repo_ref
+        else:
+            raise ValueError("Invalid URL")
+
+    def _gotRef(repo_ref: str):
+        api_url = computeApiUrl(url)
+        GetQuery(on_done=_onQueryDone, tcpc_cap=tcpc_cap, url=api_url)
+
+    def _onDefBranch(err: ?str, branch: ?str):
+        if branch != None:
+            _gotRef(branch)
+
+        if err != None:
+            on_done(ValueError(err), None)
+
+    def _go():
+        # Which ref should we use?
+        # - if both ref argument and URL fragment is set, ensure they match up!
+        # - if ref argument is set, use that
+        # - if ref argument is empty, look for branch embedded in URL as
+        #   fragment and use that
+        # - if no fragment, look up default branch and use that!
+        url_ref = repo_url.ref
+        if ref != None and url_ref != None:
+            if ref != url_ref:
+                on_done(ValueError("Ref mismatch"), None)
+                return
+        if ref == None:
+            if url_ref != None:
+                _gotRef(url_ref)
+            else:
+                FetchDefaultBranch(_onDefBranch, url=url, tcpc_cap=tcpc_cap)
+                return
+    _go()


### PR DESCRIPTION
We now support simple upgrades of pkg dependencies. Running 'acton pkg upgrade' will upgrade the pkg dependencies configured in build.act.json. It only supports updating a git branch reference to the HEAD of that branch. E.g. with a config like this, note the repo_url attribute:

    {
        "dependencies": {
            "foo": {
                "repo_url": "https://github.com/actonlang/foo.git",
                "url": "https://github.com/actonlang/foo/archive/275323b45c318ef600c1b016e17c4337e4186a40.zip",
                "hash": "1220cd47344f8a1e7fe86741c7b0257a63567b4c17ad583bddf690eedd67a032abdd"
            }
        },
        "zig_dependencies": {}
    }

We can upgrade by resolving what the branch HEAD currently points to, which updates the URL and we also download + recompute the hash and update build.act.json based on that. Since there is no branch specified, it uses the default branch (main on the foo repo in this example).

It is possible to specify a different branch using a URL fragment, like so:

    https://github.com/actonlang/foo.git#foobar

This would upgrade to HEAD of the foobar branch.

This current work is based on the intent of the user to use a branch like main for a dependency. This is fundamentally incompatible with the Acton view of package dependencies where the hash is really the primary way of specifying what source we want. The hash is the hash of the content in the repository, so it is a proxy for saying "we want exactly this content". It is conceptually more specific than git commit. And we certainly can't use a branch since the HEAD of the branch changes, and thus the branch, as a reference mutates and then there's a new hash which produces a hash mismatch. However, we can't download a hash. We need some other reference, and that's where git commits come in. Now, it's pretty painful to manually track git commits and manually add + recompute the hash for upgrades, so that is what this new 'acton pkg upgrade' actually solves. In the future we will add support for git tags as well, so the user can be prompted to upgrade to a particular tag.