### PR TITLE
Use upload/download-artifact@v4

### DIFF
--- a/.github/workflows/test-app.yml
+++ b/.github/workflows/test-app.yml
@@ -14,7 +14,7 @@ jobs:
           sudo apt update
           sudo apt install -y gdb
       - name: "Download .deb files"
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: acton-debs
       - name: "Install acton from .deb"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,7 +107,7 @@ jobs:
       - name: "Build a release"
         run: make -C ${{ github.workspace }} release
       - name: "Upload artifact"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: acton-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.arch }}
           path: ${{ github.workspace }}/acton-*
@@ -118,7 +118,7 @@ jobs:
           make -C ${{ github.workspace }} test
       - name: "Upload whole test dir as artifact on test failure"
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-debug-${{ matrix.os }}-${{ github.run_id }}.zip
           path: |
@@ -222,7 +222,7 @@ jobs:
       - name: "Build a release"
         run: make -C ${GITHUB_WORKSPACE} release
       - name: "Upload artifact"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: acton-${{ matrix.os }}-${{ matrix.version }}
           path: ${{ github.workspace }}/acton-*
@@ -233,7 +233,7 @@ jobs:
           make -C ${GITHUB_WORKSPACE} test
       - name: "Upload whole test dir as artifact on test failure"
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-debug-${{ matrix.os }}-${{ github.run_id }}.zip
           path: |
@@ -297,7 +297,7 @@ jobs:
           ls ${{ steps.vars.outputs.debdir }}/../
           mv ${{ steps.vars.outputs.debdir }}/../acton_* ${{ steps.vars.outputs.debdir }}/
       - name: "Upload artifact"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: acton-debs
           # Using a wildcard and then deb here to force the entire directory to
@@ -320,12 +320,12 @@ jobs:
           system_profiler SPHardwareDataType
       - name: "Download artifacts for Macos x86_64, built on macos-13"
         if: ${{ matrix.os == 'macos-13' }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: acton-macos-13-x86_64
       - name: "Download artifacts for Macos arm64, built on macos-14"
         if: ${{ matrix.os == 'macos-14' || matrix.os == 'macos-15' }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: acton-macos-14-aarch64
       - name: "Extract acton"
@@ -378,7 +378,7 @@ jobs:
           env
           cat /proc/cpuinfo
       - name: "Download .deb files"
-        uses: actions/download-artifact@v3 # Ubuntu 18.04 doesn't support v4 which uses Node 20 which depends on glibc 2.28
+        uses: actions/download-artifact@v4
         with:
           name: acton-debs
       - name: "Install acton from .deb"
@@ -411,7 +411,7 @@ jobs:
           mv /tmp/core* .
       - name: "Upload core file & binaries as artifacts on test failure"
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coredumps-${{ matrix.os }}-${{ matrix.version }}-${{ github.run_id }}.zip
           path: |
@@ -442,7 +442,7 @@ jobs:
           cd ../perf
           acton test perf --record
       - name: "Download .deb files"
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: acton-debs
       - name: "Install acton from .deb"
@@ -473,7 +473,7 @@ jobs:
             ~/.cache/acton/
           key: test-telemetrify
       - name: "Download .deb files"
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: acton-debs
       - name: "Install acton from .deb"
@@ -536,19 +536,19 @@ jobs:
       - name: "Check out repository code"
         uses: actions/checkout@v4
       - name: "Download artifacts for Macos aarch64, built on macos-14"
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: acton-macos-14-aarch64
       - name: "Download artifacts for Macos x86_64, built on macos-13"
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: acton-macos-13-x86_64
       - name: "Download artifacts for Linux x86_64, built on Debian:12"
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: acton-debian-12
       - name: "Download artifacts for Debian Linux x86_64"
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: acton-debs
       - name: "List downloaded artifacts"
@@ -607,15 +607,15 @@ jobs:
       - name: "Check out repository code"
         uses: actions/checkout@v4
       - name: "Download artifacts for Macos, built on macos-13"
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: acton-macos-13-x86_64
       - name: "Download artifacts for Linux, built on Debian:12"
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: acton-debian-12
       - name: "Download artifacts for Debian Linux"
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: acton-debs
       - name: "List downloaded artifacts"
@@ -659,7 +659,7 @@ jobs:
           path: apt
           ssh-key: ${{ secrets.APT_DEPLOY_KEY }}
       - name: "Download artifacts for Debian Linux"
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: acton-debs
       - name: "Get the version"
@@ -704,7 +704,7 @@ jobs:
           path: apt
           ssh-key: ${{ secrets.APT_TIP_DEPLOY_KEY }}
       - name: "Download artifacts for Debian Linux"
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: acton-debs
       - name: "Get the version"


### PR DESCRIPTION
v3 no longer works. We used v3 for a long time because v4 requires Node 20 which in turn requires a newer glibc which made it basically impossible to run on Ubuntu 18.04 and similar old distributions. But 18.04 broke anyway, so we removed it so now we are fine moving to v4. It should appraently be quite a bit faster...