### PR TITLE
Assert nbytes >= nchars for B_str allocator

### DIFF
--- a/base/builtin/str.c
+++ b/base/builtin/str.c
@@ -42,6 +42,7 @@ static struct B_str whitespace_struct = {&B_strG_methods,6,6,(unsigned char *)" 
 static B_str whitespace_str = &whitespace_struct;
 
 #define NEW_UNFILLED_STR(nm,nchrs,nbtes)        \
+    assert(nbtes >= nchrs);                     \
     nm = acton_malloc(sizeof(struct B_str));           \
     (nm)->$class = &B_strG_methods;               \
     (nm)->nchars = nchrs;                       \

--- a/base/src/xml.ext.c
+++ b/base/src/xml.ext.c
@@ -4,6 +4,7 @@
 
 // TODO: The macro below is from builtin/str.c. We should not duplicate it...
 #define NEW_UNFILLED_STR(nm, nchrs, nbtes)      \
+    assert(nbtes >= nchrs);                     \
     nm = acton_malloc(sizeof(struct B_str));           \
     (nm)->$class = &B_strG_methods;               \
     (nm)->nchars = nchrs;                       \


### PR DESCRIPTION
If the string contains wide (Unicode) characters then nbytes > nchars, but nbytes must never be less than nchars.