### PR TITLE
Support transitive dependencies

### DIFF
--- a/cli/src/acton.act
+++ b/cli/src/acton.act
@@ -9,6 +9,7 @@ import testing
 from buildy import *
 from testing import TestInfo
 
+import acton_cli.deps as deps
 import acton_cli.github as cli_gh
 
 def get_zig_local_cache_dir(file_cap: file.FileCap):
@@ -190,7 +191,14 @@ actor BuildProject(process_cap, env, args, on_build_success: action(str) -> None
 
     def build_project():
         search_paths = []
-        for dep_name, dep in build_config.dependencies.items():
+
+        all_deps = deps.get_deps_recursive(fcap, fs.cwd())
+        # Add transitive dependencies to write new build.zig(.zon)
+        build_config.dependencies.update(all_deps.pkg_deps.items())
+        build_config.zig_dependencies.update(all_deps.zig_deps.items())
+        write_buildzig(file.FileCap(env.cap), build_config)
+
+        for dep_name, dep in all_deps.pkg_deps.items():
             dep_hash = dep.hash
             dep_path = dep.path
             if dep_path is not None:

--- a/cli/src/acton_cli/deps.act
+++ b/cli/src/acton_cli/deps.act
@@ -1,0 +1,38 @@
+import file
+
+from buildy import *
+
+def get_deps_recursive(file_cap: file.FileCap, proj_dir: str, fsin: ?file.FS=None) -> (pkg_deps: dict[str, PkgDependency], zig_deps: dict[str, ZigDependency]):
+    fs = fsin if fsin is not None else file.FS(file_cap)
+    rfile_cap = file.ReadFileCap(file_cap)
+
+    def get_dep_path(dep: Dependency) -> str:
+        dep_path = dep.path
+        if dep_path is not None:
+            return file.join_path([proj_dir, dep_path])
+
+        dep_hash = dep.hash
+        if dep_hash is not None:
+            return file.join_path([fs.homedir(), ".cache", "acton", "deps", "%s-%s" % (dep.name, dep_hash)])
+        raise ValueError("Dependency %s has no path or hash" % dep.name)
+
+    try:
+        bconf_path = file.join_path([proj_dir, "build.act.json"])
+        build_config = BuildConfig.from_json(file.ReadFile(rfile_cap, bconf_path).read().decode())
+
+        pkg_res: dict[str, PkgDependency] = {}
+        zig_res: dict[str, ZigDependency] = {}
+
+        pkg_res.update(build_config.dependencies.items())
+        zig_res.update(build_config.zig_dependencies.items())
+
+        for dep_name, dep in build_config.dependencies.items():
+            dpath = get_dep_path(dep)
+            dep_deps = get_deps_recursive(file_cap, get_dep_path(dep), fs)
+            pkg_res.update(dep_deps.pkg_deps.items())
+            zig_res.update(dep_deps.zig_deps.items())
+
+        return (pkg_deps=pkg_res, zig_deps=zig_res)
+
+    except FileNotFoundError:
+        return (pkg_deps={}, zig_deps={})


### PR DESCRIPTION
acton build now reads dependencies recursively for deps, so if our current project depends on A and A depends on B, we will now dig out the B dependency and add it internally for resolving modules etc.

Fixes #2003 