### PR TITLE
Avoid double printing values

### DIFF
--- a/base/src/testing.act
+++ b/base/src/testing.act
@@ -818,7 +818,7 @@ actor TestExecutor(syscap, config, t: Test, report_complete, env):
             if val != None:
                 exp_val = get_expected(t.module, t.name)
                 if exp_val == None or exp_val != None and val != exp_val:
-                    exc = NotEqualError(val, exp_val, "Test output does not match expected golden value.\nActual  : %s\nExpected: %s" % (val, exp_val if exp_val != None else "None"))
+                    exc = NotEqualError(val, exp_val, "Test output does not match expected golden value.\nActual  : %s\nExpected: %s" % (val, exp_val if exp_val != None else "None"), print_vals=False)
                     _report_result(t, sw, non_gc_mem_usage_before, gc_total_bytes_start, gc_time_start, False, exc, val)
                     return
             _report_result(t, sw, non_gc_mem_usage_before, gc_total_bytes_start, gc_time_start, s, e, val)


### PR DESCRIPTION
The builtin exceptions have changed such that they now print the actual values as part of the exception message. Since we already print the values in the specific message we have for golden tests, we suppress the other printing of vals.