### PR TITLE
Make type error location "clickable"

### DIFF
--- a/compiler/actonc/Main.hs
+++ b/compiler/actonc/Main.hs
@@ -876,8 +876,13 @@ handle errKind f src paths mn ex = do
     putStrLn (Acton.Parser.makeReport (f ex) src)
     handleCleanup paths mn
 
+modNameToFilename :: A.ModName -> String
+modNameToFilename mn = joinPath (map nameToString names) ++ ".act"
+  where
+    A.ModName names = mn
+
 handleTypeError opts errKind f src paths mn ex = do
-    printDiag opts $ mkErrorDiagnostic (modNameToString mn) src (typeReport ex (modNameToString mn) src)
+    printDiag opts $ mkErrorDiagnostic (modNameToFilename mn) src (typeReport ex (modNameToFilename mn) src)
     handleCleanup paths mn
 
 handleCleanup paths mn = do

--- a/compiler/actonc/test/typeerrors/ex1.golden
+++ b/compiler/actonc/test/typeerrors/ex1.golden
@@ -1,7 +1,7 @@
 Building file test/typeerrors/ex1.act using temporary scratch directory
   Compiling ex1.act for development
 [error]: Incompatible types
-     +--> ex1@4:5-4:9
+     +--> ex1.act@4:5-4:9
      |
    1 | def f(x,y):
      :     ^ 

--- a/compiler/actonc/test/typeerrors/ex10.golden
+++ b/compiler/actonc/test/typeerrors/ex10.golden
@@ -1,7 +1,7 @@
 Building file test/typeerrors/ex10.act using temporary scratch directory
   Compiling ex10.act for development
 [error]: Constraint violation
-     +--> ex10@4:5-4:15
+     +--> ex10.act@4:5-4:15
      |
    4 |     except int:
      :     ^--------- 

--- a/compiler/actonc/test/typeerrors/ex11.golden
+++ b/compiler/actonc/test/typeerrors/ex11.golden
@@ -1,7 +1,7 @@
 Building file test/typeerrors/ex11.act using temporary scratch directory
   Compiling ex11.act for development
 [error]: Constraint violation
-     +--> ex11@4:5-4:11
+     +--> ex11.act@4:5-4:11
      |
    1 | def f(s):
      :     ^ 

--- a/compiler/actonc/test/typeerrors/ex13.golden
+++ b/compiler/actonc/test/typeerrors/ex13.golden
@@ -1,7 +1,7 @@
 Building file test/typeerrors/ex13.act using temporary scratch directory
   Compiling ex13.act for development
 [error]: Incompatible types
-     +--> ex13@2:7-2:13
+     +--> ex13.act@2:7-2:13
      |
    2 |   a = Act(7)
      :       ^-----

--- a/compiler/actonc/test/typeerrors/ex14.golden
+++ b/compiler/actonc/test/typeerrors/ex14.golden
@@ -1,7 +1,7 @@
 Building file test/typeerrors/ex14.act using temporary scratch directory
   Compiling ex14.act for development
 [error]: Incompatible types
-     +--> ex14@2:12-2:16
+     +--> ex14.act@2:12-2:16
      |
    2 |     return g(x)
      :            ^---

--- a/compiler/actonc/test/typeerrors/ex15.golden
+++ b/compiler/actonc/test/typeerrors/ex15.golden
@@ -1,7 +1,7 @@
 Building file test/typeerrors/ex15.act using temporary scratch directory
   Compiling ex15.act for development
 [error]: Cannot satisfy the following simultaneous constraints for the unknown types
-     +--> ex15@2:9-2:10
+     +--> ex15.act@2:9-2:10
      |
    2 |     y = 1
      :         ^

--- a/compiler/actonc/test/typeerrors/ex16.golden
+++ b/compiler/actonc/test/typeerrors/ex16.golden
@@ -1,7 +1,7 @@
 Building file test/typeerrors/ex16.act using temporary scratch directory
   Compiling ex16.act for development
 [error]: Constraint violation
-     +--> ex16@6:9-6:19
+     +--> ex16.act@6:9-6:19
      |
    6 |         foo.append(4)
      :         ^--------- 

--- a/compiler/actonc/test/typeerrors/ex17.golden
+++ b/compiler/actonc/test/typeerrors/ex17.golden
@@ -1,7 +1,7 @@
 Building file test/typeerrors/ex17.act using temporary scratch directory
   Compiling ex17.act for development
 [error]: Cannot satisfy the following simultaneous constraints for the unknown types
-     +--> ex17@2:5-2:17
+     +--> ex17.act@2:5-2:17
      |
    2 | a = pow(3,"hej")
      :     ^-----------

--- a/compiler/actonc/test/typeerrors/ex18.golden
+++ b/compiler/actonc/test/typeerrors/ex18.golden
@@ -1,7 +1,7 @@
 Building file test/typeerrors/ex18.act using temporary scratch directory
   Compiling ex18.act for development
 [error]: Cannot satisfy the following simultaneous constraints for the unknown type t0
-     +--> ex18@2:12-2:27
+     +--> ex18.act@2:12-2:27
      |
    2 |     return len(ls) + "hej"
      :            ^--------------

--- a/compiler/actonc/test/typeerrors/ex19.golden
+++ b/compiler/actonc/test/typeerrors/ex19.golden
@@ -1,7 +1,7 @@
 Building file test/typeerrors/ex19.act using temporary scratch directory
   Compiling ex19.act for development
 [error]: Cannot satisfy the following simultaneous constraints for the unknown types
-     +--> ex19@1:5-1:6
+     +--> ex19.act@1:5-1:6
      |
    1 | def f(x,y):
      :     ^ 

--- a/compiler/actonc/test/typeerrors/ex2.golden
+++ b/compiler/actonc/test/typeerrors/ex2.golden
@@ -1,7 +1,7 @@
 Building file test/typeerrors/ex2.act using temporary scratch directory
   Compiling ex2.act for development
 [error]: Incompatible types
-     +--> ex2@4:5-4:13
+     +--> ex2.act@4:5-4:13
      |
    1 | def f(x,y):
      :     ^ 

--- a/compiler/actonc/test/typeerrors/ex20.golden
+++ b/compiler/actonc/test/typeerrors/ex20.golden
@@ -1,7 +1,7 @@
 Building file test/typeerrors/ex20.act using temporary scratch directory
   Compiling ex20.act for development
 [error]: Constraint violation
-     +--> ex20@1:1-1:2
+     +--> ex20.act@1:1-1:2
      |
    1 |    f : (str,str) -> str
      :    ^ 

--- a/compiler/actonc/test/typeerrors/ex21.golden
+++ b/compiler/actonc/test/typeerrors/ex21.golden
@@ -1,7 +1,7 @@
 Building file test/typeerrors/ex21.act using temporary scratch directory
   Compiling ex21.act for development
 [error]: Constraint violation
-     +--> ex21@4:10-4:25
+     +--> ex21.act@4:10-4:25
      |
    4 |    print(math.sin("hej"))
      :          ^-------------- 

--- a/compiler/actonc/test/typeerrors/ex22.golden
+++ b/compiler/actonc/test/typeerrors/ex22.golden
@@ -1,7 +1,7 @@
 Building file test/typeerrors/ex22.act using temporary scratch directory
   Compiling ex22.act for development
 [error]: Incompatible types
-     +--> ex22@1:1-1:2
+     +--> ex22.act@1:1-1:2
      |
    1 |    f : [A(Plus)] => (A) -> A
      :    ^ 

--- a/compiler/actonc/test/typeerrors/ex23.golden
+++ b/compiler/actonc/test/typeerrors/ex23.golden
@@ -1,7 +1,7 @@
 Building file test/typeerrors/ex23.act using temporary scratch directory
   Compiling ex23.act for development
 [error]: Cannot satisfy the following simultaneous constraints for the unknown types
-     +--> ex23@2:11-2:12
+     +--> ex23.act@2:11-2:12
      |
    2 |     if s==7:
      :        ^--^ 

--- a/compiler/actonc/test/typeerrors/ex24.golden
+++ b/compiler/actonc/test/typeerrors/ex24.golden
@@ -1,7 +1,7 @@
 Building file test/typeerrors/ex24.act using temporary scratch directory
   Compiling ex24.act for development
 [error]: Type unification error
-     +--> ex24@4:9-4:14
+     +--> ex24.act@4:9-4:14
      |
    4 |     a : ?str = ""
      :         ^---- 

--- a/compiler/actonc/test/typeerrors/ex4.golden
+++ b/compiler/actonc/test/typeerrors/ex4.golden
@@ -1,7 +1,7 @@
 Building file test/typeerrors/ex4.act using temporary scratch directory
   Compiling ex4.act for development
 [error]: Incompatible types
-     +--> ex4@5:22-5:26
+     +--> ex4.act@5:22-5:26
      |
    1 | def f(x,y):
      :     ^ 

--- a/compiler/actonc/test/typeerrors/ex5.golden
+++ b/compiler/actonc/test/typeerrors/ex5.golden
@@ -1,7 +1,7 @@
 Building file test/typeerrors/ex5.act using temporary scratch directory
   Compiling ex5.act for development
 [error]: Incompatible types
-     +--> ex5@7:5-7:15
+     +--> ex5.act@7:5-7:15
      |
    4 | def apply(g,x):
      :     ^---- 

--- a/compiler/actonc/test/typeerrors/ex6.golden
+++ b/compiler/actonc/test/typeerrors/ex6.golden
@@ -1,7 +1,7 @@
 Building file test/typeerrors/ex6.act using temporary scratch directory
   Compiling ex6.act for development
 [error]: Incompatible types
-     +--> ex6@1:9-1:16
+     +--> ex6.act@1:9-1:16
      |
    1 | (a,b) = (1,3,5)
      :         ^------

--- a/compiler/actonc/test/typeerrors/ex7.golden
+++ b/compiler/actonc/test/typeerrors/ex7.golden
@@ -1,7 +1,7 @@
 Building file test/typeerrors/ex7.act using temporary scratch directory
   Compiling ex7.act for development
 [error]: Constraint violation
-     +--> ex7@4:16-4:17
+     +--> ex7.act@4:16-4:17
      |
    4 |         return k
      :                ^

--- a/compiler/actonc/test/typeerrors/ex8.golden
+++ b/compiler/actonc/test/typeerrors/ex8.golden
@@ -1,7 +1,7 @@
 Building file test/typeerrors/ex8.act using temporary scratch directory
   Compiling ex8.act for development
 [error]: Cannot satisfy the following simultaneous constraints for the unknown type t0
-     +--> ex8@3:14-3:15
+     +--> ex8.act@3:14-3:15
      |
    3 |     for x in n:
      :              ^ 

--- a/compiler/actonc/test/typeerrors/ex9.golden
+++ b/compiler/actonc/test/typeerrors/ex9.golden
@@ -1,7 +1,7 @@
 Building file test/typeerrors/ex9.act using temporary scratch directory
   Compiling ex9.act for development
 [error]: Cannot satisfy the following simultaneous constraints for the unknown types
-     +--> ex9@1:5-1:6
+     +--> ex9.act@1:5-1:6
      |
    1 | def f(x,y):
      :     ^ 

--- a/compiler/actonc/test/typeerrors/funargs1.golden
+++ b/compiler/actonc/test/typeerrors/funargs1.golden
@@ -1,7 +1,7 @@
 Building file test/typeerrors/funargs1.act using temporary scratch directory
   Compiling funargs1.act for development
 [error]: Unexpected keyword argument
-     +--> funargs1@4:9-4:10
+     +--> funargs1.act@4:9-4:10
      |
    4 | a = f(3,x=3,y=3)
      :         ^ 

--- a/compiler/actonc/test/typeerrors/funargs2.golden
+++ b/compiler/actonc/test/typeerrors/funargs2.golden
@@ -1,7 +1,7 @@
 Building file test/typeerrors/funargs2.act using temporary scratch directory
   Compiling funargs2.act for development
 [error]: Unexpected keyword argument
-     +--> funargs2@4:9-4:10
+     +--> funargs2.act@4:9-4:10
      |
    4 | a = f(3,z=3,y=3)
      :         ^ 

--- a/compiler/actonc/test/typeerrors/funargs4.golden
+++ b/compiler/actonc/test/typeerrors/funargs4.golden
@@ -1,7 +1,7 @@
 Building file test/typeerrors/funargs4.act using temporary scratch directory
   Compiling funargs4.act for development
 [error]: Unexpected keyword argument
-     +--> funargs4@4:9-4:10
+     +--> funargs4.act@4:9-4:10
      |
    4 | a = f(4,x=3,y=4)
      :         ^ 

--- a/compiler/actonc/test/typeerrors/funargs5.golden
+++ b/compiler/actonc/test/typeerrors/funargs5.golden
@@ -1,7 +1,7 @@
 Building file test/typeerrors/funargs5.act using temporary scratch directory
   Compiling funargs5.act for development
 [error]: Incompatible types
-     +--> funargs5@4:5-4:15
+     +--> funargs5.act@4:5-4:15
      |
    1 | def f(x,y,*z,w):
      :     ^ 

--- a/compiler/actonc/test/typeerrors/funargs6.golden
+++ b/compiler/actonc/test/typeerrors/funargs6.golden
@@ -1,7 +1,7 @@
 Building file test/typeerrors/funargs6.act using temporary scratch directory
   Compiling funargs6.act for development
 [error]: Incompatible types
-     +--> funargs6@4:5-4:13
+     +--> funargs6.act@4:5-4:13
      |
    1 | def f(x,y,*z,w):
      :     ^ 


### PR DESCRIPTION
Use the real filesystem path to the module where a type error was raised.  This means replacing "." with path separator and appending the ".act" suffix. So foo.bar@123 becomes foo/bar.act@123

This makes it possible for VS Code to create a clickable link to the file. Well, almost, because VS Code does not recognize "@" as a file - location separator. Not sure if the diagnostic package can be tweaked to use ":" instead of "@"?