### PR TITLE
Fix base64.decode buffer allocation, UTF-8 handling, change input/output to bytes

### DIFF
--- a/base/src/base64.act
+++ b/base/src/base64.act
@@ -1,5 +1,5 @@
-def encode(data: str) -> str:
+def encode(data: bytes) -> bytes:
     NotImplemented
 
-def decode(data: str) -> str:
+def decode(data: bytes) -> bytes:
     NotImplemented

--- a/test/stdlib_tests/src/test_base64.act
+++ b/test/stdlib_tests/src/test_base64.act
@@ -6,6 +6,12 @@ def _test_base64():
     i = "foobar"
     for a in range(1000):
         e = base64.encode(i)
-        #testing.assertEqual(e, "Zm9vYmFy")
+        testing.assertEqual(e, "Zm9vYmFy")
         d = base64.decode(e)
         testing.assertEqual(i, d)
+
+    h = "Hello Acton 🫡"
+    e = base64.encode(h)
+    testing.assertEqual(e, "SGVsbG8gQWN0b24g8J+roQ==")
+    d = base64.decode(e)
+    testing.assertEqual(h, d)

--- a/test/stdlib_tests/src/test_base64.act
+++ b/test/stdlib_tests/src/test_base64.act
@@ -3,15 +3,15 @@ import base64
 import testing
 
 def _test_base64():
-    i = "foobar"
+    i = b"foobar"
     for a in range(1000):
         e = base64.encode(i)
-        testing.assertEqual(e, "Zm9vYmFy")
+        testing.assertEqual(e, b"Zm9vYmFy")
         d = base64.decode(e)
         testing.assertEqual(i, d)
 
-    h = "Hello Acton 🫡"
+    h = "Hello Acton 🫡".encode()
     e = base64.encode(h)
-    testing.assertEqual(e, "SGVsbG8gQWN0b24g8J+roQ==")
+    testing.assertEqual(e, b"SGVsbG8gQWN0b24g8J+roQ==")
     d = base64.decode(e)
     testing.assertEqual(h, d)


### PR DESCRIPTION
We must use decoder.calcSizeForSlice() instead of calcSizeUpperBound() to get an exact number of bytes we will decode, without padding. If we allocate the maximum size including padding, we may decode less bytes and then our decoded buffer may end up containing garbage.

We also align with other languages (including Python) on the input and output types for encode and decode - the functions now work with Acton bytes instead of str.