### PR TITLE
Raise ValueError from base64.decode() if input is not base64 encoded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ test/**/*.log
 # tests organized as acton projects; ignore all but source
 test/*/*/out/**
 test/*/*/build.sh
+compiler/actonc/test/project/*/out
 
 
 **/.build/sys/*

--- a/base/__root.zig
+++ b/base/__root.zig
@@ -28,8 +28,8 @@ export fn base64Q_decode(data: *acton.bytes) callconv(.C) *acton.bytes {
     const data_slice = std.mem.sliceTo(data.str, 0);
     // And then compute the exact number of bytes we need to decode, without padding
     const out_len = decoder.calcSizeForSlice(data_slice) catch {
-        acton.raise_value_error("Invalid base64 input data");
-        unreachable;
+        acton.raise_ValueError("Invalid base64 input data");
+        unreachable; // raise above does longjmp so this is unreachable
     };
     const buffer = alloc.alloc(u8, out_len) catch @panic("OOM");
     decoder.decode(buffer, std.mem.span(data.str)) catch unreachable;

--- a/base/__root.zig
+++ b/base/__root.zig
@@ -27,7 +27,10 @@ export fn base64Q_decode(data: *acton.bytes) callconv(.C) *acton.bytes {
     // Convert null-terminated string to slice for decoder
     const data_slice = std.mem.sliceTo(data.str, 0);
     // And then compute the exact number of bytes we need to decode, without padding
-    const out_len = decoder.calcSizeForSlice(data_slice) catch unreachable;
+    const out_len = decoder.calcSizeForSlice(data_slice) catch {
+        acton.raise_value_error("Invalid base64 input data");
+        unreachable;
+    };
     const buffer = alloc.alloc(u8, out_len) catch @panic("OOM");
     decoder.decode(buffer, std.mem.span(data.str)) catch unreachable;
 

--- a/base/acton.zig
+++ b/base/acton.zig
@@ -33,7 +33,7 @@ pub const ValueError = extern struct {
 
 // This is the equivalent of the expanded macro in C:
 //   $NEW(B_ValueError,to$str(message))
-pub fn new_value_error(message: []const u8) *c_acton.B_ValueError {
+pub fn new_ValueError(message: []const u8) *c_acton.B_ValueError {
     const alloc = gc.allocator();
 
     const error_ptr = alloc.create(ValueError) catch @panic("OOM");
@@ -48,10 +48,12 @@ pub fn new_value_error(message: []const u8) *c_acton.B_ValueError {
 
 // This is the equivalent of the function call in C:
 //   $RAISE((B_BaseException)$NEW(B_ValueError,to$str(message)))
-pub fn raise_value_error(message: []const u8) void {
-    const error_ptr = new_value_error(message);
+pub fn raise_ValueError(message: []const u8) void {
+    const error_ptr = new_ValueError(message);
     // @ptrCast is used to cast the pointer to the correct type expected by the C function
     c_acton.@"$RAISE"(@ptrCast(error_ptr));
+    // RAISE does not return, it does a longjmp, so this code is unreachable
+    unreachable;
 }
 
 test "str struct" {

--- a/test/stdlib_tests/src/test_base64.act
+++ b/test/stdlib_tests/src/test_base64.act
@@ -15,3 +15,13 @@ def _test_base64():
     testing.assertEqual(e, b"SGVsbG8gQWN0b24g8J+roQ==")
     d = base64.decode(e)
     testing.assertEqual(h, d)
+
+def _test_base64_decode_garbage():
+    # Invalid base64
+    i = b"garbage"
+    try:
+        d = base64.decode(i)
+    except ValueError as e:
+        testing.assertEqual(str(e), "ValueError: Invalid base64 input data")
+    else:
+        raise Exception("Expected ValueError")


### PR DESCRIPTION
Closes #2196 