### PR TITLE
Fix aarch64 linux cross compile

### DIFF
--- a/cli/src/acton.act
+++ b/cli/src/acton.act
@@ -1425,6 +1425,7 @@ actor main(env):
         p.add_option("tempdir", "str", "?", "", "Directory for temporary build files")
         p.add_option("syspath", "str", "?", "", "syspath")
         p.add_option("target", "str", "?", "", "Target, e.g. x86_64-linux-gnu.2.28")
+        p.add_option("cpu", "str", "?", "", "CPU, e.g. x86_64")
         p.add_option("dep", "strlist", "+", [], "Override path to dependency, e.g. --dep-path foo=../my-foo-repo")
         p.add_arg("file", ".act file to compile, or .ty to show", False, "?")
 

--- a/compiler/actonc/Main.hs
+++ b/compiler/actonc/Main.hs
@@ -984,7 +984,7 @@ zigBuild env opts paths tasks binTasks = do
         global_cache_dir = joinPath [ homeDir, ".cache", "acton", "zig-global-cache" ]
         no_threads = if isWindowsOS (C.target opts) then True else C.no_threads opts
         target_cpu = if (C.cpu opts /= "")
-                       then C.cpu opts
+                       then " -Dcpu=" ++ C.cpu opts
                        else
                          case (splitOn "-" (C.target opts)) of
                            ("native":_)            -> defCpu

--- a/compiler/actonc/Main.hs
+++ b/compiler/actonc/Main.hs
@@ -958,7 +958,7 @@ makeAlwaysRelative base target =
                in joinPath (replicate baseCount "..") </> targetPath
             | otherwise -> path  -- makeRelative found overlap, use its result
 
-
+-- TODO: replace all of this with generic+crypto?!
 #if defined(darwin_HOST_OS) && defined(aarch64_HOST_ARCH)
 defCpu = " -Dcpu=apple_a15 "
 #elif defined(darwin_HOST_OS) && defined(x86_64_HOST_ARCH)
@@ -991,6 +991,7 @@ zigBuild env opts paths tasks binTasks = do
                            ("aarch64":"macos":_)   -> " -Dcpu=apple_a15 "
     -- TODO: how do we do better here? Windows presumably runs on many CPUs that are not aarch64. We really just want to enable AES
                            ("aarch64":"windows":_) -> " -Dcpu=apple_a15 "
+                           ("aarch64":"linux":_)   -> " -Dcpu=cortex_a72 "
                            ("x86_64":_:_)          -> " -Dcpu=westmere "
                            (_:_:_)                 -> defCpu
         buildZigPath = joinPath [projPath paths, "build.zig"]


### PR DESCRIPTION
When cross-compiling on amd64 host for arm64, Zig picks the *baseline* default CPU. But that is not sufficient to compile Mbed-TLS, it needs AES. For other cross-compilation targets we already provide a default CPU model with the required instructions. We now use *[cortex_a72](https://en.wikipedia.org/wiki/ARM_Cortex-A72)* CPU for cross-compiling for `aarch64-linux-*`. This is the first AWS Graviton from 2018. Not sure if we should target something more modern? I guess it does make a difference in the Zig compiler output?

I also found that using *generic+crytpo* works for all cross-compile targets, but again, what does that mean in terms of other optimizations?