### PR TITLE
Handle error during output deduplication

### DIFF
--- a/base/src/testing.act
+++ b/base/src/testing.act
@@ -1070,7 +1070,9 @@ class ProjectTestResults(object):
                                 # Extract iteration number and content
                                 lines = iteration.split('\n', 1)
                                 iteration_num = int(lines[0])
-                                content = lines[1].strip()
+                                content = ""
+                                if len(lines) > 1: # might not be any real test output yet!?
+                                    content = lines[1].strip()
 
                                 # Add to result dictionary
                                 if content not in result:


### PR DESCRIPTION
I'm not sure when this happens but I have gotten an exception thrown for a IndexError and this is the only place I can find. After this fix I can no longer reproduce (though reproduction case was probably <1% in the first place, so a little hard to tell). I suppose we don't have enough test output yet, but I don't really get why because we should print \n, so I think there should always be a second part that is at least the empty string... but I guess not. Doesn't hurt to be defensive.

Fixes #2188