### PR TITLE
Test discovery 2.0

### DIFF
--- a/base/src/testing.act
+++ b/base/src/testing.act
@@ -271,9 +271,14 @@ def eq_opt[T(Eq)](a: ?T, b: ?T) -> bool:
 class TestLogger(logging.Logger):
     pass
 
+class SyncT(value):
+    def __init__(self, log_handler: logging.Handler):
+        self.log_handler = log_handler
+
 class AsyncT(value):
-    def __init__(self, report_result: action(?bool, ?Exception, ?str) -> None):
+    def __init__(self, report_result: action(?bool, ?Exception, ?str) -> None, log_handler: logging.Handler):
         self.report_result = report_result
+        self.log_handler = log_handler
 
     def success(self, output: ?str=None):
         self.report_result(True, None, output)
@@ -283,6 +288,22 @@ class AsyncT(value):
 
     def error(self, exception: Exception):
         self.report_result(None, exception, None)
+
+class EnvT(value):
+    def __init__(self, report_result: action(?bool, ?Exception, ?str) -> None, env: Env, log_handler: logging.Handler):
+        self.report_result = report_result
+        self.env = env
+        self.log_handler = log_handler
+
+    def success(self, output: ?str=None):
+        self.report_result(True, None, output)
+
+    def failure(self, exception: Exception):
+        self.report_result(False, exception, None)
+
+    def error(self, exception: Exception):
+        self.report_result(None, exception, None)
+
 
 class Test(object):
     module: str
@@ -299,9 +320,15 @@ class Test(object):
             self.run_test(report_result, env, log_handler)
         elif isinstance(self, SyncActorTest):
             self.run_test(report_result, env, log_handler)
+        elif isinstance(self, SimpleSyncTest):
+            self.run_test(report_result, env, log_handler)
+        elif isinstance(self, SyncTest):
+            self.run_test(report_result, env, log_handler)
         elif isinstance(self, AsyncActorTest):
             self.run_test(report_result, env, log_handler)
         elif isinstance(self, AsyncTest):
+            self.run_test(report_result, env, log_handler)
+        elif isinstance(self, OldEnvTest):
             self.run_test(report_result, env, log_handler)
         elif isinstance(self, EnvTest):
             self.run_test(report_result, env, log_handler)
@@ -393,6 +420,52 @@ class SyncActorTest(Test):
             exception = e
         report_result(success, exception, output)
 
+class SimpleSyncTest(Test):
+    def __init__(self, fn: proc() -> None, name: str, desc: str, module: str):
+        self.fn = fn
+        self.name = name
+        self.desc = desc
+        self.module = module
+
+    def run_test(self, report_result: action(?bool, ?Exception, ?str) -> None, env: Env, log_handler: logging.Handler):
+        output = None
+        success = None
+        exception = None
+        try:
+            output = self.fn()
+            success = True
+            exception = None
+        except AssertionError as e:
+            success = False
+            exception = e
+        except Exception as e:
+            success = None
+            exception = e
+        report_result(success, exception, output)
+
+class SyncTest(Test):
+    def __init__(self, fn: proc(SyncT) -> None, name: str, desc: str, module: str):
+        self.fn = fn
+        self.name = name
+        self.desc = desc
+        self.module = module
+
+    def run_test(self, report_result: action(?bool, ?Exception, ?str) -> None, env: Env, log_handler: logging.Handler):
+        output = None
+        success = None
+        exception = None
+        try:
+            output = self.fn(SyncT(log_handler))
+            success = True
+            exception = None
+        except AssertionError as e:
+            success = False
+            exception = e
+        except Exception as e:
+            success = None
+            exception = e
+        report_result(success, exception, output)
+
 class AsyncActorTest(Test):
     def __init__(self, fn: proc(action(?bool, ?Exception) -> None, logging.Handler) -> None, name: str, desc: str, module: str):
         self.fn = fn
@@ -413,9 +486,9 @@ class AsyncTest(Test):
         self.module = module
 
     def run_test(self, report_result: action(?bool, ?Exception, ?str) -> None, env: Env, log_handler: logging.Handler):
-        self.fn(AsyncT(report_result))
+        self.fn(AsyncT(report_result, log_handler))
 
-class EnvTest(Test):
+class OldEnvTest(Test):
     def __init__(self, fn: proc(action(?bool, ?Exception) -> None, Env, logging.Handler) -> None, name: str, desc: str, module: str):
         self.fn = fn
         self.name = name
@@ -426,6 +499,16 @@ class EnvTest(Test):
         def repres(success: ?bool, exception: ?Exception):
             report_result(success, exception, None)
         self.fn(repres, env, log_handler)
+
+class EnvTest(Test):
+    def __init__(self, fn: proc(EnvT) -> None, name: str, desc: str, module: str):
+        self.fn = fn
+        self.name = name
+        self.desc = desc
+        self.module = module
+
+    def run_test(self, report_result: action(?bool, ?Exception, ?str) -> None, env: Env, log_handler: logging.Handler):
+        self.fn(EnvT(report_result, env, log_handler))
 
 
 class TestResult(object):
@@ -1170,8 +1253,11 @@ class ProjectTestResults(object):
 actor test_runner(env: Env,
                   unit_tests: dict[str, UnitTest],
                   sync_actor_tests: dict[str, SyncActorTest],
+                  simple_sync_tests: dict[str, SimpleSyncTest],
+                  sync_tests: dict[str, SyncTest],
                   async_actor_tests: dict[str, AsyncActorTest],
                   async_tests: dict[str, AsyncTest],
+                  old_env_tests: dict[str, OldEnvTest],
                   env_tests: dict[str, EnvTest]):
     sw = time.Stopwatch()
     var all_tests = {}
@@ -1180,9 +1266,15 @@ actor test_runner(env: Env,
         all_tests[name] = t
     for name, t in sync_actor_tests.items():
         all_tests[name] = t
+    for name, t in simple_sync_tests.items():
+        all_tests[name] = t
+    for name, t in sync_tests.items():
+        all_tests[name] = t
     for name, t in async_actor_tests.items():
         all_tests[name] = t
     for name, t in async_tests.items():
+        all_tests[name] = t
+    for name, t in old_env_tests.items():
         all_tests[name] = t
     for name, t in env_tests.items():
         all_tests[name] = t

--- a/compiler/lib/src/Acton/Types.hs
+++ b/compiler/lib/src/Acton/Types.hs
@@ -41,7 +41,7 @@ reconstruct fname env0 (Module m i ss)  = do --traceM ("#################### ori
                                              --traceM (render (pretty env0'))
                                              return (iface, Module m i ss1T, env0')
                                              
-  where ssT                             = if hasTesting i then ss ++ testStmts (emptyDict,emptyDict,emptyDict,emptyDict,emptyDict) else ss
+  where ssT                             = if hasTesting i then ss ++ testStmts (emptyDict,emptyDict,emptyDict,emptyDict,emptyDict,emptyDict,emptyDict,emptyDict) else ss
         ss1T                            = if hasTesting i then rmTests ss1 ++ finalStmts env2 (modNameStr m) ss1 else ss1
         env1                            = reserve (assigned ssT) (typeX env0)
         (te,ss1)                        = runTypeM $ infTop env1 ssT
@@ -51,7 +51,7 @@ reconstruct fname env0 (Module m i ss)  = do --traceM ("#################### ori
         env0'                           = convEnvProtos env0
         hasTesting i                    = Import NoLoc [ModuleItem (ModName [name "testing"]) Nothing] `elem` i
         rmTests (Assign _ [PVar _ n _] _ : ss)
-          | nstr n `elem` ["__unit_tests","__sync_actor_tests","__async_actor_tests","__async_tests", "__env_tests"]
+          | nstr n `elem` ["__unit_tests","__sync_actor_tests","__simple_sync_tests","__sync_tests","__async_actor_tests","__async_tests", "__old_env_tests", "__env_tests"]
                                         = rmTests ss
         rmTests (Decl _ [Actor _ n _ _ _ _] : ss)
           | nstr n == "__test_main"     = rmTests ss
@@ -1693,16 +1693,19 @@ instance InfEnvT [Pattern] where
 tEnv                                    = tCon (TC (gname [name "__builtin__"] (name "Env")) []) 
 emptyDict                               = Dict NoLoc []
 
-testStmts (uts, sats, aats, ats, ets) = [dictAssign "__unit_tests" "UnitTest" uts,
+testStmts (uts, sats, ssts, sts, aats, ats, oets, ets) = [dictAssign "__unit_tests" "UnitTest" uts,
                                            dictAssign "__sync_actor_tests" "SyncActorTest" sats,
+                                           dictAssign "__simple_sync_tests" "SimpleSyncTest" ssts,
+                                           dictAssign "__sync_tests" "SyncTest" sts,
                                            dictAssign "__async_actor_tests" "AsyncActorTest" aats,
                                            dictAssign "__async_tests" "AsyncTest" ats,
+                                           dictAssign "__old_env_tests" "OldEnvTest" oets,
                                            dictAssign "__env_tests" "EnvTest" ets,
                                            testActor]
 
 finalStmts env m ss =
-    let (uts, sats, aats, ats, ets) = testFuns env m ss
-    in testStmts (mkDict "UnitTest" uts, mkDict "SyncActorTest" sats, mkDict "AsyncActorTest" aats, mkDict "AsyncTest" ats, mkDict "EnvTest" ets)
+    let (uts, sats, ssts, sts, aats, ats, oets, ets) = testFuns env m ss
+    in testStmts (mkDict "UnitTest" uts, mkDict "SyncActorTest" sats, mkDict "SimpleSyncTest" ssts, mkDict "SyncTest" sts, mkDict "AsyncActorTest" aats, mkDict "AsyncTest" ats, mkDict "OldEnvTest" oets, mkDict "EnvTest" ets)
 
 gname ns n                              = GName (ModName ns) n
 dername a b                             = Derived (name a) (name b)
@@ -1717,7 +1720,7 @@ mkDict cl as                            = eCall (tApp (eQVar primMkDict) [tStr, 
 testActor                               = sDecl [Actor NoLoc (name "__test_main") []
                                                  PosNIL (KwdPar (name "env")  (Just tEnv) Nothing KwdNIL)
                                              [sExpr (eCall (eQVar (gname [name "testing"] (name "test_runner")))
-                                                           (map (eVar . name) ["env","__unit_tests","__sync_actor_tests","__async_actor_tests","__async_tests","__env_tests"]))]]
+                                                           (map (eVar . name) ["env","__unit_tests","__sync_actor_tests","__simple_sync_tests","__sync_tests","__async_actor_tests","__async_tests","__old_env_tests","__env_tests"]))]]
 
 row2list (TRow _ _ _ t r)               = t : row2list r
 row2list (TNil _ _)                     = []
@@ -1733,44 +1736,52 @@ mkAssoc d testType modName =
   where comment (Expr _ s@(Strings _ ss) : _) = s
         comment _ = Strings NoLoc [""]
 
-testFuns :: Env0 -> String -> Suite -> ([Assoc],[Assoc],[Assoc],[Assoc],[Assoc])
-testFuns env modName ss = tF ss [] [] [] [] []
+testFuns :: Env0 -> String -> Suite -> ([Assoc],[Assoc],[Assoc],[Assoc],[Assoc],[Assoc],[Assoc],[Assoc])
+testFuns env modName ss = tF ss [] [] [] [] [] [] [] []
   where
-    tF (With _ _ ss' : ss) uts sats aats ats ets = tF (ss' ++ ss) uts sats aats ats ets
-    tF (Decl l (d@Def{}:ds) : ss) uts sats aats ats ets
+    tF (With _ _ ss' : ss) uts sats ssts sts aats ats oets ets = tF (ss' ++ ss) uts sats ssts sts aats ats oets ets
+    tF (Decl l (d@Def{}:ds) : ss) uts sats ssts sts aats ats oets ets
       | isTestName (dname d) =
           case testType (findQName (NoQ (dname d)) env) of
             Just UnitType ->
-              tF (Decl l ds : ss) (mkAssoc d (name "UnitTest") modName : uts) sats aats ats ets
+              tF (Decl l ds : ss) (mkAssoc d (name "UnitTest") modName : uts) sats ssts sts aats ats oets ets
             Just SyncType ->
-              tF (Decl l ds : ss) uts (mkAssoc d (name "SyncActorTest") modName : sats) aats ats ets
+              tF (Decl l ds : ss) uts (mkAssoc d (name "SyncActorTest") modName : sats) ssts sts aats ats oets ets
+            Just SimpleSyncTest ->
+              tF (Decl l ds : ss) uts sats (mkAssoc d (name "SimpleSyncTest") modName : ssts) sts aats ats oets ets
+            Just SyncTest ->
+              tF (Decl l ds : ss) uts sats ssts (mkAssoc d (name "SyncTest") modName : sts) aats ats oets ets
             Just AsyncType ->
-              tF (Decl l ds : ss) uts sats (mkAssoc d (name "AsyncActorTest") modName : aats) ats ets
+              tF (Decl l ds : ss) uts sats ssts sts (mkAssoc d (name "AsyncActorTest") modName : aats) ats oets ets
             Just AsyncTest ->
-              tF (Decl l ds : ss) uts sats aats (mkAssoc d (name "AsyncTest") modName : ats) ets
-            Just EnvType ->
-              tF (Decl l ds : ss) uts sats aats ats (mkAssoc d (name "EnvTest") modName : ets)
-            Nothing -> tF (Decl l ds : ss) uts sats aats ats ets
-    tF (Decl l (_:ds) : ss) uts sats aats ats ets = tF (Decl l ds : ss) uts sats aats ats ets
-    tF (Decl _ [] : ss) uts sats aats ats ets = tF ss uts sats aats ats ets
-    tF (_ : ss) uts sats aats ats ets = tF ss uts sats aats ats ets
-    tF [] uts sats aats ats ets = (reverse uts, reverse sats, reverse aats, reverse ats, reverse ets)
+              tF (Decl l ds : ss) uts sats ssts sts aats (mkAssoc d (name "AsyncTest") modName : ats) oets ets
+            Just OldEnvType ->
+              tF (Decl l ds : ss) uts sats ssts sts aats ats (mkAssoc d (name "OldEnvTest") modName : oets) ets
+            Just EnvTest ->
+              tF (Decl l ds : ss) uts sats ssts sts aats ats oets (mkAssoc d (name "EnvTest") modName : ets)
+            Nothing -> tF (Decl l ds : ss) uts sats ssts sts aats ats oets ets
+    tF (Decl l (_:ds) : ss) uts sats ssts sts aats ats oets ets = tF (Decl l ds : ss) uts sats ssts sts aats ats oets ets
+    tF (Decl _ [] : ss) uts sats ssts sts aats ats oets ets = tF ss uts sats ssts sts aats ats oets ets
+    tF (_ : ss) uts sats ssts sts aats ats oets ets = tF ss uts sats ssts sts aats ats oets ets
+    tF [] uts sats ssts sts aats ats oets ets = (reverse uts, reverse sats, reverse aats, reverse ssts, reverse sts, reverse ats, reverse oets, reverse ets)
 
 isTestName n                             = take 6 (nstr n) == "_test_"
 
-data TestType = UnitType | SyncType | AsyncType | AsyncTest | EnvType
+data TestType = UnitType | SyncType | SimpleSyncTest | SyncTest | AsyncType | AsyncTest | OldEnvType | EnvTest
                 deriving (Eq,Show,Read)
 
 testType (NDef (TSchema _ []  (TFun _ fx (TNil _ PRow) k res)) _)
               | res /= tNone && res /= tStr = Nothing
               | otherwise    = case row2list k of
-                                []         -> if fx == fxPure || fx == fxMut then Just UnitType else Nothing
-                                [t]        -> if t == logging_handler then Just SyncType else if t == asyncT then Just AsyncTest else Nothing
+                                []         -> if fx == fxPure || fx == fxMut then Just UnitType else if fx == fxProc then Just SimpleSyncTest else Nothing
+                                [t]        -> if t == logging_handler then Just SyncType else if t == syncT then Just SyncTest else if t == asyncT then Just AsyncTest else if t == envT then Just EnvTest else Nothing
                                 [t1,t2]    -> if t2 == logging_handler && isGoodAction t1 then Just AsyncType else Nothing
-                                [t1,t2,t3] -> if t3 == logging_handler && isGoodAction t1 && t2 == tEnv then Just EnvType else Nothing
+                                [t1,t2,t3] -> if t3 == logging_handler && isGoodAction t1 && t2 == tEnv then Just OldEnvType else Nothing
                                 _          -> Nothing
     where logging_handler      =  tCon (TC (gname [name "logging"] (name "Handler")) [])
+          syncT                =  tCon (TC (gname [name "testing"] (name "SyncT")) [])
           asyncT               =  tCon (TC (gname [name "testing"] (name "AsyncT")) [])
+          envT                 =  tCon (TC (gname [name "testing"] (name "EnvT")) [])
           isGoodAction t@(TFun _ fx p (TNil _ KRow) res)
              | fx == fxAction
                && res == tNone  = case row2list p of

--- a/test/stdlib_tests/src/test_testing.act
+++ b/test/stdlib_tests/src/test_testing.act
@@ -6,40 +6,79 @@ actor MathTester():
         return a + b
 
 
-actor SyncTester(log_handler):
+actor SyncActTester(log_handler):
     log = logging.Logger(log_handler)
     def test():
         m = MathTester()
-        log.info("SyncTester.test()", None)
+        log.info("SyncActTester.test()")
         testing.assertEqual(m.add(1, 2), 3, "1 + 2 = 3")
 
-actor AsyncTester(report_result, log_handler):
-    log = logging.Logger(log_handler)
+actor SimpleSyncTester():
     def test():
-        log.info("AsyncTester.test()", None)
-        report_result(True, None)
+        m = MathTester()
+        print("SimpleSyncTester.test()")
+        testing.assertEqual(m.add(1, 2), 3, "1 + 2 = 3")
 
-actor EnvTester(report_result, env, log_handler):
+actor SyncTester(t):
+    log = logging.Logger(t.log_handler)
+    def test():
+        m = MathTester()
+        log.info("SyncTester.test()")
+        print("SyncTester.test()")
+        testing.assertEqual(m.add(1, 2), 3, "1 + 2 = 3")
+
+actor AsyncActTester(report_result, log_handler):
     log = logging.Logger(log_handler)
     def test():
-        log.info("EnvTester.test()", None)
+        log.info("AsyncTester.test()")
         report_result(True, None)
+    after 0: test()
+
+actor AsyncTester(t):
+    log = logging.Logger(t.log_handler)
+    def test():
+        log.info("AsyncTester.test()", {"data": "test"})
+        t.success()
+    after 0: test()
+
+actor OldEnvTester(report_result, env, log_handler):
+    log = logging.Logger(log_handler)
+    def test():
+        log.info("EnvTester.test()")
+        report_result(True, None)
+    after 0: test()
+
+actor EnvTester(t):
+    log = logging.Logger(t.log_handler)
+    def test():
+        log.info("EnvTester.test() wthreads:", {"nr_wthreads": t.env.nr_wthreads})
+        print("EnvTester.test() wthreads:", t.env.nr_wthreads)
+        t.success()
+    after 0: test()
 
 def _test_foo() -> None:
     pass
 
 def _test_syncact(log_handler: logging.Handler) -> None:
-    s = SyncTester(log_handler)
+    s = SyncActTester(log_handler)
+    return s.test()
+
+def _test_simple_sync() -> None:
+    s = SimpleSyncTester()
+    return s.test()
+
+def _test_sync(t: testing.SyncT) -> None:
+    s = SyncTester(t)
     return s.test()
 
 def _test_asyncact(report_result, log_handler: logging.Handler) -> None:
-    s = AsyncTester(report_result, log_handler)
-    s.test()
+    s = AsyncActTester(report_result, log_handler)
 
 def _test_async(t: testing.AsyncT) -> None:
-    t.success()
+    s = AsyncTester(t)
 
-# this doesn't work because actonc doesn't infer the right type signature
-def _test_envtest(report_result, env, log_handler: logging.Handler) -> None:
-    s = EnvTester(report_result, env, log_handler)
-    s.test()
+def _test_oldenvtest(report_result, env: Env, log_handler: logging.Handler) -> None:
+    s = OldEnvTester(report_result, env, log_handler)
+
+def _test_envtest(t: testing.EnvT) -> None:
+    s = EnvTester(t)


### PR DESCRIPTION
The new style of test discovery is based on a single, explicitly typed, argument to the test function. Relying on type inferrence for test discovery is brittle. If we knew something was a test, we could presume it would take a argument aligned with a test function and do type checking based on that, but test discovery is done after type inferrence & checking, so we don't know. Often the test function type signature can be inferred to something else and thus discovery doesn't work.

The new style using explicit types, like

def _test_foo(t: testing.EnvT):
    ...

Means test discovery becomes deterministic. We also make it more easy to extend the test environment since we can add new attributes to the EnvT object without affecting test discovery.

pure def _test_foo():
proc def _test_foo():
proc def _test_foo(t: testing.SyncT):
proc def _test_foo(t: testing.AsyncT):
proc def _test_foo(t: testing.EnvT):

Unit tests still take no argument at all. For synchronous actor tests, we have the possibiltiy of giving it an argument, in case we want to access t.log_handler, or take no arguments at all.

Fixes #2122 