### PR TITLE
Don't require newline at end of file

### DIFF
--- a/compiler/actonc/test/syntaxerrors/err1.act
+++ b/compiler/actonc/test/syntaxerrors/err1.act
@@ -1,16 +1,3 @@
-# Copyright (C) 2019-2021 Data Ductus AB
-#
-# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-#
-# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-#
-# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#
-
 def f(x): if x>pass:
     return 1
   else

--- a/compiler/actonc/test/syntaxerrors/err1.golden
+++ b/compiler/actonc/test/syntaxerrors/err1.golden
@@ -2,10 +2,10 @@ Building file test/syntaxerrors/err1.act using temporary scratch directory
 
 ERROR: Error when compiling err1 module: Syntax error
 
-test/syntaxerrors/err1.act:14:11:
-   |
-14 | def f(x): if x>pass:
-   |           ^^^^^^^^^^^
+test/syntaxerrors/err1.act:1:11:
+  |
+1 | def f(x): if x>pass:
+  |           ^^^^^^^^^^^
 unexpected "if x>pass:<newline>   "
 expecting end of line or simple statement
 

--- a/compiler/actonc/test/syntaxerrors/err2.act
+++ b/compiler/actonc/test/syntaxerrors/err2.act
@@ -1,18 +1,4 @@
-# Copyright (C) 2019-2021 Data Ductus AB
-#
-# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-#
-# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-#
-# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#
-
 def f(x):
-   actor a():
-      pass
-
-   return 2+x
+    actor a():
+        pass
+    return 2+x

--- a/compiler/actonc/test/syntaxerrors/err2.golden
+++ b/compiler/actonc/test/syntaxerrors/err2.golden
@@ -2,9 +2,9 @@ Building file test/syntaxerrors/err2.act using temporary scratch directory
 
 ERROR: Error when compiling err2 module: Context error
 
-   |
-15 |   actor a():
-   |   ^^^^^
+  |
+2 |    actor a():
+  |    ^^^^^
 actor declaration only allowed on the module top level
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 

--- a/compiler/actonc/test/syntaxerrors/err3.act
+++ b/compiler/actonc/test/syntaxerrors/err3.act
@@ -1,15 +1,2 @@
-# Copyright (C) 2019-2021 Data Ductus AB
-#
-# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-#
-# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-#
-# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#
-
 def f(x):
-   return 2+
+    return 2+

--- a/compiler/actonc/test/syntaxerrors/err3.golden
+++ b/compiler/actonc/test/syntaxerrors/err3.golden
@@ -2,11 +2,11 @@ Building file test/syntaxerrors/err3.act using temporary scratch directory
 
 ERROR: Error when compiling err3 module: Syntax error
 
-test/syntaxerrors/err3.act:15:13:
-   |
-15 |    return 2+
-   |             ^
-unexpected end of input
+test/syntaxerrors/err3.act:2:14:
+  |
+2 |     return 2+
+  |              ^
+unexpected newline
 expecting atomic expression or unary operator
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 

--- a/compiler/actonc/test/syntaxerrors/err4.act
+++ b/compiler/actonc/test/syntaxerrors/err4.act
@@ -1,16 +1,2 @@
-# Copyright (C) 2019-2021 Data Ductus AB
-#
-# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-#
-# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-#
-# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#
-
 def f(x):
-   return x+pass
-   
+    return x+pass

--- a/compiler/actonc/test/syntaxerrors/err4.golden
+++ b/compiler/actonc/test/syntaxerrors/err4.golden
@@ -2,11 +2,11 @@ Building file test/syntaxerrors/err4.act using temporary scratch directory
 
 ERROR: Error when compiling err4 module: Syntax error
 
-test/syntaxerrors/err4.act:15:13:
-   |
-15 |    return x+pass
-   |             ^^^^^
-unexpected "pass<newline>   "
+test/syntaxerrors/err4.act:2:14:
+  |
+2 |     return x+pass
+  |              ^^^^^
+unexpected "pass<newline>"
 expecting atomic expression or unary operator
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 

--- a/compiler/actonc/test/syntaxerrors/err5.act
+++ b/compiler/actonc/test/syntaxerrors/err5.act
@@ -1,17 +1,3 @@
-# Copyright (C) 2019-2021 Data Ductus AB
-#
-# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-#
-# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-#
-# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#
-
 def f(x:
-   y = x * 2
-   return x + y
-   
+    y = x * 2
+    return x + y

--- a/compiler/actonc/test/syntaxerrors/err5.golden
+++ b/compiler/actonc/test/syntaxerrors/err5.golden
@@ -2,10 +2,10 @@ Building file test/syntaxerrors/err5.act using temporary scratch directory
 
 ERROR: Error when compiling err5 module: Syntax error
 
-test/syntaxerrors/err5.act:16:4:
-   |
-16 |    return x + y
-   |    ^
+test/syntaxerrors/err5.act:3:5:
+  |
+3 |     return x + y
+  |     ^
 unexpected 'r'
 expecting a closing parenthesis, call arguments, slice/index expression, comma, if clause, or operator
 

--- a/compiler/actonc/test/syntaxerrors/err6.act
+++ b/compiler/actonc/test/syntaxerrors/err6.act
@@ -1,16 +1,3 @@
-# Copyright (C) 2019-2021 Data Ductus AB
-#
-# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-#
-# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-#
-# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#
-
 def f(X):
-  a = 2
-  return X+a
+    a = 2
+    return X+a

--- a/compiler/actonc/test/syntaxerrors/err6.golden
+++ b/compiler/actonc/test/syntaxerrors/err6.golden
@@ -2,10 +2,10 @@ Building file test/syntaxerrors/err6.act using temporary scratch directory
 
 ERROR: Error when compiling err6 module: Syntax error
 
-test/syntaxerrors/err6.act:14:7:
-   |
-14 | def f(X):
-   |       ^^
+test/syntaxerrors/err6.act:1:7:
+  |
+1 | def f(X):
+  |       ^^
 unexpected "X)"
 expecting "**", '*', or name (not type variable)
 

--- a/compiler/actonc/test/syntaxerrors/err7.act
+++ b/compiler/actonc/test/syntaxerrors/err7.act
@@ -1,14 +1,1 @@
-# Copyright (C) 2019-2021 Data Ductus AB
-#
-# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-#
-# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-#
-# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#
-
 f : [a (Eq)] => (a,a) -> bool

--- a/compiler/actonc/test/syntaxerrors/err7.golden
+++ b/compiler/actonc/test/syntaxerrors/err7.golden
@@ -2,10 +2,10 @@ Building file test/syntaxerrors/err7.act using temporary scratch directory
 
 ERROR: Error when compiling err7 module: Syntax error
 
-test/syntaxerrors/err7.act:14:6:
-   |
-14 | f : [a (Eq)] => (a,a) -> bool
-   |      ^
+test/syntaxerrors/err7.act:1:6:
+  |
+1 | f : [a (Eq)] => (a,a) -> bool
+  |      ^
 unexpected 'a'
 expecting type variable (upper case letter optionally followed by digits)
 

--- a/compiler/actonc/test/syntaxerrors/err8.act
+++ b/compiler/actonc/test/syntaxerrors/err8.act
@@ -1,16 +1,3 @@
-# Copyright (C) 2019-2021 Data Ductus AB
-#
-# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-#
-# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-#
-# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#
-
 def f(x):
     y = 2
      z = x+y

--- a/compiler/actonc/test/syntaxerrors/err8.golden
+++ b/compiler/actonc/test/syntaxerrors/err8.golden
@@ -1,9 +1,9 @@
 Building file test/syntaxerrors/err8.act using temporary scratch directory
 
 ERROR: Error when compiling err8 module: Indentation error
-   |
-16 |     z = x+y
-   |     ^
+  |
+3 |     z = x+y
+  |     ^
 Too much indentation
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 

--- a/compiler/actonc/test/syntaxerrors/err9.act
+++ b/compiler/actonc/test/syntaxerrors/err9.act
@@ -1,14 +1,1 @@
-# Copyright (C) 2019-2021 Data Ductus AB
-#
-# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-#
-# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-#
-# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#
-
 f : [A]

--- a/compiler/actonc/test/syntaxerrors/err9.golden
+++ b/compiler/actonc/test/syntaxerrors/err9.golden
@@ -2,11 +2,11 @@ Building file test/syntaxerrors/err9.act using temporary scratch directory
 
 ERROR: Error when compiling err9 module: Syntax error
 
-test/syntaxerrors/err9.act:14:8:
-   |
-14 | f : [A]
-   |        ^
-unexpected end of input
+test/syntaxerrors/err9.act:1:8:
+  |
+1 | f : [A]
+  |        ^
+unexpected newline
 expecting "=>"
 
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 


### PR DESCRIPTION
There's lots of tools that strive to not write newlines at the end of a file. I have seen editors do this and lately I noticed AI agents produce files without a newline. The Acton parser throws an error at this, which seems excessive.. so now change that. The fix here is to just add a newline if one isn't present. That's a little hacky but simpler than changing parsing rules. I can't really see any drawbacks to this.