### PR TITLE
Keep NotImplemented extension annotations until CodeGen,

### DIFF
--- a/compiler/lib/src/Acton/Converter.hs
+++ b/compiler/lib/src/Acton/Converter.hs
@@ -39,9 +39,7 @@ pruneStmts xs (s@Assign{} : ss)
   | null ns                             = pruneStmts xs ss
   | otherwise                           = s : pruneStmts xs ss
   where ns                              = bound s `intersect` xs
-pruneStmts xs (s : ss)
-  | isNotImpl s                         = pruneStmts xs ss
-  | otherwise                           = s : pruneStmts xs ss
+pruneStmts xs (s : ss)                  = s : pruneStmts xs ss
 pruneStmts xs []                        = []
 
 pruneBody env n ss                      = pruneStmts xs ss


### PR DESCRIPTION
for the benefit of proper generation of constructor functions even in the case when no NotImplemented methods reveal that the extension class has its missing parts implemented in C.