### PR TITLE
Include diff in testing.assertEqual(a, b) exception

### DIFF
--- a/base/src/testing.act
+++ b/base/src/testing.act
@@ -16,17 +16,21 @@ class NotEqualError[T](AssertionError):
     a: ?T
     b: ?T
 
-    def __init__(self, a, b, msg: ?str=None, print_vals: bool=True):
+    def __init__(self, a, b, msg: ?str=None, print_vals: bool=True, diff_str: ?str=None):
         self.a = a
         self.b = b
         self.error_message = msg if msg != None else "Expected equal values but they are non-equal."
         self.print_vals = print_vals
+        self.diff_str = diff_str
 
     def __str__(self):
         msg = "%s: %s" % (self._name(), self.error_message)
         if self.print_vals:
             msg += " A: " + opt_str(self.a)
             msg += " B: " + opt_str(self.b)
+        ds = self.diff_str
+        if ds is not None:
+            msg += "\n" + ds
         return msg
 
 class EqualError[T](AssertionError):
@@ -196,13 +200,18 @@ class NotIsInstanceError[T](AssertionError):
         self.error_message = msg if msg != None else "expected type of specific instance"
 
 
-def assertEqual[T(Eq)](a: ?T, b: ?T, msg: ?str, print_vals: bool=True):
+def assertEqual[T(Eq)](a: ?T, b: ?T, msg: ?str, print_vals: bool=True, print_diff: bool=True):
     """Assert that two values are equal
     """
     if ((a == None and b != None)
         or (a != None and b == None)
         or (a != None and b != None and not (a == b))):
-        raise NotEqualError(a, b, msg, print_vals)
+        diff_str = None
+        if print_diff:
+            # We calculate diff here and not in NotEqualError.__str__ because the
+            # "mut" effect leaks out of the diff() function, but __str__() must be pure
+            diff_str = f"{term.normal}{diff.diff(opt_str(a), opt_str(b), color=True)}{term.normal}"
+        raise NotEqualError(a, b, msg, print_vals, diff_str)
 
 def assertNotEqual[T(Eq)](a: ?T, b: ?T, msg: ?str, print_vals: bool=True):
     """Assert that two values are not equal
@@ -926,7 +935,7 @@ actor TestExecutor(syscap, config, t: Test, report_complete, env):
             if val != None:
                 exp_val = get_expected(t.module, t.name)
                 if exp_val == None or exp_val != None and val != exp_val:
-                    exc = NotEqualError(val, exp_val, f"Test output does not match expected golden value.\n{term.normal}{diff.diff(str(exp_val), val, color=True)}", print_vals=False)
+                    exc = NotEqualError(val, exp_val, f"Test output does not match expected golden value.", diff_str=f"{term.normal}{diff.diff(str(exp_val), val, color=True)}", print_vals=False)
                     _report_result(t, sw, non_gc_mem_usage_before, gc_total_bytes_start, gc_time_start, False, exc, val)
                     return
             _report_result(t, sw, non_gc_mem_usage_before, gc_total_bytes_start, gc_time_start, s, e, val)

--- a/test/stdlib_tests/src/test_testing_asserts.act
+++ b/test/stdlib_tests/src/test_testing_asserts.act
@@ -2,14 +2,15 @@
 import testing
 from testing import NotEqualError
 
-def _test_assert_equal() -> None:
+def _test_assert_equal():
     """Test assertEqual"""
+    messages = []
 
     # should raise NotEqualError because 1 != 2
     try:
         testing.assertEqual(1, 2)
     except AssertionError as e:
-        pass
+        messages.append(str(e))
     else:
         raise Exception("assertEqual(1, 2) should have raised NotEqualError")
 
@@ -17,7 +18,7 @@ def _test_assert_equal() -> None:
     try:
         testing.assertEqual(1, None)
     except AssertionError as e:
-        pass
+        messages.append(str(e))
     else:
         raise Exception("assertEqual(1, None) should have raised NotEqualError")
 
@@ -25,7 +26,7 @@ def _test_assert_equal() -> None:
     try:
         testing.assertEqual(None, 1)
     except AssertionError as e:
-        pass
+        messages.append(str(e))
     else:
         raise Exception("assertEqual(None, 1) should have raised NotEqualError")
 
@@ -35,8 +36,11 @@ def _test_assert_equal() -> None:
     except AssertionError as e:
         raise Exception("assertEqual(None, None) should not have raised NotEqual")
 
-def _test_assert_not_equal() -> None:
+    return "\n".join(messages)
+
+def _test_assert_not_equal():
     """Test assertNotEqual"""
+    messages = []
 
     # should not raise NotEqualError because 1 != 2
     try:
@@ -60,13 +64,15 @@ def _test_assert_not_equal() -> None:
     try:
         testing.assertNotEqual(None, None)
     except AssertionError as e:
-        pass
+        messages.append(str(e))
     else:
         raise Exception("assertNotEqual(None, None) should have raised NotEqual")
 
     try:
         testing.assertNotEqual(1, 1)
     except AssertionError as e:
-        pass
+        messages.append(str(e))
     else:
         raise Exception("assertNotEqual(1, 1) should have raised NotEqual")
+
+    return "\n".join(messages)

--- a/test/stdlib_tests/test/golden/test_testing_asserts/assert_equal
+++ b/test/stdlib_tests/test/golden/test_testing_asserts/assert_equal
@@ -1,0 +1,3 @@
+testing.NotEqualError: Expected equal values but they are non-equal. A: 1 B: 2
+testing.NotEqualError: Expected equal values but they are non-equal. A: 1 B: None
+testing.NotEqualError: Expected equal values but they are non-equal. A: None B: 1

--- a/test/stdlib_tests/test/golden/test_testing_asserts/assert_equal
+++ b/test/stdlib_tests/test/golden/test_testing_asserts/assert_equal
@@ -1,3 +1,15 @@
 testing.NotEqualError: Expected equal values but they are non-equal. A: 1 B: 2
+[0m[38;5;251m@@ -1,1 +1,1 @@
+[0m[31m-1
+[0m[32m+2
+[0m[0m
 testing.NotEqualError: Expected equal values but they are non-equal. A: 1 B: None
+[0m[38;5;251m@@ -1,1 +1,1 @@
+[0m[31m-1
+[0m[32m+None
+[0m[0m
 testing.NotEqualError: Expected equal values but they are non-equal. A: None B: 1
+[0m[38;5;251m@@ -1,1 +1,1 @@
+[0m[31m-None
+[0m[32m+1
+[0m[0m

--- a/test/stdlib_tests/test/golden/test_testing_asserts/assert_not_equal
+++ b/test/stdlib_tests/test/golden/test_testing_asserts/assert_not_equal
@@ -1,0 +1,2 @@
+testing.EqualError: Expected non-equal values but they are equal. A: None B: None
+testing.EqualError: Expected non-equal values but they are equal. A: 1 B: 1


### PR DESCRIPTION
If the `testing.assertEqual(a, b)` assertion fails, we now include the diff output in the exception message. That is in addition to the A, B values which are also printed in full.

I find that in this case the full output is also useful if one wants to copy & paste the output and update the expected value in the test.