### PR TITLE
Fix VERSION substitution in Homebrew PR creation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -820,10 +820,10 @@ jobs:
         with:
           path: homebrew-acton
           token: ${{ secrets.ACTBOT_PAT }}
-          branch: acton-v${VERSION}
-          title: "acton v${VERSION}"
+          branch: acton-v${{ env.VERSION }}
+          title: "acton v${{ env.VERSION }}"
           body: |
             Automatic update triggered by release on actonlang/acton.
           committer: Acton Bot <actbot@acton-lang.org>
-          commit-message: "acton v${VERSION}"
+          commit-message: "acton v${{ env.VERSION }}"
           signoff: false


### PR DESCRIPTION
## Summary
- Fixed GitHub Actions workflow to properly substitute VERSION variable in Homebrew PR creation

## Problem
The `peter-evans/create-pull-request` action was using shell variable syntax `${VERSION}` in YAML fields that are evaluated by GitHub Actions, not by the shell. This caused the literal string `"${VERSION}"` to appear in:
- PR titles (e.g., `acton v${VERSION}`)
- Branch names 
- Commit messages

## Solution
Changed to use GitHub Actions expression syntax `${{ env.VERSION }}` for proper variable substitution in the action parameters.

## Test plan
The fix will be validated when the next release is created - the Homebrew PR should show the actual version number instead of the literal `${VERSION}` string.