### PR TITLE
Fix string 'in' operator for substrings found at position 0

### DIFF
--- a/base/builtin/str.c
+++ b/base/builtin/str.c
@@ -1309,7 +1309,7 @@ B_int B_ContainerD_strD___len__ (B_ContainerD_str wit, B_str s){
 
  
 B_bool B_ContainerD_strD___contains__ (B_ContainerD_str wit, B_str s, B_str sub) {
-    return toB_bool(bmh(s->str,sub->str,s->nbytes,sub->nbytes) > 0);
+    return toB_bool(bmh(s->str,sub->str,s->nbytes,sub->nbytes) >= 0);
 }
 
 B_bool B_ContainerD_strD___containsnot__ (B_ContainerD_str wit, B_str s, B_str sub) {

--- a/test/builtins_auto/test_str.act
+++ b/test/builtins_auto/test_str.act
@@ -1,5 +1,7 @@
 def test_str_find():
     s = "hello, world!"
+    if s.find("hello, world!") != 0:
+        raise ValueError("find() did not return the correct index: " + str(s.find("hello, world!")))
     if s.find("world") != 7:
         raise ValueError("find() did not return the correct index: " + str(s.find("world")))
     if s.find("world", 0) != 7:
@@ -139,6 +141,10 @@ actor main(env):
     except Exception as e:
         print("Unexpected exception during testing:", e)
         await async env.exit(1)
+
+    if "hello, world!" not in "hello, world!":
+        print("ERROR: 'hello, world!' not in 'hello, world!'")
+        env.exit(1)
 
     b = b'\xde\xad\xbe\xef'
     if b.hex() != "deadbeef":


### PR DESCRIPTION
The __contains__ method was using bmh() > 0 which incorrectly returned false when a substring was found at the beginning of the string (position 0). Changed condition to bmh() >= 0 to include position 0 matches.