### PR TITLE
DocPrinter: use NModule instead of TEnv

### DIFF
--- a/compiler/actonc/Main.hs
+++ b/compiler/actonc/Main.hs
@@ -429,9 +429,9 @@ printDocs opts = do
                         Nothing -> if inGui then C.HtmlFormat else C.AsciiFormat
 
                 docOutput <- case format of
-                    C.HtmlFormat -> return $ DocP.printHtmlDoc tenv parsed
-                    C.AsciiFormat -> return $ DocP.printAsciiDoc False tenv parsed
-                    C.MarkdownFormat -> return $ DocP.printMdDoc tenv parsed
+                    C.HtmlFormat -> return $ DocP.printHtmlDoc nmod parsed
+                    C.AsciiFormat -> return $ DocP.printAsciiDoc False nmod parsed
+                    C.MarkdownFormat -> return $ DocP.printMdDoc nmod parsed
 
                 -- Handle output destination
                 case C.outputFile opts of
@@ -977,7 +977,7 @@ runRestPasses opts paths env0 parsed stubMode = do
                               simplifiedTypeEnv = simp env1 modTypeEnv
                           createDirectoryIfMissing True docFileDir
                           -- Use parsed (original AST) to preserve docstrings
-                          let htmlDoc = DocP.printHtmlDoc simplifiedTypeEnv parsed
+                          let htmlDoc = DocP.printHtmlDoc (A.NModule simplifiedTypeEnv mdoc) parsed
                           writeFile docFile htmlDoc
 
                       --traceM ("#################### typed env0:")

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -250,29 +250,29 @@ testDocFiles env0 moduleNames = do
           (nmod, tchecked, typeEnv) <- Acton.Types.reconstruct "" env kchecked
           let S.NModule tenv mdoc = nmod
           -- The new environment includes the processed module
-          return (env, accModules ++ [(modName, parsed, tenv)])
+          return (env, accModules ++ [(modName, parsed, nmod)])
     
     (finalEnv, mods) <- foldM processModule (env0, []) moduleNames
     setCurrentDirectory oldDir
     return mods
   
   -- Generate documentation for each module
-  forM_ modules $ \(modName, parsed, tenv) -> do
+  forM_ modules $ \(modName, parsed, nmod) -> do
     describe modName $ do
       it "generates ASCII documentation (plain)" $ do
-        let asciiDoc = DocP.printAsciiDoc False tenv parsed
+        let asciiDoc = DocP.printAsciiDoc False nmod parsed
         goldenTextFile (testDir </> goldenDir </> modName ++ ".txt") $ return $ T.pack asciiDoc
 
       it "generates ASCII documentation (styled)" $ do
-        let asciiDoc = DocP.printAsciiDoc True tenv parsed
+        let asciiDoc = DocP.printAsciiDoc True nmod parsed
         goldenTextFile (testDir </> goldenDir </> modName ++ "-color.txt") $ return $ T.pack asciiDoc
 
       it "generates Markdown documentation" $ do
-        let mdDoc = DocP.printMdDoc tenv parsed
+        let mdDoc = DocP.printMdDoc nmod parsed
         goldenTextFile (testDir </> goldenDir </> modName ++ ".md") $ return $ T.pack mdDoc
 
       it "generates HTML documentation" $ do
-        let htmlDoc = DocP.printHtmlDoc tenv parsed
+        let htmlDoc = DocP.printHtmlDoc nmod parsed
         goldenTextFile (testDir </> goldenDir </> modName ++ ".html") $ return $ T.pack htmlDoc
 
 parseAct env0 act_file = do


### PR DESCRIPTION
- Update all DocPrinter functions to accept NModule instead of TEnv
- Use module docstrings from NModule, remove AST fallback logic
- Fix Main.hs to pass real NModule
- Remove backward compatibility code and TODOs
- Implement imported class extraction from TEnv