### PR TITLE
Add global command-line options to actonc

### DIFF
--- a/compiler/lib/src/Acton/CommandLineParser.hs
+++ b/compiler/lib/src/Acton/CommandLineParser.hs
@@ -18,10 +18,20 @@ defTarget = "x86_64-linux-gnu.2.27"
 parseCmdLine        :: IO CmdLineOptions
 parseCmdLine        = execParser (info (cmdLineParser <**> helper) descr)
 
-data CmdLineOptions = CompileOpt [String] CompileOptions
+data CmdLineOptions = CompileOpt [String] GlobalOptions CompileOptions
                     | VersionOpt VersionOptions
-                    | CmdOpt Command
+                    | CmdOpt GlobalOptions Command
                     deriving Show
+
+data ColorWhen = Auto | Always | Never deriving (Show, Eq)
+
+data GlobalOptions = GlobalOptions {
+                        tty :: Bool,
+                        debug :: Bool,
+                        quiet :: Bool,
+                        timing :: Bool,
+                        color :: ColorWhen
+                     } deriving Show
 
 data VersionOptions = VersionOptions {
                         version :: Bool,
@@ -32,6 +42,7 @@ data Command        = New NewOptions
                     | Build BuildOptions
                     | Cloud CloudOptions
                     | Doc DocOptions
+                    | Version VersionOptions
                     deriving Show
 
 
@@ -41,7 +52,6 @@ data NewOptions     = NewOptions {
 
 data CompileOptions   = CompileOptions {
                          alwaysbuild :: Bool,
-                         tty         :: Bool,
                          db          :: Bool,
                          parse       :: Bool,
                          kinds       :: Bool,
@@ -56,12 +66,9 @@ data CompileOptions   = CompileOptions {
                          cgen        :: Bool,
                          ccmd        :: Bool,
                          ty          :: Bool,
-                         timing      :: Bool,
                          autostub    :: Bool,
                          stub        :: Bool,
                          cpedantic   :: Bool,
-                         quiet       :: Bool,
-                         debug       :: Bool,
                          dev         :: Bool,
                          listimports :: Bool,
                          sub         :: Bool,
@@ -79,11 +86,9 @@ data CompileOptions   = CompileOptions {
 
 data BuildOptions = BuildOptions {
                          alwaysB     :: Bool,
-                         ttyB        :: Bool,
                          cpedanticB  :: Bool,
                          dbB         :: Bool,
                          no_threadsB :: Bool,
-                         debugB      :: Bool,
                          devB        :: Bool,
                          listimportsB :: Bool,
                          only_buildB :: Bool,
@@ -91,8 +96,6 @@ data BuildOptions = BuildOptions {
                          autostubB   :: Bool,
                          rootB       :: String,
                          ccmdB       :: Bool,
-                         quietB      :: Bool,
-                         timingB     :: Bool,
                          targetB     :: String,
                          cpuB        :: String,
                          testB       :: Bool,
@@ -120,18 +123,40 @@ data DocFormat = AsciiFormat | MarkdownFormat | HtmlFormat deriving (Show, Eq)
 -- Internal stuff
 
 cmdLineParser       :: Parser CmdLineOptions
-cmdLineParser       = (CmdOpt <$> hsubparser
-                        (  command "new"   (info newCommand (progDesc "Create a new Acton project"))
-                        <> command "build" (info buildCommand (progDesc "Build an Acton project"))
-                        <> command "cloud" (info cloudCommand (progDesc "Run an Acton project in the cloud"))
-                        <> command "doc"   (info docCommand (progDesc "Show type and docstring info"))
-                      ))
-                     <|> (CompileOpt <$> (fmap (:[]) $ argument str (metavar "ACTONFILE" <> help "Compile Acton file" <> completer (bashCompleter "file -X '!*.act' -o plusdirs"))) <*> compileOptions)
+cmdLineParser       = hsubparser
+                        (  command "new"     (info (CmdOpt <$> globalOptions <*> (New <$> newOptions)) (progDesc "Create a new Acton project"))
+                        <> command "build"   (info (CmdOpt <$> globalOptions <*> (Build <$> buildOptions)) (progDesc "Build an Acton project"))
+                        <> command "cloud"   (info (CmdOpt <$> globalOptions <*> (Cloud <$> cloudOptions)) (progDesc "Run an Acton project in the cloud"))
+                        <> command "doc"     (info (CmdOpt <$> globalOptions <*> (Doc <$> docOptions)) (progDesc "Show type and docstring info"))
+                        <> command "version" (info (CmdOpt <$> globalOptions <*> (Version <$> versionOptions)) (progDesc "Show version information"))
+                      )
+                     <|> (CompileOpt <$> (fmap (:[]) $ argument str (metavar "ACTONFILE" <> help "Compile Acton file" <> completer (bashCompleter "file -X '!*.act' -o plusdirs"))) <*> globalOptions <*> compileOptions)
                      <|> (VersionOpt <$> versionOptions)
 
+globalOptions :: Parser GlobalOptions
+globalOptions = GlobalOptions
+    <$> switch (long "tty"    <> help "Act as if run from interactive TTY")
+    <*> switch (long "debug"  <> help "Print debug stuff")
+    <*> switch (long "quiet"  <> help "Don't print stuff")
+    <*> switch (long "timing" <> help "Print timing information")
+    <*> option colorReader
+        (long "color"
+         <> metavar "WHEN"
+         <> value Auto
+         <> help "Use colored output (WHEN: auto, always, never)"
+        )
+  where
+    colorReader :: ReadM ColorWhen
+    colorReader = eitherReader $ \s ->
+        case s of
+            "auto"   -> Right Auto
+            "always" -> Right Always
+            "never"  -> Right Never
+            _        -> Left $ "Invalid color option: " ++ s ++ " (expected: auto, always, never)"
+
 versionOptions         = VersionOptions <$>
-                                         switch (long "version"         <> help "Show version information")
-                                     <*> switch (long "numeric-version" <> help "Show numeric version")
+                                         switch (long "version" <> short 'v' <> help "Show version information")
+                                     <*> switch (long "numeric-version" <> short 'n' <> help "Show numeric version")
 
 
 {-
@@ -141,11 +166,10 @@ generalOptions         = GeneralOptions <$>
                          <*> switch (long "dev"        <> help "Development mode; include debug symbols etc")
  -}
 
-newCommand = New <$> (NewOptions <$> argument (str :: ReadM String) (metavar "PROJECTDIR"))
+newOptions = NewOptions <$> argument (str :: ReadM String) (metavar "PROJECTDIR")
 
 compileOptions = CompileOptions
         <$> switch (long "always-build" <> help "Show the result of parsing")
-        <*> switch (long "tty"          <> help "Act as if run from interactive TTY")
         <*> switch (long "db"           <> help "Enable DB backend")
         <*> switch (long "parse"        <> help "Show the result of parsing")
         <*> switch (long "kinds"        <> help "Show all the result after kind-checking")
@@ -160,12 +184,9 @@ compileOptions = CompileOptions
         <*> switch (long "cgen"         <> help "Show the generated .c code")
         <*> switch (long "ccmd"         <> help "Show CC / LD commands")
         <*> switch (long "ty"           <> help "Write .ty file to src file directory")
-        <*> switch (long "timing"       <> help "Print timing information")
         <*> switch (long "auto-stub"    <> help "Allow automatic stub detection")
         <*> switch (long "stub"         <> help "Stub (.ty) file generation only")
         <*> switch (long "cpedantic"    <> help "Pedantic C compilation with -Werror")
-        <*> switch (long "quiet"        <> help "Don't print stuff")
-        <*> switch (long "debug"        <> help "Print debug stuff")
         <*> switch (long "dev"          <> help "Development mode; include debug symbols etc")
         <*> switch (long "list-imports" <> help "List module imports")
         <*> switch (long "sub")
@@ -180,14 +201,11 @@ compileOptions = CompileOptions
         <*> switch (long "test"         <> help "Build tests")
         <*> many (strOption (long "searchpath" <> metavar "DIR" <> help "Add search path"))
 
-buildCommand          = Build <$> (
-    BuildOptions
+buildOptions = BuildOptions
         <$> switch (long "always-build" <> help "Development mode; include debug symbols etc")
-        <*> switch (long "tty"          <> help "Act as if run from interactive TTY")
         <*> switch (long "cpedantic"    <> help "Pedantic C compilation with -Werror")
         <*> switch (long "db"           <> help "Enable DB backend")
         <*> switch (long "no-threads"   <> help "Don't use threads")
-        <*> switch (long "debug"        <> help "Print debug stuff")
         <*> switch (long "dev"          <> help "Development mode; include debug symbols etc")
         <*> switch (long "list-imports" <> help "List module imports")
         <*> switch (long "only-build"   <> help "Only perform final build of .c files, do not compile .act files")
@@ -195,28 +213,22 @@ buildCommand          = Build <$> (
         <*> switch (long "auto-stub"    <> help "Allow automatic stub detection")
         <*> strOption (long "root"      <> metavar "ROOTACTOR" <> value "" <> help "Set root actor")
         <*> switch (long "ccmd"         <> help "Show CC / LD commands")
-        <*> switch (long "quiet"        <> help "Don't print stuff")
-        <*> switch (long "timing"       <> help "Print timing information")
         <*> strOption (long "target"    <> metavar "TARGET" <> value defTarget <> help "Target, e.g. x86_64-linux-gnu.2.28")
         <*> strOption (long "cpu"       <> metavar "CPU" <> value "" <> help "CPU, e.g. skylake")
         <*> switch (long "test"         <> help "Build tests")
         <*> many (strOption (long "searchpath" <> metavar "DIR" <> help "Add search path"))
-    )
 
-cloudCommand        = Cloud <$> (
-    CloudOptions
+cloudOptions = CloudOptions
         <$> switch (long "run"          <> help "Help run!")
         <*> switch (long "list"         <> help "Help list!")
         <*> switch (long "show"         <> help "Help show!")
-        <*> switch (long "stop"         <> help "Help stop!"))
+        <*> switch (long "stop"         <> help "Help stop!")
 
-docCommand          = Doc <$> docOptions
+docOptions = DocOptions
+    <$> (argument str (metavar "FILE" <> help "Input file (.act or .ty) - optional in projects" <> completer (bashCompleter "file -X '!*.act' -X '!*.ty' -o plusdirs")) <|> pure "")
+    <*> formatFlags
+    <*> optional (strOption (long "output" <> short 'o' <> metavar "FILE" <> help "Output file (default: stdout)"))
   where
-    docOptions = DocOptions
-        <$> (argument str (metavar "FILE" <> help "Input file (.act or .ty) - optional in projects" <> completer (bashCompleter "file -X '!*.act' -X '!*.ty' -o plusdirs")) <|> pure "")
-        <*> formatFlags
-        <*> optional (strOption (long "output" <> short 'o' <> metavar "FILE" <> help "Output file (default: stdout)"))
-
     -- Parse format flags - simple and explicit
     formatFlags = optional (
               flag' AsciiFormat (short 't' <> help "Terminal output (ASCII format)")


### PR DESCRIPTION
Refactor command-line parsing to support global options (--tty, --debug, --quiet, --timing) that work across all subcommands. This eliminates duplicate field definitions between CompileOptions and BuildOptions, providing a cleaner architecture where global options are defined once in GlobalOptions and shared across all commands.

Key changes:
- Add GlobalOptions type with gtty, gdebug, gquiet, gtiming fields
- Remove duplicate fields from CompileOptions and BuildOptions
- Update all commands (build, doc, version) to use global options
- Thread GlobalOptions through the compilation pipeline
- Maintain backward compatibility with existing command-line interface