### PR TITLE
Add color support to acton doc command

### DIFF
--- a/cli/src/acton.act
+++ b/cli/src/acton.act
@@ -1377,7 +1377,10 @@ actor main(env):
             cmdargs.extend(["-o", output_file])
         
         # Force color based on TTY (since stdio is piped)
-        cmdargs.append("--color=always" if env.is_tty() else "--color=never")
+        if env.is_tty():
+            cmdargs.extend(["--color", "always"])
+        else:
+            cmdargs.extend(["--color", "never"])
         
         # Pass through global options
         if args.get_bool("debug"):

--- a/compiler/actonc/Main.hs
+++ b/compiler/actonc/Main.hs
@@ -436,7 +436,9 @@ printDocs gopts opts = do
 
                 docOutput <- case format of
                     C.HtmlFormat -> return $ DocP.printHtmlDoc nmod parsed
-                    C.AsciiFormat -> return $ DocP.printAsciiDoc False nmod parsed
+                    C.AsciiFormat -> do
+                        shouldColor <- useColor gopts
+                        return $ DocP.printAsciiDoc shouldColor nmod parsed
                     C.MarkdownFormat -> return $ DocP.printMdDoc nmod parsed
 
                 -- Handle output destination


### PR DESCRIPTION
Enable TTY detection and color output for the acton doc command:
- CLI passes --color flag to actonc based on TTY detection
- Compiler respects color settings for ASCII documentation output
- Supports --color always/never/auto flags and NO_COLOR env var
- Terminal output now includes colored function names and types

NO_COLOR takes precedence, so `acton doc foo.act -t` will render with colors but `NO_COLOR=1 acton doc foo.act -t` will be plain ASCII.

Part of #2273 