### PR TITLE
Remove bullet points from ASCII doc output

### DIFF
--- a/compiler/lib/src/Acton/DocPrinter.hs
+++ b/compiler/lib/src/Acton/DocPrinter.hs
@@ -818,7 +818,7 @@ docDeclUnified useStyle tenv (Class _ n q a b ddoc) =
     -- Document a single attribute
     docAttrUnified :: Bool -> (Name, Maybe Type) -> Doc
     docAttrUnified useStyle (name, mtype) =
-        text "- " <> pretty name <>
+        pretty name <>
         case mtype of
             Just t -> text ": " <> pretty (SimplifiedType t)
             Nothing -> empty
@@ -845,7 +845,7 @@ docDeclUnified useStyle tenv (Class _ n q a b ddoc) =
                                     then empty
                                     else docRetTypeStyled useStyle useStyle (Just t)
                           Nothing -> empty
-            header = text "- " <> text (bold useStyle) <> pretty methodName <> text (reset useStyle) <>
+            header = text (bold useStyle) <> pretty methodName <> text (reset useStyle) <>
                      docGenerics q <> paramsWithTypes <> showRetType
             docstrDoc = case docstr of
                 Just ds -> text ds
@@ -923,7 +923,7 @@ docDeclUnified useStyle tenv (Protocol _ n q a b ddoc) =
     docProtocolMethod :: (Name, QBinds, PosPar, KwdPar, Maybe Type, Maybe String) -> Doc
     docProtocolMethod (methodName, q, p, k, retType, docstr) =
         -- Protocol methods are just signatures
-        let header = text "- " <> pretty methodName <> text ":" <+>
+        let header = pretty methodName <> text ":" <+>
                      case retType of
                          Just t -> pretty (SimplifiedType t)
                          Nothing -> text "()"

--- a/compiler/lib/test/doc-golden/bar-color.txt
+++ b/compiler/lib/test/doc-golden/bar-color.txt
@@ -18,25 +18,25 @@ that are used across the application.
     
 
   [33mAttributes:[0m
-    - value: str
-    - label: str
-    - count: int
+    value: str
+    label: str
+    count: int
 
   [33mMethods:[0m
-    - [1m__init__[0m(self, value: [32mstr[0m, label: [32mstr[0m)
+    [1m__init__[0m(self, value: [32mstr[0m, label: [32mstr[0m)
       Initialize data with value and label
 
         Args:
             value: The data value
             label: A descriptive label
         
-    - [1mget_value[0m(self) -> [32mstr[0m
+    [1mget_value[0m(self) -> [32mstr[0m
       Get the stored value
 
         Returns:
             The data value
         
-    - [1mupdate[0m(self, new_value: [32mstr[0m)
+    [1mupdate[0m(self, new_value: [32mstr[0m)
       Update the value
 
         Args:
@@ -45,7 +45,7 @@ that are used across the application.
         Note:
             This increments the access count
         
-    - [1mget_info[0m(self) -> [32mstr[0m
+    [1mget_info[0m(self) -> [32mstr[0m
       Get formatted information about this data
 
         Returns:
@@ -63,17 +63,17 @@ that are used across the application.
     
 
   [33mAttributes:[0m
-    - items: list[T]
-    - name: str
+    items: list[T]
+    name: str
 
   [33mMethods:[0m
-    - [1m__init__[0m(self, name: [32mstr[0m)
+    [1m__init__[0m(self, name: [32mstr[0m)
       Create an empty container
 
         Args:
             name: Container name for identification
         
-    - [1madd[0m(self, item: [32mT[0m)
+    [1madd[0m(self, item: [32mT[0m)
       Add an item to the container
 
         Args:
@@ -82,13 +82,13 @@ that are used across the application.
         Raises:
             ValueError: If container is full
         
-    - [1mget_all[0m(self) -> [32mlist[T][0m
+    [1mget_all[0m(self) -> [32mlist[T][0m
       Get all items
 
         Returns:
             List of all items in the container
         
-    - [1mfilter[0m[U](self, predicate: [32m(T) -> bool[0m, transform: [32m(T) -> U[0m) -> [32mlist[U][0m
+    [1mfilter[0m[U](self, predicate: [32m(T) -> bool[0m, transform: [32m(T) -> U[0m) -> [32mlist[U][0m
       Filter and transform items
 
         Args:
@@ -105,7 +105,7 @@ that are used across the application.
             >>> c.filter(lambda x: x > 1, lambda x: str(x))
             ["2"]
         
-    - [1mcount[0m(self) -> [32mint[0m
+    [1mcount[0m(self) -> [32mint[0m
       Get number of items in container
 
         Returns:
@@ -167,9 +167,9 @@ that are used across the application.
     
 
   [33mMethods:[0m
-    - process: T
-    - validate: bool
-    - get_metadata: dict[str,str]
+    process: T
+    validate: bool
+    get_metadata: dict[str,str]
 
 [36mextension[0m Data(Processable[str])
   Makes Data implement the Processable protocol

--- a/compiler/lib/test/doc-golden/bar.txt
+++ b/compiler/lib/test/doc-golden/bar.txt
@@ -18,25 +18,25 @@ class Data(object)
     
 
   Attributes:
-    - value: str
-    - label: str
-    - count: int
+    value: str
+    label: str
+    count: int
 
   Methods:
-    - __init__(self, value: str, label: str)
+    __init__(self, value: str, label: str)
       Initialize data with value and label
 
         Args:
             value: The data value
             label: A descriptive label
         
-    - get_value(self) -> str
+    get_value(self) -> str
       Get the stored value
 
         Returns:
             The data value
         
-    - update(self, new_value: str)
+    update(self, new_value: str)
       Update the value
 
         Args:
@@ -45,7 +45,7 @@ class Data(object)
         Note:
             This increments the access count
         
-    - get_info(self) -> str
+    get_info(self) -> str
       Get formatted information about this data
 
         Returns:
@@ -63,17 +63,17 @@ class Container[T](object)
     
 
   Attributes:
-    - items: list[T]
-    - name: str
+    items: list[T]
+    name: str
 
   Methods:
-    - __init__(self, name: str)
+    __init__(self, name: str)
       Create an empty container
 
         Args:
             name: Container name for identification
         
-    - add(self, item: T)
+    add(self, item: T)
       Add an item to the container
 
         Args:
@@ -82,13 +82,13 @@ class Container[T](object)
         Raises:
             ValueError: If container is full
         
-    - get_all(self) -> list[T]
+    get_all(self) -> list[T]
       Get all items
 
         Returns:
             List of all items in the container
         
-    - filter[U](self, predicate: (T) -> bool, transform: (T) -> U) -> list[U]
+    filter[U](self, predicate: (T) -> bool, transform: (T) -> U) -> list[U]
       Filter and transform items
 
         Args:
@@ -105,7 +105,7 @@ class Container[T](object)
             >>> c.filter(lambda x: x > 1, lambda x: str(x))
             ["2"]
         
-    - count(self) -> int
+    count(self) -> int
       Get number of items in container
 
         Returns:
@@ -167,9 +167,9 @@ protocol Processable[T]
     
 
   Methods:
-    - process: T
-    - validate: bool
-    - get_metadata: dict[str,str]
+    process: T
+    validate: bool
+    get_metadata: dict[str,str]
 
 extension Data(Processable[str])
   Makes Data implement the Processable protocol


### PR DESCRIPTION
Replace bullet point lists with indentation-based hierarchy for attributes and methods in ASCII documentation output for class & protocol attributes, methods.

Part of #2273