### PR TITLE
More f-strings for stdlib

### DIFF
--- a/base/src/__builtin__.act
+++ b/base/src/__builtin__.act
@@ -381,7 +381,7 @@ class IndexError (LookupError):
         self.error_message = msg if msg is not None else "List index out of range"
 
     def __str__(self):
-        return f"{self._name()}: {self.error_message}, index: {str(self.index)}"
+        return f"{self._name()}: {self.error_message}, index: {self.index}"
 
 class KeyError(LookupError):
     def __init__(self, key: value, msg: ?str=None):
@@ -1009,7 +1009,7 @@ actor StringDecoder(cb_out: action(str) -> None, encoding: ?str="utf-8", on_erro
         if on_error is not None:
             on_error("Invalid UTF-8", buf)
         else:
-            raise ValueError("Invalid UTF-8: %s" % str(buf))
+            raise ValueError(f"Invalid UTF-8: {str(buf)}")
 
 ## Environment ################################################
 

--- a/base/src/argparse.act
+++ b/base/src/argparse.act
@@ -239,7 +239,7 @@ class Args(object):
             val = opt.value
             if isinstance(val, bool):
                 return val
-            raise ValueError(f"Option value {val} is not a bool")
+            raise ValueError(f"Option value {str(val)} is not a bool")
         except KeyError:
             raise ArgumentError(f"Option '{name}' not found")
 
@@ -251,7 +251,7 @@ class Args(object):
             val = opt.value
             if isinstance(val, int):
                 return val
-            raise ValueError(f"Option value '{val}' is not a int")
+            raise ValueError(f"Option value '{str(val)}' is not a int")
         except KeyError:
             raise ArgumentError(f"Option '{name}' not found")
 
@@ -263,7 +263,7 @@ class Args(object):
             val = opt.value
             if isinstance(val, str):
                 return val
-            raise ValueError(f"Option value '{val}' is not a str")
+            raise ValueError(f"Option value '{str(val)}' is not a str")
         except KeyError:
             raise ArgumentError(f"Option '{name}' not found")
 
@@ -275,7 +275,7 @@ class Args(object):
             val = opt.value
             if isinstance(val, list):
                 return val
-            raise ValueError(f"Option value '{val}' is not a list[str]")
+            raise ValueError(f"Option value '{str(val)}' is not a list[str]")
         except KeyError:
             raise ArgumentError(f"Option '{name}' not found")
 
@@ -325,7 +325,6 @@ class Parser(object):
 
         self.opts[name] = (name=name, type=type, nargs=nargs, default=default, help=help, short=short)
 
-
     def add_arg(self, name: str, help: str="", required: bool=True, nargs: str="?"):
         if nargs == "+" or nargs == "*":
             for arg in self.args:
@@ -349,14 +348,14 @@ class Parser(object):
             short_opt = opt.short
             if opt.type == "bool":
                 if short_opt is not None:
-                    short_opts += " [-%s]" % short_opt
+                    short_opts += f" [-{short_opt}]"
                 else:
-                    short_opts += " [--%s]" % name
+                    short_opts += f" [--{name}]"
             else:
                 if short_opt is not None:
-                    short_opts += " [-%s %s]" % (short_opt, name.upper())
+                    short_opts += f" [-{short_opt} {name.upper()}]"
                 else:
-                    short_opts += " [--%s %s]" % (name, name.upper())
+                    short_opts += f" [--{name} {name.upper()}]"
         for arg in self.args:
             n = arg.name
             if n is not None:
@@ -487,7 +486,7 @@ class Parser(object):
                         newval.append(val)
                         res.options[akey] = ("type"="strlist", "value"=newval)
                 else:
-                    #raise ArgumentError("Unknown option %s" % arg)
+                    #raise ArgumentError(f"Unknown option {arg}")
                     rest.append(arg)
             elif arg.startswith('-') and len(arg) > 1:
                 # Handle short options (-x or -xyz for grouped bools only)

--- a/base/src/http.act
+++ b/base/src/http.act
@@ -157,7 +157,7 @@ class Request(object):
         self.body = body
 
     def __str__(self):
-        return f"<http.Request {str(self.method)} {str(self.path)} {str(self.version)} {self.headers.__str__()} {str(self.body)}>"
+        return f"<http.Request {self.method} {self.path} {str(self.version)} {self.headers.__str__()} {str(self.body)}>"
 
 extension Request(Eq):
     def __eq__(self, other):
@@ -181,7 +181,7 @@ class Response(object):
         self.body = body
 
     def __str__(self) -> str:
-        return f"<http.Response {str(self.status)}>"
+        return f"<http.Response {self.status}>"
 
     def decode_json(self):
         return json.decode(self.body.decode())
@@ -214,7 +214,7 @@ def parse_message(i: bytes, log: logging.Logger) -> (?Message, bytes):
         rest = b""
         if "content-length" in headers:
             clen = int(headers["content-length"].strip(" "))
-            log.trace("Got content-length in headers, expecting %d bytes" % clen, None)
+            log.trace(f"Got content-length in headers, expecting {clen} bytes", None)
             if len(rs[1]) >= clen:
                 body = rs[1][:clen]
                 rest = rs[1][clen:]
@@ -230,7 +230,7 @@ def parse_message(i: bytes, log: logging.Logger) -> (?Message, bytes):
                 log.trace("Got chunked transfer-encoding", None)
                 reached_end = False
                 rest = rs[1]
-                log.trace("Rest: %s" % str(rest), None)
+                log.trace(f"Rest: {str(rest)}", None)
                 body = b""
                 while not reached_end:
                     maybe_chunk = rest.split(b"\r\n", 1)
@@ -240,28 +240,31 @@ def parse_message(i: bytes, log: logging.Logger) -> (?Message, bytes):
                     elif len(maybe_chunk) == 2:
                         chunk_header = maybe_chunk[0].strip(b"\r\n")
                         rest = maybe_chunk[1]
-                        log.trace("Chunk header: %s" % chunk_header.decode()[:20], None)
+                        header_preview = chunk_header.decode()[:20]
+                        log.trace(f"Chunk header: {header_preview}", None)
                         if chunk_header == b"":
                             log.trace("Empty chunk header", None)
                             return None, i
                         else:
                             try:
                                 clen = int(chunk_header.decode(), 16)
-                                log.trace("Chunk length: %d" % clen, None)
+                                log.trace(f"Chunk length: {clen}", None)
                             except ValueError:
                                 log.trace("Chunk header not a length", None)
                             else:
                                 if len(rest) >= clen:
                                     gap = rest[clen-10:clen+10]
                                     chunk = rest[:clen]
-                                    log.trace("Read chunk: %s" % str(chunk), None)
+                                    log.trace(f"Read chunk: {str(chunk)}", None)
                                     rest = rest[clen:]
                                     if len(rest) < 2 and rest[0:2] != b"\r\n":
                                         log.trace("Could not find chunk end marker", None)
                                         return None, i
                                     rest = rest[2:]
                                     #log.trace("Enough data to reach end of chunk", None)
-                                    log.trace("Enough data to reach end of chunk, chunk gap: %s|%s" % (str(chunk[-5:]), str(rest[:5])), None)
+                                    chunk_preview = str(chunk[-5:])
+                                    rest_preview = str(rest[:5])
+                                    log.trace(f"Enough data to reach end of chunk, chunk gap: {chunk_preview}|{rest_preview}", None)
                                     body += chunk
                                     if clen == 0:
                                         reached_end = True
@@ -398,7 +401,7 @@ actor Server(conn: net.TCPListenConnection, on_accept: action(Server) -> None, l
 
     def on_tcp_error(conn, error):
         # TODO: the conn should really be in here, but type error!?
-        _log.trace("There was an error: %s from: %s" % (str(error), str("")), None)
+        _log.trace(f"There was an error: {str(error)} from: {str("")}", None)
 
     def close():
         conn.close()
@@ -463,7 +466,7 @@ actor Client(cap: net.TCPConnectCap, address: str, on_connect: action(Client) ->
             tls_port = port if port is not None else 443
             tls_conn = net.TLSConnection(cap, address, tls_port, _on_tls_connect, _on_tls_receive, _on_tls_error, None, tls_verify)
         else:
-            raise ValueError("Only http and https schemes are supported. Unsupported scheme: %s" % scheme)
+            raise ValueError(f"Only http and https schemes are supported. Unsupported scheme: {scheme}")
 
     def _on_conn_connect():
         # If there are outstanding requests, it probably means we were

--- a/base/src/logging.act
+++ b/base/src/logging.act
@@ -157,7 +157,7 @@ class DefaultFormatter(Formatter):
         if msg is None and data is None:
             return
         str_path = '>'.join(m.path)
-        text = str(m.ts) + " %-7s" % lvl_name
+        text = f"{str(m.ts)} {lvl_name:<7}"
         if len(str_path) > 0:
             text += str_path + ": "
         text += f"{m.actor_class}[{str(m.actor_id)}]: "

--- a/base/src/testing.act
+++ b/base/src/testing.act
@@ -26,8 +26,8 @@ class NotEqualError[T](AssertionError):
     def __str__(self):
         msg = f"{self._name()}: {self.error_message}"
         if self.print_vals:
-            msg += f" A: {opt_str(self.a)}"
-            msg += f" B: {opt_str(self.b)}"
+            msg += f" A: {self.a}"
+            msg += f" B: {self.b}"
         ds = self.diff_str
         if ds is not None:
             msg += "\n" + ds
@@ -46,8 +46,8 @@ class EqualError[T](AssertionError):
     def __str__(self):
         msg = f"{self._name()}: {self.error_message}"
         if self.print_vals:
-            msg += f" A: {opt_str(self.a)}"
-            msg += f" B: {opt_str(self.b)}"
+            msg += f" A: {self.a}"
+            msg += f" B: {self.b}"
         return msg
 
 class NotTrueError[T](AssertionError):
@@ -61,7 +61,7 @@ class NotTrueError[T](AssertionError):
     def __str__(self):
         msg = f"{self._name()}: {self.error_message}"
         if self.print_vals:
-            msg += f", value: {opt_str(self.a)}"
+            msg += f", value: {self.a}"
         return msg
 
 class NotFalseError[T](AssertionError):
@@ -75,7 +75,7 @@ class NotFalseError[T](AssertionError):
     def __str__(self):
         msg = f"{self._name()}: {self.error_message}"
         if self.print_vals:
-            msg += f", value: {opt_str(self.a)}"
+            msg += f", value: {self.a}"
         return msg
 
 class NotNoneError[T](AssertionError):
@@ -89,7 +89,7 @@ class NotNoneError[T](AssertionError):
     def __str__(self):
         msg = f"{self._name()}: {self.error_message}"
         if self.print_vals:
-            msg += f", value: {opt_str(self.a)}"
+            msg += f", value: {self.a}"
         return msg
 
 class NoneError[T](AssertionError):
@@ -104,7 +104,7 @@ class NoneError[T](AssertionError):
         msg = f"{self._name()}: {self.error_message}"
         if self.print_vals:
             a = self.a
-            msg += f", value: {opt_str(a)}"
+            msg += f", value: {a}"
         return msg
 
 class NotInError[T,U](AssertionError):
@@ -120,8 +120,8 @@ class NotInError[T,U](AssertionError):
     def __str__(self):
         msg = f"{self._name()}: {self.error_message}"
         if self.print_vals:
-            msg += f", element: {opt_str(self.a)}"
-            msg += f", container: {opt_str(self.b)}"
+            msg += f", element: {self.a}"
+            msg += f", container: {self.b}"
         return msg
 
 class InError[T,U](AssertionError):
@@ -137,8 +137,8 @@ class InError[T,U](AssertionError):
     def __str__(self):
         msg = f"{self._name()}: {self.error_message}"
         if self.print_vals:
-            msg += f", element: {opt_str(self.a)}"
-            msg += f", container: {opt_str(self.b)}"
+            msg += f", element: {self.a}"
+            msg += f", container: {self.b}"
         return msg
 
 class NotIsError[T](AssertionError):
@@ -210,7 +210,7 @@ def assertEqual[T(Eq)](a: ?T, b: ?T, msg: ?str, print_vals: bool=True, print_dif
         if print_diff:
             # We calculate diff here and not in NotEqualError.__str__ because the
             # "mut" effect leaks out of the diff() function, but __str__() must be pure
-            diff_str = f"{term.normal}{diff.diff(opt_str(a), opt_str(b), color=True)}{term.normal}"
+            diff_str = f"{term.normal}{diff.diff(str(a), str(b), color=True)}{term.normal}"
         raise NotEqualError(a, b, msg, print_vals, diff_str)
 
 def assertNotEqual[T(Eq)](a: ?T, b: ?T, msg: ?str, print_vals: bool=True):
@@ -904,7 +904,7 @@ actor TestExecutor(syscap, config, t: Test, report_complete, env):
             acton.rts.gc(syscap)
         non_gc_mem_usage_after = int(acton.rts.get_rss(syscap) - acton.rts.get_mem_usage(syscap))
         non_gc_mem_usage_delta = non_gc_mem_usage_after - non_gc_mem_usage_before
-        #print("non-GC memory before: %d  after: %d  delta: %d" % (non_gc_mem_usage_before, non_gc_mem_usage_after, non_gc_mem_usage_delta))
+        #print(f"non-GC memory before: {non_gc_mem_usage_before}  after: {non_gc_mem_usage_after}  delta: {non_gc_mem_usage_delta}")
         complete = True if test_dur > config.min_test_duration else False
         if test_info != None:
             exc = str(exception) if exception != None else None
@@ -1103,7 +1103,7 @@ class ProjectTestResults(object):
                 print("\nTests")
                 self.printed_lines += 2
             elif len(self.results[module_name]) > 0:
-                print("\nTests - module %s:" % module_name)
+                print(f"\nTests - module {module_name}:")
                 self.printed_lines += 2
 
             for test_name, tinfo in self.results[module_name].items():
@@ -1159,7 +1159,7 @@ class ProjectTestResults(object):
                 if tinfo.complete:
                     if exc != None:
                         for line in str(exc).splitlines(None):
-                            print(term.red + "    %s" % (line) + term.normal)
+                            print(f"{term.red}    {line}{term.normal}")
                             self.printed_lines += 1
                     # Print std_out/std_err if the test failed
                     if tinfo.num_failures > 0 or tinfo.num_errors > 0:
@@ -1207,7 +1207,7 @@ class ProjectTestResults(object):
                                 if len(chunks) == 1:
                                     pass
                                 else:
-                                    print("      == %d test runs with this output:" % len(test_runs))
+                                    print(f"      == {len(test_runs)} test runs with this output:")
                                     self.printed_lines += 1
                                 for line in chunk.splitlines():
                                     print("      " + line)
@@ -1223,7 +1223,7 @@ class ProjectTestResults(object):
                                 if len(chunks) == 1:
                                     pass
                                 else:
-                                    print("      == %d test runs with this output:" % len(test_runs))
+                                    print(f"      == {len(test_runs)} test runs with this output:")
                                     self.printed_lines += 1
                                 for line in chunk.splitlines():
                                     print("      " + line)
@@ -1309,7 +1309,7 @@ actor test_runner(env: Env,
         test_name = args.get_str("name")
         test_fun_name = "_test_" + test_name
         if test_fun_name not in all_tests:
-            print("Test not found: %s" % test_name)
+            print(f"Test not found: {test_name}")
             env.exit(1)
         the_test = all_tests[test_fun_name]
         tests_complete = set()

--- a/base/src/time.act
+++ b/base/src/time.act
@@ -279,9 +279,9 @@ class Timezone:
                 tz_str = "+"
             else:
                 tz_str = "-"
-            tz_str += "%02d" % (self.offset // 3600)
+            tz_str += f"{self.offset // 3600:02d}"
             if self.offset % 3600 > 0:
-                tz_str += ":%02d" % ((self.offset % 3600) // 60)
+                tz_str += f":{(self.offset % 3600) // 60:02d}"
         return tz_str
 
 
@@ -433,10 +433,10 @@ class Instant(object):
         self.clock = c
 
     def __str__(self):
-        return "%d.%018d" % (self.second, self.attosecond)
+        return f"{self.second}.{self.attosecond:018d}"
 
     def __repr__(self):
-        return "Instant(%d, %d)" % (self.second, self.attosecond)
+        return f"Instant({self.second}, {self.attosecond})"
 
     def str_ms(self):
         """Return a string representation of the duration with milliseconds.

--- a/base/src/uri.act
+++ b/base/src/uri.act
@@ -67,10 +67,7 @@ class URI(object):
 
     def __repr__(self) -> str:
         """Return a detailed string representation for debugging."""
-        return "URI(scheme='%s', authority='%s', host='%s', port=%s, path='%s', query='%s', fragment='%s')" % (
-                opt_str(self.scheme), opt_str(self.authority),
-                opt_str(self.host), opt_str(self.port), opt_str(self.path),
-                opt_str(self.query), opt_str(self.fragment))
+        return f"URI(scheme='{self.scheme}', authority='{self.authority}', host='{self.host}', port={self.port}, path='{self.path}', query='{self.query}', fragment='{self.fragment}')"
 
 
 def e_str[T](s: ?T) -> str:
@@ -157,10 +154,10 @@ def parse_authority(uri: str) -> (?str, ?str, ?int, str):
         try:
             port = int(host_part[1])
             if port < 0 or port > 65535:
-                raise ValueError("Port must be between 0 and 65535: %s" % host_part[1])
+                raise ValueError(f"Port must be between 0 and 65535: {host_part[1]}")
             return authority, host_part[0], port, remainder
         except ValueError:
-            raise ValueError("Invalid port: %s" % host_part[1])
+            raise ValueError(f"Invalid port: {host_part[1]}")
     else:
         return authority, authority, None, remainder
 


### PR DESCRIPTION
Replace more % formatting and string concatenation with f-string syntax

Slice expressions don't work in f-strings, so those are still kept.