### PR TITLE
Remove unneeded code in process.act

### DIFF
--- a/base/src/process.act
+++ b/base/src/process.act
@@ -157,17 +157,6 @@ actor RunProcess(cap: ProcessCap,
             if _out_done and _err_done and _exited:
                 on_exit(_process, _exit_code, _signal, out_buf, err_buf)
 
-    # Handle PATH inheritance for custom environments
-    # Only inherit PATH if the executable doesn't contain a slash (/)
-    # When the executable contains /, PATH is not used for resolution,
-    # so we respect the user's exact environment specification
-    if env is not None and "PATH" not in env and "/" not in cmd[0]:
-        parent_path = _get_env_path()
-        if parent_path is not None:
-            # Create a shallow copy to avoid mutating the caller's dict
-            env = dict(env.items())
-            env["PATH"] = parent_path
-
     _p = Process(cap, cmd, _on_stdout, _on_stderr, _on_exit, on_error, workdir, env, timeout)
     _process = _p
 

--- a/test/stdlib_tests/src/test_process_env.act
+++ b/test/stdlib_tests/src/test_process_env.act
@@ -3,46 +3,6 @@ import process
 import testing
 
 
-actor ProcessEnvExclusiveTester(t: testing.EnvT):
-    """Custom env with single variable (no PATH) - verify exclusive behavior"""
-    log = logging.Logger(t.log_handler)
-
-    def on_stdout(p, data):
-        if data is not None:
-            output = data.decode()
-            # Parse environment variables
-            vars = {}
-            for line in output.strip().splitlines():
-                if "=" in line:
-                    parts = line.split("=", 1)
-                    vars[parts[0]] = parts[1]
-
-            # Should have exactly FOO and PATH, nothing else
-            if "FOO" in vars and vars["FOO"] == "BAR" and "PATH" in vars and len(vars) == 2:
-                log.info("PASS: Exclusive environment with FOO=BAR and inherited PATH")
-                t.success()
-            else:
-                log.error("FAIL: Expected only FOO and PATH, got: " + str(vars.keys()))
-                t.failure(AssertionError("Expected only FOO and PATH, got: " + str(vars.keys())))
-
-    def on_exit(p, exit_code, term_signal):
-        pass
-
-    def on_stderr(p, data):
-        if data is not None:
-            log.warning("Stderr: " + str(data))
-
-    def on_error(p, error):
-        log.error("Process error: " + error)
-        t.error(Exception("Process error: " + error))
-
-    log.debug("Starting test: Single environment variable")
-    pc = process.ProcessCap(t.env.cap)
-    p1 = process.Process(pc, ["env"], on_stdout, on_stderr, on_exit, on_error,
-                       env={"FOO": "BAR"})
-
-
-
 actor ProcessEnvInheritAllTester(t: testing.EnvT):
     """No custom env (inherit all including PATH)"""
     log = logging.Logger(t.log_handler)
@@ -137,10 +97,6 @@ actor ProcessEnvCustomPathTester(t: testing.EnvT):
     p4 = process.Process(pc, ["env"], on_stdout, on_stderr, on_exit, on_error,
                        env={"PATH": "/custom/path:/usr/bin"})
 
-
-def _test_process_env_exclusive(t: testing.EnvT):
-    """Custom env with single var - exclusive environment (only specified vars + PATH)"""
-    ProcessEnvExclusiveTester(t)
 
 def _test_process_env_inherit_all(t: testing.EnvT):
     """No custom env - inherit all environment variables"""


### PR DESCRIPTION
We don't need to do PATH injection in `RunProcess` actor, it uses `Process` internally.