### PR TITLE
Use diagnose lib for printing parser errors

### DIFF
--- a/compiler/actonc/package.yaml.in
+++ b/compiler/actonc/package.yaml.in
@@ -33,6 +33,7 @@ executables:
       - directory >= 1.3.1
       - filelock
       - filepath
+      - megaparsec
       - prettyprinter
       - process
       - split

--- a/compiler/actonc/test/syntaxerrors/err1.golden
+++ b/compiler/actonc/test/syntaxerrors/err1.golden
@@ -1,13 +1,12 @@
 Building file test/syntaxerrors/err1.act using temporary scratch directory
+[error Parse error]: unexpected "if x>pass:<newline>   "
+                     expecting end of line or simple statement
 
-ERROR: Error when compiling err1 module: Syntax error
-
-test/syntaxerrors/err1.act:1:11:
-  |
-1 | def f(x): if x>pass:
-  |           ^^^^^^^^^^^
-unexpected "if x>pass:<newline>   "
-expecting end of line or simple statement
-
-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
-
+     +--> test/syntaxerrors/err1.act@1:11-1:12
+     |
+   1 | def f(x): if x>pass:
+     :           ^ 
+     :           `- unexpected "if x>pass:<newline>   "
+     :              expecting end of line or simple statement
+     :              
+-----+

--- a/compiler/actonc/test/syntaxerrors/err2.golden
+++ b/compiler/actonc/test/syntaxerrors/err2.golden
@@ -1,11 +1,8 @@
 Building file test/syntaxerrors/err2.act using temporary scratch directory
-
-ERROR: Error when compiling err2 module: Context error
-
-  |
-2 |    actor a():
-  |    ^^^^^
-actor declaration only allowed on the module top level
-
-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
-
+[error Context error]: actor declaration only allowed on the module top level
+     +--> err2.act@2:5-2:10
+     |
+   2 |     actor a():
+     :     ^---- 
+     :     `- actor declaration only allowed on the module top level
+-----+

--- a/compiler/actonc/test/syntaxerrors/err3.golden
+++ b/compiler/actonc/test/syntaxerrors/err3.golden
@@ -1,13 +1,12 @@
 Building file test/syntaxerrors/err3.act using temporary scratch directory
+[error Parse error]: unexpected newline
+                     expecting atomic expression or unary operator
 
-ERROR: Error when compiling err3 module: Syntax error
-
-test/syntaxerrors/err3.act:2:14:
-  |
-2 |     return 2+
-  |              ^
-unexpected newline
-expecting atomic expression or unary operator
-
-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
-
+     +--> test/syntaxerrors/err3.act@2:14-2:15
+     |
+   2 |     return 2+
+     :              ^
+     :              `- unexpected newline
+     :                 expecting atomic expression or unary operator
+     :                 
+-----+

--- a/compiler/actonc/test/syntaxerrors/err4.golden
+++ b/compiler/actonc/test/syntaxerrors/err4.golden
@@ -1,13 +1,12 @@
 Building file test/syntaxerrors/err4.act using temporary scratch directory
+[error Parse error]: unexpected "pass<newline>"
+                     expecting atomic expression or unary operator
 
-ERROR: Error when compiling err4 module: Syntax error
-
-test/syntaxerrors/err4.act:2:14:
-  |
-2 |     return x+pass
-  |              ^^^^^
-unexpected "pass<newline>"
-expecting atomic expression or unary operator
-
-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
-
+     +--> test/syntaxerrors/err4.act@2:14-2:15
+     |
+   2 |     return x+pass
+     :              ^ 
+     :              `- unexpected "pass<newline>"
+     :                 expecting atomic expression or unary operator
+     :                 
+-----+

--- a/compiler/actonc/test/syntaxerrors/err5.golden
+++ b/compiler/actonc/test/syntaxerrors/err5.golden
@@ -1,13 +1,12 @@
 Building file test/syntaxerrors/err5.act using temporary scratch directory
+[error Parse error]: unexpected 'r'
+                     expecting a closing parenthesis, call arguments, slice/index expression, comma, if clause, or operator
 
-ERROR: Error when compiling err5 module: Syntax error
-
-test/syntaxerrors/err5.act:3:5:
-  |
-3 |     return x + y
-  |     ^
-unexpected 'r'
-expecting a closing parenthesis, call arguments, slice/index expression, comma, if clause, or operator
-
-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
-
+     +--> test/syntaxerrors/err5.act@3:5-3:6
+     |
+   3 |     return x + y
+     :     ^ 
+     :     `- unexpected 'r'
+     :        expecting a closing parenthesis, call arguments, slice/index expression, comma, if clause, or operator
+     :        
+-----+

--- a/compiler/actonc/test/syntaxerrors/err6.golden
+++ b/compiler/actonc/test/syntaxerrors/err6.golden
@@ -1,13 +1,12 @@
 Building file test/syntaxerrors/err6.act using temporary scratch directory
+[error Parse error]: unexpected "X)"
+                     expecting "**", '*', or name (not type variable)
 
-ERROR: Error when compiling err6 module: Syntax error
-
-test/syntaxerrors/err6.act:1:7:
-  |
-1 | def f(X):
-  |       ^^
-unexpected "X)"
-expecting "**", '*', or name (not type variable)
-
-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
-
+     +--> test/syntaxerrors/err6.act@1:7-1:8
+     |
+   1 | def f(X):
+     :       ^ 
+     :       `- unexpected "X)"
+     :          expecting "**", '*', or name (not type variable)
+     :          
+-----+

--- a/compiler/actonc/test/syntaxerrors/err7.golden
+++ b/compiler/actonc/test/syntaxerrors/err7.golden
@@ -1,13 +1,12 @@
 Building file test/syntaxerrors/err7.act using temporary scratch directory
+[error Parse error]: unexpected 'a'
+                     expecting type variable (upper case letter optionally followed by digits)
 
-ERROR: Error when compiling err7 module: Syntax error
-
-test/syntaxerrors/err7.act:1:6:
-  |
-1 | f : [a (Eq)] => (a,a) -> bool
-  |      ^
-unexpected 'a'
-expecting type variable (upper case letter optionally followed by digits)
-
-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
-
+     +--> test/syntaxerrors/err7.act@1:6-1:7
+     |
+   1 | f : [a (Eq)] => (a,a) -> bool
+     :      ^ 
+     :      `- unexpected 'a'
+     :         expecting type variable (upper case letter optionally followed by digits)
+     :         
+-----+

--- a/compiler/actonc/test/syntaxerrors/err8.golden
+++ b/compiler/actonc/test/syntaxerrors/err8.golden
@@ -1,10 +1,8 @@
 Building file test/syntaxerrors/err8.act using temporary scratch directory
-
-ERROR: Error when compiling err8 module: Indentation error
-  |
-3 |     z = x+y
-  |     ^
-Too much indentation
-
-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
-
+[error Indentation error]: Too much indentation
+     +--> err8.act@3:6-3:6
+     |
+   3 |      z = x+y
+     :       
+     :      `- Too much indentation
+-----+

--- a/compiler/actonc/test/syntaxerrors/err9.golden
+++ b/compiler/actonc/test/syntaxerrors/err9.golden
@@ -1,13 +1,12 @@
 Building file test/syntaxerrors/err9.act using temporary scratch directory
+[error Parse error]: unexpected newline
+                     expecting "=>"
 
-ERROR: Error when compiling err9 module: Syntax error
-
-test/syntaxerrors/err9.act:1:8:
-  |
-1 | f : [A]
-  |        ^
-unexpected newline
-expecting "=>"
-
-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
-
+     +--> test/syntaxerrors/err9.act@1:8-1:9
+     |
+   1 | f : [A]
+     :        ^
+     :        `- unexpected newline
+     :           expecting "=>"
+     :           
+-----+

--- a/compiler/actonc/test/typeerrors/funargs3.golden
+++ b/compiler/actonc/test/typeerrors/funargs3.golden
@@ -1,13 +1,12 @@
 Building file test/typeerrors/funargs3.act using temporary scratch directory
+[error Parse error]: unexpected '4'
+                     expecting "**" or a closing parenthesis
 
-ERROR: Error when compiling funargs3 module: Syntax error
-
-test/typeerrors/funargs3.act:4:11:
-  |
-4 | a = f(x=3,4)
-  |           ^
-unexpected '4'
-expecting "**" or a closing parenthesis
-
-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
-
+     +--> test/typeerrors/funargs3.act@4:11-4:12
+     |
+   4 | a = f(x=3,4)
+     :           ^ 
+     :           `- unexpected '4'
+     :              expecting "**" or a closing parenthesis
+     :              
+-----+

--- a/compiler/lib/package.yaml.in
+++ b/compiler/lib/package.yaml.in
@@ -24,6 +24,7 @@ library:
     - Acton.CodeGen
     - Acton.CommandLineParser
     - Acton.Deactorizer
+    - Acton.Diagnostics
     - Acton.DocPrinter
     - Acton.Env
     - Acton.Kinds

--- a/compiler/lib/src/Acton/Diagnostics.hs
+++ b/compiler/lib/src/Acton/Diagnostics.hs
@@ -1,0 +1,85 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+module Acton.Diagnostics where
+
+import Error.Diagnose.Diagnostic
+import Error.Diagnose.Report
+import Error.Diagnose.Position
+import Error.Diagnose.Style
+import Error.Diagnose (addReport, addFile, printDiagnostic, prettyDiagnostic)
+
+import Data.List (intersperse, isPrefixOf, isInfixOf, intercalate)
+import Data.Maybe (fromMaybe)
+import Control.Exception (Exception(..), SomeException)
+import qualified Data.List.NonEmpty as NE
+import Text.Read (readMaybe)
+import Data.Char (isDigit, isSpace)
+
+import Text.Megaparsec (PosState(..), reachOffset)
+import Text.Megaparsec.Error (ParseErrorBundle(..), parseErrorPretty, bundleErrors, errorBundlePretty, ShowErrorComponent(..), ParseError(..), errorOffset, parseErrorTextPretty)
+import Text.Megaparsec.Pos (SourcePos(..), unPos, sourceLine, sourceColumn, mkPos)
+import qualified Text.Megaparsec.Error as ME
+
+import Acton.Syntax
+import SrcLocation
+import Utils (SrcLoc(..))
+import Acton.Parser () -- Import for ShowErrorComponent String instance
+
+
+-- | Create a Diagnose Diagnostic from a Megaparsec ParseErrorBundle using structured data
+parseDiagnosticFromBundle :: String -> String -> ParseErrorBundle String String -> Diagnostic String
+parseDiagnosticFromBundle filename src bundle =
+    let -- Extract the first error (most relevant)
+        firstError = NE.head (bundleErrors bundle)
+        -- Get the error offset
+        offset = errorOffset firstError
+        -- Get the position state and calculate source position
+        posState = bundlePosState bundle
+        (_, newPosState) = reachOffset offset posState
+        sourcePos = pstateSourcePos newPosState
+        line = unPos (sourceLine sourcePos)
+        col = unPos (sourceColumn sourcePos)
+        -- Get the error message
+        msg = parseErrorTextPretty firstError
+
+        -- For parse errors, we only have a single position, not a span
+        -- Just highlight one character at the error position
+        -- Create position span
+        position = Position (line, col) (line, col + 1) filename
+
+        -- Create the report
+        report = Err (Just "Parse error") msg [(position, This msg)] []
+        diagnostic = addReport mempty report
+    in addFile diagnostic filename src
+
+
+
+-- | Create a Diagnose Diagnostic for errors with structured location data
+errorDiagnosticWithLoc :: String -> String -> String -> SrcLoc -> String -> Diagnostic String
+errorDiagnosticWithLoc errorKind filename src srcLoc msg =
+    let (line, col, endCol) = case srcLoc of
+            NoLoc -> (1, 1, 2)  -- Default if no location
+            Loc startOffset endOffset ->
+                -- Use Megaparsec's reachOffset to convert offset to position
+                -- Create a minimal PosState for the conversion
+                let initialState = PosState
+                        { pstateInput = src
+                        , pstateOffset = 0
+                        , pstateSourcePos = SourcePos filename (mkPos 1) (mkPos 1)
+                        , pstateTabWidth = mkPos 8
+                        , pstateLinePrefix = ""
+                        }
+                    (_, startState) = reachOffset startOffset initialState
+                    (_, endState) = reachOffset endOffset initialState
+                    startPos = pstateSourcePos startState
+                    endPos = pstateSourcePos endState
+                in (unPos (sourceLine startPos), unPos (sourceColumn startPos), unPos (sourceColumn endPos))
+
+        -- Create position span
+        position = Position (line, col) (line, endCol) filename
+
+        -- Create the report
+        report = Err (Just errorKind) msg [(position, This msg)] []
+        diagnostic = addReport mempty report
+    in addFile diagnostic filename src
+

--- a/compiler/lib/src/Acton/Parser.hs
+++ b/compiler/lib/src/Acton/Parser.hs
@@ -12,6 +12,7 @@
 --
 
 {-# LANGUAGE FlexibleInstances #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 module Acton.Parser where
 
 import qualified Control.Monad.Trans.State.Strict as St
@@ -38,6 +39,10 @@ import Utils
 import Debug.Trace
 import System.IO.Unsafe
 
+-- Orphan instance needed for errorBundlePretty
+instance ShowErrorComponent String where
+  showErrorComponent s = s
+
 -- Context errors -------------------------------------------------------------------------------
 
 tr :: Show a => String -> Parser a -> Parser a
@@ -49,9 +54,6 @@ tr msg p = do
 
 makeReport ps src = errReport (map setSpan ps) src
   where setSpan (loc, msg) = (extractSrcSpan loc src, msg)
-
-instance ShowErrorComponent [Char] where
-  showErrorComponent s = s
 
 --- Main parsing and error message functions ------------------------------------------------------
 
@@ -70,10 +72,6 @@ parseModule qn fileName fileContent =
 parseTestStr b p str = case runParser (St.evalStateT p (b,[])) "" str of
                          Left err -> putStrLn (errorBundlePretty err)
                          Right t  -> print t
-
-parserError :: ParseErrorBundle String String -> [(SrcLoc,String)]
-parserError err = [(NoLoc,errorBundlePretty err)]
-
 
 extractSrcSpan :: SrcLoc -> String -> SrcSpan
 extractSrcSpan NoLoc src = SpanEmpty


### PR DESCRIPTION
This integrates the diagnose library with megaparsec to provide beautiful error messages.

The integration only affects actual megaparsec parse errors. Context errors and indentation errors continue to use their existing error handlers.