### PR TITLE
Improve error messages for type variable name violations

### DIFF
--- a/compiler/actonc/Main.hs
+++ b/compiler/actonc/Main.hs
@@ -19,6 +19,7 @@ import Prelude hiding (readFile, writeFile)
 import qualified Acton.Parser
 import qualified Acton.Syntax as A
 import Text.Megaparsec.Error (ParseErrorBundle)
+import Acton.Parser (CustomParseError)
 import qualified Acton.CommandLineParser as C
 import qualified Acton.Relabel
 import qualified Acton.Env
@@ -729,7 +730,7 @@ parseActFile gopts opts paths actFile = do
                                                                    ++ ": " ++ fmtTime(timeParse - timeRead))
                     stubMode <- detectStubMode paths actFile opts
                     return $ ActonTask (modName paths) srcContent m stubMode
-    where handleParseError :: String -> ParseErrorBundle String String -> IO A.Module
+    where handleParseError :: String -> ParseErrorBundle String CustomParseError -> IO A.Module
           handleParseError srcContent bundle = do
                     let diagnostic = Diag.parseDiagnosticFromBundle actFile srcContent bundle
                     printDiag gopts opts diagnostic

--- a/compiler/actonc/test/syntaxerrors/err41.act
+++ b/compiler/actonc/test/syntaxerrors/err41.act
@@ -1,0 +1,2 @@
+class Z(value):
+    pass

--- a/compiler/actonc/test/syntaxerrors/err41.golden
+++ b/compiler/actonc/test/syntaxerrors/err41.golden
@@ -1,11 +1,11 @@
-Building file test/syntaxerrors/err6.act using temporary scratch directory
+Building file test/syntaxerrors/err41.act using temporary scratch directory
 [error Parse error]: Invalid name (reserved for type variables)
 
-     +--> test/syntaxerrors/err6.act@1:7-1:8
+     +--> test/syntaxerrors/err41.act@1:7-1:8
      |
-   1 | def f(X):
+   1 | class Z(value):
      :       ^ 
-     :       `- invalid name 'X'
+     :       `- invalid name 'Z'
      :
      | Hint: Single upper case character (optionally followed by digits) are reserved for type variables. Use a longer name.
 -----+

--- a/compiler/actonc/test/syntaxerrors/err42.act
+++ b/compiler/actonc/test/syntaxerrors/err42.act
@@ -1,0 +1,2 @@
+def Z():
+    pass

--- a/compiler/actonc/test/syntaxerrors/err42.golden
+++ b/compiler/actonc/test/syntaxerrors/err42.golden
@@ -1,11 +1,11 @@
-Building file test/syntaxerrors/err6.act using temporary scratch directory
+Building file test/syntaxerrors/err42.act using temporary scratch directory
 [error Parse error]: Invalid name (reserved for type variables)
 
-     +--> test/syntaxerrors/err6.act@1:7-1:8
+     +--> test/syntaxerrors/err42.act@1:5-1:6
      |
-   1 | def f(X):
-     :       ^ 
-     :       `- invalid name 'X'
+   1 | def Z():
+     :     ^ 
+     :     `- invalid name 'Z'
      :
      | Hint: Single upper case character (optionally followed by digits) are reserved for type variables. Use a longer name.
 -----+

--- a/docs/acton-by-example/src/SUMMARY.md
+++ b/docs/acton-by-example/src/SUMMARY.md
@@ -42,6 +42,7 @@
     - [for](control_flow/for.md)
     - [while](control_flow/while.md)
     - [after / sleep](control_flow/after_sleep.md)
+  - [Naming](naming.md)
   - [Security](security.md)
     - [Capabilities](security/capabilities.md)
   - [Environment](environment.md)

--- a/docs/acton-by-example/src/naming.md
+++ b/docs/acton-by-example/src/naming.md
@@ -1,0 +1,7 @@
+# Naming
+
+Acton has naming rules and conventions. Type variable names are reserved, so it is invalid to name a class `A` since all single character upper case names are reserved for type variables. Function and class names typically follow a convention as here outlined:
+
+- **Functions**: `my_fun`, `another_fun_thing` - lower case characters with `_` to separate words
+- **Actors** & **Classes**: `Foo`, `Bar`: Two or more alpha numeric characters, starting with an upper case character
+- **Type variables**: `A`, `T1`: single upper case character, possibly followed by digits


### PR DESCRIPTION
When users try to use single uppercase letters (optionally followed by
digits) as names for classes, functions, or parameters, provide a clear
error message explaining that these names are reserved for type variables.

The error now shows:
- Title: "Invalid name (reserved for type variables)"
- Marker: "invalid name 'X'" (showing the specific name)
- Hint: Explanation about type variable naming rules

This uses Megaparsec's typed error system with a CustomParseError ADT
and integrates with the Diagnose library's hint system for better
structured error reporting.

Also add a doc section mentioning reserved names and conventions.

Fixes #2063 