### PR TITLE
Check for uninitialized class attributes in __init__

### DIFF
--- a/compiler/actonc/test/typeerrors/uninitialized_class_attribute.act
+++ b/compiler/actonc/test/typeerrors/uninitialized_class_attribute.act
@@ -1,0 +1,14 @@
+class Foo(object):
+    count: int
+
+    def __init__(self, a: int):
+        self.a = a
+
+    def increment(self):
+        self.count += 1
+        print(f"Count is now {self.count}")
+
+actor main(env):
+    f = Foo(42)
+    f.increment()
+    env.exit(0)

--- a/compiler/actonc/test/typeerrors/uninitialized_class_attribute.golden
+++ b/compiler/actonc/test/typeerrors/uninitialized_class_attribute.golden
@@ -1,0 +1,9 @@
+Building file test/typeerrors/uninitialized_class_attribute.act using temporary scratch directory
+  Compiling uninitialized_class_attribute.act for development
+[error Compilation error]: attribute 'count' is not initialized in __init__
+     +--> uninitialized_class_attribute.act@2:5-2:10
+     |
+   2 |     count: int
+     :     ^---- 
+     :     `- attribute 'count' is not initialized in __init__
+-----+

--- a/compiler/actonc/test/typeerrors/uninitialized_inherited_attribute.act
+++ b/compiler/actonc/test/typeerrors/uninitialized_inherited_attribute.act
@@ -1,0 +1,16 @@
+class Base(object):
+    base_count: int
+    
+    def __init__(self):
+        self.base_count = 0
+
+class Derived(Base):
+    derived_value: str
+    
+    def __init__(self):
+        # Forgot to call Base.__init__ or initialize base_count
+        self.derived_value = "hello"
+
+actor main(env):
+    d = Derived()
+    env.exit(0)

--- a/compiler/actonc/test/typeerrors/uninitialized_inherited_attribute.golden
+++ b/compiler/actonc/test/typeerrors/uninitialized_inherited_attribute.golden
@@ -1,0 +1,9 @@
+Building file test/typeerrors/uninitialized_inherited_attribute.act using temporary scratch directory
+  Compiling uninitialized_inherited_attribute.act for development
+[error Compilation error]: attribute 'base_count' is not initialized in __init__
+     +--> uninitialized_inherited_attribute.act@2:5-2:15
+     |
+   2 |     base_count: int
+     :     ^--------- 
+     :     `- attribute 'base_count' is not initialized in __init__
+-----+

--- a/compiler/actonc/test/typeerrors/uninitialized_multiple_attributes.act
+++ b/compiler/actonc/test/typeerrors/uninitialized_multiple_attributes.act
@@ -1,0 +1,12 @@
+class Bar(object):
+    x: int
+    y: str
+    z: float
+
+    def __init__(self):
+        self.x = 42
+        # y and z are not initialized
+
+actor main(env):
+    b = Bar()
+    env.exit(0)

--- a/compiler/actonc/test/typeerrors/uninitialized_multiple_attributes.golden
+++ b/compiler/actonc/test/typeerrors/uninitialized_multiple_attributes.golden
@@ -1,0 +1,9 @@
+Building file test/typeerrors/uninitialized_multiple_attributes.act using temporary scratch directory
+  Compiling uninitialized_multiple_attributes.act for development
+[error Compilation error]: attribute 'y' is not initialized in __init__
+     +--> uninitialized_multiple_attributes.act@3:5-3:6
+     |
+   3 |     y: str
+     :     ^ 
+     :     `- attribute 'y' is not initialized in __init__
+-----+


### PR DESCRIPTION
Add compiler check to ensure all class attributes are initialized in the __init__ method. This prevents runtime errors from accessing uninitialized attributes.

The implementation:
- Extracts shared logic for finding __init__ and scanning self assignments
- infProperties uses it to find NEW properties (as before)
- New check uses it to verify ALL expected properties are initialized
- Reports error at attribute declaration location with clear message

Test cases included for single and multiple uninitialized attributes.