### PR TITLE
Fix .endswith() for short / long str

### DIFF
--- a/base/builtin/str.c
+++ b/base/builtin/str.c
@@ -609,6 +609,7 @@ B_bool B_strD_endswith(B_str s, B_str sub, B_int start, B_int end) {
     B_int st = start;
     B_int en = end;
     if (fix_start_end(s->nchars,&st,&en) < 0) return B_False;
+    if (en-st < sub->nbytes) return B_False;
     int isascii = s->nchars==s->nbytes;
     unsigned char *p = skip_chars(s->str + s->nbytes,from$int(en) - s->nchars,isascii) - sub->nbytes;
     unsigned char *q = sub->str;

--- a/base/builtin/str.c
+++ b/base/builtin/str.c
@@ -229,7 +229,7 @@ static int char_no(B_str text,int i) {
     return res;
 }
 
-static unsigned char *skip_chars(unsigned char* start,int n, int isascii) {
+static unsigned char *skip_chars(unsigned char* start, int n, int isascii) {
     unsigned char *res = start;
     if (isascii)
         return start+n;
@@ -275,7 +275,6 @@ static int get_index(int i, int nchars) {
 
 static int fix_start_end(int nchars, B_int *start, B_int *end) {
     if (*start==NULL) {
-        *start = acton_malloc(sizeof(struct B_int));
         *start = to$int(0);
     } else {
         int st = from$int(*start);
@@ -287,7 +286,6 @@ static int fix_start_end(int nchars, B_int *start, B_int *end) {
         *start = to$int(st);
     }
     if (*end==NULL) {
-        *end = acton_malloc(sizeof(struct B_int));
         *end = to$int(nchars);
     } else {
         int en = from$int(*end);

--- a/test/builtins_auto/test_str.act
+++ b/test/builtins_auto/test_str.act
@@ -134,10 +134,26 @@ def test_empty_str_methods():
         raise ValueError("str.zfill() failed: " + s.zfill(5))
 
 
+def test_endswith():
+    s = "foobar"
+    if not s.endswith("foobar"):
+        raise ValueError("Unexpected result for endswith('foobar')")
+
+    if not s.endswith("bar"):
+        raise ValueError("Unexpected result for endswith('bar')")
+
+    if s.endswith("banana"):
+        raise ValueError("Unexpected result for endswith('banana')")
+
+    if s.endswith("longbanana"):
+        raise ValueError("Unexpected result for endswith('longbanana')")
+
+
 actor main(env):
     try:
         test_str_find()
         test_empty_str_methods()
+        test_endswith()
     except Exception as e:
         print("Unexpected exception during testing:", e)
         await async env.exit(1)


### PR DESCRIPTION
If the haystack str we are looking for the needle in is shorter than the needle, we would calculate an incorrect starting position, potentially pointing to uninitialized memory. Now explicitly check length to make sure we stay within bounds of haystack str.

Added some test cases but since we often allocate memory deterministically, I can't reproduce the issue I saw with this test. However, the out-of-bounds problem that I saw when running `acton test` no longer occurs in hundreds of test runs - it used to pop up in like half the runs previously.

Fixes #2350