### PR TITLE
Avoid rebuilds for actonc

### DIFF
--- a/compiler/actonc/package.yaml.in
+++ b/compiler/actonc/package.yaml.in
@@ -15,31 +15,38 @@ copyright:           "Data Ductus, Deutsche Telekom"
 # common to point users to the README.md file.
 description:         Please see the README on Github at <https://github.com/githubuser/simple#readme>
 
+dependencies:
+  - MissingH
+  - acton
+  - async
+  - base >= 4.7 && < 5
+  - bytestring
+  - clock
+  - containers
+  - data-default-class
+  - diagnose
+  - dir-traverse
+  - directory >= 1.3.1
+  - filelock
+  - filepath
+  - megaparsec
+  - prettyprinter
+  - process
+  - split
+  - system-filepath
+  - tasty
+  - tasty-expected-failure
+  - tasty-golden
+  - tasty-hunit
+  - temporary
+  - time
+  - timeit
+  - unix
+
 executables:
   actonc:
     main:                Main.hs
     source-dirs:         .
-    dependencies:
-      - MissingH
-      - acton
-      - async
-      - base >= 4.7 && < 5
-      - bytestring
-      - clock
-      - containers
-      - data-default-class
-      - diagnose
-      - dir-traverse
-      - directory >= 1.3.1
-      - filelock
-      - filepath
-      - megaparsec
-      - prettyprinter
-      - process
-      - split
-      - system-filepath
-      - temporary
-      - unix
     when:
     - condition: os(linux)
       ld-options:
@@ -49,21 +56,6 @@ tests:
   test_actonc:
     main:                test.hs
     source-dirs:         .
-    dependencies:
-      - base
-      - bytestring
-      - dir-traverse
-      - directory
-      - filepath
-      - process
-      - split
-      - system-filepath
-      - tasty
-      - tasty-expected-failure
-      - tasty-golden
-      - tasty-hunit
-      - time
-      - timeit
     ghc-options:
       - -threaded
       - -rtsopts

--- a/compiler/lib/package.yaml.in
+++ b/compiler/lib/package.yaml.in
@@ -15,6 +15,34 @@ copyright:           "2018 Author name here"
 # common to point users to the README.md file.
 description:         Please see the README on Github at <https://github.com/githubuser/simple#readme>
 
+dependencies:
+  - array
+  - base
+  - binary
+  - bytestring
+  - containers
+  - deepseq
+  - diagnose
+  - dir-traverse
+  - directory >= 1.3.1
+  - filelock
+  - filepath
+  - hashable
+  - megaparsec
+  - mtl
+  - optparse-applicative
+  - parser-combinators
+  - pretty
+  - prettyprinter
+  - scientific
+  - sydtest
+  - sydtest-discover
+  - text
+  - transformers
+  - unix
+  - utf8-string
+  - zlib
+
 library:
   source-dirs: src
   exposed-modules:
@@ -41,62 +69,13 @@ library:
     - Utils
     - Pretty
     - InterfaceFiles
-  dependencies:
-    - array
-    - base
-    - binary
-    - bytestring
-    - containers
-    - deepseq
-    - diagnose
-    - dir-traverse
-    - directory >= 1.3.1
-    - filelock
-    - filepath
-    - hashable
-    - megaparsec
-    - mtl
-    - optparse-applicative
-    - parser-combinators
-    - pretty
-    - scientific
-    - text
-    - transformers
-    - unix
-    - utf8-string
-    - zlib
 
 tests:
-  test:
+  test_lib:
     main: ActonSpec.hs
     source-dirs: test
     dependencies:
       - acton
-      - array
-      - base
-      - binary
-      - bytestring
-      - containers
-      - deepseq
-      - diagnose
-      - dir-traverse
-      - directory >= 1.3.1
-      - filelock
-      - filepath
-      - hashable
-      - megaparsec
-      - mtl
-      - parser-combinators
-      - pretty
-      - prettyprinter
-      - scientific
-      - text
-      - transformers
-      - unix
-      - utf8-string
-      - zlib
-      - sydtest
-      - sydtest-discover
     ghc-options:
       - -threaded
       - -rtsopts


### PR DESCRIPTION
I don't quite understand how or why but it seemed we got a lot of complete rebuilds of the Acton library which underpins actonc. stack / ghc would say something build dependencies being changed and then "unregister" the whole acton library and then rebuild it from scratch. That's fairly annoying given that it takes quite a long time.  Doing `make` and `make test` interleaved would pretty much result in rebuilds every time, presumably because the list of dependencies was different for the test suite vs the actual library?

By simplifying dependencies for actonc / acton lib it seems we avoid this situation and every `make` or `make test` invocation now only builds the changed stuff. Much better!

This was extra annoying using AI code tools since they'd tend to shift between `stack test acton` and then trying to build their own little .act test files (and would then invoke `make` which would take extra long).