### PR TITLE
Revamp actonc debug / verbose mode

### DIFF
--- a/cli/src/acton.act
+++ b/cli/src/acton.act
@@ -1388,8 +1388,10 @@ actor main(env):
             cmdargs.extend(["--color", "never"])
         
         # Pass through global options
-        if args.get_bool("debug"):
-            cmdargs.append("--debug")
+        if args.get_bool("verbose"):
+            cmdargs.append("--verbose")
+        if args.get_bool("verbose-zig"):
+            cmdargs.append("--verbose-zig")
         if args.get_bool("quiet"):
             cmdargs.append("--quiet")
         if args.get_bool("timing"):
@@ -1463,7 +1465,7 @@ actor main(env):
         p.add_bool("stub", "Stub (.ty) file generation only")
         p.add_bool("cpedantic", "Pedantic C compilation")
         p.add_bool("quiet", "Be quiet")
-        p.add_bool("debug", "Print debug stuff")
+        p.add_bool("verbose", "Verbose output")
         p.add_bool("dev", "Development mode")
         p.add_bool("no-threads", "Don't use threads")
         p.add_bool("only-build", "Only perform final build of .c files, do not compile .act files")

--- a/compiler/lib/src/Acton/CommandLineParser.hs
+++ b/compiler/lib/src/Acton/CommandLineParser.hs
@@ -26,11 +26,12 @@ data CmdLineOptions = CompileOpt [String] GlobalOptions CompileOptions
 data ColorWhen = Auto | Always | Never deriving (Show, Eq)
 
 data GlobalOptions = GlobalOptions {
-                        tty :: Bool,
-                        debug :: Bool,
-                        quiet :: Bool,
-                        timing :: Bool,
-                        color :: ColorWhen
+                        tty          :: Bool,
+                        verbose      :: Bool,
+                        verboseZig   :: Bool,
+                        quiet        :: Bool,
+                        timing       :: Bool,
+                        color        :: ColorWhen
                      } deriving Show
 
 data VersionOptions = VersionOptions {
@@ -135,10 +136,11 @@ cmdLineParser       = hsubparser
 
 globalOptions :: Parser GlobalOptions
 globalOptions = GlobalOptions
-    <$> switch (long "tty"    <> help "Act as if run from interactive TTY")
-    <*> switch (long "debug"  <> help "Print debug stuff")
-    <*> switch (long "quiet"  <> help "Don't print stuff")
-    <*> switch (long "timing" <> help "Print timing information")
+    <$> switch (long "tty"         <> help "Act as if run from interactive TTY")
+    <*> switch (long "verbose"     <> help "Verbose output")
+    <*> switch (long "verbose-zig" <> help "Verbose Zig output")
+    <*> switch (long "quiet"       <> help "Don't print stuff")
+    <*> switch (long "timing"      <> help "Print timing information")
     <*> option colorReader
         (long "color"
          <> metavar "WHEN"


### PR DESCRIPTION
Renamed debug mode to verbose mode. I think this much better aligns with what it does and avoids confusion with debug builds. Also adding a --verbose-zig option since I found that getting verbose zig output is normally not what we want. It's two very separate use cases to do --verbose for verbose output from actonc and --verbose-zig for getting debug output about the low level Zig based build process.

Fixes #2097