### PR TITLE
Avoid writing .ty in Types.reconstruct

### DIFF
--- a/compiler/actonc/Main.hs
+++ b/compiler/actonc/Main.hs
@@ -427,7 +427,7 @@ printDocs gopts opts = do
                 env0 <- Acton.Env.initEnv (sysTypes paths) False
                 env <- Acton.Env.mkEnv (searchPath paths) env0 parsed
                 kchecked <- Acton.Kinds.check env parsed
-                (nmod, _, env') <- Acton.Types.reconstruct "" env kchecked
+                (nmod, _, env', _) <- Acton.Types.reconstruct env kchecked
                 let A.NModule tenv mdoc = nmod
 
                 -- 1. If format is explicitly set (via -t, --html, --markdown), use it
@@ -970,7 +970,8 @@ runRestPasses gopts opts paths env0 parsed stubMode = do
                       timeKindsCheck <- getTime Monotonic
                       iff (C.timing gopts) $ putStrLn("    Pass: Kinds check     : " ++ fmtTime (timeKindsCheck - timeEnv))
 
-                      (nmod,tchecked,typeEnv) <- Acton.Types.reconstruct outbase env kchecked
+                      (nmod,tchecked,typeEnv,mrefs) <- Acton.Types.reconstruct env kchecked
+                      InterfaceFiles.writeFile (outbase ++ ".ty") mrefs nmod
 
                       let A.NModule iface mdoc = nmod
                       iff (C.types opts && mn == (modName paths)) $ dump mn "types" (Pretty.print tchecked)

--- a/compiler/lib/src/Acton/Types.hs
+++ b/compiler/lib/src/Acton/Types.hs
@@ -55,14 +55,13 @@ unescapeString ('\\':'"':xs) = '"' : unescapeString xs
 unescapeString ('\\':'\'':xs) = '\'' : unescapeString xs
 unescapeString (x:xs) = x : unescapeString xs
 
-reconstruct                             :: String -> Env0 -> Module -> IO (NameInfo, Module, Env0)
-reconstruct fname env0 (Module m i ss)  = do --traceM ("#################### original env0 for " ++ prstr m ++ ":")
+reconstruct                             :: Env0 -> Module -> IO (NameInfo, Module, Env0, [Acton.Syntax.ModName])
+reconstruct env0 (Module m i ss)         = do --traceM ("#################### original env0 for " ++ prstr m ++ ":")
                                              --traceM (render (pretty env0))
                                              let nmod = NModule iface moduleDocstring
-                                             InterfaceFiles.writeFile (fname ++ ".ty") mrefs nmod
                                              --traceM ("#################### converted env0:")
                                              --traceM (render (pretty env0'))
-                                             return (nmod, Module m i ss1T, env0')
+                                             return (nmod, Module m i ss1T, env0', mrefs)
 
   where moduleDocstring                 = extractDocstring ss
         ssT                             = if hasTesting i then genTestActorWrappers env0 ss ++ testStmts (emptyDict,emptyDict,emptyDict,emptyDict,emptyDict) else ss

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -478,7 +478,7 @@ testDocFiles env0 moduleNames = do
           parsed <- P.parseModule (S.modName [base]) act_file src
           env <- Acton.Env.mkEnv [sysTypesPath] accEnv parsed
           kchecked <- Acton.Kinds.check env parsed
-          (nmod, tchecked, typeEnv) <- Acton.Types.reconstruct "" env kchecked
+          (nmod, tchecked, typeEnv, _) <- Acton.Types.reconstruct env kchecked
           let S.NModule tenv mdoc = nmod
           -- The new environment includes the processed module
           return (env, accModules ++ [(modName, parsed, nmod)])
@@ -544,7 +544,7 @@ testTypes env0 testname = do
   (env, parsed) <- parseAct env0 act_file
 
   kchecked <- liftIO $ Acton.Kinds.check env parsed
-  (nmod, tchecked, typeEnv) <- liftIO $ Acton.Types.reconstruct "" env kchecked
+  (nmod, tchecked, typeEnv, _) <- liftIO $ Acton.Types.reconstruct env kchecked
   let S.NModule tenv mdoc = nmod
 
   genTests "Type Check" dir testname kchecked tchecked
@@ -557,7 +557,7 @@ testNorm env0 testname = do
   (env, parsed) <- parseAct env0 act_file
 
   kchecked <- liftIO $ Acton.Kinds.check env parsed
-  (nmod, tchecked, typeEnv) <- liftIO $ Acton.Types.reconstruct "" env kchecked
+  (nmod, tchecked, typeEnv, _) <- liftIO $ Acton.Types.reconstruct env kchecked
   let S.NModule tenv mdoc = nmod
   (normalized, normEnv) <- liftIO $ Acton.Normalizer.normalize typeEnv tchecked
 
@@ -571,7 +571,7 @@ testDeact env0 testname = do
   (env, parsed) <- parseAct env0 act_file
 
   kchecked <- liftIO $ Acton.Kinds.check env parsed
-  (nmod, tchecked, typeEnv) <- liftIO $ Acton.Types.reconstruct "" env kchecked
+  (nmod, tchecked, typeEnv, _) <- liftIO $ Acton.Types.reconstruct env kchecked
   let S.NModule tenv mdoc = nmod
   (normalized, normEnv) <- liftIO $ Acton.Normalizer.normalize typeEnv tchecked
   (deacted, deactEnv) <- liftIO $ Acton.Deactorizer.deactorize normEnv normalized
@@ -586,7 +586,7 @@ testCps env0 testname = do
   (env, parsed) <- parseAct env0 act_file
 
   kchecked <- liftIO $ Acton.Kinds.check env parsed
-  (nmod, tchecked, typeEnv) <- liftIO $ Acton.Types.reconstruct "" env kchecked
+  (nmod, tchecked, typeEnv, _) <- liftIO $ Acton.Types.reconstruct env kchecked
   let S.NModule tenv mdoc = nmod
   (normalized, normEnv) <- liftIO $ Acton.Normalizer.normalize typeEnv tchecked
   (deacted, deactEnv) <- liftIO $ Acton.Deactorizer.deactorize normEnv normalized
@@ -602,7 +602,7 @@ testLL env0 testname = do
   (env, parsed) <- parseAct env0 act_file
 
   kchecked <- liftIO $ Acton.Kinds.check env parsed
-  (nmod, tchecked, typeEnv) <- liftIO $ Acton.Types.reconstruct "" env kchecked
+  (nmod, tchecked, typeEnv, _) <- liftIO $ Acton.Types.reconstruct env kchecked
   let S.NModule tenv mdoc = nmod
   (normalized, normEnv) <- liftIO $ Acton.Normalizer.normalize typeEnv tchecked
   (deacted, deactEnv) <- liftIO $ Acton.Deactorizer.deactorize normEnv normalized
@@ -619,7 +619,7 @@ testBoxing env0 testname = do
   (env, parsed) <- parseAct env0 act_file
 
   kchecked <- liftIO $ Acton.Kinds.check env parsed
-  (nmod, tchecked, typeEnv) <- liftIO $ Acton.Types.reconstruct "" env kchecked
+  (nmod, tchecked, typeEnv, _) <- liftIO $ Acton.Types.reconstruct env kchecked
   let S.NModule tenv mdoc = nmod
   (normalized, normEnv) <- liftIO $ Acton.Normalizer.normalize typeEnv tchecked
   (deacted, deactEnv) <- liftIO $ Acton.Deactorizer.deactorize normEnv normalized
@@ -637,7 +637,7 @@ testCodeGen env0 testname = do
   (env, parsed) <- parseAct env0 act_file
 
   kchecked <- liftIO $ Acton.Kinds.check env parsed
-  (nmod, tchecked, typeEnv) <- liftIO $ Acton.Types.reconstruct "" env kchecked
+  (nmod, tchecked, typeEnv, _) <- liftIO $ Acton.Types.reconstruct env kchecked
   let S.NModule tenv mdoc = nmod
   (normalized, normEnv) <- liftIO $ Acton.Normalizer.normalize typeEnv tchecked
   (deacted, deactEnv) <- liftIO $ Acton.Deactorizer.deactorize normEnv normalized
@@ -666,7 +666,7 @@ testDocstrings env0 testname = do
   (env, parsed) <- parseAct env0 act_file
 
   kchecked <- liftIO $ Acton.Kinds.check env parsed
-  (nmod, tchecked, typeEnv) <- liftIO $ Acton.Types.reconstruct "" env kchecked
+  (nmod, tchecked, typeEnv, _) <- liftIO $ Acton.Types.reconstruct env kchecked
   let S.NModule tenv mdoc = nmod
 
   -- Extract docstrings from the parsed AST


### PR DESCRIPTION
Instead of letting Types.reconstruct directly write a .ty file, we return the necessary information and write it from actonc instead. This way, reconstruct is "pure" (not haskell pure) in the sense that it doesn't have side effects of writing files to the file system - much nicer for running when testing etc.

Fixes #2345