### PR TITLE
Adopt Zig optimization levels in Acton

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -12,7 +12,7 @@ body:
     id: version
     attributes:
       label: Acton Version
-      description: "The output of `actonc --version`"
+      description: "The output of `acton version`"
       placeholder: "0.16.3"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/ice.yaml
+++ b/.github/ISSUE_TEMPLATE/ice.yaml
@@ -12,7 +12,7 @@ body:
     id: version
     attributes:
       label: Acton Version
-      description: "The output of `actonc --version`"
+      description: "The output of `acton version`"
       placeholder: "0.16.3"
     validations:
       required: true
@@ -38,8 +38,7 @@ body:
         ERROR: internal compiler error: compilation of generated C code failed
         NOTE: this is likely a bug in actonc, please report this at:
         NOTE: https://github.com/actonlang/acton/issues/new?template=ice.md
-        NOTE: acton 0.5.2.20210904.7.7.37 compiled by ghc 8.10 on linux x86_64
-        NOTE: cc: cc (Debian 10.2.1-6) 10.2.1 20210110
+        NOTE: acton 0.5.2.20210904.7.7.37
         $
     validations:
       required: true

--- a/.github/workflows/test-app.yml
+++ b/.github/workflows/test-app.yml
@@ -25,7 +25,7 @@ jobs:
       - name: "Install acton from .deb"
         run: |
           sudo apt install -y ./deb/acton_*.deb
-          acton --version
+          acton version
       - name: "Clone app repo"
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -405,7 +405,7 @@ jobs:
         run: |
           apt update
           apt install -y ./deb/acton_*.deb
-          acton --version
+          acton version
       - name: "Enable dumping core files to /tmp/core..."
         run: |
           apt install -qy procps
@@ -454,10 +454,10 @@ jobs:
           echo "deb http://aptip.acton-lang.io/ tip main" | sudo tee /etc/apt/sources.list.d/acton.list
           sudo apt-get update
           sudo apt-get install -qy acton
-          acton --version
+          acton version
       - name: "Run perf tests and record"
         run: |
-          acton --version
+          acton version
           cd test/stdlib_tests
           acton test perf --record
           cd ../perf
@@ -469,7 +469,7 @@ jobs:
       - name: "Install acton from .deb"
         run: |
           sudo dpkg -i ./deb/acton_*.deb
-          acton --version
+          acton version
       - name: "Run perf tests to compare"
         run: |
           cd test/stdlib_tests
@@ -502,7 +502,7 @@ jobs:
           apt update
           apt install -qy make netcat-openbsd
           apt install -y ./deb/acton_*.deb
-          acton --version
+          acton version
       - name: "Clone Telemetrify and check out acton-next branch"
         uses: actions/checkout@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -370,7 +370,7 @@ dist/backend%: backend/%
 dist/base: base base/.build base/__root.zig base/acton.zig base/build.zig base/build.zig.zon base/acton.zig dist/bin/actonc $(DEPS)
 	mkdir -p $@ $@/.build $@/out
 	cp -a base/__root.zig base/Acton.toml base/acton.zig base/build.zig base/build.zig.zon base/builtin base/rts base/src base/stdlib dist/base/
-	cd dist/base && ../bin/actonc build --dev --auto-stub && rm -rf .build
+	cd dist/base && ../bin/actonc build --auto-stub && rm -rf .build
 
 # This does a little hack, first copying and then moving the file in place. This
 # is to avoid an error if the executable is currently running. cp tries to open

--- a/base/rts/rts.c
+++ b/base/rts/rts.c
@@ -2418,7 +2418,7 @@ int main(int argc, char **argv) {
      */
     static struct option long_options[] = {
         {"rts-bt-dbg", NULL, 'x', "Interactively debug on SIGILL / SIGSEGV"},
-        {"rts-debug", NULL, 'd', "RTS debug, requires program to be compiled with --dev"},
+        {"rts-debug", NULL, 'd', "RTS debug, requires program to be compiled with --optimize Debug"},
         {"rts-ddb-host", "HOST", 'h', "DDB hostname"},
         {"rts-ddb-port", "PORT", 'p', "DDB port [32000]"},
         {"rts-ddb-replication", "FACTOR", 'r', "DDB replication factor [3]"},
@@ -2491,7 +2491,7 @@ int main(int argc, char **argv) {
             case 'd':
                 #ifndef DEV
                 fprintf(stderr, "ERROR: RTS debug not supported.\n");
-                fprintf(stderr, "HINT: Recompile this program using: actonc --dev ...\n");
+                fprintf(stderr, "HINT: Recompile this program using: actonc --optimize Debug ...\n");
                 exit(1);
                 #endif
                 log_set_quiet(false);

--- a/cli/src/acton.act
+++ b/cli/src/acton.act
@@ -1451,10 +1451,7 @@ actor main(env):
         run_tests = CmdListTest(env, args)
 
     def _cmd_version(args):
-        if args.get_bool("full"):
-            CompilerRunner(process_cap, env, ["version"])
-        else:
-            CompilerRunner(process_cap, env, ["version", "--numeric-version"])
+        CompilerRunner(process_cap, env, ["version"])
 
     def _cmd_zigpkg(args):
         env.exit(0)
@@ -1537,7 +1534,6 @@ actor main(env):
         testperfp = testp.add_cmd("perf", "Perf", _cmd_test_perf)
 
         version_p = p.add_cmd("version", "Show version", _cmd_version)
-        version_p.add_bool("full", "Show full version info")
 
         p_zigpkg = p.add_cmd("zig-pkg", "Manage Zig package dependencies", _cmd_zigpkg)
 

--- a/cli/src/acton.act
+++ b/cli/src/acton.act
@@ -165,7 +165,7 @@ actor CompilerRunner(process_cap, env, args, wdir=None, on_exit: ?action(int, in
 actor BuildProject(process_cap, env, args, on_build_success: action(str) -> None, on_build_failure: action(int, int, str) -> None, build_tests: bool=False, files: list[str]=[]):
     """Build the project including dependencies
 
-    - check for dependencies.json, if found, download dependencies
+    - check for build.act.json, if found, download dependencies
     - build dependencies
     - build
     """
@@ -358,13 +358,13 @@ actor BuildProject(process_cap, env, args, on_build_success: action(str) -> None
         env.exit(1)
 
     def check_for_buildconfig():
-        """Check if dependencies.json exists
+        """Check if build.act.json exists
 
-        If there is a dependencies.json file, we will read it and check if the
+        If there is a build.act.json file, we will read it and check if the
         dependencies also exist locally. If not, we will download them and
         proceed to build the dependencies and then build the project.
 
-        If there is no dependencies.json file, we will build the project.
+        If there is no build.act.json file, we will build the project.
         """
         try:
             build_config = BuildConfig.from_json(file.ReadFile(rfcap, "build.act.json").read().decode())

--- a/cli/src/acton.act
+++ b/cli/src/acton.act
@@ -1452,9 +1452,9 @@ actor main(env):
 
     def _cmd_version(args):
         if args.get_bool("full"):
-            CompilerRunner(process_cap, env, ["--version"])
+            CompilerRunner(process_cap, env, ["version"])
         else:
-            CompilerRunner(process_cap, env, ["--numeric-version"])
+            CompilerRunner(process_cap, env, ["version", "--numeric-version"])
 
     def _cmd_zigpkg(args):
         env.exit(0)

--- a/cli/src/acton.act
+++ b/cli/src/acton.act
@@ -246,7 +246,6 @@ actor BuildProject(process_cap, env, args, on_build_success: action(str) -> None
             cmdargs.extend([files[0]])
         cmdargs.extend(build_cmd_args(args))
         if build_tests:
-            cmdargs.append("--dev")
             cmdargs.append("--test")
         cmd = cmdargs + search_path_arg
         cr = CompilerRunner(
@@ -303,9 +302,6 @@ actor BuildProject(process_cap, env, args, on_build_success: action(str) -> None
                     raise ValueError("Dependency %s has no path or hash" % dep_name)
                 print(" -", dep_name)
                 cmd = ["build"] + dep_build_cmd_args(args) + dep_args
-                # Build deps in dev mode if we are building tests
-                if build_tests:
-                    cmd.append("--dev")
                 cr = CompilerRunner(
                     process_cap,
                     env,
@@ -767,9 +763,23 @@ def dep_build_cmd_args(args):
 
 def build_cmd_args(args):
     cmdargs = []
+
+    # Handle backward compatibility for --dev and --release flags
+    optimize_mode = "Debug"
+    if args.get_bool("dev"):
+        optimize_mode = "Debug"
+    if args.get_bool("release"):
+        optimize_mode = "ReleaseFast"
+
+    # Use explicit --optimize argument if set, otherwise use the default
+    optimize_arg = args.get_str("optimize")
+    if optimize_arg != "":
+        optimize_mode = optimize_arg
+    cmdargs.extend(["--optimize", optimize_mode])
+
     for argname, arg in args.options.items():
         # TODO: reverse this logic, we should only pass in a small set of options, not all
-        if argname in {"file", "record", "golden-update"}:
+        if argname in {"file", "record", "golden-update", "dev", "release", "optimize"}:
             continue
 
         if arg.type == "bool":
@@ -1476,6 +1486,8 @@ actor main(env):
         p.add_bool("quiet", "Be quiet")
         p.add_bool("verbose", "Verbose output")
         p.add_bool("dev", "Development mode")
+        p.add_option("optimize", "str", "?", "", "Optimization mode (Debug, ReleaseSafe, ReleaseSmall, ReleaseFast)")
+        p.add_bool("release", "Release mode (alias for --optimize=ReleaseFast)")
         p.add_bool("no-threads", "Don't use threads")
         p.add_bool("only-build", "Only perform final build of .c files, do not compile .act files")
         p.add_bool("skip-build", "Skip final build of .c files")

--- a/compiler/actonc/test.hs
+++ b/compiler/actonc/test.hs
@@ -352,7 +352,7 @@ buildThing opts thing = do
     projPath <- canonicalizePath thing
     curDir <- getCurrentDirectory
     let wd = if proj then projPath else curDir
-    let actCmd    = (id actonc) ++ " " ++ (if proj then "build " else thing) ++ " --dev --always-build " ++ opts
+    let actCmd    = (id actonc) ++ " " ++ (if proj then "build " else thing) ++ " --always-build " ++ opts
     (returnCode, cmdOut, cmdErr) <- readCreateProcessWithExitCode (shell $ actCmd){ cwd = Just wd } ""
     return (returnCode, cmdOut, cmdErr)
 

--- a/compiler/actonc/test/typeerrors/actor_self_reserved_assignment.golden
+++ b/compiler/actonc/test/typeerrors/actor_self_reserved_assignment.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/actor_self_reserved_assignment.act using temporary scratch directory
-  Compiling actor_self_reserved_assignment.act for development
+  Compiling actor_self_reserved_assignment.act with Debug
 [error]: 'self' cannot be used as a parameter name in actors.
      +--> actor_self_reserved_assignment.act@2:5-2:9
      |

--- a/compiler/actonc/test/typeerrors/actor_self_reserved_constructor_param.golden
+++ b/compiler/actonc/test/typeerrors/actor_self_reserved_constructor_param.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/actor_self_reserved_constructor_param.act using temporary scratch directory
-  Compiling actor_self_reserved_constructor_param.act for development
+  Compiling actor_self_reserved_constructor_param.act with Debug
 [error]: 'self' cannot be used as a parameter name in actors.
      +--> actor_self_reserved_constructor_param.act@1:19-1:23
      |

--- a/compiler/actonc/test/typeerrors/actor_self_reserved_except_as.golden
+++ b/compiler/actonc/test/typeerrors/actor_self_reserved_except_as.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/actor_self_reserved_except_as.act using temporary scratch directory
-  Compiling actor_self_reserved_except_as.act for development
+  Compiling actor_self_reserved_except_as.act with Debug
 [error]: 'self' cannot be used as a parameter name in actors.
      +--> actor_self_reserved_except_as.act@4:26-4:30
      |

--- a/compiler/actonc/test/typeerrors/actor_self_reserved_loop_var.golden
+++ b/compiler/actonc/test/typeerrors/actor_self_reserved_loop_var.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/actor_self_reserved_loop_var.act using temporary scratch directory
-  Compiling actor_self_reserved_loop_var.act for development
+  Compiling actor_self_reserved_loop_var.act with Debug
 [error]: 'self' cannot be used as a parameter name in actors.
      +--> actor_self_reserved_loop_var.act@2:9-2:13
      |

--- a/compiler/actonc/test/typeerrors/actor_self_reserved_method_name.golden
+++ b/compiler/actonc/test/typeerrors/actor_self_reserved_method_name.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/actor_self_reserved_method_name.act using temporary scratch directory
-  Compiling actor_self_reserved_method_name.act for development
+  Compiling actor_self_reserved_method_name.act with Debug
 [error]: 'self' cannot be used as a parameter name in actors.
      +--> actor_self_reserved_method_name.act@2:9-2:13
      |

--- a/compiler/actonc/test/typeerrors/actor_self_reserved_method_param.golden
+++ b/compiler/actonc/test/typeerrors/actor_self_reserved_method_param.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/actor_self_reserved_method_param.act using temporary scratch directory
-  Compiling actor_self_reserved_method_param.act for development
+  Compiling actor_self_reserved_method_param.act with Debug
 [error]: 'self' cannot be used as a parameter name in actors.
      +--> actor_self_reserved_method_param.act@2:28-2:32
      |

--- a/compiler/actonc/test/typeerrors/actor_self_reserved_variable.golden
+++ b/compiler/actonc/test/typeerrors/actor_self_reserved_variable.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/actor_self_reserved_variable.act using temporary scratch directory
-  Compiling actor_self_reserved_variable.act for development
+  Compiling actor_self_reserved_variable.act with Debug
 [error]: 'self' cannot be used as a parameter name in actors.
      +--> actor_self_reserved_variable.act@2:9-2:13
      |

--- a/compiler/actonc/test/typeerrors/ex1.golden
+++ b/compiler/actonc/test/typeerrors/ex1.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex1.act using temporary scratch directory
-  Compiling ex1.act for development
+  Compiling ex1.act with Debug
 [error]: Incompatible types
      +--> ex1.act@4:5-4:9
      |

--- a/compiler/actonc/test/typeerrors/ex10.golden
+++ b/compiler/actonc/test/typeerrors/ex10.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex10.act using temporary scratch directory
-  Compiling ex10.act for development
+  Compiling ex10.act with Debug
 [error]: Constraint violation
      +--> ex10.act@4:5-4:15
      |

--- a/compiler/actonc/test/typeerrors/ex11.golden
+++ b/compiler/actonc/test/typeerrors/ex11.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex11.act using temporary scratch directory
-  Compiling ex11.act for development
+  Compiling ex11.act with Debug
 [error]: Constraint violation
      +--> ex11.act@4:5-4:11
      |

--- a/compiler/actonc/test/typeerrors/ex13.golden
+++ b/compiler/actonc/test/typeerrors/ex13.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex13.act using temporary scratch directory
-  Compiling ex13.act for development
+  Compiling ex13.act with Debug
 [error]: Incompatible types
      +--> ex13.act@2:7-2:13
      |

--- a/compiler/actonc/test/typeerrors/ex14.golden
+++ b/compiler/actonc/test/typeerrors/ex14.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex14.act using temporary scratch directory
-  Compiling ex14.act for development
+  Compiling ex14.act with Debug
 [error]: Incompatible types
      +--> ex14.act@2:12-2:16
      |

--- a/compiler/actonc/test/typeerrors/ex15.golden
+++ b/compiler/actonc/test/typeerrors/ex15.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex15.act using temporary scratch directory
-  Compiling ex15.act for development
+  Compiling ex15.act with Debug
 [error]: Cannot satisfy the following simultaneous constraints for the unknown types
      +--> ex15.act@2:9-2:10
      |

--- a/compiler/actonc/test/typeerrors/ex16.golden
+++ b/compiler/actonc/test/typeerrors/ex16.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex16.act using temporary scratch directory
-  Compiling ex16.act for development
+  Compiling ex16.act with Debug
 [error]: Constraint violation
      +--> ex16.act@6:9-6:22
      |

--- a/compiler/actonc/test/typeerrors/ex17.golden
+++ b/compiler/actonc/test/typeerrors/ex17.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex17.act using temporary scratch directory
-  Compiling ex17.act for development
+  Compiling ex17.act with Debug
 [error]: Cannot satisfy the following simultaneous constraints for the unknown types
      +--> ex17.act@2:5-2:17
      |

--- a/compiler/actonc/test/typeerrors/ex18.golden
+++ b/compiler/actonc/test/typeerrors/ex18.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex18.act using temporary scratch directory
-  Compiling ex18.act for development
+  Compiling ex18.act with Debug
 [error]: Cannot satisfy the following simultaneous constraints for the unknown type t0
      +--> ex18.act@2:12-2:27
      |

--- a/compiler/actonc/test/typeerrors/ex19.golden
+++ b/compiler/actonc/test/typeerrors/ex19.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex19.act using temporary scratch directory
-  Compiling ex19.act for development
+  Compiling ex19.act with Debug
 [error]: Cannot satisfy the following simultaneous constraints for the unknown types
      +--> ex19.act@1:5-1:6
      |

--- a/compiler/actonc/test/typeerrors/ex2.golden
+++ b/compiler/actonc/test/typeerrors/ex2.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex2.act using temporary scratch directory
-  Compiling ex2.act for development
+  Compiling ex2.act with Debug
 [error]: Incompatible types
      +--> ex2.act@4:5-4:13
      |

--- a/compiler/actonc/test/typeerrors/ex20.golden
+++ b/compiler/actonc/test/typeerrors/ex20.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex20.act using temporary scratch directory
-  Compiling ex20.act for development
+  Compiling ex20.act with Debug
 [error]: Constraint violation
      +--> ex20.act@1:1-1:2
      |

--- a/compiler/actonc/test/typeerrors/ex21.golden
+++ b/compiler/actonc/test/typeerrors/ex21.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex21.act using temporary scratch directory
-  Compiling ex21.act for development
+  Compiling ex21.act with Debug
 [error]: Constraint violation
      +--> ex21.act@4:10-4:25
      |

--- a/compiler/actonc/test/typeerrors/ex22.golden
+++ b/compiler/actonc/test/typeerrors/ex22.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex22.act using temporary scratch directory
-  Compiling ex22.act for development
+  Compiling ex22.act with Debug
 [error]: Incompatible types
      +--> ex22.act@1:1-1:2
      |

--- a/compiler/actonc/test/typeerrors/ex23.golden
+++ b/compiler/actonc/test/typeerrors/ex23.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex23.act using temporary scratch directory
-  Compiling ex23.act for development
+  Compiling ex23.act with Debug
 [error]: Cannot satisfy the following simultaneous constraints for the unknown types
      +--> ex23.act@2:11-2:12
      |

--- a/compiler/actonc/test/typeerrors/ex24.golden
+++ b/compiler/actonc/test/typeerrors/ex24.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex24.act using temporary scratch directory
-  Compiling ex24.act for development
+  Compiling ex24.act with Debug
 [error]: Type unification error
      +--> ex24.act@5:13-5:16
      |

--- a/compiler/actonc/test/typeerrors/ex25.golden
+++ b/compiler/actonc/test/typeerrors/ex25.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex25.act using temporary scratch directory
-  Compiling ex25.act for development
+  Compiling ex25.act with Debug
 [error]: Incompatible types
      +--> ex25.act@8:9-8:16
      |

--- a/compiler/actonc/test/typeerrors/ex26.golden
+++ b/compiler/actonc/test/typeerrors/ex26.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex26.act using temporary scratch directory
-  Compiling ex26.act for development
+  Compiling ex26.act with Debug
 [error]: Constraint violation
      +--> ex26.act@15:5-15:33
      |

--- a/compiler/actonc/test/typeerrors/ex27.golden
+++ b/compiler/actonc/test/typeerrors/ex27.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex27.act using temporary scratch directory
-  Compiling ex27.act for development
+  Compiling ex27.act with Debug
 [error]: Type unification error
      +--> ex27.act@5:5-6:1
      |

--- a/compiler/actonc/test/typeerrors/ex4.golden
+++ b/compiler/actonc/test/typeerrors/ex4.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex4.act using temporary scratch directory
-  Compiling ex4.act for development
+  Compiling ex4.act with Debug
 [error]: Incompatible types
      +--> ex4.act@5:22-5:26
      |

--- a/compiler/actonc/test/typeerrors/ex5.golden
+++ b/compiler/actonc/test/typeerrors/ex5.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex5.act using temporary scratch directory
-  Compiling ex5.act for development
+  Compiling ex5.act with Debug
 [error]: Incompatible types
      +--> ex5.act@7:5-7:15
      |

--- a/compiler/actonc/test/typeerrors/ex6.golden
+++ b/compiler/actonc/test/typeerrors/ex6.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex6.act using temporary scratch directory
-  Compiling ex6.act for development
+  Compiling ex6.act with Debug
 [error]: Incompatible types
      +--> ex6.act@1:9-1:16
      |

--- a/compiler/actonc/test/typeerrors/ex7.golden
+++ b/compiler/actonc/test/typeerrors/ex7.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex7.act using temporary scratch directory
-  Compiling ex7.act for development
+  Compiling ex7.act with Debug
 [error]: Constraint violation
      +--> ex7.act@4:16-4:17
      |

--- a/compiler/actonc/test/typeerrors/ex8.golden
+++ b/compiler/actonc/test/typeerrors/ex8.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex8.act using temporary scratch directory
-  Compiling ex8.act for development
+  Compiling ex8.act with Debug
 [error]: Cannot satisfy the following simultaneous constraints for the unknown type t0
      +--> ex8.act@3:14-3:15
      |

--- a/compiler/actonc/test/typeerrors/ex9.golden
+++ b/compiler/actonc/test/typeerrors/ex9.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex9.act using temporary scratch directory
-  Compiling ex9.act for development
+  Compiling ex9.act with Debug
 [error]: Cannot satisfy the following simultaneous constraints for the unknown types
      +--> ex9.act@1:5-1:6
      |

--- a/compiler/actonc/test/typeerrors/funargs1.golden
+++ b/compiler/actonc/test/typeerrors/funargs1.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/funargs1.act using temporary scratch directory
-  Compiling funargs1.act for development
+  Compiling funargs1.act with Debug
 [error]: Unexpected keyword argument
      +--> funargs1.act@4:9-4:10
      |

--- a/compiler/actonc/test/typeerrors/funargs2.golden
+++ b/compiler/actonc/test/typeerrors/funargs2.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/funargs2.act using temporary scratch directory
-  Compiling funargs2.act for development
+  Compiling funargs2.act with Debug
 [error]: Unexpected keyword argument
      +--> funargs2.act@4:9-4:10
      |

--- a/compiler/actonc/test/typeerrors/funargs4.golden
+++ b/compiler/actonc/test/typeerrors/funargs4.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/funargs4.act using temporary scratch directory
-  Compiling funargs4.act for development
+  Compiling funargs4.act with Debug
 [error]: Unexpected keyword argument
      +--> funargs4.act@4:9-4:10
      |

--- a/compiler/actonc/test/typeerrors/funargs5.golden
+++ b/compiler/actonc/test/typeerrors/funargs5.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/funargs5.act using temporary scratch directory
-  Compiling funargs5.act for development
+  Compiling funargs5.act with Debug
 [error]: Incompatible types
      +--> funargs5.act@4:5-4:15
      |

--- a/compiler/actonc/test/typeerrors/funargs6.golden
+++ b/compiler/actonc/test/typeerrors/funargs6.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/funargs6.act using temporary scratch directory
-  Compiling funargs6.act for development
+  Compiling funargs6.act with Debug
 [error]: Incompatible types
      +--> funargs6.act@4:5-4:13
      |

--- a/compiler/lib/src/Acton/CommandLineParser.hs
+++ b/compiler/lib/src/Acton/CommandLineParser.hs
@@ -19,7 +19,6 @@ parseCmdLine        :: IO CmdLineOptions
 parseCmdLine        = execParser (info (cmdLineParser <**> helper) descr)
 
 data CmdLineOptions = CompileOpt [String] GlobalOptions CompileOptions
-                    | VersionOpt VersionOptions
                     | CmdOpt GlobalOptions Command
                     deriving Show
 
@@ -36,16 +35,11 @@ data GlobalOptions = GlobalOptions {
                         color        :: ColorWhen
                      } deriving Show
 
-data VersionOptions = VersionOptions {
-                        version :: Bool,
-                        numeric_version :: Bool
-                     } deriving Show
-
 data Command        = New NewOptions
                     | Build BuildOptions
                     | Cloud CloudOptions
                     | Doc DocOptions
-                    | Version VersionOptions
+                    | Version
                     deriving Show
 
 
@@ -131,10 +125,9 @@ cmdLineParser       = hsubparser
                         <> command "build"   (info (CmdOpt <$> globalOptions <*> (Build <$> buildOptions)) (progDesc "Build an Acton project"))
                         <> command "cloud"   (info (CmdOpt <$> globalOptions <*> (Cloud <$> cloudOptions)) (progDesc "Run an Acton project in the cloud"))
                         <> command "doc"     (info (CmdOpt <$> globalOptions <*> (Doc <$> docOptions)) (progDesc "Show type and docstring info"))
-                        <> command "version" (info (CmdOpt <$> globalOptions <*> (Version <$> versionOptions)) (progDesc "Show version information"))
+                        <> command "version" (info (CmdOpt <$> globalOptions <*> pure Version) (progDesc "Show version"))
                       )
                      <|> (CompileOpt <$> (fmap (:[]) $ argument str (metavar "ACTONFILE" <> help "Compile Acton file" <> completer (bashCompleter "file -X '!*.act' -o plusdirs"))) <*> globalOptions <*> compileOptions)
-                     <|> (VersionOpt <$> versionOptions)
 
 globalOptions :: Parser GlobalOptions
 globalOptions = GlobalOptions
@@ -166,10 +159,6 @@ optimizeReader = eitherReader $ \s ->
         "ReleaseSmall" -> Right ReleaseSmall
         "ReleaseFast" -> Right ReleaseFast
         _             -> Left $ "Invalid optimize option: " ++ s ++ " (expected: Debug, ReleaseSafe, ReleaseSmall, ReleaseFast)"
-
-versionOptions         = VersionOptions <$>
-                                         switch (long "version" <> short 'v' <> help "Show version information")
-                                     <*> switch (long "numeric-version" <> short 'n' <> help "Show numeric version")
 
 
 {-

--- a/docs/acton-guide/src/rts.md
+++ b/docs/acton-guide/src/rts.md
@@ -18,7 +18,7 @@ The Acton RTS reads and consumes the following options and arguments. All
 other parameters are passed verbatim to the Acton application. Option
 arguments can be passed either with --rts-option=ARG or --rts-option ARG
 
-  --rts-debug                       RTS debug, requires program to be compiled with --dev
+  --rts-debug                       RTS debug, requires program to be compiled with --optimize Debug
   --rts-ddb-host=HOST               DDB hostname
   --rts-ddb-port=PORT               DDB port [32000]
   --rts-ddb-replication=FACTOR      DDB replication factor [3]

--- a/test/Makefile
+++ b/test/Makefile
@@ -17,19 +17,19 @@ DDB_TESTS=test_db_app test_db_resume_tcp_server test_db_resume_tcp_client
 # a simple app. We do not really verify that the RTS uses the database - we
 # assume it does and would fail catastrohpically if it encounters an error.
 test_db_app:
-	$(ACTONC) --db --dev rts_db/ddb_test_app.act
-	$(ACTONC) --db --dev rts_db/test_db_app.act
+	$(ACTONC) --db rts_db/ddb_test_app.act
+	$(ACTONC) --db rts_db/test_db_app.act
 	rts_db/test_db_app
 
 test_db_resume_tcp_server:
-	$(ACTONC) --db --dev rts_db/ddb_test_server.act
-	$(ACTONC) --db --dev rts_db/test_tcp_server.act
+	$(ACTONC) --db rts_db/ddb_test_server.act
+	$(ACTONC) --db rts_db/test_tcp_server.act
 	rts_db/test_tcp_server
 
 test_db_resume_tcp_client:
-	$(ACTONC) --db --dev rts_db/ddb_test_server.act
-	$(ACTONC) --db --dev rts_db/ddb_test_client.act
-	$(ACTONC) --db --dev rts_db/test_tcp_client.act
+	$(ACTONC) --db rts_db/ddb_test_server.act
+	$(ACTONC) --db rts_db/ddb_test_client.act
+	$(ACTONC) --db rts_db/test_tcp_client.act
 	rts_db/test_tcp_client
 
 


### PR DESCRIPTION
- Replace --dev flag with --optimize flag accepting: Debug, ReleaseSafe, ReleaseSmall, ReleaseFast
- Change default from ReleaseFast to Debug (matching Zig's default)
- Maintain backward compatibility: --dev maps to Debug, new --release maps to ReleaseFast
- Update all uses of --dev throughout codebase (test.hs, Makefiles, docs), mostly removing it, since it is now the default

Fixes #2075 