### PR TITLE
Let repr & type accept an optional value

### DIFF
--- a/base/src/__builtin__.act
+++ b/base/src/__builtin__.act
@@ -958,8 +958,10 @@ def print(*args, sep: str=" ", end: str="\n", err: bool=False, flush: bool=False
     """
     NotImplemented
 
-def repr(x : value):
-    return x.__repr__()
+def repr(x: ?value):
+    if x is not None:
+        return x.__repr__()
+    return "None"
 
 def reversed(seq : Sequence[A]) -> Iterator[A]:
     return seq.__reversed__()
@@ -982,7 +984,7 @@ def gcd(a : int, b : int) -> int:
 def xgcd(a : int, b : int) -> (int, int, int):
     NotImplemented
 
-def type(a: value) -> str:
+def type(a: ?value) -> str:
     """Get the name of the type of something as a string
 
     Do not use this for meta-programming. Use isinstance().

--- a/base/src/__builtin__.ext.c
+++ b/base/src/__builtin__.ext.c
@@ -24,7 +24,9 @@ B_str B_BaseExceptionD__name (B_BaseException self) {
 }
 
 B_str B_type(B_value a) {
-    return to$str(unmangle_name(a->$class->$GCINFO));
+    if (a)
+        return to$str(unmangle_name(a->$class->$GCINFO));
+    return to$str("None");
 }
 
 $R B_EnvD_getenvbG_local (B_Env self, $Cont C_cont, B_bytes name) {

--- a/test/builtins_auto/test_repr_str_type_none.act
+++ b/test/builtins_auto/test_repr_str_type_none.act
@@ -1,0 +1,28 @@
+
+def test_repr():
+    print(repr(None))
+    return repr(None) == "None"
+
+def test_str():
+    print(str(None))
+    return str(None) == "None"
+
+def test_type():
+    print(type(None))
+    return type(None) == "None"
+
+tests = {
+    "test_repr": test_type,
+    "test_str": test_str,
+    "test_type": test_type,
+    }
+
+actor main(env):
+    failed = False
+    for name, t in tests.items():
+        print("== test: {name}")
+        if not t():
+            print("-- FAILED test: {name}")
+            failed = True
+        print()
+    env.exit(1 if failed else 0)


### PR DESCRIPTION
Just like we made str(?value) we now allow repr() and type() to take an optional type, which makes it more convenient to use repr() & type()

There are functions like optional_repr among Acton application to work around this - those are no longer needed!