### PR TITLE
Fix protocol extension constructor generation

### DIFF
--- a/compiler/lib/test/9-codegen/protofoo.c
+++ b/compiler/lib/test/9-codegen/protofoo.c
@@ -102,13 +102,37 @@ protofooQ_Key protofooQ_KeyG_new(B_int G_1) {
     return $tmp;
 }
 struct protofooQ_KeyG_class protofooQ_KeyG_methods;
+B_NoneType protofooQ_EqD_KeyD___init__ (protofooQ_EqD_Key W_self) {
+    ((B_NoneType (*) (B_Eq))B_EqG_methods.__init__)(((B_Eq)W_self));
+    return B_None;
+}
+B_bool protofooQ_EqD_KeyD___eq__ (protofooQ_EqD_Key W_self, protofooQ_Key a, protofooQ_Key b) {
+    B_bool N_tmp = ((B_bool (*) (B_Eq, B_int, B_int))protofooQ_W_14->$class->__eq__)(protofooQ_W_14, a->x, b->x);
+    return N_tmp;
+}
+void protofooQ_EqD_KeyD___serialize__ (protofooQ_EqD_Key self, $Serial$state state) {
+}
+protofooQ_EqD_Key protofooQ_EqD_KeyD___deserialize__ (protofooQ_EqD_Key self, $Serial$state state) {
+    if (!self) {
+        if (!state) {
+            self = acton_malloc(sizeof(struct protofooQ_EqD_Key));
+            self->$class = &protofooQ_EqD_KeyG_methods;
+            return self;
+        }
+        self = $DNEW(protofooQ_EqD_Key, state);
+    }
+    return self;
+}
+protofooQ_EqD_Key protofooQ_EqD_KeyG_new() {
+    protofooQ_EqD_Key $tmp = acton_malloc(sizeof(struct protofooQ_EqD_Key));
+    $tmp->$class = &protofooQ_EqD_KeyG_methods;
+    protofooQ_EqD_KeyG_methods.__init__($tmp);
+    return $tmp;
+}
+struct protofooQ_EqD_KeyG_class protofooQ_EqD_KeyG_methods;
 B_NoneType protofooQ_HashableD_KeyD___init__ (protofooQ_HashableD_Key W_self) {
     ((B_NoneType (*) (B_Hashable))B_HashableG_methods.__init__)(((B_Hashable)W_self));
     return B_None;
-}
-B_bool protofooQ_HashableD_KeyD___eq__ (protofooQ_HashableD_Key W_self, protofooQ_Key a, protofooQ_Key b) {
-    B_bool N_tmp = ((B_bool (*) (B_Eq, B_int, B_int))protofooQ_W_14->$class->__eq__)(protofooQ_W_14, a->x, b->x);
-    return N_tmp;
 }
 B_NoneType protofooQ_HashableD_KeyD_hash (protofooQ_HashableD_Key W_self, protofooQ_Key self, B_hasher hasher) {
     ((B_NoneType (*) (B_Hashable, B_int, B_hasher))protofooQ_W_194->$class->hash)(protofooQ_W_194, self->x, hasher);
@@ -218,6 +242,19 @@ void protofooQ___init__ () {
         $register(&protofooQ_KeyG_methods);
     }
     {
+        protofooQ_EqD_KeyG_methods.$GCINFO = "protofooQ_EqD_Key";
+        protofooQ_EqD_KeyG_methods.$superclass = ($SuperG_class)&B_EqG_methods;
+        protofooQ_EqD_KeyG_methods.__bool__ = (B_bool (*) (protofooQ_EqD_Key))B_valueG_methods.__bool__;
+        protofooQ_EqD_KeyG_methods.__str__ = (B_str (*) (protofooQ_EqD_Key))B_valueG_methods.__str__;
+        protofooQ_EqD_KeyG_methods.__repr__ = (B_str (*) (protofooQ_EqD_Key))B_valueG_methods.__repr__;
+        protofooQ_EqD_KeyG_methods.__ne__ = (B_bool (*) (protofooQ_EqD_Key, protofooQ_Key, protofooQ_Key))B_EqG_methods.__ne__;
+        protofooQ_EqD_KeyG_methods.__init__ = protofooQ_EqD_KeyD___init__;
+        protofooQ_EqD_KeyG_methods.__eq__ = protofooQ_EqD_KeyD___eq__;
+        protofooQ_EqD_KeyG_methods.__serialize__ = protofooQ_EqD_KeyD___serialize__;
+        protofooQ_EqD_KeyG_methods.__deserialize__ = protofooQ_EqD_KeyD___deserialize__;
+        $register(&protofooQ_EqD_KeyG_methods);
+    }
+    {
         protofooQ_HashableD_KeyG_methods.$GCINFO = "protofooQ_HashableD_Key";
         protofooQ_HashableD_KeyG_methods.$superclass = ($SuperG_class)&B_HashableG_methods;
         protofooQ_HashableD_KeyG_methods.__bool__ = (B_bool (*) (protofooQ_HashableD_Key))B_valueG_methods.__bool__;
@@ -225,7 +262,6 @@ void protofooQ___init__ () {
         protofooQ_HashableD_KeyG_methods.__repr__ = (B_str (*) (protofooQ_HashableD_Key))B_valueG_methods.__repr__;
         protofooQ_HashableD_KeyG_methods.__ne__ = (B_bool (*) (protofooQ_HashableD_Key, protofooQ_Key, protofooQ_Key))B_EqG_methods.__ne__;
         protofooQ_HashableD_KeyG_methods.__init__ = protofooQ_HashableD_KeyD___init__;
-        protofooQ_HashableD_KeyG_methods.__eq__ = protofooQ_HashableD_KeyD___eq__;
         protofooQ_HashableD_KeyG_methods.hash = protofooQ_HashableD_KeyD_hash;
         protofooQ_HashableD_KeyG_methods.__serialize__ = protofooQ_HashableD_KeyD___serialize__;
         protofooQ_HashableD_KeyG_methods.__deserialize__ = protofooQ_HashableD_KeyD___deserialize__;

--- a/compiler/lib/test/9-codegen/protofoo.c
+++ b/compiler/lib/test/9-codegen/protofoo.c
@@ -1,0 +1,247 @@
+#include "rts/common.h"
+#include "out/types/protofoo.h"
+B_Eq protofooQ_W_14;
+B_Hashable protofooQ_W_194;
+$R protofooQ_L_1C_1cont ($Cont C_cont, protofooQ_main G_act, B_NoneType C_2res) {
+    return $R_CONT(C_cont, G_act);
+}
+B_NoneType protofooQ_L_2ContD___init__ (protofooQ_L_2Cont L_self, $Cont C_cont, protofooQ_main G_act) {
+    L_self->C_cont = C_cont;
+    L_self->G_act = G_act;
+    return B_None;
+}
+$R protofooQ_L_2ContD___call__ (protofooQ_L_2Cont L_self, B_NoneType G_1) {
+    $Cont C_cont = L_self->C_cont;
+    protofooQ_main G_act = L_self->G_act;
+    return protofooQ_L_1C_1cont(C_cont, G_act, G_1);
+}
+void protofooQ_L_2ContD___serialize__ (protofooQ_L_2Cont self, $Serial$state state) {
+    $step_serialize(self->C_cont, state);
+    $step_serialize(self->G_act, state);
+}
+protofooQ_L_2Cont protofooQ_L_2ContD___deserialize__ (protofooQ_L_2Cont self, $Serial$state state) {
+    if (!self) {
+        if (!state) {
+            self = acton_malloc(sizeof(struct protofooQ_L_2Cont));
+            self->$class = &protofooQ_L_2ContG_methods;
+            return self;
+        }
+        self = $DNEW(protofooQ_L_2Cont, state);
+    }
+    self->C_cont = $step_deserialize(state);
+    self->G_act = $step_deserialize(state);
+    return self;
+}
+protofooQ_L_2Cont protofooQ_L_2ContG_new($Cont G_1, protofooQ_main G_2) {
+    protofooQ_L_2Cont $tmp = acton_malloc(sizeof(struct protofooQ_L_2Cont));
+    $tmp->$class = &protofooQ_L_2ContG_methods;
+    protofooQ_L_2ContG_methods.__init__($tmp, G_1, G_2);
+    return $tmp;
+}
+struct protofooQ_L_2ContG_class protofooQ_L_2ContG_methods;
+B_NoneType protofooQ_L_3procD___init__ (protofooQ_L_3proc L_self, protofooQ_main G_act, B_Env env) {
+    L_self->G_act = G_act;
+    L_self->env = env;
+    return B_None;
+}
+$R protofooQ_L_3procD___call__ (protofooQ_L_3proc L_self, $Cont C_cont) {
+    protofooQ_main G_act = L_self->G_act;
+    B_Env env = L_self->env;
+    return (($R (*) (protofooQ_main, $Cont, B_Env))G_act->$class->__init__)(G_act, C_cont, env);
+}
+$R protofooQ_L_3procD___exec__ (protofooQ_L_3proc L_self, $Cont C_cont) {
+    return (($R (*) (protofooQ_L_3proc, $Cont))L_self->$class->__call__)(L_self, C_cont);
+}
+void protofooQ_L_3procD___serialize__ (protofooQ_L_3proc self, $Serial$state state) {
+    $step_serialize(self->G_act, state);
+    $step_serialize(self->env, state);
+}
+protofooQ_L_3proc protofooQ_L_3procD___deserialize__ (protofooQ_L_3proc self, $Serial$state state) {
+    if (!self) {
+        if (!state) {
+            self = acton_malloc(sizeof(struct protofooQ_L_3proc));
+            self->$class = &protofooQ_L_3procG_methods;
+            return self;
+        }
+        self = $DNEW(protofooQ_L_3proc, state);
+    }
+    self->G_act = $step_deserialize(state);
+    self->env = $step_deserialize(state);
+    return self;
+}
+protofooQ_L_3proc protofooQ_L_3procG_new(protofooQ_main G_1, B_Env G_2) {
+    protofooQ_L_3proc $tmp = acton_malloc(sizeof(struct protofooQ_L_3proc));
+    $tmp->$class = &protofooQ_L_3procG_methods;
+    protofooQ_L_3procG_methods.__init__($tmp, G_1, G_2);
+    return $tmp;
+}
+struct protofooQ_L_3procG_class protofooQ_L_3procG_methods;
+B_NoneType protofooQ_KeyD___init__ (protofooQ_Key self, B_int x) {
+    self->x = x;
+    return B_None;
+}
+void protofooQ_KeyD___serialize__ (protofooQ_Key self, $Serial$state state) {
+    $step_serialize(self->x, state);
+}
+protofooQ_Key protofooQ_KeyD___deserialize__ (protofooQ_Key self, $Serial$state state) {
+    if (!self) {
+        if (!state) {
+            self = acton_malloc(sizeof(struct protofooQ_Key));
+            self->$class = &protofooQ_KeyG_methods;
+            return self;
+        }
+        self = $DNEW(protofooQ_Key, state);
+    }
+    self->x = $step_deserialize(state);
+    return self;
+}
+protofooQ_Key protofooQ_KeyG_new(B_int G_1) {
+    protofooQ_Key $tmp = acton_malloc(sizeof(struct protofooQ_Key));
+    $tmp->$class = &protofooQ_KeyG_methods;
+    protofooQ_KeyG_methods.__init__($tmp, G_1);
+    return $tmp;
+}
+struct protofooQ_KeyG_class protofooQ_KeyG_methods;
+B_NoneType protofooQ_HashableD_KeyD___init__ (protofooQ_HashableD_Key W_self) {
+    ((B_NoneType (*) (B_Hashable))B_HashableG_methods.__init__)(((B_Hashable)W_self));
+    return B_None;
+}
+B_bool protofooQ_HashableD_KeyD___eq__ (protofooQ_HashableD_Key W_self, protofooQ_Key a, protofooQ_Key b) {
+    B_bool N_tmp = ((B_bool (*) (B_Eq, B_int, B_int))protofooQ_W_14->$class->__eq__)(protofooQ_W_14, a->x, b->x);
+    return N_tmp;
+}
+B_NoneType protofooQ_HashableD_KeyD_hash (protofooQ_HashableD_Key W_self, protofooQ_Key self, B_hasher hasher) {
+    ((B_NoneType (*) (B_Hashable, B_int, B_hasher))protofooQ_W_194->$class->hash)(protofooQ_W_194, self->x, hasher);
+    return B_None;
+}
+void protofooQ_HashableD_KeyD___serialize__ (protofooQ_HashableD_Key self, $Serial$state state) {
+}
+protofooQ_HashableD_Key protofooQ_HashableD_KeyD___deserialize__ (protofooQ_HashableD_Key self, $Serial$state state) {
+    if (!self) {
+        if (!state) {
+            self = acton_malloc(sizeof(struct protofooQ_HashableD_Key));
+            self->$class = &protofooQ_HashableD_KeyG_methods;
+            return self;
+        }
+        self = $DNEW(protofooQ_HashableD_Key, state);
+    }
+    return self;
+}
+protofooQ_HashableD_Key protofooQ_HashableD_KeyG_new() {
+    protofooQ_HashableD_Key $tmp = acton_malloc(sizeof(struct protofooQ_HashableD_Key));
+    $tmp->$class = &protofooQ_HashableD_KeyG_methods;
+    protofooQ_HashableD_KeyG_methods.__init__($tmp);
+    return $tmp;
+}
+struct protofooQ_HashableD_KeyG_class protofooQ_HashableD_KeyG_methods;
+$R protofooQ_mainD___init__ (protofooQ_main self, $Cont C_cont, B_Env env) {
+    B_Hashable W_117 = ((B_Hashable)protofooQ_HashableD_KeyG_new());
+    self->k = ((protofooQ_Key)protofooQ_KeyG_new(to$int(42)));
+    ((B_NoneType (*) (B_tuple, B_str, B_str, B_bool, B_bool))B_print)($NEWTUPLE(1, ((B_u64 (*) (B_Hashable, protofooQ_Key))B_hash)(W_117, self->k)), B_None, B_None, B_None, B_None);
+    ((B_Msg (*) (B_Env, B_int))env->$class->exit)(env, to$int(0));
+    return $R_CONT(C_cont, B_None);
+}
+void protofooQ_mainD___serialize__ (protofooQ_main self, $Serial$state state) {
+    $ActorG_methods.__serialize__(($Actor)self, state);
+    $step_serialize(self->k, state);
+}
+protofooQ_main protofooQ_mainD___deserialize__ (protofooQ_main self, $Serial$state state) {
+    if (!self) {
+        if (!state) {
+            self = acton_malloc(sizeof(struct protofooQ_main));
+            self->$class = &protofooQ_mainG_methods;
+            return self;
+        }
+        self = $DNEW(protofooQ_main, state);
+    }
+    $ActorG_methods.__deserialize__(($Actor)self, state);
+    self->k = $step_deserialize(state);
+    return self;
+}
+void protofooQ_mainD__GC_finalizer (void *obj, void *cdata) {
+    protofooQ_main self = (protofooQ_main)obj;
+    self->$class->__cleanup__(self);
+}
+$R protofooQ_mainG_new($Cont G_1, B_Env G_2) {
+    protofooQ_main $tmp = acton_malloc(sizeof(struct protofooQ_main));
+    $tmp->$class = &protofooQ_mainG_methods;
+    return protofooQ_mainG_methods.__init__($tmp, $CONSTCONT($tmp, G_1), G_2);
+}
+struct protofooQ_mainG_class protofooQ_mainG_methods;
+$R protofooQ_mainG_newact ($Cont C_cont, B_Env env) {
+    protofooQ_main G_act = $NEWACTOR(protofooQ_main);
+    if ((void*)G_act->$class->__cleanup__ != (void*)$ActorD___cleanup__) $GCfinalizer(G_act, protofooQ_mainD__GC_finalizer);
+    return $AWAIT((($Cont)protofooQ_L_2ContG_new(C_cont, G_act)), $ASYNC((($Actor)G_act), (($Cont)protofooQ_L_3procG_new(G_act, env))));
+}
+int protofooQ_done$ = 0;
+void protofooQ___init__ () {
+    if (protofooQ_done$) return;
+    protofooQ_done$ = 1;
+    B_Eq W_14 = (B_Eq)B_OrdD_intG_witness;
+    protofooQ_W_14 = W_14;
+    B_Hashable W_194 = (B_Hashable)B_HashableD_intG_witness;
+    protofooQ_W_194 = W_194;
+    {
+        protofooQ_L_2ContG_methods.$GCINFO = "protofooQ_L_2Cont";
+        protofooQ_L_2ContG_methods.$superclass = ($SuperG_class)&$ContG_methods;
+        protofooQ_L_2ContG_methods.__bool__ = (B_bool (*) (protofooQ_L_2Cont))B_valueG_methods.__bool__;
+        protofooQ_L_2ContG_methods.__str__ = (B_str (*) (protofooQ_L_2Cont))B_valueG_methods.__str__;
+        protofooQ_L_2ContG_methods.__repr__ = (B_str (*) (protofooQ_L_2Cont))B_valueG_methods.__repr__;
+        protofooQ_L_2ContG_methods.__init__ = protofooQ_L_2ContD___init__;
+        protofooQ_L_2ContG_methods.__call__ = protofooQ_L_2ContD___call__;
+        protofooQ_L_2ContG_methods.__serialize__ = protofooQ_L_2ContD___serialize__;
+        protofooQ_L_2ContG_methods.__deserialize__ = protofooQ_L_2ContD___deserialize__;
+        $register(&protofooQ_L_2ContG_methods);
+    }
+    {
+        protofooQ_L_3procG_methods.$GCINFO = "protofooQ_L_3proc";
+        protofooQ_L_3procG_methods.$superclass = ($SuperG_class)&$procG_methods;
+        protofooQ_L_3procG_methods.__bool__ = (B_bool (*) (protofooQ_L_3proc))B_valueG_methods.__bool__;
+        protofooQ_L_3procG_methods.__str__ = (B_str (*) (protofooQ_L_3proc))B_valueG_methods.__str__;
+        protofooQ_L_3procG_methods.__repr__ = (B_str (*) (protofooQ_L_3proc))B_valueG_methods.__repr__;
+        protofooQ_L_3procG_methods.__init__ = protofooQ_L_3procD___init__;
+        protofooQ_L_3procG_methods.__call__ = protofooQ_L_3procD___call__;
+        protofooQ_L_3procG_methods.__exec__ = protofooQ_L_3procD___exec__;
+        protofooQ_L_3procG_methods.__serialize__ = protofooQ_L_3procD___serialize__;
+        protofooQ_L_3procG_methods.__deserialize__ = protofooQ_L_3procD___deserialize__;
+        $register(&protofooQ_L_3procG_methods);
+    }
+    {
+        protofooQ_KeyG_methods.$GCINFO = "protofooQ_Key";
+        protofooQ_KeyG_methods.$superclass = ($SuperG_class)&B_valueG_methods;
+        protofooQ_KeyG_methods.__bool__ = (B_bool (*) (protofooQ_Key))B_valueG_methods.__bool__;
+        protofooQ_KeyG_methods.__str__ = (B_str (*) (protofooQ_Key))B_valueG_methods.__str__;
+        protofooQ_KeyG_methods.__repr__ = (B_str (*) (protofooQ_Key))B_valueG_methods.__repr__;
+        protofooQ_KeyG_methods.__init__ = protofooQ_KeyD___init__;
+        protofooQ_KeyG_methods.__serialize__ = protofooQ_KeyD___serialize__;
+        protofooQ_KeyG_methods.__deserialize__ = protofooQ_KeyD___deserialize__;
+        $register(&protofooQ_KeyG_methods);
+    }
+    {
+        protofooQ_HashableD_KeyG_methods.$GCINFO = "protofooQ_HashableD_Key";
+        protofooQ_HashableD_KeyG_methods.$superclass = ($SuperG_class)&B_HashableG_methods;
+        protofooQ_HashableD_KeyG_methods.__bool__ = (B_bool (*) (protofooQ_HashableD_Key))B_valueG_methods.__bool__;
+        protofooQ_HashableD_KeyG_methods.__str__ = (B_str (*) (protofooQ_HashableD_Key))B_valueG_methods.__str__;
+        protofooQ_HashableD_KeyG_methods.__repr__ = (B_str (*) (protofooQ_HashableD_Key))B_valueG_methods.__repr__;
+        protofooQ_HashableD_KeyG_methods.__ne__ = (B_bool (*) (protofooQ_HashableD_Key, protofooQ_Key, protofooQ_Key))B_EqG_methods.__ne__;
+        protofooQ_HashableD_KeyG_methods.__init__ = protofooQ_HashableD_KeyD___init__;
+        protofooQ_HashableD_KeyG_methods.__eq__ = protofooQ_HashableD_KeyD___eq__;
+        protofooQ_HashableD_KeyG_methods.hash = protofooQ_HashableD_KeyD_hash;
+        protofooQ_HashableD_KeyG_methods.__serialize__ = protofooQ_HashableD_KeyD___serialize__;
+        protofooQ_HashableD_KeyG_methods.__deserialize__ = protofooQ_HashableD_KeyD___deserialize__;
+        $register(&protofooQ_HashableD_KeyG_methods);
+    }
+    {
+        protofooQ_mainG_methods.$GCINFO = "protofooQ_main";
+        protofooQ_mainG_methods.$superclass = ($SuperG_class)&$ActorG_methods;
+        protofooQ_mainG_methods.__bool__ = (B_bool (*) (protofooQ_main))$ActorG_methods.__bool__;
+        protofooQ_mainG_methods.__str__ = (B_str (*) (protofooQ_main))$ActorG_methods.__str__;
+        protofooQ_mainG_methods.__repr__ = (B_str (*) (protofooQ_main))$ActorG_methods.__repr__;
+        protofooQ_mainG_methods.__resume__ = (B_NoneType (*) (protofooQ_main))$ActorG_methods.__resume__;
+        protofooQ_mainG_methods.__cleanup__ = (B_NoneType (*) (protofooQ_main))$ActorG_methods.__cleanup__;
+        protofooQ_mainG_methods.__init__ = protofooQ_mainD___init__;
+        protofooQ_mainG_methods.__serialize__ = protofooQ_mainD___serialize__;
+        protofooQ_mainG_methods.__deserialize__ = protofooQ_mainD___deserialize__;
+        $register(&protofooQ_mainG_methods);
+    }
+}

--- a/compiler/lib/test/9-codegen/protofoo.h
+++ b/compiler/lib/test/9-codegen/protofoo.h
@@ -6,11 +6,13 @@ extern B_Hashable protofooQ_W_194;
 struct protofooQ_L_2Cont;
 struct protofooQ_L_3proc;
 struct protofooQ_Key;
+struct protofooQ_EqD_Key;
 struct protofooQ_HashableD_Key;
 struct protofooQ_main;
 typedef struct protofooQ_L_2Cont *protofooQ_L_2Cont;
 typedef struct protofooQ_L_3proc *protofooQ_L_3proc;
 typedef struct protofooQ_Key *protofooQ_Key;
+typedef struct protofooQ_EqD_Key *protofooQ_EqD_Key;
 typedef struct protofooQ_HashableD_Key *protofooQ_HashableD_Key;
 typedef struct protofooQ_main *protofooQ_main;
 $R protofooQ_L_1C_1cont ($Cont, protofooQ_main, B_NoneType);
@@ -64,6 +66,22 @@ struct protofooQ_Key {
     struct protofooQ_KeyG_class *$class;
     B_int x;
 };
+struct protofooQ_EqD_KeyG_class {
+    char *$GCINFO;
+    int $class_id;
+    $SuperG_class $superclass;
+    B_NoneType (*__init__) (protofooQ_EqD_Key);
+    void (*__serialize__) (protofooQ_EqD_Key, $Serial$state);
+    protofooQ_EqD_Key (*__deserialize__) (protofooQ_EqD_Key, $Serial$state);
+    B_bool (*__bool__) (protofooQ_EqD_Key);
+    B_str (*__str__) (protofooQ_EqD_Key);
+    B_str (*__repr__) (protofooQ_EqD_Key);
+    B_bool (*__eq__) (protofooQ_EqD_Key, protofooQ_Key, protofooQ_Key);
+    B_bool (*__ne__) (protofooQ_EqD_Key, protofooQ_Key, protofooQ_Key);
+};
+struct protofooQ_EqD_Key {
+    struct protofooQ_EqD_KeyG_class *$class;
+};
 struct protofooQ_HashableD_KeyG_class {
     char *$GCINFO;
     int $class_id;
@@ -115,8 +133,9 @@ extern struct protofooQ_L_3procG_class protofooQ_L_3procG_methods;
 protofooQ_L_3proc protofooQ_L_3procG_new(protofooQ_main, B_Env);
 extern struct protofooQ_KeyG_class protofooQ_KeyG_methods;
 protofooQ_Key protofooQ_KeyG_new(B_int);
+extern struct protofooQ_EqD_KeyG_class protofooQ_EqD_KeyG_methods;
+protofooQ_EqD_Key protofooQ_EqD_KeyG_new();
 extern struct protofooQ_HashableD_KeyG_class protofooQ_HashableD_KeyG_methods;
-protofooQ_HashableD_Key protofooQ_HashableD_KeyG_new();
 extern struct protofooQ_mainG_class protofooQ_mainG_methods;
 $R protofooQ_mainG_new($Cont, B_Env);
 void protofooQ___init__ ();

--- a/compiler/lib/test/9-codegen/protofoo.h
+++ b/compiler/lib/test/9-codegen/protofoo.h
@@ -1,0 +1,122 @@
+#pragma once
+#include "builtin/builtin.h"
+#include "rts/rts.h"
+extern B_Eq protofooQ_W_14;
+extern B_Hashable protofooQ_W_194;
+struct protofooQ_L_2Cont;
+struct protofooQ_L_3proc;
+struct protofooQ_Key;
+struct protofooQ_HashableD_Key;
+struct protofooQ_main;
+typedef struct protofooQ_L_2Cont *protofooQ_L_2Cont;
+typedef struct protofooQ_L_3proc *protofooQ_L_3proc;
+typedef struct protofooQ_Key *protofooQ_Key;
+typedef struct protofooQ_HashableD_Key *protofooQ_HashableD_Key;
+typedef struct protofooQ_main *protofooQ_main;
+$R protofooQ_L_1C_1cont ($Cont, protofooQ_main, B_NoneType);
+struct protofooQ_L_2ContG_class {
+    char *$GCINFO;
+    int $class_id;
+    $SuperG_class $superclass;
+    B_NoneType (*__init__) (protofooQ_L_2Cont, $Cont, protofooQ_main);
+    void (*__serialize__) (protofooQ_L_2Cont, $Serial$state);
+    protofooQ_L_2Cont (*__deserialize__) (protofooQ_L_2Cont, $Serial$state);
+    B_bool (*__bool__) (protofooQ_L_2Cont);
+    B_str (*__str__) (protofooQ_L_2Cont);
+    B_str (*__repr__) (protofooQ_L_2Cont);
+    $R (*__call__) (protofooQ_L_2Cont, B_NoneType);
+};
+struct protofooQ_L_2Cont {
+    struct protofooQ_L_2ContG_class *$class;
+    $Cont C_cont;
+    protofooQ_main G_act;
+};
+struct protofooQ_L_3procG_class {
+    char *$GCINFO;
+    int $class_id;
+    $SuperG_class $superclass;
+    B_NoneType (*__init__) (protofooQ_L_3proc, protofooQ_main, B_Env);
+    void (*__serialize__) (protofooQ_L_3proc, $Serial$state);
+    protofooQ_L_3proc (*__deserialize__) (protofooQ_L_3proc, $Serial$state);
+    B_bool (*__bool__) (protofooQ_L_3proc);
+    B_str (*__str__) (protofooQ_L_3proc);
+    B_str (*__repr__) (protofooQ_L_3proc);
+    $R (*__call__) (protofooQ_L_3proc, $Cont);
+    $R (*__exec__) (protofooQ_L_3proc, $Cont);
+};
+struct protofooQ_L_3proc {
+    struct protofooQ_L_3procG_class *$class;
+    protofooQ_main G_act;
+    B_Env env;
+};
+struct protofooQ_KeyG_class {
+    char *$GCINFO;
+    int $class_id;
+    $SuperG_class $superclass;
+    B_NoneType (*__init__) (protofooQ_Key, B_int);
+    void (*__serialize__) (protofooQ_Key, $Serial$state);
+    protofooQ_Key (*__deserialize__) (protofooQ_Key, $Serial$state);
+    B_bool (*__bool__) (protofooQ_Key);
+    B_str (*__str__) (protofooQ_Key);
+    B_str (*__repr__) (protofooQ_Key);
+};
+struct protofooQ_Key {
+    struct protofooQ_KeyG_class *$class;
+    B_int x;
+};
+struct protofooQ_HashableD_KeyG_class {
+    char *$GCINFO;
+    int $class_id;
+    $SuperG_class $superclass;
+    B_NoneType (*__init__) (protofooQ_HashableD_Key);
+    void (*__serialize__) (protofooQ_HashableD_Key, $Serial$state);
+    protofooQ_HashableD_Key (*__deserialize__) (protofooQ_HashableD_Key, $Serial$state);
+    B_bool (*__bool__) (protofooQ_HashableD_Key);
+    B_str (*__str__) (protofooQ_HashableD_Key);
+    B_str (*__repr__) (protofooQ_HashableD_Key);
+    B_bool (*__eq__) (protofooQ_HashableD_Key, protofooQ_Key, protofooQ_Key);
+    B_bool (*__ne__) (protofooQ_HashableD_Key, protofooQ_Key, protofooQ_Key);
+    B_NoneType (*hash) (protofooQ_HashableD_Key, protofooQ_Key, B_hasher);
+};
+struct protofooQ_HashableD_Key {
+    struct protofooQ_HashableD_KeyG_class *$class;
+};
+struct protofooQ_mainG_class {
+    char *$GCINFO;
+    int $class_id;
+    $SuperG_class $superclass;
+    $R (*__init__) (protofooQ_main, $Cont, B_Env);
+    void (*__serialize__) (protofooQ_main, $Serial$state);
+    protofooQ_main (*__deserialize__) (protofooQ_main, $Serial$state);
+    B_bool (*__bool__) (protofooQ_main);
+    B_str (*__str__) (protofooQ_main);
+    B_str (*__repr__) (protofooQ_main);
+    B_NoneType (*__resume__) (protofooQ_main);
+    B_NoneType (*__cleanup__) (protofooQ_main);
+};
+struct protofooQ_main {
+    struct protofooQ_mainG_class *$class;
+    $Actor $next;
+    B_Msg $msg;
+    B_Msg $msg_tail;
+    $Lock $msg_lock;
+    $int64 $affinity;
+    B_Msg $outgoing;
+    B_Msg $waitsfor;
+    $int64 $consume_hd;
+    $Catcher $catcher;
+    $long $globkey;
+    protofooQ_Key k;
+};
+$R protofooQ_mainG_newact ($Cont, B_Env);
+extern struct protofooQ_L_2ContG_class protofooQ_L_2ContG_methods;
+protofooQ_L_2Cont protofooQ_L_2ContG_new($Cont, protofooQ_main);
+extern struct protofooQ_L_3procG_class protofooQ_L_3procG_methods;
+protofooQ_L_3proc protofooQ_L_3procG_new(protofooQ_main, B_Env);
+extern struct protofooQ_KeyG_class protofooQ_KeyG_methods;
+protofooQ_Key protofooQ_KeyG_new(B_int);
+extern struct protofooQ_HashableD_KeyG_class protofooQ_HashableD_KeyG_methods;
+protofooQ_HashableD_Key protofooQ_HashableD_KeyG_new();
+extern struct protofooQ_mainG_class protofooQ_mainG_methods;
+$R protofooQ_mainG_new($Cont, B_Env);
+void protofooQ___init__ ();

--- a/compiler/lib/test/9-codegen/protofoo.input
+++ b/compiler/lib/test/9-codegen/protofoo.input
@@ -1,0 +1,68 @@
+
+W_14: __builtin__.Eq[__builtin__.int] = __builtin__.OrdD_int()
+
+W_194: __builtin__.Hashable[__builtin__.int] = __builtin__.HashableD_int()
+
+# recursive group:
+proc def L_1C_1cont (C_cont : $Cont[main], G_act : main, C_2res : None) -> $R:
+    return $R_CONT@[main](C_cont, G_act)
+class L_2Cont ($Cont[None], __builtin__.value):
+    @property
+    C_cont : $Cont[main]
+    @property
+    G_act : main
+    pure def __init__ (L_self : L_2Cont, C_cont : $Cont[main], G_act : main) -> None:
+        L_self.C_cont = C_cont
+        L_self.G_act = G_act
+        return None
+    proc def __call__ (L_self : L_2Cont, G_1 : None) -> $R:
+        C_cont: $Cont[main] = L_self.C_cont
+        G_act: main = L_self.G_act
+        return L_1C_1cont(C_cont, G_act, G_1)
+class L_3proc ($proc[(), None], __builtin__.value):
+    @property
+    G_act : main
+    @property
+    env : __builtin__.Env
+    pure def __init__ (L_self : L_3proc, G_act : main, env : __builtin__.Env) -> None:
+        L_self.G_act = G_act
+        L_self.env = env
+        return None
+    # recursive group:
+    proc def __call__ (L_self : L_3proc, C_cont : $Cont[None]) -> $R:
+        G_act: main = L_self.G_act
+        env: __builtin__.Env = L_self.env
+        return G_act.__init__(C_cont, env)
+    proc def __exec__ (L_self : L_3proc, C_cont : $Cont[None]) -> $R:
+        return L_self.__call__(C_cont)
+    # (recursive group)
+class Key (__builtin__.value):
+    @property
+    x : __builtin__.int
+    pure def __init__ (self : Key, x : __builtin__.int) -> None:
+        self.x = x
+        return None
+class HashableD_Key (__builtin__.Hashable[Key], __builtin__.Eq[Key], __builtin__.value):
+    pure def __init__ (W_self : HashableD_Key) -> None:
+        __builtin__.Hashable.__init__@[Key](W_self)
+        return None
+    pure def __eq__ (W_self : HashableD_Key, a : Key, b : Key) -> __builtin__.bool:
+        N_tmp: __builtin__.bool = W_14.__eq__(a.x, b.x)
+        return N_tmp
+    pure def hash (W_self : HashableD_Key, self : Key, hasher : __builtin__.hasher) -> None:
+        W_194.hash(self.x, hasher)
+        return None
+class main ($Actor, __builtin__.value):
+    @property
+    k : Key
+    proc def __init__ (self : main, C_cont : $Cont[None], env : __builtin__.Env) -> $R:
+        W_117: __builtin__.Hashable[Key] = HashableD_Key()
+        self.k = Key(42)
+        print@[(__builtin__.u64,)]((hash@[Key](W_117, self.k),), None, None, None, None)
+        (async env.exit)(0)
+        return $R_CONT@[None](C_cont, None)
+proc def mainG_newact (C_cont : $Cont[main], env : __builtin__.Env) -> $R:
+    G_act: main = $NEWACTOR@[main]()
+    $GCfinalizer@[main](G_act)
+    return $AWAIT@[None](L_2Cont(C_cont, G_act), $ASYNC@[None](G_act, L_3proc(G_act, env)))
+# (recursive group)

--- a/compiler/lib/test/9-codegen/protofoo.input
+++ b/compiler/lib/test/9-codegen/protofoo.input
@@ -42,13 +42,17 @@ class Key (__builtin__.value):
     pure def __init__ (self : Key, x : __builtin__.int) -> None:
         self.x = x
         return None
+class EqD_Key (__builtin__.Eq[Key], __builtin__.value):
+    pure def __init__ (W_self : EqD_Key) -> None:
+        __builtin__.Eq.__init__@[Key](W_self)
+        return None
+    pure def __eq__ (W_self : EqD_Key, a : Key, b : Key) -> __builtin__.bool:
+        N_tmp: __builtin__.bool = W_14.__eq__(a.x, b.x)
+        return N_tmp
 class HashableD_Key (__builtin__.Hashable[Key], __builtin__.Eq[Key], __builtin__.value):
     pure def __init__ (W_self : HashableD_Key) -> None:
         __builtin__.Hashable.__init__@[Key](W_self)
         return None
-    pure def __eq__ (W_self : HashableD_Key, a : Key, b : Key) -> __builtin__.bool:
-        N_tmp: __builtin__.bool = W_14.__eq__(a.x, b.x)
-        return N_tmp
     pure def hash (W_self : HashableD_Key, self : Key, hasher : __builtin__.hasher) -> None:
         W_194.hash(self.x, hasher)
         return None

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -356,6 +356,7 @@ main = do
 
     describe "Pass 9: CodeGen" $ do
       testCodeGen env0 ["deact"]
+      testCodeGen env0 ["protofoo"]
 
 
 

--- a/compiler/lib/test/src/protofoo.act
+++ b/compiler/lib/test/src/protofoo.act
@@ -1,0 +1,15 @@
+class Key:
+    def __init__(self, x):
+        self.x = x
+
+extension Key(Hashable):
+    def __eq__(a, b) -> bool:
+        return a.x == b.x
+
+    def hash(self, hasher):
+        self.x.hash(hasher)
+
+actor main(env):
+    k = Key(42)
+    print(hash(k))
+    env.exit(0)

--- a/test/core_lang_auto/test_protocol_extension_inheritance.act
+++ b/test/core_lang_auto/test_protocol_extension_inheritance.act
@@ -1,3 +1,6 @@
+# Test protocol extensions where the protocol inherits from another protocol
+# Regression test: extensions should get constructors even with inherited abstract methods
+
 class Key:
     def __init__(self, x):
         self.x = x


### PR DESCRIPTION
Protocol extensions with inherited methods weren't getting constructor
functions generated, causing C compilation errors. This is a incomplete patch that fixes the symptoms for single-inheriting extensions.

When a protocol extends another (e.g., Hashable extends Eq), extensions
implementing the child protocol were incorrectly treated as abstract:
- `extension Key(Eq)` implements `__eq__`
- `extension Key(Hashable)` implements `hash`
- But `HashableD_Key` inherits from `Eq[Key]`, so `abstractAttrs` sees the inherited `__eq__` as abstract
- `declCon` then skips constructor generation for the abstract class `HashableD_Key`

This caused undefined symbol errors:

    error: call to undeclared function 'HashableD_KeyG_new'

Earlier compiler passes already verify that extensions provide all
required methods. The issue is purely in code generation - extensions
shouldn't be treated as abstract due to inherited methods from parent
protocols.

Extensions are converted to classes by `convExtension` by the Converter.
By the time CodeGen runs, `declCon` handles all class declarations:
user-defined classes, protocol extensions (converted to classes), and
actors. Protocol extensions get `Derived` names from
`extensionName` (e.g., `Derived Hashable Key` → `HashableD_Key`), while
regular classes keep their simple names.

The fix detects protocol extensions by their `Derived` naming pattern.
Since only protocol extensions have `Derived` names when `declCon`
processes class declarations, this reliably identifies them.

This allows protocol extensions to get constructors regardless of
inherited abstract methods while preserving the abstract class check
that prevents regular user-defined abstract classes from getting
constructors.

In practice, a lot of Acton program that used a workaround, like so:
```python
class Key:
    def __init__(self, x):
        self.x = x

extension Key(Hashable):
    def __eq__(a, b) -> bool:
        return a.x == b.x

    def hash(self, hasher):
        self.x.hash(hasher)
```

can now instead be written in the more proper way:
```python
class Key:
    def __init__(self, x):
        self.x = x

extension Key(Eq):
    def __eq__(a, b) -> bool:
        return a.x == b.x

extension Key(Hashable):
    def hash(self, hasher):
        self.x.hash(hasher)
```
