### PR TITLE
Fix bytes.startswith() when needle length equal to haystack length

### DIFF
--- a/base/builtin/str.c
+++ b/base/builtin/str.c
@@ -2274,7 +2274,7 @@ B_bool B_bytearrayD_startswith(B_bytearray s, B_bytearray sub, B_int start, B_in
     B_int en = end;
     if (fix_start_end(s->nbytes,&st,&en) < 0) return B_False;
     unsigned char *p = s->str + from$int(st);
-    if (sub->nbytes > 0 && p+sub->nbytes >= s->str+s->nbytes) return B_False;
+    if (sub->nbytes > 0 && p+sub->nbytes > s->str+s->nbytes) return B_False;
     unsigned char *q = sub->str;
     for (int i=0; i<sub->nbytes; i++) {
         if (p >= s->str + from$int(en) || *p++ != *q++) {
@@ -3395,7 +3395,7 @@ B_bool B_bytesD_startswith(B_bytes s, B_bytes sub, B_int start, B_int end) {
     B_int en = end;
     if (fix_start_end(s->nbytes,&st,&en) < 0) return B_False;
     unsigned char *p = s->str + from$int(st);
-    if (sub->nbytes > 0 && p+sub->nbytes >= s->str+s->nbytes) return B_False;
+    if (sub->nbytes > 0 && p+sub->nbytes > s->str+s->nbytes) return B_False;
     unsigned char *q = sub->str;
     for (int i=0; i<sub->nbytes; i++) {
         if (p >= s->str + from$int(en) || *p++ != *q++) {

--- a/test/builtins_auto/test_bytearray.act
+++ b/test/builtins_auto/test_bytearray.act
@@ -4,15 +4,16 @@ def test_bytearray_basic():
         raise ValueError("Length of bytearray incorrect: " + str(len(ba)))
     if ba[0] != 104:  # ASCII 'h'
         raise ValueError("Indexing failed: " + str(ba[0]))
-    
+
     # Test modification
     ba[0] = 72  # ASCII 'H'
     if ba[0] != 72:
         raise ValueError("Modification failed: " + str(ba[0]))
-    
+
     # Test slicing
     if ba[0:5] != bytearray(b"Hello"):
         raise ValueError("Slicing failed: " + str(ba[0:5]))
+    return True
 
 def test_bytearray_find():
     ba = bytearray(b"hello, world!")
@@ -29,24 +30,26 @@ def test_bytearray_find():
         raise ValueError("find() did not return -1 when the substring is not found")
     if ba.find(bytearray(b"crap")) != -1:
         raise ValueError("find() did not return -1 when the substring is not found")
+    return True
 
 def test_bytearray_sequence_methods():
     ba = bytearray(b"test")
-    
+
     # Test append
     ba.append(33)  # ASCII '!'
     if ba != bytearray(b"test!"):
         raise ValueError("append() failed: " + str(ba))
-    
+
     # Test insert
     ba.insert(0, 65)  # ASCII 'A'
     if ba != bytearray(b"Atest!"):
         raise ValueError("insert() failed: " + str(ba))
-    
+
     # Test reverse
     ba.reverse()
     if ba != bytearray(b"!tsetA"):
         raise ValueError("reverse() failed: " + str(ba))
+    return True
 
 def test_empty_bytearray_methods():
     ba = bytearray(b"")
@@ -162,6 +165,48 @@ def test_empty_bytearray_methods():
     if ba.zfill(5) != bytearray(b"00000"):
         raise ValueError("bytearray.zfill() failed: " + str(ba.zfill(5)))
 
+    return True
+
+def test_bytearray_startswith_same_length():
+    # Test case for the bug: same length strings
+    ba1 = bytearray(b"foo")
+    if not ba1.startswith(bytearray(b"foo")):
+        raise ValueError("bytearray.startswith() failed: bytearray(b'foo').startswith(bytearray(b'foo')) returned False")
+    return True
+
+def test_bytearray_startswith_prefix():
+    # Test normal prefix matching
+    ba2 = bytearray(b"hello world")
+    if not ba2.startswith(bytearray(b"hello")):
+        raise ValueError("bytearray.startswith() failed: bytearray(b'hello world').startswith(bytearray(b'hello')) returned False")
+    return True
+
+def test_bytearray_startswith_not_prefix():
+    # Test that non-prefix returns False
+    ba2 = bytearray(b"hello world")
+    if ba2.startswith(bytearray(b"world")):
+        raise ValueError("bytearray.startswith() failed: bytearray(b'hello world').startswith(bytearray(b'world')) returned True")
+    return True
+
+def test_bytearray_startswith_empty():
+    # Test empty prefix
+    ba2 = bytearray(b"hello world")
+    if not ba2.startswith(bytearray(b"")):
+        raise ValueError("bytearray.startswith() failed: empty prefix should always return True")
+    return True
+
+def test_bytearray_startswith_single_char():
+    # Test with single character
+    if not bytearray(b"a").startswith(bytearray(b"a")):
+        raise ValueError("bytearray.startswith() failed: bytearray(b'a').startswith(bytearray(b'a')) returned False")
+    return True
+
+def test_bytearray_startswith_longer_prefix():
+    # Test longer prefix than string
+    if bytearray(b"foo").startswith(bytearray(b"foobar")):
+        raise ValueError("bytearray.startswith() failed: prefix longer than string returned True")
+    return True
+
 def test_hex_methods():
     # Test hex encoding/decoding
     ba = bytearray(b"\xde\xad\xbe\xef")
@@ -170,17 +215,40 @@ def test_hex_methods():
 
     if bytearray.from_hex("deadbeef").hex() != "deadbeef":
         raise ValueError("bytearray.from_hex() failed: " + bytearray.from_hex("deadbeef").hex())
+    return True
+
+tests = {
+    "test_bytearray_basic": test_bytearray_basic,
+    "test_bytearray_find": test_bytearray_find,
+    "test_bytearray_sequence_methods": test_bytearray_sequence_methods,
+    "test_bytearray_startswith_same_length": test_bytearray_startswith_same_length,
+    "test_bytearray_startswith_prefix": test_bytearray_startswith_prefix,
+    "test_bytearray_startswith_not_prefix": test_bytearray_startswith_not_prefix,
+    "test_bytearray_startswith_empty": test_bytearray_startswith_empty,
+    "test_bytearray_startswith_single_char": test_bytearray_startswith_single_char,
+    "test_bytearray_startswith_longer_prefix": test_bytearray_startswith_longer_prefix,
+    "test_empty_bytearray_methods": test_empty_bytearray_methods,
+    "test_hex_methods": test_hex_methods,
+}
 
 actor main(env):
-    try:
-        test_bytearray_basic()
-        test_bytearray_find()
-        test_bytearray_sequence_methods()
-        test_empty_bytearray_methods()
-        test_hex_methods()
-        print("All bytearray tests passed!")
-    except Exception as e:
-        print("Unexpected exception during testing:", e)
-        await async env.exit(1)
+    failed = []
+    for name, t in tests.items():
+        print("== test: " + name)
+        try:
+            if not t():
+                print("-- FAILED test: " + name)
+                failed.append(name)
+        except Exception as e:
+            print("-- FAILED test: " + name + " with exception: " + str(e))
+            failed.append(name)
+        print()
 
-    env.exit(0)
+    if len(failed) == 0:
+        print("All {len(tests)} tests OK!")
+    else:
+        print("\n{len(failed)} of {len(tests)} tests failed:")
+        for name in failed:
+            print(" - {name}")
+
+    env.exit(max([0, min([len(failed), 1])]))

--- a/test/builtins_auto/test_bytearray.act
+++ b/test/builtins_auto/test_bytearray.act
@@ -1,254 +1,355 @@
-def test_bytearray_basic():
+def test_bytearray_basic_len():
     ba = bytearray(b"hello, world!")
-    if len(ba) != 13:
-        raise ValueError("Length of bytearray incorrect: " + str(len(ba)))
-    if ba[0] != 104:  # ASCII 'h'
-        raise ValueError("Indexing failed: " + str(ba[0]))
+    result = len(ba)
+    print("len(bytearray(b'hello, world!')): {result}")
+    return result == 13
 
-    # Test modification
+def test_bytearray_basic_indexing():
+    ba = bytearray(b"hello, world!")
+    result = ba[0]
+    print("bytearray(b'hello, world!')[0]: {result}")
+    return result == 104  # ASCII 'h'
+
+def test_bytearray_basic_modification():
+    ba = bytearray(b"hello, world!")
     ba[0] = 72  # ASCII 'H'
-    if ba[0] != 72:
-        raise ValueError("Modification failed: " + str(ba[0]))
+    result = ba[0]
+    print("bytearray modification ba[0] = 72, result: {result}")
+    return result == 72
 
-    # Test slicing
-    if ba[0:5] != bytearray(b"Hello"):
-        raise ValueError("Slicing failed: " + str(ba[0:5]))
-    return True
+def test_bytearray_basic_slicing():
+    ba = bytearray(b"hello, world!")
+    ba[0] = 72  # ASCII 'H'
+    result = ba[0:5]
+    print("bytearray(b'Hello, world!')[0:5]: {result}")
+    return result == bytearray(b"Hello")
 
 def test_bytearray_find():
     ba = bytearray(b"hello, world!")
     world = bytearray(b"world")
-    if ba.find(world) != 7:
-        raise ValueError("find() did not return the correct index: " + str(ba.find(world)))
-    if ba.find(world, 0) != 7:
-        raise ValueError("find() did not return the correct index: " + str(ba.find(world, 0)))
-    if ba.find(world, 8) != -1:
-        raise ValueError("find() did not return -1 when the substring is not found")
-    if ba.find(world, 0, 5) != -1:
-        raise ValueError("find() did not return -1 when the substring is not found")
-    if ba.find(world, 0, 7) != -1:
-        raise ValueError("find() did not return -1 when the substring is not found")
-    if ba.find(bytearray(b"crap")) != -1:
-        raise ValueError("find() did not return -1 when the substring is not found")
-    return True
+    print("Testing bytearray.find()")
+    return (ba.find(world) == 7 and
+            ba.find(world, 0) == 7 and
+            ba.find(world, 8) == -1 and
+            ba.find(world, 0, 5) == -1 and
+            ba.find(world, 0, 7) == -1 and
+            ba.find(bytearray(b"crap")) == -1)
 
-def test_bytearray_sequence_methods():
+def test_bytearray_append():
     ba = bytearray(b"test")
-
-    # Test append
     ba.append(33)  # ASCII '!'
-    if ba != bytearray(b"test!"):
-        raise ValueError("append() failed: " + str(ba))
+    result = ba
+    print("bytearray(b'test').append(33): {result}")
+    return result == bytearray(b"test!")
 
-    # Test insert
+def test_bytearray_insert():
+    ba = bytearray(b"test")
     ba.insert(0, 65)  # ASCII 'A'
-    if ba != bytearray(b"Atest!"):
-        raise ValueError("insert() failed: " + str(ba))
+    result = ba
+    print("bytearray(b'test').insert(0, 65): {result}")
+    return result == bytearray(b"Atest")
 
-    # Test reverse
+def test_bytearray_reverse():
+    ba = bytearray(b"test")
     ba.reverse()
-    if ba != bytearray(b"!tsetA"):
-        raise ValueError("reverse() failed: " + str(ba))
-    return True
+    result = ba
+    print("bytearray(b'test').reverse(): {result}")
+    return result == bytearray(b"tset")
 
-def test_empty_bytearray_methods():
-    ba = bytearray(b"")
+def test_empty_bytearray_capitalize():
+    result = bytearray(b"").capitalize()
+    print("empty bytearray.capitalize(): {result}")
+    return result == bytearray(b"")
 
-    # Test all bytearray methods with empty bytearray
-    if ba.capitalize() != ba:
-        raise ValueError("bytearray.capitalize() failed: " + str(ba.capitalize()))
+def test_empty_bytearray_center():
+    result = bytearray(b"").center(5)
+    print("empty bytearray.center(5): {result}")
+    return result == bytearray(b"     ")
 
-    if ba.center(5) != bytearray(b"     "):
-        raise ValueError("bytearray.center() failed: " + str(ba.center(5)))
+def test_empty_bytearray_count():
+    result = bytearray(b"").count(bytearray(b"a"))
+    print("empty bytearray.count(bytearray(b'a')): {result}")
+    return result == 0
 
-    if ba.count(bytearray(b"a")) != 0:
-        raise ValueError("bytearray.count() failed: " + str(ba.count(bytearray(b"a"))))
+def test_empty_bytearray_decode():
+    result = bytearray(b"").decode()
+    print("empty bytearray.decode(): '{result}'")
+    return result == ""
 
-    if ba.decode() != "":
-        raise ValueError("bytearray.decode() failed: " + str(ba.decode()))
+def test_empty_bytearray_endswith():
+    result = bytearray(b"").endswith(bytearray(b""))
+    print("empty bytearray.endswith(bytearray(b'')): {result}")
+    return result == True
 
-    if ba.endswith(bytearray(b"")) != True:
-        raise ValueError("bytearray.endswith() failed: " + str(ba.endswith(bytearray(b""))))
+def test_empty_bytearray_expandtabs():
+    result = bytearray(b"").expandtabs()
+    print("empty bytearray.expandtabs(): {result}")
+    return result == bytearray(b"")
 
-    if ba.expandtabs() != bytearray(b""):
-        raise ValueError("bytearray.expandtabs() failed: " + str(ba.expandtabs()))
+def test_empty_bytearray_find():
+    result = bytearray(b"").find(bytearray(b"a"))
+    print("empty bytearray.find(bytearray(b'a')): {result}")
+    return result == -1
 
-    if ba.find(bytearray(b"a")) != -1:
-        raise ValueError("bytearray.find() failed: " + str(ba.find(bytearray(b"a"))))
-
+def test_empty_bytearray_index():
+    print("empty bytearray.index(bytearray(b'a')): testing exception")
     try:
-        ba.index(bytearray(b"a"))
-        raise ValueError("bytearray.index() didn't raise ValueError")
+        bytearray(b"").index(bytearray(b"a"))
+        return False
     except ValueError:
-        pass
+        return True
 
-    if ba.isalnum() != False:
-        raise ValueError("bytearray.isalnum() failed: " + str(ba.isalnum()))
+def test_empty_bytearray_isalnum():
+    result = bytearray(b"").isalnum()
+    print("empty bytearray.isalnum(): {result}")
+    return result == False
 
-    if ba.isalpha() != False:
-        raise ValueError("bytearray.isalpha() failed: " + str(ba.isalpha()))
+def test_empty_bytearray_isalpha():
+    result = bytearray(b"").isalpha()
+    print("empty bytearray.isalpha(): {result}")
+    return result == False
 
-    if ba.isascii() != True:
-        raise ValueError("bytearray.isascii() failed: " + str(ba.isascii()))
+def test_empty_bytearray_isascii():
+    result = bytearray(b"").isascii()
+    print("empty bytearray.isascii(): {result}")
+    return result == True
 
-    if ba.isdigit() != False:
-        raise ValueError("bytearray.isdigit() failed: " + str(ba.isdigit()))
+def test_empty_bytearray_isdigit():
+    result = bytearray(b"").isdigit()
+    print("empty bytearray.isdigit(): {result}")
+    return result == False
 
-    if ba.islower() != False:
-        raise ValueError("bytearray.islower() failed: " + str(ba.islower()))
+def test_empty_bytearray_islower():
+    result = bytearray(b"").islower()
+    print("empty bytearray.islower(): {result}")
+    return result == False
 
-    if ba.isspace() != False:
-        raise ValueError("bytearray.isspace() failed: " + str(ba.isspace()))
+def test_empty_bytearray_isspace():
+    result = bytearray(b"").isspace()
+    print("empty bytearray.isspace(): {result}")
+    return result == False
 
-    if ba.istitle() != False:
-        raise ValueError("bytearray.istitle() failed: " + str(ba.istitle()))
+def test_empty_bytearray_istitle():
+    result = bytearray(b"").istitle()
+    print("empty bytearray.istitle(): {result}")
+    return result == False
 
-    if ba.isupper() != False:
-        raise ValueError("bytearray.isupper() failed: " + str(ba.isupper()))
+def test_empty_bytearray_isupper():
+    result = bytearray(b"").isupper()
+    print("empty bytearray.isupper(): {result}")
+    return result == False
 
-    if ba.join([bytearray(b"a"), bytearray(b"b"), bytearray(b"c")]) != bytearray(b"abc"):
-        raise ValueError("bytearray.join() failed: " + str(ba.join([bytearray(b"a"), bytearray(b"b"), bytearray(b"c")])))
+def test_empty_bytearray_join():
+    result = bytearray(b"").join([bytearray(b"a"), bytearray(b"b"), bytearray(b"c")])
+    print("empty bytearray.join([bytearray(b'a'), bytearray(b'b'), bytearray(b'c')]): {result}")
+    return result == bytearray(b"abc")
 
-    if ba.ljust(5) != bytearray(b"     "):
-        raise ValueError("bytearray.ljust() failed: " + str(ba.ljust(5)))
+def test_empty_bytearray_ljust():
+    result = bytearray(b"").ljust(5)
+    print("empty bytearray.ljust(5): {result}")
+    return result == bytearray(b"     ")
 
-    if ba.lower() != bytearray(b""):
-        raise ValueError("bytearray.lower() failed: " + str(ba.lower()))
+def test_empty_bytearray_lower():
+    result = bytearray(b"").lower()
+    print("empty bytearray.lower(): {result}")
+    return result == bytearray(b"")
 
-    if ba.lstrip() != bytearray(b""):
-        raise ValueError("bytearray.lstrip() failed: " + str(ba.lstrip()))
+def test_empty_bytearray_lstrip():
+    result = bytearray(b"").lstrip()
+    print("empty bytearray.lstrip(): {result}")
+    return result == bytearray(b"")
 
-    parts = ba.partition(bytearray(b"a"))
-    if parts.0 != bytearray(b"") or parts.1 != bytearray(b"") or parts.2 != bytearray(b""):
-        raise ValueError("bytearray.partition() failed: " + str(parts.0) + " " + str(parts.1) + " " + str(parts.2))
+def test_empty_bytearray_partition():
+    sp = bytearray(b"").partition(bytearray(b"a"))
+    print("empty bytearray.partition(bytearray(b'a')): ({sp.0}, {sp.1}, {sp.2})")
+    return sp.0 == bytearray(b"") and sp.1 == bytearray(b"") and sp.2 == bytearray(b"")
 
-    if ba.replace(bytearray(b""), bytearray(b"")) != bytearray(b""):
-        raise ValueError("bytearray.replace() failed: " + str(ba.replace(bytearray(b""), bytearray(b""))))
+def test_empty_bytearray_replace():
+    result = bytearray(b"").replace(bytearray(b"a"), bytearray(b"b"))
+    print("empty bytearray.replace(bytearray(b'a'), bytearray(b'b')): {result}")
+    return result == bytearray(b"")
 
-    if ba.replace(bytearray(b"a"), bytearray(b"b")) != bytearray(b""):
-        raise ValueError("bytearray.replace() failed: " + str(ba.replace(bytearray(b"a"), bytearray(b"b"))))
+def test_empty_bytearray_replace_empty():
+    result = bytearray(b"").replace(bytearray(b""), bytearray(b""))
+    print("empty bytearray.replace(bytearray(b''), bytearray(b'')): {result}")
+    return result == bytearray(b"")
 
-    if ba.rfind(bytearray(b"a")) != -1:
-        raise ValueError("bytearray.rfind() failed: " + str(ba.rfind(bytearray(b"a"))))
+def test_empty_bytearray_rfind():
+    result = bytearray(b"").rfind(bytearray(b"a"))
+    print("empty bytearray.rfind(bytearray(b'a')): {result}")
+    return result == -1
 
+def test_empty_bytearray_rindex():
+    print("empty bytearray.rindex(bytearray(b'a')): testing exception")
     try:
-        ba.rindex(bytearray(b"a"))
-        raise ValueError("bytearray.rindex() didn't raise ValueError")
+        bytearray(b"").rindex(bytearray(b"a"))
+        return False
     except ValueError:
-        pass
+        return True
 
-    if ba.rjust(5) != bytearray(b"     "):
-        raise ValueError("bytearray.rjust() failed: " + str(ba.rjust(5)))
+def test_empty_bytearray_rjust():
+    result = bytearray(b"").rjust(5)
+    print("empty bytearray.rjust(5): {result}")
+    return result == bytearray(b"     ")
 
-    parts = ba.rpartition(bytearray(b"a"))
-    if parts.0 != bytearray(b"") or parts.1 != bytearray(b"") or parts.2 != bytearray(b""):
-        raise ValueError("bytearray.rpartition() failed: " + str(parts.0) + " " + str(parts.1) + " " + str(parts.2))
+def test_empty_bytearray_rpartition():
+    sp = bytearray(b"").rpartition(bytearray(b"a"))
+    print("empty bytearray.rpartition(bytearray(b'a')): ({sp.0}, {sp.1}, {sp.2})")
+    return sp.0 == bytearray(b"") and sp.1 == bytearray(b"") and sp.2 == bytearray(b"")
 
-    if ba.rstrip() != bytearray(b""):
-        raise ValueError("bytearray.rstrip() failed: " + str(ba.rstrip()))
+def test_empty_bytearray_rstrip():
+    result = bytearray(b"").rstrip()
+    print("empty bytearray.rstrip(): {result}")
+    return result == bytearray(b"")
 
-    if ba.split(bytearray(b"a")) != [bytearray(b"")]:
-        raise ValueError("bytearray.split() failed: " + str(ba.split(bytearray(b"a"))))
+def test_empty_bytearray_split():
+    result = bytearray(b"").split(bytearray(b"a"))
+    print("empty bytearray.split(bytearray(b'a')): {result}")
+    return result == [bytearray(b"")]
 
-    if ba.splitlines() != []:
-        raise ValueError("bytearray.splitlines() failed: " + str(ba.splitlines()))
+def test_empty_bytearray_splitlines():
+    result = bytearray(b"").splitlines()
+    print("empty bytearray.splitlines(): {result}")
+    return result == []
 
-    if ba.startswith(bytearray(b"")) != True:
-        raise ValueError("bytearray.startswith() failed: " + str(ba.startswith(bytearray(b""))))
+def test_empty_bytearray_startswith():
+    result = bytearray(b"").startswith(bytearray(b""))
+    print("empty bytearray.startswith(bytearray(b'')): {result}")
+    return result == True
 
-    if ba.strip() != bytearray(b""):
-        raise ValueError("bytearray.strip() failed: " + str(ba.strip()))
+def test_empty_bytearray_strip():
+    result = bytearray(b"").strip()
+    print("empty bytearray.strip(): {result}")
+    return result == bytearray(b"")
 
-    if ba.upper() != bytearray(b""):
-        raise ValueError("bytearray.upper() failed: " + str(ba.upper()))
+def test_empty_bytearray_upper():
+    result = bytearray(b"").upper()
+    print("empty bytearray.upper(): {result}")
+    return result == bytearray(b"")
 
-    if ba.zfill(5) != bytearray(b"00000"):
-        raise ValueError("bytearray.zfill() failed: " + str(ba.zfill(5)))
-
-    return True
+def test_empty_bytearray_zfill():
+    result = bytearray(b"").zfill(5)
+    print("empty bytearray.zfill(5): {result}")
+    return result == bytearray(b"00000")
 
 def test_bytearray_startswith_same_length():
-    # Test case for the bug: same length strings
-    ba1 = bytearray(b"foo")
-    if not ba1.startswith(bytearray(b"foo")):
-        raise ValueError("bytearray.startswith() failed: bytearray(b'foo').startswith(bytearray(b'foo')) returned False")
-    return True
+    result = bytearray(b"foo").startswith(bytearray(b"foo"))
+    print("bytearray(b'foo').startswith(bytearray(b'foo')): {result}")
+    return result == True
 
 def test_bytearray_startswith_prefix():
-    # Test normal prefix matching
-    ba2 = bytearray(b"hello world")
-    if not ba2.startswith(bytearray(b"hello")):
-        raise ValueError("bytearray.startswith() failed: bytearray(b'hello world').startswith(bytearray(b'hello')) returned False")
-    return True
+    result = bytearray(b"hello world").startswith(bytearray(b"hello"))
+    print("bytearray(b'hello world').startswith(bytearray(b'hello')): {result}")
+    return result == True
 
 def test_bytearray_startswith_not_prefix():
-    # Test that non-prefix returns False
-    ba2 = bytearray(b"hello world")
-    if ba2.startswith(bytearray(b"world")):
-        raise ValueError("bytearray.startswith() failed: bytearray(b'hello world').startswith(bytearray(b'world')) returned True")
-    return True
+    result = bytearray(b"hello world").startswith(bytearray(b"world"))
+    print("bytearray(b'hello world').startswith(bytearray(b'world')): {result}")
+    return result == False
 
 def test_bytearray_startswith_empty():
-    # Test empty prefix
-    ba2 = bytearray(b"hello world")
-    if not ba2.startswith(bytearray(b"")):
-        raise ValueError("bytearray.startswith() failed: empty prefix should always return True")
-    return True
+    result = bytearray(b"hello world").startswith(bytearray(b""))
+    print("bytearray(b'hello world').startswith(bytearray(b'')): {result}")
+    return result == True
 
 def test_bytearray_startswith_single_char():
-    # Test with single character
-    if not bytearray(b"a").startswith(bytearray(b"a")):
-        raise ValueError("bytearray.startswith() failed: bytearray(b'a').startswith(bytearray(b'a')) returned False")
-    return True
+    result = bytearray(b"a").startswith(bytearray(b"a"))
+    print("bytearray(b'a').startswith(bytearray(b'a')): {result}")
+    return result == True
 
 def test_bytearray_startswith_longer_prefix():
-    # Test longer prefix than string
-    if bytearray(b"foo").startswith(bytearray(b"foobar")):
-        raise ValueError("bytearray.startswith() failed: prefix longer than string returned True")
-    return True
+    result = bytearray(b"foo").startswith(bytearray(b"foobar"))
+    print("bytearray(b'foo').startswith(bytearray(b'foobar')): {result}")
+    return result == False
 
-def test_hex_methods():
-    # Test hex encoding/decoding
+def test_empty_bytearray_hex():
+    result = bytearray(b"\xde\xad\xbe\xef").hex()
+    print("empty bytearray.hex(): '{result}'")
+    return result == "deadbeef"
+
+def test_empty_bytearray_from_hex():
+    result = bytearray.from_hex("deadbeef").hex()
+    print("empty bytearray.from_hex(''): {result}")
+    return result == "deadbeef"
+
+def test_bytearray_hex():
     ba = bytearray(b"\xde\xad\xbe\xef")
-    if ba.hex() != "deadbeef":
-        raise ValueError("bytearray.hex() failed: " + ba.hex())
+    result = ba.hex()
+    print("bytearray.hex(): {result}")
+    return result == "deadbeef"
 
-    if bytearray.from_hex("deadbeef").hex() != "deadbeef":
-        raise ValueError("bytearray.from_hex() failed: " + bytearray.from_hex("deadbeef").hex())
-    return True
+def test_bytearray_from_hex():
+    result = bytearray.from_hex("deadbeef").hex()
+    print("bytearray.from_hex('deadbeef').hex(): {result}")
+    return result == "deadbeef"
 
 tests = {
-    "test_bytearray_basic": test_bytearray_basic,
+    "test_bytearray_basic_len": test_bytearray_basic_len,
+    "test_bytearray_basic_indexing": test_bytearray_basic_indexing,
+    "test_bytearray_basic_modification": test_bytearray_basic_modification,
+    "test_bytearray_basic_slicing": test_bytearray_basic_slicing,
     "test_bytearray_find": test_bytearray_find,
-    "test_bytearray_sequence_methods": test_bytearray_sequence_methods,
+    "test_bytearray_append": test_bytearray_append,
+    "test_bytearray_insert": test_bytearray_insert,
+    "test_bytearray_reverse": test_bytearray_reverse,
+    "test_empty_bytearray_capitalize": test_empty_bytearray_capitalize,
+    "test_empty_bytearray_center": test_empty_bytearray_center,
+    "test_empty_bytearray_count": test_empty_bytearray_count,
+    "test_empty_bytearray_decode": test_empty_bytearray_decode,
+    "test_empty_bytearray_endswith": test_empty_bytearray_endswith,
+    "test_empty_bytearray_expandtabs": test_empty_bytearray_expandtabs,
+    "test_empty_bytearray_find": test_empty_bytearray_find,
+    "test_empty_bytearray_index": test_empty_bytearray_index,
+    "test_empty_bytearray_isalnum": test_empty_bytearray_isalnum,
+    "test_empty_bytearray_isalpha": test_empty_bytearray_isalpha,
+    "test_empty_bytearray_isascii": test_empty_bytearray_isascii,
+    "test_empty_bytearray_isdigit": test_empty_bytearray_isdigit,
+    "test_empty_bytearray_islower": test_empty_bytearray_islower,
+    "test_empty_bytearray_isspace": test_empty_bytearray_isspace,
+    "test_empty_bytearray_istitle": test_empty_bytearray_istitle,
+    "test_empty_bytearray_isupper": test_empty_bytearray_isupper,
+    "test_empty_bytearray_join": test_empty_bytearray_join,
+    "test_empty_bytearray_ljust": test_empty_bytearray_ljust,
+    "test_empty_bytearray_lower": test_empty_bytearray_lower,
+    "test_empty_bytearray_lstrip": test_empty_bytearray_lstrip,
+    "test_empty_bytearray_partition": test_empty_bytearray_partition,
+    "test_empty_bytearray_replace": test_empty_bytearray_replace,
+    "test_empty_bytearray_replace_empty": test_empty_bytearray_replace_empty,
+    "test_empty_bytearray_rfind": test_empty_bytearray_rfind,
+    "test_empty_bytearray_rindex": test_empty_bytearray_rindex,
+    "test_empty_bytearray_rjust": test_empty_bytearray_rjust,
+    "test_empty_bytearray_rpartition": test_empty_bytearray_rpartition,
+    "test_empty_bytearray_rstrip": test_empty_bytearray_rstrip,
+    "test_empty_bytearray_split": test_empty_bytearray_split,
+    "test_empty_bytearray_splitlines": test_empty_bytearray_splitlines,
+    "test_empty_bytearray_startswith": test_empty_bytearray_startswith,
+    "test_empty_bytearray_strip": test_empty_bytearray_strip,
+    "test_empty_bytearray_upper": test_empty_bytearray_upper,
+    "test_empty_bytearray_zfill": test_empty_bytearray_zfill,
+    "test_empty_bytearray_hex": test_empty_bytearray_hex,
+    "test_empty_bytearray_from_hex": test_empty_bytearray_from_hex,
     "test_bytearray_startswith_same_length": test_bytearray_startswith_same_length,
     "test_bytearray_startswith_prefix": test_bytearray_startswith_prefix,
     "test_bytearray_startswith_not_prefix": test_bytearray_startswith_not_prefix,
     "test_bytearray_startswith_empty": test_bytearray_startswith_empty,
     "test_bytearray_startswith_single_char": test_bytearray_startswith_single_char,
     "test_bytearray_startswith_longer_prefix": test_bytearray_startswith_longer_prefix,
-    "test_empty_bytearray_methods": test_empty_bytearray_methods,
-    "test_hex_methods": test_hex_methods,
+    "test_bytearray_hex": test_bytearray_hex,
+    "test_bytearray_from_hex": test_bytearray_from_hex,
 }
 
 actor main(env):
     failed = []
     for name, t in tests.items():
         print("== test: " + name)
-        try:
-            if not t():
-                print("-- FAILED test: " + name)
-                failed.append(name)
-        except Exception as e:
-            print("-- FAILED test: " + name + " with exception: " + str(e))
+        if not t():
+            print("-- FAILED test: " + name)
             failed.append(name)
         print()
-
     if len(failed) == 0:
         print("All {len(tests)} tests OK!")
     else:
         print("\n{len(failed)} of {len(tests)} tests failed:")
         for name in failed:
             print(" - {name}")
-
     env.exit(max([0, min([len(failed), 1])]))

--- a/test/builtins_auto/test_bytes.act
+++ b/test/builtins_auto/test_bytes.act
@@ -1,202 +1,306 @@
+def test_bytes_basic_len():
+    b = b"hello, world!"
+    result = len(b)
+    print("len(b'hello, world!'): {result}")
+    return result == 13
+
+def test_bytes_basic_indexing():
+    b = b"hello, world!"
+    result = b[0]
+    print("b'hello, world!'[0]: {result}")
+    return result == 104  # ASCII 'h'
+
+def test_bytes_basic_slicing():
+    b = b"hello, world!"
+    result = b[0:5]
+    print("b'hello, world!'[0:5]: {result}")
+    return result == b"hello"
+
 def test_bytes_find():
     b = b"hello, world!"
-    if b.find(b"world") != 7:
-        raise ValueError("find() did not return the correct index: " + str(b.find(b"world")))
-    if b.find(b"world", 0) != 7:
-        raise ValueError("find() did not return the correct index: " + str(b.find(b"world")))
-    if b.find(b"world", 8) != -1:
-        raise ValueError("find() did not return -1 when the substring is not found")
-    if b.find(b"world", 0, 5) != -1:
-        raise ValueError("find() did not return -1 when the substring is not found")
-    if b.find(b"world", 0, 7) != -1:
-        raise ValueError("find() did not return -1 when the substring is not found")
-    if b.find(b"crap") != -1:
-        raise ValueError("find() did not return -1 when the substring is not found")
-    return True
+    print("Testing bytes.find()")
+    return (b.find(b"hello, world!") == 0 and
+            b.find(b"world") == 7 and
+            b.find(b"world", 0) == 7 and
+            b.find(b"world", 8) == -1 and
+            b.find(b"world", 0, 5) == -1 and
+            b.find(b"world", 0, 7) == -1 and
+            b.find(b"crap") == -1)
 
+def test_empty_bytes_capitalize():
+    result = b"".capitalize()
+    print("empty bytes.capitalize(): {result}")
+    return result == b""
+
+def test_empty_bytes_center():
+    result = b"".center(5)
+    print("empty bytes.center(5): {result}")
+    return result == b"     "
+
+def test_empty_bytes_count():
+    result = b"".count(b"a")
+    print("empty bytes.count(b'a'): {result}")
+    return result == 0
+
+def test_empty_bytes_decode():
+    result = b"".decode()
+    print("empty bytes.decode(): '{result}'")
+    return result == ""
+
+def test_empty_bytes_endswith():
+    result = b"".endswith(b"")
+    print("empty bytes.endswith(b''): {result}")
+    return result == True
+
+def test_empty_bytes_expandtabs():
+    result = b"".expandtabs()
+    print("empty bytes.expandtabs(): {result}")
+    return result == b""
+
+def test_empty_bytes_find():
+    result = b"".find(b"a")
+    print("empty bytes.find(b'a'): {result}")
+    return result == -1
+
+def test_empty_bytes_index():
+    print("empty bytes.index(b'a'): testing exception")
+    try:
+        b"".index(b"a")
+        return False
+    except ValueError:
+        return True
+
+def test_empty_bytes_isalnum():
+    result = b"".isalnum()
+    print("empty bytes.isalnum(): {result}")
+    return result == False
+
+def test_empty_bytes_isalpha():
+    result = b"".isalpha()
+    print("empty bytes.isalpha(): {result}")
+    return result == False
+
+def test_empty_bytes_isascii():
+    result = b"".isascii()
+    print("empty bytes.isascii(): {result}")
+    return result == True
+
+def test_empty_bytes_isdigit():
+    result = b"".isdigit()
+    print("empty bytes.isdigit(): {result}")
+    return result == False
+
+def test_empty_bytes_islower():
+    result = b"".islower()
+    print("empty bytes.islower(): {result}")
+    return result == False
+
+def test_empty_bytes_isspace():
+    result = b"".isspace()
+    print("empty bytes.isspace(): {result}")
+    return result == False
+
+def test_empty_bytes_istitle():
+    result = b"".istitle()
+    print("empty bytes.istitle(): {result}")
+    return result == False
+
+def test_empty_bytes_isupper():
+    result = b"".isupper()
+    print("empty bytes.isupper(): {result}")
+    return result == False
+
+def test_empty_bytes_join():
+    result = b"".join([b"a", b"b", b"c"])
+    print("empty bytes.join([b'a', b'b', b'c']): {result}")
+    return result == b"abc"
+
+def test_empty_bytes_ljust():
+    result = b"".ljust(5)
+    print("empty bytes.ljust(5): {result}")
+    return result == b"     "
+
+def test_empty_bytes_lower():
+    result = b"".lower()
+    print("empty bytes.lower(): {result}")
+    return result == b""
+
+def test_empty_bytes_lstrip():
+    result = b"".lstrip()
+    print("empty bytes.lstrip(): {result}")
+    return result == b""
+
+def test_empty_bytes_partition():
+    sp = b"".partition(b"a")
+    print("empty bytes.partition(b'a'): ({sp.0}, {sp.1}, {sp.2})")
+    return sp.0 == b"" and sp.1 == b"" and sp.2 == b""
+
+def test_empty_bytes_replace():
+    result = b"".replace(b"a", b"b")
+    print("empty bytes.replace(b'a', b'b'): {result}")
+    return result == b""
+
+def test_empty_bytes_replace_empty():
+    result = b"".replace(b"", b"")
+    print("empty bytes.replace(b'', b''): {result}")
+    return result == b""
+
+def test_empty_bytes_rfind():
+    result = b"".rfind(b"a")
+    print("empty bytes.rfind(b'a'): {result}")
+    return result == -1
+
+def test_empty_bytes_rindex():
+    print("empty bytes.rindex(b'a'): testing exception")
+    try:
+        b"".rindex(b"a")
+        return False
+    except ValueError:
+        return True
+
+def test_empty_bytes_rjust():
+    result = b"".rjust(5)
+    print("empty bytes.rjust(5): {result}")
+    return result == b"     "
+
+def test_empty_bytes_rpartition():
+    sp = b"".rpartition(b"a")
+    print("empty bytes.rpartition(b'a'): ({sp.0}, {sp.1}, {sp.2})")
+    return sp.0 == b"" and sp.1 == b"" and sp.2 == b""
+
+def test_empty_bytes_rstrip():
+    result = b"".rstrip()
+    print("empty bytes.rstrip(): {result}")
+    return result == b""
+
+def test_empty_bytes_split():
+    result = b"".split(b"a")
+    print("empty bytes.split(b'a'): {result}")
+    return result == [b""]
+
+def test_empty_bytes_splitlines():
+    result = b"".splitlines()
+    print("empty bytes.splitlines(): {result}")
+    return result == []
+
+def test_empty_bytes_startswith():
+    result = b"".startswith(b"")
+    print("empty bytes.startswith(b''): {result}")
+    return result == True
+
+def test_empty_bytes_strip():
+    result = b"".strip()
+    print("empty bytes.strip(): {result}")
+    return result == b""
+
+def test_empty_bytes_upper():
+    result = b"".upper()
+    print("empty bytes.upper(): {result}")
+    return result == b""
+
+def test_empty_bytes_zfill():
+    result = b"".zfill(5)
+    print("empty bytes.zfill(5): {result}")
+    return result == b"00000"
+
+def test_empty_bytes_hex():
+    result = b"".hex()
+    print("empty bytes.hex(): '{result}'")
+    return result == ""
+
+def test_empty_bytes_from_hex():
+    result = bytes.from_hex("")
+    print("empty bytes.from_hex(''): {result}")
+    return result == b""
 
 def test_bytes_startswith_same_length():
-    # Test case for the bug: same length strings
-    b1 = b"foo"
-    if not b1.startswith(b"foo"):
-        raise ValueError("bytes.startswith() failed: b'foo'.startswith(b'foo') returned False")
-    return True
+    result = b"foo".startswith(b"foo")
+    print("b'foo'.startswith(b'foo'): {result}")
+    return result == True
 
 def test_bytes_startswith_prefix():
-    # Test normal prefix matching
-    b2 = b"hello world"
-    if not b2.startswith(b"hello"):
-        raise ValueError("bytes.startswith() failed: b'hello world'.startswith(b'hello') returned False")
-    return True
+    result = b"hello world".startswith(b"hello")
+    print("b'hello world'.startswith(b'hello'): {result}")
+    return result == True
 
 def test_bytes_startswith_not_prefix():
-    # Test that non-prefix returns False
-    b2 = b"hello world"
-    if b2.startswith(b"world"):
-        raise ValueError("bytes.startswith() failed: b'hello world'.startswith(b'world') returned True")
-    return True
+    result = b"hello world".startswith(b"world")
+    print("b'hello world'.startswith(b'world'): {result}")
+    return result == False
 
 def test_bytes_startswith_empty():
-    # Test empty prefix
-    b2 = b"hello world"
-    if not b2.startswith(b""):
-        raise ValueError("bytes.startswith() failed: empty prefix should always return True")
-    return True
+    result = b"hello world".startswith(b"")
+    print("b'hello world'.startswith(b''): {result}")
+    return result == True
 
 def test_bytes_startswith_single_char():
-    # Test with single character
-    if not b"a".startswith(b"a"):
-        raise ValueError("bytes.startswith() failed: b'a'.startswith(b'a') returned False")
-    return True
+    result = b"a".startswith(b"a")
+    print("b'a'.startswith(b'a'): {result}")
+    return result == True
 
 def test_bytes_startswith_longer_prefix():
-    # Test longer prefix than string
-    if b"foo".startswith(b"foobar"):
-        raise ValueError("bytes.startswith() failed: prefix longer than string returned True")
-    return True
-
-
-def test_empty_bytes_methods():
-    b = b""
-
-    # Test all bytes methods with empty bytes
-    if b.capitalize() != b"":
-        raise ValueError("bytes.capitalize() failed: " + str(b.capitalize()))
-
-    if b.center(5) != b"     ":
-        raise ValueError("bytes.center() failed: " + str(b.center(5)))
-
-    if b.count(b"a") != 0:
-        raise ValueError("bytes.count() failed: " + str(b.count(b"a")))
-
-    if b.decode() != "":
-        raise ValueError("bytes.decode() failed: " + str(b.decode()))
-
-    if b.endswith(b"") != True:
-        raise ValueError("bytes.endswith() failed: " + str(b.endswith(b"")))
-
-    if b.expandtabs() != b"":
-        raise ValueError("bytes.expandtabs() failed: " + str(b.expandtabs()))
-
-    if b.find(b"a") != -1:
-        raise ValueError("bytes.find() failed: " + str(b.find(b"a")))
-
-    try:
-        b.index(b"a")
-        raise ValueError("bytes.index() didn't raise ValueError")
-    except ValueError:
-        pass
-
-    if b.isalnum() != False:
-        raise ValueError("bytes.isalnum() failed: " + str(b.isalnum()))
-
-    if b.isalpha() != False:
-        raise ValueError("bytes.isalpha() failed: " + str(b.isalpha()))
-
-    if b.isascii() != True:
-        raise ValueError("bytes.isascii() failed: " + str(b.isascii()))
-
-    if b.isdigit() != False:
-        raise ValueError("bytes.isdigit() failed: " + str(b.isdigit()))
-
-    if b.islower() != False:
-        raise ValueError("bytes.islower() failed: " + str(b.islower()))
-
-    if b.isspace() != False:
-        raise ValueError("bytes.isspace() failed: " + str(b.isspace()))
-
-    if b.istitle() != False:
-        raise ValueError("bytes.istitle() failed: " + str(b.istitle()))
-
-    if b.isupper() != False:
-        raise ValueError("bytes.isupper() failed: " + str(b.isupper()))
-
-    if b.join([b"a", b"b", b"c"]) != b"abc":
-        raise ValueError("bytes.join() failed: " + str(b.join([b"a", b"b", b"c"])))
-
-    if b.ljust(5) != b"     ":
-        raise ValueError("bytes.ljust() failed: " + str(b.ljust(5)))
-
-    if b.lower() != b"":
-        raise ValueError("bytes.lower() failed: " + str(b.lower()))
-
-    if b.lstrip() != b"":
-        raise ValueError("bytes.lstrip() failed: " + str(b.lstrip()))
-
-    sp = b.partition(b"a")
-    if sp.0 != b"" or sp.1 != b"" or sp.2 != b"":
-        sp = b.partition(b"a")
-        raise ValueError("bytes.partition() failed: " + str(sp.0) + str(sp.1) + str(sp.2))
-
-    if b.replace(b"a", b"b") != b"":
-        raise ValueError("bytes.replace() failed: " + str(b.replace(b"a", b"b")))
-
-    if b.rfind(b"a") != -1:
-        raise ValueError("bytes.rfind() failed: " + str(b.rfind(b"a")))
-
-    try:
-        b.rindex(b"a")
-        raise ValueError("bytes.rindex() didn't raise ValueError")
-    except ValueError:
-        pass
-
-    if b.rjust(5) != b"     ":
-        raise ValueError("bytes.rjust() failed: " + str(b.rjust(5)))
-
-    sp = b.rpartition(b"a")
-    if sp.0 != b"" or sp.1 != b"" or sp.2 != b"":
-        sp = b.rpartition(b"a")
-        raise ValueError("bytes.rpartition() failed: " + str(sp.0) + str(sp.1) + str(sp.2))
-
-    if b.rstrip() != b"":
-        raise ValueError("bytes.rstrip() failed: " + str(b.rstrip()))
-
-    if b.split(b"a") != [b""]:
-        raise ValueError("bytes.split() failed: " + str(b.split(b"a")))
-
-    if b.splitlines() != []:
-        raise ValueError("bytes.splitlines() failed: " + str(b.splitlines()))
-
-    if b.startswith(b"") != True:
-        raise ValueError("bytes.startswith() failed: " + str(b.startswith(b"")))
-
-    if b.strip() != b"":
-        raise ValueError("bytes.strip() failed: " + str(b.strip()))
-
-    if b.upper() != b"":
-        raise ValueError("bytes.upper() failed: " + str(b.upper()))
-
-    if b.zfill(5) != b"00000":
-        raise ValueError("bytes.zfill() failed: " + str(b.zfill(5)))
-
-    if b"".hex() != "":
-        raise ValueError("bytes.hex() failed: " + str(b.hex()))
-
-    if bytes.from_hex("") != b"":
-        raise ValueError("bytes.from_hex() failed: " + str(bytes.from_hex("")))
-
-    return True
+    result = b"foo".startswith(b"foobar")
+    print("b'foo'.startswith(b'foobar'): {result}")
+    return result == False
 
 def test_bytes_hex():
     b = b'\xde\xad\xbe\xef'
-    if b.hex() != "deadbeef":
-        raise ValueError("bytes.hex() failed: " + b.hex())
-    return True
+    result = b.hex()
+    print("bytes.hex(): {result}")
+    return result == "deadbeef"
 
 def test_bytes_from_hex():
-    if bytes.from_hex("deadbeef").hex() != "deadbeef":
-        raise ValueError("bytes.from_hex() failed: " + bytes.from_hex("deadbeef").hex())
-    return True
+    result = bytes.from_hex("deadbeef").hex()
+    print("bytes.from_hex('deadbeef').hex(): {result}")
+    return result == "deadbeef"
 
 tests = {
+    "test_bytes_basic_len": test_bytes_basic_len,
+    "test_bytes_basic_indexing": test_bytes_basic_indexing,
+    "test_bytes_basic_slicing": test_bytes_basic_slicing,
     "test_bytes_find": test_bytes_find,
+    "test_empty_bytes_capitalize": test_empty_bytes_capitalize,
+    "test_empty_bytes_center": test_empty_bytes_center,
+    "test_empty_bytes_count": test_empty_bytes_count,
+    "test_empty_bytes_decode": test_empty_bytes_decode,
+    "test_empty_bytes_endswith": test_empty_bytes_endswith,
+    "test_empty_bytes_expandtabs": test_empty_bytes_expandtabs,
+    "test_empty_bytes_find": test_empty_bytes_find,
+    "test_empty_bytes_index": test_empty_bytes_index,
+    "test_empty_bytes_isalnum": test_empty_bytes_isalnum,
+    "test_empty_bytes_isalpha": test_empty_bytes_isalpha,
+    "test_empty_bytes_isascii": test_empty_bytes_isascii,
+    "test_empty_bytes_isdigit": test_empty_bytes_isdigit,
+    "test_empty_bytes_islower": test_empty_bytes_islower,
+    "test_empty_bytes_isspace": test_empty_bytes_isspace,
+    "test_empty_bytes_istitle": test_empty_bytes_istitle,
+    "test_empty_bytes_isupper": test_empty_bytes_isupper,
+    "test_empty_bytes_join": test_empty_bytes_join,
+    "test_empty_bytes_ljust": test_empty_bytes_ljust,
+    "test_empty_bytes_lower": test_empty_bytes_lower,
+    "test_empty_bytes_lstrip": test_empty_bytes_lstrip,
+    "test_empty_bytes_partition": test_empty_bytes_partition,
+    "test_empty_bytes_replace": test_empty_bytes_replace,
+    "test_empty_bytes_replace_empty": test_empty_bytes_replace_empty,
+    "test_empty_bytes_rfind": test_empty_bytes_rfind,
+    "test_empty_bytes_rindex": test_empty_bytes_rindex,
+    "test_empty_bytes_rjust": test_empty_bytes_rjust,
+    "test_empty_bytes_rpartition": test_empty_bytes_rpartition,
+    "test_empty_bytes_rstrip": test_empty_bytes_rstrip,
+    "test_empty_bytes_split": test_empty_bytes_split,
+    "test_empty_bytes_splitlines": test_empty_bytes_splitlines,
+    "test_empty_bytes_startswith": test_empty_bytes_startswith,
+    "test_empty_bytes_strip": test_empty_bytes_strip,
+    "test_empty_bytes_upper": test_empty_bytes_upper,
+    "test_empty_bytes_zfill": test_empty_bytes_zfill,
+    "test_empty_bytes_hex": test_empty_bytes_hex,
+    "test_empty_bytes_from_hex": test_empty_bytes_from_hex,
     "test_bytes_startswith_same_length": test_bytes_startswith_same_length,
     "test_bytes_startswith_prefix": test_bytes_startswith_prefix,
     "test_bytes_startswith_not_prefix": test_bytes_startswith_not_prefix,
     "test_bytes_startswith_empty": test_bytes_startswith_empty,
     "test_bytes_startswith_single_char": test_bytes_startswith_single_char,
     "test_bytes_startswith_longer_prefix": test_bytes_startswith_longer_prefix,
-    "test_empty_bytes_methods": test_empty_bytes_methods,
     "test_bytes_hex": test_bytes_hex,
     "test_bytes_from_hex": test_bytes_from_hex,
 }
@@ -205,20 +309,14 @@ actor main(env):
     failed = []
     for name, t in tests.items():
         print("== test: " + name)
-        try:
-            if not t():
-                print("-- FAILED test: " + name)
-                failed.append(name)
-        except Exception as e:
-            print("-- FAILED test: " + name + " with exception: " + str(e))
+        if not t():
+            print("-- FAILED test: " + name)
             failed.append(name)
         print()
-
     if len(failed) == 0:
         print("All {len(tests)} tests OK!")
     else:
         print("\n{len(failed)} of {len(tests)} tests failed:")
         for name in failed:
             print(" - {name}")
-
     env.exit(max([0, min([len(failed), 1])]))

--- a/test/builtins_auto/test_bytes.act
+++ b/test/builtins_auto/test_bytes.act
@@ -12,6 +12,48 @@ def test_bytes_find():
         raise ValueError("find() did not return -1 when the substring is not found")
     if b.find(b"crap") != -1:
         raise ValueError("find() did not return -1 when the substring is not found")
+    return True
+
+
+def test_bytes_startswith_same_length():
+    # Test case for the bug: same length strings
+    b1 = b"foo"
+    if not b1.startswith(b"foo"):
+        raise ValueError("bytes.startswith() failed: b'foo'.startswith(b'foo') returned False")
+    return True
+
+def test_bytes_startswith_prefix():
+    # Test normal prefix matching
+    b2 = b"hello world"
+    if not b2.startswith(b"hello"):
+        raise ValueError("bytes.startswith() failed: b'hello world'.startswith(b'hello') returned False")
+    return True
+
+def test_bytes_startswith_not_prefix():
+    # Test that non-prefix returns False
+    b2 = b"hello world"
+    if b2.startswith(b"world"):
+        raise ValueError("bytes.startswith() failed: b'hello world'.startswith(b'world') returned True")
+    return True
+
+def test_bytes_startswith_empty():
+    # Test empty prefix
+    b2 = b"hello world"
+    if not b2.startswith(b""):
+        raise ValueError("bytes.startswith() failed: empty prefix should always return True")
+    return True
+
+def test_bytes_startswith_single_char():
+    # Test with single character
+    if not b"a".startswith(b"a"):
+        raise ValueError("bytes.startswith() failed: b'a'.startswith(b'a') returned False")
+    return True
+
+def test_bytes_startswith_longer_prefix():
+    # Test longer prefix than string
+    if b"foo".startswith(b"foobar"):
+        raise ValueError("bytes.startswith() failed: prefix longer than string returned True")
+    return True
 
 
 def test_empty_bytes_methods():
@@ -126,29 +168,57 @@ def test_empty_bytes_methods():
 
     if b.zfill(5) != b"00000":
         raise ValueError("bytes.zfill() failed: " + str(b.zfill(5)))
-        
+
     if b"".hex() != "":
         raise ValueError("bytes.hex() failed: " + str(b.hex()))
 
     if bytes.from_hex("") != b"":
         raise ValueError("bytes.from_hex() failed: " + str(bytes.from_hex("")))
 
-actor main(env):
-    try:
-        test_bytes_find()
-        test_empty_bytes_methods()
-    except Exception as e:
-        print("Unexpected exception during testing:", e)
-        await async env.exit(1)
+    return True
 
-    # Test bytes.hex() and bytes.from_hex()
+def test_bytes_hex():
     b = b'\xde\xad\xbe\xef'
     if b.hex() != "deadbeef":
-        print("ERROR: bytes.hex():", b.hex())
-        env.exit(1)
+        raise ValueError("bytes.hex() failed: " + b.hex())
+    return True
 
+def test_bytes_from_hex():
     if bytes.from_hex("deadbeef").hex() != "deadbeef":
-        print("ERROR: bytes.from_hex():", bytes.from_hex("deadbeef").hex())
-        env.exit(1)
+        raise ValueError("bytes.from_hex() failed: " + bytes.from_hex("deadbeef").hex())
+    return True
 
-    env.exit(0)
+tests = {
+    "test_bytes_find": test_bytes_find,
+    "test_bytes_startswith_same_length": test_bytes_startswith_same_length,
+    "test_bytes_startswith_prefix": test_bytes_startswith_prefix,
+    "test_bytes_startswith_not_prefix": test_bytes_startswith_not_prefix,
+    "test_bytes_startswith_empty": test_bytes_startswith_empty,
+    "test_bytes_startswith_single_char": test_bytes_startswith_single_char,
+    "test_bytes_startswith_longer_prefix": test_bytes_startswith_longer_prefix,
+    "test_empty_bytes_methods": test_empty_bytes_methods,
+    "test_bytes_hex": test_bytes_hex,
+    "test_bytes_from_hex": test_bytes_from_hex,
+}
+
+actor main(env):
+    failed = []
+    for name, t in tests.items():
+        print("== test: " + name)
+        try:
+            if not t():
+                print("-- FAILED test: " + name)
+                failed.append(name)
+        except Exception as e:
+            print("-- FAILED test: " + name + " with exception: " + str(e))
+            failed.append(name)
+        print()
+
+    if len(failed) == 0:
+        print("All {len(tests)} tests OK!")
+    else:
+        print("\n{len(failed)} of {len(tests)} tests failed:")
+        for name in failed:
+            print(" - {name}")
+
+    env.exit(max([0, min([len(failed), 1])]))

--- a/test/builtins_auto/test_str.act
+++ b/test/builtins_auto/test_str.act
@@ -199,6 +199,36 @@ def test_str_contains():
     print("'hello, world!' in 'hello, world!': {result}")
     return result == True
 
+def test_str_startswith_same_length():
+    result = "hello world".startswith("hello world")
+    print("'hello world'.startswith('hello world'): {result}")
+    return result == True
+
+def test_str_startswith_prefix():
+    result = "hello world".startswith("hello")
+    print("'hello world'.startswith('hello'): {result}")
+    return result == True
+
+def test_str_startswith_not_prefix():
+    result = "hello world".startswith("world")
+    print("'hello world'.startswith('world'): {result}")
+    return result == False
+
+def test_str_startswith_empty():
+    result = "hello world".startswith("")
+    print("'hello world'.startswith(''): {result}")
+    return result == True
+
+def test_str_startswith_single_char():
+    result = "a".startswith("a")
+    print("'a'.startswith('a'): {result}")
+    return result == True
+
+def test_str_startswith_longer_prefix():
+    result = "foo".startswith("foobar")
+    print("'foo'.startswith('foobar'): {result}")
+    return result == False
+
 def test_bytes_hex():
     b = b'\xde\xad\xbe\xef'
     result = b.hex()
@@ -271,6 +301,12 @@ tests = {
     "test_empty_str_zfill": test_empty_str_zfill,
     "test_endswith": test_endswith,
     "test_str_contains": test_str_contains,
+    "test_str_startswith_same_length": test_str_startswith_same_length,
+    "test_str_startswith_prefix": test_str_startswith_prefix,
+    "test_str_startswith_not_prefix": test_str_startswith_not_prefix,
+    "test_str_startswith_empty": test_str_startswith_empty,
+    "test_str_startswith_single_char": test_str_startswith_single_char,
+    "test_str_startswith_longer_prefix": test_str_startswith_longer_prefix,
     "test_bytes_hex": test_bytes_hex,
     "test_bytes_from_hex": test_bytes_from_hex,
     "test_helloworld": test_helloworld,


### PR DESCRIPTION
bytes.startswith() wouldn't recognize equality when the needle is the same length as the total haystack, i.e. `b"foo".startswith(b"foo")` would return `False`. It's now fixed!

Same issue for bytearray and the same fix. There are a handful of new tests for covering .startswith(). In addition the test_bytes.act and test_bytearray.act modules have been restructured and aligned on the test style we have in some other builtin test styles. Small simple functions for each test with a bool return value and not much else. Simple!

Fixes #2399 