### PR TITLE
Remove stub compilation mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -370,7 +370,7 @@ dist/backend%: backend/%
 dist/base: base base/.build base/__root.zig base/acton.zig base/build.zig base/build.zig.zon base/acton.zig dist/bin/actonc $(DEPS)
 	mkdir -p $@ $@/.build $@/out
 	cp -a base/__root.zig base/Acton.toml base/acton.zig base/build.zig base/build.zig.zon base/builtin base/rts base/src dist/base/
-	cd dist/base && ../bin/actonc build --auto-stub && rm -rf .build
+	cd dist/base && ../bin/actonc build && rm -rf .build
 
 # This does a little hack, first copying and then moving the file in place. This
 # is to avoid an error if the executable is currently running. cp tries to open

--- a/cli/src/acton.act
+++ b/cli/src/acton.act
@@ -1494,8 +1494,6 @@ actor main(env):
         p.add_bool("cgen", "Show generated .c code")
         p.add_bool("ccmd", "Show CC / LD command lines")
         p.add_bool("timing", "Show timing information")
-        p.add_bool("auto-stub", "Allow automatica stub detection")
-        p.add_bool("stub", "Stub (.ty) file generation only")
         p.add_bool("cpedantic", "Pedantic C compilation")
         p.add_bool("quiet", "Be quiet")
         p.add_bool("verbose", "Verbose output")

--- a/compiler/lib/src/Acton/CommandLineParser.hs
+++ b/compiler/lib/src/Acton/CommandLineParser.hs
@@ -64,8 +64,6 @@ data CompileOptions   = CompileOptions {
                          cgen        :: Bool,
                          ccmd        :: Bool,
                          ty          :: Bool,
-                         autostub    :: Bool,
-                         stub        :: Bool,
                          cpedantic   :: Bool,
                          optimize    :: OptimizeMode,
                          listimports :: Bool,
@@ -170,8 +168,6 @@ compileOptions = CompileOptions
         <*> switch (long "cgen"         <> help "Show the generated .c code")
         <*> switch (long "ccmd"         <> help "Show CC / LD commands")
         <*> switch (long "ty"           <> help "Write .ty file to src file directory")
-        <*> switch (long "auto-stub"    <> help "Allow automatic stub detection")
-        <*> switch (long "stub"         <> help "Stub (.ty) file generation only")
         <*> switch (long "cpedantic"    <> help "Pedantic C compilation with -Werror")
         <*> optimizeOption
         <*> switch (long "list-imports" <> help "List module imports")

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -51,7 +51,6 @@ data EnvF x                 = EnvF {
                                 modules    :: TEnv,
                                 witnesses  :: [Witness],
                                 thismod    :: Maybe ModName,
-                                stub       :: Bool,
                                 envX       :: x }
 
 type Env0                   = EnvF ()
@@ -59,7 +58,7 @@ type Env0                   = EnvF ()
 
 setX                        :: EnvF y -> x -> EnvF x
 setX env x                  = EnvF { names = names env, imports = imports env, modules = modules env,
-                                     witnesses = witnesses env, thismod = thismod env, stub = stub env,
+                                     witnesses = witnesses env, thismod = thismod env,
                                      envX = x }
 
 modX                        :: EnvF x -> (x -> x) -> EnvF x
@@ -413,7 +412,6 @@ initEnv path True          = return $ EnvF{ names = [(nPrim,NMAlias mPrim)],
                                             modules = [(nPrim,NModule primEnv Nothing)],
                                             witnesses = primWits,
                                             thismod = Nothing,
-                                            stub = False,
                                             envX = () }
 initEnv path False         = do (_,nmod) <- InterfaceFiles.readFile (joinPath [path,"__builtin__.ty"])
                                 let NModule envBuiltin builtinDocstring = nmod
@@ -422,7 +420,6 @@ initEnv path False         = do (_,nmod) <- InterfaceFiles.readFile (joinPath [p
                                                  modules = [(nPrim,NModule primEnv Nothing), (nBuiltin,NModule envBuiltin builtinDocstring)],
                                                  witnesses = primWits,
                                                  thismod = Nothing,
-                                                 stub = False,
                                                  envX = () }
                                     env = importAll mBuiltin envBuiltin $ importWits mBuiltin envBuiltin $ env0
                                 return env

--- a/compiler/lib/src/Acton/Types.hs
+++ b/compiler/lib/src/Acton/Types.hs
@@ -217,7 +217,7 @@ infSuiteEnv env ss                      = do (cs,te,ss') <- infEnv env ss
                                              return (cs, te, ss')
 
 checkSigs env te
-  | stub env || null ns                 = return ()
+  | null ns                            = return ()
   | otherwise                           = err2 ns "Signature lacks subsequent binding"
   where (sigs,terms)                    = sigTerms te
         ns                              = dom sigs \\ dom terms
@@ -869,7 +869,7 @@ instance Check Decl where
                                              checkSelfInActor env1 Nothing (Just p) (Just k)
                                              (csp,te1,p') <- infEnv env1 p
                                              (csk,te2,k') <- infEnv (define te1 env1) k
-                                             (csb,te,b') <- (if stub env then infEnv else infSuiteEnv) (define te2 $ define te1 env1) b
+                                             (csb,te,b') <- infSuiteEnv (define te2 $ define te1 env1) b
                                              (cs0,eq0) <- matchActorAssumption env1 n p' k' te
                                              popFX
                                              (cs1,eq1) <- solveScoped env1 (tvSelf:tvs) te tNone (csp++csk++csb++cs0)


### PR DESCRIPTION
Stub mode was only used for numpy module which has been removed. The new style is to use .ext.c files and NotImplemented in the body of functions rather than the legacy stub mode compilation, so even if we decide to bring back numpy, it will never be using stub mode again. This simplifies the compilation pipeline.

Fixes #2411