### PR TITLE
Rename Exception.error_message -> .msg

### DIFF
--- a/base/src/__builtin__.act
+++ b/base/src/__builtin__.act
@@ -341,18 +341,19 @@ class Msg[A] (value):
 
 ## Exceptions ##################################################################################
 
-# All exceptions should have a human readable error in the error_message field.
+# All exceptions should have a human readable error in the msg field.
 # It is generally set by the constructor for each exception class that inherits
 # from BaseException to something appropriate for that particular exception. It
 # is also a common convention to accept a message as an argument to the
 # constructor, which can be used to override the default message.
 class BaseException (value):
-    error_message: str
+    msg: str
+
     def __init__(self, msg: ?str) -> None:
-        self.error_message = msg if msg is not None else ""
+        self.msg = msg if msg is not None else ""
 
     def __str__(self):
-        return f"{self._name()}: {self.error_message}"
+        return f"{self._name()}: {self.msg}"
 
     def _name(self) -> str:
         NotImplemented
@@ -378,18 +379,18 @@ class LookupError (Exception):
 class IndexError (LookupError):
     def __init__(self, index: int, msg: ?str=None):
         self.index = index
-        self.error_message = msg if msg is not None else "List index out of range"
+        self.msg = msg if msg is not None else "List index out of range"
 
     def __str__(self):
-        return f"{self._name()}: {self.error_message}, index: {self.index}"
+        return f"{self._name()}: {self.msg}, index: {self.index}"
 
 class KeyError(LookupError):
     def __init__(self, key: value, msg: ?str=None):
         self.key = key
-        self.error_message = msg if msg is not None else "Key not found"
+        self.msg = msg if msg is not None else "Key not found"
 
     def __str__(self):
-        return f"{self._name()}: {self.error_message}, key: {str(self.key)}"
+        return f"{self._name()}: {self.msg}, key: {str(self.key)}"
 
 class MemoryError (Exception):
     pass

--- a/base/src/argparse.act
+++ b/base/src/argparse.act
@@ -29,10 +29,10 @@ actor main(env):
             print("Following file changes...")
 
     except argparse.PrintUsage as exc:
-        print(exc.error_message)
+        print(exc.msg)
         env.exit(0)
     except argparse.ArgumentError as exc:
-        print(exc.error_message, err=True)
+        print(exc.msg, err=True)
         env.exit(1)
 ```
 

--- a/base/src/testing.act
+++ b/base/src/testing.act
@@ -19,12 +19,12 @@ class NotEqualError[T](AssertionError):
     def __init__(self, a, b, msg: ?str=None, print_vals: bool=True, diff_str: ?str=None):
         self.a = a
         self.b = b
-        self.error_message = msg if msg is not None else "Expected equal values but they are non-equal."
+        self.msg = msg if msg is not None else "Expected equal values but they are non-equal."
         self.print_vals = print_vals
         self.diff_str = diff_str
 
     def __str__(self):
-        msg = f"{self._name()}: {self.error_message}"
+        msg = f"{self._name()}: {self.msg}"
         if self.print_vals:
             msg += f" A: {self.a}"
             msg += f" B: {self.b}"
@@ -40,11 +40,11 @@ class EqualError[T](AssertionError):
     def __init__(self, a, b, msg: ?str=None, print_vals: bool=True):
         self.a = a
         self.b = b
-        self.error_message = msg if msg is not None else "Expected non-equal values but they are equal."
+        self.msg = msg if msg is not None else "Expected non-equal values but they are equal."
         self.print_vals = print_vals
 
     def __str__(self):
-        msg = f"{self._name()}: {self.error_message}"
+        msg = f"{self._name()}: {self.msg}"
         if self.print_vals:
             msg += f" A: {self.a}"
             msg += f" B: {self.b}"
@@ -55,11 +55,11 @@ class NotTrueError[T](AssertionError):
 
     def __init__(self, a, msg: ?str=None, print_vals: bool=True):
         self.a = a
-        self.error_message = msg if msg is not None else "Expected True but got non-True"
+        self.msg = msg if msg is not None else "Expected True but got non-True"
         self.print_vals = print_vals
 
     def __str__(self):
-        msg = f"{self._name()}: {self.error_message}"
+        msg = f"{self._name()}: {self.msg}"
         if self.print_vals:
             msg += f", value: {self.a}"
         return msg
@@ -69,11 +69,11 @@ class NotFalseError[T](AssertionError):
 
     def __init__(self, a, msg: ?str=None, print_vals: bool=True):
         self.a = a
-        self.error_message = msg if msg is not None else "Expected False but got non-False."
+        self.msg = msg if msg is not None else "Expected False but got non-False."
         self.print_vals = print_vals
 
     def __str__(self):
-        msg = f"{self._name()}: {self.error_message}"
+        msg = f"{self._name()}: {self.msg}"
         if self.print_vals:
             msg += f", value: {self.a}"
         return msg
@@ -83,11 +83,11 @@ class NotNoneError[T](AssertionError):
 
     def __init__(self, a, msg: ?str=None, print_vals: bool=True):
         self.a = a
-        self.error_message = msg if msg is not None else "Expected None but got non-None."
+        self.msg = msg if msg is not None else "Expected None but got non-None."
         self.print_vals = print_vals
 
     def __str__(self):
-        msg = f"{self._name()}: {self.error_message}"
+        msg = f"{self._name()}: {self.msg}"
         if self.print_vals:
             msg += f", value: {self.a}"
         return msg
@@ -97,11 +97,11 @@ class NoneError[T](AssertionError):
 
     def __init__(self, a, msg: ?str=None, print_vals: bool=True):
         self.a = a
-        self.error_message = msg if msg is not None else "Expected non-None but got None."
+        self.msg = msg if msg is not None else "Expected non-None but got None."
         self.print_vals = print_vals
 
     def __str__(self):
-        msg = f"{self._name()}: {self.error_message}"
+        msg = f"{self._name()}: {self.msg}"
         if self.print_vals:
             a = self.a
             msg += f", value: {a}"
@@ -114,11 +114,11 @@ class NotInError[T,U](AssertionError):
     def __init__(self, a, b, msg: ?str=None, print_vals: bool=True):
         self.a = a
         self.b = b
-        self.error_message = msg if msg is not None else "Expected element not in container"
+        self.msg = msg if msg is not None else "Expected element not in container"
         self.print_vals = print_vals
 
     def __str__(self):
-        msg = f"{self._name()}: {self.error_message}"
+        msg = f"{self._name()}: {self.msg}"
         if self.print_vals:
             msg += f", element: {self.a}"
             msg += f", container: {self.b}"
@@ -131,11 +131,11 @@ class InError[T,U](AssertionError):
     def __init__(self, a, b, msg: ?str=None, print_vals: bool=True):
         self.a = a
         self.b = b
-        self.error_message = msg if msg is not None else "Expected element in container"
+        self.msg = msg if msg is not None else "Expected element in container"
         self.print_vals = print_vals
 
     def __str__(self):
-        msg = f"{self._name()}: {self.error_message}"
+        msg = f"{self._name()}: {self.msg}"
         if self.print_vals:
             msg += f", element: {self.a}"
             msg += f", container: {self.b}"
@@ -148,11 +148,11 @@ class NotIsError[T](AssertionError):
     def __init__(self, a, b, msg: ?str=None, print_vals: bool=True):
         self.a = a
         self.b = b
-        self.error_message = msg if msg is not None else "Expected both objects to be the same identity (is)"
+        self.msg = msg if msg is not None else "Expected both objects to be the same identity (is)"
         self.print_vals = print_vals
 
     def __str__(self):
-        msg = f"{self._name()}: {self.error_message}"
+        msg = f"{self._name()}: {self.msg}"
         if self.print_vals:
             msg += f" A: {str(self.a)}"
             msg += f" B: {str(self.b)}"
@@ -165,11 +165,11 @@ class IsError[T](AssertionError):
     def __init__(self, a, b, msg: ?str=None, print_vals: bool=True):
         self.a = a
         self.b = b
-        self.error_message = msg if msg is not None else "Expected both objects to be different identities (is not)"
+        self.msg = msg if msg is not None else "Expected both objects to be different identities (is not)"
         self.print_vals = print_vals
 
     def __str__(self):
-        msg = f"{self._name()}: {self.error_message}"
+        msg = f"{self._name()}: {self.msg}"
         if self.print_vals:
             msg += f" A: {str(self.a)}"
             msg += f" B: {str(self.b)}"
@@ -177,7 +177,7 @@ class IsError[T](AssertionError):
 
 class NotRaisesError(AssertionError):
     def __init__(self, msg: ?str=None, print_vals: bool=True):
-        self.error_message = msg if msg is not None else "Expected exception not raised"
+        self.msg = msg if msg is not None else "Expected exception not raised"
         self.print_vals = print_vals
 
 class IsInstanceError[T](AssertionError):
@@ -187,7 +187,7 @@ class IsInstanceError[T](AssertionError):
     def __init__(self, a, t: str, msg: ?str=None, print_vals: bool=True):
         self.a = a
         self.t = t
-        self.error_message = msg if msg is not None else "expected type of specific instance"
+        self.msg = msg if msg is not None else "expected type of specific instance"
         self.print_vals = print_vals
 
 class NotIsInstanceError[T](AssertionError):
@@ -197,7 +197,7 @@ class NotIsInstanceError[T](AssertionError):
     def __init__(self, a, t: str, msg: ?str=None, print_vals: bool=True):
         self.a = a
         self.t = t
-        self.error_message = msg if msg is not None else "expected type of specific instance"
+        self.msg = msg if msg is not None else "expected type of specific instance"
 
 
 def assertEqual[T(Eq)](a: ?T, b: ?T, msg: ?str, print_vals: bool=True, print_diff: bool=True):
@@ -1335,8 +1335,8 @@ actor test_runner(env: Env,
     try:
         _parse_args()
     except argparse.PrintUsage as exc:
-        print(exc.error_message)
+        print(exc.msg)
         env.exit(0)
     except argparse.ArgumentError as exc:
-        print(exc.error_message)
+        print(exc.msg)
         env.exit(1)

--- a/cli/src/acton.act
+++ b/cli/src/acton.act
@@ -371,7 +371,7 @@ actor BuildProject(process_cap, env, args, on_build_success: action(str) -> None
         except FileNotFoundError:
             pass
         except ValueError as e:
-            print("ERROR:", e.error_message)
+            print("ERROR:", e.msg)
             env.exit(1)
             return
 
@@ -955,7 +955,7 @@ actor CmdFetch(env, args):
             env.exit(0)
             return
         except ValueError as e:
-            print("ERROR:", e.error_message)
+            print("ERROR:", e.msg)
             env.exit(1)
             return
     _read_build_config()
@@ -993,7 +993,7 @@ actor CmdPkgAdd(env, args):
             # Ignore, we create a new file
             pass
         except ValueError as e:
-            print("ERROR:", e.error_message)
+            print("ERROR:", e.msg)
             await async env.exit(1)
         return BuildConfig()
 
@@ -1106,7 +1106,7 @@ actor CmdPkgUpgrade(env, args):
             # Ignore, we create a new file
             pass
         except ValueError as e:
-            print("ERROR:", e.error_message)
+            print("ERROR:", e.msg)
             await async env.exit(1)
         return BuildConfig()
 
@@ -1161,7 +1161,7 @@ actor CmdPkgUpgrade(env, args):
         if url is not None:
             new_pkg_urls[dep_name] = url
         if err is not None:
-            print("Error fetching ref for %s:" % dep_name, err.error_message)
+            print("Error fetching ref for %s:" % dep_name, err.msg)
         if len(remaining_fetch_ref) == 0:
             _zig_fetch()
 
@@ -1206,7 +1206,7 @@ actor CmdPkgRemove(env, args):
             # Ignore, we create a new file
             pass
         except ValueError as e:
-            print("ERROR:", e.error_message)
+            print("ERROR:", e.msg)
             await async env.exit(1)
         return BuildConfig()
 
@@ -1258,7 +1258,7 @@ actor CmdZigPkgAdd(env, args):
             # Ignore, we create a new file
             pass
         except ValueError as e:
-            print("ERROR:", e.error_message)
+            print("ERROR:", e.msg)
             await async env.exit(1)
         return BuildConfig()
 
@@ -1328,7 +1328,7 @@ actor CmdZigPkgRemove(env, args):
             print("No build.act.json file found, nothing to do.")
             env.exit(0)
         except ValueError as e:
-            print("ERROR:", e.error_message)
+            print("ERROR:", e.msg)
             env.exit(1)
 
     def _remove_zig_pkg(build_config, dep_name):
@@ -1586,8 +1586,8 @@ actor main(env):
             else:
                 env.exit(0)
     except argparse.PrintUsage as exc:
-        print(exc.error_message)
+        print(exc.msg)
         env.exit(0)
     except argparse.ArgumentError as exc:
-        print(exc.error_message)
+        print(exc.msg)
         env.exit(1)

--- a/test/stdlib_auto/test_argparse.act
+++ b/test/stdlib_auto/test_argparse.act
@@ -288,8 +288,8 @@ actor test_help_subcmd():
             args = p.parse(["./app", "build", "--help"])
         except argparse.PrintUsage as e:
             # We want to see the help for the build command
-            if "HAXX" not in e.error_message:
-                raise ValueError("Expected help for build command, got:\n" + e.error_message)
+            if "HAXX" not in e.msg:
+                raise ValueError("Expected help for build command, got:\n{e.msg}")
             return
         raise ValueError("Expected PrintUsage")
     test()


### PR DESCRIPTION
.error_message is just really long and unwieldy so a shorter .msg is a little easier and more natural to work with.