### PR TITLE
Improve XML parse error reporting

### DIFF
--- a/base/src/xml.act
+++ b/base/src/xml.act
@@ -23,6 +23,32 @@ n.text and c.tail for all children of n.
     def encode(self) -> str:
         NotImplemented
 
+class XmlParseError(ValueError):
+    """Exception raised for XML parsing errors
+
+    Attributes:
+        line: The line number where the error occurred (if available)
+        column: The column number where the error occurred (if available)
+    """
+    line: ?int
+    column: ?int
+
+    def __init__(self, msg: ?str, line: ?int=None, column: ?int=None):
+        self.error_message = msg if msg is not None else ""
+        self.line = line
+        self.column = column
+
+    def __str__(self):
+        context = ""
+        if self.line is not None:
+            context += ":{self.line}"
+        if self.column is not None:
+            context += ":{self.column}"
+        return "{self._name()}{context}: {self.error_message}"
+
+    def __repr__(self):
+        return "{self._name()}({repr(self.error_message)}, {repr(self.line)}, {repr(self.column)})"
+
 def decode(data : str) -> Node:
     NotImplemented
 

--- a/base/src/xml.ext.c
+++ b/base/src/xml.ext.c
@@ -20,7 +20,7 @@ xmlQ_Node $NodePtr2Node(xmlNodePtr node) {
     }
     if (node->type != XML_ELEMENT_NODE) {
         char *errmsg = NULL;
-        $RAISE(((B_BaseException)B_RuntimeErrorG_new($FORMAT("Unexpected nodetype %d, content is %s", node->type, node->content))));
+        RAISE(xmlQ_XmlParseError, $FORMAT("Unexpected nodetype %d, content is %s", node->type, node->content), NULL, NULL);
     }
 
     B_list nsdefs = B_listG_new(NULL, NULL);
@@ -74,7 +74,17 @@ xmlQ_Node xmlQ_decode(B_str data) {
     if (!doc) {
         xmlErrorPtr err = xmlGetLastError();
         B_str errmsg;
+        B_int line = NULL;
+        B_int column = NULL;
+
         if (err && err->message) {
+            if (err->line > 0) {
+                line = to$int(err->line);
+            }
+            if (err->int2 > 0) {  // int2 contains the column in libxml2
+                column = to$int(err->int2);
+            }
+
             // Strip trailing whitespace from error message if needed
             int orig_len = strlen(err->message);
             int len = orig_len;
@@ -87,15 +97,15 @@ xmlQ_Node xmlQ_decode(B_str data) {
                 char msg_clean[len + 1];
                 strncpy(msg_clean, err->message, len);
                 msg_clean[len] = '\0';
-                errmsg = $FORMAT("XML parse error: %s", msg_clean);
+                errmsg = to$str(msg_clean);
             } else {
                 // Use original message as-is
-                errmsg = $FORMAT("XML parse error: %s", err->message);
+                errmsg = to$str(err->message);
             }
         } else {
             errmsg = to$str("XML parse error");
         }
-        $RAISE(((B_BaseException)B_RuntimeErrorG_new(errmsg)));
+        RAISE(xmlQ_XmlParseError, errmsg, line, column);
     }
     xmlNodePtr root = xmlDocGetRootElement(doc);
     xmlQ_Node t = $NodePtr2Node(root);

--- a/test/stdlib_tests/src/test_xml.act
+++ b/test/stdlib_tests/src/test_xml.act
@@ -52,3 +52,12 @@ def _test_xml_skip_comment_first():
     d = xml.decode(test_xml)
     e = xml.encode(d)
     testing.assertEqual(e, "<a>woo</a>", "XML str -> data -> XML str (remove comment first)")
+
+def _test_xml_parse_error():
+    test_xml = "<a>garbage"
+    try:
+        xml.decode(test_xml)
+    except xml.XmlParseError as e:
+        testing.assertEqual(e.error_message, "Premature end of data in tag a line 1")
+    else:
+        testing.error("Expected exception on parsing error")


### PR DESCRIPTION
Use xmlGetLastError() to get the last error from libxml2. Strip trailing whitespace from the message if present.

We already get more verbose output from libxml2 on stderr, but this allows us to pass at least some hints about what went wrong via an exception.