### PR TITLE
Fix XML prefixed attribute decoding

### DIFF
--- a/base/src/xml.ext.c
+++ b/base/src/xml.ext.c
@@ -136,7 +136,20 @@ xmlQ_Node $NodePtr2Node(xmlNodePtr node) {
     B_list attributes = B_listG_new(NULL, NULL);
     xmlAttrPtr attr = node->properties;
     while (attr) {
-        wit->$class->append(wit,attributes, $NEWTUPLE(2, to$str((char *)attr->name), to$str((char *)xmlGetProp(node, attr->name))));
+        B_str attr_name;
+        // libxml2 handles namespace prefixes in two ways:
+        // 1. Defined namespaces: attr->ns is set, attr->name has local name only
+        //    e.g., xmlns:ns="http://foo" ns:op="x" -> attr->ns->prefix="ns", attr->name="op"
+        // 2. Undefined namespaces: attr->ns is NULL, attr->name contains the full prefixed name
+        //    e.g., ns:op="x" (no xmlns:ns) -> attr->ns=NULL, attr->name="ns:op"
+        if (attr->ns && attr->ns->prefix) {
+            // Reconstruct prefixed name for defined namespace
+            attr_name = $FORMAT("%s:%s", attr->ns->prefix, attr->name);
+        } else {
+            // Use name as-is (either unprefixed or undefined prefix already in name)
+            attr_name = to$str((char *)attr->name);
+        }
+        wit->$class->append(wit,attributes, $NEWTUPLE(2, attr_name, to$str((char *)xmlGetProp(node, attr->name))));
         attr = attr->next;
     }
 

--- a/test/stdlib_tests/src/test_xml.act
+++ b/test/stdlib_tests/src/test_xml.act
@@ -150,3 +150,31 @@ def _test_xml_cdata_roundtrip():
     testing.assertEqual(e, "<data>&lt;special> &amp; chars</data>")
     d2 = xml.decode(e)
     testing.assertEqual(d2.text, "<special> & chars", "CDATA: roundtrip content not preserved")
+
+def _test_xml_namespace_attributes_defined():
+    """Test defined namespace prefix on attributes (with xmlns declaration)"""
+    test_xml = """<a xmlns:ns="http://foo" ns:operation="remove"><ns:b ns:type="element">text</ns:b></a>"""
+    d = xml.decode(test_xml)
+    attr = d.attributes[0]
+    testing.assertEqual(attr.0, 'ns:operation', "Defined namespace: attribute not preserved")
+    # Check child node's namespace attribute
+    child = d.children[0]
+    child_attr = child.attributes[0]
+    testing.assertEqual(child_attr.0, 'ns:type', "Defined namespace: child attribute not preserved")
+    testing.assertEqual(child_attr.1, 'element', "Defined namespace: child attribute value not preserved")
+    e = xml.encode(d)
+    testing.assertEqual(e, test_xml, "Defined namespace: roundtrip failed")
+
+def _test_xml_namespace_attributes_undefined():
+    """Test undefined namespace prefix on attributes (no xmlns declaration)"""
+    test_xml = """<a undef:attr="value"><b other:attr="child">text</b></a>"""
+    d = xml.decode(test_xml)
+    attr = d.attributes[0]
+    testing.assertEqual(attr.0, 'undef:attr', "Undefined namespace: attribute not preserved")
+    # Check child node's undefined namespace attribute
+    child = d.children[0]
+    child_attr = child.attributes[0]
+    testing.assertEqual(child_attr.0, 'other:attr', "Undefined namespace: child attribute not preserved")
+    testing.assertEqual(child_attr.1, 'child', "Undefined namespace: child attribute value not preserved")
+    e = xml.encode(d)
+    testing.assertEqual(e, test_xml, "Undefined namespace: roundtrip failed")


### PR DESCRIPTION
Preserve namespace prefixes on attributes during XML decode.  libxml2 handles namespace prefixes differently for defined vs undefined namespaces - now we handle both cases correctly. There is room for improvement in how the attributes are represented in xml.Node. We could for example use namedtuple with fields to store the name *and* the namespace qualifier (prefix, uri).

Closes #2431 