### PR TITLE
Use content hash for up-to-date check

### DIFF
--- a/compiler/actonc/package.yaml.in
+++ b/compiler/actonc/package.yaml.in
@@ -20,9 +20,11 @@ dependencies:
   - acton
   - async
   - base >= 4.7 && < 5
+  - base16-bytestring
   - bytestring
   - clock
   - containers
+  - cryptohash-sha256
   - data-default-class
   - diagnose
   - dir-traverse

--- a/compiler/lib/src/Acton/CodeGen.hs
+++ b/compiler/lib/src/Acton/CodeGen.hs
@@ -33,12 +33,13 @@ import Prelude hiding ((<>))
 import System.FilePath.Posix
 import Numeric
 
-generate                            :: Acton.Env.Env0 -> FilePath -> Module -> IO (String,String,String)
-generate env srcbase m              = do return (n, h, c)
+generate                            :: Acton.Env.Env0 -> FilePath -> Module -> String -> IO (String,String,String)
+generate env srcbase m hash         = do return (n, h, c)
 
   where n                           = concat (Data.List.intersperse "." (modPath (modname m))) --render $ quotes $ gen env0 (modname m)
-        h                           = render $ hModule env0 m
-        c                           = render $ cModule env0 srcbase m
+        hashComment                 = text "/* Acton source hash:" <+> text hash <+> text "*/"
+        h                           = render $ hashComment $+$ hModule env0 m
+        c                           = render $ hashComment $+$ cModule env0 srcbase m
         env0                        = genEnv $ setMod (modname m) env
 
 genRoot                            :: Acton.Env.Env0 -> QName -> IO String

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -443,7 +443,7 @@ initEnv path True          = return $ EnvF{ names = [(nPrim,NMAlias mPrim)],
                                             witnesses = primWits,
                                             thismod = Nothing,
                                             envX = () }
-initEnv path False         = do (_,nmod) <- InterfaceFiles.readFile (joinPath [path,"__builtin__.ty"])
+initEnv path False         = do (_,nmod,_) <- InterfaceFiles.readFile (joinPath [path,"__builtin__.ty"])
                                 let NModule envBuiltin builtinDocstring = nmod
                                     env0 = EnvF{ names = [(nPrim,NMAlias mPrim), (nBuiltin,NMAlias mBuiltin)],
                                                  imports = [mPrim,mBuiltin],
@@ -1219,7 +1219,7 @@ doImp spath env m            = case lookupMod m env of
                                         case tyFile of
                                           Nothing -> fileNotFound m
                                           Just tyF -> do
-                                            (ms,nmod) <- InterfaceFiles.readFile tyF
+                                            (ms,nmod,_) <- InterfaceFiles.readFile tyF
                                             env' <- subImp spath env ms
                                             let NModule te mdoc = nmod
                                             return (addMod m te mdoc env', te)

--- a/compiler/lib/src/Acton/Syntax.hs
+++ b/compiler/lib/src/Acton/Syntax.hs
@@ -23,7 +23,7 @@ import Control.DeepSeq
 import Prelude hiding((<>))
 
 version :: [Int]
-version = [0,2]
+version = [0,3]
 
 data Module     = Module        { modname::ModName, imps::[Import], mbody::Suite } deriving (Eq,Show)
 

--- a/compiler/lib/src/Acton/Types.hs
+++ b/compiler/lib/src/Acton/Types.hs
@@ -89,7 +89,7 @@ reconstruct env0 (Module m i ss)         = do --traceM ("#################### or
         ss1T' = __name__assign : ss1T
 
 
-showTyFile env0 m fname         = do (ms,nmod) <- InterfaceFiles.readFile fname
+showTyFile env0 m fname         = do (ms,nmod,_) <- InterfaceFiles.readFile fname
                                      putStrLn ("\n#################################### Interface:")
                                      let NModule te mdoc = nmod
                                      forM_ mdoc $ \docstring ->

--- a/compiler/lib/test/9-codegen/deact.c
+++ b/compiler/lib/test/9-codegen/deact.c
@@ -1,3 +1,4 @@
+/* Acton source hash: test-hash */
 #include "rts/common.h"
 #include "out/types/deact.h"
 B_Times deactQ_W_223;

--- a/compiler/lib/test/9-codegen/deact.h
+++ b/compiler/lib/test/9-codegen/deact.h
@@ -1,3 +1,4 @@
+/* Acton source hash: test-hash */
 #pragma once
 #include "builtin/builtin.h"
 #include "rts/rts.h"

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -730,7 +730,7 @@ testCodeGen env0 modulePaths = do
           (cpstyled, cpsEnv) <- Acton.CPS.convert deactEnv deacted
           (lifted,liftEnv) <- Acton.LambdaLifter.liftModule cpsEnv cpstyled
           boxed <- Acton.Boxing.doBoxing liftEnv lifted
-          (n,h,c) <- Acton.CodeGen.generate liftEnv "" boxed
+          (n,h,c) <- Acton.CodeGen.generate liftEnv "" boxed "test-hash"
           let newAccEnv = Acton.Env.addMod (S.modname parsed) tenv mdoc accEnv
           return (newAccEnv, accModules ++ [(takeFileName modulePath, boxed, n, h, c)])
 


### PR DESCRIPTION
The compiler now uses SHA256 content hashing to determine when source files have actually changed, preventing unnecessary recompilation when files are touched but their content remains the same. This is particularly useful when switching branches or when build tools update timestamps without modifying file contents.

The implementation stores source file hashes in the .ty interface files and compares them during the up-to-date check. When timestamps indicate a source file is newer, the compiler reads the file's content and computes its hash. If the hash matches the stored value, compilation is skipped even though the timestamp suggested a rebuild was needed.

Additionally, this change fixes file locking errors that occurred during parallel compilation of dependencies by implementing atomic file writes using PID-based temporary files. The .ty format version has been bumped to 0.3 to reflect these changes.