### PR TITLE
Fix bytes.split() and bytearray.split() empty edge case

### DIFF
--- a/base/builtin/str.c
+++ b/base/builtin/str.c
@@ -2217,7 +2217,7 @@ B_list B_bytearrayD_split(B_bytearray s, B_bytearray sep, B_int maxsplit) {
             $RAISE((B_BaseException)$NEW(B_ValueError,to$str("split for bytearray: separator is empty string")));
         }
         if (s->nbytes==0) { // for some unfathomable reason, this is the behaviour of the Python method
-            wit->$class->append(wit,res,null_str);
+            wit->$class->append(wit,res,toB_bytearray(""));
             return res;
         }
         B_bytearray ls, rs, ssep;
@@ -3338,7 +3338,7 @@ B_list B_bytesD_split(B_bytes s, B_bytes sep, B_int maxsplit) {
             $RAISE((B_BaseException)$NEW(B_ValueError,to$str("split for bytes: separator is empty string")));
         }
         if (s->nbytes==0) { // for some unfathomable reason, this is the behaviour of the Python method
-            wit->$class->append(wit,res,null_str);
+            wit->$class->append(wit,res,null_bytes);
             return res;
         }
         B_bytes ls, rs, ssep;


### PR DESCRIPTION
bytes.split() was incorrectly returning null_str instead of null_bytes when splitting an empty bytes object with a separator. bytearray.split() had the same issue, now returns toB_bytearray("").

Part of #2449 