### PR TITLE
Fix violation of UTF-8 invariant in str creation

### DIFF
--- a/base/builtin/str.c
+++ b/base/builtin/str.c
@@ -95,13 +95,15 @@ B_str to$str(char *str) {
     int nchars = 0;
     bool isascii = true;
     unsigned char *p = (unsigned char*)str;
-    while (*p++ != 0)
+    while (*p != 0) {
         if (*p >= 0x80) {
             isascii = false;
             break;
         }
+        p++;
+    }
     if (isascii) {
-        nbytes = p - (unsigned char*)str - 1;
+        nbytes = p - (unsigned char*)str;
         NEW_UNFILLED_STR(res, nbytes, nbytes);
         memcpy(res->str, str, nbytes);
         return res;
@@ -135,11 +137,13 @@ B_str to_str_noc(char *str) {
 
     bool isascii = true;
     unsigned char *p = (unsigned char*)str;
-    while (*p++ != 0)
+    while (*p != 0) {
         if (*p >= 0x80) {
             isascii = false;
             break;
         }
+        p++;
+    }
     p = (unsigned char*)str;
     int cp, cpnbytes;
     if (!isascii) {

--- a/test/builtins_auto/test_str.act
+++ b/test/builtins_auto/test_str.act
@@ -1,3 +1,4 @@
+
 def test_str_find():
     s = "hello, world!"
     print("Testing str.find()")
@@ -264,6 +265,30 @@ def test_strip_list_str():
     a = ["".strip()]
     return str(a) == "['']"
 
+def test_decode_invalid_utf8_continuation():
+    try:
+        # \xe8 expects continuation bytes (10xxxxxx) but \x03 is not
+        s = b"\xe8\x03".decode()
+        return False
+    except ValueError:
+        return True
+
+def test_decode_invalid_utf8_start():
+    try:
+        # \xff is not a valid UTF-8 start byte
+        s = b"\xff\xfe".decode()
+        return False
+    except ValueError:
+        return True
+
+def test_decode_invalid_utf8_mid():
+    try:
+        # Random invalid UTF-8 found while fuzzing HTTP server
+        s = b"Host: loca\xe8\x03o-Length".decode()
+        return False
+    except ValueError:
+        return True
+
 tests = {
     "test_str_find": test_str_find,
     "test_empty_str_capitalize": test_empty_str_capitalize,
@@ -313,6 +338,9 @@ tests = {
     "test_limdef": test_limdef,
     "test_encode_decode": test_encode_decode,
     "test_strip_list_str": test_strip_list_str,
+    "test_decode_invalid_utf8_continuation": test_decode_invalid_utf8_continuation,
+    "test_decode_invalid_utf8_start": test_decode_invalid_utf8_start,
+    "test_decode_invalid_utf8_mid": test_decode_invalid_utf8_mid,
 }
 
 actor main(env):


### PR DESCRIPTION
Acton strings must always contain valid UTF-8. Functions in str.c rely on this, so we must ensure that B_str is always valid and raise an exception if it is not valid.

to$str() and to_str_noc() had incorrect ASCII detection that checked bytes after incrementing the pointer, skipping the first byte. This caused strings starting with non-ASCII bytes (e.g., \xe8\x03) to be misclassified as ASCII, bypassing UTF-8 validation entirely.