### PR TITLE
Handle malformed HTTP request gracefully

### DIFF
--- a/base/src/http.act
+++ b/base/src/http.act
@@ -207,8 +207,12 @@ def parse_message(i: bytes, log: logging.Logger) -> (?Message, bytes):
                 # TODO: silently ignore or explicitly throw error or something?
                 pass
             else:
-                hname = hv[0].decode().strip(" ").lower()
-                headers[hname] = hv[1].decode().strip(" ")
+                try:
+                    hname = hv[0].decode().strip(" ").lower()
+                    headers[hname] = hv[1].decode().strip(" ")
+                except ValueError:
+                    log.debug("Invalid header")
+                    return None, i
 
         # TODO: why do we have to init body & rest here? seems we segfault otherwise...
         body = b""
@@ -240,15 +244,19 @@ def parse_message(i: bytes, log: logging.Logger) -> (?Message, bytes):
                         return None, i
                     elif len(maybe_chunk) == 2:
                         chunk_header = maybe_chunk[0].strip(b"\r\n")
-                        rest = maybe_chunk[1]
-                        header_preview = chunk_header.decode()[:20]
-                        log.trace(f"Chunk header: {header_preview}", None)
                         if chunk_header == b"":
                             log.trace("Empty chunk header", None)
                             return None, i
+                        try:
+                            chunk_header_str = chunk_header.decode()
+                        except ValueError:
+                            log.debug("Invalid chunk header")
+                            return None, i
                         else:
+                            rest = maybe_chunk[1]
+                            log.trace(f"Chunk header: {chunk_header[:20]}", None)
                             try:
-                                clen = int(chunk_header.decode(), 16)
+                                clen = int(chunk_header_str, 16)
                                 log.trace(f"Chunk length: {clen}", None)
                             except ValueError:
                                 log.trace("Chunk header not a length", None)
@@ -294,18 +302,23 @@ def parse_request(i: bytes, log: logging.Logger) -> (?Request, bytes):
         if len(slparts) != 3:
             # HTTP request must have exactly 3 parts: METHOD PATH HTTP/VERSION
             return None, b""
-        method = slparts[0].decode()
-        path = slparts[1].decode()
-        verparts = slparts[2].split(b"/", 1)
-        if len(verparts) != 2:
-            # invalid request
-            # TODO: actually HTTP 0.9 might only have 2 parts, but we don't support that
+        try:
+            method = slparts[0].decode()
+            path = slparts[1].decode()
+        except ValueError:
+            log.debug("Invalid method/path")
             return None, b""
-        version = verparts[1]
-        if version != b"1.1" and version != b"1.0":
-            return None, b""
-        req = Request(method, path, version, msg.headers, msg.body)
-        return req, rest
+        else:
+            verparts = slparts[2].split(b"/", 1)
+            if len(verparts) != 2:
+                # invalid request
+                # TODO: actually HTTP 0.9 might only have 2 parts, but we don't support that
+                return None, b""
+            version = verparts[1]
+            if version != b"1.1" and version != b"1.0":
+                return None, b""
+            req = Request(method, path, version, msg.headers, msg.body)
+            return req, rest
     return None, i
 
 def parse_response(i: bytes, log: logging.Logger) -> (?Response, bytes):
@@ -325,9 +338,14 @@ def parse_response(i: bytes, log: logging.Logger) -> (?Response, bytes):
             log.trace("Invalid HTTP version", None)
             return None, b""
 
-        status = int(slparts[1].decode())
-        resp = Response(version, status, msg.headers, msg.body)
-        return resp, b""
+        try:
+            status = int(slparts[1].decode())
+        except ValueError:
+            log.debug("Invalid status")
+            return None, b""
+        else:
+            resp = Response(version, status, msg.headers, msg.body)
+            return resp, b""
     return None, i
 
 

--- a/test/stdlib_tests/src/test_http.act
+++ b/test/stdlib_tests/src/test_http.act
@@ -4,8 +4,8 @@ import http
 import logging
 import testing
 
-def _test_http_parser(log_handler: logging.Handler):
-    log = logging.Logger(log_handler)
+def _test_http_parser(st: testing.SyncT):
+    log = logging.Logger(st.log_handler)
     def partializer(testfun, query, parsed) -> bool:
         # Go through query byte by byte, and feed it to the parser one more
         # byte at a time until we get a complete request
@@ -30,12 +30,15 @@ def _test_http_parser(log_handler: logging.Handler):
          expected = http.Request("GET", "/", b"1.1", {"host": "127.0.0.1:8000", "user-agent": "curl/7.85.0", "accept": "*/*", "content-length": "5"}, b"hello")),
         (query = b"GET / HTTP/1.1\r\nHost: 127.0.0.1:8000\r\nUser-Agent: curl/7.85.0\r\nAccept: */*\r\nTransfer-Encoding: chunked\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\nE\r\n in\r\n\r\nchunks.\r\n0\r\n\r\n",
          expected = http.Request("GET", "/", b"1.1", {"host": "127.0.0.1:8000", "user-agent": "curl/7.85.0", "accept": "*/*", "transfer-encoding": "chunked"}, b"Wikipedia in\r\n\r\nchunks.")),
+        (query = b"GET / HTTP/1.1\r\nHost: loca\xe8\x03o-Length\r\n\r\n",
+         expected = None),
     ]
     all_good = True
     for t in tests:
         query = t.query
         expected = t.expected
         # Parse whole request
+        log.debug("== {t.query}")
         parsed, rest = http.parse_request(t.query, log)
         testing.assertEqual(expected, parsed, "Parsed request does not match expected")
 
@@ -46,11 +49,10 @@ def _test_http_parser(log_handler: logging.Handler):
             if req is not None:
                 testing.assertEqual(expected, req, "Parsed request does not match expected")
 
-# TODO: why do we have to have an actor here? all this code would preferably go right in the _test function
-actor _actest_http_client_server(report_result, env, log_handler: logging.Handler):
-    log = logging.Logger(log_handler)
+actor _HttpClientServer(t: testing.EnvT):
+    log = logging.Logger(t.log_handler)
 
-    serv_cap = net.TCPListenCap(net.TCPCap(net.NetCap(env.cap)))
+    serv_cap = net.TCPListenCap(net.TCPCap(net.NetCap(t.env.cap)))
 
     def _on_http_accept(server):
         server.cb_install(_on_http_server_request, _on_http_server_error)
@@ -67,13 +69,11 @@ actor _actest_http_client_server(report_result, env, log_handler: logging.Handle
         c.get("/", _on_http_receive)
 
     def _on_http_receive(c, data):
-        report_result(True, None)
+        log.debug(str(data))
+        t.success()
 
     def _on_http_error(c, errmsg):
         print(errmsg)
 
-    conn_cap = net.TCPConnectCap(net.TCPCap(net.NetCap(env.cap)))
+    conn_cap = net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap)))
     client = http.Client(conn_cap, "127.0.0.1", _on_http_connect, _on_http_error, scheme="http", port=8473)
-
-def _test_http_client_server(report_result, env, log_handler: logging.Handler):
-    _actest_http_client_server(report_result, env, log_handler)


### PR DESCRIPTION
The HTTP Server actor decodes parts of the HTTP request to str. If the
part is not a valid UTF-8 string, it is not a valid HTTP request, so we
stop processing.