### PR TITLE
Make mkdir and rmdir idempotent

### DIFF
--- a/base/src/file.ext.c
+++ b/base/src/file.ext.c
@@ -127,7 +127,7 @@ $R fileQ_FSD_homedirG_local (fileQ_FS self, $Cont C_cont) {
 $R fileQ_FSD_mkdirG_local (fileQ_FS self, $Cont C_cont, B_str filename) {
     uv_fs_t *req = (uv_fs_t *)acton_malloc(sizeof(uv_fs_t));
     int r = uv_fs_mkdir(get_uv_loop(), req, (char *)fromB_str(filename), 0777, NULL);
-    if (r < 0) {
+    if (r < 0 && r != UV_EEXIST) {
         char errmsg[1024] = "Error creating directory: ";
         uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
         log_warn(errmsg);
@@ -192,7 +192,7 @@ $R fileQ_FSD_lstatG_local (fileQ_FS self, $Cont C_cont, B_str filename) {
 $R fileQ_FSD_rmdirG_local (fileQ_FS self, $Cont C_cont, B_str dirname) {
     uv_fs_t *req = (uv_fs_t *)acton_malloc(sizeof(uv_fs_t));
     int r = uv_fs_rmdir(get_uv_loop(), req, (char *)fromB_str(dirname), NULL);
-    if (r < 0) {
+    if (r < 0 && r != UV_ENOENT) {
         char errmsg[1024] = "Error removing directory: ";
         uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
         log_warn(errmsg);

--- a/test/stdlib_tests/src/test_file.act
+++ b/test/stdlib_tests/src/test_file.act
@@ -3,6 +3,21 @@ import file
 import logging
 import testing
 
+actor _test_mkdir_idempotent(t: testing.EnvT):
+    fc = file.FileCap(t.env.cap)
+    fs = file.FS(fc)
+    tmpdir = fs.mktmpdir()
+    fs.mkdir(tmpdir + "/foo")
+    fs.mkdir(tmpdir + "/foo")
+    t.success()
+
+actor _test_rmdir_idempotent(t: testing.EnvT):
+    fc = file.FileCap(t.env.cap)
+    fs = file.FS(fc)
+    tmpdir = fs.mktmpdir()
+    fs.rmdir(tmpdir + "/foo")
+    t.success()
+
 def _test_file_walk(report_result: action(?bool, ?Exception) -> None, env: Env, log_handler: logging.Handler) -> None:
     try:
         fc = file.FileCap(env.cap)


### PR DESCRIPTION
mkdir now succeeds if directory already exists (EEXIST). rmdir now succeeds if directory does not exist (ENOENT). Added test cases for both operations.

Fixes #2436 