### PR TITLE
Make Acton CLI responsible for build.zig, build.zig.zon

### DIFF
--- a/cli/src/acton.act
+++ b/cli/src/acton.act
@@ -110,6 +110,7 @@ actor CacheSizeChecker(cap: file.FileCap):
     check_caches()
 
 def write_buildzig(file_cap, build_config: BuildConfig):
+    """Unconditionally write build.zig and build.zig.zon files for the project"""
     fs = file.FS(file_cap)
 
     def get_build_zig_templates():
@@ -120,6 +121,11 @@ def write_buildzig(file_cap, build_config: BuildConfig):
         build_zig_zon_template = file.ReadFile(
             file.ReadFileCap(file_cap),
             file.join_path([base_path(file_cap), "builder", "build.zig.zon"])).read().decode()
+
+        # Replace SYSPATH with the relative path to the Acton system installation (Zig requires relative paths)
+        syspath = file.get_relative_path(base_path(file_cap), fs.cwd())
+        build_zig_zon_template = build_zig_zon_template.replace("SYSPATH", syspath)
+
         return build_zig_template, build_zig_zon_template
 
     build_zig_tpl, build_zig_zon_tpl = get_build_zig_templates()
@@ -170,7 +176,7 @@ actor CompilerRunner(process_cap, env, args, wdir=None, on_exit: ?action(int, in
             on_exit(exit_code, term_signal, std_out_buf, std_err_buf)
         else:
             if exit_code != 0:
-                print("actonc exited with code: ", exit_code, " terminated with signal:", term_signal)
+                print("{exe} exited with code: ", exit_code, " terminated with signal:", term_signal)
             env.exit(exit_code)
 
     def on_actonc_error(p, error: str):
@@ -187,6 +193,8 @@ actor CompilerRunner(process_cap, env, args, wdir=None, on_exit: ?action(int, in
     cmd = [fs.exepath() + ("c" if exe == "actonc" else "")] + args
     if env.is_tty():
         cmd.append("--tty")
+    if exe == "actonc": # run actonc as a sub-compiler
+        cmd.append("--sub")
     p = process.Process(process_cap, cmd, on_actonc_std_out, on_actonc_std_err, on_actonc_exit, on_actonc_error, wdir)
 
     def stop():

--- a/compiler/actonc/Main.hs
+++ b/compiler/actonc/Main.hs
@@ -1201,7 +1201,6 @@ zigBuild env gopts opts paths tasks binTasks = do
     iff (not (quiet gopts opts)) $ putStrLn("  Final compilation step")
     timeStart <- getTime Monotonic
 
-    -- custom build.zig ?
     homeDir <- getHomeDirectory
     let local_cache_dir = joinPath [ homeDir, ".cache", "acton", "zig-local-cache" ]
         global_cache_dir = joinPath [ homeDir, ".cache", "acton", "zig-global-cache" ]
@@ -1217,28 +1216,35 @@ zigBuild env gopts opts paths tasks binTasks = do
                            ("aarch64":"linux":_)   -> " -Dcpu=cortex_a72 "
                            ("x86_64":_:_)          -> " -Dcpu=westmere "
                            (_:_:_)                 -> defCpu
-        buildZigPath = joinPath [projPath paths, "build.zig"]
-        buildZonPath = joinPath [projPath paths, "build.zig.zon"]
 
-    buildZigExists <- doesFileExist buildZigPath
-    buildZonExists <- doesFileExist buildZonPath
-    -- Compute relative path from current directory (projPath paths)
-    let relativeSysPath = makeAlwaysRelative (projPath paths) (sysPath paths)
-    iff (not buildZigExists) $ do
-      let distBuildZigPath = joinPath [(sysPath paths), "builder", "build.zig"]
-      copyFile distBuildZigPath buildZigPath
-    if buildZonExists
+    -- If actonc runs as a standalone compiler (not a sub-compiler from Acton CLI),
+    -- then we may need to generate build.zig and build.zig.zon. We do not do so
+    -- unconditionally, however, to avoid overwriting any customizations.
+    if not (C.sub gopts)
       then do
-        curBuildZon <- readFile buildZonPath
-        let newBuildZon = replace "SYSPATH" relativeSysPath curBuildZon
-        removeFile buildZonPath
-          `catch` handleNotExists
-        writeFile buildZonPath newBuildZon
-      else do
-        let distBuildZonPath = joinPath [(sysPath paths), "builder", "build.zig.zon"]
-        distBuildZon <- readFile distBuildZonPath
-        let buildZon = replace "SYSPATH" relativeSysPath distBuildZon
-        writeFile buildZonPath buildZon
+        let buildZigPath = joinPath [projPath paths, "build.zig"]
+            buildZonPath = joinPath [projPath paths, "build.zig.zon"]
+
+        buildZigExists <- doesFileExist buildZigPath
+        buildZonExists <- doesFileExist buildZonPath
+        -- Compute relative path from current directory (projPath paths)
+        let relativeSysPath = makeAlwaysRelative (projPath paths) (sysPath paths)
+        iff (not buildZigExists) $ do
+          let distBuildZigPath = joinPath [(sysPath paths), "builder", "build.zig"]
+          copyFile distBuildZigPath buildZigPath
+        if buildZonExists
+          then do
+            curBuildZon <- readFile buildZonPath
+            let newBuildZon = replace "SYSPATH" relativeSysPath curBuildZon
+            removeFile buildZonPath
+              `catch` handleNotExists
+            writeFile buildZonPath newBuildZon
+          else do
+            let distBuildZonPath = joinPath [(sysPath paths), "builder", "build.zig.zon"]
+            distBuildZon <- readFile distBuildZonPath
+            let buildZon = replace "SYSPATH" relativeSysPath distBuildZon
+            writeFile buildZonPath buildZon
+      else return ()
 
     let zigCmdBase = zig paths ++ " build " ++ " --cache-dir " ++ local_cache_dir ++
                  " --global-cache-dir " ++ global_cache_dir ++


### PR DESCRIPTION
Acton CLI now replaces the SYSPATH placeholder in build.zig.zon (from dist/builder/build.zig.zon) with the correct relative path to the Acton distribution. Previously this was only done in actonc, which made way for a race condition when building projects with a diamond-shaped dependency tree.

actonc now *does not* touch build.zig and build.zig.zon when started as a sub-compiler from Acton CLI (--sub flag). When started as a standalone compiler, for example when building Acton CLI itself, it still ensures that both files exist.