### PR TITLE
Use B_bool singletons in toB_bool(b)

### DIFF
--- a/base/builtin/bool.c
+++ b/base/builtin/bool.c
@@ -52,10 +52,7 @@ B_bool B_boolG_new(B_value s) {
 }
 
 B_bool toB_bool(long b) {
-    B_bool res = acton_malloc(sizeof(struct B_bool));
-    res->$class = &B_boolG_methods;
-    res->val = b;
-    return res;
+    return b ? B_True : B_False;
 }
     
 long fromB_bool(B_bool b) {


### PR DESCRIPTION
Do not allocate a new B_bool whenever we need an Acton bool!