### PR TITLE
Perform all C compilation in one go

### DIFF
--- a/cli/src/acton.act
+++ b/cli/src/acton.act
@@ -418,7 +418,7 @@ actor BuildProject(process_cap, env, args, on_build_success: action(str) -> None
                 else:
                     raise ValueError("Dependency %s has no path or hash" % dep_name)
                 print(" -", dep_name)
-                cmd = ["build"] + dep_build_cmd_args(args) + dep_args
+                cmd = ["build", "--skip-build"] + dep_build_cmd_args(args) + dep_args
                 cr = CompilerRunner(
                     process_cap,
                     env,


### PR DESCRIPTION
When we compile a project with dependencies we first call `acton build` in each dependency, which recursively will first compile the whole dependency tree before we proceed to compile the main project. It is really unnecessary to even invoke Zig to compile the lowered C files since we are going to do that anyway from the main project. We now skip it by passing --skip-build. This wasn't possible before because while we want to skip the Zig build, we do want to write a build.zig(.zon) and that wasn't properly done earlier, but it now is, so we have all the things in place to skip the Zig build for dependencies now.