### PR TITLE
add decode_list/encode_list for array-root JSON

### DIFF
--- a/base/src/json.act
+++ b/base/src/json.act
@@ -13,8 +13,14 @@ actor Json():
     action def decode(data: str) -> dict[str, ?value]:
         return decode(data)
 
+    action def decode_list(data: str) -> list[?value]:
+        return decode_list(data)
+
     action def encode(data: dict[str, ?value]) -> str:
         return encode(data)
+
+    action def encode_list(data: list[?value], pretty=False) -> str:
+        return encode_list(data, pretty)
 
 
 def decode(data: str) -> dict[str, ?value]:
@@ -22,7 +28,17 @@ def decode(data: str) -> dict[str, ?value]:
     """
     NotImplemented
 
+def decode_list(data: str) -> list[?value]:
+    """Decode a JSON string (containing an array) into a list of values
+    """
+    NotImplemented
+
 def encode(data: dict[str, ?value], pretty=False) -> str:
     """Encode a dictionary into a JSON string
+    """
+    NotImplemented
+
+def encode_list(data: list[?value], pretty=False) -> str:
+    """Encode a list into a JSON array string
     """
     NotImplemented

--- a/test/stdlib_tests/src/test_json.act
+++ b/test/stdlib_tests/src/test_json.act
@@ -22,3 +22,18 @@ def _test_json():
         testing.assertNotNone(e, "Failed to encode to JSON")
         testing.assertEqual(s, e, "Input output via JSON round trip does not match")
 
+def _test_json_list_decode():
+    test_arrays = [
+        r"""[1,2,3]""",
+        r"""[true,false,null]""",
+        r"""["a","b","c"]""",
+        r"""[[1,2],[3,4]]""",
+        r"""[{"a":1},{"b":2}]""",
+        r"""["x",null,10,3.14,{"k":"v"},[5]]""",
+    ]
+    for s in test_arrays:
+        l = json.decode_list(s)
+        testing.assertNotNone(l, "json.decode_list() returned None")
+        e = json.encode_list(l)
+        testing.assertNotNone(e, "json.encode_list() returned None")
+        testing.assertEqual(s, e, "JSON array roundtrip does not match")


### PR DESCRIPTION
Some JSON documents aren't documents at all, they have an array as the root element, and now we add a decode_list & encode_list function to conveniently allow decoding and encoding of such array-rooted JSON

Fixes #2444 