### PR TITLE
Set xml.Node text, tail to None when empty

### DIFF
--- a/base/src/xml.ext.c
+++ b/base/src/xml.ext.c
@@ -75,7 +75,7 @@ static unsigned char* copy_with_xml_escape(unsigned char *dst, B_str src, int es
 static B_str collect_text_cdata_nodes(xmlNodePtr *cur_ptr) {
     xmlNodePtr cur = *cur_ptr;
     if (!cur || (cur->type != XML_TEXT_NODE && cur->type != XML_CDATA_SECTION_NODE)) {
-        return to$str("");
+        return NULL;
     }
 
     // Count total length of combined text and CDATA nodes
@@ -106,7 +106,7 @@ static B_str collect_text_cdata_nodes(xmlNodePtr *cur_ptr) {
     }
 
     *cur_ptr = cur;
-    return to$str("");
+    return NULL;
 }
 
 xmlQ_Node $NodePtr2Node(xmlNodePtr node) {

--- a/test/stdlib_tests/src/test_xml.act
+++ b/test/stdlib_tests/src/test_xml.act
@@ -178,3 +178,14 @@ def _test_xml_namespace_attributes_undefined():
     testing.assertEqual(child_attr.1, 'child', "Undefined namespace: child attribute value not preserved")
     e = xml.encode(d)
     testing.assertEqual(e, test_xml, "Undefined namespace: roundtrip failed")
+
+def _test_xml_empty_none():
+    test_xml = """<data>
+    <a></a>
+    <b />
+    <c><!-- comment --></c>
+</data>"""
+    d = xml.decode(test_xml)
+    for c in d.children:
+        testing.assertNone(c.text, f"{c.tag}: get text")
+        testing.assertEqual(len(c.children), 0, f"{c.tag}: get children")


### PR DESCRIPTION
When we're decoding an XML string to xml.Node, set text and tail attributes to *None*, not empty string when no value is present. The attributes are already typed as `?str` in the initializer. This also aligns the behavior with Python (etree, lxml).