### PR TITLE
Add pretty argument to xml.Node.encode()

### DIFF
--- a/base/src/xml.act
+++ b/base/src/xml.act
@@ -20,7 +20,7 @@ n.text and c.tail for all children of n.
         self.text = text
         self.tail = tail
 
-    def encode(self) -> str:
+    def encode(self, pretty=False) -> str:
         NotImplemented
 
 class XmlParseError(ValueError):
@@ -52,9 +52,8 @@ class XmlParseError(ValueError):
 def decode(data : str) -> Node:
     NotImplemented
 
-# TODO: add arg to pretty-print, default=True
-def encode(node : Node) -> str:
-    return node.encode()
+def encode(node: Node, pretty=False) -> str:
+    return node.encode(pretty)
 
 def toplevel_text(node):
      """Returns the toplevel text in node, as if all subelements were replaced by sep"""
@@ -68,3 +67,7 @@ def toplevel_text(node):
          if tl is not None:
              chunks.append(tl)
      return sep.join(chunks)
+
+def encode_nodes(nodes: list[Node], pretty=False) -> str:
+    sep = "\n" if pretty else ""
+    return sep.join([node.encode(pretty) for node in nodes])

--- a/test/stdlib_tests/src/test_xml.act
+++ b/test/stdlib_tests/src/test_xml.act
@@ -15,11 +15,11 @@ def _test_xml_roundtrip():
     # TODO: remove indent after adding argument to xml.encode() to not pretty print
     test_xml = [
         """<a>    <b>hello</b></a>""",
-        """<a attr="foo" battr="bar">    <b></b></a>""",
+        """<a attr="foo" battr="bar">    <b/></a>""",
         """<a>\n    <b1>hej</b1>\n    <b2>test</b2>\n</a>""",
         """<a xmlns="http://foo"><b>2</b></a>""",
         """<a xmlns:ns="http://foo"><ns:b>2</ns:b></a>""",
-        """<data><l>čaw</l><baw></baw></data>""",
+        """<data><l>čaw</l><baw/></data>""",
         """<a>100 ㏀</a>""",
     ]
     for s in test_xml:
@@ -93,17 +93,17 @@ def _test_xml_entity_escaping_text():
 def _test_xml_entity_escaping_attributes():
     """Test encoding of raw special characters in attributes"""
     node = xml.Node("a", attributes=[("attr", '< & > "quotes"')])
-    testing.assertEqual(xml.encode(node), '<a attr="&lt; &amp; > &quot;quotes&quot;"></a>', "Attribute escaping failed")
+    testing.assertEqual(xml.encode(node), '<a attr="&lt; &amp; > &quot;quotes&quot;"/>', "Attribute escaping failed")
 
 def _test_xml_entity_escaping_tail():
     """Test encoding of raw special characters in tail text"""
     node = xml.Node("a", children=[xml.Node("b", tail=" < & > tail")])
-    testing.assertEqual(xml.encode(node), "<a><b></b> &lt; &amp; > tail</a>", "Tail escaping failed")
+    testing.assertEqual(xml.encode(node), "<a><b/> &lt; &amp; > tail</a>", "Tail escaping failed")
 
 def _test_xml_entity_escaping_single_quotes():
     """Test that single quotes in attributes are not escaped (we quote with double quotes)"""
     node = xml.Node("a", attributes=[("attr", "it's fine")])
-    testing.assertEqual(xml.encode(node), """<a attr="it's fine"></a>""", "Single quotes should not be escaped")
+    testing.assertEqual(xml.encode(node), """<a attr="it's fine"/>""", "Single quotes should not be escaped")
 
 def _test_xml_entity_escaping_utf8():
     """Test that encoding leaves UTF-8 multi-byte characters intact"""
@@ -189,3 +189,27 @@ def _test_xml_empty_none():
     for c in d.children:
         testing.assertNone(c.text, f"{c.tag}: get text")
         testing.assertEqual(len(c.children), 0, f"{c.tag}: get children")
+
+def _test_xml_pretty():
+    root = xml.Node("document",
+        nsdefs=[("ns", "http://example.com")],
+        attributes=[("version", "1.0")],
+        children=[
+            xml.Node("header", text="Document Title"),  # Text-only element
+            xml.Node("empty"),  # Empty element
+            xml.Node("section",
+                attributes=[("id", "main")],
+                children=[
+                    xml.Node("paragraph", text="Some text"),
+                    xml.Node("nested",
+                        children=[
+                            xml.Node("deep", prefix="ns", text="Namespaced content"),
+                            xml.Node("another")
+                        ]
+                    )
+                ]
+            )
+        ]
+    )
+
+    return root.encode(True)

--- a/test/stdlib_tests/test/golden/test_xml/xml_pretty
+++ b/test/stdlib_tests/test/golden/test_xml/xml_pretty
@@ -1,0 +1,11 @@
+<document xmlns:ns="http://example.com" version="1.0">
+  <header>Document Title</header>
+  <empty/>
+  <section id="main">
+    <paragraph>Some text</paragraph>
+    <nested>
+      <ns:deep>Namespaced content</ns:deep>
+      <another/>
+    </nested>
+  </section>
+</document>


### PR DESCRIPTION
Pretty-print the encoded XML document with newlines and two spaces of indentation for child nodes. Defaults to False (aligned with json.act). There is no extra newline at the end, but I think that is fine?

Empty XML nodes (no text or child nodes) are encoded with self-closing
tag regardless of the pretty-print option: `<tag/>`