### PR TITLE
Enable actonc GHC parallel (big) nursery

### DIFF
--- a/cli/src/acton.act
+++ b/cli/src/acton.act
@@ -187,7 +187,10 @@ actor CompilerRunner(process_cap, env, args, wdir=None, on_exit: ?action(int, in
     fs = file.FS(file.FileCap(env.cap))
     # We find the path to actonc by looking at the executable path of the
     # current process. Since we are called 'acton', we just add a 'c'.
-    cmd = [fs.exepath() + ("c" if exe == "actonc" else "")] + args
+    cmd = [fs.exepath() + ("c" if exe == "actonc" else "")]
+    if exe == "actonc":
+        cmd += ["+RTS", "-N", "-A64M", "-RTS"]
+    cmd += args
     if env.is_tty():
         cmd.append("--tty")
     p = process.Process(process_cap, cmd, on_actonc_std_out, on_actonc_std_err, on_actonc_exit, on_actonc_error, wdir)

--- a/compiler/actonc/package.yaml.in
+++ b/compiler/actonc/package.yaml.in
@@ -53,6 +53,10 @@ executables:
   actonc:
     main:                Main.hs
     source-dirs:         .
+    ghc-options:
+      - -threaded
+      - -rtsopts
+      - -with-rtsopts=-N
     when:
     - condition: os(linux)
       ld-options:


### PR DESCRIPTION
We enable parallel GC, which acts on the first generation 0 - the nursery, and set the size of the nursery to 32MB. This improves performance for our normal compilation tasks, something like 10%, with no extra effort.

The actonc Haskell GHC runtime system is now threaded but there are likely no other drawbacks to that. It's been debated for years whether GHC should enable a threaded runtime per default and the argument against it is that in Haskell, there are programs that run slower in a threaded environment, essentially because they are single threaded and the no-threads environment avoids some overhead. In our case, the threaded runtime is provably faster, so it's a simple choice for us. This is faster, let's go!