### PR TITLE
Concurrently build modules

### DIFF
--- a/cli/src/acton.act
+++ b/cli/src/acton.act
@@ -1615,6 +1615,7 @@ actor main(env):
         p.add_bool("only-build", "Only perform final build of .c files, do not compile .act files")
         p.add_bool("skip-build", "Skip final build of .c files")
         p.add_bool("tty", "Controlling terminal is interactive")
+        p.add_option("jobs", "int", "?", 0, "Max parallel compiler jobs (0 = auto)")
         p.add_option("root", "str", "?", "", "Set root actor")
         p.add_option("tempdir", "str", "?", "", "Directory for temporary build files")
         p.add_option("syspath", "str", "?", "", "syspath")

--- a/compiler/actonc/test/rebuild/golden/file_02-initial-build.golden
+++ b/compiler/actonc/test/rebuild/golden/file_02-initial-build.golden
@@ -1,12 +1,12 @@
 Building file src/c.act in project .
   Stale a: source changed
   Compiling a.act with Debug
-   Finished compilation in   0.000 s
+   Finished compilation of a in   0.000 s
   Stale b: source changed
   Compiling b.act with Debug
-   Finished compilation in   0.000 s
+   Finished compilation of b in   0.000 s
   Stale c: source changed
   Compiling c.act with Debug
-   Finished compilation in   0.000 s
+   Finished compilation of c in   0.000 s
   Final compilation step
    Finished final compilation step in   0.000 s

--- a/compiler/actonc/test/rebuild/golden/file_06-change-a-impl.golden
+++ b/compiler/actonc/test/rebuild/golden/file_06-change-a-impl.golden
@@ -1,7 +1,7 @@
 Building file src/c.act in project .
   Stale a: source changed
   Compiling a.act with Debug
-   Finished compilation in   0.000 s
+   Finished compilation of a in   0.000 s
   Fresh b: using cached .ty
   Fresh c: using cached .ty
   Final compilation step

--- a/compiler/actonc/test/rebuild/golden/file_08-change-b-impl.golden
+++ b/compiler/actonc/test/rebuild/golden/file_08-change-b-impl.golden
@@ -2,9 +2,9 @@ Building file src/c.act in project .
   Fresh a: using cached .ty
   Stale b: source changed
   Compiling b.act with Debug
-   Finished compilation in   0.000 s
+   Finished compilation of b in   0.000 s
   Stale c: iface changes in b 4ed61e7a → d1422048
   Compiling c.act with Debug
-   Finished compilation in   0.000 s
+   Finished compilation of c in   0.000 s
   Final compilation step
    Finished final compilation step in   0.000 s

--- a/compiler/actonc/test/rebuild/golden/project_02-initial-build.golden
+++ b/compiler/actonc/test/rebuild/golden/project_02-initial-build.golden
@@ -1,11 +1,11 @@
   Stale a: source changed
   Compiling a.act with Debug
-   Finished compilation in   0.000 s
+   Finished compilation of a in   0.000 s
   Stale b: source changed
   Compiling b.act with Debug
-   Finished compilation in   0.000 s
+   Finished compilation of b in   0.000 s
   Stale c: source changed
   Compiling c.act with Debug
-   Finished compilation in   0.000 s
+   Finished compilation of c in   0.000 s
   Final compilation step
    Finished final compilation step in   0.000 s

--- a/compiler/actonc/test/rebuild/golden/project_06-change-a-impl.golden
+++ b/compiler/actonc/test/rebuild/golden/project_06-change-a-impl.golden
@@ -1,6 +1,6 @@
   Stale a: source changed
   Compiling a.act with Debug
-   Finished compilation in   0.000 s
+   Finished compilation of a in   0.000 s
   Fresh b: using cached .ty
   Fresh c: using cached .ty
   Final compilation step

--- a/compiler/actonc/test/rebuild/golden/project_08-change-b-impl.golden
+++ b/compiler/actonc/test/rebuild/golden/project_08-change-b-impl.golden
@@ -1,7 +1,7 @@
   Fresh a: using cached .ty
   Stale b: source changed
   Compiling b.act with Debug
-   Finished compilation in   0.000 s
+   Finished compilation of b in   0.000 s
   Fresh c: using cached .ty
   Final compilation step
    Finished final compilation step in   0.000 s

--- a/compiler/actonc/test/rebuild/golden/project_10-change-a-iface.golden
+++ b/compiler/actonc/test/rebuild/golden/project_10-change-a-iface.golden
@@ -1,11 +1,11 @@
   Stale a: source changed
   Compiling a.act with Debug
-   Finished compilation in   0.000 s
+   Finished compilation of a in   0.000 s
   Stale b: iface changes in a df462c35 → 366981bd
   Compiling b.act with Debug
-   Finished compilation in   0.000 s
+   Finished compilation of b in   0.000 s
   Stale c: iface changes in b d1422048 → 4bb55265
   Compiling c.act with Debug
-   Finished compilation in   0.000 s
+   Finished compilation of c in   0.000 s
   Final compilation step
    Finished final compilation step in   0.000 s

--- a/compiler/actonc/test/rebuild/golden/project_11-change-b-doc.golden
+++ b/compiler/actonc/test/rebuild/golden/project_11-change-b-doc.golden
@@ -1,7 +1,7 @@
   Fresh a: using cached .ty
   Stale b: source changed
   Compiling b.act with Debug
-   Finished compilation in   0.000 s
+   Finished compilation of b in   0.000 s
   Fresh c: using cached .ty
   Final compilation step
    Finished final compilation step in   0.000 s

--- a/compiler/actonc/test_rebuild.hs
+++ b/compiler/actonc/test_rebuild.hs
@@ -47,7 +47,8 @@ sanitize = LBS.fromStrict . TE.encodeUtf8 . T.unlines . map (padZero . redact) .
     isVolatile :: T.Text -> Bool
     isVolatile t =
       T.isInfixOf "zigCmd" t ||
-      T.isInfixOf "Building project in" t
+      T.isInfixOf "Building project in" t ||
+      T.isInfixOf "Building [cap" t
 
     -- Replace occurrences of durations like "0.184 s" with a stable token "0.000 s".
     redact :: T.Text -> T.Text

--- a/compiler/lib/src/Acton/CommandLineParser.hs
+++ b/compiler/lib/src/Acton/CommandLineParser.hs
@@ -33,7 +33,8 @@ data GlobalOptions = GlobalOptions {
                         timing       :: Bool,
                         tty          :: Bool,
                         verbose      :: Bool,
-                        verboseZig   :: Bool
+                        verboseZig   :: Bool,
+                        jobs         :: Int
                      } deriving Show
 
 data Command        = New NewOptions
@@ -125,6 +126,7 @@ globalOptions = GlobalOptions
     <*> switch (long "tty"         <> help "Act as if run from interactive TTY")
     <*> switch (long "verbose"     <> help "Verbose output")
     <*> switch (long "verbose-zig" <> help "Verbose Zig output")
+    <*> option auto (long "jobs"   <> metavar "N" <> value 0 <> help "Max parallel compiler jobs (0 = auto)")
   where
     colorReader :: ReadM ColorWhen
     colorReader = eitherReader $ \s ->


### PR DESCRIPTION
actonc is now threaded - well, that was recently enabled separately, to get parallel GC - but now we actually make use of it by compiling multiple modules concurrently using multiple threads. Scaleout isn't perfect, like we are seeing something like a 10-20% drop in per-module performance. I.e., a module that took 10 seconds to compile before now takes like 11-12 seconds, but in exchange we can actually compile modules concurrently so the overall throughput is close to linear improvement, i.e. 10 modules compile like 9x as fast now, given there are at least 10 CPU cores available.

The default is to run as many concurrent modules as there are CPU cores available.

The work split and data flow is actor-like, in that there is a central main thread that coordinates the work. It maintains the Env that contains compiled modules. When there is work to compile a module, it creates async thread workers to compile each module, feeding in the shared env at that point - like a snapshot. Once a module compilation worker is done, the result is fed back to the main coordinating thread, which extends the environment and starts new worker threads for the next tasks. This means we avoid sharing any state between threads with MVar or similar and overall get a simpler and more readable control flow.

We also have some hackery for doing a global cache for loading .ty files, using MVars to get fast cached reads.

Still, there does seem to be a small degradation in no-op performance. Rebuilding a project that is up-to-date now takes slightly longer to determine that it is indeed up-to-date (0.5s -> 0.7s for sorespo), but this is quite minor and in the great scheme of things we can afford a regression given the important gains to concurrent compilation.

Fixes #620