### PR TITLE
Fix JSON encoding for fixed-size ints

### DIFF
--- a/base/src/json.ext.c
+++ b/base/src/json.ext.c
@@ -57,6 +57,33 @@ void jsonQ_encode_dict(yyjson_mut_doc *doc, yyjson_mut_val *node, B_dict data) {
                     yyjson_mut_obj_add_val(doc, node, key, d);
                     jsonQ_encode_dict(doc, d, (B_dict)v);
                     break;
+                case I8_ID:;
+                    yyjson_mut_obj_add_int(doc, node, key, ((B_i8)v)->val);
+                    break;
+                case I16_ID:;
+                    yyjson_mut_obj_add_int(doc, node, key, ((B_i16)v)->val);
+                    break;
+                case I32_ID:;
+                    yyjson_mut_obj_add_int(doc, node, key, ((B_i32)v)->val);
+                    break;
+                case I64_ID:;
+                    yyjson_mut_obj_add_int(doc, node, key, ((B_i64)v)->val);
+                    break;
+                case U1_ID:;
+                    yyjson_mut_obj_add_uint(doc, node, key, ((B_u1)v)->val);
+                    break;
+                case U8_ID:;
+                    yyjson_mut_obj_add_uint(doc, node, key, ((B_u8)v)->val);
+                    break;
+                case U16_ID:;
+                    yyjson_mut_obj_add_uint(doc, node, key, ((B_u16)v)->val);
+                    break;
+                case U32_ID:;
+                    yyjson_mut_obj_add_uint(doc, node, key, ((B_u32)v)->val);
+                    break;
+                case U64_ID:;
+                    yyjson_mut_obj_add_uint(doc, node, key, ((B_u64)v)->val);
+                    break;
                 default:;
                     // TODO: hmm, at least handle all builtin types? and that's it,
                     // maybe? like we really shouldn't accept user-defined types
@@ -102,6 +129,33 @@ void jsonQ_encode_list_into(yyjson_mut_doc *doc, yyjson_mut_val *node, B_list da
                     } else {
                         // TODO: raise exception
                     }
+                    break;
+                case I8_ID:;
+                    yyjson_mut_arr_add_int(doc, node, ((B_i8)v)->val);
+                    break;
+                case I16_ID:;
+                    yyjson_mut_arr_add_int(doc, node, ((B_i16)v)->val);
+                    break;
+                case I32_ID:;
+                    yyjson_mut_arr_add_int(doc, node, ((B_i32)v)->val);
+                    break;
+                case I64_ID:;
+                    yyjson_mut_arr_add_int(doc, node, ((B_i64)v)->val);
+                    break;
+                case U1_ID:;
+                    yyjson_mut_arr_add_uint(doc, node, ((B_u1)v)->val);
+                    break;
+                case U8_ID:;
+                    yyjson_mut_arr_add_uint(doc, node, ((B_u8)v)->val);
+                    break;
+                case U16_ID:;
+                    yyjson_mut_arr_add_uint(doc, node, ((B_u16)v)->val);
+                    break;
+                case U32_ID:;
+                    yyjson_mut_arr_add_uint(doc, node, ((B_u32)v)->val);
+                    break;
+                case U64_ID:;
+                    yyjson_mut_arr_add_uint(doc, node, ((B_u64)v)->val);
                     break;
                 default:;
                     // TODO: hmm, at least handle all builtin types? and that's it,

--- a/test/stdlib_tests/src/test_json.act
+++ b/test/stdlib_tests/src/test_json.act
@@ -37,3 +37,22 @@ def _test_json_list_decode():
         e = json.encode_list(l)
         testing.assertNotNone(e, "json.encode_list() returned None")
         testing.assertEqual(s, e, "JSON array roundtrip does not match")
+
+def _test_json_encode_fixed_size_int():
+    d = {
+        "int": 4,
+        "i8": i8(-128),
+        "i16": i16(-32768),
+        "i32": i32(-2147483648),
+        "i64": i64(-9223372036854775808),
+        "u1": u1(1),
+        "u8": u8(255),
+        "u16": u16(65535),
+        "u32": u32(4294967295),
+        "u64": u64(18446744073709551615)
+    }
+    j = json.encode(d)
+    testing.assertEqual(
+        j,
+        r"""{"int":4,"i8":-128,"i16":-32768,"i32":-2147483648,"i64":-9223372036854775808,"u1":1,"u8":255,"u16":65535,"u32":4294967295,"u64":18446744073709551615}"""
+    )


### PR DESCRIPTION
The fixed-size int types (like i64, u64, ...) were not recognized by the JSON encoder. ~~Checking the GCINFO string name is surely not the most optimal way of detecting the size of the fixed int, but it seems the class_id field is not set for those?!~~

~~`v->$class->$class_id` is 0 for all fixed size instances, is that how it's supposed to be?~~

EDIT: I added class_id for all fixed-size ints in #2532 