### PR TITLE
Bump syntax version to rebuild after int change

### DIFF
--- a/compiler/lib/src/Acton/Syntax.hs
+++ b/compiler/lib/src/Acton/Syntax.hs
@@ -25,7 +25,7 @@ import Control.DeepSeq
 import Prelude hiding((<>))
 
 version :: [Int]
-version = [0,6]
+version = [0,7]
 
 data Module     = Module        { modname::ModName, imps::[Import], mbody::Suite } deriving (Eq,Show,Generic,NFData)
 


### PR DESCRIPTION
We're abusing the syntax version (we haven't really changed the syntax) to indicate whenever we need a rebuild to happen. In this case we've changed out the int type (in a previous branch / PR), so all code needs to be considered stale and recompile. Bumping version is the easy way to get that!