### PR TITLE
cli: forward --dep overrides to actonc build

### DIFF
--- a/cli/src/acton.act
+++ b/cli/src/acton.act
@@ -1033,6 +1033,11 @@ def build_cmd_args(args):
             if args.get_int(argname) != 0:
                 cmdargs.append("--" + argname)
                 cmdargs.append(str(args.get_int(argname)))
+        elif arg.type == "strlist":
+            list_args = args.get_strlist(argname)
+            for larg in list_args:
+                cmdargs.append("--" + argname)
+                cmdargs.append(larg)
 
     return cmdargs
 


### PR DESCRIPTION
This is actually more generic, working for any strlist arg, but it's primarily for solving --dep propagation right now