### PR TITLE
Apply dep overrides for declared deps

### DIFF
--- a/test/compiler/dep_override/Build.act
+++ b/test/compiler/dep_override/Build.act
@@ -1,0 +1,5 @@
+name = "dep_override"
+
+dependencies = {
+  "dep_a": (path="deps/dep_a_missing")
+}

--- a/test/compiler/dep_override/deps/dep_a/Build.act
+++ b/test/compiler/dep_override/deps/dep_a/Build.act
@@ -1,0 +1,6 @@
+name = "dep_a"
+
+dependencies = {
+  "dep_b": (path="../dep_b_missing")
+  , "dep_c": (path="../dep_c")
+}

--- a/test/compiler/dep_override/deps/dep_a/src/a.act
+++ b/test/compiler/dep_override/deps/dep_a/src/a.act
@@ -1,0 +1,5 @@
+import b
+import c
+
+def answer_a() -> int:
+    return b.answer_b() + c.answer_c()

--- a/test/compiler/dep_override/deps/dep_b/Build.act
+++ b/test/compiler/dep_override/deps/dep_b/Build.act
@@ -1,0 +1,4 @@
+name = "dep_b"
+
+dependencies = {
+}

--- a/test/compiler/dep_override/deps/dep_b/src/b.act
+++ b/test/compiler/dep_override/deps/dep_b/src/b.act
@@ -1,0 +1,2 @@
+def answer_b() -> int:
+    return 41

--- a/test/compiler/dep_override/deps/dep_c/Build.act
+++ b/test/compiler/dep_override/deps/dep_c/Build.act
@@ -1,0 +1,4 @@
+name = "dep_c"
+
+dependencies = {
+}

--- a/test/compiler/dep_override/deps/dep_c/src/c.act
+++ b/test/compiler/dep_override/deps/dep_c/src/c.act
@@ -1,0 +1,2 @@
+def answer_c() -> int:
+    return 1

--- a/test/compiler/dep_override/src/main.act
+++ b/test/compiler/dep_override/src/main.act
@@ -1,0 +1,5 @@
+import a
+
+actor main(env):
+    print(str(a.answer_a()))
+    env.exit(0)


### PR DESCRIPTION
We mistakenly applied dep overrides unconditionally, thus introducing dependencies in a project that didn't declare them. This also led to compile cycles as a dependency could get a dependency to itself.

We now only override the path with --dep overrides for dependencies that are actually declared in the project (Build.act or build.act.json).