### PR TITLE
Parse docstrings as docstrings

### DIFF
--- a/compiler/actonc/test/syntaxerrors/err20.golden
+++ b/compiler/actonc/test/syntaxerrors/err20.golden
@@ -1,12 +1,12 @@
 Building file test/syntaxerrors/err20.act using temporary scratch directory
 [error Parse error]: unexpected '@'
-                     expecting bytes literal, end of input, end of line, import statement, statement, or string literal
+                     expecting docstring, end of input, end of line, import statement, or statement
 
      +--> test/syntaxerrors/err20.act@2:1-2:2
      |
    2 | @
      : ^
      : `- unexpected '@'
-     :    expecting bytes literal, end of input, end of line, import statement, statement, or string literal
+     :    expecting docstring, end of input, end of line, import statement, or statement
      :    
 -----+

--- a/compiler/lib/src/Acton/Types.hs
+++ b/compiler/lib/src/Acton/Types.hs
@@ -43,7 +43,7 @@ import Data.Maybe (mapMaybe)
 
 -- | Extract docstring from the first statement of a Suite if it's a string expression
 extractDocstring :: Suite -> Maybe String
-extractDocstring (Expr _ (Strings _ [s]) : _) = Just (unescapeString $ stripQuotes s)
+extractDocstring (Expr _ (Strings _ ss) : _) = Just (unescapeString $ stripQuotes (concat ss))
   where
     stripQuotes ('"':'"':'"':xs) | take 3 (reverse xs) == "\"\"\"" = take (length xs - 3) xs
     stripQuotes ('\'':'\'':'\'':xs) | take 3 (reverse xs) == "'''" = take (length xs - 3) xs

--- a/compiler/lib/test/1-parse/docstrings.input
+++ b/compiler/lib/test/1-parse/docstrings.input
@@ -1,6 +1,6 @@
 import math
 
-"Test module for docstring functionality."
+"Test module for docstring functionality with {braces}."
 
 def test_function (x : int) -> int:
     """Test function with docstring."""
@@ -36,6 +36,10 @@ def function_with_multiple_strings (x : int) -> int:
     "Second string is not"
     return x
 
+def function_with_f_prefix_docstring () -> int:
+    "Not a docstring %s" % str(1)
+    return 1
+
 def function_with_single_quotes (x : int) -> int:
     """Single quote docstring"""
     return x
@@ -47,6 +51,10 @@ def function_with_triple_single_quotes (x : int) -> int:
 def function_with_mixed_quotes (x : int) -> int:
     """Mixed 'quotes' in docstring"""
     return x
+
+def function_with_braces_docstring ():
+    """Docstring with {braces} should not interpolate."""
+    pass
 
 def function_empty_docstring ():
     """"""

--- a/compiler/lib/test/1-parse/docstrings.output
+++ b/compiler/lib/test/1-parse/docstrings.output
@@ -1,6 +1,6 @@
 import math
 
-"Test module for docstring functionality."
+"Test module for docstring functionality with {braces}."
 
 def test_function (x : int) -> int:
     """Test function with docstring."""
@@ -36,6 +36,10 @@ def function_with_multiple_strings (x : int) -> int:
     "Second string is not"
     return x
 
+def function_with_f_prefix_docstring () -> int:
+    "Not a docstring %s" % str(1)
+    return 1
+
 def function_with_single_quotes (x : int) -> int:
     """Single quote docstring"""
     return x
@@ -47,6 +51,10 @@ def function_with_triple_single_quotes (x : int) -> int:
 def function_with_mixed_quotes (x : int) -> int:
     """Mixed 'quotes' in docstring"""
     return x
+
+def function_with_braces_docstring ():
+    """Docstring with {braces} should not interpolate."""
+    pass
 
 def function_empty_docstring ():
     """"""

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -1194,7 +1194,9 @@ testDocstrings env0 testname = do
     -- Basic functionality tests
     it "extracts module docstrings" $ do
       case mdoc of
-        Just doc -> doc `shouldContain` "Test module"
+        Just doc -> do
+          doc `shouldContain` "Test module"
+          doc `shouldContain` "{braces}"
         Nothing -> expectationFailure "Module docstring not extracted"
 
     it "extracts function docstrings" $ do
@@ -1249,6 +1251,12 @@ testDocstrings env0 testname = do
         Just Nothing -> expectationFailure "Function should have docstring"
         Nothing -> expectationFailure "Function not found"
 
+    it "does not treat f-prefixed strings as docstrings" $ do
+      case lookup "function_with_f_prefix_docstring" docstrings of
+        Just Nothing -> return ()
+        Just (Just _) -> expectationFailure "f-prefixed string should not be docstring"
+        Nothing -> expectationFailure "Function not found"
+
     it "handles single quote docstrings" $ do
       case lookup "function_with_single_quotes" docstrings of
         Just (Just doc) -> doc `shouldContain` "Single quote"
@@ -1264,6 +1272,12 @@ testDocstrings env0 testname = do
     it "handles mixed quotes in docstrings" $ do
       case lookup "function_with_mixed_quotes" docstrings of
         Just (Just doc) -> doc `shouldContain` "Mixed 'quotes'"
+        Just Nothing -> expectationFailure "Function should have docstring"
+        Nothing -> expectationFailure "Function not found"
+
+    it "does not interpolate docstrings" $ do
+      case lookup "function_with_braces_docstring" docstrings of
+        Just (Just doc) -> doc `shouldContain` "{braces}"
         Just Nothing -> expectationFailure "Function should have docstring"
         Nothing -> expectationFailure "Function not found"
 

--- a/compiler/lib/test/src/docstrings.act
+++ b/compiler/lib/test/src/docstrings.act
@@ -1,4 +1,4 @@
-"""Test module for docstring functionality."""
+"""Test module for docstring functionality with {braces}."""
 
 import math
 
@@ -39,6 +39,10 @@ def function_with_multiple_strings(x: int) -> int:
     "Second string is not"
     return x
 
+def function_with_f_prefix_docstring() -> int:
+    f"Not a docstring {1}"
+    return 1
+
 def function_with_single_quotes(x: int) -> int:
     'Single quote docstring'
     return x
@@ -50,6 +54,10 @@ def function_with_triple_single_quotes(x: int) -> int:
 def function_with_mixed_quotes(x: int) -> int:
     """Mixed 'quotes' in docstring"""
     return x
+
+def function_with_braces_docstring():
+    """Docstring with {braces} should not interpolate."""
+    pass
 
 def function_empty_docstring():
     """"""


### PR DESCRIPTION
Docstrings were first parsed as normal strings and later extracted to be placed separately as proper docstring attributes on Decls. This meant interpolation and f-string formatting ran on docstring content, which we don't actually want. Docstrings are docstrings, they shouldn't interpolate, and we reject f-prefixed docstrings so they stay ordinary expression statements.

Now we parse docstrings directly as docstring literals so braces stay literal. This also opens the door to future docstring-specific handling, like having embedded exampels in docstrings that we can type check.

Fixes #2409 