### PR TITLE
Hide private names from interfaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -309,6 +309,9 @@ test-compiler:
 	cd compiler && stack test acton
 	cd compiler && stack test actonc --ta '-p "compiler"'
 
+test-compiler-accept:
+	cd compiler && stack test acton --test-arguments "--golden-start --golden-reset"
+
 test-cross-compile:
 	cd compiler && stack test actonc --ta '-p "cross-compilation"'
 

--- a/compiler/actonc/Main.hs
+++ b/compiler/actonc/Main.hs
@@ -690,7 +690,7 @@ expectedRootStubs paths tasks = do
     return (concat roots)
   where
     mkStub outbase n =
-      if nameToString n == "__test_main"
+      if nameToString n == "test_main"
         then outbase ++ ".test_root.c"
         else outbase ++ ".root.c"
 
@@ -908,7 +908,7 @@ compileFiles gopts opts srcFiles allowPrune = do
         preBinTasks
           | null (C.root opts') = map (\t -> BinTask True (modNameToString (name t)) (A.GName (name t) (A.name "main")) False) rootTasks
           | otherwise        = [binTask]
-        preTestBinTasks = map (\t -> BinTask True (modNameToString (name t)) (A.GName (name t) (A.name "__test_main")) True) rootTasks
+        preTestBinTasks = map (\t -> BinTask True (modNameToString (name t)) (A.GName (name t) (A.name "test_main")) True) rootTasks
     -- Generate build.zig(.zon) for dependencies too, to satisfy Zig builder links.
     let projKeys = Data.Set.fromList (map (tkProj . gtKey) globalTasks)
     forM_ (Data.Set.toList projKeys) $ \p -> do

--- a/compiler/lib/src/Acton/Names.hs
+++ b/compiler/lib/src/Acton/Names.hs
@@ -149,6 +149,14 @@ isHidden _                          = True
 
 notHidden                           = filter (not . isHidden)
 
+isPrivateName                       :: Name -> Bool
+isPrivateName n                     = case nstr n of
+                                        ('_':_) -> True
+                                        _       -> False
+
+isPublicName                        :: Name -> Bool
+isPublicName                        = not . isPrivateName
+
 
 -- Free and bound names ------------
 

--- a/compiler/lib/src/Acton/Syntax.hs
+++ b/compiler/lib/src/Acton/Syntax.hs
@@ -25,7 +25,7 @@ import Control.DeepSeq
 import Prelude hiding((<>))
 
 version :: [Int]
-version = [0,7]
+version = [0,8]
 
 data Module     = Module        { modname::ModName, imps::[Import], mbody::Suite } deriving (Eq,Show,Generic,NFData)
 

--- a/compiler/lib/src/InterfaceFiles.hs
+++ b/compiler/lib/src/InterfaceFiles.hs
@@ -25,7 +25,7 @@
 --   3) ifaceHash    :: ByteString                  -- SHA-256 of public NameInfo (doc-free)
 --                                                 -- augmented with imports' iface hashes
 --   4) imports      :: [(A.ModName, ByteString)]   -- imported module and iface hash used
---   5) roots        :: [A.Name]                    -- root actors (e.g., main or __test_main)
+--   5) roots        :: [A.Name]                    -- root actors (e.g., main or test_main)
 --   6) docstring    :: Maybe String                -- module docstring
 --   7) nameInfo     :: A.NameInfo                  -- type/name environment
 --   8) typedModule  :: A.Module                    -- typed module

--- a/compiler/lib/test/3-types/test_discovery.output
+++ b/compiler/lib/test/3-types/test_discovery.output
@@ -82,5 +82,5 @@ __async_tests: __builtin__.dict[__builtin__.str, testing.AsyncTest] = $mkDict@[_
 
 __env_tests: __builtin__.dict[__builtin__.str, testing.EnvTest] = $mkDict@[__builtin__.str, testing.EnvTest](__builtin__.HashableD_str(), {"_test_EnvTester": testing.EnvTest(_test_EnvTester, "_test_EnvTester", "", "test_discovery")})
 
-actor __test_main (env : __builtin__.Env):
+actor test_main (env : __builtin__.Env):
     testing.test_runner(env, __unit_tests, __simple_sync_tests, __sync_tests, __async_tests, __env_tests)

--- a/compiler/lib/test/src/import_private.act
+++ b/compiler/lib/test/src/import_private.act
@@ -1,0 +1,6 @@
+from import_private_a import *
+
+actor main(env):
+    print(__foo)
+    print(public_value)
+    env.exit(0)

--- a/compiler/lib/test/src/import_private_a.act
+++ b/compiler/lib/test/src/import_private_a.act
@@ -1,0 +1,2 @@
+__foo: int = 1
+public_value: int = 2

--- a/compiler/lib/test/src/import_private_qualified.act
+++ b/compiler/lib/test/src/import_private_qualified.act
@@ -1,0 +1,5 @@
+import import_private_a
+
+actor main(env):
+    print(import_private_a.__foo)
+    env.exit(0)


### PR DESCRIPTION
Private names should not be part of a module's public interface. They previously leaked through .ty files and could be accessed via star imports or qualified access, and they also affected the interface hash.

Filter underscore-prefixed names out of the exported interface. This makes qualified access to private names fail as expected.

Rename __test_main to test_main so test roots remain public, update the compiler references and the golden output, and add regression fixtures for both star import and qualified access.

Fixes #1537