### PR TITLE
Add ignore-compiler-mtime flag

### DIFF
--- a/cli/src/acton.act
+++ b/cli/src/acton.act
@@ -970,7 +970,7 @@ def dep_build_cmd_args(args):
     """
     cmdargs = []
     for argname, arg in args.options.items():
-        if argname in {"always-build", "cpu", "dep", "target"}:
+        if argname in {"always-build", "ignore-compiler-mtime", "cpu", "dep", "target"}:
             if arg.type == "bool":
                 if args.get_bool(argname):
                     cmdargs.append("--" + argname)
@@ -1001,6 +1001,7 @@ def build_cmd_args(args):
             "deact",
             "dep",
             "hgen",
+            "ignore-compiler-mtime",
             "kinds",
             "llift",
             "jobs",
@@ -2034,6 +2035,7 @@ actor main(env):
         p.add_bool("timing", "Show timing information")
         p.add_bool("cpedantic", "Pedantic C compilation")
         p.add_bool("dbg-no-lines", "Disable emission of C #line directives (for debugging)")
+        p.add_bool("ignore-compiler-mtime", "Ignore actonc mtime when checking .ty freshness")
         p.add_bool("quiet", "Be quiet")
         p.add_bool("verbose", "Verbose output")
         p.add_bool("old-build", "Use old acton-side build pipeline instead of calling actonc directly")

--- a/compiler/lib/src/Acton/CommandLineParser.hs
+++ b/compiler/lib/src/Acton/CommandLineParser.hs
@@ -54,6 +54,7 @@ data NewOptions     = NewOptions {
 
 data CompileOptions   = CompileOptions {
                          alwaysbuild :: Bool,
+                         ignore_compiler_mtime :: Bool,
                          db          :: Bool,
                          parse       :: Bool,
                          parse_ast   :: Bool,
@@ -165,6 +166,7 @@ newOptions = NewOptions <$> argument (str :: ReadM String) (metavar "PROJECTDIR"
 
 compileOptions = CompileOptions
         <$> switch (long "always-build" <> help "Show the result of parsing")
+        <*> switch (long "ignore-compiler-mtime" <> help "Ignore actonc mtime when checking .ty freshness")
         <*> switch (long "db"           <> help "Enable DB backend")
         <*> switch (long "parse"        <> help "Show the result of parsing")
         <*> switch (long "parse-ast"    <> help "Show the raw AST (Haskell Show)")


### PR DESCRIPTION
actonc treats .ty as stale when the compiler binary is newer, which is usually correct after upgrades of Acton. Add --ignore-compiler-mtime to bypass that check for core compiler development workflows while keeping the new default in place.

Wire the flag through acton and dependency builds so it stays consistent across project builds.