### PR TITLE
Rename ignore-compiler flag

### DIFF
--- a/cli/src/acton.act
+++ b/cli/src/acton.act
@@ -970,7 +970,7 @@ def dep_build_cmd_args(args):
     """
     cmdargs = []
     for argname, arg in args.options.items():
-        if argname in {"always-build", "ignore-compiler-mtime", "cpu", "dep", "target"}:
+        if argname in {"always-build", "ignore-compiler-version", "cpu", "dep", "target"}:
             if arg.type == "bool":
                 if args.get_bool(argname):
                     cmdargs.append("--" + argname)
@@ -1001,7 +1001,7 @@ def build_cmd_args(args):
             "deact",
             "dep",
             "hgen",
-            "ignore-compiler-mtime",
+            "ignore-compiler-version",
             "kinds",
             "llift",
             "jobs",
@@ -2035,7 +2035,7 @@ actor main(env):
         p.add_bool("timing", "Show timing information")
         p.add_bool("cpedantic", "Pedantic C compilation")
         p.add_bool("dbg-no-lines", "Disable emission of C #line directives (for debugging)")
-        p.add_bool("ignore-compiler-mtime", "Ignore actonc mtime when checking .ty freshness")
+        p.add_bool("ignore-compiler-version", "Ignore actonc version when checking .ty freshness")
         p.add_bool("quiet", "Be quiet")
         p.add_bool("verbose", "Verbose output")
         p.add_bool("old-build", "Use old acton-side build pipeline instead of calling actonc directly")

--- a/compiler/actonc/Main.hs
+++ b/compiler/actonc/Main.hs
@@ -748,7 +748,7 @@ High-level Steps
      - If .ty is missing/unreadable → parse .act to obtain imports (ActonTask).
      - If .ty exists and both .act and actonc mtime <= .ty mtime → trust .ty
        header imports and create a TyTask stub (no heavy decode) for graph
-       building. Use --ignore-compiler-mtime to skip the actonc part.
+       building. Use --ignore-compiler-version to skip the actonc part.
      - If .act appears newer than .ty → verify by content hash:
        – If stored srcHash == current srcHash → header is still valid (TyTask)
        – Else → parse .act now to get accurate imports (ActonTask)
@@ -1847,7 +1847,7 @@ filterActFile file =
 -- Decide how to represent a module for the graph:
 -- 1) If .ty is missing/unreadable -> parse .act to obtain imports (ActonTask).
 -- 2) If .ty exists and both .act and actonc mtime <= .ty mtime -> trust header imports (TyTask).
---    (Use --ignore-compiler-mtime to skip the actonc check.)
+--    (Use --ignore-compiler-version to skip the actonc check.)
 -- 3) If actonc is newer than .ty -> recompile from source (ActonTask).
 -- 4) If .act appears newer than .ty -> verify by content hash:
 --      - If stored srcHash == current srcHash -> header is still valid (TyTask)

--- a/compiler/lib/src/Acton/CommandLineParser.hs
+++ b/compiler/lib/src/Acton/CommandLineParser.hs
@@ -166,7 +166,7 @@ newOptions = NewOptions <$> argument (str :: ReadM String) (metavar "PROJECTDIR"
 
 compileOptions = CompileOptions
         <$> switch (long "always-build" <> help "Show the result of parsing")
-        <*> switch (long "ignore-compiler-mtime" <> help "Ignore actonc mtime when checking .ty freshness")
+        <*> switch (long "ignore-compiler-version" <> help "Ignore actonc version when checking .ty freshness")
         <*> switch (long "db"           <> help "Enable DB backend")
         <*> switch (long "parse"        <> help "Show the result of parsing")
         <*> switch (long "parse-ast"    <> help "Show the raw AST (Haskell Show)")


### PR DESCRIPTION
I want to use this option for also ignoring the version of the compiler in test scenarios in which case it's less about mtime and more about other "version identifiers", like we might be using content hashing or time-based version numbers and this flag can cover it all.