### PR TITLE
argparse: preserve rest args after --

### DIFF
--- a/base/src/argparse.act
+++ b/base/src/argparse.act
@@ -449,7 +449,7 @@ class Parser(object):
             start = 0
             end = len(arg)
             if arg == '--':
-                rest = argv[p+1:]
+                rest.extend(argv[p+1:])
                 break
             elif arg.startswith('--'):
                 start = 2


### PR DESCRIPTION
Fixes argparse to extend the existing rest args after -- instead of overwriting them, so subcommand passthrough works as expected.