### PR TITLE
Upgrade to Zig v0.14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ export ZIG_LOCAL_CACHE_DIR
 ACTON=$(TD)/dist/bin/acton
 ACTONC=dist/bin/actonc
 ACTC=$(TD)/dist/bin/actonc
-ZIG_VERSION:=0.13.0
+ZIG_VERSION:=0.14.1
 ZIG=$(TD)/dist/zig/zig
 CURL:=curl --fail --location --retry 5 --retry-delay 2 --retry-max-time 120 --retry-all-errors --retry-connrefused
 AR=$(ZIG) ar
@@ -160,7 +160,7 @@ clean-downloads:
 
 
 # /deps/libargp --------------------------------------------
-LIBARGP_REF=a30e99cda3fabc591727a8df3aee5524c2392e15
+LIBARGP_REF=a6b4bd28410e88a8d5736128ecba0d593f03dfd3
 deps-download/$(LIBARGP_REF).tar.gz:
 	mkdir -p deps-download
 	$(CURL) -o $@ https://github.com/actonlang/argp-standalone/archive/$(LIBARGP_REF).tar.gz
@@ -183,7 +183,7 @@ dist/deps/libbsdnt: deps-download/$(LIBBSDNT_REF).tar.gz
 	touch "$(TD)/$@"
 
 # /deps/libgc --------------------------------------------
-LIBGC_REF=0a23b211b558137de7ee654c5527a54113142517
+LIBGC_REF=b65b95a8e893bdb7256e5a82cb459db24f09577e
 deps-download/$(LIBGC_REF).tar.gz:
 	mkdir -p deps-download
 	$(CURL) -o $@ https://github.com/actonlang/bdwgc/archive/$(LIBGC_REF).tar.gz
@@ -217,7 +217,7 @@ dist/deps/libprotobuf_c: deps-download/$(LIBPROTOBUF_C_REF).tar.gz
 	touch "$(TD)/$@"
 
 # /deps/tlsuv ---------------------------------------------
-TLSUV_REF=8854f5626963e443fd8647793f18173140de6a7e
+TLSUV_REF=246b37003ab3f787020fd473779fd05a5e51a96b
 deps-download/$(TLSUV_REF).tar.gz:
 	mkdir -p deps-download
 	$(CURL) -o $@ https://github.com/actonlang/tlsuv/archive/$(TLSUV_REF).tar.gz
@@ -244,7 +244,7 @@ dist/deps/libuuid: deps/libuuid
 	cp -a "$</"* "$(TD)/$@"
 
 # /deps/libuv --------------------------------------------
-LIBUV_REF=f20620733fb8fb5fb261699bbb858887ac6ec0bb
+LIBUV_REF=0112183b6aa43f27ef5985a143f0aff1689e1e16
 deps-download/$(LIBUV_REF).tar.gz:
 	mkdir -p deps-download
 	$(CURL) -o $@ https://github.com/actonlang/libuv/archive/$(LIBUV_REF).tar.gz
@@ -267,7 +267,7 @@ dist/deps/libxml2: deps-download/$(LIBXML2_REF).tar.gz
 	touch "$(TD)/$@"
 
 # /deps/pcre2 --------------------------------------------
-LIBPCRE2_REF=e9967bee566dedc213d467660bc25ed495bb693b
+LIBPCRE2_REF=2f798e7b2bd9eec36e7ff3ba5eefe66371320e2f
 deps-download/$(LIBPCRE2_REF).tar.gz:
 	mkdir -p deps-download
 	$(CURL) -o $@ https://github.com/actonlang/pcre2/archive/$(LIBPCRE2_REF).tar.gz
@@ -278,7 +278,7 @@ dist/deps/pcre2: deps-download/$(LIBPCRE2_REF).tar.gz
 	touch "$(TD)/$@"
 
 # /deps/libsnappy_c --------------------------------------------
-LIBSNAPPY_C_REF=3f5b95957558a35c2becbe6b628c8219477dd5a4
+LIBSNAPPY_C_REF=8342b6cfb99f861e7768a4255f8a4efe7de83d3b
 deps-download/$(LIBSNAPPY_C_REF).tar.gz:
 	mkdir -p deps-download
 	$(CURL) -o $@ https://github.com/actonlang/snappy/archive/$(LIBSNAPPY_C_REF).tar.gz
@@ -426,7 +426,7 @@ dist/completion/acton.bash-completion: completion/acton.bash-completion
 	mkdir -p "$(dir $@)"
 	cp "$<" "$@"
 
-dist/zig: deps-download/zig-$(OS)-$(ARCH)-$(ZIG_VERSION).tar.xz
+dist/zig: deps-download/zig-$(ARCH)-$(OS)-$(ZIG_VERSION).tar.xz
 	mkdir -p "$@"
 	cd "$@" && tar Jx --strip-components=1 -f "../../$^"
 	rm -rf "$@/doc"
@@ -435,13 +435,13 @@ dist/zig: deps-download/zig-$(OS)-$(ARCH)-$(ZIG_VERSION).tar.xz
 
 # Check if ZIG_VERSION contains -dev, in which case we pull down a nightly,
 # otherwise its a release
-deps-download/zig-$(OS)-$(ARCH)-$(ZIG_VERSION).tar.xz:
+deps-download/zig-$(ARCH)-$(OS)-$(ZIG_VERSION).tar.xz:
 	mkdir -p deps-download
 ifeq ($(findstring -dev,$(ZIG_VERSION)),-dev)
-	$(CURL) -o $@ https://github.com/actonlang/zigballs/raw/main/zig-$(OS)-$(ARCH)-$(ZIG_VERSION).tar.xz
-#	$(CURL) -o $@ https://ziglang.org/builds/zig-$(OS)-$(ARCH)-$(ZIG_VERSION).tar.xz
+	$(CURL) -o $@ https://github.com/actonlang/zigballs/raw/main/zig-$(ARCH)-$(OS)-$(ZIG_VERSION).tar.xz
+#	$(CURL) -o $@ https://ziglang.org/builds/zig-$(ARCH)-$(OS)-$(ZIG_VERSION).tar.xz
 else
-	$(CURL) -o $@ https://ziglang.org/download/$(ZIG_VERSION)/zig-$(OS)-$(ARCH)-$(ZIG_VERSION).tar.xz
+	$(CURL) -o $@ https://ziglang.org/download/$(ZIG_VERSION)/zig-$(ARCH)-$(OS)-$(ZIG_VERSION).tar.xz
 endif
 
 .PHONY: distribution1 distribution clean-distribution

--- a/backend/build.zig
+++ b/backend/build.zig
@@ -91,10 +91,11 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     libactondb.addCSourceFiles(.{
+        .root = b.path("."),
         .files = &libactondb_sources,
         .flags = flags.items
     });
-    libactondb.defineCMacro("LOG_USER_COLOR", "");
+    libactondb.root_module.addCMacro("LOG_USER_COLOR", "");
     libactondb.linkLibrary(dep_libgc.artifact("gc"));
     libactondb.linkLibrary(dep_libprotobuf_c.artifact("protobuf-c"));
     libactondb.linkLibrary(dep_libuuid.artifact("uuid"));
@@ -115,7 +116,6 @@ pub fn build(b: *std.Build) void {
         "-fno-sanitize=undefined",
     }});
     actondb.addCSourceFile(.{ .file = b.path("log.c"), .flags = flags.items });
-    actondb.addLibraryPath(b.path("../lib"));
     actondb.linkLibrary(libactondb);
     actondb.linkLibrary(dep_libargp.artifact("argp"));
     actondb.linkLibrary(dep_libnetstring.artifact("netstring"));

--- a/backend/build.zig.zon
+++ b/backend/build.zig.zon
@@ -1,6 +1,8 @@
 .{
-    .name = "backend",
+    .name = .actondb,
     .version = "0.0.0",
+    .fingerprint = 0xb1be0c7ca3b92d45,
+    .minimum_zig_version = "0.14.1",
     .dependencies = .{
         .libargp = .{
             .path = "deps/libargp/",

--- a/base/build.zig.zon
+++ b/base/build.zig.zon
@@ -1,6 +1,8 @@
 .{
-    .name = "actonbase",
+    .name = .actonbase,
     .version = "0.0.0",
+    .fingerprint = 0xd50287f7af37f221,
+    .minimum_zig_version = "0.14.1",
     .dependencies = .{
         // Dependencies from build.act.json
         // base dependencies

--- a/base/src/buildy.act
+++ b/base/src/buildy.act
@@ -31,12 +31,15 @@ class BuildSpec(object):
     description: ?str
     dependencies: dict[str, PkgDependency]
     zig_dependencies: dict[str, ZigDependency]
+    # Acton-managed package fingerprint (string, e.g. "0x1234abcd...")
+    fingerprint: ?str
 
-    def __init__(self, name: ?str=None, description: ?str=None, dependencies: dict[str, PkgDependency]={}, zig_dependencies: dict[str, ZigDependency]={}):
+    def __init__(self, name: ?str=None, description: ?str=None, dependencies: dict[str, PkgDependency]={}, zig_dependencies: dict[str, ZigDependency]={}, fingerprint: ?str=None):
         self.name = name
         self.description = description
         self.dependencies = dependencies
         self.zig_dependencies = zig_dependencies
+        self.fingerprint = fingerprint
 
     @staticmethod
     def from_json(data: str):
@@ -45,6 +48,7 @@ class BuildSpec(object):
         description = None
         new_dependencies = {}
         new_zig_dependencies = {}
+        new_fingerprint: ?str = None
         if isinstance(jd, dict):
             for key, value in jd.items():
                 if isinstance(key, str):
@@ -86,12 +90,19 @@ class BuildSpec(object):
                                     raise ValueError("Invalid build.act.json, zig_dependencies should be a dict")
                         else:
                             raise ValueError("Invalid build.act.json, zig_dependencies should be a dict")
+                    elif key == "fingerprint":
+                        if value is None:
+                            new_fingerprint = None
+                        elif isinstance(value, str):
+                            new_fingerprint = value
+                        else:
+                            raise ValueError("Invalid build.act.json, fingerprint should be a string like 0xdeadbeef...")
                     else:
                         raise ValueError(f"Invalid build.act.json, unknown key '{key}'")
                 else:
                     raise ValueError("Invalid build.act.json, non-string key found in top level dict")
 
-            return BuildSpec(name, description, new_dependencies, new_zig_dependencies)
+            return BuildSpec(name, description, new_dependencies, new_zig_dependencies, new_fingerprint)
         raise ValueError("Invalid build.act.json, top level should be a dict")
 
     def to_json(self) -> str:
@@ -111,8 +122,20 @@ class BuildSpec(object):
         description = self.description
         if description is not None:
             res["description"] = description
+        if self.fingerprint is not None:
+            res["fingerprint"] = self.fingerprint
         return json.encode(res, pretty=True)
 
+def extract_fingerprint(zon_text: str) -> ?str:
+    for line in zon_text.split("\n"):
+        sline = line.strip()
+        if sline.startswith(".fingerprint"):
+            parts = sline.split("=", 1)
+            if len(parts) == 2:
+                value = parts[1].strip().rstrip(",")
+                if re.match(r"^0x[0-9a-fA-F]+$", value) is not None and value != "0xacedf00dacedf00d":
+                    return value
+    return None
 
 class Dependency(object):
     name: str
@@ -352,7 +375,12 @@ def gen_buildzigzon(template: str, build_config: BuildSpec, relative_syspath: st
         "",
     ]
     for line in template.split("\n"):
-        res.append(line.replace(r"{{syspath}}", relative_syspath))
+        line = line.replace(r"{{syspath}}", relative_syspath)
+        if "{{fingerprint}}" in line:
+            if build_config.fingerprint is None:
+                continue
+            line = line.replace(r"{{fingerprint}}", str(build_config.fingerprint))
+        res.append(line)
         sline = line.strip()
         if sline == "// Dependencies from build.act.json":
             res.append(deps)

--- a/builder/build.zig.zon
+++ b/builder/build.zig.zon
@@ -1,6 +1,8 @@
 .{
-    .name = "actonproject",
+    .name = .actonproject,
     .version = "0.0.0",
+    .fingerprint = {{fingerprint}},
+    .minimum_zig_version = "0.14.1",
     .dependencies = .{
         // Dependencies from build.act.json
         // base dependencies

--- a/cli/src/acton.act
+++ b/cli/src/acton.act
@@ -128,6 +128,19 @@ def write_buildzig(file_cap, build_spec):
         return build_zig_template, build_zig_zon_template
 
     build_zig_tpl, build_zig_zon_tpl = get_build_zig_templates()
+    if build_spec.fingerprint == "0xacedf00dacedf00d":
+        build_spec.fingerprint = None
+    if build_spec.fingerprint is None:
+        try:
+            existing_zon = file.ReadFile(
+                file.ReadFileCap(file_cap), "build.zig.zon").read().decode()
+            fp = extract_fingerprint(existing_zon)
+            if fp is not None:
+                build_spec.fingerprint = fp
+        except FileNotFoundError:
+            pass
+        except:
+            pass
     # Write build.zig
     b_file = file.WriteFile(file.WriteFileCap(file_cap), "build.zig")
     b_file.write(gen_buildzig(build_zig_tpl, build_spec).encode())

--- a/compiler/actonc/Main.hs
+++ b/compiler/actonc/Main.hs
@@ -54,16 +54,19 @@ import Control.Exception (bracketOnError)
 import Control.Concurrent (ThreadId, forkIO, killThread, threadDelay)
 import Control.Concurrent.Chan (Chan, newChan, writeChan, readChan)
 import Control.Monad
+import Data.Bits
 import Data.Default.Class (def)
 import Data.List.Split
 import Data.IORef
 import Data.Maybe (catMaybes, isJust, listToMaybe, fromMaybe)
 import Data.Monoid ((<>))
 import Data.Ord
+import Data.Word (Word32, Word64)
 import Data.Graph
 import Data.String.Utils (replace)
 import Data.Version (showVersion)
 import Data.Char (isAlpha, toLower, isSpace)
+import qualified Data.ByteString as BS
 import qualified Data.List
 import Data.Either (partitionEithers)
 import qualified Data.Map as M
@@ -96,7 +99,9 @@ import qualified System.FSNotify as FS
 import qualified System.Environment
 import qualified System.Exit
 import qualified Paths_actonc
+import System.Random (randomRIO)
 import Text.Printf
+import Numeric (showHex)
 
 import qualified Data.ByteString.Char8 as B
 import qualified Data.ByteString.Lazy as BL
@@ -207,6 +212,28 @@ writeFile f c = do
     hSetEncoding h utf8
     hPutStr h c
     hClose h
+
+ignoreIOException :: IOException -> IO ()
+ignoreIOException _ = return ()
+
+writeFileAtomic :: FilePath -> String -> IO ()
+writeFileAtomic f c = do
+    let dir = takeDirectory f
+    bracketOnError
+      (openTempFile dir ".acton-tmp")
+      (\(tmpPath, tmpHandle) -> do
+          hClose tmpHandle `catch` ignoreIOException
+          removeFile tmpPath `catch` ignoreIOException)
+      (\(tmpPath, tmpHandle) -> do
+          hSetEncoding tmpHandle utf8
+          hPutStr tmpHandle c
+          hClose tmpHandle
+          renameFile tmpPath f `catch` handleRenameError tmpPath)
+  where
+    handleRenameError :: FilePath -> IOException -> IO ()
+    handleRenameError tmpPath _ = do
+        removeFile f `catch` ignoreIOException
+        renameFile tmpPath f
 
 -- | Format a TimeSpec as seconds with millisecond precision.
 fmtTime t =
@@ -1940,6 +1967,30 @@ runZig gopts opts zigExe zigArgs paths wd = do
           cleanup gopts opts paths
           unless (C.watch opts) System.Exit.exitFailure
 
+crc32IsoHdlc :: BS.ByteString -> Word32
+crc32IsoHdlc bs = complement (BS.foldl' update 0xffffffff bs)
+  where
+    update crc byte = go 0 (crc `xor` fromIntegral byte)
+    go 8 crc = crc
+    go n crc =
+        let crc' = if (crc .&. 1) /= 0
+                     then (crc `shiftR` 1) `xor` 0xEDB88320
+                     else crc `shiftR` 1
+        in go (n + 1) crc'
+
+formatFingerprint :: Word64 -> String
+formatFingerprint fp =
+    let hex = showHex fp ""
+        padded = replicate (16 - length hex) '0' ++ hex
+    in "0x" ++ padded
+
+generateFingerprint :: String -> IO String
+generateFingerprint name = do
+    ident <- randomRIO (1, 0xfffffffe :: Word32)
+    let checksum = crc32IsoHdlc (B.pack name)
+        fp = (fromIntegral checksum `shiftL` 32) .|. fromIntegral ident
+    return (formatFingerprint fp)
+
 -- Render build.zig and build.zig.zon from templates and BuildSpec
 -- rootPins: dependency pins from the main project (applied to all deps, including transitive)
 genBuildZigFiles :: M.Map String BuildSpec.PkgDep -> [(String, FilePath)] -> Paths -> IO ()
@@ -1953,6 +2004,7 @@ genBuildZigFiles rootPins depOverrides paths = do
         distBuildZonPath = joinPath [sys, "builder", "build.zig.zon"]
     buildZigTemplate <- readFile distBuildZigPath
     buildZonTemplate <- readFile distBuildZonPath
+    fp <- generateFingerprint "actonproject"
     spec0 <- loadBuildSpec proj
     spec  <- traverse (applyDepOverrides proj depOverrides) spec0
     (transPkgs, transZigs) <- collectDepsRecursive proj rootPins depOverrides
@@ -1964,13 +2016,14 @@ genBuildZigFiles rootPins depOverrides paths = do
     let applyPins deps = M.mapWithKey (\n d -> M.findWithDefault d n rootPins) deps
         mergedSpec = fmap (\s -> s { BuildSpec.dependencies     = applyPins (BuildSpec.dependencies s) `M.union` transPkgs
                                    , BuildSpec.zig_dependencies = BuildSpec.zig_dependencies s `M.union` transZigs }) normalizedSpec
+        zonWithFp = replace "{{fingerprint}}" fp
     case mergedSpec of
       Nothing -> do
         writeFile buildZigPath buildZigTemplate
-        writeFile buildZonPath (replace "{{syspath}}" relSys buildZonTemplate)
+        writeFileAtomic buildZonPath (zonWithFp (replace "{{syspath}}" relSys buildZonTemplate))
       Just s -> do
         writeFile buildZigPath (genBuildZig buildZigTemplate s)
-        writeFile buildZonPath (genBuildZigZon buildZonTemplate relSys depsRootAbs projAbs s)
+        writeFileAtomic buildZonPath (genBuildZigZon buildZonTemplate relSys depsRootAbs projAbs fp s)
 
 genBuildZig :: String -> BuildSpec.BuildSpec -> String
 genBuildZig template spec =
@@ -2015,12 +2068,12 @@ genBuildZig template spec =
     zigExeLink (name, dep) = concat [ "            executable.linkLibrary(dep_" ++ name ++ ".artifact(\"" ++ art ++ "\"));\n"
                                     | art <- BuildSpec.artifacts dep ]
 
-genBuildZigZon :: String -> String -> FilePath -> FilePath -> BuildSpec.BuildSpec -> String
-genBuildZigZon template relSys depsRootAbs projAbs spec =
+genBuildZigZon :: String -> String -> FilePath -> FilePath -> String -> BuildSpec.BuildSpec -> String
+genBuildZigZon template relSys depsRootAbs projAbs fingerprint spec =
     let pkgDeps = concatMap (pkgToZon projAbs depsRootAbs) (M.toList (BuildSpec.dependencies spec))
         zigDeps = concatMap zigToZon (M.toList (BuildSpec.zig_dependencies spec))
         deps = pkgDeps ++ zigDeps
-        replaced = map (replace "{{syspath}}" relSys) (lines template)
+        replaced = map (replace "{{fingerprint}}" fingerprint . replace "{{syspath}}" relSys) (lines template)
         header = [ "// AUTOMATICALLY GENERATED BY ACTON BUILD SYSTEM"
                  , "// DO NOT EDIT, CHANGES WILL BE OVERWRITTEN!!!!!"
                  , ""
@@ -2065,7 +2118,9 @@ genBuildZigZon template relSys depsRootAbs projAbs spec =
     maybeEmpty (Just s) = s
     maybeEmpty Nothing  = ""
 
-#if defined(aarch64_HOST_ARCH)
+#if defined(darwin_HOST_OS) && defined(aarch64_HOST_ARCH)
+defCpuFlag = ["-Dcpu=apple_m1"]
+#elif defined(aarch64_HOST_ARCH)
 defCpuFlag = ["-Dcpu=generic+crypto"]
 #elif defined(x86_64_HOST_ARCH)
 defCpuFlag = ["-Dcpu=x86_64_v2+aes"]
@@ -2120,11 +2175,12 @@ zigBuild env gopts opts paths tasks binTasks allowPrune = do
         cpuArgs =
             if (C.cpu opts /= "") then ["-Dcpu=" ++ C.cpu opts]
             else case (splitOn "-" (C.target opts)) of
-                   ("native":_)   -> defCpuFlag
-                   ("aarch64":_)  -> ["-Dcpu=generic+crypto"]
-                   ("x86_64":_)   -> ["-Dcpu=x86_64_v2+aes"]
-                   (_:_)          -> defCpuFlag
-                   []             -> defCpuFlag
+                   ("native":_)            -> defCpuFlag
+                   ("aarch64":"macos":_)   -> ["-Dcpu=apple_m1"]
+                   ("aarch64":_)           -> ["-Dcpu=generic+crypto"]
+                   ("x86_64":_)            -> ["-Dcpu=x86_64_v2+aes"]
+                   (_:_)                   -> defCpuFlag
+                   []                      -> defCpuFlag
         optArgs = ["-Doptimize=" ++ optimizeModeToZig (C.optimize opts)]
         featureArgs = concat [ if C.db opts then ["-Ddb"] else []
                              , if no_threads then ["-Dno_threads"] else []

--- a/compiler/actonc/package.yaml.in
+++ b/compiler/actonc/package.yaml.in
@@ -39,6 +39,7 @@ dependencies:
   - prettyprinter
   - pretty-show
   - process
+  - random
   - split
   - system-filepath
   - sydtest

--- a/compiler/actonc/test/project/simple/build.sh
+++ b/compiler/actonc/test/project/simple/build.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-cd ..
-/home/kll/terastream/acton/dist/zig/zig cc  -target x86_64-linux-gnu.2.28  -Werror=return-type  -O3  -c  -isystem /home/kll/terastream/acton/dist/inc -Isimple -Isimple/out -I/home/kll/terastream/acton/dist -I/home/kll/terastream/acton/dist/../deps/instdir/include -o/home/kll/terastream/acton/compiler/test/actonc/project/simple/out/rel/lib/a.o simple/out/types/a.c
-/home/kll/terastream/acton/dist/zig/zig ar  rcs /home/kll/terastream/acton/compiler/test/actonc/project/simple/out/rel/lib/libActonProject.a /home/kll/terastream/acton/compiler/test/actonc/project/simple/out/rel/lib/a.o

--- a/deps/libnetstring/build.zig
+++ b/deps/libnetstring/build.zig
@@ -16,6 +16,7 @@ pub fn build(b: *std.Build) void {
     };
 
     lib.addCSourceFiles(.{
+        .root = b.path("."),
         .files = &source_files,
         .flags = &[_][]const u8{}
     });

--- a/deps/libuuid/build.zig
+++ b/deps/libuuid/build.zig
@@ -30,6 +30,7 @@ pub fn build(b: *std.Build) void {
     };
 
     lib.addCSourceFiles(.{
+        .root = b.path("."),
         .files = &source_files,
         .flags = &[_][]const u8{
             "-DHAVE_NANOSLEEP",

--- a/deps/libyyjson/build.zig
+++ b/deps/libyyjson/build.zig
@@ -16,6 +16,7 @@ pub fn build(b: *std.Build) void {
     };
 
     lib.addCSourceFiles(.{
+        .root = b.path("."),
         .files = &source_files,
         .flags = &[_][]const u8{}
     });


### PR DESCRIPTION
Pull in new versions of various deps.

Zig v0.14 has a new fingerprint field in build.zig.zon that is mandatory. We don't really care about this but we have to write something so we currently generate a random one - seem to work and I don't think it impacts caching etc.

Not entirely sure why, but it seems we need to use apple_m1 CPU on MacOS to get MbedTLS to compile now.

Fixes #2190 