### PR TITLE
Improve error handling for back passes

### DIFF
--- a/compiler/lib/src/Acton/DocPrinter.hs
+++ b/compiler/lib/src/Acton/DocPrinter.hs
@@ -3550,7 +3550,7 @@ generateDocIndex docDir tasks = do
             , "</body>"
             , "</html>"
             ]
-    writeFile indexFile indexHtml
+    writeFileUtf8Atomic indexFile indexHtml
   where
     generateModuleEntry :: (ModName, Maybe String) -> [String]
     generateModuleEntry (mn, mDoc) =


### PR DESCRIPTION
All user errors are, by design and definition, only in the front passes so during the last refactoring where those were broken out and run separately from the back passes, actually handling back passes were forgotten. The only errors from back passes are compilers bugs, so we don't pipe them through in such an elaborate way as for the front passes, but I pretty much forgot about them entirely with the consequence that we ended up completely burrying them. Not only that, but we counted any back jobs regardless of actual output result (success / done) as finished and so we moved on to the final zig build even when there were module failues in the back passes. That's fixed now.

We also saw weird failures with truncated files. This comes from an error in CodeGen ( on the solver-next branch ), since Haskell is lazy and CodeGen is the last pass, its output is lazyily streamed - actually pulled out by the file, and so when we encountered the error relatively late, we ended up with truncated output. This was visible both in the .c and with --cgen - we did get slightly different locations for the truncation which I believe is related to buffering by some block size.

Error are now properly surfaced and we don't proceed with futher compilation once we encounter errors in back passes. Files are also written atomically using a temporary file + rename, so we avoid torn files overall (even if the source reason in this case is fixed too).