### PR TITLE
Remove the Acton cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -207,13 +207,6 @@ jobs:
           path: |
             ~/.stack
           key: test-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.arch }}
-      - name: "Cache Acton"
-        if: matrix.cache == true
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cache/acton/
-          key: test-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.arch }}-acton
       - name: "chown our home dir to avoid stack complaining"
         run: chown -R root:root /github/home
       - name: "Install build prerequisites"
@@ -509,12 +502,6 @@ jobs:
     container:
       image: debian:experimental
     steps:
-      - name: "Cache stuff"
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cache/acton/
-          key: test-telemetrify
       - name: "Download .deb files"
         uses: actions/download-artifact@v7
         with:


### PR DESCRIPTION
We seem to be approaching the max cache size, which results in evictions of the last used cache and then we just get churn. Thus reducing the cache size per job is important. While the acton cache obviously helps, it helps a lot less than the stack cache which saves us 30 minutes of work with less than 1GB of disk space whereas the acton cache takes over 2 GB and probably saves on the order of a few minutes.