### PR TITLE
Invalidate .ty when compiler is newer

### DIFF
--- a/compiler/lib/src/Acton/CommandLineParser.hs
+++ b/compiler/lib/src/Acton/CommandLineParser.hs
@@ -61,7 +61,7 @@ data NewOptions     = NewOptions {
 
 data CompileOptions   = CompileOptions {
                          alwaysbuild :: Bool,
-                         ignore_compiler_mtime :: Bool,
+                         ignore_compiler_version :: Bool,
                          db          :: Bool,
                          parse       :: Bool,
                          parse_ast   :: Bool,


### PR DESCRIPTION
Fixes #2193.