### PR TITLE
Fix print builtin for lists with optional elements

### DIFF
--- a/base/builtin/list.c
+++ b/base/builtin/list.c
@@ -107,7 +107,11 @@ B_str B_listD___str__(B_list self) {
     B_SequenceD_list wit2 = B_SequenceD_listG_new();
     for (int i=0; i< self->length; i++) {
         B_value elem = (B_value)self->data[i];
-        wit2->$class->append(wit2, s2, elem->$class->__repr__(elem));
+        if (elem == B_None) {
+            wit2->$class->append(wit2, s2, to$str("None"));
+        } else {
+            wit2->$class->append(wit2, s2, elem->$class->__repr__(elem));
+        }
     }
     return B_strD_join_par('[',s2,']');
 }

--- a/test/builtins_auto/list.act
+++ b/test/builtins_auto/list.act
@@ -146,6 +146,11 @@ actor main(env):
         print("Unexpected result of [].__bool__():", l)
         await async env.exit(1)
 
+    opt: list[?str] = ["a", None, "b"]
+    if opt.__str__() != "['a', None, 'b']":
+        print("Unexpected result of list.__str__() with None:", opt)
+        await async env.exit(1)
+
 #shrinking
     l = list(range(30))
     for i in range(20):


### PR DESCRIPTION
A list of type list[?T] may contain None values, which must be printed as "None".