### PR TITLE
Combined project/module printing in build output

### DIFF
--- a/compiler/acton/test/rebuild/golden/file_02-initial-build.golden
+++ b/compiler/acton/test/rebuild/golden/file_02-initial-build.golden
@@ -1,12 +1,12 @@
 Building file src/c.act in project .
 Resolving dependencies (fetching if missing)...
   Stale a: source changed
-   Finished type check of     rebuild/a     0.000 s
+   Finished type check of     a     0.000 s
   Stale b: source changed
-   Finished type check of     rebuild/b     0.000 s
+   Finished type check of     b     0.000 s
   Stale c: source changed
-   Finished type check of     rebuild/c     0.000 s
-   Finished compilation of    rebuild/a     0.000 s
-   Finished compilation of    rebuild/b     0.000 s
-   Finished compilation of    rebuild/c     0.000 s
-   Finished final compilation               0.000 s
+   Finished type check of     c     0.000 s
+   Finished compilation of    a     0.000 s
+   Finished compilation of    b     0.000 s
+   Finished compilation of    c     0.000 s
+   Finished final compilation       0.000 s

--- a/compiler/acton/test/rebuild/golden/file_03-up-to-date.golden
+++ b/compiler/acton/test/rebuild/golden/file_03-up-to-date.golden
@@ -3,4 +3,4 @@ Resolving dependencies (fetching if missing)...
   Fresh a: using cached .ty
   Fresh b: using cached .ty
   Fresh c: using cached .ty
-   Finished final compilation               0.000 s
+   Finished final compilation       0.000 s

--- a/compiler/acton/test/rebuild/golden/file_04-touch-no-rebuild.golden
+++ b/compiler/acton/test/rebuild/golden/file_04-touch-no-rebuild.golden
@@ -3,4 +3,4 @@ Resolving dependencies (fetching if missing)...
   Fresh a: using cached .ty
   Fresh b: using cached .ty
   Fresh c: using cached .ty
-   Finished final compilation               0.000 s
+   Finished final compilation       0.000 s

--- a/compiler/acton/test/rebuild/golden/file_06-change-a-impl.golden
+++ b/compiler/acton/test/rebuild/golden/file_06-change-a-impl.golden
@@ -2,10 +2,10 @@ Building file src/c.act in project .
 Resolving dependencies (fetching if missing)...
   Stale a: source changed
   Hash deltas a: ~aaa{src b5d455b9 -> 8df17e22, impl dc32e16d -> ffd0693d}
-   Finished type check of     rebuild/a     0.000 s
+   Finished type check of     a     0.000 s
   Stale b: impl changes in a.aaa dc32e16d → ffd0693d (used by baa)
   Stale c: impl changes in b.baa f8c877f7 → 0372700c (used by main)
-   Finished compilation of    rebuild/a     0.000 s
-   Finished compilation of    rebuild/b     0.000 s
-   Finished compilation of    rebuild/c     0.000 s
-   Finished final compilation               0.000 s
+   Finished compilation of    a     0.000 s
+   Finished compilation of    b     0.000 s
+   Finished compilation of    c     0.000 s
+   Finished final compilation       0.000 s

--- a/compiler/acton/test/rebuild/golden/file_08-change-b-impl.golden
+++ b/compiler/acton/test/rebuild/golden/file_08-change-b-impl.golden
@@ -3,8 +3,8 @@ Resolving dependencies (fetching if missing)...
   Fresh a: using cached .ty
   Stale b: source changed
   Hash deltas b: +DocInfo, ~baa{src a5c65622 -> 1bb00ba9, impl 0372700c -> 3c1bc1bc}
-   Finished type check of     rebuild/b     0.000 s
+   Finished type check of     b     0.000 s
   Stale c: impl changes in b.baa 0372700c → 3c1bc1bc (used by main)
-   Finished compilation of    rebuild/b     0.000 s
-   Finished compilation of    rebuild/c     0.000 s
-   Finished final compilation               0.000 s
+   Finished compilation of    b     0.000 s
+   Finished compilation of    c     0.000 s
+   Finished final compilation       0.000 s

--- a/compiler/acton/test/rebuild/golden/project_02-initial-build.golden
+++ b/compiler/acton/test/rebuild/golden/project_02-initial-build.golden
@@ -1,11 +1,11 @@
 Resolving dependencies (fetching if missing)...
   Stale a: source changed
-   Finished type check of     rebuild/a     0.000 s
+   Finished type check of     a     0.000 s
   Stale b: source changed
-   Finished type check of     rebuild/b     0.000 s
+   Finished type check of     b     0.000 s
   Stale c: source changed
-   Finished type check of     rebuild/c     0.000 s
-   Finished compilation of    rebuild/a     0.000 s
-   Finished compilation of    rebuild/b     0.000 s
-   Finished compilation of    rebuild/c     0.000 s
-   Finished final compilation               0.000 s
+   Finished type check of     c     0.000 s
+   Finished compilation of    a     0.000 s
+   Finished compilation of    b     0.000 s
+   Finished compilation of    c     0.000 s
+   Finished final compilation       0.000 s

--- a/compiler/acton/test/rebuild/golden/project_03-up-to-date.golden
+++ b/compiler/acton/test/rebuild/golden/project_03-up-to-date.golden
@@ -2,4 +2,4 @@ Resolving dependencies (fetching if missing)...
   Fresh a: using cached .ty
   Fresh b: using cached .ty
   Fresh c: using cached .ty
-   Finished final compilation               0.000 s
+   Finished final compilation       0.000 s

--- a/compiler/acton/test/rebuild/golden/project_04-touch-no-rebuild.golden
+++ b/compiler/acton/test/rebuild/golden/project_04-touch-no-rebuild.golden
@@ -2,4 +2,4 @@ Resolving dependencies (fetching if missing)...
   Fresh a: using cached .ty
   Fresh b: using cached .ty
   Fresh c: using cached .ty
-   Finished final compilation               0.000 s
+   Finished final compilation       0.000 s

--- a/compiler/acton/test/rebuild/golden/project_06-change-a-impl.golden
+++ b/compiler/acton/test/rebuild/golden/project_06-change-a-impl.golden
@@ -1,10 +1,10 @@
 Resolving dependencies (fetching if missing)...
   Stale a: source changed
   Hash deltas a: ~aaa{src b5d455b9 -> 8df17e22, impl dc32e16d -> ffd0693d}
-   Finished type check of     rebuild/a     0.000 s
+   Finished type check of     a     0.000 s
   Stale b: impl changes in a.aaa dc32e16d → ffd0693d (used by baa)
   Stale c: impl changes in b.baa f8c877f7 → 0372700c (used by main)
-   Finished compilation of    rebuild/a     0.000 s
-   Finished compilation of    rebuild/b     0.000 s
-   Finished compilation of    rebuild/c     0.000 s
-   Finished final compilation               0.000 s
+   Finished compilation of    a     0.000 s
+   Finished compilation of    b     0.000 s
+   Finished compilation of    c     0.000 s
+   Finished final compilation       0.000 s

--- a/compiler/acton/test/rebuild/golden/project_08-change-b-impl.golden
+++ b/compiler/acton/test/rebuild/golden/project_08-change-b-impl.golden
@@ -2,8 +2,8 @@ Resolving dependencies (fetching if missing)...
   Fresh a: using cached .ty
   Stale b: source changed
   Hash deltas b: ~DocInfo{impl 670f5ddb -> beff209e}, ~baa{src a5c65622 -> 1bb00ba9, impl 0372700c -> 3c1bc1bc}
-   Finished type check of     rebuild/b     0.000 s
+   Finished type check of     b     0.000 s
   Stale c: impl changes in b.baa 0372700c → 3c1bc1bc (used by main)
-   Finished compilation of    rebuild/b     0.000 s
-   Finished compilation of    rebuild/c     0.000 s
-   Finished final compilation               0.000 s
+   Finished compilation of    b     0.000 s
+   Finished compilation of    c     0.000 s
+   Finished final compilation       0.000 s

--- a/compiler/acton/test/rebuild/golden/project_10-change-a-iface.golden
+++ b/compiler/acton/test/rebuild/golden/project_10-change-a-iface.golden
@@ -1,14 +1,14 @@
 Resolving dependencies (fetching if missing)...
   Stale a: source changed
   Hash deltas a: -W_3, ~aaa{src 8df17e22 -> c7be204e, pub effe126a -> 4d083345, impl ffd0693d -> 60da3ff8}
-   Finished type check of     rebuild/a     0.000 s
+   Finished type check of     a     0.000 s
   Stale b: pub changes in a.aaa effe126a → 4d083345 (used by baa)
   Hash deltas b: ~baa{pub abea1a6b -> 18d7ab30, impl 3c1bc1bc -> e9429599}
-   Finished type check of     rebuild/b     0.000 s
+   Finished type check of     b     0.000 s
   Stale c: pub changes in b.baa abea1a6b → 18d7ab30 (used by main)
   Hash deltas c: ~main{impl ea554c85 -> 75e6644a}
-   Finished type check of     rebuild/c     0.000 s
-   Finished compilation of    rebuild/a     0.000 s
-   Finished compilation of    rebuild/b     0.000 s
-   Finished compilation of    rebuild/c     0.000 s
-   Finished final compilation               0.000 s
+   Finished type check of     c     0.000 s
+   Finished compilation of    a     0.000 s
+   Finished compilation of    b     0.000 s
+   Finished compilation of    c     0.000 s
+   Finished final compilation       0.000 s

--- a/compiler/acton/test/rebuild/golden/project_11-change-b-doc.golden
+++ b/compiler/acton/test/rebuild/golden/project_11-change-b-doc.golden
@@ -2,7 +2,7 @@ Resolving dependencies (fetching if missing)...
   Fresh a: using cached .ty
   Stale b: source changed
   Hash deltas b: ~DocInfo{src c1e824d9 -> a9b2749d, impl beff209e -> c401aad0}
-   Finished type check of     rebuild/b     0.000 s
+   Finished type check of     b     0.000 s
   Fresh c: using cached .ty
-   Finished compilation of    rebuild/b     0.000 s
-   Finished final compilation               0.000 s
+   Finished compilation of    b     0.000 s
+   Finished final compilation       0.000 s

--- a/compiler/acton/test/rebuild/golden/project_12-codegen-stale.golden
+++ b/compiler/acton/test/rebuild/golden/project_12-codegen-stale.golden
@@ -2,5 +2,5 @@ Resolving dependencies (fetching if missing)...
   Fresh a: using cached .ty
   Stale b: generated code out of date {impl c missing -> e3352a26, h missing -> e3352a26}
   Fresh c: using cached .ty
-   Finished compilation of    rebuild/b     0.000 s
-   Finished final compilation               0.000 s
+   Finished compilation of    b     0.000 s
+   Finished final compilation       0.000 s

--- a/compiler/acton/test_incremental.hs
+++ b/compiler/acton/test_incremental.hs
@@ -214,12 +214,20 @@ buildOutFile = do
 -- | Check whether build output reports typechecking for a module.
 typechecked :: T.Text -> T.Text -> Bool
 typechecked out modName =
-  any (\line -> "Finished type check of" `T.isInfixOf` line && modName `T.isInfixOf` line) (T.lines out)
+  any (\line -> "Finished type check of" `T.isInfixOf` line && matchesModule line modName) (T.lines out)
 
 -- | Check whether build output reports compilation for a module.
 compiled :: T.Text -> T.Text -> Bool
 compiled out modName =
-  any (\line -> "Finished compilation of" `T.isInfixOf` line && modName `T.isInfixOf` line) (T.lines out)
+  any (\line -> "Finished compilation of" `T.isInfixOf` line && matchesModule line modName) (T.lines out)
+
+-- | Match module labels across legacy "proj/mod" and new "proj.mod" formats.
+matchesModule :: T.Text -> T.Text -> Bool
+matchesModule line modName =
+  let dotName = T.replace "/" "." modName
+      leafName = T.takeWhileEnd (/= '/') modName
+      tokens = T.words line
+  in any (`elem` tokens) [modName, dotName, leafName]
 
 -- | Remove a file if it exists.
 removeIfExists :: FilePath -> IO ()


### PR DESCRIPTION
Rather than print the project and module as two separate columns with
alignment, we just concatenate them together into a import style module
name. For example, module foo.bar in project banana would be shown as:
```
  Finished type check of     banana  /foo.bar              0.032 s
```
Project was its own column, and since we have the total build graph of
modules across all projects, we'd find the longest name and then align
all the output... which was nice, but just also sort of unnecessary. The
idea is now that you would normally import banana.foo.bar, so let's just
print it like that:
```
  Finished type check of     banana.foo.bar              0.032 s
```
We've also removed the project name for the root project. For compiling
individual files, this makes a big difference as it hides the scratch
directories. Before we had:
```
$ acton examples/helloworld.act
Building file examples/helloworld.act using temporary scratch directory
   Finished type check of     scratch0/helloworld     0.007 s
   Finished compilation of    scratch0/helloworld     0.004 s
   Finished final compilation                         7.937 s
$
```
And now it's:
```
$ acton examples/helloworld.act
Building file examples/helloworld.act using temporary scratch directory
   Finished type check of     helloworld     0.017 s
   Finished compilation of    helloworld     0.007 s
   Finished final compilation                8.210 s
$
```