### PR TITLE
Align test progress with build progress

### DIFF
--- a/compiler/acton/TestFormat.hs
+++ b/compiler/acton/TestFormat.hs
@@ -97,7 +97,7 @@ colorizeStatusPart useColor cached statusRaw runs =
 -- | Format a single test result line with alignment and timing.
 formatTestLineWith :: Bool -> (TestResult -> String) -> Int -> String -> TestResult -> String
 formatTestLineWith useColor statusFn nameWidth display res =
-    let prefix0 = "  " ++ display ++ ": "
+    let prefix0 = "   " ++ display ++ ": "
         padding = replicate (max 0 (nameWidth - length prefix0)) ' '
         statusRaw = statusFn res
         runs = printf "%4d runs in %3.3fms" (trNumIterations res) (trTestDuration res)

--- a/compiler/acton/TestUI.hs
+++ b/compiler/acton/TestUI.hs
@@ -159,8 +159,8 @@ testSpinnerLoop ui = do
 renderLiveLine :: Char -> String -> String
 renderLiveLine spinner line =
     case line of
-      ' ':' ':rest -> spinner : ' ' : rest
-      _ -> spinner : ' ' : line
+      ' ':' ':' ':rest -> ' ' : spinner : ' ' : rest
+      _ -> ' ' : spinner : ' ' : line
 
 moduleHeaderLine :: String -> String
 moduleHeaderLine modName


### PR DESCRIPTION
The build progress uses 3 space indent where the middle character prints the braille spinner. For testing we used 2 with the braille spinner on char 1 (0 - the first!). We now align on the build output and thus I've added 1 space for test output. I think it's more visually appealing.