### PR TITLE
Add optional chaining

### DIFF
--- a/compiler/lib/src/Acton/Desugar.hs
+++ b/compiler/lib/src/Acton/Desugar.hs
@@ -1,0 +1,45 @@
+-- Copyright (C) 2019-2021 Data Ductus AB
+--
+-- Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+--
+-- 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+--
+-- 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+--
+-- 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+--
+-- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
+
+module Acton.Desugar (desugarOptDot) where
+
+import Acton.Syntax
+import Utils (SrcLoc)
+
+-- | Desugar a single optional-chain access like @a?.b@ into a
+--   null‑short‑circuiting lambda application:
+--
+--   1. Bind the base expression exactly once into a fresh temp.
+--      This preserves evaluation order and avoids duplicating side effects.
+--   2. Build a conditional that returns @tmp.b@ when @tmp is not None@,
+--      otherwise returns @None@.
+--   3. Wrap the conditional in a lambda and apply it to the base expression.
+--
+--   Conceptually:
+--
+--     a?.b
+--       ==> (lambda tmp: tmp.b if tmp is not None else None)(a)
+--
+--   This keeps the rewrite local to the parser so later passes never see
+--   an OptDot node, while still producing a normal expression tree that the
+--   type checker can handle.
+desugarOptDot :: SrcLoc -> Expr -> Name -> Expr
+desugarOptDot l base attr =
+  let tmp = Internal Tempvar "opt" 0
+      tmpVar = Var l (NoQ tmp)
+      noneExpr = None l
+      testExpr = CompOp l tmpVar [OpArg IsNot noneExpr]
+      thenExpr = Dot l tmpVar attr
+      condExpr = Cond l thenExpr testExpr noneExpr
+      lambdaExpr = Lambda l (PosPar tmp Nothing Nothing PosNIL) KwdNIL condExpr tWild
+  in Call l lambdaExpr (PosArg base PosNil) KwdNil

--- a/compiler/lib/src/Acton/Parser.hs
+++ b/compiler/lib/src/Acton/Parser.hs
@@ -39,6 +39,7 @@ import qualified Data.List.NonEmpty
 import qualified Acton.Syntax as S
 import qualified Acton.Builtin as Builtin
 import qualified Acton.Names as Names
+import qualified Acton.Desugar as Desugar
 import Utils
 import Debug.Trace
 import System.IO.Unsafe
@@ -1781,6 +1782,11 @@ atom_expr = do
                       (do
                          (ps,ks) <- parens funargs
                          return (\a -> S.Call NoLoc a ps ks))
+                     <|>
+                      (do
+                         _ <- symbol "?."
+                         nm <- name
+                         return (\a -> Desugar.desugarOptDot (loc a `upto` loc nm) a nm))
                      <|>
                       (do
                          dot

--- a/test/core_lang_auto/optchain.act
+++ b/test/core_lang_auto/optchain.act
@@ -1,0 +1,23 @@
+class Gamma():
+    def __init__(self, s: ?str):
+        self.s = s
+
+class Beta():
+    def __init__(self, c: ?Gamma):
+        self.c = c
+
+class Alpha():
+    def __init__(self, b: ?Beta):
+        self.b = b
+
+actor main(env):
+    a1 = None
+    print(a1?.b?.c?.s)
+
+    a2 = Alpha(Beta(None))
+    print(a2?.b?.c?.s)
+
+    a3 = Alpha(Beta(Gamma("hello")))
+    print(a3?.b?.c?.s)
+
+    env.exit(0)


### PR DESCRIPTION
We now support ?. for chaining accesses over optionals, like

  v = a?.b?.c?.s

Internally, ?. is parsed as an optional-dot and desugared / rewritten to lambdas for accessing the value or just returning None.