### PR TITLE
Fix LSP stdout framing corruption

### DIFF
--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -2343,8 +2343,8 @@ discoverProjects sysAbs rootProj depOverrides = do
                                                then (dep, Nothing)
                                                else (pinDep, Just dep)
                                    when (isJust conflict) $
-                                     putStrLn ("Warning: dependency '" ++ depName ++ "' in " ++ dirAbs
-                                               ++ " overridden by root pin")
+                                     hPutStrLn stderr ("Warning: dependency '" ++ depName ++ "' in " ++ dirAbs
+                                                       ++ " overridden by root pin")
                                    depBase <- resolveDepBase dirAbs depName chosenDep
                                    depAbs  <- normalizePathSafe depBase
                                    return (depName, depAbs)
@@ -2695,14 +2695,16 @@ fetchDependencies gopts paths depOverrides = do
           present <- doesDirectoryExist (cacheDir h)
           if present
             then do
-              putStrLn ("Using cached " ++ kind ++ " dependency " ++ name ++ " (" ++ h ++ ")")
+              unless (C.quiet gopts) $
+                putStrLn ("Using cached " ++ kind ++ " dependency " ++ name ++ " (" ++ h ++ ")")
               return (Right h)
             else runFetch kind name url mh cacheDir zigExe globalCache
         Nothing ->
           runFetch kind name url mh cacheDir zigExe globalCache
 
     runFetch kind name url mh cacheDir zigExe globalCache = do
-      putStrLn ("Fetching " ++ kind ++ " dependency " ++ name ++ " from " ++ url)
+      unless (C.quiet gopts) $
+        putStrLn ("Fetching " ++ kind ++ " dependency " ++ name ++ " from " ++ url)
       let cmd = proc zigExe ["fetch", "--global-cache-dir", globalCache, url]
       res <- try (readCreateProcessWithExitCode cmd "") :: IO (Either SomeException (ExitCode, String, String))
       case res of

--- a/compiler/lib/src/InterfaceFiles.hs
+++ b/compiler/lib/src/InterfaceFiles.hs
@@ -89,7 +89,7 @@ readFile f = do
     if vs == A.version
       then return (map fst imps, nmod, tmod, moduleSrcBytesHash, modulePubHash, moduleImplHash, imps, nameHashes, roots, mdoc)
       else do
-        putStrLn ("Interface file has version " ++ show vs ++ "; current version is " ++ show A.version)
+        hPutStrLn stderr ("Interface file has version " ++ show vs ++ "; current version is " ++ show A.version)
         System.Exit.exitFailure
 
 -- Read only small header fields from .ty: (moduleSrcBytesHash, modulePubHash,


### PR DESCRIPTION
The LSP server communicates over stdio, so any non-protocol output on stdout can corrupt JSON-RPC framing and make VS Code lose sync with messages like "Header must provide a Content-Length property".

We had compiler paths that could emit plain text to stdout during LSP-triggered compile work (especially dependency-related output), which can interleave with LSP packets and break parsing. This originated from the compiler legacy where this was all in the old "actonc" that outputted messages meant for human consumption, then we moved it into a common library for use by the LSP-server as well but never removed the messages that were unconditionally printed.

We now add conditions to silence messages based on the quiet options or output errors to stderr instead of stdout as to not interfere with the LSP communication.

Fixes #2627