### PR TITLE
Stabilize test output by sanitizing hashes

### DIFF
--- a/compiler/acton/test/rebuild/golden/file_06-change-a-impl.golden
+++ b/compiler/acton/test/rebuild/golden/file_06-change-a-impl.golden
@@ -1,10 +1,10 @@
 Building file src/c.act in project .
 Resolving dependencies (fetching if missing)...
   Stale a: source changed
-  Hash deltas a: ~aaa{src b5d455b9 -> 8df17e22, impl 5aa091f6 -> 864e3b8b}
+  Hash deltas a: ~aaa{src HASH1 -> HASH2, impl HASH1 -> HASH2}
    Finished type check of     a     0.000 s
-  Stale b: impl changes in a.aaa 5aa091f6 → 864e3b8b (used by baa)
-  Stale c: impl changes in b.baa cf2d0b67 → e0e86dc8 (used by main)
+  Stale b: impl changes in a.aaa HASH1 → HASH2 (used by baa)
+  Stale c: impl changes in b.baa HASH1 → HASH2 (used by main)
    Finished compilation of    a     0.000 s
    Finished compilation of    b     0.000 s
    Finished compilation of    c     0.000 s

--- a/compiler/acton/test/rebuild/golden/file_08-change-b-impl.golden
+++ b/compiler/acton/test/rebuild/golden/file_08-change-b-impl.golden
@@ -2,9 +2,9 @@ Building file src/c.act in project .
 Resolving dependencies (fetching if missing)...
   Fresh a: using cached .ty
   Stale b: source changed
-  Hash deltas b: +DocInfo, ~baa{src a5c65622 -> 1bb00ba9, impl e0e86dc8 -> 3efc177c}
+  Hash deltas b: +DocInfo, ~baa{src HASH1 -> HASH2, impl HASH1 -> HASH2}
    Finished type check of     b     0.000 s
-  Stale c: impl changes in b.baa e0e86dc8 → 3efc177c (used by main)
+  Stale c: impl changes in b.baa HASH1 → HASH2 (used by main)
    Finished compilation of    b     0.000 s
    Finished compilation of    c     0.000 s
    Finished final compilation       0.000 s

--- a/compiler/acton/test/rebuild/golden/project_06-change-a-impl.golden
+++ b/compiler/acton/test/rebuild/golden/project_06-change-a-impl.golden
@@ -1,9 +1,9 @@
 Resolving dependencies (fetching if missing)...
   Stale a: source changed
-  Hash deltas a: ~aaa{src b5d455b9 -> 8df17e22, impl 5aa091f6 -> 864e3b8b}
+  Hash deltas a: ~aaa{src HASH1 -> HASH2, impl HASH1 -> HASH2}
    Finished type check of     a     0.000 s
-  Stale b: impl changes in a.aaa 5aa091f6 → 864e3b8b (used by baa)
-  Stale c: impl changes in b.baa cf2d0b67 → e0e86dc8 (used by main)
+  Stale b: impl changes in a.aaa HASH1 → HASH2 (used by baa)
+  Stale c: impl changes in b.baa HASH1 → HASH2 (used by main)
    Finished compilation of    a     0.000 s
    Finished compilation of    b     0.000 s
    Finished compilation of    c     0.000 s

--- a/compiler/acton/test/rebuild/golden/project_08-change-b-impl.golden
+++ b/compiler/acton/test/rebuild/golden/project_08-change-b-impl.golden
@@ -1,9 +1,9 @@
 Resolving dependencies (fetching if missing)...
   Fresh a: using cached .ty
   Stale b: source changed
-  Hash deltas b: ~DocInfo{impl babab0b9 -> ffbd9ff2}, ~baa{src a5c65622 -> 1bb00ba9, impl e0e86dc8 -> 3efc177c}
+  Hash deltas b: ~DocInfo{impl HASH1 -> HASH2}, ~baa{src HASH1 -> HASH2, impl HASH1 -> HASH2}
    Finished type check of     b     0.000 s
-  Stale c: impl changes in b.baa e0e86dc8 → 3efc177c (used by main)
+  Stale c: impl changes in b.baa HASH1 → HASH2 (used by main)
    Finished compilation of    b     0.000 s
    Finished compilation of    c     0.000 s
    Finished final compilation       0.000 s

--- a/compiler/acton/test/rebuild/golden/project_10-change-a-iface.golden
+++ b/compiler/acton/test/rebuild/golden/project_10-change-a-iface.golden
@@ -1,12 +1,12 @@
 Resolving dependencies (fetching if missing)...
   Stale a: source changed
-  Hash deltas a: -W_3, ~aaa{src 8df17e22 -> c7be204e, pub e690b8f5 -> 90fd190c, impl 864e3b8b -> 60da3ff8}
+  Hash deltas a: -W_3, ~aaa{src HASH1 -> HASH2, pub HASH1 -> HASH2, impl HASH1 -> HASH2}
    Finished type check of     a     0.000 s
-  Stale b: pub changes in a.aaa e690b8f5 → 90fd190c (used by baa)
-  Hash deltas b: ~baa{pub 3e88d782 -> 8cc0f2dd, impl 3efc177c -> e9429599}
+  Stale b: pub changes in a.aaa HASH1 → HASH2 (used by baa)
+  Hash deltas b: ~baa{pub HASH1 -> HASH2, impl HASH1 -> HASH2}
    Finished type check of     b     0.000 s
-  Stale c: pub changes in b.baa 3e88d782 → 8cc0f2dd (used by main)
-  Hash deltas c: ~main{impl 3eb0c945 -> 73625256}
+  Stale c: pub changes in b.baa HASH1 → HASH2 (used by main)
+  Hash deltas c: ~main{impl HASH1 -> HASH2}
    Finished type check of     c     0.000 s
    Finished compilation of    a     0.000 s
    Finished compilation of    b     0.000 s

--- a/compiler/acton/test/rebuild/golden/project_11-change-b-doc.golden
+++ b/compiler/acton/test/rebuild/golden/project_11-change-b-doc.golden
@@ -1,7 +1,7 @@
 Resolving dependencies (fetching if missing)...
   Fresh a: using cached .ty
   Stale b: source changed
-  Hash deltas b: ~DocInfo{src c1e824d9 -> a9b2749d, impl ffbd9ff2 -> 95eec81b}
+  Hash deltas b: ~DocInfo{src HASH1 -> HASH2, impl HASH1 -> HASH2}
    Finished type check of     b     0.000 s
   Fresh c: using cached .ty
    Finished compilation of    b     0.000 s

--- a/compiler/acton/test/rebuild/golden/project_12-codegen-stale.golden
+++ b/compiler/acton/test/rebuild/golden/project_12-codegen-stale.golden
@@ -1,6 +1,6 @@
 Resolving dependencies (fetching if missing)...
   Fresh a: using cached .ty
-  Stale b: generated code out of date {impl c missing -> 12336013, h missing -> 12336013}
+  Stale b: generated code out of date {impl c missing -> HASH2, h missing -> HASH2}
   Fresh c: using cached .ty
    Finished compilation of    b     0.000 s
    Finished final compilation       0.000 s


### PR DESCRIPTION
We test our rebuild logic in order to verify that changes correctly triggers rebuilding modules etc. As part of that output we see the raw hash values. We are not actually interested in the exact hash value, just the fact that a hash has changed and that we correctly react to it. To that end we now replace the concrete hash value with HASH1 and HASH2 so that the snapshot testing output can remain stable over time, yet correctly capture the behavior.