### PR TITLE
Validate --dep local paths as Acton project roots

### DIFF
--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -1958,10 +1958,11 @@ zigBuild env gopts opts paths tasks binTasks allowPrune mProgressUI = do
 
     -- Generate build.zig and build.zig.zon directly from Build.act/build.act.json.
     iff (not isSysProj) $ do
+      depOverrides <- normalizeDepOverrides (projPath paths) (C.dep_overrides opts)
       pinsSpec0 <- loadBuildSpec (projPath paths)
-      pinsSpec  <- traverse (applyDepOverrides (projPath paths) (C.dep_overrides opts)) pinsSpec0
+      pinsSpec  <- traverse (applyDepOverrides (projPath paths) depOverrides) pinsSpec0
       let pins = maybe M.empty BuildSpec.dependencies pinsSpec
-      genBuildZigFiles pins (C.dep_overrides opts) paths
+      genBuildZigFiles pins depOverrides paths
 
     let zigExe = zig paths
         baseArgs = ["build","--cache-dir", local_cache_dir,


### PR DESCRIPTION
Before we try to use a path provided using --dep as an actual dependency, we validate that it looks like an Acton project in order to provide a better error message when it is not.

Fixes #2625