### PR TITLE
Rework deps HTTP download, support http_proxy

### DIFF
--- a/compiler/lib/package.yaml.in
+++ b/compiler/lib/package.yaml.in
@@ -34,6 +34,9 @@ dependencies:
   - filelock
   - filepath
   - hashable
+  - http-client
+  - http-client-tls
+  - http-types
   - megaparsec
   - mtl
   - optparse-applicative


### PR DESCRIPTION
We now download dependency artifacts using the Haskell http-client library. Previously we called out to `zig fetch` which in turn automatically downloaded the necessary file, extracted it and performed the hash check. A key issue for us has been the poor proxy support offered by zig fetch. Zig uses its own HTTP client library and while it has some HTTP proxy supports, there are scenarios for which it fails. I don't know the precise details of those scenarios but it is relatively simple to reproduce. Using the Haskell http-client, which is a fair bit more mature and seems to offer more complete proxy support, we work around this.

zig fetch supports local file paths, so we don't have to change the main logic around how these artifacts are extracted and hash checked, that is still performed by zig fetch!

Fixes #2614 

Fixes #2562 