### PR TITLE
Require Build.act name + fingerprint in root project

### DIFF
--- a/base/Build.act
+++ b/base/Build.act
@@ -1,3 +1,6 @@
+name = "base"
+fingerprint = 0xc0b4fe61c0b4fe61
+
 dependencies = {
     "actondb": (
         path="../backend/"

--- a/compiler/acton/test/project/auto_root/Build.act
+++ b/compiler/acton/test/project/auto_root/Build.act
@@ -1,0 +1,2 @@
+name = "auto_root"
+fingerprint = 0x25d729578a471226

--- a/compiler/acton/test/project/conf_2bin/Build.act
+++ b/compiler/acton/test/project/conf_2bin/Build.act
@@ -1,3 +1,6 @@
+name = "conf_2bin"
+fingerprint = 0x3a0f2be8959f1099
+
 bins = {
     "a": "a.main",
     "b": "b.main",

--- a/compiler/acton/test/project/missing_src/Build.act
+++ b/compiler/acton/test/project/missing_src/Build.act
@@ -1,0 +1,2 @@
+name = "missing_src"
+fingerprint = 0x3d6d0220ba420c23

--- a/compiler/acton/test/project/prune_executables/Build.act
+++ b/compiler/acton/test/project/prune_executables/Build.act
@@ -1,1 +1,4 @@
 
+name = "prune_executables"
+fingerprint = 0xdd6b7ba1f8e40503
+

--- a/compiler/acton/test/project/prune_partials/Build.act
+++ b/compiler/acton/test/project/prune_partials/Build.act
@@ -1,1 +1,4 @@
 
+name = "prune_partials"
+fingerprint = 0x014428b3365086ba
+

--- a/compiler/acton/test/project/prune_roots/Build.act
+++ b/compiler/acton/test/project/prune_roots/Build.act
@@ -1,1 +1,4 @@
 
+name = "prune_roots"
+fingerprint = 0x1d991f5a9ab61159
+

--- a/compiler/acton/test/project/qualified_root/Build.act
+++ b/compiler/acton/test/project/qualified_root/Build.act
@@ -1,0 +1,2 @@
+name = "qualified_root"
+fingerprint = 0xe20efcacd51a52a5

--- a/compiler/acton/test/project/simple/Build.act
+++ b/compiler/acton/test/project/simple/Build.act
@@ -1,0 +1,2 @@
+name = "simple"
+fingerprint = 0xc17b3d02f0801944

--- a/compiler/acton/test/rebuild/Build.act
+++ b/compiler/acton/test/rebuild/Build.act
@@ -1,1 +1,2 @@
 name = "rebuild"
+fingerprint = 0xc5208553327e37b8

--- a/test/compiler/acton_proj_deps/Build.act
+++ b/test/compiler/acton_proj_deps/Build.act
@@ -1,4 +1,5 @@
 name = "acton_proj_deps"
+fingerprint = 0xdaf39f735e4b3c9d
 
 dependencies = {
   "dep_a": (path="deps/dep_a")

--- a/test/compiler/acton_proj_deps/deps/dep_a/Build.act
+++ b/test/compiler/acton_proj_deps/deps/dep_a/Build.act
@@ -1,4 +1,5 @@
 name = "dep_a"
+fingerprint = 0xf50f59a4783b4aab
 
 dependencies = {
   "dep_b": (path="../dep_b")

--- a/test/compiler/acton_proj_deps/deps/dep_b/Build.act
+++ b/test/compiler/acton_proj_deps/deps/dep_b/Build.act
@@ -1,4 +1,5 @@
 name = "dep_b"
+fingerprint = 0x6c06081ee1321b11
 
 dependencies = {
 }

--- a/test/compiler/dep-api-change/Build.act
+++ b/test/compiler/dep-api-change/Build.act
@@ -1,3 +1,6 @@
+name = "dep_api_change"
+fingerprint = 0xbd306978666b735b
+
 dependencies = {
     "libfoo": (
         path="deps/libfoo"

--- a/test/compiler/dep-api-change/deps/libfoo/Build.act
+++ b/test/compiler/dep-api-change/deps/libfoo/Build.act
@@ -1,0 +1,2 @@
+name = "libfoo"
+fingerprint = 0xb8cbf80508642044

--- a/test/compiler/dep_override/Build.act
+++ b/test/compiler/dep_override/Build.act
@@ -1,4 +1,5 @@
 name = "dep_override"
+fingerprint = 0xcd8179d196da1527
 
 dependencies = {
   "dep_a": (path="deps/dep_a_missing")

--- a/test/compiler/dep_override/deps/dep_a/Build.act
+++ b/test/compiler/dep_override/deps/dep_a/Build.act
@@ -1,4 +1,5 @@
 name = "dep_a"
+fingerprint = 0xf50f59a402fa4e49
 
 dependencies = {
   "dep_b": (path="../dep_b_missing")

--- a/test/compiler/dep_override/deps/dep_b/Build.act
+++ b/test/compiler/dep_override/deps/dep_b/Build.act
@@ -1,4 +1,5 @@
 name = "dep_b"
+fingerprint = 0x6c06081e9bf31ff3
 
 dependencies = {
 }

--- a/test/compiler/dep_override/deps/dep_c/Build.act
+++ b/test/compiler/dep_override/deps/dep_c/Build.act
@@ -1,4 +1,5 @@
 name = "dep_c"
+fingerprint = 0x1b013888ecf42f65
 
 dependencies = {
 }

--- a/test/compiler/hello/Build.act
+++ b/test/compiler/hello/Build.act
@@ -1,0 +1,2 @@
+name = "hello"
+fingerprint = 0x3610a6864bda1545

--- a/test/compiler/many_modules/Build.act
+++ b/test/compiler/many_modules/Build.act
@@ -1,0 +1,2 @@
+name = "many_modules"
+fingerprint = 0xf081deffabdab209

--- a/test/compiler/mixed-dots/Build.act
+++ b/test/compiler/mixed-dots/Build.act
@@ -1,0 +1,2 @@
+name = "mixed_dots"
+fingerprint = 0xcdde5c45e91788b8

--- a/test/compiler/rebuild-import/Build.act
+++ b/test/compiler/rebuild-import/Build.act
@@ -1,0 +1,2 @@
+name = "rebuild_import"
+fingerprint = 0xb86f6eefc57a9ffe

--- a/test/compiler/rebuild/Build.act
+++ b/test/compiler/rebuild/Build.act
@@ -1,0 +1,2 @@
+name = "rebuild"
+fingerprint = 0xc5208553779f9e22

--- a/test/compiler/subdash/Build.act
+++ b/test/compiler/subdash/Build.act
@@ -1,0 +1,2 @@
+name = "subdash"
+fingerprint = 0x42dbaf8bf064b4fa

--- a/test/compiler/test_deps/Build.act
+++ b/test/compiler/test_deps/Build.act
@@ -1,3 +1,6 @@
+name = "test_deps"
+fingerprint = 0x3856c53c8417f6d8
+
 dependencies = {
     "a_b": (
         path="deps/a-b"

--- a/test/compiler/test_deps/deps/a-b/Build.act
+++ b/test/compiler/test_deps/deps/a-b/Build.act
@@ -1,0 +1,2 @@
+name = "a_b"
+fingerprint = 0x28cb39ea006f4d87

--- a/test/compiler/unused_dep/Build.act
+++ b/test/compiler/unused_dep/Build.act
@@ -1,4 +1,5 @@
 name = "unused_dep_proj"
+fingerprint = 0x4a234a795914933e
 
 dependencies = {
   "dep_unused": (path="deps/dep_unused")

--- a/test/compiler/unused_dep/deps/dep_unused/Build.act
+++ b/test/compiler/unused_dep/deps/dep_unused/Build.act
@@ -1,4 +1,5 @@
 name = "dep_unused"
+fingerprint = 0x7151e903e0ce7b19
 
 dependencies = {
 }

--- a/test/core_lang_auto/imported_class/Build.act
+++ b/test/core_lang_auto/imported_class/Build.act
@@ -1,0 +1,2 @@
+name = "imported_class"
+fingerprint = 0x33390571c288ff7b

--- a/test/perf/Build.act
+++ b/test/perf/Build.act
@@ -1,0 +1,2 @@
+name = "perf"
+fingerprint = 0xbdbfa95241146352

--- a/test/regression_auto/import_actor/Build.act
+++ b/test/regression_auto/import_actor/Build.act
@@ -1,0 +1,2 @@
+name = "import_actor"
+fingerprint = 0xa920f937cfebf664

--- a/test/stdlib_tests/Build.act
+++ b/test/stdlib_tests/Build.act
@@ -1,0 +1,2 @@
+name = "stdlib_tests"
+fingerprint = 0xfeb6359d68c4a929

--- a/test/test_doc_printing/Build.act
+++ b/test/test_doc_printing/Build.act
@@ -1,4 +1,5 @@
 name = "test_doc_printing"
+fingerprint = 0x7dbd90981f02f1f2
 
 dependencies = {}
 zig_dependencies = {}

--- a/test/test_testing/Build.act
+++ b/test/test_testing/Build.act
@@ -1,0 +1,2 @@
+name = "test_testing"
+fingerprint = 0x34b28ecea2c0127a


### PR DESCRIPTION
It is now required to have a name and fingerprint field in Build.act in the root project, that is, in the project you are currently trying to compile. It is still possible to have dependencies on other projects that do not have a Build.act with name + fingerprint, but that will also soon no longer be possible. name + fp everywhere!!