### PR TITLE
Use ubuntu 22.04 for build-debs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -261,7 +261,7 @@ jobs:
         arch: [amd64, arm64]
     runs-on: ${{ matrix.arch == 'amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
     container:
-      image: debian:12
+      image: ubuntu:22.04
     env:
       LANG: en_US.UTF-8
       LC_ALL: en_US.UTF-8
@@ -270,6 +270,7 @@ jobs:
       - name: "Show platform and environment"
         run: |
           env
+          ldd --version | head -n1
           cat /proc/cpuinfo
           uname -a
       - name: "Set BUILD_RELEASE when we are building for a version tag"

--- a/debian/rules
+++ b/debian/rules
@@ -28,6 +28,11 @@ override_dh_strip:
 override_dh_dwz:
 	@echo "Skipping dwz"
 
+# Force a legacy-compatible .deb compression format.
+# Newer dpkg defaults may emit control.tar.zst, which Debian 11 cannot unpack.
+override_dh_builddeb:
+	dh_builddeb -- -Zxz --uniform-compression
+
 # dh_make generated override targets
 # This is example for Cmake (See https://bugs.debian.org/641051 )
 #override_dh_auto_configure:


### PR DESCRIPTION
We want to build our deb on the oldest possible distribution with the oldest possible version of glibc since that allows us to run on older distros. Debian 12 that we have been using seems to produce builds for glibc 2.36 whereas Ubuntu 22.04 uses glibc 2.35 - it's just a single number but it does mean we should be able to run on for example Ubuntu 22.04.

AFAIK the switch from Debian to Ubuntu shouldn't really matter much for the produced deb files, they build platforms are virtually identical. While packages are normally stamped with the distro they are built *for*, we have that hard-coded anyway, so I don't think that Ubuntu colors or build.

Fixes #2646