### PR TITLE
Dynamically link glibc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ compiler/package.yaml
 compiler/acton/acton.cabal
 compiler/acton/package.yaml
 compiler/lib/package.yaml
+compiler/lib/libacton.cabal
 compiler/lsp-server/package.yaml
 compiler/lsp-server/lsp-server-acton.cabal
 test/package.yaml

--- a/compiler/acton/package.yaml.in
+++ b/compiler/acton/package.yaml.in
@@ -82,8 +82,10 @@ executables:
         - -optl-no-pie
         - -pgml=../tools/ld-wrapper.sh
     - condition: os(linux) && !arch(aarch64)
-      ld-options:
-        - -static
+      ghc-options:
+        - -no-pie
+        - -optl-no-pie
+        - -pgml=../tools/ld-wrapper.sh
 
 tests:
   test_acton:

--- a/compiler/lsp-server/package.yaml.in
+++ b/compiler/lsp-server/package.yaml.in
@@ -49,5 +49,7 @@ executables:
           - -optl-no-pie
           - -pgml=../tools/ld-wrapper.sh
       - condition: os(linux) && !arch(aarch64)
-        ld-options:
-          - -static
+        ghc-options:
+          - -no-pie
+          - -optl-no-pie
+          - -pgml=../tools/ld-wrapper.sh

--- a/compiler/tools/ld-wrapper.sh
+++ b/compiler/tools/ld-wrapper.sh
@@ -6,7 +6,7 @@ state="static"
 arch="$(uname -m 2>/dev/null || true)"
 allow_dynamic_glibc=false
 case "$arch" in
-  aarch64|arm64)
+  aarch64|arm64|x86_64|amd64)
     allow_dynamic_glibc=true
     ;;
 esac


### PR DESCRIPTION
We now dynamically link glibc on Linux on x86_64 while keeping other libs static, just like we already do for aarch64.