### PR TITLE
Add capability-based test skipping

### DIFF
--- a/base/src/testing.act
+++ b/base/src/testing.act
@@ -320,14 +320,29 @@ def eq_opt[T(Eq)](a: ?T, b: ?T) -> bool:
 class TestLogger(logging.Logger):
     pass
 
+class SkipTest(AssertionError):
+    pass
+
+class AbortTest(Exception):
+    pass
+
 class SyncT(value):
-    def __init__(self, log_handler: logging.Handler):
+    def __init__(self, log_handler: logging.Handler, tags: set[str]):
         self.log_handler = log_handler
+        self.tags = tags
+
+    def skip(self, reason: ?str="Skipped"):
+        raise SkipTest(reason)
+
+    def require(self, tag: str):
+        if tag not in self.tags:
+            self.skip(f"Missing required capability '{tag}' (enable with --tag {tag})")
 
 class AsyncT(value):
-    def __init__(self, report_result: action(?bool, ?Exception, ?str) -> None, log_handler: logging.Handler):
+    def __init__(self, report_result: action(?bool, ?Exception, ?str) -> None, log_handler: logging.Handler, tags: set[str]):
         self.report_result = report_result
         self.log_handler = log_handler
+        self.tags = tags
 
     def success(self, output: ?str=None):
         self.report_result(True, None, output)
@@ -338,11 +353,20 @@ class AsyncT(value):
     def error(self, exception: Exception):
         self.report_result(None, exception, None)
 
+    def skip(self, reason: ?str="Skipped"):
+        self.report_result(True, SkipTest(reason), None)
+        raise AbortTest(reason)
+
+    def require(self, tag: str):
+        if tag not in self.tags:
+            self.skip(f"Missing required capability '{tag}' (enable with --tag {tag})")
+
 class EnvT(value):
-    def __init__(self, report_result: action(?bool, ?Exception, ?str) -> None, env: Env, log_handler: logging.Handler):
+    def __init__(self, report_result: action(?bool, ?Exception, ?str) -> None, env: Env, log_handler: logging.Handler, tags: set[str]):
         self.report_result = report_result
         self.env = env
         self.log_handler = log_handler
+        self.tags = tags
 
     def success(self, output: ?str=None):
         self.report_result(True, None, output)
@@ -352,6 +376,14 @@ class EnvT(value):
 
     def error(self, exception: Exception):
         self.report_result(None, exception, None)
+
+    def skip(self, reason: ?str="Skipped"):
+        self.report_result(True, SkipTest(reason), None)
+        raise AbortTest(reason)
+
+    def require(self, tag: str):
+        if tag not in self.tags:
+            self.skip(f"Missing required capability '{tag}' (enable with --tag {tag})")
 
 
 class Test(object):
@@ -375,17 +407,17 @@ class Test(object):
             n = n[:-8]
         return n
 
-    def run(self, report_result: action(?bool, ?Exception, ?str) -> None, env: Env, log_handler: logging.Handler):
+    def run(self, report_result: action(?bool, ?Exception, ?str) -> None, env: Env, log_handler: logging.Handler, tags: set[str]):
         if isinstance(self, UnitTest):
-            self.run_test(report_result, env, log_handler)
+            self.run_test(report_result, env, log_handler, tags)
         elif isinstance(self, SimpleSyncTest):
-            self.run_test(report_result, env, log_handler)
+            self.run_test(report_result, env, log_handler, tags)
         elif isinstance(self, SyncTest):
-            self.run_test(report_result, env, log_handler)
+            self.run_test(report_result, env, log_handler, tags)
         elif isinstance(self, AsyncTest):
-            self.run_test(report_result, env, log_handler)
+            self.run_test(report_result, env, log_handler, tags)
         elif isinstance(self, EnvTest):
-            self.run_test(report_result, env, log_handler)
+            self.run_test(report_result, env, log_handler, tags)
         else:
             raise ValueError("Test: Invalid test type")
 
@@ -441,7 +473,7 @@ class UnitTest(Test):
         self.desc = desc
         self.module = module
 
-    def run_test(self, report_result: action(?bool, ?Exception, ?str) -> None, env: Env, log_handler: logging.Handler):
+    def run_test(self, report_result: action(?bool, ?Exception, ?str) -> None, env: Env, log_handler: logging.Handler, tags: set[str]):
         output = None
         success = None
         exception = None
@@ -449,6 +481,9 @@ class UnitTest(Test):
             output = self.fn()
             success = True
             exception = None
+        except SkipTest as e:
+            success = True
+            exception = e
         except AssertionError as e:
             success = False
             exception = e
@@ -464,7 +499,7 @@ class SimpleSyncTest(Test):
         self.desc = desc
         self.module = module
 
-    def run_test(self, report_result: action(?bool, ?Exception, ?str) -> None, env: Env, log_handler: logging.Handler):
+    def run_test(self, report_result: action(?bool, ?Exception, ?str) -> None, env: Env, log_handler: logging.Handler, tags: set[str]):
         output = None
         success = None
         exception = None
@@ -472,6 +507,9 @@ class SimpleSyncTest(Test):
             output = self.fn()
             success = True
             exception = None
+        except SkipTest as e:
+            success = True
+            exception = e
         except AssertionError as e:
             success = False
             exception = e
@@ -487,14 +525,17 @@ class SyncTest(Test):
         self.desc = desc
         self.module = module
 
-    def run_test(self, report_result: action(?bool, ?Exception, ?str) -> None, env: Env, log_handler: logging.Handler):
+    def run_test(self, report_result: action(?bool, ?Exception, ?str) -> None, env: Env, log_handler: logging.Handler, tags: set[str]):
         output = None
         success = None
         exception = None
         try:
-            output = self.fn(SyncT(log_handler))
+            output = self.fn(SyncT(log_handler, tags))
             success = True
             exception = None
+        except SkipTest as e:
+            success = True
+            exception = e
         except AssertionError as e:
             success = False
             exception = e
@@ -510,8 +551,11 @@ class AsyncTest(Test):
         self.desc = desc
         self.module = module
 
-    def run_test(self, report_result: action(?bool, ?Exception, ?str) -> None, env: Env, log_handler: logging.Handler):
-        self.fn(AsyncT(report_result, log_handler))
+    def run_test(self, report_result: action(?bool, ?Exception, ?str) -> None, env: Env, log_handler: logging.Handler, tags: set[str]):
+        try:
+            self.fn(AsyncT(report_result, log_handler, tags))
+        except AbortTest:
+            pass
 
 class EnvTest(Test):
     def __init__(self, fn: proc(EnvT) -> None, name: str, desc: str, module: str):
@@ -520,8 +564,11 @@ class EnvTest(Test):
         self.desc = desc
         self.module = module
 
-    def run_test(self, report_result: action(?bool, ?Exception, ?str) -> None, env: Env, log_handler: logging.Handler):
-        self.fn(EnvT(report_result, env, log_handler))
+    def run_test(self, report_result: action(?bool, ?Exception, ?str) -> None, env: Env, log_handler: logging.Handler, tags: set[str]):
+        try:
+            self.fn(EnvT(report_result, env, log_handler, tags))
+        except AbortTest:
+            pass
 
 
 class TestResult(object):
@@ -538,14 +585,26 @@ class TestResult(object):
       - for asynchronous actor & env tests, the report_result callback was called with TestResult(success=None, exception=AssertionError)
     """
     success: ?bool
+    skipped: bool
+    skip_reason: ?str
     exception: ?str
     output: ?str
     duration: float
     mem_usage_delta: int
     non_gc_mem_usage_delta: int
 
-    def __init__(self, success: ?bool, exception: ?str, output: ?str, duration: float, mem_usage_delta: int, non_gc_mem_usage_delta: int):
+    def __init__(self,
+                 success: ?bool,
+                 exception: ?str,
+                 output: ?str,
+                 duration: float,
+                 mem_usage_delta: int,
+                 non_gc_mem_usage_delta: int,
+                 skipped: bool=False,
+                 skip_reason: ?str=None):
         self.success = success
+        self.skipped = skipped
+        self.skip_reason = skip_reason
         self.exception = exception
         self.output = output
         self.duration = duration
@@ -555,6 +614,8 @@ class TestResult(object):
     def to_json(self):
         return {
             "success": self.success,
+            "skipped": self.skipped,
+            "skip_reason": self.skip_reason,
             "exception": self.exception,
             "output": self.output,
             "duration": self.duration,
@@ -565,19 +626,27 @@ class TestResult(object):
     @staticmethod
     def from_json(data: dict[str, str]) -> TestResult:
         success = data["success"]
+        skipped = False
+        if "skipped" in data:
+            skipped = data["skipped"]
+        skip_reason = None
+        if "skip_reason" in data:
+            skip_reason = data["skip_reason"]
         exception = data["exception"]
         output = data["output"]
         duration = data["duration"]
         mem_usage_delta = data["mem_usage_delta"]
         non_gc_mem_usage_delta = data["non_gc_mem_usage_delta"]
         if (isinstance(success, bool)
-            and isinstance(exception, str)
-            and isinstance(output, str)
+            and isinstance(skipped, bool)
+            and (skip_reason is None or isinstance(skip_reason, str))
+            and (exception is None or isinstance(exception, str))
+            and (output is None or isinstance(output, str))
             and isinstance(duration, float)
             and isinstance(mem_usage_delta, int)
             and isinstance(non_gc_mem_usage_delta, int)
             ):
-            return TestResult(success, exception, output, duration, mem_usage_delta, non_gc_mem_usage_delta)
+            return TestResult(success, exception, output, duration, mem_usage_delta, non_gc_mem_usage_delta, skipped, skip_reason)
         raise ValueError("Invalid TestResult JSON")
 
 
@@ -585,6 +654,8 @@ class TestInfo(object):
     definition: Test
     complete: bool
     success: ?bool
+    skipped: bool
+    skip_reason: ?str
     exception: ?str
     output: ?str
     std_out: ?str
@@ -598,6 +669,7 @@ class TestInfo(object):
     total_duration: float
     test_duration: float
     num_iterations: int
+    num_skipped: int
     num_failures: int
     num_errors: int
     mem_usage_delta_avg: int
@@ -609,6 +681,8 @@ class TestInfo(object):
                  definition: Test,
                  complete: bool=False,
                  success: ?bool=None,
+                 skipped: bool=False,
+                 skip_reason: ?str=None,
                  exception: ?str=None,
                  output: ?str=None,
                  std_out: ?str=None,
@@ -620,6 +694,7 @@ class TestInfo(object):
                  total_duration: float=0.0,
                  test_duration: float=0.0,
                  num_iterations: int=0,
+                 num_skipped: int=0,
                  num_failures: int=0,
                  num_errors: int=0,
                  mem_usage_delta_avg: int=0,
@@ -629,6 +704,8 @@ class TestInfo(object):
         self.definition = definition
         self.complete = complete
         self.success = success
+        self.skipped = skipped
+        self.skip_reason = skip_reason
         self.exception = exception
         self.output = output
         self.std_out = std_out
@@ -642,6 +719,7 @@ class TestInfo(object):
         self.total_duration = total_duration
         self.test_duration = test_duration
         self.num_iterations = num_iterations
+        self.num_skipped = num_skipped
         self.num_failures = num_failures
         self.num_errors = num_errors
         self.mem_usage_delta_avg = mem_usage_delta_avg
@@ -656,6 +734,7 @@ class TestInfo(object):
             # First result
             self.output = result.output
             self.exception = result.exception
+            self.skip_reason = result.skip_reason
 
         self.results.append(result)
 
@@ -672,16 +751,20 @@ class TestInfo(object):
         self.avg_duration = -1.0
         self.total_duration = 0.0
         self.num_iterations = int(len(self.results))
+        self.num_skipped = 0
         self.num_failures = 0
         self.num_errors = 0
         self.mem_usage_delta_avg = 0
         self.non_gc_mem_usage_delta_avg = 0
         self.non_gc_mem_inc_count = 0
         for result in self.results:
-            res_success = result.success
-            if res_success == False:
+            if result.skipped:
+                self.num_skipped += 1
+                if self.skip_reason is None:
+                    self.skip_reason = result.skip_reason
+            elif result.success == False:
                 self.num_failures += 1
-            elif res_success is None:
+            elif result.success is None:
                 self.num_errors += 1
 
         for result in self.results[1:]:
@@ -710,6 +793,7 @@ class TestInfo(object):
             self.success = None
         else:
             self.success = True
+        self.skipped = self.num_skipped > 0 and self.num_failures == 0 and self.num_errors == 0
 
         if (self.num_failures == 0 and self.num_errors == 0) or self.num_failures == self.num_iterations or self.num_errors == self.num_iterations:
             self.flaky = False
@@ -753,6 +837,8 @@ class TestInfo(object):
             "definition": self.definition.to_json(),
             "complete": self.complete,
             "success": self.success,
+            "skipped": self.skipped,
+            "skip_reason": self.skip_reason,
             "exception": self.exception,
             "output": self.output,
             "std_out": self.std_out,
@@ -764,6 +850,7 @@ class TestInfo(object):
             "total_duration": self.total_duration,
             "test_duration": self.test_duration,
             "num_iterations": self.num_iterations,
+            "num_skipped": self.num_skipped,
             "num_failures": self.num_failures,
             "num_errors": self.num_errors,
             "mem_usage_delta_avg": self.mem_usage_delta_avg,
@@ -786,6 +873,18 @@ class TestInfo(object):
         success: ?bool = None
         if suc is not None and isinstance(suc, bool):
             success = suc
+        sk = False
+        if "skipped" in json_data:
+            sk = json_data["skipped"]
+        skipped = False
+        if isinstance(sk, bool):
+            skipped = sk
+        skip_reason_d = None
+        if "skip_reason" in json_data:
+            skip_reason_d = json_data["skip_reason"]
+        skip_reason: ?str = None
+        if skip_reason_d is not None and isinstance(skip_reason_d, str):
+            skip_reason = skip_reason_d
         exc = json_data["exception"]
         exception: ?str = None
         if exc is not None and isinstance(exc, str):
@@ -809,6 +908,9 @@ class TestInfo(object):
         total_duration = json_data["total_duration"]
         test_duration = json_data["test_duration"]
         num_iterations = json_data["num_iterations"]
+        num_skipped = 0
+        if "num_skipped" in json_data:
+            num_skipped = json_data["num_skipped"]
         num_failures = json_data["num_failures"]
         num_errors = json_data["num_errors"]
         mem_usage_delta_avg = json_data["mem_usage_delta_avg"]
@@ -826,6 +928,7 @@ class TestInfo(object):
             and isinstance(total_duration, float)
             and isinstance(test_duration, float)
             and isinstance(num_iterations, int)
+            and isinstance(num_skipped, int)
             and isinstance(num_failures, int)
             and isinstance(num_errors, int)
             and isinstance(mem_usage_delta_avg, int)
@@ -835,6 +938,8 @@ class TestInfo(object):
             return TestInfo(definition,
                             complete,
                             success,
+                            skipped,
+                            skip_reason,
                             exception,
                             output,
                             std_out,
@@ -846,6 +951,7 @@ class TestInfo(object):
                             total_duration,
                             test_duration,
                             num_iterations,
+                            num_skipped,
                             num_failures,
                             num_errors,
                             mem_usage_delta_avg,
@@ -862,14 +968,25 @@ class TestRunnerConfig(object):
     max_time: float
     min_time: float
     output_enabled: bool
+    tags: set[str]
 
     def __init__(self, perf_mode: bool, args):
+        def split_tags(tag_args: list[str]) -> set[str]:
+            tags = set()
+            for raw_tags in tag_args:
+                for t in raw_tags.split(","):
+                    tag = t.strip()
+                    if tag != "":
+                        tags.add(tag)
+            return tags
+
         self.perf_mode = perf_mode
         self.output_enabled = False if args.get_bool("no_output") else True
         self.min_iter = args.get_int("min-iter")
         self.max_iter = max([args.get_int("max-iter"), self.min_iter])
         self.min_time = float(args.get_int("min-time")) / 1000.0
         self.max_time = max([float(args.get_int("max-time")) / 1000.0, self.min_time])
+        self.tags = split_tags(args.get_strlist("tag"))
 
 class TimeoutError(Exception):
     pass
@@ -923,7 +1040,18 @@ actor TestExecutor(syscap, config, t: Test, report_complete, env):
         non_gc_mem_usage_delta = non_gc_mem_usage_after - non_gc_mem_usage_before
         #print(f"non-GC memory before: {non_gc_mem_usage_before}  after: {non_gc_mem_usage_after}  delta: {non_gc_mem_usage_delta}")
 
+        skipped = isinstance(exception, SkipTest)
+        skip_reason = None
+        if skipped:
+            skip_exc = exception
+            if skip_exc is not None:
+                skip_reason = str(skip_exc)
+            success = True
+            exception = None
+
         complete = False
+        if skipped:
+            complete = True
         if test_dur > config.min_time and iteration > config.min_iter:
             complete = True
         if config.max_time > 0 and test_dur > config.max_time:
@@ -933,7 +1061,7 @@ actor TestExecutor(syscap, config, t: Test, report_complete, env):
 
         if test_info is not None:
             exc = str(exception) if exception is not None else None
-            test_info.update(complete, TestResult(success, exc, val, testiter_dur, mem_usage_delta, non_gc_mem_usage_delta), test_dur*1000.0)
+            test_info.update(complete, TestResult(success, exc, val, testiter_dur, mem_usage_delta, non_gc_mem_usage_delta, skipped=skipped, skip_reason=skip_reason), test_dur*1000.0)
         if last_report.elapsed().to_float() > 0.05 or complete:
             if test_info is not None and config.output_enabled:
                 print("\n" + json.encode({"test_info": test_info.to_json()}), err=True)
@@ -966,7 +1094,9 @@ actor TestExecutor(syscap, config, t: Test, report_complete, env):
             _report_result(t, sw, non_gc_mem_usage_before, gc_total_bytes_start, gc_time_start, s, e, val)
 
         try:
-            t.run(repres, env, log_handler)
+            t.run(repres, env, log_handler, config.tags)
+        except SkipTest as e:
+            _report_result(t, sw, non_gc_mem_usage_before, gc_total_bytes_start, gc_time_start, True, e, None)
         except AssertionError as e:
             _report_result(t, sw, non_gc_mem_usage_before, gc_total_bytes_start, gc_time_start, False, e, None)
         except Exception as e:
@@ -1105,6 +1235,7 @@ class ProjectTestResults(object):
 
         errors = 0
         failures = 0
+        skipped = 0
         complete = True
         if set(self.results.keys()) != self.expected_modules:
             complete = False
@@ -1144,7 +1275,10 @@ class ProjectTestResults(object):
                 msg = ""
                 run_info = ""
                 if tinfo.complete:
-                    if exc is not None:
+                    if tinfo.skipped:
+                        skipped += 1
+                        msg += term.yellow + "SKIP" + term.normal
+                    elif exc is not None:
                         msg += term.bold + term.red
                         if tinfo.flaky:
                             msg += "FLAKY "
@@ -1183,6 +1317,9 @@ class ProjectTestResults(object):
                                                                         tinfo.num_iterations))
                     self.printed_lines += 3
                 if tinfo.complete:
+                    if tinfo.skipped and tinfo.skip_reason is not None:
+                        print(f"{term.yellow}    skipped: {tinfo.skip_reason}{term.normal}")
+                        self.printed_lines += 1
                     if exc is not None:
                         for line in str(exc).splitlines(None):
                             print(f"{term.red}    {line}{term.normal}")
@@ -1276,7 +1413,10 @@ class ProjectTestResults(object):
                 print()
                 return 1
             else:
-                print(f"{term.green}All {self.num_tests()} tests passed ({self.sw.elapsed().str_ms()}s){term.normal}")
+                if skipped > 0:
+                    print(f"{term.green}All {self.num_tests()} tests passed, {skipped} skipped ({self.sw.elapsed().str_ms()}s){term.normal}")
+                else:
+                    print(f"{term.green}All {self.num_tests()} tests passed ({self.sw.elapsed().str_ms()}s){term.normal}")
                 print()
                 return 0
         else:
@@ -1377,6 +1517,7 @@ actor test_runner(env: Env,
         tp.add_option("min-iter", "int", default=3, help="Minumum number of iterations to run")
         tp.add_option("max-time", "int", default=1000, help="Maximum time to run a test in milliseconds")
         tp.add_option("min-time", "int", default=50, help="Minimum time to run a test in milliseconds")
+        tp.add_option("tag", "strlist", default=[], help="Enable test capability tag")
         pp = tp.add_cmd("perf", "Performance benchmark tests", _run_perf_tests)
 
         args = p.parse(env.argv)

--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -222,12 +222,13 @@ parseFlagTests =
   , flagGolden "cgen flag prints c" "test/parse/simple.cgen.golden" ["--quiet", "--dbg-no-lines", "--cgen"]
   , flagGolden "all flags combined" "test/parse/simple.all.golden"
         ["--quiet", "--parse", "--kinds", "--types", "--sigs", "--norm", "--deact", "--cps", "--llift", "--box", "--dbg-no-lines", "--hgen"]
-  , testCase "acton test --help includes --no-cache" $ do
+  , testCase "acton test --help includes --no-cache and --tag" $ do
       acton <- canonicalizePath "../../dist/bin/acton"
       (returnCode, cmdOut, cmdErr) <- readCreateProcessWithExitCode (proc acton ["test", "--help"]) ""
       assertEqual "acton test --help should succeed" ExitSuccess returnCode
       assertEqual "acton test --help stderr" "" cmdErr
       assertBool "acton test --help should include --no-cache" ("--no-cache" `isInfixOf` cmdOut)
+      assertBool "acton test --help should include --tag" ("--tag" `isInfixOf` cmdOut)
   ]
   where
     flagGolden label golden flags =

--- a/compiler/lib/src/Acton/CommandLineParser.hs
+++ b/compiler/lib/src/Acton/CommandLineParser.hs
@@ -136,6 +136,7 @@ data TestOptions = TestOptions
     , testMinIter      :: Int
     , testMaxTime      :: Int
     , testMinTime      :: Int
+    , testTags         :: [String]
     , testModules      :: [String]
     , testNames        :: [String]
     } deriving Show
@@ -392,6 +393,7 @@ testOptions = TestOptions
     <*> option auto (long "min-iter" <> metavar "N" <> value 3 <> help "Minimum number of iterations to run a test")
     <*> option auto (long "max-time" <> metavar "MS" <> value 1000 <> help "Maximum time to run a test in milliseconds")
     <*> option auto (long "min-time" <> metavar "MS" <> value 50 <> help "Minimum time to run a test in milliseconds")
+    <*> many (strOption (long "tag" <> metavar "TAG" <> help "Enable test capability TAG for testing.require()"))
     <*> many (strOption (long "module" <> metavar "MODULE" <> help "Filter on test module name"))
     <*> many (strOption (long "name" <> metavar "NAME" <> help "Filter on test name (regex, anchored; use .* for substrings)"))
 

--- a/compiler/lib/src/Acton/Testing.hs
+++ b/compiler/lib/src/Acton/Testing.hs
@@ -61,6 +61,8 @@ data TestResult = TestResult
   , trName         :: String
   , trComplete     :: Bool
   , trSuccess      :: Maybe Bool
+  , trSkipped      :: Bool
+  , trSkipReason   :: Maybe String
   , trException    :: Maybe String
   , trOutput       :: Maybe String
   , trStdOut       :: Maybe String
@@ -76,7 +78,7 @@ data TestResult = TestResult
   } deriving (Show)
 
 testCacheVersion :: Int
-testCacheVersion = 1
+testCacheVersion = 2
 
 data TestRunContext = TestRunContext
   { trcCompilerVersion :: String
@@ -107,6 +109,8 @@ instance Aeson.FromJSON TestRunContext where
 data TestCachedResult = TestCachedResult
   { tcrComplete     :: Bool
   , tcrSuccess      :: Maybe Bool
+  , tcrSkipped      :: Bool
+  , tcrSkipReason   :: Maybe String
   , tcrException    :: Maybe String
   , tcrOutput       :: Maybe String
   , tcrStdOut       :: Maybe String
@@ -122,6 +126,8 @@ instance Aeson.ToJSON TestCachedResult where
   toJSON res = Aeson.object
     [ AesonKey.fromString "complete" Aeson..= tcrComplete res
     , AesonKey.fromString "success" Aeson..= tcrSuccess res
+    , AesonKey.fromString "skipped" Aeson..= tcrSkipped res
+    , AesonKey.fromString "skip_reason" Aeson..= tcrSkipReason res
     , AesonKey.fromString "exception" Aeson..= tcrException res
     , AesonKey.fromString "output" Aeson..= tcrOutput res
     , AesonKey.fromString "std_out" Aeson..= tcrStdOut res
@@ -138,6 +144,8 @@ instance Aeson.FromJSON TestCachedResult where
     TestCachedResult
       <$> o Aeson..: AesonKey.fromString "complete"
       <*> o Aeson..:? AesonKey.fromString "success"
+      <*> o Aeson..:? AesonKey.fromString "skipped" Aeson..!= False
+      <*> o Aeson..:? AesonKey.fromString "skip_reason"
       <*> o Aeson..:? AesonKey.fromString "exception"
       <*> o Aeson..:? AesonKey.fromString "output"
       <*> o Aeson..:? AesonKey.fromString "std_out"
@@ -193,6 +201,8 @@ cachedResultFromTest :: TestResult -> TestCachedResult
 cachedResultFromTest res = TestCachedResult
   { tcrComplete = trComplete res
   , tcrSuccess = trSuccess res
+  , tcrSkipped = trSkipped res
+  , tcrSkipReason = trSkipReason res
   , tcrException = trException res
   , tcrOutput = trOutput res
   , tcrStdOut = trStdOut res
@@ -211,6 +221,8 @@ testResultFromCache modName testName res = TestResult
   , trName = testName
   , trComplete = tcrComplete res
   , trSuccess = tcrSuccess res
+  , trSkipped = tcrSkipped res
+  , trSkipReason = tcrSkipReason res
   , trException = tcrException res
   , trOutput = tcrOutput res
   , trStdOut = tcrStdOut res

--- a/docs/acton-guide/src/SUMMARY.md
+++ b/docs/acton-guide/src/SUMMARY.md
@@ -63,6 +63,7 @@
   - [Sync actor tests](testing/sync_actor_test.md)
   - [Async actor tests](testing/async_actor_test.md)
   - [Env tests](testing/env_test.md)
+  - [Snapshot testing](testing/snapshot.md)
   - [Failures vs errors](testing/failures_errors.md)
   - [Flaky tests](testing/flaky.md)
   - [Performance testing](testing/performance.md)

--- a/docs/acton-guide/src/testing.md
+++ b/docs/acton-guide/src/testing.md
@@ -46,6 +46,8 @@ There are 4 kinds of tests
   
 When possible, strive to use unit tests rather than actor based tests and strive to avoid env tests.
 
+For snapshot-based assertions, see [Snapshot testing](testing/snapshot.md).
+
 ## Cached test results
 
 The Acton test runner caches test results which means that repeated invokations of `acton test` might not actually (re)run tests. Cached failures and errors are still shown by default, so you never miss a failing test. Cached successes are hidden unless you pass `--show-cached`. Pass `--no-cache` to force all selected tests to run, even if cached results exist.
@@ -63,3 +65,31 @@ acton test --module foo --module bar
 ```
 
 This will only run tests from the `foo` and `bar` modules, skipping all other test modules.
+
+## Capability-gated tests
+
+Some tests depend on external capabilities (for example network services, hardware, or system setup). In tests that receive a test context argument (`t`), use `t.require(...)` and pass available capabilities with `--tag`:
+
+```python
+import testing
+
+def _test_external_service(t):
+    t.require("external-service")
+    # test logic that depends on external-service being available
+```
+
+Run with capabilities:
+
+```sh
+acton test --tag external-service
+```
+
+If the required capability is not enabled, the test is marked as skipped.
+Capabilities are runtime environment signals used by `t.require(...)`; they are not a pre-test selection/filter mechanism. This applies to test context objects like `SyncT`, `AsyncT`, and `EnvT`.
+
+You can also skip explicitly:
+
+```python
+def _test_todo(t):
+    t.skip("not implemented yet")
+```

--- a/docs/acton-guide/src/testing/async_actor_test.md
+++ b/docs/acton-guide/src/testing/async_actor_test.md
@@ -44,6 +44,10 @@ All 1 tests passed (0.695s)
 
 If a particular module is written to be called asynchronously, you will need to use asynchronous tests to test it.
 
+`testing.AsyncT` also provides:
+- `t.require(tag)` to skip a test when a required capability is not enabled via `acton test --tag TAG`
+- `t.skip(reason)` to explicitly skip the current test
+
 The test discovery system finds asynchronous tests by looking for *actors* that take a `testing.AsyncT` parameter.
 
 *Snapshot testing* can be enabled by providing an output of type *str* to the `.success(output: ?str)` function. The Acton test framework will take care about recognizing the test as a snapshot test and comparing its output to the expected *snapshot value*.

--- a/docs/acton-guide/src/testing/env_test.md
+++ b/docs/acton-guide/src/testing/env_test.md
@@ -42,4 +42,8 @@ All 1 tests passed (0.689s)
 
 The test discovery system finds environment tests by looking for *actors* that take a `testing.EnvT` parameter.
 
+`testing.EnvT` also provides:
+- `t.require(tag)` to skip a test when a required capability is not enabled via `acton test --tag TAG`
+- `t.skip(reason)` to explicitly skip the current test
+
 *Snapshot testing* can be enabled by providing an output of type *str* to the `.success(output: ?str)` function. The Acton test framework will take care about recognizing the test as a snapshot test and comparing its output to the expected *snapshot value*.

--- a/docs/acton-guide/src/testing/snapshot.md
+++ b/docs/acton-guide/src/testing/snapshot.md
@@ -1,0 +1,68 @@
+# Snapshot testing
+
+Snapshot tests compare a produced string with a stored expected value. You can produce snapshot output from unit/sync test functions by returning `str`, or from async/env tests by calling `t.success("...")`.
+
+```python
+import testing
+
+def _test_rendered_profile() -> str:
+    return '{"name":"Alice","role":"admin"}'
+```
+
+Acton writes snapshot files in your project under `snapshots/output/<module>/<test_name>` (latest produced value) and `snapshots/expected/<module>/<test_name>` (expected value used for comparison). Test names in those paths use the display test name, so `_test_foo` becomes `foo`.
+
+When an expected snapshot differs (or is missing), running tests normally shows a mismatch:
+
+```sh
+$ acton test
+Building project in /home/user/example
+...
+Tests - module main:
+   rendered_profile: FAIL           :  254 runs in 50.045ms
+    testing.NotEqualError: Test output does not match expected snapshot value.
+    @@ -1,1 +1,1 @@
+    -{"name":"Alice","role":"user"}
+    +{"name":"Alice","role":"admin"}
+
+1 out of 1 tests failed (0.244s)
+```
+
+When the new output is correct, accept it as the new expected value with:
+
+```sh
+$ acton test --accept
+Building project in /home/user/example
+...
+Tests - module main:
+   rendered_profile: UPDATED        :  243 runs in 50.445ms
+
+All 1 tests passed (0.246s)
+```
+
+`--accept` is the idiomatic flag (aliases: `--snapshot-update`, `--golden-update`).
+
+For tests that produce snapshot output, `snapshots/output/...` is written on every run. That is intentional: it makes it easy to use external diff tools (`diff`, `vimdiff`, `meld`, etc.) against `snapshots/expected/...` without any extra export step.
+
+For example, to inspect the current snapshot difference for the test above:
+
+```sh
+diff -u snapshots/expected/main/rendered_profile snapshots/output/main/rendered_profile
+```
+
+## Common workflow
+
+1. Run `acton test`.
+2. If there is a snapshot mismatch, inspect it directly, for example:
+
+```sh
+diff -u snapshots/expected/main/rendered_profile snapshots/output/main/rendered_profile
+```
+
+3. Accept changes with `acton test --accept`.
+4. Run `acton test` again to confirm everything passes.
+
+An alternative workflow is to accept first, then inspect version-controlled snapshot changes with Git:
+
+1. Run `acton test --accept`.
+2. Review what changed with `git diff -- snapshots/expected`.
+3. Keep or revert changes before commit, then run `acton test`.

--- a/docs/acton-guide/src/testing/sync_actor_test.md
+++ b/docs/acton-guide/src/testing/sync_actor_test.md
@@ -59,6 +59,10 @@ All 4 tests passed (0.655s)
 
 Since the Acton RTS is multi-threaded and actors are scheduled concurrently on worker threads, using actors imply a degree of non-determinism and so unlike unit tests, which are completely deterministic, actors tests are fundamentally non-deterministic. You can still write deterministic tests as long as you pay attention to how you construct your test results.
 
+`testing.SyncT` also provides:
+- `t.require(tag)` to skip a test when a required capability is not enabled via `acton test --tag TAG`
+- `t.skip(reason)` to explicitly skip the current test
+
 For example, actor A might be scheduled before or after actor B so if the test relies on ordering of the output, it could fail or succeed intermittently. Interacting with the surrounding environment by reading files or communicating over the network introduces even more sources of non-determinism. Avoid it if you can. 
 
 The test discovery system finds synchronous tests through:

--- a/test/stdlib_tests/src/test_testing.act
+++ b/test/stdlib_tests/src/test_testing.act
@@ -37,6 +37,14 @@ def _test_sync(t: testing.SyncT):
     m = MathTester()
     return str(m.add(1, 2))  # Should return "3"
 
+def _test_skip_explicit(t: testing.SyncT):
+    t.skip("skip, not implemented")
+    return None
+
+def _test_skip_by_missing_tag(t: testing.SyncT):
+    t.require("network")
+    return None
+
 def _test_simple_sync_snapshot():
     m = MathTester()
     return "simple sync snapshot: " + str(m.add(2, 3))
@@ -46,6 +54,14 @@ def _test_async_snapshot(t: testing.AsyncT):
 
 def _test_env_snapshot(t: testing.EnvT):
     t.success("env snapshot")
+
+actor _test_AsyncRequireShortCircuit(t: testing.AsyncT):
+    t.require("network")
+    t.failure(AssertionError("should not run after require"))
+
+actor _test_EnvRequireShortCircuit(t: testing.EnvT):
+    t.require("network")
+    t.failure(AssertionError("should not run after require"))
 
 actor AsyncTester(t: testing.AsyncT):
     log = logging.Logger(t.log_handler)


### PR DESCRIPTION
Some tests depend on capabilities that are not always present, such as network access, external services, or machine-specific setup. Until now that either forced every environment to provide everything or let these tests fail for reasons unrelated to correctness.

This change introduces an explicit skip path so tests can declare preconditions and be reported as skipped instead of failed. The test context APIs now expose this consistently across SyncT, AsyncT, and EnvT: `t.skip(...)` for direct skips and `t.require(tag)` for capability-gated execution. `require` intentionally takes only the capability tag and uses a standard message when the capability is missing, which keeps CI output predictable and easy to scan.

Capabilities are declared from the CLI with a single repeatable `--tag` flag. We deliberately position tags as runtime capability signals, not as a pre-test selection or filtering mechanism.

Skipped results are propagated through execution, rendered as `SKIP` in text output (including live status), and emitted in JSON with `skip_reason` so external tooling can distinguish skips from passes and failures.

The testing guide now includes a dedicated snapshot testing page.