### PR TITLE
Build GHC with Zig CC and control glibc target version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -231,6 +231,8 @@ jobs:
       - name: "Build Acton"
         run: |
           make -j2 -C ${GITHUB_WORKSPACE} BUILD_RELEASE=${{ env.BUILD_RELEASE }} BUILD_TIME=${BUILD_TIME}
+      - name: "Show Acton linkage (ldd)"
+        run: make -C ${GITHUB_WORKSPACE} ldd
       - name: "Build a release"
         run: make -C ${GITHUB_WORKSPACE} release BUILD_TIME=${BUILD_TIME}
       - name: "Upload artifact"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -213,7 +213,7 @@ jobs:
         run: |
           export DEBIAN_FRONTEND=noninteractive
           apt-get update
-          apt-get install -qy bzip2 curl g++ haskell-stack libtinfo-dev make procps zlib1g-dev
+          apt-get install -qy bzip2 curl g++ haskell-stack libncurses-dev make procps zlib1g-dev
           apt-get install -qy gdb
       - name: "locale en_US.UTF-8"
         run: |
@@ -284,7 +284,7 @@ jobs:
       - name: "Install build prerequisites"
         run: |
           apt-get update
-          apt-get install -qy bzip2 curl g++ haskell-stack libtinfo-dev make procps zlib1g-dev
+          apt-get install -qy bzip2 curl g++ haskell-stack libncurses-dev make procps zlib1g-dev
           apt-get install -qy bash-completion build-essential debhelper devscripts
       - name: "Prepare stack directories"
         run: |

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,7 @@ help:
 	@echo "Available make targets:"
 	@echo "  all     - build everything"
 	@echo "  test    - run the test suite"
+	@echo "  ldd     - show dynamic linkage for dist/bin/acton (Linux)"
 	@echo ""
 	@echo "  clean   - /normal/ clean repo"
 	@echo "  clean-all - thorough cleaning"
@@ -311,6 +312,15 @@ test: dist/bin/acton
 	$(MAKE) test-stdlib
 	$(MAKE) -C backend test
 	$(MAKE) test-rts-db
+
+.PHONY: ldd
+ldd: dist/bin/acton
+ifeq ($(OS),linux)
+	@echo "Inspecting dynamic linkage for $(ACTON)"
+	@ldd "$(ACTON)" || true
+else
+	@echo "ldd target is Linux-only; current OS is $(shell uname -s)"
+endif
 
 test-builtins:
 	cd compiler && stack test acton --ta '-p "Builtins"'

--- a/compiler/tools/zig-cc.sh
+++ b/compiler/tools/zig-cc.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env sh
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+ROOT_DIR="$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)"
+ZIG_BIN="$ROOT_DIR/dist/zig/zig"
+
+if [ ! -x "$ZIG_BIN" ]; then
+  echo "error: expected Zig at $ZIG_BIN; run 'make dist/zig' first" >&2
+  exit 1
+fi
+
+has_explicit_target=false
+expect_target_arg=false
+for arg in "$@"; do
+  if [ "$expect_target_arg" = true ]; then
+    has_explicit_target=true
+    expect_target_arg=false
+    continue
+  fi
+
+  case "$arg" in
+    -target)
+      expect_target_arg=true
+      ;;
+    -target=*)
+      has_explicit_target=true
+      ;;
+    --target)
+      expect_target_arg=true
+      ;;
+    --target=*)
+      has_explicit_target=true
+      ;;
+  esac
+done
+
+if [ "$(uname -s 2>/dev/null || true)" = "Linux" ] \
+   && [ -n "${ACTON_ZIG_GLIBC_VERSION:-}" ] \
+   && [ "$has_explicit_target" = false ]; then
+  zig_host_target="$("$ZIG_BIN" env 2>/dev/null | awk -F'"' '/\.target = "/ {print $2; exit}')"
+  if [ -z "$zig_host_target" ]; then
+    echo "error: failed to derive Zig host target from '$ZIG_BIN env'" >&2
+    exit 1
+  fi
+
+  case "$zig_host_target" in
+    *-gnu*)
+      ;;
+    *)
+      echo "error: requested ACTON_ZIG_GLIBC_VERSION but host target '$zig_host_target' is not GNU libc based" >&2
+      exit 1
+      ;;
+  esac
+
+  zig_host_arch="${zig_host_target%%-*}"
+  if [ -z "$zig_host_arch" ]; then
+    echo "error: failed to derive host architecture from Zig target '$zig_host_target'" >&2
+    exit 1
+  fi
+
+  exec "$ZIG_BIN" cc -target "$zig_host_arch-linux-gnu.${ACTON_ZIG_GLIBC_VERSION}" "$@"
+fi
+
+exec "$ZIG_BIN" cc "$@"

--- a/compiler/tools/zig-cxx.sh
+++ b/compiler/tools/zig-cxx.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env sh
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+ROOT_DIR="$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)"
+ZIG_BIN="$ROOT_DIR/dist/zig/zig"
+
+if [ ! -x "$ZIG_BIN" ]; then
+  echo "error: expected Zig at $ZIG_BIN; run 'make dist/zig' first" >&2
+  exit 1
+fi
+
+has_explicit_target=false
+expect_target_arg=false
+for arg in "$@"; do
+  if [ "$expect_target_arg" = true ]; then
+    has_explicit_target=true
+    expect_target_arg=false
+    continue
+  fi
+
+  case "$arg" in
+    -target)
+      expect_target_arg=true
+      ;;
+    -target=*)
+      has_explicit_target=true
+      ;;
+    --target)
+      expect_target_arg=true
+      ;;
+    --target=*)
+      has_explicit_target=true
+      ;;
+  esac
+done
+
+if [ "$(uname -s 2>/dev/null || true)" = "Linux" ] \
+   && [ -n "${ACTON_ZIG_GLIBC_VERSION:-}" ] \
+   && [ "$has_explicit_target" = false ]; then
+  zig_host_target="$("$ZIG_BIN" env 2>/dev/null | awk -F'"' '/\.target = "/ {print $2; exit}')"
+  if [ -z "$zig_host_target" ]; then
+    echo "error: failed to derive Zig host target from '$ZIG_BIN env'" >&2
+    exit 1
+  fi
+
+  case "$zig_host_target" in
+    *-gnu*)
+      ;;
+    *)
+      echo "error: requested ACTON_ZIG_GLIBC_VERSION but host target '$zig_host_target' is not GNU libc based" >&2
+      exit 1
+      ;;
+  esac
+
+  zig_host_arch="${zig_host_target%%-*}"
+  if [ -z "$zig_host_arch" ]; then
+    echo "error: failed to derive host architecture from Zig target '$zig_host_target'" >&2
+    exit 1
+  fi
+
+  exec "$ZIG_BIN" c++ -target "$zig_host_arch-linux-gnu.${ACTON_ZIG_GLIBC_VERSION}" "$@"
+fi
+
+exec "$ZIG_BIN" c++ "$@"

--- a/docs/acton-dev-guide/src/getting_started/build.md
+++ b/docs/acton-dev-guide/src/getting_started/build.md
@@ -31,5 +31,7 @@ dist/bin/actonc path/to/file.act   # compatibility alias
 ## Caching and build knobs
 
 - `ZIG_LOCAL_CACHE_DIR` controls Zig's cache location (defaults to `~/.cache/acton/zig-local-cache` when `HOME` is set).
+- Stack uses `compiler/tools/zig-cc.sh` / `compiler/tools/zig-cxx.sh` so GHC/Cabal go through `dist/zig/zig`.
+- On Linux, set `ACTON_ZIG_GLIBC_VERSION=<major.minor>` to force Zig CC/C++ wrappers to pass `-target <host-arch>-linux-gnu.<major.minor>` (for example `2.35`).
 - `BUILD_RELEASE=1 make` stamps release versions; default builds get a timestamped version suffix.
 - On Linux, the Makefile pins the default target to glibc 2.27 for compatibility.


### PR DESCRIPTION
The key change here is that the GHC/Stack build path now goes through Zig CC. Once Zig is the compiler driver in that path, we can explicitly choose which GNU libc version we target instead of inheriting whatever happens to be on the build host.

On Linux, the Zig wrapper scripts accept ACTON_ZIG_GLIBC_VERSION and derive a -target of the form <host-arch>-linux-gnu.<major.minor> from zig env, so we do not hard-code CPU architecture while still pinning a glibc baseline.

If an explicit target is already supplied, it takes precedence. macOS behavior is unchanged.

The Makefile now defaults ACTON_ZIG_GLIBC_VERSION to 2.27 on Linux and exports it, and the dev guide documents the knob. In practice this gives us deliberate control over glibc compatibility for the compiler build products.