### PR TITLE
Pass explicit module selection into generated Zig builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ ACTONC_HS=$(wildcard compiler/lib/src/*.hs compiler/lib/src/*/*.hs compiler/acto
 ACTONLSP_HS=$(wildcard compiler/lsp-server/*.hs)
 # NOTE: we're unsetting CC & CXX to avoid using zig cc & zig c++ for stack /
 # ghc, which doesn't seem to work properly
-dist/bin/acton: compiler/lib/package.yaml.in compiler/acton/package.yaml.in compiler/lsp-server/package.yaml.in compiler/stack.yaml $(ACTONC_HS) $(ACTONLSP_HS) version.mk
+dist/bin/acton: compiler/lib/package.yaml.in compiler/acton/package.yaml.in compiler/lsp-server/package.yaml.in compiler/stack.yaml $(ACTONC_HS) $(ACTONLSP_HS) version.mk dist/builder
 	mkdir -p dist/bin
 	rm -f dist/bin/actonc
 	cd compiler && sed 's,^version: BUILD_VERSION,version: "$(VERSION)",' < lib/package.yaml.in > lib/package.yaml


### PR DESCRIPTION
A recent CI failure came from stale C artifacts in dependency out/types being picked up by build.zig filesystem discovery. In the failing shape, the root project overrode a transitive path dependency and the dependency builder still compiled stale modules that were not part of the selected compile tasks, triggering downstream C compilation errors.

This change removes discovery-based selection from the generated builder and makes module/root selection explicit. The compiler now computes selected C module paths from needed tasks, passes them to the root zig invocation as -Dacton_modules and -Dacton_root_stubs, and injects matching acton_modules options into b.dependency(...) calls for package dependencies. Dependency invocations intentionally pass empty root stubs so only library objects are built for deps.

The builder template now requires explicit acton_modules and acton_root_stubs options, parses those lists, and compiles only what was selected. Old out/types walking logic and the now-redundant only_lib path were removed, and executable linking is gated on explicit root stubs.

Makefile now makes dist/bin/acton depend on dist/builder so rebuilt compiler binaries always carry synchronized builder templates. A regression test was added to cover stale out/types artifacts in path dependencies with transitive overrides, and it passes with this wiring.