### PR TITLE
Fetch transitive path dependency caches before discovery

### DIFF
--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -105,6 +105,49 @@ compilerTests =
         (returnCode, cmdOut, cmdErr) <- readCreateProcessWithExitCode (shell $ "rm -rf ../../test/compiler/test_deps/deps/a/build.zig*") ""
         (returnCode, cmdOut, cmdErr) <- readCreateProcessWithExitCode (shell $ "rm -rf ../../test/compiler/test_deps/deps/a/out") ""
         runActon "build" ExitSuccess False "../../test/compiler/test_deps/"
+  , testCase "path dependency fetches transitive cached deps before discovery" $ do
+        withSystemTempDirectory "acton-transitive-path-fetch" $ \tmp -> do
+          actonExe <- canonicalizePath "../../dist/bin/acton"
+          env0 <- getEnvironment
+          let homeDir = tmp </> "home"
+              rootProj = tmp </> "root"
+              specProj = rootProj </> "spec"
+              fakeHash = "transitive-hash-does-not-exist"
+              envWithHome = ("HOME", homeDir) : filter ((/= "HOME") . fst) env0
+              mkFp name = Fingerprint.formatFingerprint
+                (Fingerprint.updateFingerprintPrefix
+                  (Fingerprint.fingerprintPrefixForName name) 1)
+          createDirectoryIfMissing True homeDir
+          createDirectoryIfMissing True (rootProj </> "src")
+          createDirectoryIfMissing True (specProj </> "src")
+          writeFile (rootProj </> "Build.act") $ unlines
+            [ "name = \"root_proj\""
+            , "fingerprint = " ++ mkFp "root_proj"
+            , "dependencies = {"
+            , "    \"spec\": (path=\"spec\")"
+            , "}"
+            , "zig_dependencies = {}"
+            ]
+          writeFile (rootProj </> "src" </> "main.act") $ unlines
+            [ "actor main(env):"
+            , "    env.exit(0)"
+            ]
+          writeFile (specProj </> "Build.act") $ unlines
+            [ "name = \"spec_proj\""
+            , "fingerprint = " ++ mkFp "spec_proj"
+            , "dependencies = {"
+            , "    \"ghost\": (hash=\"" ++ fakeHash ++ "\")"
+            , "}"
+            , "zig_dependencies = {}"
+            ]
+          writeFile (specProj </> "src" </> "specproj.act") "def marker() -> int:\n    return 1\n"
+          (returnCode, _cmdOut, cmdErr) <- readCreateProcessWithExitCode
+            (proc actonExe ["build"]) { cwd = Just rootProj, env = Just envWithHome } ""
+          assertEqual "acton should fail for unfetchable transitive dependency" (ExitFailure 1) returnCode
+          assertBool "should fail during dependency fetch/copy, not later Build.act load"
+            ("not present in Zig cache after fetch" `isInfixOf` cmdErr)
+          assertBool "should not fail with missing Build.act in unresolved deps cache path"
+            (not ("Missing Build.act in " `isInfixOf` cmdErr))
   , testCase "path dep build ignores stale dep out/types modules" $ do
         withSystemTempDirectory "acton-stale-path-dep" $ \tmp ->
           do

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -3012,8 +3012,8 @@ fetchDependencies gopts paths depOverrides = do
     if isTmp paths
       then return ()
       else do
-        spec0 <- loadBuildSpec (projPath paths)
-        spec <- applyDepOverrides (projPath paths) depOverrides spec0
+        rootSpec0 <- loadBuildSpec (projPath paths)
+        rootSpec <- applyDepOverrides (projPath paths) depOverrides rootSpec0
         unless (C.quiet gopts) $
           putStrLn "Resolving dependencies (fetching if missing)..."
         home <- getHomeDirectory
@@ -3023,54 +3023,99 @@ fetchDependencies gopts paths depOverrides = do
             cacheDir h  = joinPath [globalCache, "p", h]
         createDirectoryIfMissing True globalCache
         createDirectoryIfMissing True depsCache
-
-        let pkgFetches = catMaybes
-              [ mkPkgFetch name dep | (name, dep) <- M.toList (BuildSpec.dependencies spec) ]
-            zigFetches = catMaybes
-              [ mkZigFetch name dep | (name, dep) <- M.toList (BuildSpec.zig_dependencies spec) ]
-
-            mkPkgFetch name dep =
-              case BuildSpec.path dep of
-                Just p | not (null p) -> Nothing
-                _ -> case (BuildSpec.url dep, BuildSpec.hash dep) of
-                       (Just u, Just h) ->
-                         Just (fetchOne "pkg" name u (Just h) cacheDir zigExe globalCache)
-                       (Just _, Nothing) ->
-                         Just (return (Left ("Dependency " ++ name ++ " is missing hash")))
-                       _ -> Nothing
-
-            mkZigFetch name dep =
-              case BuildSpec.zpath dep of
-                Just p | not (null p) -> Nothing
-                _ -> case (BuildSpec.zurl dep, BuildSpec.zhash dep) of
-                       (Just u, Just h) ->
-                         Just (fetchOne "zig" name u (Just h) cacheDir zigExe globalCache)
-                       (Just _, Nothing) ->
-                         Just (return (Left ("Zig dependency " ++ name ++ " is missing hash")))
-                       _ -> Nothing
-
-        results <- mapConcurrently id (pkgFetches ++ zigFetches)
-        let errs = [ e | Left e <- results ]
-        unless (null errs) $ throwProjectError (unlines errs)
-
-        forM_ (M.toList (BuildSpec.dependencies spec)) $ \(name, dep) -> do
-          case BuildSpec.path dep of
-            Just p | not (null p) -> return ()
-            _ -> case BuildSpec.hash dep of
-                   Nothing -> return ()
-                   Just h -> do
-                     let src = cacheDir h
-                         dst = joinPath [depsCache, name ++ "-" ++ h]
-                     exists <- doesDirectoryExist dst
-                     unless exists $ do
-                       srcOk <- doesDirectoryExist src
-                       unless srcOk $
-                         throwProjectError ("Dependency " ++ name ++ " not present in Zig cache after fetch: " ++ src)
-                       when (C.verbose gopts) $
-                         putStrLn ("Copying dependency " ++ name ++ " (" ++ h ++ ") from Zig cache")
-                       copyTree src dst
-          return ()
+        let rootPins = BuildSpec.dependencies rootSpec
+        _ <- walkProject rootPins cacheDir zigExe globalCache depsCache
+                         Data.Set.empty (projPath paths) rootSpec
+        return ()
   where
+    walkProject rootPins cacheDir zigExe globalCache depsCache seen projDir spec = do
+      projAbs <- normalizePathSafe projDir
+      if Data.Set.member projAbs seen
+        then return seen
+        else do
+          selectedDeps <- forM (M.toList (BuildSpec.dependencies spec)) $
+            selectDependency rootPins projAbs
+          let pkgFetches = catMaybes
+                [ mkPkgFetch cacheDir zigExe globalCache name dep | (name, dep) <- selectedDeps ]
+              zigFetches = catMaybes
+                [ mkZigFetch cacheDir zigExe globalCache name dep
+                | (name, dep) <- M.toList (BuildSpec.zig_dependencies spec)
+                ]
+          results <- mapConcurrently id (pkgFetches ++ zigFetches)
+          let errs = [ e | Left e <- results ]
+          unless (null errs) $ throwProjectError (unlines errs)
+          forM_ selectedDeps $ \(name, dep) -> copyPkgDep cacheDir depsCache name dep
+          let seen' = Data.Set.insert projAbs seen
+          foldM (walkDependency rootPins cacheDir zigExe globalCache depsCache projAbs)
+                seen' selectedDeps
+
+    selectDependency rootPins base (depName, dep) = do
+      let (chosenDep, conflict) =
+            case M.lookup depName rootPins of
+              Nothing -> (dep, Nothing)
+              Just pinDep ->
+                if pinDep == dep
+                  then (dep, Nothing)
+                  else (pinDep, Just dep)
+      when (isJust conflict) $
+        unless (C.quiet gopts) $
+          putStrLn ("Warning: dependency '" ++ depName ++ "' in " ++ base
+                    ++ " overridden by root pin")
+      return (depName, chosenDep)
+
+    walkDependency rootPins cacheDir zigExe globalCache depsCache base seen (depName, dep) = do
+      depBase <- resolveDepBase base depName dep
+      depAbs <- normalizePathSafe depBase
+      depExists <- doesDirectoryExist depAbs
+      if not depExists
+        then case BuildSpec.path dep of
+               Just p | not (null p) ->
+                 throwProjectError ("Dependency " ++ depName ++ " path does not exist: " ++ depAbs ++ "\n"
+                                    ++ "Hint: Local dependency paths must point to an Acton project root\n"
+                                    ++ "(directory with src/ and Build.act).")
+               _ -> return seen
+        else do
+          depSpec0 <- loadBuildSpec depAbs
+          depSpec <- applyDepOverrides depAbs depOverrides depSpec0
+          walkProject rootPins cacheDir zigExe globalCache depsCache seen depAbs depSpec
+
+    mkPkgFetch cacheDir zigExe globalCache name dep =
+      case BuildSpec.path dep of
+        Just p | not (null p) -> Nothing
+        _ -> case (BuildSpec.url dep, BuildSpec.hash dep) of
+               (Just u, Just h) ->
+                 Just (fetchOne "pkg" name u (Just h) cacheDir zigExe globalCache)
+               (Just _, Nothing) ->
+                 Just (return (Left ("Dependency " ++ name ++ " is missing hash")))
+               _ -> Nothing
+
+    mkZigFetch cacheDir zigExe globalCache name dep =
+      case BuildSpec.zpath dep of
+        Just p | not (null p) -> Nothing
+        _ -> case (BuildSpec.zurl dep, BuildSpec.zhash dep) of
+               (Just u, Just h) ->
+                 Just (fetchOne "zig" name u (Just h) cacheDir zigExe globalCache)
+               (Just _, Nothing) ->
+                 Just (return (Left ("Zig dependency " ++ name ++ " is missing hash")))
+               _ -> Nothing
+
+    copyPkgDep cacheDir depsCache name dep =
+      case BuildSpec.path dep of
+        Just p | not (null p) -> return ()
+        _ -> case BuildSpec.hash dep of
+               Nothing -> return ()
+               Just h -> do
+                 let src = cacheDir h
+                     dst = joinPath [depsCache, name ++ "-" ++ h]
+                 exists <- doesDirectoryExist dst
+                 unless exists $ do
+                   srcOk <- doesDirectoryExist src
+                   unless srcOk $
+                     throwProjectError ("Dependency " ++ name ++ " not present in Zig cache after fetch: " ++ src)
+                   when (C.verbose gopts) $
+                     putStrLn ("Copying dependency " ++ name ++ " (" ++ h ++ ") from Zig cache")
+                   copyTree src dst
+
     fetchOne kind name url mh cacheDir zigExe globalCache = do
       case mh of
         Just h -> do


### PR DESCRIPTION
A build of a root project with a path dependency could fail before typechecking when the path dependency had remote hashed dependencies that were not already present in ~/.cache/acton/deps.

The fetch phase only considered direct dependencies from the root Build.act and explicitly skipped path dependencies, while project discovery later traversed into those path dependencies and immediately loaded their remote deps from deps cache paths. On a clean cache this produced "Missing Build.act in .../deps/<name>-<hash>" even though the referenced package archive was valid.

This change makes fetchDependencies recurse over all reachable projects, including through path dependencies, and fetch/copy package dependencies for each visited project before discovery attempts to load them. The traversal keeps root pin override behavior aligned with discoverProjects so selected dependency variants stay consistent between fetch and compile planning.

A regression test was added to compiler tests to assert that transitive dependencies reached via a path dependency fail at fetch/copy time when unavailable, and do not fail later with missing Build.act from unresolved deps cache directories.