### PR TITLE
Fix UTF-8 char-byte offsets in str partitioning

### DIFF
--- a/base/builtin/str.c
+++ b/base/builtin/str.c
@@ -181,11 +181,11 @@ static int byte_length(unsigned int cp) {
 
 // #bytes in UTF-8 for char starting with byte c
 static int byte_length2(unsigned char c) {
-    if (c < 0x7f)
+    if (c < 0x80)
         return 1;
-    else if (c < 0xdf)
+    else if (c < 0xe0)
         return 2;
-    else if (c < 0xef)
+    else if (c < 0xf0)
         return 3;
     else
         return 4;
@@ -255,8 +255,11 @@ static unsigned char *skip_chars(unsigned char* start, int n, int isascii) {
 static int byte_no(B_str text, int i) {
     int res = 0;
     unsigned char *t = text->str;
-    for (int k=0; k<i; k++)
-        res += byte_length2(t[k]);
+    for (int k=0; k<i; k++) {
+        int n = byte_length2(*t);
+        res += n;
+        t += n;
+    }
     return res;
 }
 
@@ -997,7 +1000,8 @@ B_tuple B_strD_partition(B_str s, B_str sep) {
     if (n<0) {
         return $NEWTUPLE(3,s,null_str,null_str);
     } else {
-        int nb = bmh(s->str,sep->str,s->nbytes,sep->nbytes);
+        int isascii = s->nchars == s->nbytes;
+        int nb = (int)(skip_chars(s->str,n,isascii)-s->str);
         B_str ls;
         NEW_UNFILLED_STR(ls,n,nb);
         memcpy(ls->str,s->str,nb);
@@ -1092,7 +1096,8 @@ B_tuple B_strD_rpartition(B_str s, B_str sep) {
     if (n<0) {
         return $NEWTUPLE(3,null_str,null_str,s);
     } else {
-        int nb = rbmh(s->str,sep->str,s->nbytes,sep->nbytes);
+        int isascii = s->nchars == s->nbytes;
+        int nb = (int)(skip_chars(s->str,n,isascii)-s->str);
         B_str ls;
         NEW_UNFILLED_STR(ls,n,nb);
         memcpy(ls->str,s->str,nb);

--- a/test/builtins_auto/test_str.act
+++ b/test/builtins_auto/test_str.act
@@ -124,6 +124,14 @@ def test_empty_str_partition():
     print("empty str.partition('a'): ({sp.0}, {sp.1}, {sp.2})")
     return sp.0 == "" and sp.1 == "" and sp.2 == ""
 
+def test_str_partition_utf8_boundary_leads():
+    # U+07FF starts with 0xDF and U+FFFF starts with 0xEF.
+    # These byte boundaries previously broke char/byte position mapping.
+    s = "\u07ffA\uffffZ"
+    sp = s.partition("Z")
+    print("utf8 boundary str.partition('Z'): ({sp.0}, {sp.1}, {sp.2})")
+    return sp.0 == "\u07ffA\uffff" and sp.1 == "Z" and sp.2 == ""
+
 def test_empty_str_replace():
     result = "".replace("a", "b")
     print("empty str.replace('a', 'b'): '{result}'")
@@ -151,6 +159,12 @@ def test_empty_str_rpartition():
     sp = "".rpartition("a")
     print("empty str.rpartition('a'): ({sp.0}, {sp.1}, {sp.2})")
     return sp.0 == "" and sp.1 == "" and sp.2 == ""
+
+def test_str_rpartition_utf8_boundary_leads():
+    s = "\u07ffA\uffffZ"
+    sp = s.rpartition("\uffff")
+    print("utf8 boundary str.rpartition('\\uffff'): ({sp.0}, {sp.1}, {sp.2})")
+    return sp.0 == "\u07ffA" and sp.1 == "\uffff" and sp.2 == "Z"
 
 def test_empty_str_rstrip():
     result = "".rstrip()
@@ -316,11 +330,13 @@ tests = {
     "test_empty_str_lower": test_empty_str_lower,
     "test_empty_str_lstrip": test_empty_str_lstrip,
     "test_empty_str_partition": test_empty_str_partition,
+    "test_str_partition_utf8_boundary_leads": test_str_partition_utf8_boundary_leads,
     "test_empty_str_replace": test_empty_str_replace,
     "test_empty_str_rfind": test_empty_str_rfind,
     "test_empty_str_rindex": test_empty_str_rindex,
     "test_empty_str_rjust": test_empty_str_rjust,
     "test_empty_str_rpartition": test_empty_str_rpartition,
+    "test_str_rpartition_utf8_boundary_leads": test_str_rpartition_utf8_boundary_leads,
     "test_empty_str_rstrip": test_empty_str_rstrip,
     "test_empty_str_split": test_empty_str_split,
     "test_empty_str_splitlines": test_empty_str_splitlines,


### PR DESCRIPTION
Lead bytes at the UTF-8 boundaries 0xDF and 0xEF were classified as starting 3-byte and 4-byte sequences respectively. This broke char/byte position mapping for strings containing U+07FF and U+FFFF and could cause partition and rpartition to slice at the wrong byte offsets.

The bug had two parts. byte_length2 used <0x7f/<0xdf/<0xef bounds instead of <0x80/<0xe0/<0xf0, and byte_no advanced through the string by indexing raw bytes with a character counter instead of stepping by codepoint width.

This change corrects the UTF-8 lead-byte thresholds, makes byte_no walk the byte buffer by codepoint width, and uses skip_chars to translate the char index returned by find and rfind into the byte offset used by partition and rpartition.

Regression tests were added for partition and rpartition with strings that include U+07FF and U+FFFF so the boundary lead-byte cases remain covered.