### PR TITLE
Clear up Acton locks responsility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@
 **/core
 **/build-cache
 **/zig-cache
-**/.actonc.lock
+**/.acton.compile.lock
 **/.acton.lock
 **/.build/
 **/*.swp

--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -196,20 +196,6 @@ printErrorAndExit msg = do
                   errorWithoutStackTrace msg
                   System.Exit.exitFailure
 
-printErrorAndCleanAndExit msg gopts opts paths = do
-                  errorWithoutStackTrace msg
-                  cleanup gopts opts paths
-                  System.Exit.exitFailure
-
-
-cleanup gopts opts paths = do
-    -- Need platform free path separators
-    removeFile (joinPath [projPath paths, ".actonc.lock"])
-      `catch` handleNotExists
-  where
-    handleNotExists :: IOException -> IO ()
-    handleNotExists _ = return ()
-
 -- our own readFile & writeFile with hard-coded utf-8 encoding (atomic writes)
 readFile f = do
     h <- openFile f ReadMode
@@ -295,7 +281,8 @@ createProject name = do
     writeFile buildActPath (BuildSpec.renderBuildAct buildSpec)
     paths <- findPaths buildActPath defaultCompileOptions
     writeFile (joinPath [ projDir, ".gitignore" ]) (
-      ".actonc.lock\n" ++
+      ".acton.compile.lock\n" ++
+      ".acton.lock\n" ++
       "build.zig\n" ++
       "build.zig.zon\n" ++
       "out\n"
@@ -366,22 +353,10 @@ buildFiles gopts opts files =
           [proj] | onlyAct && all (== Just proj) projDirs -> do
             let sp = Source.diskSourceProvider
                 runBuild opts' =
-                  withProjectCompileLock proj $
+                  withProjectLockNotice gopts proj $
                     compileFiles sp gopts opts' absFiles False
-            withOwnerLockOrOnlyBuild gopts proj
-              (runBuild opts)
-              (runBuild opts { C.only_build = True })
+            runBuild opts
           _ -> mapM_ (runFile gopts opts) files
-
--- | Compute the path to the per-project compile lock.
-projectCompileLockPath :: FilePath -> FilePath
-projectCompileLockPath projDir =
-    joinPath [projDir, ".actonc.lock"]
-
--- | Run an action while holding the per-project compile lock.
-withProjectCompileLock :: FilePath -> IO a -> IO a
-withProjectCompileLock projDir action =
-    withFileLock (projectCompileLockPath projDir) Exclusive (\_ -> action)
 
 -- | Collect all source files in a project's src/ directory.
 projectSourceFiles :: Paths -> IO [FilePath]
@@ -389,29 +364,25 @@ projectSourceFiles paths = do
     allFiles <- getFilesRecursive (srcDir paths)
     return (catMaybes (map filterActFile allFiles))
 
--- | Prefer the compile-owner lock, fallback to only-build when unavailable.
-withOwnerLockOrOnlyBuild :: C.GlobalOptions -> FilePath -> IO a -> IO a -> IO a
-withOwnerLockOrOnlyBuild gopts projDir runFull runFallback = do
-    ownerLock <- tryCompileOwnerLock projDir
-    case ownerLock of
-      Just lock -> runFull `finally` releaseCompileOwnerLock lock
-      Nothing -> do
-        unless (C.quiet gopts) $
-          putStrLn "Compiler already running; running final build only."
-        runFallback
-
--- | Require the compile-owner lock or abort with a message.
-withOwnerLockOrExit :: FilePath -> String -> IO a -> IO a
-withOwnerLockOrExit projDir msg action = do
-    ownerLock <- tryCompileOwnerLock projDir
-    case ownerLock of
+withBackgroundCompilerLockOrExit :: FilePath -> String -> IO a -> IO a
+withBackgroundCompilerLockOrExit projDir msg action = do
+    mlock <- tryBackgroundCompilerLock projDir
+    case mlock of
       Nothing -> printErrorAndExit msg
-      Just lock -> action `finally` releaseCompileOwnerLock lock
+      Just lock -> action `finally` releaseBackgroundCompilerLock lock
 
-withProjectLockForGen :: CompileScheduler -> Int -> FilePath -> IO () -> IO ()
-withProjectLockForGen sched gen projDir action =
+withProjectLockNotice :: C.GlobalOptions -> FilePath -> IO a -> IO a
+withProjectLockNotice gopts projDir action =
+    withProjectLockOnWait projDir onWait action
+  where
+    onWait =
+      unless (C.quiet gopts) $
+        putStrLn ("Waiting for compiler lock in " ++ projDir)
+
+withProjectLockForGen :: C.GlobalOptions -> CompileScheduler -> Int -> FilePath -> IO () -> IO ()
+withProjectLockForGen gopts sched gen projDir action =
     whenCurrentGen sched gen $
-      withProjectCompileLock projDir $
+      withProjectLockNotice gopts projDir $
         whenCurrentGen sched gen action
 
 requireProjectLayout :: Paths -> IO ()
@@ -494,13 +465,11 @@ buildProjectOnce gopts opts = do
                 iff (not(C.quiet gopts)) $ do
                   putStrLn("Building project in " ++ projPath paths)
                 let projDir = projPath paths
-                    runBuild opts' = withProjectCompileLock projDir $ do
+                    runBuild opts' = withProjectLockNotice gopts projDir $ do
                       srcFiles <- projectSourceFiles paths
                       compileFiles sp gopts opts' srcFiles True
                       generateProjectDocIndex sp gopts opts' paths srcFiles
-                withOwnerLockOrOnlyBuild gopts projDir
-                  (runBuild opts)
-                  (runBuild opts { C.only_build = True })
+                runBuild opts
 
 -- Test runner -------------------------------------------------------------------------------------------------
 
@@ -545,22 +514,23 @@ runTestsWatch gopts opts topts mode paths = do
     let sp = Source.diskSourceProvider
         projDir = projPath paths
         srcRoot = srcDir paths
-    (sched, progressUI, progressState) <- initCompileWatchContext gopts
-    testParallel <- testMaxParallel gopts
-    let runOnce gen mChanged = do
-          withProjectLockForGen sched gen projDir $ do
-            logProjectBuild gopts progressUI progressState projDir
-            srcFiles <- projectSourceFiles paths
-            hadErrors <- compileFilesChanged sp gopts opts srcFiles True mChanged (Just (sched, gen)) (Just (progressUI, progressState))
-            unless hadErrors $ do
-              testModules <- listTestModules opts paths
-              modulesToTest <- selectTestModules paths srcFiles mChanged testModules
-              unless (null modulesToTest) $
-                do
-                  useColorOut <- useColor gopts
-                  void $ runProjectTests useColorOut gopts opts paths topts mode modulesToTest testParallel
-    withOwnerLockOrExit projDir "Another compiler is running; cannot start test watch." $
-      runWatchProject gopts projDir srcRoot sched runOnce
+    withBackgroundCompilerLockOrExit projDir
+      "Another long-running Acton compiler is already running; cannot start test watch." $ do
+        (sched, progressUI, progressState) <- initCompileWatchContext gopts
+        testParallel <- testMaxParallel gopts
+        let runOnce gen mChanged = do
+              withProjectLockForGen gopts sched gen projDir $ do
+                logProjectBuild gopts progressUI progressState projDir
+                srcFiles <- projectSourceFiles paths
+                hadErrors <- compileFilesChanged sp gopts opts srcFiles True mChanged (Just (sched, gen)) (Just (progressUI, progressState))
+                unless hadErrors $ do
+                  testModules <- listTestModules opts paths
+                  modulesToTest <- selectTestModules paths srcFiles mChanged testModules
+                  unless (null modulesToTest) $
+                    do
+                      useColorOut <- useColor gopts
+                      void $ runProjectTests useColorOut gopts opts paths topts mode modulesToTest testParallel
+        runWatchProject gopts projDir srcRoot sched runOnce
 
 selectTestModules :: Paths -> [FilePath] -> Maybe [FilePath] -> [String] -> IO [String]
 selectTestModules paths srcFiles mChanged testModules =
@@ -629,16 +599,17 @@ watchProjectAt :: C.GlobalOptions -> C.CompileOptions -> FilePath -> IO ()
 watchProjectAt gopts opts projDir = do
                 let sp = Source.diskSourceProvider
                 paths <- loadProjectPathsAt projDir opts
-                withOwnerLockOrExit (projPath paths) "Another compiler is running; cannot start watch." $ do
-                  (sched, progressUI, progressState) <- initCompileWatchContext gopts
-                  let runOnce gen mChanged =
-                        withProjectLockForGen sched gen (projPath paths) $ do
-                          logProjectBuild gopts progressUI progressState (projPath paths)
-                          srcFiles <- projectSourceFiles paths
-                          void $ compileFilesChanged sp gopts opts srcFiles True mChanged (Just (sched, gen)) (Just (progressUI, progressState))
-                          when (isNothing mChanged) $
-                            generateProjectDocIndex sp gopts opts paths srcFiles
-                  runWatchProject gopts (projPath paths) (srcDir paths) sched runOnce
+                withBackgroundCompilerLockOrExit (projPath paths)
+                  "Another long-running Acton compiler is already running; cannot start watch." $ do
+                    (sched, progressUI, progressState) <- initCompileWatchContext gopts
+                    let runOnce gen mChanged =
+                          withProjectLockForGen gopts sched gen (projPath paths) $ do
+                            logProjectBuild gopts progressUI progressState (projPath paths)
+                            srcFiles <- projectSourceFiles paths
+                            void $ compileFilesChanged sp gopts opts srcFiles True mChanged (Just (sched, gen)) (Just (progressUI, progressState))
+                            when (isNothing mChanged) $
+                              generateProjectDocIndex sp gopts opts paths srcFiles
+                    runWatchProject gopts (projPath paths) (srcDir paths) sched runOnce
 
 -- | Build a single file, optionally running in watch mode.
 buildFile :: C.GlobalOptions -> C.CompileOptions -> FilePath -> IO ()
@@ -661,11 +632,9 @@ buildFileOnce gopts opts file = do
         iff (not(C.quiet gopts)) $ do
           putStrLn("Building file " ++ file ++ " in project " ++ relProj)
         let runBuild opts' =
-              withProjectCompileLock proj $
+              withProjectLockNotice gopts proj $
                 compileFiles sp gopts opts' [file] False
-        withOwnerLockOrOnlyBuild gopts proj
-          (runBuild opts)
-          (runBuild opts { C.only_build = True })
+        runBuild opts
       Nothing -> do
         -- Not in a project, use scratch directory for compilation unless
         -- --tempdir is provided - then use that
@@ -1099,13 +1068,11 @@ compileFilesChanged sp gopts opts srcFiles allowPrune mChangedPaths mSched mProg
               runPlan plan = do
                 let cctx = cpContext plan
                     opts' = ccOpts cctx
-                    pathsRoot = ccPathsRoot cctx
                     watchMode = C.watch opts'
                 cliHooks <- initCliCompileHooks progressUI progressState gopts sched gen plan
                 let clearProgress = whenCurrentGen sched gen (cchClearProgress cliHooks)
                     finalizeCompile onError = do
                       clearProgress
-                      cleanup gopts opts' pathsRoot
                       onError
                       return True
                     reportCompileError msg =
@@ -1834,7 +1801,6 @@ runZig gopts opts zigExe zigArgs paths wd mProgressUI = do
           printIce ("compilation of generated Zig code failed, returned error code" ++ show ret)
           putStrLn $ "zig stdout:\n" ++ zigStdout
           putStrLn $ "zig stderr:\n" ++ zigStderr
-          cleanup gopts opts paths
           unless (C.watch opts) System.Exit.exitFailure
 
 generateFingerprint :: String -> IO String
@@ -2055,7 +2021,6 @@ zigBuild env gopts opts paths rootSpec tasks binTasks allowPrune rootModules dep
             dstBinFile = joinPath [ binDir paths, exeName ]
         copyFile srcBinFile dstBinFile
       else return ()
-    cleanup gopts opts paths
     timeEnd <- getTime Monotonic
     return (timeEnd - timeStart)
 

--- a/compiler/acton/test/incremental_cases/.gitignore
+++ b/compiler/acton/test/incremental_cases/.gitignore
@@ -3,5 +3,5 @@
 /deps/
 /out/
 /build.zig*
-/.actonc.lock
+/.acton.compile.lock
 /.acton.lock

--- a/compiler/acton/test/rebuild/.gitignore
+++ b/compiler/acton/test/rebuild/.gitignore
@@ -2,5 +2,5 @@
 /deps/
 /out/
 /build.zig*
-/.actonc.lock
+/.acton.compile.lock
 /.acton.lock

--- a/compiler/acton/test_incremental.hs
+++ b/compiler/acton/test_incremental.hs
@@ -18,6 +18,7 @@ import qualified Data.Map.Strict as M
 import           System.Directory
 import           System.Exit
 import           System.FilePath
+import           System.IO (Handle)
 import           System.Process
 import           Data.Time.Clock        (getCurrentTime)
 import           System.Directory       (setModificationTime)
@@ -256,9 +257,12 @@ ensureCleanAt proj = do
   outExists <- doesDirectoryExist outDir
   when outExists $ E.catch (removeDirectoryRecursive outDir) handler
   -- Remove potential leftover project lock file
-  let lockFile = proj </> ".actonc.lock"
+  let lockFile = proj </> ".acton.lock"
   lockExists <- doesFileExist lockFile
   when lockExists $ E.catch (removeFile lockFile) handler
+  let bgLockFile = proj </> ".acton.compile.lock"
+  bgLockExists <- doesFileExist bgLockFile
+  when bgLockExists $ E.catch (removeFile bgLockFile) handler
 
 -- | Run a shell command in a directory and capture stdout+stderr.
 runIn :: FilePath -> String -> IO (ExitCode, T.Text)
@@ -339,8 +343,17 @@ ensureCleanProjectAt proj = do
   removeDirIfExists (proj </> "deps")
   removeIfExists (proj </> "build.zig")
   removeIfExists (proj </> "build.zig.zon")
+  removeIfExists (proj </> ".acton.compile.lock")
   removeIfExists (proj </> ".acton.lock")
-  removeIfExists (proj </> ".actonc.lock")
+
+withBackgroundCompilerLockHeld :: FilePath -> IO a -> IO a
+withBackgroundCompilerLockHeld proj action = do
+  mlock <- Compile.tryBackgroundCompilerLock proj
+  case mlock of
+    Nothing ->
+      assertFailure ("failed to acquire .acton.compile.lock in " ++ proj)
+    Just lock ->
+      action `E.finally` Compile.releaseBackgroundCompilerLock lock
 
 -- | Write a Build.act file with optional path deps.
 writeBuildAct :: FilePath -> String -> [(String, FilePath)] -> IO ()
@@ -759,31 +772,6 @@ p15_rebuild_import = testCase "15-rebuild with stdlib import" $ do
   res1 <- runActonIn casesProjDir ["build", "--color", "never"]
   assertExitSuccess "initial build" res1
   res2 <- runActonIn casesProjDir ["build", "--color", "never"]
-  assertExitSuccess "second build" res2
-
-p15b_transitive_stdlib_import :: TestTree
-p15b_transitive_stdlib_import = testCase "15b-transitive stdlib import via cached module" $ do
-  let proj = casesProjDir
-      src = casesSrcDir
-  ensureCasesProject
-  writeFileUtf8 (src </> "b.act") $ T.unlines
-    [ "import logging"
-    , ""
-    , "class Box(logging.Logger):"
-    , "    pass"
-    ]
-  writeFileUtf8 (src </> "main.act") $ T.unlines
-    [ "import b"
-    , ""
-    , "class Consumer(b.Box):"
-    , "    pass"
-    , ""
-    , "actor main(env):"
-    , "    env.exit(0)"
-    ]
-  res1 <- runActonIn proj ["build", "--color", "never"]
-  assertExitSuccess "initial build" res1
-  res2 <- runActonIn proj ["build", "--color", "never"]
   assertExitSuccess "second build" res2
 
 p16_dep_api_change :: TestTree
@@ -1766,6 +1754,96 @@ p37_impl_refresh_missing_dep_hashes_reruns_front =
       (not (T.isInfixOf "NoItem" out2))
     assertBool ("expected main.act to type check after fallback\n" ++ T.unpack out2) (typechecked out2 modMain)
 
+p38_project_lock_blocks_build :: TestTree
+p38_project_lock_blocks_build =
+  testCase "38-project lock blocks concurrent build" $ do
+    let proj = casesProjDir
+        src = casesSrcDir
+    ensureCasesProject
+    writeFileUtf8 (src </> "main.act") $ T.unlines
+      [ "actor main(env: Env):"
+      , "    env.exit(0)"
+      ]
+    actonExe <- actonPath
+    res <- Compile.withProjectLock proj $ do
+      (_, mOut, mErr, ph) <- createProcess
+        (proc actonExe ["build", "--color", "never", "--jobs", "1"])
+          { cwd = Just proj
+          , std_out = CreatePipe
+          , std_err = CreatePipe
+          }
+      let outH = requirePipe "stdout" mOut
+          errH = requirePipe "stderr" mErr
+      (do
+          threadDelay 500000
+          mExit <- getProcessExitCode ph
+          case mExit of
+            Nothing -> pure ()
+            Just ec -> assertFailure ("build should have blocked on .acton.lock, exited early with " ++ show ec)
+          pure (ph, outH, errH))
+        `E.onException` do
+          terminateProcess ph
+          _ <- waitForProcess ph
+          pure ()
+    let (ph, outH, errH) = res
+    ec <- waitForProcess ph
+    out <- T.hGetContents outH
+    err <- T.hGetContents errH
+    assertEqual "build should succeed after lock is released" ExitSuccess ec
+    let combined = out <> err
+    assertBool ("expected wait message while build was blocked\n" ++ T.unpack combined)
+      (T.isInfixOf "Waiting for compiler lock in" combined)
+  where
+    requirePipe :: String -> Maybe Handle -> Handle
+    requirePipe label =
+      maybe (error ("missing " ++ label ++ " pipe for lock wait test")) id
+
+p39_background_lock_does_not_block_build :: TestTree
+p39_background_lock_does_not_block_build =
+  testCase "39-background compiler lock does not block build" $ do
+    let proj = casesProjDir
+        src = casesSrcDir
+    ensureCasesProject
+    writeFileUtf8 (src </> "main.act") $ T.unlines
+      [ "actor main(env: Env):"
+      , "    env.exit(0)"
+      ]
+    withBackgroundCompilerLockHeld proj $ do
+      res@(_ec, out) <- runActonIn proj ["build", "--color", "never", "--verbose"]
+      assertExitSuccess "build should run under .acton.compile.lock" res
+      assertBool ("expected build to rerun front passes while background lock is held\n" ++ T.unpack out)
+        (typechecked out "main")
+
+p40_background_lock_blocks_watch :: TestTree
+p40_background_lock_blocks_watch =
+  testCase "40-background compiler lock blocks watch" $ do
+    let proj = casesProjDir
+        src = casesSrcDir
+    ensureCasesProject
+    writeFileUtf8 (src </> "main.act") $ T.unlines
+      [ "actor main(env: Env):"
+      , "    env.exit(0)"
+      ]
+    withBackgroundCompilerLockHeld proj $ do
+      actonExe <- actonPath
+      (_, _, _, ph) <- createProcess (proc actonExe ["build", "--watch", "--color", "never", "--jobs", "1"]) { cwd = Just proj }
+      (do
+          threadDelay 500000
+          mExit <- getProcessExitCode ph
+          case mExit of
+            Nothing -> do
+              terminateProcess ph
+              _ <- waitForProcess ph
+              assertFailure "watch should fail quickly when .acton.compile.lock is already held"
+            Just ExitSuccess ->
+              assertFailure "watch should not succeed when .acton.compile.lock is already held"
+            Just (ExitFailure _) ->
+              pure ())
+        `E.onException` do
+          terminateProcess ph
+          _ <- waitForProcess ph
+          pure ()
+
 -- Main -----------------------------------------------------------------------
 
 -- | Tasty entry point for incremental tests.
@@ -1801,7 +1879,6 @@ main = defaultMain $ localOption (NumThreads 1) $ testGroup "incremental"
   , sequentialTestGroup "incremental-project-cases" AllSucceed
       [ p14_partial_rebuild
       , p15_rebuild_import
-      , p15b_transitive_stdlib_import
       , p16_dep_api_change
       , p17_dep_impl_change
       , p18_type_only_deps
@@ -1824,5 +1901,8 @@ main = defaultMain $ localOption (NumThreads 1) $ testGroup "incremental"
       , p35_changed_path_keeps_unaffected_provider
       , p36_removed_dep_name_triggers_front_refresh
       , p37_impl_refresh_missing_dep_hashes_reruns_front
+      , p38_project_lock_blocks_build
+      , p39_background_lock_does_not_block_build
+      , p40_background_lock_blocks_watch
       ]
   ]

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -139,9 +139,13 @@ module Acton.Compile
   , runBackPasses
   , runBackJobs
   , findProjectDir
-  , compileOwnerLockPath
-  , tryCompileOwnerLock
-  , releaseCompileOwnerLock
+  , BackgroundCompilerLock
+  , backgroundCompilerLockPath
+  , tryBackgroundCompilerLock
+  , releaseBackgroundCompilerLock
+  , projectLockPath
+  , withProjectLockOnWait
+  , withProjectLock
   , findPaths
   , discoverProjects
   , pathsForModule
@@ -239,7 +243,7 @@ import System.Clock
 import System.Directory
 import System.Directory.Recursive
 import System.Environment (getExecutablePath, lookupEnv)
-import System.FileLock (FileLock, SharedExclusive(Exclusive), tryLockFile, unlockFile)
+import System.FileLock (FileLock, SharedExclusive(Exclusive), tryLockFile, unlockFile, withFileLock)
 import System.FilePath ((</>))
 import System.FilePath.Posix
 import System.Exit (ExitCode(..))
@@ -598,7 +602,6 @@ prepareCompilePlanFromContext sp gopts ctx srcFiles allowPrune mChangedPaths = d
             , projSysPath = sysAbs
             , projSysTypes = joinPath [sysAbs, "base", "out", "types"]
             , projBuildSpec = scratchBuildSpec rootProj
-            , projLocks = joinPath [projPath pathsRoot, ".actonc.lock"]
             , projDeps = []
             }
       return (M.singleton rootProj ctx')
@@ -2565,7 +2568,6 @@ data ProjCtx = ProjCtx {
                      projSysPath :: FilePath,
                      projSysTypes:: FilePath,
                      projBuildSpec :: BuildSpec.BuildSpec,
-                     projLocks    :: FilePath,
                      projDeps     :: [(String, FilePath)]          -- resolved dependency roots (abs paths)
                    } deriving (Show)
 
@@ -2631,7 +2633,6 @@ discoverProjects gopts sysAbs rootProj depOverrides = do
           let outDir   = joinPath [dirAbs, "out"]
               typesDir = joinPath [outDir, "types"]
               srcDir'  = joinPath [dirAbs, "src"]
-              lockPath = joinPath [dirAbs, ".actonc.lock"]
               ctx = ProjCtx { projRoot = dirAbs
                             , projOutDir = outDir
                             , projTypesDir = typesDir
@@ -2639,7 +2640,6 @@ discoverProjects gopts sysAbs rootProj depOverrides = do
                             , projSysPath = sysAbs
                             , projSysTypes = joinPath [sysAbs, "base", "out", "types"]
                             , projBuildSpec = spec
-                            , projLocks = lockPath
                             , projDeps = [ (n, p) | (n, p, _) <- reverse deps ]
                             }
               acc' = M.insert dirAbs ctx acc
@@ -2730,21 +2730,28 @@ findProjectDir path = do
             else findProjectDir (takeDirectory path)
 
 
--- | Path to the compile-owner lock for a project root.
-compileOwnerLockPath :: FilePath -> FilePath
-compileOwnerLockPath projDir =
+-- | Opaque handle for the lifetime lock of a long-running project compiler.
+data BackgroundCompilerLock = BackgroundCompilerLock FileLock FilePath
+
+-- | Path to the lock held for the lifetime of a long-running project compiler.
+--
+-- This lock only establishes unique ownership of a background compiler
+-- process such as LSP or watch mode. It does not imply that project state
+-- is current, so all compile/build work must still take 'withProjectLock'.
+backgroundCompilerLockPath :: FilePath -> FilePath
+backgroundCompilerLockPath projDir =
     joinPath [projDir, ".acton.compile.lock"]
 
--- | Acquire the compile-owner lock for a project root, if available.
-tryCompileOwnerLock :: FilePath -> IO (Maybe (FileLock, FilePath))
-tryCompileOwnerLock projDir = do
-    let lockPath = compileOwnerLockPath projDir
+-- | Acquire the long-running compiler lock for a project root, if available.
+tryBackgroundCompilerLock :: FilePath -> IO (Maybe BackgroundCompilerLock)
+tryBackgroundCompilerLock projDir = do
+    let lockPath = backgroundCompilerLockPath projDir
     mlock <- tryLockFile lockPath Exclusive
-    return ((\lock -> (lock, lockPath)) <$> mlock)
+    return ((\lock -> BackgroundCompilerLock lock lockPath) <$> mlock)
 
--- | Release a compile-owner lock and remove the lock file if possible.
-releaseCompileOwnerLock :: (FileLock, FilePath) -> IO ()
-releaseCompileOwnerLock (lock, lockPath) = do
+-- | Release the long-running compiler lock and remove its lock file if possible.
+releaseBackgroundCompilerLock :: BackgroundCompilerLock -> IO ()
+releaseBackgroundCompilerLock (BackgroundCompilerLock lock lockPath) = do
     unlockFile lock
     mlock <- tryLockFile lockPath Exclusive
     case mlock of
@@ -2755,6 +2762,30 @@ releaseCompileOwnerLock (lock, lockPath) = do
   where
     handleNotExists :: IOException -> IO ()
     handleNotExists _ = return ()
+
+-- | Path to the single per-project compiler work lock.
+projectLockPath :: FilePath -> FilePath
+projectLockPath projDir =
+    joinPath [projDir, ".acton.lock"]
+
+-- | Run an action while holding the single per-project compiler work lock.
+--
+-- If the lock is not immediately available, run the callback once before
+-- blocking until the lock can be acquired.
+withProjectLockOnWait :: FilePath -> IO () -> IO a -> IO a
+withProjectLockOnWait projDir onWait action = do
+    let lockPath = projectLockPath projDir
+    mlock <- tryLockFile lockPath Exclusive
+    case mlock of
+      Just lock -> action `finally` unlockFile lock
+      Nothing -> do
+        onWait
+        withFileLock lockPath Exclusive (\_ -> action)
+
+-- | Run an action while holding the single per-project compiler work lock.
+withProjectLock :: FilePath -> IO a -> IO a
+withProjectLock projDir action =
+    withProjectLockOnWait projDir (return ()) action
 
 
 -- | Compute Paths for a given source file and compile options.

--- a/compiler/lsp-server/Main.hs
+++ b/compiler/lsp-server/Main.hs
@@ -2,18 +2,16 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-import Control.Exception (try, finally)
-import Control.Monad (void, when, forM_)
+import Control.Exception (finally, try)
+import Control.Monad (forM_, void, when)
 import Control.Monad.IO.Class
 import Data.IORef
 import qualified Data.HashMap.Strict as HM
-import qualified Data.Map as M
 import Data.Maybe (fromMaybe, listToMaybe)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import GHC.Conc (getNumCapabilities)
 import System.IO.Unsafe (unsafePerformIO)
-import System.FileLock (FileLock)
 
 import Language.LSP.Protocol.Message
 import Language.LSP.Protocol.Types hiding (Diagnostic, Position)
@@ -32,8 +30,8 @@ import Error.Diagnose.Position (Position(..))
 
 type OverlayMap = HM.HashMap FilePath Source.SourceSnapshot
 type UriMap = HM.HashMap FilePath Uri
-type CompileOwnerMap = HM.HashMap FilePath (FileLock, FilePath)
-type CompileOwnerWarned = HM.HashMap FilePath ()
+type BackgroundCompilerLockMap = HM.HashMap FilePath Compile.BackgroundCompilerLock
+type BackgroundCompilerWarned = HM.HashMap FilePath ()
 
 -- | Debounce delay (microseconds) before recompiling on edits.
 debounceMicros :: Int
@@ -49,15 +47,15 @@ overlaysRef = unsafePerformIO (newIORef HM.empty)
 uriByPathRef :: IORef UriMap
 uriByPathRef = unsafePerformIO (newIORef HM.empty)
 
-{-# NOINLINE compileOwnerLocksRef #-}
--- | Map project roots to held compile-owner locks.
-compileOwnerLocksRef :: IORef CompileOwnerMap
-compileOwnerLocksRef = unsafePerformIO (newIORef HM.empty)
+{-# NOINLINE backgroundCompilerLocksRef #-}
+-- | Map project roots to held background-compiler locks.
+backgroundCompilerLocksRef :: IORef BackgroundCompilerLockMap
+backgroundCompilerLocksRef = unsafePerformIO (newIORef HM.empty)
 
-{-# NOINLINE compileOwnerWarnedRef #-}
--- | Remember which projects have already warned about an active compiler.
-compileOwnerWarnedRef :: IORef CompileOwnerWarned
-compileOwnerWarnedRef = unsafePerformIO (newIORef HM.empty)
+{-# NOINLINE backgroundCompilerWarnedRef #-}
+-- | Remember which projects have already warned about another background compiler.
+backgroundCompilerWarnedRef :: IORef BackgroundCompilerWarned
+backgroundCompilerWarnedRef = unsafePerformIO (newIORef HM.empty)
 
 {-# NOINLINE compileScheduler #-}
 -- | Shared compile scheduler for LSP events and back jobs.
@@ -134,37 +132,38 @@ lookupUri path = do
   m <- readIORef uriByPathRef
   return (fromMaybe (filePathToUri path) (HM.lookup path m))
 
-ensureCompileOwnerLock :: FilePath -> IO Bool
-ensureCompileOwnerLock projRoot = do
-  locks <- readIORef compileOwnerLocksRef
+ensureBackgroundCompilerLock :: FilePath -> IO Bool
+ensureBackgroundCompilerLock projRoot = do
+  locks <- readIORef backgroundCompilerLocksRef
   case HM.lookup projRoot locks of
     Just _ -> return True
     Nothing -> do
-      mlock <- Compile.tryCompileOwnerLock projRoot
+      mlock <- Compile.tryBackgroundCompilerLock projRoot
       case mlock of
         Nothing -> return False
-        Just lockInfo -> do
-          atomicModifyIORef' compileOwnerLocksRef $ \m -> (HM.insert projRoot lockInfo m, ())
-          atomicModifyIORef' compileOwnerWarnedRef $ \m -> (HM.delete projRoot m, ())
+        Just lock -> do
+          atomicModifyIORef' backgroundCompilerLocksRef $ \m -> (HM.insert projRoot lock m, ())
+          atomicModifyIORef' backgroundCompilerWarnedRef $ \m -> (HM.delete projRoot m, ())
           return True
 
-releaseCompileOwnerLocks :: IO ()
-releaseCompileOwnerLocks = do
-  locks <- readIORef compileOwnerLocksRef
-  forM_ (HM.elems locks) Compile.releaseCompileOwnerLock
-  writeIORef compileOwnerLocksRef HM.empty
+releaseBackgroundCompilerLocks :: IO ()
+releaseBackgroundCompilerLocks = do
+  locks <- readIORef backgroundCompilerLocksRef
+  forM_ (HM.elems locks) Compile.releaseBackgroundCompilerLock
+  writeIORef backgroundCompilerLocksRef HM.empty
 
-warnCompileOwnerLocked :: FilePath -> LspM () ()
-warnCompileOwnerLocked projRoot = do
-  first <- liftIO $ atomicModifyIORef' compileOwnerWarnedRef $ \m ->
+warnBackgroundCompilerLocked :: FilePath -> LspM () ()
+warnBackgroundCompilerLocked projRoot = do
+  first <- liftIO $ atomicModifyIORef' backgroundCompilerWarnedRef $ \m ->
     if HM.member projRoot m
       then (m, False)
       else (HM.insert projRoot () m, True)
   when first $
     sendNotification SMethod_WindowShowMessage
       (ShowMessageParams MessageType_Warning
-        (T.pack ("Another Acton compiler is already running in " ++ projRoot ++
+        (T.pack ("Another long-running Acton compiler is already running in " ++ projRoot ++
                  "; LSP compilation is disabled until it exits.")))
+
 -- | Run an action only if the compile generation is current.
 whenCurrentGen :: Int -> LspM () () -> LspM () ()
 whenCurrentGen gen action = do
@@ -234,19 +233,23 @@ runCompile gen path = do
   let gopts = lspGlobalOpts
       opts = lspCompileOpts
       sp = overlaySourceProvider overlaysRef
-  planE <- liftIO $ (try $ do
-    Compile.prepareCompilePlan sp gopts compileScheduler opts [path] False (Just [path])
-    ) :: LspM () (Either Compile.ProjectError Compile.CompilePlan)
-  case planE of
-    Left (Compile.ProjectError msg) -> notifyCompileError gen msg
-    Right plan -> do
-      let rootProj = Compile.ccRootProj (Compile.cpContext plan)
-      withCompileOwnerLock gen rootProj $
-        runCompilePlanWithHooks gen sp gopts plan
+  rootProj <- liftIO $ resolveCompileRoot path opts
+  withBackgroundCompilerLock gen rootProj $
+    runCompilePlanWithHooks gen rootProj path sp gopts opts
 
--- | Run a compile plan after verifying we own the project lock.
-runCompilePlanWithHooks :: Int -> Source.SourceProvider -> C.GlobalOptions -> Compile.CompilePlan -> LspM () ()
-runCompilePlanWithHooks gen sp gopts plan = do
+-- | Resolve the project root used for compile locking.
+resolveCompileRoot :: FilePath -> C.CompileOptions -> IO FilePath
+resolveCompileRoot path opts = do
+  mproj <- Compile.findProjectDir path
+  case mproj of
+    Just proj -> Compile.normalizePathSafe proj
+    Nothing -> do
+      paths <- Compile.findPaths path opts
+      Compile.normalizePathSafe (Compile.projPath paths)
+
+-- | Prepare and run a compile while holding the per-run project work lock.
+runCompilePlanWithHooks :: Int -> FilePath -> FilePath -> Source.SourceProvider -> C.GlobalOptions -> C.CompileOptions -> LspM () ()
+runCompilePlanWithHooks gen rootProj path sp gopts opts = do
   env <- getLspEnv
   let taskPath t = Compile.srcFile (Compile.gtPaths t) (Compile.tkMod (Compile.gtKey t))
       publishFor t diags =
@@ -259,18 +262,42 @@ runCompilePlanWithHooks gen sp gopts plan = do
             publishFor t []
         , Compile.chOnInfo = \_ -> return ()
         }
-  compileRes <- liftIO $ Compile.runCompilePlan sp gopts plan compileScheduler gen hooks
+  compileRes <- liftIO $
+    Compile.withProjectLock rootProj $
+      do
+        planE <- (try $ do
+          Compile.prepareCompilePlan sp gopts compileScheduler opts [path] False (Just [path])
+          ) :: IO (Either Compile.ProjectError Compile.CompilePlan)
+        case planE of
+          Left (Compile.ProjectError msg) ->
+            return (Left msg)
+          Right plan -> do
+            runRes <- Compile.runCompilePlan sp gopts plan compileScheduler gen hooks
+            case runRes of
+              Left err ->
+                return (Left (Compile.compileFailureMessage err))
+              Right _ -> do
+                let opts' = Compile.ccOpts (Compile.cpContext plan)
+                backFailure <-
+                  if C.only_build opts'
+                    then return Nothing
+                    else Compile.backQueueWait (Compile.csBackQueue compileScheduler) gen
+                case backFailure of
+                  Just failure ->
+                    return (Left (Compile.backPassFailureMessage failure))
+                  Nothing ->
+                    return (Right ())
   case compileRes of
-    Left err -> notifyCompileError gen (Compile.compileFailureMessage err)
-    Right _ -> return ()
+    Left msg -> notifyCompileError gen msg
+    Right () -> return ()
 
--- | Execute an action only when the compile-owner lock is available.
-withCompileOwnerLock :: Int -> FilePath -> LspM () () -> LspM () ()
-withCompileOwnerLock gen rootProj action = do
-  lockOk <- liftIO $ ensureCompileOwnerLock rootProj
+-- | Execute an action only when we own the long-running compiler lock.
+withBackgroundCompilerLock :: Int -> FilePath -> LspM () () -> LspM () ()
+withBackgroundCompilerLock gen rootProj action = do
+  lockOk <- liftIO $ ensureBackgroundCompilerLock rootProj
   if lockOk
     then action
-    else whenCurrentGen gen $ warnCompileOwnerLocked rootProj
+    else whenCurrentGen gen $ warnBackgroundCompilerLocked rootProj
 
 -- | Schedule a compile run with a debounce delay.
 scheduleCompile :: Int -> FilePath -> LspM () ()
@@ -327,7 +354,7 @@ handlers =
 -- | Start the Acton LSP server with the configured handlers.
 main :: IO Int
 main =
-  runServer serverDef `finally` releaseCompileOwnerLocks
+  runServer serverDef `finally` releaseBackgroundCompilerLocks
   where
     serverDef =
       ServerDefinition

--- a/compiler/lsp-server/package.yaml.in
+++ b/compiler/lsp-server/package.yaml.in
@@ -27,7 +27,6 @@ executables:
       - containers
       - directory
       - filepath
-      - filelock
       - mtl
       - megaparsec
       - aeson

--- a/test/compiler/dep-api-change/.gitignore
+++ b/test/compiler/dep-api-change/.gitignore
@@ -1,5 +1,5 @@
 .acton.lock
-.actonc.lock
+.acton.lock
 build.zig*
 out
 deps/libfoo/src/libfoo.act

--- a/test/compiler/hello/.gitignore
+++ b/test/compiler/hello/.gitignore
@@ -1,4 +1,4 @@
-.actonc.lock
+.acton.lock
 build-cache
 out
 build.zig*

--- a/test/compiler/subdash/.gitignore
+++ b/test/compiler/subdash/.gitignore
@@ -1,3 +1,3 @@
-.actonc.lock
+.acton.lock
 out
 build.zig*

--- a/test/compiler/test_deps/.gitignore
+++ b/test/compiler/test_deps/.gitignore
@@ -1,3 +1,3 @@
-.actonc.lock
+.acton.lock
 out
 build.zig*

--- a/test/compiler/test_deps/deps/a-b/.gitignore
+++ b/test/compiler/test_deps/deps/a-b/.gitignore
@@ -1,3 +1,3 @@
-.actonc.lock
+.acton.lock
 out
 build.zig*

--- a/test/stdlib_tests/.gitignore
+++ b/test/stdlib_tests/.gitignore
@@ -1,5 +1,5 @@
 *.swp
 .acton.lock
-.actonc.lock
+.acton.lock
 build.zig*
 out


### PR DESCRIPTION
Clear up semantics and responsibilities between the .acton.lock and .acton.compile.lock

.acton.lock is the work lock for compiler activity that reads or mutates project build state. Every compile or build path takes it while preparing the compile plan, running front passes, queuing or draining back work, and updating generated outputs. A standalone acton build therefore always runs the normal pipeline under this lock.

The long-running lock remains .acton.compile.lock. It is held for the lifetime of background compilers such as watch mode and the LSP server, preventing multiple background compilers from owning the same project at once. Its presence is no longer used to let another compiler skip front or back passes and jump straight to the final build. It is only used to prevent multiple background compilers.

The project work lock is renamed from .actonc.lock to .acton.lock throughout the tree. Lock handling is shared through Acton.Compile, so lsp-server-acton no longer depends on filelock directly. LSP also now holds .acton.lock across compile-plan preparation and back-queue draining so fetch, prune, and generated file writes remain serialized with CLI builds.

CLI builds now emit a wait message when blocked on .acton.lock. Regression coverage asserts that .acton.lock still blocks concurrent builds, while .acton.compile.lock blocks competing watches but does not block a normal build.