### PR TITLE
Validate cached snapshot tests against expected metadata

### DIFF
--- a/compiler/acton/TestRunner.hs
+++ b/compiler/acton/TestRunner.hs
@@ -39,6 +39,7 @@ import qualified Data.ByteString.Lazy as BL
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import Control.Exception (SomeException, displayException, evaluate, onException, try)
+import Data.Time.Clock (UTCTime)
 import qualified Text.Regex.TDFA as TDFA
 import Data.Version (showVersion)
 import qualified Paths_acton
@@ -188,10 +189,14 @@ runProjectTests useColorOut gopts opts paths topts mode modules maxParallel = do
                 classifyCachedTests logCache cacheEntries testHashInfos allTests
               return cachedResults
             else return []
+        cachedResults1 <-
+          if useCache
+            then filterReusableCachedSnapshotResults logCache paths cachedResults0
+            else return []
         cachedResults <-
           if C.testSnapshotUpdate topts
-            then mapM (applySnapshotUpdate paths) cachedResults0
-            else return cachedResults0
+            then mapM (applySnapshotUpdate paths) cachedResults1
+            else return cachedResults1
         let showCached = C.testShowCached topts
         when (not emitJson && not useCache) $
           putStrLn "Skipping test result cache (--no-cache); running all selected tests"
@@ -836,6 +841,69 @@ applySnapshotUpdate paths res =
             writeFile (snapshotDir </> fileName) out
             return (markSnapshotUpdated res)
       _ -> return res
+
+-- | Reuse cached snapshot results only when the on-disk snapshot metadata still
+-- | shows that the expected file predates the last produced output. Any
+-- | uncertainty forces a rerun.
+filterReusableCachedSnapshotResults :: (String -> IO ()) -> Paths -> [TestResult] -> IO [TestResult]
+filterReusableCachedSnapshotResults logCache paths =
+    fmap catMaybes . mapM keepIfReusable
+  where
+    keepIfReusable res =
+      case trOutput res of
+        Nothing -> return (Just res)
+        Just _ -> do
+          reusable <- snapshotMetadataAllowsCacheHit logCache paths res
+          if reusable
+            then return (Just res)
+            else return Nothing
+
+snapshotCacheLabel :: TestResult -> String
+snapshotCacheLabel res = trModule res ++ "." ++ trName res
+
+snapshotMetadataAllowsCacheHit :: (String -> IO ()) -> Paths -> TestResult -> IO Bool
+snapshotMetadataAllowsCacheHit logCache paths res = do
+    mExpected <- readFirstExistingSnapshotMeta expectedPaths
+    case mExpected of
+      Nothing -> miss "missing expected snapshot"
+      Just (expectedSize, expectedMTime) -> do
+        mOutput <- readSnapshotMeta outputPath
+        case mOutput of
+          Nothing -> miss "missing snapshot output"
+          Just (outputSize, outputMTime)
+            | expectedSize /= outputSize -> miss "snapshot size changed"
+            | expectedMTime >= outputMTime -> miss "snapshot expected is newer than output"
+            | otherwise -> return True
+  where
+    fileName = displayTestName (trName res)
+    expectedPaths =
+      [ joinPath [projPath paths, "snapshots", "expected", trModule res, fileName]
+      , joinPath [projPath paths, "test", "golden", trModule res, fileName]
+      ]
+    outputPath = joinPath [projPath paths, "snapshots", "output", trModule res, fileName]
+    miss reason = do
+      logCache ("[test-cache] " ++ snapshotCacheLabel res ++ " cache=miss (" ++ reason ++ ")")
+      return False
+
+readFirstExistingSnapshotMeta :: [FilePath] -> IO (Maybe (Integer, UTCTime))
+readFirstExistingSnapshotMeta [] = return Nothing
+readFirstExistingSnapshotMeta (path:rest) = do
+    mMeta <- readSnapshotMeta path
+    case mMeta of
+      Just meta -> return (Just meta)
+      Nothing -> readFirstExistingSnapshotMeta rest
+
+readSnapshotMeta :: FilePath -> IO (Maybe (Integer, UTCTime))
+readSnapshotMeta path = do
+    exists <- doesFileExist path
+    if not exists
+      then return Nothing
+      else do
+        sizeE <- (try :: IO a -> IO (Either SomeException a)) $ getFileSize path
+        timeE <- (try :: IO a -> IO (Either SomeException a)) $ getModificationTime path
+        case (sizeE, timeE) of
+          (Right size, Right mtime) -> return (Just (size, mtime))
+          _ -> return Nothing
 
 snapshotMismatchPrefix :: String
 snapshotMismatchPrefix = "testing.NotEqualError: Test output does not match expected snapshot value"

--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -27,6 +27,7 @@ import Test.Tasty.HUnit
 
 import qualified PkgCommands
 import qualified Acton.Fingerprint as Fingerprint
+import qualified Paths_acton
 
 -- The default is to build and run each test program with the expectation that
 -- both compilation and running the program is successful as determined by exit
@@ -358,6 +359,63 @@ parseFlagTests =
       assertEqual "acton test --help stderr" "" cmdErr
       assertBool "acton test --help should include --no-cache" ("--no-cache" `isInfixOf` cmdOut)
       assertBool "acton test --help should include --tag" ("--tag" `isInfixOf` cmdOut)
+  , testCase "acton test reruns cached snapshot when expected file changes" $ do
+      withSystemTempDirectory "acton-test-snapshot-cache" $ \proj -> do
+        actonBinDir <- Paths_acton.getBinDir
+        let distActon = "../../dist/bin/acton"
+            actonCandidate = actonBinDir </> "acton"
+        hasDistActon <- doesFileExist distActon
+        acton <- canonicalizePath $
+          if hasDistActon
+            then distActon
+            else actonCandidate
+        let name = "snapshot_cache"
+            fp = Fingerprint.formatFingerprint
+              (Fingerprint.updateFingerprintPrefix
+                (Fingerprint.fingerprintPrefixForName name) 1)
+            srcDir = proj </> "src"
+            modName = "snap"
+            srcFile = srcDir </> modName <.> "act"
+            expectedDir = proj </> "snapshots" </> "expected" </> modName
+            expectedFile = expectedDir </> "stable"
+            runTest args = readCreateProcessWithExitCode (proc acton ("test" : args)) { cwd = Just proj } ""
+
+        createDirectoryIfMissing True srcDir
+        createDirectoryIfMissing True expectedDir
+        writeFile (proj </> "Build.act") $ unlines
+          [ "name = \"" ++ name ++ "\""
+          , "fingerprint = " ++ fp
+          , ""
+          ]
+        writeFile srcFile $ unlines
+          [ "import testing"
+          , ""
+          , "def _test_stable() -> str:"
+          , "    return \"snapshot v1\""
+          ]
+        writeFile expectedFile "snapshot v1"
+
+        (code1, out1, err1) <- runTest ["--iter", "1"]
+        when (code1 /= ExitSuccess) $
+          assertFailure ("initial acton test failed:\nstdout:\n" ++ out1 ++ "\nstderr:\n" ++ err1)
+
+        (code2, out2, err2) <- runTest ["--iter", "1", "--show-cached"]
+        when (code2 /= ExitSuccess) $
+          assertFailure ("cached acton test failed:\nstdout:\n" ++ out2 ++ "\nstderr:\n" ++ err2)
+        assertBool "second run should reuse cached snapshot result"
+          ("Using cached results for 1 tests" `isInfixOf` out2)
+        assertBool "cached run should mark the result as cached"
+          ("* = cached test result" `isInfixOf` out2)
+
+        writeFile expectedFile "snapshot v2"
+
+        (code3, out3, err3) <- runTest ["--iter", "1", "--show-cached"]
+        assertEqual "changed expected snapshot should invalidate cached success" (ExitFailure 1) code3
+        assertBool "rerun should report snapshot mismatch"
+          ("Test output does not match expected snapshot value" `isInfixOf` out3
+            || "Test output does not match expected snapshot value" `isInfixOf` err3)
+        assertBool "stale cached snapshot result should not be reused after expected change"
+          (not ("Using cached results for 1 tests" `isInfixOf` out3))
   ]
   where
     flagGolden label golden flags =

--- a/docs/acton-dev-guide/src/compiler/test_cache.md
+++ b/docs/acton-dev-guide/src/compiler/test_cache.md
@@ -61,7 +61,13 @@ failures/errors, iterations, and duration).
 ## Behavior
 
 - If the cached run hash matches the newly computed run hash, the test is
-  skipped and its cached result is used.
+  normally skipped and its cached result is used.
+- Snapshot tests add one more guard: a cached result is only reused when the
+  `snapshots/output/...` file exists, the current expected snapshot file has
+  the same size as that output file, and the expected snapshot has an older
+  modification time. If the output file is missing, the expected file changed
+  or disappeared, or the metadata does not prove it is older than the last
+  produced output, the test is rerun.
 - With `--no-cache`, cached results are ignored and all selected tests are run.
 - Cached failures and errors still contribute to the overall test exit code.
 - By default, cached successes are hidden from output; cached failures/errors

--- a/docs/acton-guide/src/testing.md
+++ b/docs/acton-guide/src/testing.md
@@ -56,6 +56,8 @@ This means that the developer experience for test driven development is great ev
 
 Note that test input need to be contained within .act source code files in order for the compiler to consider them part of the content hash. You cannot use external .txt files or similar as input to test functions, since the compiler won't consider those parts of the implementation. Also see [incremental compilation](compilation/incremental.md) for more details on content hashing and how it applies to testing.
 
+Snapshot tests are the main exception: even when the test code hash matches the cache, `acton test` still checks the expected snapshot file on disk against the cached `snapshots/output/...` metadata. If the output snapshot is missing, the expected file changed, or Acton cannot cheaply prove the expected file is older than the last produced output, the test is rerun instead of trusting the cached result.
+
 ## Module Filtering
 
 You can run tests from specific modules using the `--module` flag:


### PR DESCRIPTION
A cached snapshot test result could be reused after the expected snapshot changed on disk, as long as the test code content hash still matched. This showed up when switching git branches: snapshots/output still reflected the old run, snapshots/expected could have been updated, and acton test would trust the cached pass.

This change makes cached snapshot reuse check the on-disk snapshot artifacts before accepting the cached result. We only reuse the cache when snapshots/output/<module>/<test> exists, the expected snapshot exists, the file sizes match, and the expected snapshot mtime is older than the output snapshot mtime. Any uncertainty falls back to rerunning the test, which keeps cache hits cheap while conservatively avoiding stale snapshot passes.

A regression test was added for acton test to cover the branch-switch style scenario where the expected snapshot changes without any source change, and the testing docs were updated to describe the extra snapshot validation.