### PR TITLE
Keep fingerprints canonical

### DIFF
--- a/compiler/lib/src/Acton/BuildSpec.hs
+++ b/compiler/lib/src/Acton/BuildSpec.hs
@@ -18,13 +18,14 @@ import qualified Data.Aeson as Ae
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.Map as Map
 import Data.Map (Map)
-import Data.Char (isDigit, isHexDigit)
-import Data.Maybe (catMaybes, fromMaybe, mapMaybe)
+import Data.Char (isSpace)
+import Data.Maybe (catMaybes, fromMaybe, isNothing, mapMaybe)
 import qualified Data.List as L
 import qualified Control.Exception as E
 import System.IO.Unsafe (unsafePerformIO)
 
 import Control.Applicative ((<|>))
+import qualified Acton.Fingerprint as Fingerprint
 import qualified Acton.Parser as AP
 import qualified Acton.Syntax as S
 import qualified Acton.Printer as Pr
@@ -112,6 +113,7 @@ data BuildSpecParseError
   = ParseError String
   | MissingProjectName
   | MissingFingerprint String
+  | InvalidFingerprint String String
   deriving (Eq, Show)
 
 renderBuildSpecParseError :: BuildSpecParseError -> String
@@ -120,6 +122,10 @@ renderBuildSpecParseError err =
     ParseError msg -> msg
     MissingProjectName -> "Missing project name (add: name = \"my_project\")"
     MissingFingerprint _ -> "Missing fingerprint (add: fingerprint = 0x1234abcd5678ef00)"
+    InvalidFingerprint name raw ->
+      "Invalid fingerprint " ++ raw ++ " (project name: " ++ show name ++ "). "
+      ++ "Expected an unquoted 64-bit hex fingerprint like "
+      ++ "0x1234abcd5678ef00"
 
 instance FromJSON BuildSpec where
   parseJSON = Ae.withObject "BuildSpec" $ \o -> do
@@ -182,7 +188,11 @@ updateBuildActFromJSON content json = do
           descPresent = KM.member "description" obj
           fpPresent   = KM.member "fingerprint" obj
       name' <- if namePresent then requireField "name" (patchName patch) else Right (specName currSpec)
-      fp' <- if fpPresent then requireField "fingerprint" (patchFingerprint patch) else Right (fingerprint currSpec)
+      fp' <- if fpPresent
+               then do
+                 fpVal <- requireField "fingerprint" (patchFingerprint patch)
+                 validatePatchFingerprint fpVal
+               else Right (fingerprint currSpec)
       desc' <- if descPresent then requireField "description" (patchDescription patch) else Right (specDescription currSpec)
       let deps' = if depsPresent then patchDependencies patch else dependencies currSpec
           zigs' = if zigPresent  then patchZigDependencies patch else zig_dependencies currSpec
@@ -205,6 +215,12 @@ updateBuildActFromJSON content json = do
       case mval of
         Just v  -> Right v
         Nothing -> Left ("Expected '" ++ label ++ "' to be present and non-null in JSON")
+
+    validatePatchFingerprint fp =
+      case Fingerprint.parseFingerprint fp of
+        Just _  -> Right fp
+        Nothing -> Left ("Expected 'fingerprint' to be a 64-bit hex literal "
+                         ++ "like 0x1234abcd5678ef00")
 
 applyTopLevelPatches :: String -> S.Module -> BuildSpec -> Bool -> Bool -> Bool -> Either String String
 applyTopLevelPatches content modAST spec namePresent descPresent fpPresent = do
@@ -343,11 +359,13 @@ parseModuleForSpec content =
 -- Extract name, description, dependencies and zig_dependencies from the AST
 extractSpecFromModule :: S.Module -> Either BuildSpecParseError BuildSpec
 extractSpecFromModule (S.Module _ _ stmts) =
-  let (mname, mdesc, mfp, deps, zigs) = foldl step (Nothing, Nothing, Nothing, Map.empty, Map.empty) stmts
-  in case (mname, mfp) of
-       (Nothing, _) -> Left MissingProjectName
-       (Just name, Nothing) -> Left (MissingFingerprint name)
-       (Just name, Just fp) ->
+  let (mname, mdesc, mfp, mfpErr, deps, zigs) =
+        foldl step (Nothing, Nothing, Nothing, Nothing, Map.empty, Map.empty) stmts
+  in case (mname, mfp, mfpErr) of
+       (Nothing, _, _) -> Left MissingProjectName
+       (Just name, Nothing, Just raw) -> Left (InvalidFingerprint name raw)
+       (Just name, Nothing, Nothing) -> Left (MissingFingerprint name)
+       (Just name, Just fp, _) ->
          Right BuildSpec { specName = name
                          , specDescription = mdesc
                          , fingerprint = fp
@@ -355,7 +373,7 @@ extractSpecFromModule (S.Module _ _ stmts) =
                          , zig_dependencies = zigs
                          }
   where
-    step (mname, mdesc, mfp, deps, zigs) stmt = case stmt of
+    step (mname, mdesc, mfp, mfpErr, deps, zigs) stmt = case stmt of
       S.Assign _ pats expr ->
         let names = mapMaybe patternVarName pats
             mname' = if "name" `elem` names
@@ -364,17 +382,22 @@ extractSpecFromModule (S.Module _ _ stmts) =
             mdesc' = if "description" `elem` names
                        then exprToSimpleString expr <|> mdesc
                        else mdesc
-            mfp'   = if "fingerprint" `elem` names
-                       then exprToFingerprint expr <|> mfp
-                       else mfp
+            (mfp', mfpErr') =
+              if "fingerprint" `elem` names
+                then case exprToFingerprint expr of
+                       Just fp -> (Just fp, Nothing)
+                       Nothing -> (mfp, if isNothing mfp
+                                          then mfpErr <|> Just (renderExpr expr)
+                                          else mfpErr)
+                else (mfp, mfpErr)
             deps'  = if "dependencies" `elem` names
                        then fromMaybe deps (exprToPkgDeps expr)
                        else deps
             zigs'  = if "zig_dependencies" `elem` names
                        then fromMaybe zigs (exprToZigDeps expr)
                        else zigs
-        in (mname', mdesc', mfp', deps', zigs')
-      _ -> (mname, mdesc, mfp, deps, zigs)
+        in (mname', mdesc', mfp', mfpErr', deps', zigs')
+      _ -> (mname, mdesc, mfp, mfpErr, deps, zigs)
 
 
 data BuildSpecPatch = BuildSpecPatch
@@ -550,18 +573,18 @@ exprToSimpleString _ = Nothing
 exprToFingerprint :: S.Expr -> Maybe String
 exprToFingerprint (S.Int _ _ lexeme) = Just lexeme
 exprToFingerprint (S.Paren _ e) = exprToFingerprint e
-exprToFingerprint e = exprToSimpleString e
+exprToFingerprint _ = Nothing
 
 renderFingerprint :: String -> String
 renderFingerprint fp
-  | isNumericFingerprint fp = fp
+  | Just formatted <- normalizeHexFingerprint fp = formatted
   | otherwise               = show fp
   where
-    isNumericFingerprint s =
-      case s of
-        '0':'x':rest -> not (null rest) && all isHexDigit rest
-        '0':'X':rest -> not (null rest) && all isHexDigit rest
-        _           -> not (null s) && all isDigit s
+    normalizeHexFingerprint raw =
+      case dropWhile isSpace raw of
+        '0':'x':_ -> Fingerprint.formatFingerprint <$> Fingerprint.parseFingerprint raw
+        '0':'X':_ -> Fingerprint.formatFingerprint <$> Fingerprint.parseFingerprint raw
+        _         -> Nothing
 
 exprToPkgDeps :: S.Expr -> Maybe (Map.Map String PkgDep)
 exprToPkgDeps (S.Dict _ assocs) = Just $ Map.fromList (mapMaybe assocToPkg assocs)

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -2951,6 +2951,12 @@ loadBuildSpec dir = do
                 throwProjectError ("Missing fingerprint in " ++ actPath ++ ".\n"
                                    ++ "ERROR: Build.act requires `fingerprint`. For example: fingerprint = " ++ suggestion ++ "\n"
                                    ++ "HINT: Fingerprint = CRC32(name) in the high 32 bits + random low 32 bits. You may choose a different value.")
+              BuildSpec.InvalidFingerprint name raw -> do
+                suggestion <- suggestFingerprint name
+                throwProjectError ("Invalid fingerprint " ++ raw ++ " in " ++ actPath
+                                   ++ " (project name: " ++ show name ++ ").\n"
+                                   ++ "Expected an unquoted 64-bit hex fingerprint like 0x1234abcd5678ef00.\n"
+                                   ++ "Suggested fingerprint: " ++ suggestion)
               BuildSpec.MissingProjectName -> do
                 suggestion <- suggestProjectName dir
                 throwProjectError ("Missing project name in " ++ actPath ++ ".\n"
@@ -3006,7 +3012,7 @@ validateFingerprint sourcePath name fpRaw =
         suggestion <- suggestFingerprint name
         throwProjectError ("Invalid fingerprint '" ++ fpRaw ++ "' in " ++ sourcePath
                            ++ " (project name: " ++ show name ++ ").\n"
-                           ++ "Expected a 64-bit numeric fingerprint like 0x1234abcd5678ef00.\n"
+                           ++ "Expected an unquoted 64-bit hex fingerprint like 0x1234abcd5678ef00.\n"
                            ++ "Suggested fingerprint: " ++ suggestion)
       Just fp -> do
         let formatted = Fingerprint.formatFingerprint fp

--- a/compiler/lib/src/Acton/Fingerprint.hs
+++ b/compiler/lib/src/Acton/Fingerprint.hs
@@ -8,9 +8,9 @@ module Acton.Fingerprint
   ) where
 
 import Data.Bits (shiftL, xor, shiftR, complement, (.|.), (.&.))
-import Data.Char (isDigit, isHexDigit, isSpace, toLower)
+import Data.Char (isSpace, toLower)
 import Data.Word (Word32, Word64)
-import Numeric (readHex, readDec, showHex)
+import Numeric (readHex, showHex)
 import qualified Data.ByteString.Char8 as B
 import qualified Data.ByteString as BS
 
@@ -50,18 +50,12 @@ parseFingerprint raw =
     in case trimmed of
          '0':'x':rest -> parseHex rest
          '0':'X':rest -> parseHex rest
-         _ | all isDigit trimmed -> parseDec trimmed
          _ -> Nothing
   where
     trim = dropWhile isSpace . reverse . dropWhile isSpace . reverse
 
     parseHex s =
       case readHex (map toLower s) of
-        [(n, "")] | n <= toInteger (maxBound :: Word64) -> Just (fromInteger n)
-        _ -> Nothing
-
-    parseDec s =
-      case readDec s of
         [(n, "")] | n <= toInteger (maxBound :: Word64) -> Just (fromInteger n)
         _ -> Nothing
 

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -598,6 +598,36 @@ main = do
             Right _ ->
               expectationFailure "Expected invalid fingerprint error"
 
+      it "errors when fingerprint is quoted hex" $ do
+        withSystemTempDirectory "acton-fp" $ \dir -> do
+          let buildAct = unlines
+                [ "name = \"demo\""
+                , "fingerprint = \"0x1234abcd5678ef00\""
+                , ""
+                ]
+          writeFile (dir </> "Build.act") buildAct
+          res <- (E.try (Compile.loadBuildSpec dir) :: IO (Either Compile.ProjectError BuildSpec.BuildSpec))
+          case res of
+            Left (Compile.ProjectError msg) ->
+              msg `shouldSatisfy` (isInfixOf "Invalid fingerprint")
+            Right _ ->
+              expectationFailure "Expected invalid fingerprint error"
+
+      it "errors when fingerprint is decimal" $ do
+        withSystemTempDirectory "acton-fp" $ \dir -> do
+          let buildAct = unlines
+                [ "name = \"demo\""
+                , "fingerprint = 1234"
+                , ""
+                ]
+          writeFile (dir </> "Build.act") buildAct
+          res <- (E.try (Compile.loadBuildSpec dir) :: IO (Either Compile.ProjectError BuildSpec.BuildSpec))
+          case res of
+            Left (Compile.ProjectError msg) ->
+              msg `shouldSatisfy` (isInfixOf "Invalid fingerprint")
+            Right _ ->
+              expectationFailure "Expected invalid fingerprint error"
+
       it "errors when name is missing" $ do
         withSystemTempDirectory "acton-fp" $ \dir -> do
           let buildAct = unlines
@@ -698,6 +728,42 @@ main = do
                   , ""
                   ]
             buildAct1 `shouldBe` expected
+
+      it "keeps hex fingerprints zero-padded when rewriting Build.act" $ do
+        let buildAct0 = unlines
+              [ "name = \"demo\""
+              , "fingerprint = 0x056275683c869ace"
+              , ""
+              , "dependencies = {}"
+              , ""
+              , "zig_dependencies = {}"
+              , ""
+              ]
+        case BuildSpec.parseBuildAct buildAct0 of
+          Left err -> expectationFailure err
+          Right (spec, _, _) ->
+            case BuildSpec.updateBuildActFromJSON buildAct0 (BuildSpec.encodeBuildSpecJSON spec) of
+              Left err -> expectationFailure err
+              Right buildAct1 -> do
+                buildAct1 `shouldSatisfy` (isInfixOf "fingerprint = 0x056275683c869ace")
+                buildAct1 `shouldSatisfy` (not . isInfixOf "fingerprint = 0x56275683c869ace")
+
+      it "rejects non-hex fingerprints in Build.act updates" $ do
+        let buildAct0 = unlines
+              [ "name = \"demo\""
+              , "fingerprint = 0x1234abcd5678ef00"
+              , ""
+              , "dependencies = {}"
+              , ""
+              , "zig_dependencies = {}"
+              , ""
+              ]
+            newJson = "{\"fingerprint\": \"1234\"}"
+        case BuildSpec.updateBuildActFromJSON buildAct0 (BL.fromStrict (B8.pack newJson)) of
+          Left err ->
+            err `shouldSatisfy` (isInfixOf "64-bit hex literal")
+          Right _ ->
+            expectationFailure "Expected Build.act update to reject decimal fingerprint"
 
       it "parses Build.act with only dependencies (zig deps missing)" $ do
         let buildAct = unlines


### PR DESCRIPTION
Build.act rewrites could shorten fingerprints that started with leading zeroes, and fingerprint validation still accepted decimal values and quoted strings even though fingerprints are defined as unquoted 64-bit hex literals.

Normalize rewritten fingerprints to the canonical 16-digit hex form and restrict fingerprint parsing and Build.act patching to 0x-prefixed hex literals. Quoted values and decimal literals are now rejected instead of being carried through validation and rewrite paths.

This keeps project creation, validation, diagnostics, upgrade suggestions, and Build.act rewrites aligned on a single fingerprint format. It also avoids spurious diffs from dropped padding and stops accepting values that cannot appear in canonical Build.act output.

Fixes #2660 