### PR TITLE
Adapt progress output to width

### DIFF
--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -104,6 +104,7 @@ import qualified Data.ByteString.Lazy as BL
 
 import TestRunner
 import TerminalProgress
+import TerminalSize
 import ZigProgress
 
 main = do
@@ -229,11 +230,24 @@ writeFileAtomic f c = do
         renameFile tmpPath f
 
 -- | Format a TimeSpec as seconds with millisecond precision.
-fmtTime t =
+fmtTimePrecise :: TimeSpec -> String
+fmtTimePrecise t =
     printf "%6.3f s" secs
   where
     secs :: Float
-    secs = (fromIntegral(sec t)) + (fromIntegral (nsec t) / 1000000000)
+    secs = (fromIntegral (sec t)) + (fromIntegral (nsec t) / 1000000000)
+
+-- | Format a TimeSpec with second granularity for compact narrow logs.
+fmtTimeCompact :: TimeSpec -> String
+fmtTimeCompact t =
+    if wholeSecs <= 0 && remNanos > 0
+      then "<1s"
+      else show roundedSecs ++ "s"
+  where
+    wholeSecs = fromIntegral (sec t) :: Integer
+    remNanos = nsec t
+    roundedSecs =
+      wholeSecs + if remNanos >= 500000000 then 1 else 0
 
 -- | Pad a string with trailing spaces for aligned output.
 padRight :: Int -> String -> String
@@ -243,6 +257,120 @@ padRight width s
   where
     width' = max 0 width
     len = length s
+
+-- | Pad a string with leading spaces for aligned output.
+padLeft :: Int -> String -> String
+padLeft width s
+    | len >= width' = s
+    | otherwise = replicate (width' - len) ' ' ++ s
+  where
+    width' = max 0 width
+    len = length s
+
+appendTimerField :: String -> Int -> String -> String
+appendTimerField base timerWidth timer
+    | null timer = base
+    | otherwise = base ++ padLeft timerWidth timer
+
+progressSpinnerThreshold :: Int
+progressSpinnerThreshold = 25
+
+progressPrefixWidth :: Int -> Int
+progressPrefixWidth cols
+    | cols >= progressSpinnerThreshold = 3
+    | otherwise = 0
+
+-- | Truncate a string on the right with an ellipsis when it does not fit.
+abbreviateRight :: Int -> String -> String
+abbreviateRight width s
+    | width <= 0 = ""
+    | length s <= width = s
+    | width <= 3 = take width s
+    | otherwise = take (width - 3) s ++ "..."
+
+-- | Compress a module label to preserve the root and as much of the tail as fits.
+fitBuildModuleLabel :: Int -> String -> String
+fitBuildModuleLabel width label
+    | width <= 0 = ""
+    | length label <= width = label
+    | width < 10 = termFitPlainLeft width label
+    | otherwise =
+        case break (== '.') label of
+          (root, '.':rest) ->
+            let rootBudget = min (length root) (max 1 (width - 4))
+                tailBudget = max 0 (width - rootBudget - 3)
+            in if tailBudget <= 0
+                 then termFitPlainLeft width label
+                 else take rootBudget root ++ "..." ++ termFitPlainLeft tailBudget rest
+          _ -> abbreviateRight width label
+
+type StatusRenderer = Int -> Maybe String
+
+staticStatusRenderer :: String -> String -> StatusRenderer
+staticStatusRenderer full short budget
+    | budget < 10 = Nothing
+    | length full <= budget = Just full
+    | length short <= budget = Just short
+    | otherwise = Just (abbreviateRight budget full)
+
+data BuildLineLayout = BuildLineLayout
+  { bllText :: String
+  , bllAligned :: Bool
+  , bllLabelCols :: Int
+  , bllHasStatus :: Bool
+  }
+
+emptyBuildLineLayout :: BuildLineLayout
+emptyBuildLineLayout = BuildLineLayout "" False 0 False
+
+-- | Fit a build line body to width while preserving module/status columns when possible.
+fitBuildLineLayout :: Int -> Int -> Int -> Bool -> String -> StatusRenderer -> BuildLineLayout
+fitBuildLineLayout width labelWidth statusWidth preserveBlankLabel modLbl renderStatus
+    | width <= 0 = emptyBuildLineLayout
+    | hasLabelColumn =
+        case renderAligned of
+          Just line -> line
+          Nothing ->
+            if null modLbl
+              then fitStatusOnly
+              else BuildLineLayout (fitBuildModuleLabel width modLbl) False (min width labelWidth) False
+    | otherwise = fitStatusOnly
+  where
+    minStatusWidth = 10
+    minLabelWidth = 10
+    hasLabelColumn = preserveBlankLabel || not (null modLbl)
+    renderAligned
+      | width < 2 + minStatusWidth = Nothing
+      | labelCols <= 0 && not (null modLbl) = Nothing
+      | not (null modLbl) && labelCols < min minLabelWidth (length modLbl) = Nothing
+      | statusCols < minStatusWidth = Nothing
+      | otherwise =
+          case renderStatus statusCols of
+            Just status ->
+              let labelText = if null modLbl then "" else fitBuildModuleLabel labelCols modLbl
+                  core =
+                    padRight labelCols labelText
+                    ++ "  "
+                    ++ padRight statusCols status
+              in Just (BuildLineLayout core True labelCols True)
+            Nothing -> Nothing
+    labelCols = min labelWidth (max 0 (width - 2 - minStatusWidth))
+    statusCols = min statusWidth (max 0 (width - labelCols - 2))
+    fitStatusOnly =
+      case renderStatus (min statusWidth width) of
+        Just status -> BuildLineLayout (termFitPlainRight width status) False 0 True
+        Nothing -> emptyBuildLineLayout
+
+-- | Fit an active build line to the current terminal width.
+fitBuildActiveLineAligned :: Int -> Int -> Int -> String -> StatusRenderer -> String
+fitBuildActiveLineAligned width labelWidth statusWidth modLbl renderStatus =
+    bllText (fitBuildLineLayout width labelWidth statusWidth False modLbl renderStatus)
+
+safeLiveWidth :: Int -> Int
+safeLiveWidth width
+    | width <= 0 = 0
+    | width == 1 = 1
+    | otherwise = width - 1
 
 -- Version handling ------------------------------------------------------------------------------------------
 
@@ -1184,7 +1312,14 @@ initCliCompileHooks progressUI progressState gopts sched gen plan = do
             | t <- neededTasks
             ]
     let gate = whenCurrentGen sched gen
-        logLine msg = gate (progressLogLine progressUI msg)
+        logLine msg = gate $ do
+          progressLogLine progressUI msg
+        logRendered render = gate $ do
+          if puWidthAware progressUI
+            then do
+              (_, cols) <- termSizeRead (puTermSize progressUI)
+              progressLogLine progressUI (render (safeLiveWidth cols))
+            else progressLogLine progressUI (render plainLogWidth)
         logDiagnostics optsT diags =
           gate (progressWithLog progressUI (printDiagnostics gopts optsT diags))
         rootProj = ccRootProj (cpContext plan)
@@ -1192,10 +1327,7 @@ initCliCompileHooks progressUI progressState gopts sched gen plan = do
         termProgress = puTermProgress progressUI
         termEnabled = termProgressEnabled termProgress
         modLabel mn = modNameToString mn
-        spinnerPrefixWidth = 3
-        frontInitialStatus = "Kinds check"
-        backActiveStatus = "Back passes"
-        finalActiveStatus = "Final compilation"
+        timeSep = "    "
         frontDoneStatus = "Type check done"
         backDoneStatus = "Compilation done"
         backFailStatus msg = "Compilation failed: " ++ msg
@@ -1216,58 +1348,139 @@ initCliCompileHooks progressUI progressState gopts sched gen plan = do
             "" -> modLabel mn
             label -> label ++ "." ++ modLabel mn
         labelWidth = maximum (0 : [ length (projectModuleLabel (tkProj (gtKey t)) (tkMod (gtKey t))) | t <- neededTasks ])
-        timeSep = "    "
         statusWidth = 68
         nameWidth = labelWidth + 2 + statusWidth
         timePadWidth = nameWidth + length timeSep
-        progressTimePadWidth = max 0 (timePadWidth - spinnerPrefixWidth)
-        doneIndent = replicate spinnerPrefixWidth ' '
-        abbreviate limit txt
-          | length txt <= limit = txt
-          | limit <= 3 = take limit txt
-          | otherwise = take (limit - 3) txt ++ "..."
-        statusColumns modLbl status =
+        plainLogWidth = timePadWidth + 8
+        detailStmtIndentWide = replicate 5 ' '
+        detailBindsIndentWide = replicate 7 ' '
+        detailStmtIndentNarrow = "  "
+        detailBindsIndentNarrow = "    "
+        plainDoneIndent = replicate 3 ' '
+        appendTimerField base timerWidth timer
+          | null timer = base
+          | otherwise = base ++ padLeft timerWidth timer
+        plainStatusColumns modLbl status =
           padRight labelWidth modLbl
           ++ "  "
-          ++ padRight statusWidth (abbreviate statusWidth status)
-        doneTimedLine modLbl status t =
-          padRight timePadWidth (doneIndent ++ statusColumns modLbl status) ++ fmtTime t
-        doneLine modLbl status =
-          doneIndent ++ statusColumns modLbl status
-        detailStmtIndent = replicate (spinnerPrefixWidth + 2) ' '
-        detailBindsIndent = replicate (spinnerPrefixWidth + 4) ' '
-        detailLine indent msg =
-          indent ++ msg
-        detailTimedLine indent msg t =
-          padRight timePadWidth (detailLine indent msg) ++ fmtTime t
+          ++ padRight statusWidth (abbreviateRight statusWidth status)
+        plainDoneTimedLine modLbl status t =
+          padRight timePadWidth (plainDoneIndent ++ plainStatusColumns modLbl status)
+          ++ fmtTimePrecise t
+        plainDoneLine modLbl status =
+          plainDoneIndent ++ plainStatusColumns modLbl status
+        pickBestLine candidates =
+          case foldl' betterCandidate Nothing candidates of
+            Just (_, line) -> line
+            Nothing -> ""
+        betterCandidate best Nothing = best
+        betterCandidate Nothing cand = cand
+        betterCandidate best@(Just (bestScore, _)) cand@(Just (candScore, _))
+          | candScore > bestScore = cand
+          | otherwise = best
+        buildLineCandidate width preserveBlankLabel modLbl statusRender timerRank timerWidth timer =
+          let doneIndent = replicate (progressPrefixWidth width) ' '
+              timerCols = if null timer then 0 else timerWidth
+              bodyWidth = max 0 (width - length doneIndent - timerCols)
+              layout = fitBuildLineLayout bodyWidth labelWidth statusWidth preserveBlankLabel modLbl statusRender
+              body = bllText layout
+              line = doneIndent ++ appendTimerField body timerWidth timer
+              score =
+                ( if bllAligned layout then 1 :: Int else 0
+                , if bllHasStatus layout then 1 :: Int else 0
+                , bllLabelCols layout
+                , timerRank
+                )
+          in if null body || length line > width
+               then Nothing
+               else Just (score, line)
+        doneStatusLine width modLbl statusRender shortStatus mt =
+          let preciseTimer = maybe "" fmtTimePrecise mt
+              compactTimer = maybe "" fmtTimeCompact mt
+              timerWidth = length preciseTimer
+              fullRenderer budget =
+                case statusRender budget of
+                  Just status
+                    | length status <= budget -> Just status
+                  _ -> Nothing
+              shortRenderer =
+                staticStatusRenderer shortStatus shortStatus
+              preserveBlankLabel = null modLbl
+          in pickBestLine
+               [ buildLineCandidate width preserveBlankLabel modLbl fullRenderer 2 timerWidth preciseTimer
+               , buildLineCandidate width preserveBlankLabel modLbl fullRenderer 1 timerWidth compactTimer
+               , buildLineCandidate width preserveBlankLabel modLbl fullRenderer 0 0 ""
+               , buildLineCandidate width preserveBlankLabel modLbl shortRenderer 1 timerWidth compactTimer
+               , buildLineCandidate width preserveBlankLabel modLbl shortRenderer 0 0 ""
+               ]
+        detailLine width indentWide indentNarrow msg =
+          let wide = indentWide ++ msg
+          in if width >= length wide then wide else indentNarrow ++ msg
+        detailTimedLine width indentWide indentNarrow msg t =
+          let precise = fmtTimePrecise t
+              wideBase = indentWide ++ msg
+              wideLine = padRight timePadWidth wideBase ++ precise
+          in if width >= length wideLine
+               then wideLine
+               else indentNarrow ++ msg ++ " " ++ fmtTimeCompact t
         frontTimingLine ft =
-          "Front timing: env " ++ fmtTime (ftEnv ft)
-          ++ ", kinds " ++ fmtTime (ftKinds ft)
-          ++ ", types " ++ fmtTime (ftTypes ft)
+          "Front timing: env " ++ fmtTimePrecise (ftEnv ft)
+          ++ ", kinds " ++ fmtTimePrecise (ftKinds ft)
+          ++ ", types " ++ fmtTimePrecise (ftTypes ft)
         typeStmtTimingLine st =
           "Type stmt " ++ show (tstCompleted st) ++ "/" ++ show (tstTotal st)
         typeStmtBindsLine st =
           "binds: " ++ intercalate ", " (tstNames st)
         backTimingLine bt =
-          "Back timing: normalize " ++ fmtTime (btNormalize bt)
-          ++ ", deactorize " ++ fmtTime (btDeactorize bt)
-          ++ ", cps " ++ fmtTime (btCPS bt)
-          ++ ", llift " ++ fmtTime (btLLift bt)
-          ++ ", boxing " ++ fmtTime (btBoxing bt)
-          ++ ", codegen " ++ fmtTime (btCodeGen bt)
-          ++ maybe "" (\t -> ", write " ++ fmtTime t) (btWriteCode bt)
-        frontDoneLine proj mn t =
-          doneTimedLine (projectModuleLabel proj mn) frontDoneStatus t
-        backDoneLine proj mn mt =
-          case mt of
-            Just t -> doneTimedLine (projectModuleLabel proj mn) backDoneStatus t
-            Nothing -> doneLine (projectModuleLabel proj mn) backDoneStatus
-        backFailLine proj mn msg =
-          doneLine (projectModuleLabel proj mn) (backFailStatus msg)
-        finalDoneLine t =
-          doneTimedLine "" finalDoneStatus t
-        progressLine proj mn status =
-          padRight progressTimePadWidth (statusColumns (projectModuleLabel proj mn) status)
+          "Back timing: normalize " ++ fmtTimePrecise (btNormalize bt)
+          ++ ", deactorize " ++ fmtTimePrecise (btDeactorize bt)
+          ++ ", cps " ++ fmtTimePrecise (btCPS bt)
+          ++ ", llift " ++ fmtTimePrecise (btLLift bt)
+          ++ ", boxing " ++ fmtTimePrecise (btBoxing bt)
+          ++ ", codegen " ++ fmtTimePrecise (btCodeGen bt)
+          ++ maybe "" (\t -> ", write " ++ fmtTimePrecise t) (btWriteCode bt)
+        frontDoneRenderer =
+          staticStatusRenderer frontDoneStatus "Typed"
+        backDoneRenderer =
+          staticStatusRenderer backDoneStatus "Built"
+        backFailRenderer msg =
+          \budget ->
+            if budget < 10
+              then Nothing
+              else Just (abbreviateRight budget (backFailStatus msg))
+        finalDoneRenderer =
+          staticStatusRenderer finalDoneStatus "Final"
+        frontDoneLine width proj mn t =
+          if puWidthAware progressUI
+            then doneStatusLine width (projectModuleLabel proj mn) frontDoneRenderer "Typed" (Just t)
+            else plainDoneTimedLine (projectModuleLabel proj mn) frontDoneStatus t
+        backDoneLine width proj mn mt =
+          if puWidthAware progressUI
+            then
+              case mt of
+                Just t -> doneStatusLine width (projectModuleLabel proj mn) backDoneRenderer "Built" (Just t)
+                Nothing -> doneStatusLine width (projectModuleLabel proj mn) backDoneRenderer "Built" Nothing
+            else
+              case mt of
+                Just t -> plainDoneTimedLine (projectModuleLabel proj mn) backDoneStatus t
+                Nothing -> plainDoneLine (projectModuleLabel proj mn) backDoneStatus
+        backFailLine width proj mn msg =
+          if puWidthAware progressUI
+            then doneStatusLine width (projectModuleLabel proj mn) (backFailRenderer msg) "Failed" Nothing
+            else plainDoneLine (projectModuleLabel proj mn) (backFailStatus msg)
+        finalDoneLine width t =
+          if puWidthAware progressUI
+            then doneStatusLine width "" finalDoneRenderer "Final" (Just t)
+            else plainDoneTimedLine "" finalDoneStatus t
+        renderProjectLine proj mn statusRender width =
+          let modLbl = projectModuleLabel proj mn
+          in fitBuildLineLayout width labelWidth statusWidth False modLbl statusRender
+        frontInitialLine proj mn =
+          renderProjectLine proj mn (staticStatusRenderer "Kinds check" "Kinds")
+        backActiveLine proj mn =
+          renderProjectLine proj mn (staticStatusRenderer "Back passes" "Back")
+        finalActiveLine width =
+          fitBuildLineLayout width labelWidth statusWidth True "" (staticStatusRenderer "Final compilation" "Final")
         clamp01 x = max 0 (min 1 x)
         progressRatio p =
           let total = fppTotal p
@@ -1278,27 +1491,30 @@ initCliCompileHooks progressUI progressState gopts sched gen plan = do
           case fppPass p of
             FrontPassKinds -> 0.10 * progressRatio p
             FrontPassTypes -> 0.10 + 0.90 * progressRatio p
-        frontStatus p =
-          let total = max 0 (fppTotal p)
-              completed = min total (max 0 (fppCompleted p))
-              countPart
-                | total > 0 = " " ++ show completed ++ "/" ++ show total
-                | otherwise = ""
-              fitTypeStatus mCurrent =
-                let prefix = "Type checking "
-                    staticLen = length prefix + length countPart
-                in if staticLen <= statusWidth
-                     then case mCurrent of
-                            Just nm -> prefix ++ abbreviate (statusWidth - staticLen) nm ++ countPart
-                            Nothing -> "Type checking" ++ countPart
-                     else abbreviate (max 0 (statusWidth - length countPart)) prefix ++ countPart
-          in case fppPass p of
-               FrontPassKinds -> "Kinds check"
-               FrontPassTypes -> fitTypeStatus (fppCurrent p)
+        frontStatusRenderer p budget
+          | budget < 10 = Nothing
+          | otherwise =
+              let total = max 0 (fppTotal p)
+                  completed = min total (max 0 (fppCompleted p))
+                  countPart
+                    | total > 0 = " " ++ show completed ++ "/" ++ show total
+                    | otherwise = ""
+                  compact =
+                    let base = if total > 0 then "Types" ++ countPart else "Types"
+                    in if length base <= budget then base else "Types"
+                  fullTypeStatus mCurrent =
+                    let prefix = "Type checking "
+                        staticLen = length prefix + length countPart
+                    in if staticLen < budget
+                         then case mCurrent of
+                                Just nm -> prefix ++ abbreviateRight (budget - staticLen) nm ++ countPart
+                                Nothing -> "Type checking" ++ countPart
+                         else compact
+              in case fppPass p of
+                   FrontPassKinds -> staticStatusRenderer "Kinds check" "Kinds" budget
+                   FrontPassTypes -> Just (fullTypeStatus (fppCurrent p))
         frontProgressLine proj mn p =
-          progressLine proj mn (frontStatus p)
-        progressFinalLine =
-          padRight progressTimePadWidth (statusColumns "" finalActiveStatus)
+          renderProjectLine proj mn (frontStatusRenderer p)
         finalKey = TaskKey rootProj (A.modName ["__final__"])
         withTerm action = when termEnabled $ gate (withProgressLock progressUI action)
         setPercent pct = withTerm (termProgressPercent termProgress pct)
@@ -1332,21 +1548,21 @@ initCliCompileHooks progressUI progressState gopts sched gen plan = do
           let proj = projPath (bjPaths job)
               mn = A.modname (biTypedMod (bjInput job))
           in do
-            gate (progressStartTask progressUI progressState (backJobKey job) (progressLine proj mn backActiveStatus) (Just 0))
+            gate (progressStartTask progressUI progressState (backJobKey job) (backActiveLine proj mn) (Just 0))
         onBackDone job result = do
           gate (progressDoneTask progressUI progressState (backJobKey job))
           creditBack (backJobKey job)
           when (not (quiet gopts optsPlan)) $
             case result of
               BackJobOk mtime mtiming -> do
-                logLine (backDoneLine (projPath (bjPaths job)) (A.modname (biTypedMod (bjInput job))) mtime)
+                logRendered (\cols -> backDoneLine cols (projPath (bjPaths job)) (A.modname (biTypedMod (bjInput job))) mtime)
                 when (C.timing gopts) $
                   forM_ mtiming $ \bt ->
-                    logLine (detailLine detailStmtIndent (backTimingLine bt))
+                    logRendered (\cols -> detailLine cols detailStmtIndentWide detailStmtIndentNarrow (backTimingLine bt))
               BackJobFailed failure ->
-                logLine (backFailLine (projPath (bjPaths job))
-                                      (A.modname (biTypedMod (bjInput job)))
-                                      (bpfMessage failure))
+                logRendered (\cols -> backFailLine cols (projPath (bjPaths job))
+                                                    (A.modname (biTypedMod (bjInput job)))
+                                                    (bpfMessage failure))
         hooks = defaultCompileHooks
           { chOnDiagnostics = \t optsT diags -> do
               gate (progressDoneTask progressUI progressState (gtKey t))
@@ -1355,13 +1571,13 @@ initCliCompileHooks progressUI progressState gopts sched gen plan = do
               forM_ (frFrontTime fr) $ \tFront -> do
                 let proj = tkProj (gtKey t)
                     mn = tkMod (gtKey t)
-                logLine (frontDoneLine proj mn tFront)
+                logRendered (\cols -> frontDoneLine cols proj mn tFront)
                 when (C.timing gopts) $
                   forM_ (frFrontTiming fr) $ \ft -> do
-                    logLine (detailLine detailStmtIndent (frontTimingLine ft))
+                    logRendered (\cols -> detailLine cols detailStmtIndentWide detailStmtIndentNarrow (frontTimingLine ft))
                     forM_ (ftTypeStmtTimings ft) $ \st -> do
-                      logLine (detailTimedLine detailStmtIndent (typeStmtTimingLine st) (tstTime st))
-                      logLine (detailLine detailBindsIndent (typeStmtBindsLine st))
+                      logRendered (\cols -> detailTimedLine cols detailStmtIndentWide detailStmtIndentNarrow (typeStmtTimingLine st) (tstTime st))
+                      logRendered (\cols -> detailLine cols detailBindsIndentWide detailBindsIndentNarrow (typeStmtBindsLine st))
               case frBackJob fr of
                 Nothing -> creditBack (gtKey t)
                 Just _ -> return ()
@@ -1369,7 +1585,7 @@ initCliCompileHooks progressUI progressState gopts sched gen plan = do
               let key = gtKey t
                   proj = tkProj key
                   mn = tkMod key
-              in gate (progressStartTask progressUI progressState key (progressLine proj mn frontInitialStatus) (Just 0))
+              in gate (progressStartTask progressUI progressState key (frontInitialLine proj mn) (Just 0))
           , chOnFrontProgress = \t p ->
               let key = gtKey t
                   proj = tkProj key
@@ -1386,14 +1602,14 @@ initCliCompileHooks progressUI progressState gopts sched gen plan = do
           , chOnInfo = logLine
           }
         onFinalStart = do
-          gate (progressStartTask progressUI progressState finalKey progressFinalLine Nothing)
+          gate (progressStartTask progressUI progressState finalKey finalActiveLine Nothing)
           setPercent 85
         onFinalDone mtime = do
           gate (progressDoneTask progressUI progressState finalKey)
           setPercent 100
           forM_ mtime $ \tFinal ->
             when (not (quiet gopts optsPlan)) $
-              logLine (finalDoneLine tFinal)
+              logRendered (\cols -> finalDoneLine cols tFinal)
     return CliCompileHooks
       { cchHooks = hooks
       , cchLogLine = logLine
@@ -2200,6 +2416,7 @@ useColor gopts = do
 
 data ProgressUI = ProgressUI
   { puEnabled :: Bool
+  , puWidthAware :: Bool
   , puMaxLines :: Int
   , puLinesRef :: IORef [String]
   , puVisibleRef :: IORef Int
@@ -2208,6 +2425,7 @@ data ProgressUI = ProgressUI
   , puCursorHiddenRef :: IORef Bool
   , puTickerRef :: IORef (Maybe ThreadId)
   , puTermProgress :: TermProgress
+  , puTermSize :: TermSize
   , puLock :: MVar ()
   }
 
@@ -2217,7 +2435,7 @@ data ProgressState = ProgressState
   }
 
 data ProgressTask = ProgressTask
-  { ptLine :: String
+  { ptRenderLine :: Int -> BuildLineLayout
   , ptStart :: TimeSpec
   , ptProgress :: Maybe Double
   }
@@ -2226,7 +2444,8 @@ data ProgressTask = ProgressTask
 initProgressUI :: C.GlobalOptions -> Int -> IO ProgressUI
 initProgressUI gopts maxLines = do
     tty <- hIsTerminalDevice stdout
-    let enabled = (tty || C.tty gopts) && not (C.quiet gopts) && not (C.noProgress gopts)
+    let widthAware = (tty || C.tty gopts) && not (C.quiet gopts)
+        enabled = widthAware && not (C.noProgress gopts)
     useColorOut <- useColor gopts
     linesRef <- newIORef []
     visibleRef <- newIORef 0
@@ -2234,9 +2453,11 @@ initProgressUI gopts maxLines = do
     cursorHiddenRef <- newIORef False
     tickerRef <- newIORef Nothing
     termProgress <- initTermProgress gopts
+    termSize <- initTermSize widthAware
     lock <- newMVar ()
     return ProgressUI
       { puEnabled = enabled
+      , puWidthAware = widthAware
       , puMaxLines = max 1 maxLines
       , puLinesRef = linesRef
       , puVisibleRef = visibleRef
@@ -2245,6 +2466,7 @@ initProgressUI gopts maxLines = do
       , puCursorHiddenRef = cursorHiddenRef
       , puTickerRef = tickerRef
       , puTermProgress = termProgress
+      , puTermSize = termSize
       , puLock = lock
       }
 
@@ -2287,13 +2509,13 @@ progressClearUnlocked ui = do
       hFlush stdout
     writeIORef (puVisibleRef ui) 0
 
+-- | Progress heartbeat interval in microseconds.
+progressTickMicros :: Int
+progressTickMicros = 80000
+
 -- | Spinner frames used by the progress UI.
 spinnerChars :: [Char]
 spinnerChars = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
-
--- | Spinner update interval in microseconds.
-spinnerTickMicros :: Int
-spinnerTickMicros = 80000
 
 -- | Hide or show the cursor during progress rendering.
 setCursorHidden :: ProgressUI -> Bool -> IO ()
@@ -2304,13 +2526,16 @@ setCursorHidden ui hidden =
         putStr (if hidden then "\ESC[?25l" else "\ESC[?25h")
         writeIORef (puCursorHiddenRef ui) hidden
 
--- | Render the current progress lines with the spinner.
+-- | Render the current progress lines with one terminal row per live line.
 progressRenderUnlocked :: ProgressUI -> IO ()
 progressRenderUnlocked ui = do
-    lines <- take (puMaxLines ui) <$> readIORef (puLinesRef ui)
+    (_, rows, cols) <- termSizeSync (puTermSize ui)
+    allLines <- readIORef (puLinesRef ui)
     prevVisible <- readIORef (puVisibleRef ui)
-    let newVisible = length lines
-        total = max prevVisible newVisible
+    let renderWidth = safeLiveWidth cols
+        visibleCap = min (puMaxLines ui) (max 0 (rows - 1))
+        lines = take visibleCap allLines
+        newVisible = length lines
     if newVisible == 0
       then do
         setCursorHidden ui False
@@ -2318,42 +2543,45 @@ progressRenderUnlocked ui = do
       else do
         when (prevVisible > 0) $
           replicateM_ prevVisible (putStr "\ESC[1A")
-        ix <- readIORef (puSpinnerRef ui)
-        let spinner = spinnerChars !! (ix `mod` length spinnerChars)
-            prefix line = ' ' : spinner : ' ' : line
-            renderLine i = do
+        spinnerIx <- readIORef (puSpinnerRef ui)
+        let spinner = spinnerChars !! (spinnerIx `mod` length spinnerChars)
+            useSpinner = progressPrefixWidth cols > 0
+            prefix line
+              | useSpinner = termFitAnsiRight renderWidth (' ' : spinner : ' ' : line)
+              | otherwise = termFitAnsiRight renderWidth line
+        let renderLine i = do
               putStr "\r\ESC[2K"
               when (i < newVisible) $
                 putStr (prefix (lines !! i))
               putStr "\n"
         setCursorHidden ui True
-        mapM_ renderLine [0 .. total - 1]
+        mapM_ renderLine [0 .. max prevVisible newVisible - 1]
         hFlush stdout
-        writeIORef (puVisibleRef ui) total
+        writeIORef (puVisibleRef ui) (max prevVisible newVisible)
 
--- | Start the spinner update thread when needed.
-startSpinnerTicker :: ProgressUI -> ProgressState -> IO ()
-startSpinnerTicker ui st =
+-- | Start the progress heartbeat thread when needed.
+startProgressTicker :: ProgressUI -> ProgressState -> IO ()
+startProgressTicker ui st =
     when (puEnabled ui) $ do
       m <- readIORef (puTickerRef ui)
       case m of
         Just _ -> return ()
         Nothing -> do
-          tid <- forkIO (spinnerLoop ui st)
+          tid <- forkIO (progressTickerLoop ui st)
           writeIORef (puTickerRef ui) (Just tid)
 
--- | Stop the spinner update thread.
-stopSpinnerTicker :: ProgressUI -> IO ()
-stopSpinnerTicker ui = do
+-- | Stop the progress heartbeat thread.
+stopProgressTicker :: ProgressUI -> IO ()
+stopProgressTicker ui = do
     m <- atomicModifyIORef' (puTickerRef ui) (\cur -> (Nothing, cur))
     forM_ m killThread
 
--- | Spinner loop that ticks and redraws at a fixed cadence.
-spinnerLoop :: ProgressUI -> ProgressState -> IO ()
-spinnerLoop ui st = do
+-- | Heartbeat loop that redraws when the terminal is resized.
+progressTickerLoop :: ProgressUI -> ProgressState -> IO ()
+progressTickerLoop ui st = do
     tid <- myThreadId
     let loop = do
-          threadDelay spinnerTickMicros
+          threadDelay progressTickMicros
           keep <- withProgressLock ui $ do
             active <- readIORef (psActive st)
             if M.null active || not (puEnabled ui)
@@ -2371,8 +2599,8 @@ spinnerLoop ui st = do
 progressSetLines :: ProgressUI -> ProgressState -> [String] -> IO ()
 progressSetLines ui st lines = withProgressLock ui $ do
     when (puEnabled ui) $ do
-      writeIORef (puLinesRef ui) (take (puMaxLines ui) lines)
-      if null lines then stopSpinnerTicker ui else startSpinnerTicker ui st
+      writeIORef (puLinesRef ui) lines
+      if null lines then stopProgressTicker ui else startProgressTicker ui st
       progressRenderUnlocked ui
 
 -- | Clear active task state and remove any rendered progress lines.
@@ -2383,22 +2611,22 @@ progressReset ui st = withProgressLock ui $ do
     writeIORef (puLinesRef ui) []
     termProgressClear (puTermProgress ui)
     when (puEnabled ui) $ do
-      stopSpinnerTicker ui
+      stopProgressTicker ui
       progressRenderUnlocked ui
 
 -- | Mark a task as active in the progress UI.
-progressStartTask :: ProgressUI -> ProgressState -> TaskKey -> String -> Maybe Double -> IO ()
-progressStartTask ui st key line mprog = withProgressLock ui $ do
+progressStartTask :: ProgressUI -> ProgressState -> TaskKey -> (Int -> BuildLineLayout) -> Maybe Double -> IO ()
+progressStartTask ui st key renderLine mprog = withProgressLock ui $ do
     now <- getTime Monotonic
-    modifyIORef' (psActive st) (M.insert key (ProgressTask line now (fmap (\x -> max 0 (min 1 x)) mprog)))
+    modifyIORef' (psActive st) (M.insert key (ProgressTask renderLine now (fmap (\x -> max 0 (min 1 x)) mprog)))
     modifyIORef' (psOrder st) (\xs -> if key `elem` xs then xs else xs ++ [key])
     progressRefreshUnlocked ui st
 
 -- | Update the rendered line for an active progress task.
-progressUpdateTask :: ProgressUI -> ProgressState -> TaskKey -> String -> Maybe Double -> IO ()
-progressUpdateTask ui st key line mprog = withProgressLock ui $ do
+progressUpdateTask :: ProgressUI -> ProgressState -> TaskKey -> (Int -> BuildLineLayout) -> Maybe Double -> IO ()
+progressUpdateTask ui st key renderLine mprog = withProgressLock ui $ do
     modifyIORef' (psActive st) (M.adjust (\task ->
-      task { ptLine = line
+      task { ptRenderLine = renderLine
            , ptProgress = fmap (\x -> max 0 (min 1 x)) mprog
            }) key)
     progressRefreshUnlocked ui st
@@ -2416,6 +2644,9 @@ progressRefreshUnlocked ui st = do
     active <- readIORef (psActive st)
     order <- readIORef (psOrder st)
     now <- getTime Monotonic
+    (_, _, cols) <- termSizeSync (puTermSize ui)
+    let renderCols = safeLiveWidth cols
+        spinnerPrefixWidth = progressPrefixWidth cols
     let progressDone = "\ESC[48;5;24m"
         progressReset = "\ESC[0m"
         paintProgressLine mprog line =
@@ -2429,12 +2660,44 @@ progressRefreshUnlocked ui st = do
                    then todo
                    else progressDone ++ done ++ progressReset ++ todo
             _ -> line
+        betterLine best Nothing = best
+        betterLine Nothing cand = cand
+        betterLine best@(Just (bestScore, _)) cand@(Just (candScore, _))
+          | candScore > bestScore = cand
+          | otherwise = best
         formatLine task =
-          paintProgressLine (ptProgress task) (ptLine task ++ fmtTime (diffTimeSpec now (ptStart task)))
+          let elapsedPrecise = fmtTimePrecise (diffTimeSpec now (ptStart task))
+              elapsedCompact = fmtTimeCompact (diffTimeSpec now (ptStart task))
+              timerWidth = length elapsedPrecise
+              liveCandidate timerRank timer =
+                let timerCols = if null timer then 0 else timerWidth
+                    bodyWidth = max 0 (renderCols - spinnerPrefixWidth - timerCols)
+                    layout = ptRenderLine task bodyWidth
+                    body = bllText layout
+                    line = appendTimerField body timerWidth timer
+                    score =
+                      ( if bllAligned layout then 1 :: Int else 0
+                      , if bllHasStatus layout then 1 :: Int else 0
+                      , bllLabelCols layout
+                      , timerRank
+                      )
+                in if null body || renderCols < spinnerPrefixWidth + length line
+                     then Nothing
+                     else Just (score, line)
+              line =
+                case foldl' betterLine Nothing
+                       [ liveCandidate 2 elapsedPrecise
+                       , liveCandidate 1 elapsedCompact
+                       , liveCandidate 0 ""
+                       ]
+                of
+                  Just (_, bestLine) -> bestLine
+                  Nothing -> bllText (ptRenderLine task (max 0 (renderCols - spinnerPrefixWidth)))
+          in paintProgressLine (ptProgress task) line
         lines = [ formatLine task | key <- order, Just task <- [M.lookup key active] ]
     when (puEnabled ui) $ do
-      writeIORef (puLinesRef ui) (take (puMaxLines ui) lines)
-      if null lines then stopSpinnerTicker ui else startSpinnerTicker ui st
+      writeIORef (puLinesRef ui) lines
+      if null lines then stopProgressTicker ui else startProgressTicker ui st
       progressRenderUnlocked ui
       termProgressHeartbeat (puTermProgress ui)
 

--- a/compiler/acton/TerminalSize.hs
+++ b/compiler/acton/TerminalSize.hs
@@ -1,0 +1,209 @@
+{-# LANGUAGE CApiFFI #-}
+
+module TerminalSize
+  ( TermSize
+  , initTermSize
+  , termSizeCurrent
+  , termSizeSync
+  , termSizeRead
+  , termVisibleLength
+  , termFitAnsiRight
+  , termFitPlainLeft
+  , termFitPlainRight
+  , termRenderedRows
+  , termRenderedRowsTotal
+  ) where
+
+import Control.Exception (SomeException, try)
+import Control.Monad (when)
+import Data.IORef
+import Data.List (isInfixOf)
+import Foreign
+import Foreign.C.Types
+import System.Environment (lookupEnv)
+import System.Posix.IO (stdOutput)
+import System.Posix.Signals (Handler(..), installHandler)
+
+data TermSize = TermSize
+  { tsEnabled :: Bool
+  , tsRowsRef :: IORef Int
+  , tsColsRef :: IORef Int
+  , tsDirtyRef :: IORef Bool
+  }
+
+data WinSize = WinSize
+  { wsRows :: CUShort
+  , wsCols :: CUShort
+  , wsXPixel :: CUShort
+  , wsYPixel :: CUShort
+  }
+
+instance Storable WinSize where
+    sizeOf _ = 8
+    alignment _ = alignment (undefined :: CUShort)
+    peek ptr =
+      WinSize
+        <$> peekByteOff ptr 0
+        <*> peekByteOff ptr 2
+        <*> peekByteOff ptr 4
+        <*> peekByteOff ptr 6
+    poke ptr (WinSize rows cols xp yp) = do
+      pokeByteOff ptr 0 rows
+      pokeByteOff ptr 2 cols
+      pokeByteOff ptr 4 xp
+      pokeByteOff ptr 6 yp
+
+foreign import capi unsafe "sys/ioctl.h value TIOCGWINSZ"
+  c_TIOCGWINSZ :: CULong
+
+foreign import capi unsafe "signal.h value SIGWINCH"
+  c_SIGWINCH :: CInt
+
+foreign import capi unsafe "sys/ioctl.h ioctl"
+  c_ioctlWinsize :: CInt -> CULong -> Ptr WinSize -> IO CInt
+
+defaultRows :: Int
+defaultRows = 24
+
+defaultCols :: Int
+defaultCols = 80
+
+initTermSize :: Bool -> IO TermSize
+initTermSize enabled = do
+    rows <- envOrDefault "LINES" defaultRows
+    cols <- envOrDefault "COLUMNS" defaultCols
+    rowsRef <- newIORef rows
+    colsRef <- newIORef cols
+    dirtyRef <- newIORef enabled
+    let ts = TermSize
+          { tsEnabled = enabled
+          , tsRowsRef = rowsRef
+          , tsColsRef = colsRef
+          , tsDirtyRef = dirtyRef
+          }
+    when enabled $ do
+      _ <- try (installHandler (fromIntegral c_SIGWINCH) (Catch (writeIORef dirtyRef True)) Nothing)
+             :: IO (Either SomeException Handler)
+      _ <- termSizeSync ts
+      return ()
+    return ts
+
+termSizeSync :: TermSize -> IO (Bool, Int, Int)
+termSizeSync ts
+  | not (tsEnabled ts) = do
+      (rows, cols) <- termSizeCurrent ts
+      return (False, rows, cols)
+  | otherwise = do
+      dirty <- atomicModifyIORef' (tsDirtyRef ts) (\cur -> (False, cur))
+      if not dirty
+        then do
+          rows <- readIORef (tsRowsRef ts)
+          cols <- readIORef (tsColsRef ts)
+          return (False, rows, cols)
+        else do
+          prevRows <- readIORef (tsRowsRef ts)
+          prevCols <- readIORef (tsColsRef ts)
+          msize <- queryTermSize
+          case msize of
+            Just (rows, cols) -> do
+              writeIORef (tsRowsRef ts) rows
+              writeIORef (tsColsRef ts) cols
+              return (rows /= prevRows || cols /= prevCols, rows, cols)
+            Nothing -> return (False, prevRows, prevCols)
+
+termSizeCurrent :: TermSize -> IO (Int, Int)
+termSizeCurrent ts = do
+    rows <- readIORef (tsRowsRef ts)
+    cols <- readIORef (tsColsRef ts)
+    return (rows, cols)
+
+termSizeRead :: TermSize -> IO (Int, Int)
+termSizeRead ts = do
+    (_, rows, cols) <- termSizeSync ts
+    return (rows, cols)
+
+termVisibleLength :: String -> Int
+termVisibleLength = go 0
+  where
+    go acc [] = acc
+    go acc ('\ESC':'[':xs) = go acc (dropAnsi xs)
+    go acc (_:xs) = go (acc + 1) xs
+
+termFitAnsiRight :: Int -> String -> String
+termFitAnsiRight width s
+  | width <= 0 = ""
+  | termVisibleLength s <= width = s
+  | otherwise =
+      let trimmed = go width s
+      in if "\ESC[" `isInfixOf` trimmed then trimmed ++ "\ESC[0m" else trimmed
+  where
+    go _ [] = []
+    go n _
+      | n <= 0 = []
+    go n ('\ESC':'[':xs) =
+      let (esc, rest) = spanAnsi xs
+      in '\ESC' : '[' : esc ++ go n rest
+    go n (x:xs) = x : go (n - 1) xs
+
+termFitPlainRight :: Int -> String -> String
+termFitPlainRight width s
+  | width <= 0 = ""
+  | length s <= width = s
+  | otherwise = take width s
+
+termFitPlainLeft :: Int -> String -> String
+termFitPlainLeft width s
+  | width <= 0 = ""
+  | length s <= width = s
+  | otherwise = drop (length s - width) s
+
+termRenderedRows :: Int -> String -> Int
+termRenderedRows width s
+  | width <= 0 = 1
+  | otherwise =
+      let visible = max 0 (termVisibleLength s)
+      in max 1 ((visible + width - 1) `div` width)
+
+termRenderedRowsTotal :: Int -> [String] -> Int
+termRenderedRowsTotal width = sum . map (termRenderedRows width)
+
+queryTermSize :: IO (Maybe (Int, Int))
+queryTermSize =
+    alloca $ \ptr -> do
+      rc <- c_ioctlWinsize (fromIntegral stdOutput) c_TIOCGWINSZ ptr
+      if rc == -1
+        then return Nothing
+        else do
+          WinSize rows cols _ _ <- peek ptr
+          let rows' = fromIntegral rows
+              cols' = fromIntegral cols
+          if rows' > 0 && cols' > 0
+            then return (Just (rows', cols'))
+            else return Nothing
+
+envOrDefault :: String -> Int -> IO Int
+envOrDefault name fallback = do
+    raw <- lookupEnv name
+    case raw >>= readMaybeInt of
+      Just n | n > 0 -> return n
+      _ -> return fallback
+
+readMaybeInt :: String -> Maybe Int
+readMaybeInt s =
+    case reads s of
+      [(n, "")] -> Just n
+      _ -> Nothing
+
+dropAnsi :: String -> String
+dropAnsi [] = []
+dropAnsi (c:cs)
+  | c >= '@' && c <= '~' = cs
+  | otherwise = dropAnsi cs
+
+spanAnsi :: String -> (String, String)
+spanAnsi [] = ([], [])
+spanAnsi (c:cs)
+  | c >= '@' && c <= '~' = ([c], cs)
+  | otherwise =
+      let (prefix, rest) = spanAnsi cs
+      in (c : prefix, rest)

--- a/compiler/acton/TestFormat.hs
+++ b/compiler/acton/TestFormat.hs
@@ -2,6 +2,9 @@ module TestFormat
   ( formatTestStatus
   , formatTestStatusLive
   , formatTestLineWith
+  , formatTestLineFitted
+  , formatTestFinalLineRenderer
+  , formatTestLiveLineRenderer
   , formatTestDetailLines
   , testColorApply
   , testColorBold
@@ -14,8 +17,9 @@ module TestFormat
 import Acton.Testing (TestResult(..))
 import Data.Char (isSpace)
 import Data.List (foldl', isPrefixOf, isInfixOf, intercalate)
-import Data.Maybe (isJust, catMaybes)
+import Data.Maybe (catMaybes, fromMaybe, isJust, listToMaybe, mapMaybe)
 import qualified Data.Map as M
+import TerminalSize (termFitPlainRight, termVisibleLength)
 import Text.Printf (printf)
 
 -- | Compute the status label (OK/FAIL/ERR/FLAKY) for a test.
@@ -102,6 +106,44 @@ colorizeStatusPart useColor cached statusRaw runs =
             else ""
     in statusColored ++ star ++ pad ++ ": " ++ runs
 
+renderStatusField :: Bool -> Bool -> String -> (String, String)
+renderStatusField useColor cached statusRaw =
+    let (statusPlain, statusRendered) = renderStatusToken useColor cached statusRaw
+        pad = replicate (max 0 (testStatusWidth - length statusPlain)) ' '
+    in (statusPlain ++ pad ++ ":", statusRendered ++ pad ++ ":")
+
+renderStatusToken :: Bool -> Bool -> String -> (String, String)
+renderStatusToken useColor cached statusRaw =
+    let suffix = if cached then "*" else ""
+        strip pref s = if pref `isPrefixOf` s then drop (length pref) s else s
+        core = strip "FLAKY " statusRaw
+        statusColored = case core of
+          "RUN" -> testColorApply useColor [testColorYellow] statusRaw
+          "SKIP" -> testColorApply useColor [testColorYellow] statusRaw
+          "OK" -> testColorApply useColor [testColorGreen] statusRaw
+          "UPDATED" -> testColorApply useColor [testColorYellow] statusRaw
+          _ -> testColorApply useColor [testColorBold, testColorRed] statusRaw
+        star =
+          if cached
+            then if useColor then testColorYellow ++ "*" ++ testColorReset else "*"
+            else ""
+    in (statusRaw ++ suffix, statusColored ++ star)
+
+formatSecondsCompact :: Double -> String
+formatSecondsCompact ms
+  | ms <= 0 = "0s"
+  | ms < 1000 = "<1s"
+  | otherwise =
+      let secs = ms / 1000
+      in show (max 1 (round secs :: Int)) ++ "s"
+
+fitTestDisplay :: Int -> String -> String
+fitTestDisplay width display
+  | width <= 0 = ""
+  | length display <= width = display
+  | width <= 3 = take width display
+  | otherwise = termFitPlainRight (width - 3) display ++ "..."
+
 -- | Format a single test result line with alignment and timing.
 formatTestLineWith :: Bool -> (TestResult -> String) -> Int -> String -> TestResult -> String
 formatTestLineWith useColor statusFn nameWidth display res =
@@ -111,6 +153,59 @@ formatTestLineWith useColor statusFn nameWidth display res =
         runs = printf "%4d runs in %3.3fms" (trNumIterations res) (trTestDuration res)
         statusPart = colorizeStatusPart useColor (trCached res) statusRaw runs
     in prefix0 ++ padding ++ statusPart
+
+-- | Format a live test line to the current terminal width.
+formatTestLineFitted :: Bool -> (TestResult -> String) -> Int -> Int -> String -> TestResult -> String
+formatTestLineFitted useColor statusFn nameWidth width display res
+  | width <= 0 = ""
+  | otherwise =
+      fromMaybe fallback (firstFit (legacyLine : map alignedLine summaries ++ map compactLine summaries))
+  where
+    indent = if width >= 4 then "   " else ""
+    statusRaw = statusFn res
+    (statusPlain, statusRendered) = renderStatusToken useColor (trCached res) statusRaw
+    (statusFieldPlain, statusFieldRendered) = renderStatusField useColor (trCached res) statusRaw
+    duration = formatSecondsCompact (trTestDuration res)
+    summaryFull = show (trNumIterations res) ++ " runs " ++ duration
+    summaryCompact = show (trNumIterations res) ++ "r " ++ duration
+    summaries = [Just summaryFull, Just summaryCompact, Nothing]
+    legacyRendered = formatTestLineWith useColor statusFn nameWidth display res
+    legacyLine
+      | termVisibleLength legacyRendered <= width = Just legacyRendered
+      | otherwise = Nothing
+    prefix0 = indent ++ display ++ ": "
+    alignedPrefix = prefix0 ++ replicate (max 0 (nameWidth - length prefix0)) ' '
+    alignedLine mSummary =
+      let summaryPad = maybe 0 (\s -> 1 + length s) mSummary
+          fixed = length alignedPrefix + length statusFieldPlain + summaryPad
+      in if fixed <= width
+           then Just (alignedPrefix
+                      ++ statusFieldRendered
+                      ++ maybe "" (\s -> " " ++ s) mSummary)
+           else Nothing
+    compactLine mSummary =
+      let summaryPad = maybe 0 (\s -> 1 + length s) mSummary
+          fixed = length indent + 2 + length statusPlain + summaryPad
+          nameBudget = width - fixed
+      in if nameBudget >= 1
+           then Just (indent
+                      ++ fitTestDisplay nameBudget display
+                      ++ ": "
+                      ++ statusRendered
+                      ++ maybe "" (\s -> " " ++ s) mSummary)
+           else Nothing
+    firstFit = listToMaybe . mapMaybe id
+    fallback
+      | width >= length statusPlain = statusRendered
+      | otherwise = fitTestDisplay width display
+
+formatTestFinalLineRenderer :: Bool -> Int -> String -> TestResult -> Int -> String
+formatTestFinalLineRenderer useColor nameWidth display res cols =
+    formatTestLineFitted useColor formatTestStatus nameWidth cols display res
+
+formatTestLiveLineRenderer :: Bool -> Int -> String -> TestResult -> Int -> String
+formatTestLiveLineRenderer useColor nameWidth display res cols =
+    formatTestLineFitted useColor formatTestStatusLive nameWidth cols display res
 
 formatTestDetailLines :: Bool -> Bool -> TestResult -> [String]
 formatTestDetailLines useColor showLog res =

--- a/compiler/acton/TestRunner.hs
+++ b/compiler/acton/TestRunner.hs
@@ -220,7 +220,7 @@ runProjectTests useColorOut gopts opts paths topts mode modules maxParallel = do
                   showLog = tpuShowLog ui
               case M.lookup key cachedMap of
                 Just cachedRes -> do
-                  let line = formatTestLineWith useColorLine formatTestStatus nameWidth display cachedRes
+                  let line = formatTestFinalLineRenderer useColorLine nameWidth display cachedRes
                       details = formatTestDetailLines useColorLine showLog cachedRes
                   if shouldShowCached cachedRes
                     then do
@@ -259,7 +259,7 @@ runProjectTests useColorOut gopts opts paths topts mode modules maxParallel = do
                             , trSnapshotUpdated = False
                             , trCached = False
                             }
-                          initLine = formatTestLineWith useColorLine formatTestStatusLive nameWidth display initRes
+                          initLine = formatTestLiveLineRenderer useColorLine nameWidth display initRes
                       started <- testUiStart ui key (tsModule spec) initLine
                       if not started
                         then return Nothing
@@ -630,8 +630,8 @@ testProgressCallbacks ui eventChan key display =
     let nameWidth = tpuNameWidth ui
         useColorOut = tpuUseColor ui
         showLog = tpuShowLog ui
-        liveLine res = formatTestLineWith useColorOut formatTestStatusLive nameWidth display res
-        finalLine res = formatTestLineWith useColorOut formatTestStatus nameWidth display res
+        liveLine res = formatTestLiveLineRenderer useColorOut nameWidth display res
+        finalLine res = formatTestFinalLineRenderer useColorOut nameWidth display res
         detailLines res = formatTestDetailLines useColorOut showLog res
     in TestProgressCallbacks
       { tpcOnLive = \res -> testUiUpdateLive ui key (liveLine res)

--- a/compiler/acton/TestUI.hs
+++ b/compiler/acton/TestUI.hs
@@ -15,63 +15,53 @@ module TestUI
   ) where
 
 import qualified Acton.CommandLineParser as C
-import TerminalProgress
 import Control.Concurrent (ThreadId, forkIO, killThread, myThreadId, threadDelay)
 import Control.Concurrent.MVar
 import Control.Monad
 import Data.IORef
 import qualified Data.List
-import Data.Ord (Down(..))
 import qualified Data.Map as M
+import Data.Ord (Down(..))
 import qualified Data.Set as Set
-import System.Environment (lookupEnv)
 import System.IO (hFlush, hIsTerminalDevice, stdout)
+import TerminalProgress
+import TerminalSize
 
 data TestKey = TestKey
   { tkModule :: String
   , tkName :: String
   } deriving (Eq, Ord, Show)
 
+type TestLine = Int -> String
+
 data TestProgressUI = TestProgressUI
   { tpuEnabled :: Bool
-  , tpuRows :: Int
   , tpuTotalLinesRef :: IORef Int
   , tpuLinesRef :: IORef [String]
+  , tpuLineRenderRef :: IORef [TestLine]
   , tpuLineIndexRef :: IORef (M.Map TestKey Int)
   , tpuLiveOrderRef :: IORef [TestKey]
   , tpuLiveSetRef :: IORef (Set.Set TestKey)
-  , tpuLiveLineRef :: IORef (M.Map TestKey String)
+  , tpuLiveLineRef :: IORef (M.Map TestKey TestLine)
   , tpuPrintedModulesRef :: IORef (Set.Set String)
   , tpuPendingDetailsRef :: IORef (M.Map TestKey [String])
   , tpuSpinnerRef :: IORef Int
-  , tpuSpinnerThreadRef :: IORef (Maybe ThreadId)
+  , tpuTickerThreadRef :: IORef (Maybe ThreadId)
   , tpuTermProgress :: TermProgress
+  , tpuTermSize :: TermSize
   , tpuLock :: MVar ()
   , tpuNameWidth :: Int
   , tpuUseColor :: Bool
   , tpuShowLog :: Bool
   }
 
-readMaybeInt :: String -> Maybe Int
-readMaybeInt s =
-    case reads s of
-      [(n, "")] -> Just n
-      _ -> Nothing
-
-getTerminalRows :: IO Int
-getTerminalRows = do
-    mRows <- lookupEnv "LINES"
-    case mRows >>= readMaybeInt of
-      Just n | n > 0 -> return n
-      _ -> return 24
-
 initTestProgressUI :: C.GlobalOptions -> Int -> Bool -> Bool -> IO TestProgressUI
 initTestProgressUI gopts nameWidth showLog useColorOut = do
     tty <- hIsTerminalDevice stdout
     let enabled = (tty || C.tty gopts) && not (C.quiet gopts)
-    rows <- if enabled then getTerminalRows else return 0
     totalLinesRef <- newIORef 0
     linesRef <- newIORef []
+    lineRenderRef <- newIORef []
     lineIndexRef <- newIORef M.empty
     liveOrderRef <- newIORef []
     liveSetRef <- newIORef Set.empty
@@ -79,14 +69,15 @@ initTestProgressUI gopts nameWidth showLog useColorOut = do
     printedModulesRef <- newIORef Set.empty
     pendingDetailsRef <- newIORef M.empty
     spinnerRef <- newIORef 0
-    spinnerThreadRef <- newIORef Nothing
+    tickerThreadRef <- newIORef Nothing
     termProgress <- initTermProgress gopts
+    termSize <- initTermSize enabled
     lock <- newMVar ()
     return TestProgressUI
       { tpuEnabled = enabled
-      , tpuRows = rows
       , tpuTotalLinesRef = totalLinesRef
       , tpuLinesRef = linesRef
+      , tpuLineRenderRef = lineRenderRef
       , tpuLineIndexRef = lineIndexRef
       , tpuLiveOrderRef = liveOrderRef
       , tpuLiveSetRef = liveSetRef
@@ -94,8 +85,9 @@ initTestProgressUI gopts nameWidth showLog useColorOut = do
       , tpuPrintedModulesRef = printedModulesRef
       , tpuPendingDetailsRef = pendingDetailsRef
       , tpuSpinnerRef = spinnerRef
-      , tpuSpinnerThreadRef = spinnerThreadRef
+      , tpuTickerThreadRef = tickerThreadRef
       , tpuTermProgress = termProgress
+      , tpuTermSize = termSize
       , tpuLock = lock
       , tpuNameWidth = nameWidth
       , tpuUseColor = useColorOut
@@ -116,90 +108,171 @@ testUiProgressClear :: TestProgressUI -> IO ()
 testUiProgressClear ui =
     withTestProgressLock ui (termProgressClear (tpuTermProgress ui))
 
-testSpinnerTickMicros :: Int
-testSpinnerTickMicros = 80000
+testTickMicros :: Int
+testTickMicros = 250000
 
-spinnerChars :: [Char]
-spinnerChars = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+testSpinnerThreshold :: Int
+testSpinnerThreshold = 25
+
+testSpinnerChars :: [Char]
+testSpinnerChars = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+
+testSpinnerEnabled :: Int -> Bool
+testSpinnerEnabled cols = cols >= testSpinnerThreshold
 
 testSpinnerChar :: TestProgressUI -> IO Char
 testSpinnerChar ui = do
     ix <- readIORef (tpuSpinnerRef ui)
-    return (spinnerChars !! (ix `mod` length spinnerChars))
-
-startTestSpinnerTicker :: TestProgressUI -> IO ()
-startTestSpinnerTicker ui =
-    when (tpuEnabled ui) $ do
-      m <- readIORef (tpuSpinnerThreadRef ui)
-      case m of
-        Just _ -> return ()
-        Nothing -> do
-          tid <- forkIO (testSpinnerLoop ui)
-          writeIORef (tpuSpinnerThreadRef ui) (Just tid)
-
-stopTestSpinnerTicker :: TestProgressUI -> IO ()
-stopTestSpinnerTicker ui = do
-    m <- atomicModifyIORef' (tpuSpinnerThreadRef ui) (\cur -> (Nothing, cur))
-    forM_ m killThread
-
-refreshTestSpinnersUnlocked :: TestProgressUI -> IO ()
-refreshTestSpinnersUnlocked ui = do
-    idxMap <- readIORef (tpuLineIndexRef ui)
-    liveLines <- readIORef (tpuLiveLineRef ui)
-    spinner <- testSpinnerChar ui
-    forM_ (M.toList liveLines) $ \(key, baseLine) ->
-      case M.lookup key idxMap of
-        Just idx -> updateLineAtUnlocked ui idx (renderLiveLine spinner baseLine)
-        Nothing -> return ()
-    termProgressHeartbeat (tpuTermProgress ui)
-
-testSpinnerLoop :: TestProgressUI -> IO ()
-testSpinnerLoop ui = do
-    tid <- myThreadId
-    let loop = do
-          threadDelay testSpinnerTickMicros
-          keep <- withTestProgressLock ui $ do
-            liveSet <- readIORef (tpuLiveSetRef ui)
-            if Set.null liveSet || not (tpuEnabled ui)
-              then return False
-              else do
-                modifyIORef' (tpuSpinnerRef ui) (+ 1)
-                refreshTestSpinnersUnlocked ui
-                return True
-          when keep loop
-    loop
-    atomicModifyIORef' (tpuSpinnerThreadRef ui) $ \cur ->
-      if cur == Just tid then (Nothing, ()) else (cur, ())
-
-renderLiveLine :: Char -> String -> String
-renderLiveLine spinner line =
-    case line of
-      ' ':' ':' ':rest -> ' ' : spinner : ' ' : rest
-      _ -> ' ' : spinner : ' ' : line
+    return (testSpinnerChars !! (ix `mod` length testSpinnerChars))
 
 moduleHeaderLine :: String -> String
 moduleHeaderLine modName
   | null modName = "Tests"
   | otherwise = "Tests - module " ++ modName ++ ":"
 
-appendLineUnlocked :: TestProgressUI -> String -> IO Int
-appendLineUnlocked ui line = do
+safeLiveWidth :: Int -> Int
+safeLiveWidth width
+  | width <= 0 = 0
+  | width == 1 = 1
+  | otherwise = width - 1
+
+staticLine :: String -> TestLine
+staticLine line cols = termFitAnsiRight cols line
+
+visibleLineCapacity :: Int -> Int
+visibleLineCapacity rows = max 0 (rows - 1)
+
+visibleStartIndex :: Int -> Int -> Int
+visibleStartIndex rows total = max 0 (total - visibleLineCapacity rows)
+
+startTestTicker :: TestProgressUI -> IO ()
+startTestTicker ui =
+    when (tpuEnabled ui) $ do
+      m <- readIORef (tpuTickerThreadRef ui)
+      case m of
+        Just _ -> return ()
+        Nothing -> do
+          tid <- forkIO (testTickerLoop ui)
+          writeIORef (tpuTickerThreadRef ui) (Just tid)
+
+stopTestTicker :: TestProgressUI -> IO ()
+stopTestTicker ui = do
+    m <- atomicModifyIORef' (tpuTickerThreadRef ui) (\cur -> (Nothing, cur))
+    forM_ m killThread
+
+testTickerLoop :: TestProgressUI -> IO ()
+testTickerLoop ui = do
+    tid <- myThreadId
+    let loop = do
+          threadDelay testTickMicros
+          keep <- withTestProgressLock ui $ do
+            liveSet <- readIORef (tpuLiveSetRef ui)
+            if Set.null liveSet || not (tpuEnabled ui)
+              then return False
+              else do
+                (_, cols) <- ensureViewportUnlocked ui
+                when (testSpinnerEnabled cols) $ do
+                  modifyIORef' (tpuSpinnerRef ui) (+ 1)
+                  refreshTestSpinnersUnlocked ui cols
+                termProgressHeartbeat (tpuTermProgress ui)
+                return True
+          when keep loop
+    loop
+    atomicModifyIORef' (tpuTickerThreadRef ui) $ \cur ->
+      if cur == Just tid then (Nothing, ()) else (cur, ())
+
+currentViewportUnlocked :: TestProgressUI -> IO (Int, Int)
+currentViewportUnlocked ui = termSizeCurrent (tpuTermSize ui)
+
+ensureViewportUnlocked :: TestProgressUI -> IO (Int, Int)
+ensureViewportUnlocked ui
+  | not (tpuEnabled ui) = return (0, 0)
+  | otherwise = do
+      (oldRows, _) <- termSizeCurrent (tpuTermSize ui)
+      (changed, rows, cols) <- termSizeSync (tpuTermSize ui)
+      when changed $
+        rerenderVisibleUnlocked ui oldRows rows cols
+      return (rows, cols)
+
+appendLineUnlocked :: TestProgressUI -> TestLine -> IO Int
+appendLineUnlocked ui lineFn = do
     idx <- readIORef (tpuTotalLinesRef ui)
-    putStrLn line
-    modifyIORef' (tpuLinesRef ui) (\xs -> xs ++ [line])
+    rendered <- renderIndexedLineUnlocked ui idx lineFn
+    putStrLn rendered
+    modifyIORef' (tpuLinesRef ui) (\xs -> xs ++ [rendered])
+    modifyIORef' (tpuLineRenderRef ui) (\xs -> xs ++ [lineFn])
     writeIORef (tpuTotalLinesRef ui) (idx + 1)
     return idx
 
-updateLineListAt :: Int -> String -> [String] -> [String]
+updateLineListAt :: Int -> a -> [a] -> [a]
 updateLineListAt idx line xs =
     case splitAt idx xs of
       (prefix, _ : rest) -> prefix ++ [line] ++ rest
       _ -> xs
 
-insertLinesListAfter :: Int -> [String] -> [String] -> [String]
+insertLinesListAfter :: Int -> [a] -> [a] -> [a]
 insertLinesListAfter idx newLines xs =
     let (prefix, rest) = splitAt (idx + 1) xs
     in prefix ++ newLines ++ rest
+
+rerenderVisibleUnlocked :: TestProgressUI -> Int -> Int -> Int -> IO ()
+rerenderVisibleUnlocked ui rowsBefore rowsAfter cols = do
+    total <- readIORef (tpuTotalLinesRef ui)
+    lineFns <- readIORef (tpuLineRenderRef ui)
+    renderedAll <- mapM (\(idx, lineFn) -> renderIndexedLineWithColsUnlocked ui cols idx lineFn) (zip [0..] lineFns)
+    let
+        oldStartIdx = visibleStartIndex rowsBefore total
+        newStartIdx = visibleStartIndex rowsAfter total
+        oldVisibleCount = max 0 (total - oldStartIdx)
+        newVisible = drop newStartIdx renderedAll
+    when (oldVisibleCount > 0) $
+      putStr ("\ESC[" ++ show oldVisibleCount ++ "A")
+    when (oldVisibleCount > 0 || not (null newVisible)) $ do
+      putStr "\r\ESC[J"
+      forM_ newVisible $ \line -> do
+        putStr "\r\ESC[2K"
+        putStr line
+        putStr "\n"
+      hFlush stdout
+    writeIORef (tpuLinesRef ui) renderedAll
+
+refreshTestSpinnersUnlocked :: TestProgressUI -> Int -> IO ()
+refreshTestSpinnersUnlocked ui cols = do
+    idxMap <- readIORef (tpuLineIndexRef ui)
+    liveLines <- readIORef (tpuLiveLineRef ui)
+    forM_ (M.toList liveLines) $ \(key, lineFn) ->
+      case M.lookup key idxMap of
+        Just idx -> updateLineAtUnlockedWithCols ui cols idx lineFn
+        Nothing -> return ()
+
+renderLiveLine :: Int -> Char -> String -> String
+renderLiveLine cols spinner line
+  | not (testSpinnerEnabled cols) = line
+  | otherwise =
+      case line of
+        ' ':' ':' ':rest -> ' ' : spinner : ' ' : rest
+        _ -> line
+
+isLiveLineIndexUnlocked :: TestProgressUI -> Int -> IO Bool
+isLiveLineIndexUnlocked ui idx = do
+    liveSet <- readIORef (tpuLiveSetRef ui)
+    idxMap <- readIORef (tpuLineIndexRef ui)
+    return (any (\key -> M.lookup key idxMap == Just idx) (Set.toList liveSet))
+
+renderIndexedLineWithColsUnlocked :: TestProgressUI -> Int -> Int -> TestLine -> IO String
+renderIndexedLineWithColsUnlocked ui cols idx lineFn = do
+    let base = lineFn (safeLiveWidth cols)
+    live <- isLiveLineIndexUnlocked ui idx
+    if live
+      then do
+        spinner <- testSpinnerChar ui
+        return (renderLiveLine cols spinner base)
+      else return base
+
+renderIndexedLineUnlocked :: TestProgressUI -> Int -> TestLine -> IO String
+renderIndexedLineUnlocked ui idx lineFn = do
+    (_, cols) <- currentViewportUnlocked ui
+    renderIndexedLineWithColsUnlocked ui cols idx lineFn
 
 ensureModuleHeaderUnlocked :: TestProgressUI -> String -> IO ()
 ensureModuleHeaderUnlocked ui modName = do
@@ -207,33 +280,37 @@ ensureModuleHeaderUnlocked ui modName = do
     unless (Set.member modName printed) $ do
       total <- readIORef (tpuTotalLinesRef ui)
       when (total > 0) $
-        void (appendLineUnlocked ui "")
-      _ <- appendLineUnlocked ui (moduleHeaderLine modName)
+        void (appendLineUnlocked ui (staticLine ""))
+      _ <- appendLineUnlocked ui (staticLine (moduleHeaderLine modName))
       writeIORef (tpuPrintedModulesRef ui) (Set.insert modName printed)
 
 canAppendLinesUnlocked :: TestProgressUI -> Int -> IO Bool
 canAppendLinesUnlocked ui n
     | not (tpuEnabled ui) = return True
     | n <= 0 = return True
-    | tpuRows ui <= 0 = return True
     | otherwise = do
-        liveOrder <- readIORef (tpuLiveOrderRef ui)
-        case liveOrder of
-          [] -> return True
-          (oldest:_) -> do
-            total <- readIORef (tpuTotalLinesRef ui)
-            idxMap <- readIORef (tpuLineIndexRef ui)
-            case M.lookup oldest idxMap of
-              Nothing -> return True
-              Just idx -> do
-                let offset = total - idx
-                return (offset + n < tpuRows ui)
+        (rows, _) <- currentViewportUnlocked ui
+        if rows <= 0
+          then return True
+          else do
+            liveOrder <- readIORef (tpuLiveOrderRef ui)
+            case liveOrder of
+              [] -> return True
+              (oldest:_) -> do
+                total <- readIORef (tpuTotalLinesRef ui)
+                idxMap <- readIORef (tpuLineIndexRef ui)
+                case M.lookup oldest idxMap of
+                  Nothing -> return True
+                  Just idx -> do
+                    let offset = total - idx
+                    return (offset + n < rows)
 
-testUiStart :: TestProgressUI -> TestKey -> String -> String -> IO Bool
-testUiStart ui key modName line = withTestProgressLock ui $ do
+testUiStart :: TestProgressUI -> TestKey -> String -> TestLine -> IO Bool
+testUiStart ui key modName lineFn = withTestProgressLock ui $ do
     if not (tpuEnabled ui)
       then return True
       else do
+        void (ensureViewportUnlocked ui)
         printed <- readIORef (tpuPrintedModulesRef ui)
         total <- readIORef (tpuTotalLinesRef ui)
         let headerNeeded = not (Set.member modName printed)
@@ -244,20 +321,21 @@ testUiStart ui key modName line = withTestProgressLock ui $ do
           then return False
           else do
             ensureModuleHeaderUnlocked ui modName
-            spinner <- testSpinnerChar ui
-            idx <- appendLineUnlocked ui (renderLiveLine spinner line)
+            idx <- readIORef (tpuTotalLinesRef ui)
             modifyIORef' (tpuLineIndexRef ui) (M.insert key idx)
             modifyIORef' (tpuLiveOrderRef ui) (\xs -> if key `elem` xs then xs else xs ++ [key])
             modifyIORef' (tpuLiveSetRef ui) (Set.insert key)
-            modifyIORef' (tpuLiveLineRef ui) (M.insert key line)
-            startTestSpinnerTicker ui
+            modifyIORef' (tpuLiveLineRef ui) (M.insert key lineFn)
+            _ <- appendLineUnlocked ui lineFn
+            startTestTicker ui
             return True
 
-testUiAppendFinal :: TestProgressUI -> TestKey -> String -> String -> IO Bool
-testUiAppendFinal ui key modName line = withTestProgressLock ui $ do
+testUiAppendFinal :: TestProgressUI -> TestKey -> String -> TestLine -> IO Bool
+testUiAppendFinal ui key modName lineFn = withTestProgressLock ui $ do
     if not (tpuEnabled ui)
       then return True
       else do
+        void (ensureViewportUnlocked ui)
         printed <- readIORef (tpuPrintedModulesRef ui)
         total <- readIORef (tpuTotalLinesRef ui)
         let headerNeeded = not (Set.member modName printed)
@@ -268,80 +346,95 @@ testUiAppendFinal ui key modName line = withTestProgressLock ui $ do
           then return False
           else do
             ensureModuleHeaderUnlocked ui modName
-            idx <- appendLineUnlocked ui line
+            idx <- appendLineUnlocked ui lineFn
             modifyIORef' (tpuLineIndexRef ui) (M.insert key idx)
             return True
 
-updateLineAtUnlocked :: TestProgressUI -> Int -> String -> IO ()
-updateLineAtUnlocked ui idx line = do
-    modifyIORef' (tpuLinesRef ui) (updateLineListAt idx line)
+updateLineAtUnlocked :: TestProgressUI -> Int -> TestLine -> IO ()
+updateLineAtUnlocked ui idx lineFn = do
+    (_, cols) <- currentViewportUnlocked ui
+    updateLineAtUnlockedWithCols ui cols idx lineFn
+
+updateLineAtUnlockedWithCols :: TestProgressUI -> Int -> Int -> TestLine -> IO ()
+updateLineAtUnlockedWithCols ui cols idx lineFn = do
+    rendered <- renderIndexedLineWithColsUnlocked ui cols idx lineFn
+    modifyIORef' (tpuLineRenderRef ui) (updateLineListAt idx lineFn)
+    modifyIORef' (tpuLinesRef ui) (updateLineListAt idx rendered)
     total <- readIORef (tpuTotalLinesRef ui)
+    (rows, _) <- currentViewportUnlocked ui
     let offset = total - idx
-    when (offset > 0 && (tpuRows ui <= 0 || offset < tpuRows ui)) $ do
+    when (offset > 0 && (rows <= 0 || offset < rows)) $ do
       putStr ("\ESC[" ++ show offset ++ "A")
       putStr "\r\ESC[2K"
-      putStr line
+      putStr rendered
       putStr ("\ESC[" ++ show offset ++ "B")
       putStr "\r"
       hFlush stdout
 
-testUiUpdateLive :: TestProgressUI -> TestKey -> String -> IO ()
-testUiUpdateLive ui key line = withTestProgressLock ui $ do
+testUiUpdateLive :: TestProgressUI -> TestKey -> TestLine -> IO ()
+testUiUpdateLive ui key lineFn = withTestProgressLock ui $ do
     when (tpuEnabled ui) $ do
+      void (ensureViewportUnlocked ui)
       idxMap <- readIORef (tpuLineIndexRef ui)
       case M.lookup key idxMap of
         Nothing -> return ()
         Just idx -> do
-          modifyIORef' (tpuLiveLineRef ui) (M.insert key line)
-          spinner <- testSpinnerChar ui
-          updateLineAtUnlocked ui idx (renderLiveLine spinner line)
+          modifyIORef' (tpuLiveLineRef ui) (M.insert key lineFn)
+          updateLineAtUnlocked ui idx lineFn
 
-testUiFinalize :: TestProgressUI -> TestKey -> String -> IO Bool
-testUiFinalize ui key line = withTestProgressLock ui $ do
+testUiFinalize :: TestProgressUI -> TestKey -> TestLine -> IO Bool
+testUiFinalize ui key lineFn = withTestProgressLock ui $ do
+    liveSet <- readIORef (tpuLiveSetRef ui)
+    let wasLive = Set.member key liveSet
+    when wasLive $ do
+      writeIORef (tpuLiveSetRef ui) (Set.delete key liveSet)
+      modifyIORef' (tpuLiveOrderRef ui) (filter (/= key))
+      modifyIORef' (tpuLiveLineRef ui) (M.delete key)
     when (tpuEnabled ui) $ do
+      void (ensureViewportUnlocked ui)
       idxMap <- readIORef (tpuLineIndexRef ui)
       case M.lookup key idxMap of
         Nothing -> return ()
-        Just idx -> updateLineAtUnlocked ui idx line
-    modifyIORef' (tpuLiveLineRef ui) (M.delete key)
-    liveSet <- readIORef (tpuLiveSetRef ui)
-    if Set.member key liveSet
+        Just idx -> updateLineAtUnlocked ui idx lineFn
+    if wasLive
       then do
-        let liveSet' = Set.delete key liveSet
-        writeIORef (tpuLiveSetRef ui) liveSet'
-        modifyIORef' (tpuLiveOrderRef ui) (filter (/= key))
+        liveSet' <- readIORef (tpuLiveSetRef ui)
         when (tpuEnabled ui && Set.null liveSet') $
-          stopTestSpinnerTicker ui
+          stopTestTicker ui
         return True
       else return False
 
-testUiUpdateFinal :: TestProgressUI -> TestKey -> String -> IO ()
-testUiUpdateFinal ui key line = withTestProgressLock ui $ do
+testUiUpdateFinal :: TestProgressUI -> TestKey -> TestLine -> IO ()
+testUiUpdateFinal ui key lineFn = withTestProgressLock ui $ do
     when (tpuEnabled ui) $ do
+      void (ensureViewportUnlocked ui)
       idxMap <- readIORef (tpuLineIndexRef ui)
       case M.lookup key idxMap of
         Nothing -> return ()
-        Just idx -> updateLineAtUnlocked ui idx line
+        Just idx -> updateLineAtUnlocked ui idx lineFn
 
 canInsertLinesUnlocked :: TestProgressUI -> Int -> Int -> IO Bool
 canInsertLinesUnlocked ui insertIdx n
     | not (tpuEnabled ui) = return True
     | n <= 0 = return True
-    | tpuRows ui <= 0 = return True
     | otherwise = do
-        liveSet <- readIORef (tpuLiveSetRef ui)
-        idxMap <- readIORef (tpuLineIndexRef ui)
-        let idxs =
-              [ idx
-              | key <- Set.toList liveSet
-              , Just idx <- [M.lookup key idxMap]
-              , idx <= insertIdx
-              ]
-        case idxs of
-          [] -> return True
-          _ -> do
-            total <- readIORef (tpuTotalLinesRef ui)
-            return ((total + n - minimum idxs) < tpuRows ui)
+        (rows, _) <- currentViewportUnlocked ui
+        if rows <= 0
+          then return True
+          else do
+            liveSet <- readIORef (tpuLiveSetRef ui)
+            idxMap <- readIORef (tpuLineIndexRef ui)
+            let idxs =
+                  [ idx
+                  | key <- Set.toList liveSet
+                  , Just idx <- [M.lookup key idxMap]
+                  , idx <= insertIdx
+                  ]
+            case idxs of
+              [] -> return True
+              _ -> do
+                total <- readIORef (tpuTotalLinesRef ui)
+                return ((total + n - minimum idxs) < rows)
 
 insertLinesAfterUnlocked :: TestProgressUI -> Int -> [String] -> IO Bool
 insertLinesAfterUnlocked ui idx lines = do
@@ -349,42 +442,48 @@ insertLinesAfterUnlocked ui idx lines = do
     if n <= 0
       then return True
       else do
+        (rows, cols) <- currentViewportUnlocked ui
         total <- readIORef (tpuTotalLinesRef ui)
         liveSet <- readIORef (tpuLiveSetRef ui)
-        let startIdx = idx + 1
+        let lineFns = map staticLine lines
+            rendered = map ($ safeLiveWidth cols) lineFns
+            startIdx = idx + 1
             offsetNew = (total + n) - startIdx
             visibleOk =
               Set.null liveSet
               || not (tpuEnabled ui)
-              || tpuRows ui <= 0
-              || offsetNew < tpuRows ui
+              || rows <= 0
+              || offsetNew < rows
         ok <- canInsertLinesUnlocked ui idx n
         if not ok || not visibleOk
           then return False
           else do
-            modifyIORef' (tpuLinesRef ui) (insertLinesListAfter idx lines)
+            modifyIORef' (tpuLineRenderRef ui) (insertLinesListAfter idx lineFns)
+            modifyIORef' (tpuLinesRef ui) (insertLinesListAfter idx rendered)
             modifyIORef' (tpuTotalLinesRef ui) (+ n)
             modifyIORef' (tpuLineIndexRef ui) (M.map (\i -> if i > idx then i + n else i))
             if not (tpuEnabled ui)
-              then mapM_ putStrLn lines
+              then mapM_ putStrLn rendered
               else rerenderFromUnlocked ui startIdx total
             return True
 
 rerenderFromUnlocked :: TestProgressUI -> Int -> Int -> IO ()
 rerenderFromUnlocked ui startIdx oldTotal = do
     let offset = oldTotal - startIdx
-    lines <- readIORef (tpuLinesRef ui)
+    renderedLines <- readIORef (tpuLinesRef ui)
+    (rows, _) <- currentViewportUnlocked ui
+    let renderedTail = drop startIdx renderedLines
     if offset <= 0
       then do
-        forM_ (drop startIdx lines) $ \line -> do
+        forM_ renderedTail $ \line -> do
           putStr "\r\ESC[2K"
           putStr line
           putStr "\n"
         hFlush stdout
-      else when (tpuRows ui <= 0 || offset < tpuRows ui) $ do
+      else when (rows <= 0 || offset < rows) $ do
         putStr ("\ESC[" ++ show offset ++ "A")
         putStr "\r\ESC[J"
-        forM_ (drop startIdx lines) $ \line -> do
+        forM_ renderedTail $ \line -> do
           putStr "\r\ESC[2K"
           putStr line
           putStr "\n"
@@ -394,14 +493,14 @@ testUiInsertDetails :: TestProgressUI -> TestKey -> [String] -> IO Bool
 testUiInsertDetails ui key lines = withTestProgressLock ui $ do
     if null lines
       then return True
-      else do
-        if not (tpuEnabled ui)
-          then return True
-          else do
-            idxMap <- readIORef (tpuLineIndexRef ui)
-            case M.lookup key idxMap of
-              Nothing -> return False
-              Just idx -> insertLinesAfterUnlocked ui idx lines
+      else if not (tpuEnabled ui)
+        then return True
+        else do
+          void (ensureViewportUnlocked ui)
+          idxMap <- readIORef (tpuLineIndexRef ui)
+          case M.lookup key idxMap of
+            Nothing -> return False
+            Just idx -> insertLinesAfterUnlocked ui idx lines
 
 queuePendingDetails :: TestProgressUI -> TestKey -> [String] -> IO ()
 queuePendingDetails ui key lines = withTestProgressLock ui $ do
@@ -410,6 +509,7 @@ queuePendingDetails ui key lines = withTestProgressLock ui $ do
 
 flushPendingDetails :: TestProgressUI -> IO ()
 flushPendingDetails ui = withTestProgressLock ui $ do
+    void (ensureViewportUnlocked ui)
     pending <- readIORef (tpuPendingDetailsRef ui)
     unless (M.null pending) $ do
       idxMap <- readIORef (tpuLineIndexRef ui)

--- a/compiler/acton/package.yaml.in
+++ b/compiler/acton/package.yaml.in
@@ -66,6 +66,7 @@ executables:
       - PkgCommands
       - Paths_acton
       - TerminalProgress
+      - TerminalSize
       - ZigProgress
       - TestFormat
       - TestRunner


### PR DESCRIPTION
The build and test progress renderers assumed a fixed terminal shape in too many places. Narrow terminals could wrap live rows, live and done lines could fall into different column layouts, and acton test no longer kept its wide padded live format. The test UI could also lose its initial spinner state and stall while repainting live rows.

Introduce explicit terminal size tracking and route the build and test formatters through width-aware renderers. Build lines now share one layout picker for live and done output, preserve failure messages as truncated status text, reserve a safety column against autowrap, and still fit to the current width when progress drawing is disabled. Test lines now reuse the legacy wide layout when it fits, fall back compactly when it does not, and render live spinners from indexed line renderers.

This keeps build output columnar at normal widths, lets test output preserve its established wide layout while still degrading predictably on narrow terminals, and makes current terminal width an input to rendering rather than an accidental side effect of the progress UI mode.

Fixes #2673