### PR TITLE
Add stress testing mode

### DIFF
--- a/base/src/testing.act
+++ b/base/src/testing.act
@@ -963,6 +963,7 @@ class TestInfo(object):
 
 class TestRunnerConfig(object):
     perf_mode: bool
+    stress_mode: bool
     max_iter: int
     min_iter: int
     max_time: float
@@ -970,7 +971,7 @@ class TestRunnerConfig(object):
     output_enabled: bool
     tags: set[str]
 
-    def __init__(self, perf_mode: bool, args):
+    def __init__(self, perf_mode: bool, stress_mode: bool, args):
         def split_tags(tag_args: list[str]) -> set[str]:
             tags = set()
             for raw_tags in tag_args:
@@ -979,19 +980,27 @@ class TestRunnerConfig(object):
                     if tag != "":
                         tags.add(tag)
             return tags
-
         self.perf_mode = perf_mode
-        self.output_enabled = False if args.get_bool("no_output") else True
+        self.stress_mode = stress_mode
+        self.output_enabled = False if stress_mode or args.get_bool("no_output") else True
         self.min_iter = args.get_int("min-iter")
-        self.max_iter = max([args.get_int("max-iter"), self.min_iter])
+        raw_max_iter = args.get_int("max-iter")
+        if raw_max_iter <= 0:
+            self.max_iter = 0
+        else:
+            self.max_iter = max([raw_max_iter, self.min_iter])
         self.min_time = float(args.get_int("min-time")) / 1000.0
-        self.max_time = max([float(args.get_int("max-time")) / 1000.0, self.min_time])
+        raw_max_time = args.get_int("max-time")
+        if raw_max_time <= 0:
+            self.max_time = 0.0
+        else:
+            self.max_time = max([float(raw_max_time) / 1000.0, self.min_time])
         self.tags = split_tags(args.get_strlist("tag"))
 
 class TimeoutError(Exception):
     pass
 
-actor TestExecutor(syscap, config, t: Test, report_complete, env):
+actor TestExecutor(syscap, config, t: Test, report_complete, report_progress, env, executor_id: int, stress_workers: int, stress_nodrift_workers: int):
     """The actual executor of tests
     """
     log_handler = logging.Handler()
@@ -1001,8 +1010,102 @@ actor TestExecutor(syscap, config, t: Test, report_complete, env):
     fs = file.FS(fcap)
     var test_sw = time.Stopwatch()
     var last_report = time.Stopwatch()
+    var progress_report_sw = time.Stopwatch()
     var test_info = None
     var iteration = 0
+    var stress_drift_rank = max([0, executor_id - stress_nodrift_workers])
+    var stress_drift_workers = max([1, stress_workers - stress_nodrift_workers])
+    var stress_last_drift_us = 0
+    var stress_total_drift_us = 0
+    var stress_est_iter_ms = 0.0
+    var stress_base_drift_us = 0
+    var stress_worker_drift_us = 0
+    var stress_startup_offset_us = 0
+    var stress_startup_done = False
+    var stress_phase_resolution_us = 0
+    var stress_target_sweep_iters = 16
+    var stress_calib_samples = 0
+    var stress_calib_target_samples = 4
+    var stress_calibrating = config.stress_mode and not config.perf_mode and executor_id >= stress_nodrift_workers
+    var stress_refine_continuous = config.stress_mode and not config.perf_mode and config.max_time <= 0.0 and executor_id >= stress_nodrift_workers
+    var stress_refine_next_iter = 0
+    var stress_refine_max_sweep_iters = 0
+
+    def _update_stress_timing_estimate(iter_ms: float):
+        if iter_ms <= 0.0:
+            return
+        if stress_est_iter_ms <= 0.0:
+            stress_est_iter_ms = iter_ms
+        else:
+            stress_est_iter_ms = (stress_est_iter_ms * 0.8) + (iter_ms * 0.2)
+
+    def _set_stress_sweep_iters(target_sweep_iters: int):
+        if stress_est_iter_ms <= 0.0:
+            return
+        stress_target_sweep_iters = max([1, target_sweep_iters])
+        stress_base_drift_us = max([1, int((stress_est_iter_ms * 1000.0) / float(stress_target_sweep_iters))])
+        stress_phase_resolution_us = stress_base_drift_us
+        stress_worker_drift_us = stress_base_drift_us * (stress_drift_rank + 1)
+
+    def _maybe_refine_stress_phase(completed_iterations: int):
+        if not stress_refine_continuous or stress_calibrating:
+            return
+        if stress_base_drift_us <= 1:
+            return
+        if completed_iterations <= 0:
+            return
+        if stress_refine_next_iter <= 0:
+            stress_refine_next_iter = max([1, stress_target_sweep_iters])
+        while completed_iterations >= stress_refine_next_iter and stress_base_drift_us > 1:
+            next_sweep = stress_target_sweep_iters * 2
+            if stress_refine_max_sweep_iters > 0 and next_sweep > stress_refine_max_sweep_iters:
+                next_sweep = stress_refine_max_sweep_iters
+            if next_sweep <= stress_target_sweep_iters:
+                break
+            _set_stress_sweep_iters(next_sweep)
+            stress_refine_next_iter += stress_target_sweep_iters
+
+    def _finalize_stress_calibration():
+        if not stress_calibrating:
+            return
+        if stress_est_iter_ms <= 0.0:
+            return
+        est_total_iters = max([16, int((config.min_time * 1000.0) / max([0.1, stress_est_iter_ms]))])
+        if est_total_iters >= 512:
+            stress_target_sweep_iters = 256
+        elif est_total_iters >= 128:
+            stress_target_sweep_iters = 64
+        else:
+            stress_target_sweep_iters = 16
+
+        _set_stress_sweep_iters(stress_target_sweep_iters)
+        stress_startup_offset_us = max([0, int((stress_est_iter_ms * 1000.0) * float(stress_drift_rank + 1) / float(stress_drift_workers + 1))])
+        if stress_refine_continuous:
+            stress_refine_next_iter = max([1, stress_target_sweep_iters])
+            stress_refine_max_sweep_iters = max([stress_target_sweep_iters, int(stress_est_iter_ms * 1000.0)])
+        stress_calibrating = False
+
+    def _stress_drift_delay() -> int:
+        if not config.stress_mode or config.perf_mode:
+            return 0
+        if executor_id < stress_nodrift_workers:
+            stress_last_drift_us = 0
+            return 0
+        if stress_calibrating:
+            stress_last_drift_us = 0
+            return 0
+        if not stress_startup_done:
+            if stress_startup_offset_us > 0:
+                acton.rts.sleep(syscap, float(stress_startup_offset_us) / 1000000.0)
+                stress_total_drift_us += stress_startup_offset_us
+            stress_startup_done = True
+        drift_us = stress_worker_drift_us
+        if drift_us <= 0:
+            drift_us = max([1, stress_drift_rank + 1])
+        stress_last_drift_us = drift_us
+        stress_total_drift_us += drift_us
+        acton.rts.sleep(syscap, float(drift_us) / 1000000.0)
+        return drift_us
 
     def _read_expected(path: str) -> ?str:
         try:
@@ -1033,6 +1136,12 @@ actor TestExecutor(syscap, config, t: Test, report_complete, env):
         gc_total_bytes_end = int(acton.rts.get_gc_total_bytes(syscap))
         mem_usage_delta = gc_total_bytes_end - gc_total_bytes_start
         test_dur = test_sw.elapsed().to_float()
+        if config.stress_mode and not config.perf_mode:
+            _update_stress_timing_estimate(testiter_dur)
+            if stress_calibrating:
+                stress_calib_samples += 1
+                if stress_calib_samples >= stress_calib_target_samples:
+                    _finalize_stress_calibration()
         if config.perf_mode:
             acton.rts.gc(syscap)
             acton.rts.gc(syscap)
@@ -1052,16 +1161,24 @@ actor TestExecutor(syscap, config, t: Test, report_complete, env):
         complete = False
         if skipped:
             complete = True
-        if test_dur > config.min_time and iteration > config.min_iter:
-            complete = True
-        if config.max_time > 0 and test_dur > config.max_time:
-            complete = True
-        if config.max_iter > 0 and iteration >= config.max_iter:
-            complete = True
+        if config.stress_mode:
+            if config.max_time > 0.0 and test_dur > config.max_time:
+                complete = True
+            if config.max_iter > 0 and iteration >= config.max_iter:
+                complete = True
+        else:
+            if test_dur > config.min_time and iteration > config.min_iter:
+                complete = True
+            if config.max_time > 0 and test_dur > config.max_time:
+                complete = True
+            if config.max_iter > 0 and iteration >= config.max_iter:
+                complete = True
 
         if test_info is not None:
             exc = str(exception) if exception is not None else None
             test_info.update(complete, TestResult(success, exc, val, testiter_dur, mem_usage_delta, non_gc_mem_usage_delta, skipped=skipped, skip_reason=skip_reason), test_dur*1000.0)
+            if config.stress_mode and not config.perf_mode and executor_id >= stress_nodrift_workers:
+                _maybe_refine_stress_phase(test_info.num_iterations)
         if last_report.elapsed().to_float() > 0.05 or complete:
             if test_info is not None and config.output_enabled:
                 print("\n" + json.encode({"test_info": test_info.to_json()}), err=True)
@@ -1069,9 +1186,19 @@ actor TestExecutor(syscap, config, t: Test, report_complete, env):
         if not complete:
             _run_fn(test)
         else:
-            report_complete(t)
+            if test_info is not None and config.stress_mode:
+                report_progress(executor_id,
+                                test_info.num_iterations,
+                                stress_last_drift_us,
+                                stress_total_drift_us,
+                                stress_est_iter_ms,
+                                stress_phase_resolution_us,
+                                stress_target_sweep_iters,
+                                stress_calibrating)
+            report_complete(executor_id, t, test_info)
 
     def _run_fn(t: Test):
+        _stress_drift_delay()
         print("\n== Running test, iteration:", iteration)
         print("\n== Running test, iteration:", iteration, err=True)
         # Run GC to get accurate memory usage
@@ -1102,6 +1229,16 @@ actor TestExecutor(syscap, config, t: Test, report_complete, env):
         except Exception as e:
             _report_result(t, sw, non_gc_mem_usage_before, gc_total_bytes_start, gc_time_start, None, e, None)
         iteration += 1
+        if config.stress_mode and (iteration == 1 or iteration % 32 == 0 or progress_report_sw.elapsed().to_float() > 0.08):
+            report_progress(executor_id,
+                            iteration,
+                            stress_last_drift_us,
+                            stress_total_drift_us,
+                            stress_est_iter_ms,
+                            stress_phase_resolution_us,
+                            stress_target_sweep_iters,
+                            stress_calibrating)
+            progress_report_sw.reset()
 
     def _run_test():
         """Get the next available test and run it"""
@@ -1455,27 +1592,247 @@ actor test_runner(env: Env,
 
 
 
-    proc def _run_tests(args, perf_mode: bool=False):
-        config = TestRunnerConfig(perf_mode, args)
+    proc def _run_tests(args, perf_mode: bool=False, stress_mode: bool=False):
+        config = TestRunnerConfig(perf_mode, stress_mode, args)
         if config.perf_mode:
             acton.rts.start_gc_performance_measurement(env.syscap)
 
-        test_concurrency = 1 if config.perf_mode else env.nr_wthreads
-        test_timeout = max([config.max_time, 2.0]) + 1.0
+        test_concurrency = 1
+        stress_nodrift_workers = 0
+        if config.stress_mode and not config.perf_mode:
+            test_concurrency = max([1, env.nr_wthreads // 2])
+            stress_nodrift_workers = min([test_concurrency, max([2, (test_concurrency + 3) // 4])])
+        test_timeout = 0.0
+        if config.max_time > 0:
+            test_timeout = max([config.max_time, 2.0]) + 1.0
 
         test_name = args.get_str("name")
         if test_name not in all_tests:
             print(f"Test not found: {test_name}")
             env.exit(1)
         the_test = all_tests[test_name]
-        tests_complete = set()
+        workers_complete = set()
+        combined_info = TestInfo(the_test)
+        combined_sw = time.Stopwatch()
+        worker_iterations = {}
+        worker_drift_us = {}
+        worker_drift_total_us = {}
+        worker_est_iter_ms = {}
+        worker_phase_resolution_us = {}
+        worker_target_sweep_iters = {}
+        worker_calibrating = {}
+        stress_phase_cov = {
+            "bins_total": 0,
+            "res_us": 0,
+            "seen_count": 0,
+            "epoch": 1
+        }
+        stress_phase_bins_epoch = {}
+        for idx in range(test_concurrency):
+            worker_iterations[idx] = 0
+            worker_drift_us[idx] = 0
+            worker_drift_total_us[idx] = 0
+            worker_est_iter_ms[idx] = 0.0
+            worker_phase_resolution_us[idx] = 0
+            if idx < stress_nodrift_workers:
+                worker_target_sweep_iters[idx] = 0
+                worker_calibrating[idx] = False
+            else:
+                worker_target_sweep_iters[idx] = 16
+                worker_calibrating[idx] = config.stress_mode
 
-        def _check_timeout(test_def):
-            if test_def in tests_complete:
+        def _total_worker_iterations() -> int:
+            total = 0
+            for idx in range(test_concurrency):
+                total += worker_iterations[idx]
+            return total
+
+        def _stress_workers_json():
+            workers = []
+            for idx in range(test_concurrency):
+                workers.append({
+                    "id": idx,
+                    "iterations": worker_iterations[idx],
+                    "drift_us": worker_drift_us[idx],
+                    "drift_total_us": worker_drift_total_us[idx],
+                    "est_iter_ms": worker_est_iter_ms[idx],
+                    "phase_resolution_us": worker_phase_resolution_us[idx],
+                    "target_sweep_iters": worker_target_sweep_iters[idx],
+                    "calibrating": worker_calibrating[idx],
+                    "sync": idx < stress_nodrift_workers
+                })
+            return workers
+
+        def _stress_est_iteration_ms() -> float:
+            total = 0.0
+            count = 0
+            for idx in range(test_concurrency):
+                est = worker_est_iter_ms[idx]
+                if est > 0.0:
+                    total += est
+                    count += 1
+            if count > 0:
+                return total / float(count)
+            return 0.0
+
+        def _stress_phase_resolution_ms() -> float:
+            worst_us = 0
+            for idx in range(stress_nodrift_workers, test_concurrency):
+                res_us = worker_phase_resolution_us[idx]
+                if res_us > worst_us:
+                    worst_us = res_us
+            if worst_us > 0:
+                return float(worst_us) / 1000.0
+            est_ms = _stress_est_iteration_ms()
+            if est_ms > 0.0:
+                return est_ms / 16.0
+            return 0.0
+
+        def _stress_target_sweep_iters() -> int:
+            target = 0
+            for idx in range(stress_nodrift_workers, test_concurrency):
+                if worker_target_sweep_iters[idx] > target:
+                    target = worker_target_sweep_iters[idx]
+            return target
+
+        def _stress_calibrating_workers() -> int:
+            count = 0
+            for idx in range(stress_nodrift_workers, test_concurrency):
+                if worker_calibrating[idx]:
+                    count += 1
+            return count
+
+        def _update_stress_phase_coverage():
+            if not config.stress_mode or config.perf_mode:
+                return
+            if test_concurrency <= stress_nodrift_workers:
+                return
+            phase_res_ms = _stress_phase_resolution_ms()
+            est_ms = _stress_est_iteration_ms()
+            if phase_res_ms <= 0.0 or est_ms <= 0.0:
+                return
+            phase_res_us = max([1, int(phase_res_ms * 1000.0)])
+            bins_total = _stress_target_sweep_iters()
+            if bins_total <= 0:
+                est_us = max([phase_res_us, int(est_ms * 1000.0)])
+                bins_total = max([1, est_us // phase_res_us])
+            if bins_total != stress_phase_cov["bins_total"] or phase_res_us != stress_phase_cov["res_us"]:
+                stress_phase_cov["bins_total"] = bins_total
+                stress_phase_cov["res_us"] = phase_res_us
+                stress_phase_cov["seen_count"] = 0
+                stress_phase_cov["epoch"] = stress_phase_cov["epoch"] + 1
+            for idx in range(stress_nodrift_workers, test_concurrency):
+                if worker_calibrating[idx]:
+                    continue
+                drift_total = worker_drift_total_us[idx]
+                if drift_total <= 0:
+                    continue
+                bin_idx = (drift_total // phase_res_us) % bins_total
+                current_epoch = stress_phase_cov["epoch"]
+                if bin_idx in stress_phase_bins_epoch and stress_phase_bins_epoch[bin_idx] == current_epoch:
+                    continue
+                stress_phase_bins_epoch[bin_idx] = current_epoch
+                stress_phase_cov["seen_count"] = stress_phase_cov["seen_count"] + 1
+
+        def _stress_payload(info: TestInfo):
+            payload = info.to_json()
+            payload["stress_worker_count"] = test_concurrency
+            payload["stress_no_drift_workers"] = stress_nodrift_workers
+            payload["stress_est_iteration_ms"] = _stress_est_iteration_ms()
+            payload["stress_phase_resolution_ms"] = _stress_phase_resolution_ms()
+            payload["stress_target_sweep_iters"] = _stress_target_sweep_iters()
+            payload["stress_calibrating_workers"] = _stress_calibrating_workers()
+            payload["stress_phase_bins_seen"] = stress_phase_cov["seen_count"]
+            payload["stress_phase_bins_total"] = stress_phase_cov["bins_total"]
+            payload["stress_workers"] = _stress_workers_json()
+            return payload
+
+        def _emit_stress_live():
+            if not config.stress_mode or len(workers_complete) >= test_concurrency:
+                return
+            payload = _stress_payload(combined_info)
+            total_iterations = _total_worker_iterations()
+            payload["complete"] = False
+            payload["success"] = None
+            payload["exception"] = None
+            payload["num_failures"] = 0
+            payload["num_errors"] = 0
+            payload["num_iterations"] = total_iterations
+            payload["test_duration"] = combined_sw.elapsed().to_float() * 1000.0
+            if total_iterations > 0:
+                print("\n" + json.encode({"test_info": payload}), err=True)
+            after 0.08: _emit_stress_live()
+
+        def _merge_worker_info(worker_info: ?TestInfo):
+            if worker_info is not None:
+                for result in worker_info.results:
+                    combined_info.update(False, result)
+
+        def report_progress(executor_id: int,
+                            iterations: int,
+                            drift_us: int,
+                            drift_total_us: int,
+                            est_iter_ms: float,
+                            phase_resolution_us: int,
+                            target_sweep_iters: int,
+                            calibrating: bool):
+            if executor_id in worker_iterations:
+                if iterations > worker_iterations[executor_id]:
+                    worker_iterations[executor_id] = iterations
+                worker_drift_us[executor_id] = drift_us
+                worker_drift_total_us[executor_id] = max([worker_drift_total_us[executor_id], drift_total_us])
+                worker_est_iter_ms[executor_id] = est_iter_ms
+                worker_phase_resolution_us[executor_id] = phase_resolution_us
+                if target_sweep_iters > 0:
+                    worker_target_sweep_iters[executor_id] = target_sweep_iters
+                worker_calibrating[executor_id] = calibrating
+                _update_stress_phase_coverage()
+
+        def _check_timeout():
+            if test_timeout <= 0.0:
+                return
+            if len(workers_complete) >= test_concurrency:
+                # Report after we hit timeout
                 return
             time_s = test_timeout * 1000.0
+            if config.stress_mode:
+                if len(combined_info.results) > 0:
+                    combined_info.update(
+                        True,
+                        TestResult(
+                            None,
+                            "Test timeout",
+                            None,
+                            time_s,
+                            0,
+                            0),
+                        time_s)
+                    payload = _stress_payload(combined_info)
+                    payload["complete"] = True
+                    payload["test_duration"] = time_s
+                    payload["num_iterations"] = max([combined_info.num_iterations, _total_worker_iterations()])
+                    print("\n" + json.encode({"test_info": payload}), err=True)
+                    env.exit(0)
+                timeout_info = TestInfo(
+                    the_test,
+                    complete=True,
+                    success=None,
+                    exception="Test timeout",
+                    min_duration=time_s,
+                    max_duration=time_s,
+                    avg_duration=time_s,
+                    total_duration=time_s,
+                    test_duration=time_s,
+                    num_iterations=max([1, _total_worker_iterations()]),
+                    num_failures=0,
+                    num_errors=1
+                    )
+                payload = _stress_payload(timeout_info)
+                payload["num_iterations"] = max([timeout_info.num_iterations, _total_worker_iterations()])
+                print("\n" + json.encode({"test_info": payload}), err=True)
+                env.exit(0)
             test_info = TestInfo(
-                test_def,
+                the_test,
                 complete=True,
                 success=None,
                 exception="Test timeout",
@@ -1488,23 +1845,39 @@ actor test_runner(env: Env,
                 num_failures=0,
                 num_errors=1
                 )
-            tests_complete.add(test_def)
             print("\n" + json.encode({"test_info": test_info.to_json()}), err=True)
             env.exit(0)
 
-        def report_complete(t):
-            if t in tests_complete:
-                # Report after we hit timeout
+        def report_complete(executor_id: int, t, worker_info: ?TestInfo):
+            if executor_id in workers_complete:
                 return
-            tests_complete.add(t)
-            env.exit(0)
+            workers_complete.add(executor_id)
+            if not config.stress_mode:
+                env.exit(0)
+                return
+            _merge_worker_info(worker_info)
+            if len(workers_complete) >= test_concurrency:
+                combined_info.complete = True
+                combined_info.test_duration = combined_sw.elapsed().to_float() * 1000.0
+                payload = _stress_payload(combined_info)
+                payload["num_iterations"] = max([combined_info.num_iterations, _total_worker_iterations()])
+                print("\n" + json.encode({"test_info": payload}), err=True)
+                env.exit(0)
 
         test_executors = []
-        te = TestExecutor(env.syscap, config, the_test, report_complete, env)
-        after test_timeout: _check_timeout(the_test)
+        for idx in range(test_concurrency):
+            te = TestExecutor(env.syscap, config, the_test, report_complete, report_progress, env, idx, test_concurrency, stress_nodrift_workers)
+            test_executors.append(te)
+        if config.stress_mode:
+            after 0.08: _emit_stress_live()
+        if test_timeout > 0.0:
+            after test_timeout: _check_timeout()
 
     proc def _run_perf_tests(args):
         _run_tests(args, perf_mode=True)
+
+    proc def _run_stress_tests(args):
+        _run_tests(args, stress_mode=True)
 
     def _parse_args():
         p = argparse.Parser()
@@ -1515,10 +1888,11 @@ actor test_runner(env: Env,
         tp.add_arg("name", "Name of the test to run")
         tp.add_option("max-iter", "int", default=10**6, help="Maximum number of iterations to run")
         tp.add_option("min-iter", "int", default=3, help="Minumum number of iterations to run")
-        tp.add_option("max-time", "int", default=1000, help="Maximum time to run a test in milliseconds")
+        tp.add_option("max-time", "int", default=1000, help="Maximum time to run a test in milliseconds (0 = no time limit)")
         tp.add_option("min-time", "int", default=50, help="Minimum time to run a test in milliseconds")
         tp.add_option("tag", "strlist", default=[], help="Enable test capability tag")
         pp = tp.add_cmd("perf", "Performance benchmark tests", _run_perf_tests)
+        sp = tp.add_cmd("stress", "Stress tests by running concurrent workers of the same test", _run_stress_tests)
 
         args = p.parse(env.argv)
         _cmd = args.cmd

--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -609,6 +609,7 @@ runTests gopts cmd = do
             C.TestRun opts  -> (TestModeRun, opts)
             C.TestList opts -> (TestModeList, opts)
             C.TestPerf opts -> (TestModePerf, opts)
+            C.TestStress opts -> (TestModeStress, opts)
         gopts' = if C.testJson topts then gopts { C.quiet = True } else gopts
         opts0 = C.testCompile topts
     let opts = opts0
@@ -631,7 +632,8 @@ runTestsOnce gopts opts topts mode paths = do
     case mode of
       TestModeList -> listProjectTests opts paths topts modules
       _ -> do
-        maxParallel <- testMaxParallel gopts
+        maxParallel0 <- testMaxParallel gopts
+        let maxParallel = if mode == TestModeStress then 1 else maxParallel0
         useColorOut <- useColor gopts
         exitCode <- runProjectTests useColorOut gopts opts paths topts mode modules maxParallel
         exitWithTestCode exitCode
@@ -645,7 +647,8 @@ runTestsWatch gopts opts topts mode paths = do
     withBackgroundCompilerLockOrExit projDir
       "Another long-running Acton compiler is already running; cannot start test watch." $ do
         (sched, progressUI, progressState) <- initCompileWatchContext gopts
-        testParallel <- testMaxParallel gopts
+        testParallel0 <- testMaxParallel gopts
+        let testParallel = if mode == TestModeStress then 1 else testParallel0
         let runOnce gen mChanged = do
               withProjectLockForGen gopts sched gen projDir $ do
                 logProjectBuild gopts progressUI progressState projDir

--- a/compiler/acton/TestFormat.hs
+++ b/compiler/acton/TestFormat.hs
@@ -20,6 +20,10 @@ import Data.List (foldl', isPrefixOf, isInfixOf, intercalate)
 import Data.Maybe (catMaybes, fromMaybe, isJust, listToMaybe, mapMaybe)
 import qualified Data.Map as M
 import TerminalSize (termFitPlainRight, termVisibleLength)
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Types as AesonTypes
+import qualified Data.Aeson.Key as AesonKey
+import qualified Data.Aeson.KeyMap as AesonKM
 import Text.Printf (printf)
 
 -- | Compute the status label (OK/FAIL/ERR/FLAKY) for a test.
@@ -150,9 +154,67 @@ formatTestLineWith useColor statusFn nameWidth display res =
     let prefix0 = "   " ++ display ++ ": "
         padding = replicate (max 0 (nameWidth - length prefix0)) ' '
         statusRaw = statusFn res
-        runs = printf "%4d runs in %3.3fms" (trNumIterations res) (trTestDuration res)
+        runs = printf "%4d runs in %3.3fms @ %6.1f/s" (trNumIterations res) (trTestDuration res) (testsPerSecond (trNumIterations res) (trTestDuration res))
         statusPart = colorizeStatusPart useColor (trCached res) statusRaw runs
-    in prefix0 ++ padding ++ statusPart
+        stressPart =
+          case stressWorkerOverview res of
+            Just txt -> " | " ++ txt
+            Nothing -> ""
+    in prefix0 ++ padding ++ statusPart ++ stressPart
+
+stressWorkerOverview :: TestResult -> Maybe String
+stressWorkerOverview res =
+    case trRaw res of
+      Aeson.Object obj ->
+        let mEstMs = lookupDouble obj "stress_est_iteration_ms"
+            mPhaseResMs = lookupDouble obj "stress_phase_resolution_ms"
+            mSweep = lookupInt obj "stress_target_sweep_iters"
+            mCalib = lookupInt obj "stress_calibrating_workers"
+            mCovSeen = lookupInt obj "stress_phase_bins_seen"
+            mCovTotal = lookupInt obj "stress_phase_bins_total"
+            extraParts =
+              catMaybes
+                [ case mEstMs of
+                    Just est | est > 0 -> Just (printf "iter~%0.3fms" est)
+                    _ -> Nothing
+                , case mPhaseResMs of
+                    Just resMs | resMs > 0 -> Just (printf "coarse~%0.3fms" resMs)
+                    _ -> Nothing
+                , case mSweep of
+                    Just sweep | sweep > 0 -> Just ("sweep=" ++ show sweep)
+                    _ -> Nothing
+                , case mCalib of
+                    Just calib | calib > 0 -> Just ("calib=" ++ show calib)
+                    _ -> Nothing
+                , case (mCovSeen, mCovTotal) of
+                    (Just seen, Just total) | total > 0 ->
+                      let pct :: Double
+                          pct = (fromIntegral seen * 100.0) / fromIntegral total
+                      in Just (printf "cov=%d/%d(%0.1f%%)" seen total pct)
+                    _ -> Nothing
+                ]
+        in if null extraParts
+             then Nothing
+             else Just (unwords extraParts)
+      _ -> Nothing
+  where
+    lookupInt :: Aeson.Object -> String -> Maybe Int
+    lookupInt o key =
+      case AesonKM.lookup (AesonKey.fromString key) o of
+        Just v -> AesonTypes.parseMaybe Aeson.parseJSON v
+        _ -> Nothing
+
+    lookupDouble :: Aeson.Object -> String -> Maybe Double
+    lookupDouble o key =
+      case AesonKM.lookup (AesonKey.fromString key) o of
+        Just v -> AesonTypes.parseMaybe Aeson.parseJSON v
+        _ -> Nothing
+
+testsPerSecond :: Int -> Double -> Double
+testsPerSecond iterations durationMs
+  | iterations <= 0 = 0
+  | durationMs <= 0 = 0
+  | otherwise = (fromIntegral iterations * 1000.0) / durationMs
 
 -- | Format a live test line to the current terminal width.
 formatTestLineFitted :: Bool -> (TestResult -> String) -> Int -> Int -> String -> TestResult -> String

--- a/compiler/acton/TestRunner.hs
+++ b/compiler/acton/TestRunner.hs
@@ -38,13 +38,14 @@ import qualified Data.Aeson.KeyMap as AesonKM
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
-import Control.Exception (SomeException, displayException, evaluate, onException, try)
 import Data.Time.Clock (UTCTime)
+import Control.Exception (SomeException, AsyncException(..), displayException, evaluate, onException, try, fromException, throwIO)
+import TerminalSize (termFitPlainRight)
 import qualified Text.Regex.TDFA as TDFA
 import Data.Version (showVersion)
 import qualified Paths_acton
 
-data TestMode = TestModeRun | TestModeList | TestModePerf deriving (Eq, Show)
+data TestMode = TestModeRun | TestModeList | TestModePerf | TestModeStress deriving (Eq, Show)
 
 data TestSpec = TestSpec
   { tsModule :: String
@@ -175,20 +176,30 @@ runProjectTests useColorOut gopts opts paths topts mode modules maxParallel = do
             nameWidth = max 20 (maxNameLen + 5)
             runContext = mkRunContext opts topts mode
             ctxHash = contextHashBytes runContext
-            useCache = not (C.testNoCache topts)
-        cache <- readTestCache (testCachePath paths) runContext
-        testHashInfos <- buildTestHashInfos paths ctxHash testsByModule
-        let cacheEntries = tcTests cache
-        when (C.verbose gopts) $
+            useCache = not (C.testNoCache topts) && mode /= TestModeStress
+        cache <-
+          if useCache
+            then readTestCache (testCachePath paths) runContext
+            else return TestCache
+              { tcVersion = testCacheVersion
+              , tcContext = runContext
+              , tcTests = M.empty
+              }
+        testHashInfos <-
+          if useCache
+            then buildTestHashInfos paths ctxHash testsByModule
+            else return M.empty
+        let cacheEntries =
+              if useCache
+                then tcTests cache
+                else M.empty
+        when (C.verbose gopts && useCache) $
           putStrLn (formatTestCacheContext ctxHash (testCachePath paths))
         let logCache = if C.verbose gopts then putStrLn else \_ -> return ()
-        cachedResults0 <-
+        (cachedResults0, _testsToRun) <-
           if useCache
-            then do
-              (cachedResults, _testsToRun) <-
-                classifyCachedTests logCache cacheEntries testHashInfos allTests
-              return cachedResults
-            else return []
+            then classifyCachedTests logCache cacheEntries testHashInfos allTests
+            else return ([], allTests)
         cachedResults1 <-
           if useCache
             then filterReusableCachedSnapshotResults logCache paths cachedResults0
@@ -199,7 +210,9 @@ runProjectTests useColorOut gopts opts paths topts mode modules maxParallel = do
             else return cachedResults1
         let showCached = C.testShowCached topts
         when (not emitJson && not useCache) $
-          putStrLn "Skipping test result cache (--no-cache); running all selected tests"
+          if mode == TestModeStress
+            then putStrLn "Skipping test result cache in stress mode; running all selected tests"
+            else putStrLn "Skipping test result cache (--no-cache); running all selected tests"
         when (not emitJson && showCached && not (null cachedResults)) $
           putStrLn ("Using cached results for " ++ show (length cachedResults) ++ " tests")
         ui <- initTestProgressUI gopts nameWidth (C.testShowLog topts) useColorOut
@@ -269,7 +282,7 @@ runProjectTests useColorOut gopts opts paths topts mode modules maxParallel = do
                       if not started
                         then return Nothing
                         else do
-                          let callbacks = testProgressCallbacks ui eventChan key display
+                          callbacks <- testProgressCallbacks ui eventChan key display
                           void $ async $ do
                             res <- runModuleTestStreaming opts paths topts mode (tsModule spec) (tsName spec)
                                     (tpuEnabled ui) callbacks
@@ -295,7 +308,11 @@ runProjectTests useColorOut gopts opts paths topts mode modules maxParallel = do
                   case evt of
                     TestEventDone res -> do
                       progressStep
-                      loop pending' (running' - 1) (res : results')
+                      let pending'' =
+                            if testResultInterrupted res
+                              then []
+                              else pending'
+                      loop pending'' (running' - 1) (res : results')
                     TestEventRoom -> loop pending' running' results'
         results <- loop specs 0 []
         timeEnd <- getTime Monotonic
@@ -312,7 +329,8 @@ runProjectTests useColorOut gopts opts paths topts mode modules maxParallel = do
               , tcContext = runContext
               , tcTests = cacheEntries'
               }
-        writeTestCache (testCachePath paths) newCache
+        when useCache $
+          writeTestCache (testCachePath paths) newCache
         if emitJson
           then do
             outputJsonReport (timeEnd - timeStart) results
@@ -330,7 +348,7 @@ runProjectTests useColorOut gopts opts paths topts mode modules maxParallel = do
       , trcTarget = C.target opts'
       , trcOptimize = show (C.optimize opts')
       , trcMode = show mode'
-      , trcArgs = testCmdArgs topts'
+      , trcArgs = testCmdArgs mode' topts'
       }
 
 testExitCode :: [TestResult] -> Int
@@ -557,7 +575,12 @@ runModuleTestStreaming :: C.CompileOptions
                        -> IO TestResult
 runModuleTestStreaming opts paths topts mode modName testName allowLive callbacks = do
     let binPath = testBinaryPath opts paths modName
-        cmd = ["test", testName] ++ (if mode == TestModePerf then ["perf"] else []) ++ testCmdArgs topts
+        modeArgs =
+          case mode of
+            TestModePerf -> ["perf"]
+            TestModeStress -> ["stress"]
+            _ -> []
+        cmd = ["test", testName] ++ modeArgs ++ testCmdArgs mode topts
     updatesRef <- newIORef []
     lineDoneRef <- newIORef False
     stdErrRef <- newIORef []
@@ -577,7 +600,17 @@ runModuleTestStreaming opts paths topts mode modName testName allowLive callback
             Just val -> case parseTestInfo val of
                           Just res -> onUpdate res
                           Nothing -> addStdErr line
-    (exitCode, out, _err) <- readProcessWithExitCodeStreaming (proc binPath cmd){ cwd = Just (projPath paths) } onErrLine
+    let procSpec = (proc binPath cmd){ cwd = Just (projPath paths), delegate_ctlc = True }
+    procRes <- try (readProcessWithExitCodeStreaming procSpec onErrLine) :: IO (Either SomeException (ExitCode, String, String))
+    (exitCode, out, _err, interruptedByUser) <-
+      case procRes of
+        Right (code, outTxt, errTxt) ->
+          return (code, outTxt, errTxt, False)
+        Left ex ->
+          case fromException ex of
+            Just UserInterrupt ->
+              return (ExitFailure (-2), "", "", True)
+            _ -> throwIO ex
     infos <- readIORef updatesRef
     stdErrLines <- reverse <$> readIORef stdErrRef
     let stdErrText = unlines stdErrLines
@@ -614,7 +647,12 @@ runModuleTestStreaming opts paths topts mode modName testName allowLive callback
           { trStdOut = mergedStd (trStdOut res0) out
           , trStdErr = mergedStd (trStdErr res0) stdErrText
           }
-        res = case exitCode of
+        interrupted = interruptedByUser || isInterruptExitCode exitCode
+        incompleteSuccessExit = mode == TestModeStress && exitCode == ExitSuccess && not (trComplete res1)
+        res
+          | mode == TestModeStress && (interrupted || incompleteSuccessExit) = finalizeInterruptedStressResult res1
+          | otherwise =
+              case exitCode of
                 ExitSuccess -> res1
                 ExitFailure code ->
                   res1 { trException = Just ("Test process exited with code " ++ show code) }
@@ -629,18 +667,90 @@ runModuleTestStreaming opts paths topts mode modName testName allowLive callback
         tpcOnDone callbacks res'
         tpcOnFinal callbacks res'
     return res'
+  where
+    isInterruptExitCode ExitSuccess = False
+    isInterruptExitCode (ExitFailure code) = code == (-2) || code == 130
 
-testProgressCallbacks :: TestProgressUI -> Chan TestEvent -> TestKey -> String -> TestProgressCallbacks
-testProgressCallbacks ui eventChan key display =
+    finalizeInterruptedStressResult res =
+      let success' =
+            case trSuccess res of
+              Just _ -> trSuccess res
+              Nothing ->
+                if trNumFailures res == 0 && trNumErrors res == 0
+                  then Just True
+                  else Nothing
+          exception' =
+            if trNumFailures res == 0 && trNumErrors res == 0
+              then Nothing
+              else trException res
+      in res
+         { trComplete = True
+         , trSuccess = success'
+         , trException = exception'
+         , trRaw = markInterruptedRaw (trRaw res)
+         }
+
+    markInterruptedRaw raw =
+      case raw of
+        Aeson.Object o ->
+          Aeson.Object (AesonKM.insert (AesonKey.fromString "interrupted") (Aeson.Bool True) o)
+        _ ->
+          Aeson.object [AesonKey.fromString "interrupted" Aeson..= True]
+
+testProgressCallbacks :: TestProgressUI -> Chan TestEvent -> TestKey -> String -> IO TestProgressCallbacks
+testProgressCallbacks ui eventChan key display = do
+    workerKeysRef <- newIORef M.empty
     let nameWidth = tpuNameWidth ui
         useColorOut = tpuUseColor ui
         showLog = tpuShowLog ui
         liveLine res = formatTestLiveLineRenderer useColorOut nameWidth display res
         finalLine res = formatTestFinalLineRenderer useColorOut nameWidth display res
         detailLines res = formatTestDetailLines useColorOut showLog res
-    in TestProgressCallbacks
+        workerLine done durationMs (wid, syncW, iterations, driftUs, driftTotalUs, calibrating) cols =
+          let role = if syncW then "sync" else "drift"
+              phase =
+                if done
+                  then "DONE"
+                  else if calibrating
+                    then "CAL "
+                    else "RUN "
+              rate = testsPerSecond iterations durationMs
+              line = printf "      w%-3d %-5s %s : %7d iters @ %7.1f/s cur=%6dus tot=%8dus"
+                            wid role phase iterations rate driftUs driftTotalUs
+          in termFitPlainRight cols line
+        workerKey wid = TestKey (tkModule key) (tkName key ++ "#worker" ++ show wid)
+        updateStressWorkers done res = do
+          let rows = stressWorkerRows res
+          unless (null rows) $ do
+            existing <- readIORef workerKeysRef
+            existing' <- foldM (\acc row@(wid, _, _, _, _, _) -> do
+              let line = workerLine done (trTestDuration res) row
+              case M.lookup wid acc of
+                Just wk -> do
+                  if done
+                    then do
+                      removed <- testUiFinalize ui wk line
+                      when removed $
+                        writeChan eventChan TestEventRoom
+                    else
+                      testUiUpdateLive ui wk line
+                  return acc
+                Nothing ->
+                  if done
+                    then return acc
+                    else do
+                      let wk = workerKey wid
+                      started <- testUiStart ui wk (tkModule key) line
+                      if started
+                        then return (M.insert wid wk acc)
+                        else return acc
+              ) existing rows
+            writeIORef workerKeysRef existing'
+    return TestProgressCallbacks
       { tpcOnLive = \res -> testUiUpdateLive ui key (liveLine res)
+          >> updateStressWorkers False res
       , tpcOnDone = \res -> do
+          updateStressWorkers True res
           removed <- testUiFinalize ui key (finalLine res)
           when removed $
             writeChan eventChan TestEventRoom
@@ -652,17 +762,88 @@ testProgressCallbacks ui eventChan key display =
             queuePendingDetails ui key details
       }
 
+stressWorkerRows :: TestResult -> [(Int, Bool, Int, Int, Int, Bool)]
+stressWorkerRows res =
+    case trRaw res of
+      Aeson.Object obj ->
+        case AesonKM.lookup (AesonKey.fromString "stress_workers") obj of
+          Just (Aeson.Array workers) ->
+            catMaybes (map parseWorker (foldr (:) [] workers))
+          _ -> []
+      _ -> []
+  where
+    parseWorker val =
+      case val of
+        Aeson.Object o -> do
+          wid <- lookupInt o "id"
+          iterations <- lookupInt o "iterations"
+          driftUs <- lookupIntDefault o "drift_us" 0
+          driftTotalUs <- lookupIntDefault o "drift_total_us" 0
+          syncW <- lookupBool o "sync"
+          calibrating <- lookupBoolDefault o "calibrating" False
+          return (wid, syncW, iterations, driftUs, driftTotalUs, calibrating)
+        _ -> Nothing
+    lookupInt o keyName =
+      case AesonKM.lookup (AesonKey.fromString keyName) o of
+        Just v -> AesonTypes.parseMaybe Aeson.parseJSON v
+        _ -> Nothing
+    lookupIntDefault o keyName defVal =
+      case lookupInt o keyName of
+        Just n -> Just n
+        Nothing -> Just defVal
+    lookupBool o keyName =
+      case AesonKM.lookup (AesonKey.fromString keyName) o of
+        Just v -> AesonTypes.parseMaybe Aeson.parseJSON v
+        _ -> Nothing
+    lookupBoolDefault o keyName defVal =
+      case lookupBool o keyName of
+        Just b -> Just b
+        Nothing -> Just defVal
+
+testsPerSecond :: Int -> Double -> Double
+testsPerSecond iterations durationMs
+  | iterations <= 0 = 0
+  | durationMs <= 0 = 0
+  | otherwise = (fromIntegral iterations * 1000.0) / durationMs
+
 -- | Build test runner arguments from TestOptions limits.
-testCmdArgs :: C.TestOptions -> [String]
-testCmdArgs topts =
+testCmdArgs :: TestMode -> C.TestOptions -> [String]
+testCmdArgs mode topts =
     let iter = C.testIter topts
+        rawMaxIter = C.testMaxIter topts
+        rawMinTime = C.testMinTime topts
+        minTime =
+          case mode of
+            TestModePerf ->
+              if not (C.testMinTimeSet topts)
+                then 1000
+                else rawMinTime
+            TestModeStress ->
+              if not (C.testMinTimeSet topts)
+                then 1000
+                else rawMinTime
+            _ -> rawMinTime
+        rawMaxTime = C.testMaxTime topts
+        modeDefaultMaxTime =
+          case mode of
+            TestModeRun -> minTime
+            TestModePerf -> 1000
+            TestModeStress -> 5000
+            _ -> 1000
+        maxTime
+          | C.testMaxTimeSet topts && rawMaxTime == 0 = 0
+          | C.testMaxTimeSet topts = max rawMaxTime minTime
+          | otherwise = modeDefaultMaxTime
+        maxIter
+          | mode == TestModeStress && maxTime == 0 && not (C.testMaxIterSet topts) = 0
+          | otherwise = rawMaxIter
         baseArgs =
           if iter > 0
             then ["--max-iter", show iter, "--min-iter", show iter, "--max-time", show (10^6), "--min-time", "1"]
-            else [ "--max-iter", show (C.testMaxIter topts)
+            else [ "--max-iter", show maxIter
                  , "--min-iter", show (C.testMinIter topts)
-                 , "--max-time", show (C.testMaxTime topts)
-                 , "--min-time", show (C.testMinTime topts)
+                 , "--max-time", show maxTime
+                 , "--min-time", show minTime
                  ]
         tagArgs = concatMap (\tag -> ["--tag", tag]) (C.testTags topts)
     in baseArgs ++ tagArgs
@@ -751,6 +932,18 @@ pickFinalTestInfo infos =
           Just i -> Just i
           Nothing -> Just (head xs)
 
+testResultInterrupted :: TestResult -> Bool
+testResultInterrupted res =
+  case trRaw res of
+    Aeson.Object obj ->
+      case AesonKM.lookup (AesonKey.fromString "interrupted") obj of
+        Just v ->
+          case AesonTypes.parseMaybe Aeson.parseJSON v of
+            Just True -> True
+            _ -> False
+        _ -> False
+    _ -> False
+
 -- | Print a summary line and return the failure/error exit code.
 printTestSummary :: Bool -> TimeSpec -> Bool -> [TestResult] -> IO Int
 printTestSummary useColor elapsed showCached results = do
@@ -759,6 +952,7 @@ printTestSummary useColor elapsed showCached results = do
         errors = length [ r | r <- results, trSuccess r == Nothing ]
         skipped = length [ r | r <- results, trSkipped r ]
         hiddenCachedSuccess = not showCached && any (\r -> trCached r && trSuccess r == Just True && not (trSkipped r)) results
+        interrupted = any testResultInterrupted results
         hasCached = any trCached results
     case total of
       0 -> do
@@ -778,6 +972,8 @@ printTestSummary useColor elapsed showCached results = do
         putStrLn ""
         when hasCached $
           putStrLn (if useColor then testColorYellow ++ "*" ++ testColorReset ++ " = cached test result" else "* = cached test result")
+        when interrupted $
+          putStrLn "Stress run interrupted by user; showing partial results collected so far."
         when hiddenCachedSuccess $
           putStrLn "Cached successful tests are hidden. Cached failures/errors are shown. Use --show-cached to include cached successes, or --no-cache to force rerunning selected tests."
         if errors > 0
@@ -811,8 +1007,20 @@ printTestResultsOrdered useColor showLog showCached nameWidth specs results = do
                         return (Set.insert modName printedMods)
                   putStrLn (formatLine spec res)
                   mapM_ putStrLn (formatTestDetailLines useColor showLog res)
+                  mapM_ putStrLn (formatStressWorkerFinalLines res)
                   go printedMods' True rest
     go Set.empty False specs
+
+formatStressWorkerFinalLines :: TestResult -> [String]
+formatStressWorkerFinalLines res =
+    map renderRow (stressWorkerRows res)
+  where
+    durationMs = trTestDuration res
+    renderRow (wid, syncW, iterations, driftUs, driftTotalUs, _calibrating) =
+      let role = if syncW then "sync" else "drift"
+          rate = testsPerSecond iterations durationMs
+      in printf "      w%-3d %-5s DONE : %7d iters @ %7.1f/s cur=%6dus tot=%8dus"
+                wid role iterations rate driftUs driftTotalUs
 
 -- | Write snapshot outputs for all tests that produced output.
 writeSnapshotOutputs :: Paths -> [TestResult] -> IO ()

--- a/compiler/lib/src/Acton/CommandLineParser.hs
+++ b/compiler/lib/src/Acton/CommandLineParser.hs
@@ -2,6 +2,7 @@
 module Acton.CommandLineParser where
 
 import Options.Applicative
+import Data.Maybe (fromMaybe, isJust)
 
 #if defined(darwin_HOST_OS) && defined(aarch64_HOST_ARCH)
 defTarget = "aarch64-macos-none"
@@ -122,6 +123,7 @@ data TestCommand
     = TestRun TestOptions
     | TestList TestOptions
     | TestPerf TestOptions
+    | TestStress TestOptions
     deriving Show
 
 data TestOptions = TestOptions
@@ -138,6 +140,9 @@ data TestOptions = TestOptions
     , testMaxTime      :: Int
     , testMinTime      :: Int
     , testTags         :: [String]
+    , testMaxIterSet   :: Bool
+    , testMaxTimeSet   :: Bool
+    , testMinTimeSet   :: Bool
     , testModules      :: [String]
     , testNames        :: [String]
     } deriving Show
@@ -360,18 +365,19 @@ optimizeOption = option optimizeReader
      <> help "Optimization mode (Debug, ReleaseSafe, ReleaseSmall, ReleaseFast)"
     )
 
-data TestModeTag = ModeList | ModePerf deriving Show
+data TestModeTag = ModeList | ModePerf | ModeStress deriving Show
 
 testCommand :: Parser TestCommand
 testCommand =
     toCmd
-      <$> optional (argument testModeReader (metavar "MODE" <> help "list | perf"))
+      <$> optional (argument testModeReader (metavar "MODE" <> help "list | perf | stress"))
       <*> testOptions
   where
     toCmd mMode opts =
       case mMode of
         Just ModeList -> TestList opts
         Just ModePerf -> TestPerf opts
+        Just ModeStress -> TestStress opts
         Nothing -> TestRun opts
 
 testModeReader :: ReadM TestModeTag
@@ -379,10 +385,11 @@ testModeReader = eitherReader $ \s ->
     case s of
       "list" -> Right ModeList
       "perf" -> Right ModePerf
-      _      -> Left "Expected 'list' or 'perf'"
+      "stress" -> Right ModeStress
+      _      -> Left "Expected 'list', 'perf' or 'stress'"
 
 testOptions :: Parser TestOptions
-testOptions = TestOptions
+testOptions = mkTestOptions
     <$> compileOptions
     <*> switch (long "show-log"      <> help "Show test log output")
     <*> switch (long "show-cached"   <> help "Show cached test results")
@@ -391,13 +398,35 @@ testOptions = TestOptions
     <*> switch (long "record"        <> help "Record test performance results")
     <*> switch (long "snapshot-update" <> long "golden-update" <> long "accept" <> help "Accept current test output as expected snapshot values")
     <*> option auto (long "iter"     <> metavar "N" <> value (-1) <> help "Number of iterations to run a test")
-    <*> option auto (long "max-iter" <> metavar "N" <> value (10^6) <> help "Maximum number of iterations to run a test")
+    <*> optional (option auto (long "max-iter" <> metavar "N" <> help "Maximum number of iterations to run a test (mode defaults when omitted)"))
     <*> option auto (long "min-iter" <> metavar "N" <> value 3 <> help "Minimum number of iterations to run a test")
-    <*> option auto (long "max-time" <> metavar "MS" <> value 1000 <> help "Maximum time to run a test in milliseconds")
-    <*> option auto (long "min-time" <> metavar "MS" <> value 50 <> help "Minimum time to run a test in milliseconds")
+    <*> optional (option auto (long "max-time" <> metavar "MS" <> help "Maximum time to run a test in milliseconds (0 = no time limit, mode defaults when omitted)"))
+    <*> optional (option auto (long "min-time" <> metavar "MS" <> help "Minimum time to run a test in milliseconds"))
     <*> many (strOption (long "tag" <> metavar "TAG" <> help "Enable test capability TAG for testing.require()"))
     <*> many (strOption (long "module" <> metavar "MODULE" <> help "Filter on test module name"))
     <*> many (strOption (long "name" <> metavar "NAME" <> help "Filter on test name (regex, anchored; use .* for substrings)"))
+  where
+    mkTestOptions testCompile testShowLog testShowCached testNoCache testJson testRecord testSnapshotUpdate testIter testMaxIterOpt testMinIter testMaxTimeOpt testMinTimeOpt testTags testModules testNames =
+      TestOptions
+        { testCompile = testCompile
+        , testShowLog = testShowLog
+        , testShowCached = testShowCached
+        , testNoCache = testNoCache
+        , testJson = testJson
+        , testRecord = testRecord
+        , testSnapshotUpdate = testSnapshotUpdate
+        , testIter = testIter
+        , testMaxIter = fromMaybe (10^6) testMaxIterOpt
+        , testMinIter = testMinIter
+        , testMaxTime = fromMaybe 1000 testMaxTimeOpt
+        , testMinTime = fromMaybe 50 testMinTimeOpt
+        , testTags = testTags
+        , testMaxIterSet = isJust testMaxIterOpt
+        , testMaxTimeSet = isJust testMaxTimeOpt
+        , testMinTimeSet = isJust testMinTimeOpt
+        , testModules = testModules
+        , testNames = testNames
+        }
 
 depOverrideReader :: ReadM (String,String)
 depOverrideReader = eitherReader $ \s ->

--- a/docs/acton-guide/src/SUMMARY.md
+++ b/docs/acton-guide/src/SUMMARY.md
@@ -67,6 +67,7 @@
   - [Failures vs errors](testing/failures_errors.md)
   - [Flaky tests](testing/flaky.md)
   - [Performance testing](testing/performance.md)
+  - [Stress testing](testing/stress.md)
   - [Perf comparison](testing/perf_record.md)
 - [Build System](compilation.md)
   - [Incremental compilation](compilation/incremental.md)

--- a/docs/acton-guide/src/testing/performance.md
+++ b/docs/acton-guide/src/testing/performance.md
@@ -34,3 +34,5 @@ All 1 tests passed (1.571s)
 
 ```
 (note that the output is rather wide, scroll horizontally to see the full output)
+
+See [Stress testing](stress.md) for concurrency-focused stress runs.

--- a/docs/acton-guide/src/testing/stress.md
+++ b/docs/acton-guide/src/testing/stress.md
@@ -1,0 +1,66 @@
+# Stress testing
+
+Stress testing is meant for concurrency bugs, especially race conditions in FFI / C integrations.
+
+Run it with:
+
+```sh
+acton test stress
+```
+
+## How stress mode runs
+
+- Runs one test function/actor at a time.
+- For that test, starts multiple concurrent workers of the same test in one process.
+- Worker count defaults to roughly `nr_wthreads / 2`.
+- Stress runs are always fresh (no test-result cache reuse).
+- By default, stress runs for up to 5 seconds per test (`--max-time 5000`).
+- Continuous mode is available with `--max-time 0`.
+- In continuous mode, `--max-iter` is unbounded unless you set it.
+- The default stress `--min-time` is 1 second unless overridden (used for calibration; stress run length is controlled by `--max-time`).
+
+## Worker scheduling
+
+Stress workers are split into:
+
+- A no-drift cohort (at least 2 workers, scaling to roughly 25% of workers)
+- A staggered-drift cohort (small per-iteration microsecond offsets)
+
+This combines synchronized overlap windows with evolving offsets over time.
+
+## Per-worker live stats
+
+In an interactive terminal, stress mode shows one live status line per worker.
+
+- sync worker line: `wN sync RUN/DONE ... @ RATE/s cur=0us tot=0us`
+- drift worker line: `wN drift RUN/DONE ... @ RATE/s cur=DRIFTus tot=TOTALus`
+
+The main test line also carries a compact worker summary:
+
+- total: `... RUNS runs in DURATIONms @ RATE/s`
+- worker mix: `workers=N (sync=S drift=D)`
+- iteration estimate, granularity and observed coverage: `iter~...ms coarse~...ms sweep=... calib=... cov=SEEN/TOTAL(PCTpct)`
+  - `iter~` is a moving estimate of one test iteration duration
+  - `coarse~` is the current phase coarseness (lower is finer)
+  - in continuous mode (`--max-time 0`), `coarse~` decreases stepwise over time as sweep depth increases
+  - `cov` is observed occupied phase bins at current coarseness (resets when coarseness is refined)
+
+Example:
+
+```txt
+racy_sum: RUN : 2400 runs in 1500.000ms @ 1600.0/s | workers=8 (sync=2 drift=6) iter~2.340ms coarse~0.037ms sweep=64 cov=37/64(57.8pct)
+```
+
+Use normal test flags to tune duration/iterations, for example:
+
+```sh
+acton test stress --max-time 30000 --min-iter 100
+```
+
+Run continuously until interrupted:
+
+```sh
+acton test stress --max-time 0
+```
+
+Press `Ctrl-C` to stop and print the partial stress result collected so far.

--- a/test/test_stress/.gitignore
+++ b/test/test_stress/.gitignore
@@ -1,0 +1,3 @@
+build.zig
+build.zig.zon
+out

--- a/test/test_stress/Build.act
+++ b/test/test_stress/Build.act
@@ -1,0 +1,2 @@
+name = "test_stress"
+fingerprint = 0xe5cbf482bef1a3c8

--- a/test/test_stress/README.md
+++ b/test/test_stress/README.md
@@ -1,0 +1,28 @@
+# test_stress
+
+Single Acton project used to exercise `acton test stress`.
+
+## Modules
+
+- `test_racy_ffi`: intentionally racy FFI behaviors (value races / publication races)
+- `test_segv_ffi`: stress-only parallel overlap path that crashes with `SIGSEGV`
+
+## Run
+
+Normal test mode (expected to pass):
+
+```sh
+../../dist/bin/acton test --module test_racy_ffi --module test_segv_ffi
+```
+
+Stress mode on race module (expected fail/flaky):
+
+```sh
+../../dist/bin/acton test stress --module test_racy_ffi --show-log
+```
+
+Stress mode on segfault module (expected process error `-11`):
+
+```sh
+../../dist/bin/acton test stress --module test_segv_ffi --show-log
+```

--- a/test/test_stress/src/racy_ffi.act
+++ b/test/test_stress/src/racy_ffi.act
@@ -1,0 +1,13 @@
+# Intentionally implemented in C via racy_ffi.ext.c
+
+def racy_sum(n: int) -> int:
+    NotImplemented
+
+def racy_format(n: int) -> str:
+    NotImplemented
+
+def subtle_lazy_magic() -> int:
+    NotImplemented
+
+def subtle_cache_mix(n: int) -> int:
+    NotImplemented

--- a/test/test_stress/src/racy_ffi.ext.c
+++ b/test/test_stress/src/racy_ffi.ext.c
@@ -1,0 +1,110 @@
+// Intentionally buggy C implementations used to stress-test Acton FFI calls.
+// These are expected to be flaky under concurrent execution.
+
+#include <stdio.h>
+#include <time.h>
+
+static int64_t shared_accumulator = 0;
+static char shared_fmt_buf[128];
+static int lazy_reset_counter = 0;
+
+static struct {
+    int ready;
+    int64_t hi;
+    int64_t lo;
+} lazy_magic_state = {0, 0, 0};
+
+static struct {
+    int valid;
+    int64_t key;
+    int64_t value;
+} subtle_cache_state = {0, 0, 0};
+
+static inline void tiny_pause(int loops) {
+    for (volatile int i = 0; i < loops; i++) {
+    }
+}
+
+static inline int64_t mix_formula(int64_t n) {
+    return (n * 1103515245LL + 12345LL) & 0x7fffffffLL;
+}
+
+void racy_ffiQ___ext_init__() {
+    shared_accumulator = 0;
+    shared_fmt_buf[0] = '\0';
+    lazy_reset_counter = 0;
+    lazy_magic_state.ready = 0;
+    lazy_magic_state.hi = 0;
+    lazy_magic_state.lo = 0;
+    subtle_cache_state.valid = 0;
+    subtle_cache_state.key = 0;
+    subtle_cache_state.value = 0;
+}
+
+// Intentionally racy: shared mutable state in a function that should behave as
+// a pure computation.
+int64_t racy_ffiQ_U_racy_sum(int64_t U_1n) {
+    shared_accumulator = 0;
+    for (int64_t i = 1; i <= U_1n; i++) {
+        shared_accumulator += i;
+        if ((i & 15) == 0) {
+            struct timespec ts = {0, 50000};  // 50 us
+            nanosleep(&ts, NULL);
+        }
+    }
+    return shared_accumulator;
+}
+
+// Intentionally racy: shared global formatting buffer used across threads.
+B_str racy_ffiQ_U_2racy_format(int64_t U_3n) {
+    int64_t sq = U_3n * U_3n;
+    snprintf(shared_fmt_buf, sizeof(shared_fmt_buf), "value:%lld:%lld",
+             (long long)U_3n, (long long)sq);
+
+    // Increase the race window so another worker can overwrite shared_fmt_buf.
+    struct timespec ts = {0, 200000};  // 200 us
+    nanosleep(&ts, NULL);
+
+    return to$str(shared_fmt_buf);
+}
+
+// Subtle publication race:
+// We deliberately set "ready" before fully initializing the payload.
+// Under concurrency, another worker can observe ready=1 and read partial state.
+int64_t racy_ffiQ_U_4subtle_lazy_magic() {
+    int rc = lazy_reset_counter++;
+    if ((rc & 1023) == 0) {
+        lazy_magic_state.ready = 0;
+        lazy_magic_state.hi = 0;
+        lazy_magic_state.lo = 0;
+    }
+
+    if (!lazy_magic_state.ready) {
+        lazy_magic_state.ready = 1;  // intentionally published too early
+        tiny_pause(1600);
+        lazy_magic_state.hi = 0x5A00;
+        tiny_pause(2200);
+        lazy_magic_state.lo = 0x5A;
+    }
+
+    tiny_pause(500);
+    return lazy_magic_state.hi + lazy_magic_state.lo;
+}
+
+// Subtle torn cache race:
+// key/valid/value are updated in a non-atomic order. Under stress, readers can
+// observe key from one write and value from another.
+int64_t racy_ffiQ_U_5subtle_cache_mix(int64_t U_6n) {
+    if (subtle_cache_state.valid && subtle_cache_state.key == U_6n) {
+        tiny_pause(300 + (int)(U_6n & 31) * 16);
+        return subtle_cache_state.value;
+    }
+
+    int64_t val = mix_formula(U_6n);
+    subtle_cache_state.valid = 1;  // intentionally published early
+    subtle_cache_state.key = U_6n;
+    tiny_pause(400 + (int)(U_6n & 31) * 18);
+    subtle_cache_state.value = val;
+    tiny_pause(300 + (int)((U_6n + 7) & 31) * 12);
+    return val;
+}

--- a/test/test_stress/src/segv_ffi.act
+++ b/test/test_stress/src/segv_ffi.act
@@ -1,0 +1,4 @@
+# Intentionally implemented in C via segv_ffi.ext.c
+
+def maybe_crash_if_parallel(n: int) -> int:
+    NotImplemented

--- a/test/test_stress/src/segv_ffi.ext.c
+++ b/test/test_stress/src/segv_ffi.ext.c
@@ -1,0 +1,27 @@
+// Intentionally crashy FFI helper for stress-testing.
+// Passes in normal single-worker mode, segfaults when concurrent calls overlap.
+
+#include <signal.h>
+
+static int active_calls = 0;
+
+static inline void hold_window() {
+    for (volatile int i = 0; i < 300000; i++) {
+    }
+}
+
+void segv_ffiQ___ext_init__() {
+    active_calls = 0;
+}
+
+int64_t segv_ffiQ_U_maybe_crash_if_parallel(int64_t U_1n) {
+    __sync_add_and_fetch(&active_calls, 1);
+    hold_window();
+    if (__sync_fetch_and_add(&active_calls, 0) > 1) {
+        signal(SIGSEGV, SIG_DFL);
+        raise(SIGSEGV);
+    }
+    hold_window();
+    __sync_sub_and_fetch(&active_calls, 1);
+    return U_1n + 1;
+}

--- a/test/test_stress/src/test_racy_ffi.act
+++ b/test/test_stress/src/test_racy_ffi.act
@@ -1,0 +1,25 @@
+import testing
+import racy_ffi
+
+def _tri(n: int) -> int:
+    return (n * (n + 1)) // 2
+
+def _mix(n: int) -> int:
+    return ((n * 1103515245 + 12345) & 0x7fffffff)
+
+def _test_racy_sum():
+    for n in range(300, 340):
+        testing.assertEqual(racy_ffi.racy_sum(n), _tri(n))
+
+def _test_racy_format():
+    for n in range(200, 260):
+        testing.assertEqual(racy_ffi.racy_format(n), "value:" + str(n) + ":" + str(n * n))
+
+def _test_subtle_lazy_magic():
+    for i in range(2000):
+        testing.assertEqual(racy_ffi.subtle_lazy_magic(), 23130)
+
+def _test_subtle_cache_mix():
+    for i in range(6000):
+        n = 200 + (i % 23)
+        testing.assertEqual(racy_ffi.subtle_cache_mix(n), _mix(n))

--- a/test/test_stress/src/test_segv_ffi.act
+++ b/test/test_stress/src/test_segv_ffi.act
@@ -1,0 +1,7 @@
+import testing
+import segv_ffi
+
+def _test_parallel_only_segv():
+    for i in range(120):
+        n = i % 127
+        testing.assertEqual(segv_ffi.maybe_crash_if_parallel(n), n + 1)

--- a/test/test_stress/src/test_simple.act
+++ b/test/test_stress/src/test_simple.act
@@ -1,0 +1,11 @@
+import testing
+
+def _test_foo():
+    a = 0
+    for i in range(99999):
+        a += 1
+
+def _test_bar():
+    a = 0
+    for i in range(99999):
+        a += 1


### PR DESCRIPTION
Acton's existing test flow is strong for functional correctness, but it can under-exercise concurrency faults when tests run in isolation. That is a blind spot for races in shared state, FFI boundaries, and C threading behavior where failures often require specific overlap timing. A dedicated stress mode is needed to repeatedly run the same test under coordinated parallel pressure so these bugs surface earlier and more reliably.

This adds a dedicated stress testing mode to acton test and integrates it through the CLI parser, test runner, runtime test executor, and documentation.

Stress mode runs one test function at a time at the outer runner layer, launches concurrent workers for that test, and skips reuse of cached results. Mode-specific defaults are now applied only when users omit flags: run keeps 50 ms behavior, perf defaults to 1 s, and stress defaults to --max-time 0 for continuous execution.

The stress executor now uses sync and drift worker cohorts, performs calibration from measured iteration durations, applies startup offsets, and reports richer live telemetry. Continuous stress runs refine phase granularity over time and include observed phase-bin coverage.

Interrupt handling was updated so Ctrl-C in stress mode returns valid partial results instead of failing the run.

A dedicated test project under test/test_stress was added with simple, racy FFI, and stress-only segfault fixtures to exercise stress behavior. The Acton guide now includes a separate stress testing chapter and links from performance testing docs.

Fixes #2577 

Closes #1914