### PR TITLE
Eliminate RTS Msg waiting gap

### DIFF
--- a/base/rts/rts.c
+++ b/base/rts/rts.c
@@ -1664,18 +1664,20 @@ void wt_work_cb(uv_check_t *ev) {
                     if(ret == VAL_STATUS_COMMIT)
                         success = 1;
                 }
-                FLUSH_outgoing_local(current);
             } else {
 #endif
                 reverse_outgoing_queue(current);
-                FLUSH_outgoing_local(current);
 #ifdef ACTON_DB
             }
 #endif
             m->$cont = r.cont;
             B_Msg x = (B_Msg)r.value;
             assert(x != NULL);
-            if (ADD_waiting(current, x)) {      // x->cont is a proper $Cont: x is still being processed so current was added to x->waiting
+
+            bool added_waiting = ADD_waiting(current, x);
+            FLUSH_outgoing_local(current);
+
+            if (added_waiting) {      // x->cont is a proper $Cont: x is still being processed so current was added to x->waiting
                 rtsd_printf("## AWAIT actor %ld : %s", current->$globkey, current->$class->$GCINFO);
             } else if (EXCEPTIONAL(x)) {        // x->cont == MARK_EXCEPTION: x->value holds the raised exception, current is not in x->waiting
                 rtsd_printf("## AWAIT/fail actor %ld : %s", current->$globkey, current->$class->$GCINFO);


### PR DESCRIPTION
An exception raised in an actor method that was awaited upon could still be reported as an unhandled exception - this is now fixed.

In the shared `$RWAIT` path we flushed buffered local outgoing messages before calling `ADD_waiting(current, x)`. That left a window where a freshly sent callee could run and raise before the caller had been linked into `x->$waiting`. When that happened the callee printed `Unhandled exception in actor` even though the same awaiting actor would immediately observe `x` as exceptional and handle that exception on its own path.

The actual control flow was never incorrect. The awaiting caller would still get the result of the awaited Msg, i.e. an exception and act accordingly. The issue was only that the called actor, which raised the exception, would observe that it was not being waited upon at that particular time and thus print the "Unhandled exception" message, purely cosmetic, but nonetheless somewhat confusing.

This change reorders the operations, records the result of `ADD_waiting(current, x)` before `FLUSH_outgoing_local(current)` and then reuses that saved state for the existing await / exceptional / wakeup branches. Control flow is the same but we eliminate the gap that spuriously caused the message to be printed.