### PR TITLE
Use canonical dep roots in build.zig.zon

### DIFF
--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -1438,6 +1438,7 @@ runCliPostCompile cliHooks gopts plan env = do
         depModuleOptsByProj = depModuleOptionsByProj selectedTasksByProj projMap
         rootModuleEntries = selectedCSourceEntriesForProj rootProj (M.findWithDefault [] rootProj selectedTasksByProj)
         rootDepModuleOpts = M.findWithDefault M.empty rootProj depModuleOptsByProj
+        rootDepPathOverrides = projectDepPathOverrides projMap rootProj
     -- Generate build.zig(.zon) for dependencies too, to satisfy Zig builder links.
     let projKeys = Data.Set.fromList (map (tkProj . gtKey) globalTasks)
     forM_ (Data.Set.toList projKeys) $ \p -> do
@@ -1450,7 +1451,8 @@ runCliPostCompile cliHooks gopts plan env = do
               logLine ("Generating build.zig for dependency project " ++ p)
             dummyPaths <- pathsForModule opts' projMap pctx (A.modName ["__gen_build__"])
             let depOpts = M.findWithDefault M.empty p depModuleOptsByProj
-            genBuildZigFiles (projBuildSpec pctx) rootPins (ccDepOverrides cctx) dummyPaths depOpts
+                depPathOverrides = projectDepPathOverrides projMap p
+            genBuildZigFiles (projBuildSpec pctx) rootPins (ccDepOverrides cctx) dummyPaths depOpts depPathOverrides
           Nothing -> return ()
     let runFinal action = do
           cchFinalStart cliHooks
@@ -1464,10 +1466,10 @@ runCliPostCompile cliHooks gopts plan env = do
           then do
             testBinTasks <- catMaybes <$> mapM (filterMainActor env pathsRoot) preTestBinTasks
             unless (altOutput opts') $
-              runFinal (compileBins gopts opts' pathsRoot env rootSpec rootTasks testBinTasks allowPrune' rootModuleEntries rootDepModuleOpts (Just (cchProgressUI cliHooks)))
+              runFinal (compileBins gopts opts' pathsRoot env rootSpec rootTasks testBinTasks allowPrune' rootModuleEntries rootDepModuleOpts rootDepPathOverrides (Just (cchProgressUI cliHooks)))
           else do
             unless (altOutput opts') $
-              runFinal (compileBins gopts opts' pathsRoot env rootSpec rootTasks preBinTasks allowPrune' rootModuleEntries rootDepModuleOpts (Just (cchProgressUI cliHooks)))
+              runFinal (compileBins gopts opts' pathsRoot env rootSpec rootTasks preBinTasks allowPrune' rootModuleEntries rootDepModuleOpts rootDepPathOverrides (Just (cchProgressUI cliHooks)))
 -- Generate documentation index for a project build by reading module docstrings
 -- from the current tasks. Uses TyTask header docs when available to avoid
 -- parsing/decoding; falls back to extracting from ActonTask ASTs.
@@ -1535,6 +1537,27 @@ depModuleOptionsByProj tasksByProj projMap =
         ]
     mkCsv depProj =
       intercalate "," (selectedCSourceEntriesForProj depProj (M.findWithDefault [] depProj tasksByProj))
+
+-- | Canonical package dependency roots reachable from one project.
+--
+-- These paths come from project discovery, so they already reflect root pin
+-- overrides and fingerprint deduplication. Reusing them for build.zig.zon keeps
+-- Zig pointed at the same dependency roots where we generated build.zig files.
+projectDepPathOverrides :: M.Map FilePath ProjCtx -> FilePath -> M.Map String FilePath
+projectDepPathOverrides projMap rootProj = snd (go Data.Set.empty rootProj M.empty)
+  where
+    go seen proj acc
+      | Data.Set.member proj seen = (seen, acc)
+      | otherwise =
+          case M.lookup proj projMap of
+            Nothing -> (Data.Set.insert proj seen, acc)
+            Just ctx ->
+              let seen' = Data.Set.insert proj seen
+              in foldl' step (seen', acc) (projDeps ctx)
+
+    step (seen, acc) (depName, depProj) =
+      let acc' = M.insertWith (\_ old -> old) depName depProj acc
+      in go seen depProj acc'
 
 -- | Remove orphaned files in out/types.
 -- Non-root files are removed if their module isn’t part of this build (i.e.
@@ -1667,9 +1690,9 @@ High-level Steps
 ================================================================================
 -}
 
-compileBins:: C.GlobalOptions -> C.CompileOptions -> Paths -> Acton.Env.Env0 -> BuildSpec.BuildSpec -> [CompileTask] -> [BinTask] -> Bool -> [FilePath] -> M.Map String String -> Maybe ProgressUI -> IO TimeSpec
-compileBins gopts opts paths env rootSpec tasks binTasks allowPrune rootModules depModuleOpts mProgressUI =
-    zigBuild env gopts opts paths rootSpec tasks binTasks allowPrune rootModules depModuleOpts mProgressUI
+compileBins:: C.GlobalOptions -> C.CompileOptions -> Paths -> Acton.Env.Env0 -> BuildSpec.BuildSpec -> [CompileTask] -> [BinTask] -> Bool -> [FilePath] -> M.Map String String -> M.Map String FilePath -> Maybe ProgressUI -> IO TimeSpec
+compileBins gopts opts paths env rootSpec tasks binTasks allowPrune rootModules depModuleOpts depPathOverrides mProgressUI =
+    zigBuild env gopts opts paths rootSpec tasks binTasks allowPrune rootModules depModuleOpts depPathOverrides mProgressUI
 
 printDiag :: C.GlobalOptions -> C.CompileOptions -> Diagnostic String -> IO ()
 printDiag gopts opts d = do
@@ -1810,10 +1833,10 @@ generateFingerprint name = do
         fp = (fromIntegral prefix `shiftL` 32) .|. fromIntegral ident
     return (Fingerprint.formatFingerprint fp)
 
--- Render build.zig and build.zig.zon from templates and BuildSpec
+-- Render build.zig and build.zig.zon from templates and BuildSpec.
 -- rootPins: dependency pins from the main project (applied to all deps, including transitive)
-genBuildZigFiles :: BuildSpec.BuildSpec -> M.Map String BuildSpec.PkgDep -> [(String, FilePath)] -> Paths -> M.Map String String -> IO ()
-genBuildZigFiles spec rootPins depOverrides paths depModuleOpts = do
+genBuildZigFiles :: BuildSpec.BuildSpec -> M.Map String BuildSpec.PkgDep -> [(String, FilePath)] -> Paths -> M.Map String String -> M.Map String FilePath -> IO ()
+genBuildZigFiles spec rootPins depOverrides paths depModuleOpts depPathOverrides = do
     let proj = projPath paths
     projAbs <- canonicalizePath proj
     let sys              = sysPath paths
@@ -1832,11 +1855,22 @@ genBuildZigFiles spec rootPins depOverrides paths depModuleOpts = do
     depsRootAbs <- normalizePathSafe (joinPath [homeDir, ".cache", "acton", "deps"])
     normalizedSpec <- normalizeSpecPaths proj spec
     let applyPins deps = M.mapWithKey (\n d -> M.findWithDefault d n rootPins) deps
-        mergedSpec = normalizedSpec { BuildSpec.dependencies     = applyPins (BuildSpec.dependencies normalizedSpec) `M.union` transPkgs
-                                    , BuildSpec.zig_dependencies = BuildSpec.zig_dependencies normalizedSpec `M.union` transZigs }
+        mergedSpec0 = normalizedSpec { BuildSpec.dependencies     = applyPins (BuildSpec.dependencies normalizedSpec) `M.union` transPkgs
+                                     , BuildSpec.zig_dependencies = BuildSpec.zig_dependencies normalizedSpec `M.union` transZigs }
+        mergedSpec = applyPkgDepPathOverrides projAbs depPathOverrides mergedSpec0
         zonWithFp = replace "{{fingerprint}}" fp . replace "{{name}}" zonName
     writeFile buildZigPath (genBuildZig buildZigTemplate mergedSpec depModuleOpts)
     writeFileAtomic buildZonPath (genBuildZigZon buildZonTemplate relSys depsRootAbs projAbs fp zonName mergedSpec)
+
+applyPkgDepPathOverrides :: FilePath -> M.Map String FilePath -> BuildSpec.BuildSpec -> BuildSpec.BuildSpec
+applyPkgDepPathOverrides projRoot depPathOverrides spec =
+    spec { BuildSpec.dependencies = M.mapWithKey rewriteDep (BuildSpec.dependencies spec) }
+  where
+    rewriteDep depName dep =
+      case M.lookup depName depPathOverrides of
+        Nothing -> dep
+        Just depPath ->
+          dep { BuildSpec.path = Just (collapseDots (makeRelativeOrAbsolute projRoot depPath)) }
 
 genBuildZig :: String -> BuildSpec.BuildSpec -> M.Map String String -> String
 genBuildZig template spec depModuleOpts =
@@ -1948,8 +1982,8 @@ defCpuFlag = ["-Dcpu=x86_64_v2+aes"]
 #endif
 
 -- | Run zig build for generated artifacts and prune stale outputs.
-zigBuild :: Acton.Env.Env0 -> C.GlobalOptions -> C.CompileOptions -> Paths -> BuildSpec.BuildSpec -> [CompileTask] -> [BinTask] -> Bool -> [FilePath] -> M.Map String String -> Maybe ProgressUI -> IO TimeSpec
-zigBuild env gopts opts paths rootSpec tasks binTasks allowPrune rootModules depModuleOpts mProgressUI = do
+zigBuild :: Acton.Env.Env0 -> C.GlobalOptions -> C.CompileOptions -> Paths -> BuildSpec.BuildSpec -> [CompileTask] -> [BinTask] -> Bool -> [FilePath] -> M.Map String String -> M.Map String FilePath -> Maybe ProgressUI -> IO TimeSpec
+zigBuild env gopts opts paths rootSpec tasks binTasks allowPrune rootModules depModuleOpts depPathOverrides mProgressUI = do
     allBinTasks <- mapM (writeRootC env gopts opts paths tasks) binTasks
     let realBinTasks = catMaybes allBinTasks
 
@@ -1981,7 +2015,7 @@ zigBuild env gopts opts paths rootSpec tasks binTasks allowPrune rootModules dep
     -- Generate build.zig and build.zig.zon directly from Build.act.
     iff (not isSysProj) $ do
       let pins = BuildSpec.dependencies rootSpec
-      genBuildZigFiles rootSpec pins depOverrides paths depModuleOpts
+      genBuildZigFiles rootSpec pins depOverrides paths depModuleOpts depPathOverrides
 
     let zigExe = zig paths
         baseArgs = ["build","--cache-dir", local_cache_dir,

--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -149,6 +149,80 @@ compilerTests =
             ("not present in Zig cache after fetch" `isInfixOf` cmdErr)
           assertBool "should not fail with missing Build.act in unresolved deps cache path"
             (not ("Missing Build.act in " `isInfixOf` cmdErr))
+  , testCase "build.zig.zon uses canonical dep roots" $ do
+        withSystemTempDirectory "acton-buildzig-zon-dedup" $ \tmp -> do
+          actonExe <- canonicalizePath "../../dist/bin/acton"
+          env0 <- getEnvironment
+          let homeDir = tmp </> "home"
+              rootProj = tmp </> "root"
+              depKeep = rootProj </> "dep_keep"
+              midProj = rootProj </> "mid"
+              depDrop = tmp </> "dep_drop"
+              envWithHome = ("HOME", homeDir) : filter ((/= "HOME") . fst) env0
+              mkFp name = Fingerprint.formatFingerprint
+                (Fingerprint.updateFingerprintPrefix
+                  (Fingerprint.fingerprintPrefixForName name) 1)
+              writeBuildActAt :: FilePath -> String -> [(String, FilePath)] -> IO ()
+              writeBuildActAt dir name deps = do
+                createDirectoryIfMissing True (dir </> "src")
+                let depsBody = intercalate ",\n"
+                      [ "    \"" ++ depName ++ "\": (\n"
+                        ++ "        path=" ++ show depPath ++ "\n"
+                        ++ "    )"
+                      | (depName, depPath) <- deps
+                      ]
+                    depsSection =
+                      if null deps
+                        then "dependencies = {}"
+                        else "dependencies = {\n" ++ depsBody ++ "\n}"
+                writeFile (dir </> "Build.act") $ unlines
+                  [ "name = " ++ show name
+                  , "fingerprint = " ++ mkFp name
+                  , ""
+                  , depsSection
+                  , ""
+                  , "zig_dependencies = {}"
+                  ]
+              runBuild dir = readCreateProcessWithExitCode
+                (proc actonExe ["build", "--always-build"]) { cwd = Just dir, env = Just envWithHome } ""
+
+          createDirectoryIfMissing True homeDir
+
+          writeBuildActAt depKeep "dep" []
+          writeFile (depKeep </> "src" </> "dep.act") $ unlines
+            [ "def keep() -> int:"
+            , "    return 1"
+            ]
+
+          writeBuildActAt depDrop "dep" []
+          writeFile (depDrop </> "src" </> "dep.act") $ unlines
+            [ "def drop() -> int:"
+            , "    return 2"
+            ]
+
+          writeBuildActAt midProj "mid" [("dep", depDrop)]
+          writeFile (midProj </> "src" </> "mid.act") $ unlines
+            [ "def marker() -> int:"
+            , "    return 41"
+            ]
+
+          writeBuildActAt rootProj "root_proj" [("dep", depKeep), ("mid", midProj)]
+          writeFile (rootProj </> "src" </> "main.act") $ unlines
+            [ "import mid"
+            , ""
+            , "actor main(env):"
+            , "    env.exit(mid.marker())"
+            ]
+
+          (returnCode, cmdOut, cmdErr) <- runBuild rootProj
+          when (returnCode /= ExitSuccess) $
+            assertFailure ("root build failed:\nstdout:\n" ++ cmdOut ++ "\nstderr:\n" ++ cmdErr)
+
+          midBuildZon <- readFile (midProj </> "build.zig.zon")
+          assertBool "mid build.zig.zon should point at the canonical dep root"
+            ("dep_keep" `isInfixOf` midBuildZon)
+          assertBool "mid build.zig.zon should not keep the overridden raw dep path"
+            (not ("dep_drop" `isInfixOf` midBuildZon))
   , testCase "path dep build ignores stale dep out/types modules" $ do
         withSystemTempDirectory "acton-stale-path-dep" $ \tmp ->
           do


### PR DESCRIPTION
Deduplicated package dependencies could still be written to build.zig.zon using the raw path from a transitive Build.act. When that raw path differed from the canonical project root chosen during discovery, Acton generated build.zig only for the canonical directory while Zig later loaded the non-canonical one and found no ActonProject artifact to link.

This change carries canonical dependency roots from project discovery into build.zig generation and rewrites package paths in the merged spec before writing build.zig.zon. Dependency builds and the final project build now agree on which package root each dep name resolves to.

Using the discovered roots keeps root pin overrides and fingerprint deduplication aligned across build planning and Zig package resolution, so transitive deps that collapse to one cache entry still export the artifacts their parents expect.

Fixes #2668