### PR TITLE
Improve stress test + add visualization

### DIFF
--- a/base/src/testing.act
+++ b/base/src/testing.act
@@ -730,7 +730,9 @@ class TestInfo(object):
     def update(self, complete, result: TestResult, test_duration: float=-1.0):
         self.complete = complete
 
-        if len(self.results) == 0:
+        first_result = len(self.results) == 0
+        prev_iterations = self.num_iterations
+        if first_result:
             # First result
             self.output = result.output
             self.exception = result.exception
@@ -741,48 +743,41 @@ class TestInfo(object):
         if not eq_opt(self.output, result.output):
             self.flaky_output = True
 
+        if self.exception is None and result.exception is not None:
+            self.exception = result.exception
+        if self.skip_reason is None and result.skip_reason is not None:
+            self.skip_reason = result.skip_reason
+
         if test_duration > 0.0:
             self.test_duration = test_duration
 
-        self.flaky = False
-        self.leaky = False
-        self.min_duration = -1.0
-        self.max_duration = -1.0
-        self.avg_duration = -1.0
-        self.total_duration = 0.0
-        self.num_iterations = int(len(self.results))
-        self.num_skipped = 0
-        self.num_failures = 0
-        self.num_errors = 0
-        self.mem_usage_delta_avg = 0
-        self.non_gc_mem_usage_delta_avg = 0
-        self.non_gc_mem_inc_count = 0
-        for result in self.results:
-            if result.skipped:
-                self.num_skipped += 1
-                if self.skip_reason is None:
-                    self.skip_reason = result.skip_reason
-            elif result.success == False:
-                self.num_failures += 1
-            elif result.success is None:
-                self.num_errors += 1
+        self.num_iterations = prev_iterations + 1
+        if result.skipped:
+            self.num_skipped += 1
+        elif result.success == False:
+            self.num_failures += 1
+        elif result.success is None:
+            self.num_errors += 1
 
-        for result in self.results[1:]:
+        if first_result:
+            self.min_duration = result.duration
+            self.max_duration = result.duration
+            self.total_duration = result.duration
+            self.avg_duration = result.duration
+            self.mem_usage_delta_avg = result.mem_usage_delta
+            self.non_gc_mem_usage_delta_avg = result.non_gc_mem_usage_delta
+            self.non_gc_mem_inc_count = 1 if result.non_gc_mem_usage_delta > 0 else 0
+        else:
             if result.duration < self.min_duration or self.min_duration < 0.0:
                 self.min_duration = result.duration
             if result.duration > self.max_duration or self.max_duration < 0.0:
                 self.max_duration = result.duration
             self.total_duration += result.duration
-
-            self.mem_usage_delta_avg += result.mem_usage_delta
-            self.non_gc_mem_usage_delta_avg += result.non_gc_mem_usage_delta
+            self.avg_duration = self.total_duration / float(self.num_iterations)
+            self.mem_usage_delta_avg = ((self.mem_usage_delta_avg * prev_iterations) + result.mem_usage_delta) // self.num_iterations
+            self.non_gc_mem_usage_delta_avg = ((self.non_gc_mem_usage_delta_avg * prev_iterations) + result.non_gc_mem_usage_delta) // self.num_iterations
             if result.non_gc_mem_usage_delta > 0:
                 self.non_gc_mem_inc_count += 1
-
-        if self.num_iterations > 0:
-            self.mem_usage_delta_avg = self.mem_usage_delta_avg // self.num_iterations-1
-            self.non_gc_mem_usage_delta_avg = self.non_gc_mem_usage_delta_avg // self.num_iterations-1
-            self.avg_duration = self.total_duration / float(self.num_iterations)
 
         if self.non_gc_mem_inc_count > min_def([1, self.num_iterations // 2],1) and self.non_gc_mem_usage_delta_avg > 0:
             self.leaky = True
@@ -1027,7 +1022,7 @@ actor TestExecutor(syscap, config, t: Test, report_complete, report_progress, en
     var stress_calib_samples = 0
     var stress_calib_target_samples = 4
     var stress_calibrating = config.stress_mode and not config.perf_mode and executor_id >= stress_nodrift_workers
-    var stress_refine_continuous = config.stress_mode and not config.perf_mode and config.max_time <= 0.0 and executor_id >= stress_nodrift_workers
+    var stress_refine_enabled = config.stress_mode and not config.perf_mode and executor_id >= stress_nodrift_workers
     var stress_refine_next_iter = 0
     var stress_refine_max_sweep_iters = 0
 
@@ -1047,8 +1042,44 @@ actor TestExecutor(syscap, config, t: Test, report_complete, report_progress, en
         stress_phase_resolution_us = stress_base_drift_us
         stress_worker_drift_us = stress_base_drift_us * (stress_drift_rank + 1)
 
+    def _stress_plan_time_s() -> float:
+        if config.max_time > 0.0:
+            return config.max_time
+        if config.min_time > 0.0:
+            return config.min_time
+        return 1.0
+
+    def _stress_round_down_pow2(n: int) -> int:
+        if n <= 1:
+            return 1
+        p = 1
+        while p <= n // 2:
+            p *= 2
+        return p
+
+    def _stress_planned_total_iters() -> int:
+        if stress_est_iter_ms <= 0.0:
+            return 0
+        plan_time_s = _stress_plan_time_s()
+        if plan_time_s <= 0.0:
+            return 0
+        return max([16, int((plan_time_s * 1000.0) / max([0.1, stress_est_iter_ms]))])
+
+    def _stress_refine_cap_iters() -> int:
+        if stress_est_iter_ms <= 0.0:
+            return 0
+        # A 1us phase step is the practical ceiling of the current delay model.
+        est_phase_cap = max([1, int(stress_est_iter_ms * 1000.0)])
+        if config.max_time <= 0.0:
+            return est_phase_cap
+        planned_iters = _stress_planned_total_iters()
+        if planned_iters <= 0:
+            return est_phase_cap
+        planned_cap = max([1, _stress_round_down_pow2(planned_iters)])
+        return max([1, min([est_phase_cap, planned_cap])])
+
     def _maybe_refine_stress_phase(completed_iterations: int):
-        if not stress_refine_continuous or stress_calibrating:
+        if not stress_refine_enabled or stress_calibrating:
             return
         if stress_base_drift_us <= 1:
             return
@@ -1070,7 +1101,7 @@ actor TestExecutor(syscap, config, t: Test, report_complete, report_progress, en
             return
         if stress_est_iter_ms <= 0.0:
             return
-        est_total_iters = max([16, int((config.min_time * 1000.0) / max([0.1, stress_est_iter_ms]))])
+        est_total_iters = _stress_planned_total_iters()
         if est_total_iters >= 512:
             stress_target_sweep_iters = 256
         elif est_total_iters >= 128:
@@ -1080,9 +1111,9 @@ actor TestExecutor(syscap, config, t: Test, report_complete, report_progress, en
 
         _set_stress_sweep_iters(stress_target_sweep_iters)
         stress_startup_offset_us = max([0, int((stress_est_iter_ms * 1000.0) * float(stress_drift_rank + 1) / float(stress_drift_workers + 1))])
-        if stress_refine_continuous:
+        if stress_refine_enabled:
             stress_refine_next_iter = max([1, stress_target_sweep_iters])
-            stress_refine_max_sweep_iters = max([stress_target_sweep_iters, int(stress_est_iter_ms * 1000.0)])
+            stress_refine_max_sweep_iters = max([stress_target_sweep_iters, _stress_refine_cap_iters()])
         stress_calibrating = False
 
     def _stress_drift_delay() -> int:
@@ -1158,20 +1189,21 @@ actor TestExecutor(syscap, config, t: Test, report_complete, report_progress, en
             success = True
             exception = None
 
+        completed_iterations = iteration + 1
         complete = False
         if skipped:
             complete = True
         if config.stress_mode:
             if config.max_time > 0.0 and test_dur > config.max_time:
                 complete = True
-            if config.max_iter > 0 and iteration >= config.max_iter:
+            if config.max_iter > 0 and completed_iterations >= config.max_iter:
                 complete = True
         else:
-            if test_dur > config.min_time and iteration > config.min_iter:
+            if test_dur > config.min_time and completed_iterations > config.min_iter:
                 complete = True
             if config.max_time > 0 and test_dur > config.max_time:
                 complete = True
-            if config.max_iter > 0 and iteration >= config.max_iter:
+            if config.max_iter > 0 and completed_iterations >= config.max_iter:
                 complete = True
 
         if test_info is not None:
@@ -1179,22 +1211,26 @@ actor TestExecutor(syscap, config, t: Test, report_complete, report_progress, en
             test_info.update(complete, TestResult(success, exc, val, testiter_dur, mem_usage_delta, non_gc_mem_usage_delta, skipped=skipped, skip_reason=skip_reason), test_dur*1000.0)
             if config.stress_mode and not config.perf_mode and executor_id >= stress_nodrift_workers:
                 _maybe_refine_stress_phase(test_info.num_iterations)
+        iteration = completed_iterations
         if last_report.elapsed().to_float() > 0.05 or complete:
             if test_info is not None and config.output_enabled:
                 print("\n" + json.encode({"test_info": test_info.to_json()}), err=True)
             last_report.reset()
+        if config.stress_mode and (iteration == 1 or iteration % 32 == 0 or progress_report_sw.elapsed().to_float() > 0.08 or complete):
+            report_progress(executor_id,
+                            iteration,
+                            stress_last_drift_us,
+                            stress_total_drift_us,
+                            stress_est_iter_ms,
+                            stress_phase_resolution_us,
+                            stress_target_sweep_iters,
+                            stress_calibrating)
+            progress_report_sw.reset()
         if not complete:
-            _run_fn(test)
+            # Re-schedule the next iteration instead of recursing so stress
+            # workers stop promptly once they cross the time budget.
+            after 0: _run_fn(test)
         else:
-            if test_info is not None and config.stress_mode:
-                report_progress(executor_id,
-                                test_info.num_iterations,
-                                stress_last_drift_us,
-                                stress_total_drift_us,
-                                stress_est_iter_ms,
-                                stress_phase_resolution_us,
-                                stress_target_sweep_iters,
-                                stress_calibrating)
             report_complete(executor_id, t, test_info)
 
     def _run_fn(t: Test):
@@ -1228,17 +1264,6 @@ actor TestExecutor(syscap, config, t: Test, report_complete, report_progress, en
             _report_result(t, sw, non_gc_mem_usage_before, gc_total_bytes_start, gc_time_start, False, e, None)
         except Exception as e:
             _report_result(t, sw, non_gc_mem_usage_before, gc_total_bytes_start, gc_time_start, None, e, None)
-        iteration += 1
-        if config.stress_mode and (iteration == 1 or iteration % 32 == 0 or progress_report_sw.elapsed().to_float() > 0.08):
-            report_progress(executor_id,
-                            iteration,
-                            stress_last_drift_us,
-                            stress_total_drift_us,
-                            stress_est_iter_ms,
-                            stress_phase_resolution_us,
-                            stress_target_sweep_iters,
-                            stress_calibrating)
-            progress_report_sw.reset()
 
     def _run_test():
         """Get the next available test and run it"""
@@ -1750,6 +1775,7 @@ actor test_runner(env: Env,
         def _emit_stress_live():
             if not config.stress_mode or len(workers_complete) >= test_concurrency:
                 return
+            _update_stress_phase_coverage()
             payload = _stress_payload(combined_info)
             total_iterations = _total_worker_iterations()
             payload["complete"] = False
@@ -1786,7 +1812,6 @@ actor test_runner(env: Env,
                 if target_sweep_iters > 0:
                     worker_target_sweep_iters[executor_id] = target_sweep_iters
                 worker_calibrating[executor_id] = calibrating
-                _update_stress_phase_coverage()
 
         def _check_timeout():
             if test_timeout <= 0.0:
@@ -1807,6 +1832,7 @@ actor test_runner(env: Env,
                             0,
                             0),
                         time_s)
+                    _update_stress_phase_coverage()
                     payload = _stress_payload(combined_info)
                     payload["complete"] = True
                     payload["test_duration"] = time_s
@@ -1827,6 +1853,7 @@ actor test_runner(env: Env,
                     num_failures=0,
                     num_errors=1
                     )
+                _update_stress_phase_coverage()
                 payload = _stress_payload(timeout_info)
                 payload["num_iterations"] = max([timeout_info.num_iterations, _total_worker_iterations()])
                 print("\n" + json.encode({"test_info": payload}), err=True)
@@ -1859,6 +1886,7 @@ actor test_runner(env: Env,
             if len(workers_complete) >= test_concurrency:
                 combined_info.complete = True
                 combined_info.test_duration = combined_sw.elapsed().to_float() * 1000.0
+                _update_stress_phase_coverage()
                 payload = _stress_payload(combined_info)
                 payload["num_iterations"] = max([combined_info.num_iterations, _total_worker_iterations()])
                 print("\n" + json.encode({"test_info": payload}), err=True)

--- a/compiler/acton/TestFormat.hs
+++ b/compiler/acton/TestFormat.hs
@@ -141,6 +141,19 @@ formatSecondsCompact ms
       let secs = ms / 1000
       in show (max 1 (round secs :: Int)) ++ "s"
 
+formatSecondsCompactPadded :: Double -> Double -> String
+formatSecondsCompactPadded expectedMs actualMs =
+    let expected = formatSecondsCompact expectedMs
+        actual = formatSecondsCompact actualMs
+        width = max (length expected) (length actual)
+    in replicate (max 0 (width - length actual)) ' ' ++ actual
+
+formatMillisPadded :: Double -> Double -> String
+formatMillisPadded expectedMs actualMs =
+    let digits ms = max 1 (length (show (max 0 (floor ms :: Int))))
+        width = max (digits expectedMs) (digits actualMs) + 4
+    in printf ("%*.*fms" :: String) width (3 :: Int) actualMs
+
 fitTestDisplay :: Int -> String -> String
 fitTestDisplay width display
   | width <= 0 = ""
@@ -149,12 +162,12 @@ fitTestDisplay width display
   | otherwise = termFitPlainRight (width - 3) display ++ "..."
 
 -- | Format a single test result line with alignment and timing.
-formatTestLineWith :: Bool -> (TestResult -> String) -> Int -> String -> TestResult -> String
-formatTestLineWith useColor statusFn nameWidth display res =
+formatTestLineWith :: Bool -> (TestResult -> String) -> Double -> Int -> String -> TestResult -> String
+formatTestLineWith useColor statusFn expectedDurationMs nameWidth display res =
     let prefix0 = "   " ++ display ++ ": "
         padding = replicate (max 0 (nameWidth - length prefix0)) ' '
         statusRaw = statusFn res
-        runs = printf "%4d runs in %3.3fms @ %6.1f/s" (trNumIterations res) (trTestDuration res) (testsPerSecond (trNumIterations res) (trTestDuration res))
+        runs = printf "%4d runs in %s @ %6.1f/s" (trNumIterations res) (formatMillisPadded expectedDurationMs (trTestDuration res)) (testsPerSecond (trNumIterations res) (trTestDuration res))
         statusPart = colorizeStatusPart useColor (trCached res) statusRaw runs
         stressPart =
           case stressWorkerOverview res of
@@ -217,8 +230,8 @@ testsPerSecond iterations durationMs
   | otherwise = (fromIntegral iterations * 1000.0) / durationMs
 
 -- | Format a live test line to the current terminal width.
-formatTestLineFitted :: Bool -> (TestResult -> String) -> Int -> Int -> String -> TestResult -> String
-formatTestLineFitted useColor statusFn nameWidth width display res
+formatTestLineFitted :: Bool -> (TestResult -> String) -> Double -> Int -> Int -> String -> TestResult -> String
+formatTestLineFitted useColor statusFn expectedDurationMs nameWidth width display res
   | width <= 0 = ""
   | otherwise =
       fromMaybe fallback (firstFit (legacyLine : map alignedLine summaries ++ map compactLine summaries))
@@ -227,11 +240,11 @@ formatTestLineFitted useColor statusFn nameWidth width display res
     statusRaw = statusFn res
     (statusPlain, statusRendered) = renderStatusToken useColor (trCached res) statusRaw
     (statusFieldPlain, statusFieldRendered) = renderStatusField useColor (trCached res) statusRaw
-    duration = formatSecondsCompact (trTestDuration res)
+    duration = formatSecondsCompactPadded expectedDurationMs (trTestDuration res)
     summaryFull = show (trNumIterations res) ++ " runs " ++ duration
     summaryCompact = show (trNumIterations res) ++ "r " ++ duration
     summaries = [Just summaryFull, Just summaryCompact, Nothing]
-    legacyRendered = formatTestLineWith useColor statusFn nameWidth display res
+    legacyRendered = formatTestLineWith useColor statusFn expectedDurationMs nameWidth display res
     legacyLine
       | termVisibleLength legacyRendered <= width = Just legacyRendered
       | otherwise = Nothing
@@ -261,13 +274,13 @@ formatTestLineFitted useColor statusFn nameWidth width display res
       | width >= length statusPlain = statusRendered
       | otherwise = fitTestDisplay width display
 
-formatTestFinalLineRenderer :: Bool -> Int -> String -> TestResult -> Int -> String
-formatTestFinalLineRenderer useColor nameWidth display res cols =
-    formatTestLineFitted useColor formatTestStatus nameWidth cols display res
+formatTestFinalLineRenderer :: Bool -> Double -> Int -> String -> TestResult -> Int -> String
+formatTestFinalLineRenderer useColor expectedDurationMs nameWidth display res cols =
+    formatTestLineFitted useColor formatTestStatus expectedDurationMs nameWidth cols display res
 
-formatTestLiveLineRenderer :: Bool -> Int -> String -> TestResult -> Int -> String
-formatTestLiveLineRenderer useColor nameWidth display res cols =
-    formatTestLineFitted useColor formatTestStatusLive nameWidth cols display res
+formatTestLiveLineRenderer :: Bool -> Double -> Int -> String -> TestResult -> Int -> String
+formatTestLiveLineRenderer useColor expectedDurationMs nameWidth display res cols =
+    formatTestLineFitted useColor formatTestStatusLive expectedDurationMs nameWidth cols display res
 
 formatTestDetailLines :: Bool -> Bool -> TestResult -> [String]
 formatTestDetailLines useColor showLog res =

--- a/compiler/acton/TestRunner.hs
+++ b/compiler/acton/TestRunner.hs
@@ -40,7 +40,7 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import Data.Time.Clock (UTCTime)
 import Control.Exception (SomeException, AsyncException(..), displayException, evaluate, onException, try, fromException, throwIO)
-import TerminalSize (termFitPlainRight)
+import TerminalSize (termFitAnsiRight)
 import qualified Text.Regex.TDFA as TDFA
 import Data.Version (showVersion)
 import qualified Paths_acton
@@ -61,6 +61,22 @@ data TestProgressCallbacks = TestProgressCallbacks
   { tpcOnLive :: TestResult -> IO ()
   , tpcOnDone :: TestResult -> IO ()
   , tpcOnFinal :: TestResult -> IO ()
+  }
+
+data StressWorkerRow = StressWorkerRow
+  { swrId :: Int
+  , swrSync :: Bool
+  , swrIterations :: Int
+  , swrDriftUs :: Int
+  , swrDriftTotalUs :: Int
+  , swrCalibrating :: Bool
+  , swrPhaseResolutionUs :: Int
+  , swrTargetSweepIters :: Int
+  }
+
+data StressPhaseLane = StressPhaseLane
+  { splPhaseResolutionUs :: Int
+  , splTargetSweepIters :: Int
   }
 
 getVer :: String
@@ -218,6 +234,12 @@ runProjectTests useColorOut gopts opts paths topts mode modules maxParallel = do
         ui <- initTestProgressUI gopts nameWidth (C.testShowLog topts) useColorOut
         let totalTests = length specs
         progressDoneRef <- newIORef 0
+        let (effectiveMinTime, effectiveMaxTime) = effectiveTestTiming mode topts
+            expectedDurationMs =
+              fromIntegral
+                (if effectiveMaxTime > 0
+                   then effectiveMaxTime
+                   else effectiveMinTime)
         let progressStep = do
               done <- atomicModifyIORef' progressDoneRef (\x -> let x' = x + 1 in (x', x'))
               let pct =
@@ -238,7 +260,7 @@ runProjectTests useColorOut gopts opts paths topts mode modules maxParallel = do
                   showLog = tpuShowLog ui
               case M.lookup key cachedMap of
                 Just cachedRes -> do
-                  let line = formatTestFinalLineRenderer useColorLine nameWidth display cachedRes
+                  let line = formatTestFinalLineRenderer useColorLine expectedDurationMs nameWidth display cachedRes
                       details = formatTestDetailLines useColorLine showLog cachedRes
                   if shouldShowCached cachedRes
                     then do
@@ -277,12 +299,12 @@ runProjectTests useColorOut gopts opts paths topts mode modules maxParallel = do
                             , trSnapshotUpdated = False
                             , trCached = False
                             }
-                          initLine = formatTestLiveLineRenderer useColorLine nameWidth display initRes
+                          initLine = formatTestLiveLineRenderer useColorLine expectedDurationMs nameWidth display initRes
                       started <- testUiStart ui key (tsModule spec) initLine
                       if not started
                         then return Nothing
                         else do
-                          callbacks <- testProgressCallbacks ui eventChan key display
+                          callbacks <- testProgressCallbacks ui eventChan key display expectedDurationMs
                           void $ async $ do
                             res <- runModuleTestStreaming opts paths topts mode (tsModule spec) (tsName spec)
                                     (tpuEnabled ui) callbacks
@@ -697,34 +719,38 @@ runModuleTestStreaming opts paths topts mode modName testName allowLive callback
         _ ->
           Aeson.object [AesonKey.fromString "interrupted" Aeson..= True]
 
-testProgressCallbacks :: TestProgressUI -> Chan TestEvent -> TestKey -> String -> IO TestProgressCallbacks
-testProgressCallbacks ui eventChan key display = do
+testProgressCallbacks :: TestProgressUI -> Chan TestEvent -> TestKey -> String -> Double -> IO TestProgressCallbacks
+testProgressCallbacks ui eventChan key display expectedDurationMs = do
     workerKeysRef <- newIORef M.empty
     let nameWidth = tpuNameWidth ui
         useColorOut = tpuUseColor ui
         showLog = tpuShowLog ui
-        liveLine res = formatTestLiveLineRenderer useColorOut nameWidth display res
-        finalLine res = formatTestFinalLineRenderer useColorOut nameWidth display res
+        liveLine res = formatTestLiveLineRenderer useColorOut expectedDurationMs nameWidth display res
+        finalLine res = formatTestFinalLineRenderer useColorOut expectedDurationMs nameWidth display res
         detailLines res = formatTestDetailLines useColorOut showLog res
-        workerLine done durationMs (wid, syncW, iterations, driftUs, driftTotalUs, calibrating) cols =
-          let role = if syncW then "sync" else "drift"
+        workerLine done durationMs laneSpec row cols =
+          let role = if swrSync row then "sync" else "drift"
               phase =
                 if done
                   then "DONE"
-                  else if calibrating
+                  else if swrCalibrating row
                     then "CAL "
                     else "RUN "
+              iterations = swrIterations row
               rate = testsPerSecond iterations durationMs
-              line = printf "      w%-3d %-5s %s : %7d iters @ %7.1f/s cur=%6dus tot=%8dus"
-                            wid role phase iterations rate driftUs driftTotalUs
-          in termFitPlainRight cols line
+              baseLine = printf "      w%-3d %-5s %s : %7d iters @ %7.1f/s cur=%6dus tot=%8dus"
+                              (swrId row) role phase iterations rate (swrDriftUs row) (swrDriftTotalUs row)
+              line = baseLine ++ renderStressPhaseLane useColorOut cols baseLine laneSpec row
+          in termFitAnsiRight cols line
         workerKey wid = TestKey (tkModule key) (tkName key ++ "#worker" ++ show wid)
         updateStressWorkers done res = do
           let rows = stressWorkerRows res
+              laneSpec = stressPhaseLaneSpec res
           unless (null rows) $ do
             existing <- readIORef workerKeysRef
-            existing' <- foldM (\acc row@(wid, _, _, _, _, _) -> do
-              let line = workerLine done (trTestDuration res) row
+            existing' <- foldM (\acc row -> do
+              let wid = swrId row
+                  line = workerLine done (trTestDuration res) laneSpec row
               case M.lookup wid acc of
                 Just wk -> do
                   if done
@@ -762,7 +788,7 @@ testProgressCallbacks ui eventChan key display = do
             queuePendingDetails ui key details
       }
 
-stressWorkerRows :: TestResult -> [(Int, Bool, Int, Int, Int, Bool)]
+stressWorkerRows :: TestResult -> [StressWorkerRow]
 stressWorkerRows res =
     case trRaw res of
       Aeson.Object obj ->
@@ -781,7 +807,18 @@ stressWorkerRows res =
           driftTotalUs <- lookupIntDefault o "drift_total_us" 0
           syncW <- lookupBool o "sync"
           calibrating <- lookupBoolDefault o "calibrating" False
-          return (wid, syncW, iterations, driftUs, driftTotalUs, calibrating)
+          phaseResolutionUs <- lookupIntDefault o "phase_resolution_us" 0
+          targetSweepIters <- lookupIntDefault o "target_sweep_iters" 0
+          return StressWorkerRow
+            { swrId = wid
+            , swrSync = syncW
+            , swrIterations = iterations
+            , swrDriftUs = driftUs
+            , swrDriftTotalUs = driftTotalUs
+            , swrCalibrating = calibrating
+            , swrPhaseResolutionUs = phaseResolutionUs
+            , swrTargetSweepIters = targetSweepIters
+            }
         _ -> Nothing
     lookupInt o keyName =
       case AesonKM.lookup (AesonKey.fromString keyName) o of
@@ -800,18 +837,134 @@ stressWorkerRows res =
         Just b -> Just b
         Nothing -> Just defVal
 
+stressPhaseLaneSpec :: TestResult -> Maybe StressPhaseLane
+stressPhaseLaneSpec res =
+    case trRaw res of
+      Aeson.Object obj -> do
+        phaseResolutionMs <- lookupDouble obj "stress_phase_resolution_ms"
+        targetSweepIters <- lookupInt obj "stress_target_sweep_iters"
+        let phaseResolutionUs = max 0 (round (phaseResolutionMs * 1000.0))
+        guard (phaseResolutionUs > 0 && targetSweepIters > 0)
+        return StressPhaseLane
+          { splPhaseResolutionUs = phaseResolutionUs
+          , splTargetSweepIters = targetSweepIters
+          }
+      _ -> Nothing
+  where
+    lookupInt o keyName =
+      case AesonKM.lookup (AesonKey.fromString keyName) o of
+        Just v -> AesonTypes.parseMaybe Aeson.parseJSON v
+        _ -> Nothing
+    lookupDouble o keyName =
+      case AesonKM.lookup (AesonKey.fromString keyName) o of
+        Just v -> (AesonTypes.parseMaybe Aeson.parseJSON v :: Maybe Double)
+        _ -> Nothing
+
+resolveStressPhaseLane :: Maybe StressPhaseLane -> StressWorkerRow -> Maybe StressPhaseLane
+resolveStressPhaseLane baseSpec row
+  | swrPhaseResolutionUs row > 0 && swrTargetSweepIters row > 0 =
+      Just StressPhaseLane
+        { splPhaseResolutionUs = swrPhaseResolutionUs row
+        , splTargetSweepIters = swrTargetSweepIters row
+        }
+  | otherwise = baseSpec
+
+renderStressPhaseLane :: Bool -> Int -> String -> Maybe StressPhaseLane -> StressWorkerRow -> String
+renderStressPhaseLane useColorOut cols baseLine baseSpec row
+  | not useColorOut = ""
+  | swrCalibrating row = ""
+  | otherwise =
+      case resolveStressPhaseLane baseSpec row of
+        Just spec ->
+          let avail = cols - length baseLine
+          in case stressPhaseLaneWidth avail of
+               Just laneWidth -> " " ++ stressPhaseLaneText laneWidth spec row
+               Nothing -> ""
+        Nothing -> ""
+
+stressPhaseLaneWidth :: Int -> Maybe Int
+stressPhaseLaneWidth avail
+  | avail < 11 = Nothing
+  | otherwise =
+      let width = min 32 (avail - 3)
+      in if width < 8 then Nothing else Just width
+
+stressPhaseLaneText :: Int -> StressPhaseLane -> StressWorkerRow -> String
+stressPhaseLaneText laneWidth spec row =
+    "|" ++ concatMap renderCell [0 .. laneWidth - 1] ++ testColorReset ++ "|"
+  where
+    totalPhaseUs = fromIntegral (max 1 (splPhaseResolutionUs spec * splTargetSweepIters spec)) :: Double
+    windowUs = fromIntegral (max 1 (splPhaseResolutionUs spec)) :: Double
+    phaseStartUs
+      | swrSync row = 0.0
+      | otherwise = fromIntegral (swrDriftTotalUs row `mod` max 1 (splPhaseResolutionUs spec * splTargetSweepIters spec))
+    centerUs = wrapPhase (phaseStartUs + (windowUs / 2.0))
+    windowCells = fromIntegral laneWidth / fromIntegral (max 1 (splTargetSweepIters spec)) :: Double
+    baselineBg = ansiBgReset
+    edgeBg = ansiBg 17
+    haloBg = ansiBg 18
+    coreBg
+      | windowCells < 0.35 = ansiBg 24
+      | windowCells < 0.70 = ansiBg 24
+      | otherwise = ansiBg 24
+
+    renderCell idx =
+      let cellStartUs = totalPhaseUs * fromIntegral idx / fromIntegral laneWidth
+          cellEndUs = totalPhaseUs * fromIntegral (idx + 1) / fromIntegral laneWidth
+          overlapFrac = circularOverlap phaseStartUs (phaseStartUs + windowUs) cellStartUs cellEndUs totalPhaseUs
+          isCore = circularContains centerUs cellStartUs cellEndUs totalPhaseUs
+          bg
+            | isCore = coreBg
+            | overlapFrac >= 0.66 = haloBg
+            | overlapFrac > 0.0 = edgeBg
+            | otherwise = baselineBg
+      in bg ++ " "
+
+    wrapPhase x
+      | totalPhaseUs <= 0.0 = 0.0
+      | otherwise =
+          let wrapped = x - (fromIntegral (floor (x / totalPhaseUs)) * totalPhaseUs)
+          in if wrapped < 0.0 then wrapped + totalPhaseUs else wrapped
+
+    circularContains point start end total =
+      overlapLinear start end point (point + 0.0001) total > 0.0
+
+    circularOverlap start end cellStart cellEnd total =
+      let segments = circularSegments start end total
+          cellSegments = circularSegments cellStart cellEnd total
+          overlapSum = sum [ overlapLinear' s1 e1 s2 e2 | (s1, e1) <- segments, (s2, e2) <- cellSegments ]
+          cellWidth = max 0.000001 (cellEnd - cellStart)
+      in overlapSum / cellWidth
+
+    circularSegments start end total
+      | total <= 0.0 = [(0.0, 1.0)]
+      | otherwise =
+          let start' = wrapPhase start
+              end' = start' + (end - start)
+          in if end' <= total
+               then [(start', end')]
+               else [(start', total), (0.0, end' - total)]
+
+    overlapLinear start end point pointEnd total =
+      let segments = circularSegments start end total
+          pointSegments = circularSegments point pointEnd total
+      in sum [ overlapLinear' s1 e1 s2 e2 | (s1, e1) <- segments, (s2, e2) <- pointSegments ]
+
+    overlapLinear' start1 end1 start2 end2 =
+      max 0.0 (min end1 end2 - max start1 start2)
+
+    ansiBg code = "\ESC[48;5;" ++ show code ++ "m"
+    ansiBgReset = "\ESC[49m"
+
 testsPerSecond :: Int -> Double -> Double
 testsPerSecond iterations durationMs
   | iterations <= 0 = 0
   | durationMs <= 0 = 0
   | otherwise = (fromIntegral iterations * 1000.0) / durationMs
 
--- | Build test runner arguments from TestOptions limits.
-testCmdArgs :: TestMode -> C.TestOptions -> [String]
-testCmdArgs mode topts =
-    let iter = C.testIter topts
-        rawMaxIter = C.testMaxIter topts
-        rawMinTime = C.testMinTime topts
+effectiveTestTiming :: TestMode -> C.TestOptions -> (Int, Int)
+effectiveTestTiming mode topts =
+    let rawMinTime = C.testMinTime topts
         minTime =
           case mode of
             TestModePerf ->
@@ -834,6 +987,14 @@ testCmdArgs mode topts =
           | C.testMaxTimeSet topts && rawMaxTime == 0 = 0
           | C.testMaxTimeSet topts = max rawMaxTime minTime
           | otherwise = modeDefaultMaxTime
+    in (minTime, maxTime)
+
+-- | Build test runner arguments from TestOptions limits.
+testCmdArgs :: TestMode -> C.TestOptions -> [String]
+testCmdArgs mode topts =
+    let iter = C.testIter topts
+        rawMaxIter = C.testMaxIter topts
+        (minTime, maxTime) = effectiveTestTiming mode topts
         maxIter
           | mode == TestModeStress && maxTime == 0 && not (C.testMaxIterSet topts) = 0
           | otherwise = rawMaxIter
@@ -988,7 +1149,7 @@ printTestResultsOrdered useColor showLog showCached nameWidth specs results = do
         isOk res = trSuccess res == Just True && trException res == Nothing && not (trSkipped res)
         shouldShow res = not (trCached res) || showCached || not (isOk res) || trSnapshotUpdated res
         formatLine spec res =
-          formatTestLineWith useColor formatTestStatus nameWidth (tsDisplay spec) res
+          formatTestLineWith useColor formatTestStatus (trTestDuration res) nameWidth (tsDisplay spec) res
     let go _ _ [] = return ()
         go printedMods printedAny (spec:rest) =
           case M.lookup (TestKey (tsModule spec) (tsName spec)) resMap of
@@ -1007,20 +1168,23 @@ printTestResultsOrdered useColor showLog showCached nameWidth specs results = do
                         return (Set.insert modName printedMods)
                   putStrLn (formatLine spec res)
                   mapM_ putStrLn (formatTestDetailLines useColor showLog res)
-                  mapM_ putStrLn (formatStressWorkerFinalLines res)
+                  mapM_ putStrLn (formatStressWorkerFinalLines useColor res)
                   go printedMods' True rest
     go Set.empty False specs
 
-formatStressWorkerFinalLines :: TestResult -> [String]
-formatStressWorkerFinalLines res =
+formatStressWorkerFinalLines :: Bool -> TestResult -> [String]
+formatStressWorkerFinalLines useColorOut res =
     map renderRow (stressWorkerRows res)
   where
     durationMs = trTestDuration res
-    renderRow (wid, syncW, iterations, driftUs, driftTotalUs, _calibrating) =
-      let role = if syncW then "sync" else "drift"
+    laneSpec = stressPhaseLaneSpec res
+    renderRow row =
+      let role = if swrSync row then "sync" else "drift"
+          iterations = swrIterations row
           rate = testsPerSecond iterations durationMs
-      in printf "      w%-3d %-5s DONE : %7d iters @ %7.1f/s cur=%6dus tot=%8dus"
-                wid role iterations rate driftUs driftTotalUs
+          baseLine = printf "      w%-3d %-5s DONE : %7d iters @ %7.1f/s cur=%6dus tot=%8dus"
+                            (swrId row) role iterations rate (swrDriftUs row) (swrDriftTotalUs row)
+      in baseLine ++ renderStressPhaseLane useColorOut (maxBound :: Int) baseLine laneSpec row
 
 -- | Write snapshot outputs for all tests that produced output.
 writeSnapshotOutputs :: Paths -> [TestResult] -> IO ()

--- a/compiler/acton/TestUI.hs
+++ b/compiler/acton/TestUI.hs
@@ -109,7 +109,7 @@ testUiProgressClear ui =
     withTestProgressLock ui (termProgressClear (tpuTermProgress ui))
 
 testTickMicros :: Int
-testTickMicros = 250000
+testTickMicros = 80000
 
 testSpinnerThreshold :: Int
 testSpinnerThreshold = 25


### PR DESCRIPTION
Fix hang in stress trest mode and vastly improve perf by computing statistics differently.

There's a new nice visualization of the stress testing progress and how it runs phase drift across the workers. It's not actually measuring where the particular workers are in terms of phase, it's just computed based on the artifical delay that we introduce in order to get phase non-alignment.  I think it gives the user a good mental model for what the stress testing does in terms of phase drift though and I think it basically does work, like when we run stress for enough time, it will do phase coverage in this way. I did some very cursory testing with a test program that printed stuff from the concurrent workers and it basically confirms this, but again, the visualization is of course a lie in the sense that it doesn't actually measure where the program is.