### PR TITLE
Use mkdtemp semantics for mktmpdir

### DIFF
--- a/base/src/file.act
+++ b/base/src/file.act
@@ -1,5 +1,3 @@
-import random
-
 class FileCap():
     def __init__(self, cap: WorldCap):
         pass
@@ -244,17 +242,9 @@ actor FS(cap: FileCap):
         """Make a directory"""
         NotImplemented
 
-    action def mktmpdir(prefix: str=""):
+    action def mktmpdir(prefix: str="") -> str:
         """Make a temporary directory"""
-        # TODO: is this better implemented with mkdtemp or similar libc
-        # function? Maybe we can have this function but then we should at least
-        # do the same thing, like create the tmp dir with exclusive flags etc to
-        # make sure its our own dir.
-        base_tmp_dir = tmpdir()
-        # TODO: use a path join function
-        new_tmp_dir = base_tmp_dir + "/" + prefix + random.randstr(16)
-        mkdir(new_tmp_dir)
-        return new_tmp_dir
+        NotImplemented
 
     action def listdir(path: str) -> list[str]:
         """List directory contents"""

--- a/base/src/file.ext.c
+++ b/base/src/file.ext.c
@@ -1,6 +1,8 @@
 #define GC_THREADS 1
 #include "gc.h"
 
+#include <stdio.h>
+#include <string.h>
 #include <sys/file.h>
 
 #include <uv.h>
@@ -136,6 +138,50 @@ $R fileQ_FSD_mkdirG_local (fileQ_FS self, $Cont C_cont, B_str filename) {
     return $R_CONT(C_cont, B_None);
 }
 
+// action def mktmpdir(prefix: str=""):
+$R fileQ_FSD_mktmpdirG_local (fileQ_FS self, $Cont C_cont, B_str prefix) {
+    uv_fs_t *req = (uv_fs_t *)acton_malloc(sizeof(uv_fs_t));
+    size_t size = 128;
+    char *tmpdir;
+    int r;
+
+    while (1) {
+        tmpdir = (char *)acton_malloc(size);
+        size_t requested = size;
+        r = uv_os_tmpdir(tmpdir, &requested);
+        if (r == UV_ENOBUFS) {
+            size = requested;
+            continue;
+        }
+        if (r < 0) {
+            char errmsg[1024] = "Error getting temporary directory: ";
+            uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
+            log_warn(errmsg);
+            $RAISE(((B_BaseException)B_OSErrorG_new(to$str(errmsg))));
+        }
+        break;
+    }
+
+    const char *cprefix = prefix == B_None ? "" : (const char *)fromB_str(prefix);
+    size_t template_size = strlen(tmpdir) + 1 + strlen(cprefix) + 6 + 1;
+    char *tpl = (char *)acton_malloc(template_size);
+    snprintf(tpl, template_size, "%s/%sXXXXXX", tmpdir, cprefix);
+
+    r = uv_fs_mkdtemp(get_uv_loop(), req, tpl, NULL);
+    if (r < 0) {
+        char errmsg[1024] = "Error creating temporary directory: ";
+        uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
+        uv_fs_req_cleanup(req);
+        log_warn(errmsg);
+        $RAISE(((B_BaseException)B_OSErrorG_new(to$str(errmsg))));
+    }
+
+    // libuv stores the resolved path in req->path, not in the template buffer.
+    B_str path = to$str(req->path);
+    uv_fs_req_cleanup(req);
+    return $R_CONT(C_cont, path);
+}
+
 // action def listdir(path: str) -> list[str]:
 $R fileQ_FSD_listdirG_local (fileQ_FS self, $Cont C_cont, B_str path) {
     B_SequenceD_list wit = B_SequenceD_listG_witness;
@@ -249,16 +295,25 @@ $R fileQ_FSD_statG_local (fileQ_FS self, $Cont C_cont, B_str filename) {
 }
 
 $R fileQ_FSD_tmpdirG_local (fileQ_FS self, $Cont C_cont) {
-    size_t size = 1024; // Initial buffer size for the tmp directory path
-    char *buffer = (char*)acton_malloc(size);
-    int r = uv_os_tmpdir(buffer, &size);
-    if (r < 0) {
-        char errmsg[1024] = "Error getting temporary directory: ";
-        uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
-        log_warn(errmsg);
-        $RAISE(((B_BaseException)B_OSErrorG_new(to$str(errmsg))));
+    size_t size = 128;
+    int r;
+
+    while (1) {
+        char *buffer = (char *)acton_malloc(size);
+        size_t requested = size;
+        r = uv_os_tmpdir(buffer, &requested);
+        if (r == UV_ENOBUFS) {
+            size = requested;
+            continue;
+        }
+        if (r < 0) {
+            char errmsg[1024] = "Error getting temporary directory: ";
+            uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
+            log_warn(errmsg);
+            $RAISE(((B_BaseException)B_OSErrorG_new(to$str(errmsg))));
+        }
+        return $R_CONT(C_cont, to$str(buffer));
     }
-    return $R_CONT(C_cont, to$str(buffer));
 }
 
 $R fileQ_ReadFileD__open_fileG_local (fileQ_ReadFile self, $Cont c$cont) {

--- a/test/stdlib_tests/src/test_file.act
+++ b/test/stdlib_tests/src/test_file.act
@@ -11,6 +11,17 @@ actor _test_mkdir_idempotent(t: testing.EnvT):
     fs.mkdir(tmpdir + "/foo")
     t.success()
 
+actor _test_mktmpdir_creates_unique_directories(t: testing.EnvT):
+    fc = file.FileCap(t.env.cap)
+    fs = file.FS(fc)
+    paths = [fs.mktmpdir("acton-mktmpdir-") for _ in range(16)]
+    testing.assertEqual(len(paths), len(set(paths)))
+    for path in paths:
+        testing.assertTrue(fs.stat(path).is_dir())
+        testing.assertTrue(path.split("/")[-1].startswith("acton-mktmpdir-"))
+        await async fs.rmdir(path)
+    t.success()
+
 actor _test_rmdir_idempotent(t: testing.EnvT):
     fc = file.FileCap(t.env.cap)
     fs = file.FS(fc)


### PR DESCRIPTION
Temporary directories were previously created by combining tmpdir(), a caller-provided prefix, and a random suffix before calling mkdir. That split path selection from path reservation and quietly tolerated EEXIST, so callers could not rely on mktmpdir returning an atomically reserved directory.

This change makes FS.mktmpdir a real runtime primitive backed by uv_fs_mkdtemp and declares its return type explicitly. tmpdir() now shares a helper that retries uv_os_tmpdir when the initial buffer is too small, so both code paths use the same hardened tmpdir lookup.

This is the correct contract for temporary directories. The caller gets an already-created unique directory, prefix preservation remains intact, and concurrent users no longer depend on best-effort randomness to avoid collisions.