### PR TITLE
Clean up libuv file requests

### DIFF
--- a/base/src/file.ext.c
+++ b/base/src/file.ext.c
@@ -77,9 +77,11 @@ $R fileQ_FSD_copyfileG_local (fileQ_FS self, $Cont C_cont, B_str src, B_str dst)
     if (r < 0) {
         char errmsg[1024] = "Error copying file: ";
         uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
+        uv_fs_req_cleanup(req);
         log_warn(errmsg);
         $RAISE(((B_BaseException)B_OSErrorG_new(to$str(errmsg))));
     }
+    uv_fs_req_cleanup(req);
     return $R_CONT(C_cont, B_None);
 }
 
@@ -132,9 +134,11 @@ $R fileQ_FSD_mkdirG_local (fileQ_FS self, $Cont C_cont, B_str filename) {
     if (r < 0 && r != UV_EEXIST) {
         char errmsg[1024] = "Error creating directory: ";
         uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
+        uv_fs_req_cleanup(req);
         log_warn(errmsg);
         $RAISE(((B_BaseException)B_OSErrorG_new(to$str(errmsg))));
     }
+    uv_fs_req_cleanup(req);
     return $R_CONT(C_cont, B_None);
 }
 
@@ -192,6 +196,7 @@ $R fileQ_FSD_listdirG_local (fileQ_FS self, $Cont C_cont, B_str path) {
     if (r < 0) {
         char errmsg[1024] = "Error listing directory: ";
         uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
+        uv_fs_req_cleanup(req);
         log_warn(errmsg);
         $RAISE(((B_BaseException)B_OSErrorG_new(to$str(errmsg))));
     }
@@ -199,6 +204,7 @@ $R fileQ_FSD_listdirG_local (fileQ_FS self, $Cont C_cont, B_str path) {
     while (uv_fs_scandir_next(req, &ent) != UV_EOF) {
         wit->$class->append(wit, res, to$str(ent.name));
     }
+    uv_fs_req_cleanup(req);
     return $R_CONT(C_cont, res);
 }
 
@@ -209,6 +215,7 @@ $R fileQ_FSD_lstatG_local (fileQ_FS self, $Cont C_cont, B_str filename) {
     if (r < 0) {
         char errmsg[1024] = "Error getting file stat: ";
         uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
+        uv_fs_req_cleanup(req);
         log_warn(errmsg);
         $RAISE((B_BaseException)B_OSErrorG_new(to$str(errmsg)));
     }
@@ -231,6 +238,7 @@ $R fileQ_FSD_lstatG_local (fileQ_FS self, $Cont C_cont, B_str filename) {
                                              toB_float(stat->st_ctim.tv_sec + stat->st_ctim.tv_nsec / 1e9),
                                              toB_float(stat->st_birthtim.tv_sec + stat->st_birthtim.tv_nsec / 1e9)
                                              );
+    uv_fs_req_cleanup(req);
     return $R_CONT(C_cont, res);
 }
 
@@ -241,9 +249,11 @@ $R fileQ_FSD_rmdirG_local (fileQ_FS self, $Cont C_cont, B_str dirname) {
     if (r < 0 && r != UV_ENOENT) {
         char errmsg[1024] = "Error removing directory: ";
         uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
+        uv_fs_req_cleanup(req);
         log_warn(errmsg);
         $RAISE(((B_BaseException)B_OSErrorG_new(to$str(errmsg))));
     }
+    uv_fs_req_cleanup(req);
     return $R_CONT(C_cont, B_None);
 }
 
@@ -254,9 +264,11 @@ $R fileQ_FSD_removeG_local (fileQ_FS self, $Cont C_cont, B_str filename) {
     if (r < 0) {
         char errmsg[1024] = "Error removing file: ";
         uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
+        uv_fs_req_cleanup(req);
         log_warn(errmsg);
         $RAISE(((B_BaseException)B_OSErrorG_new(to$str(errmsg))));
     }
+    uv_fs_req_cleanup(req);
     return $R_CONT(C_cont, B_None);
 }
 
@@ -265,10 +277,12 @@ $R fileQ_FSD_statG_local (fileQ_FS self, $Cont C_cont, B_str filename) {
     uv_fs_t *req = (uv_fs_t *)acton_malloc(sizeof(uv_fs_t));
     int r = uv_fs_stat(get_uv_loop(), req, (char *)fromB_str(filename), NULL);
     if (r == UV_ENOENT) {
+        uv_fs_req_cleanup(req);
         $RAISE(((B_BaseException)B_FileNotFoundErrorG_new(filename)));
     } else if (r < 0) {
         char errmsg[1024] = "Error getting file stat: ";
         uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
+        uv_fs_req_cleanup(req);
         log_warn(errmsg);
         $RAISE(((B_BaseException)B_OSErrorG_new(to$str(errmsg))));
     }
@@ -291,6 +305,7 @@ $R fileQ_FSD_statG_local (fileQ_FS self, $Cont C_cont, B_str filename) {
                                              toB_float(stat->st_ctim.tv_sec + stat->st_ctim.tv_nsec / 1e9),
                                              toB_float(stat->st_birthtim.tv_sec + stat->st_birthtim.tv_nsec / 1e9)
                                              );
+    uv_fs_req_cleanup(req);
     return $R_CONT(C_cont, res);
 }
 
@@ -321,15 +336,18 @@ $R fileQ_ReadFileD__open_fileG_local (fileQ_ReadFile self, $Cont c$cont) {
     uv_fs_t *req = (uv_fs_t *)acton_malloc(sizeof(uv_fs_t));
     int r = uv_fs_open(get_uv_loop(), req, (char *)fromB_str(self->filename), UV_FS_O_RDONLY, 0, NULL);
     if (r == UV_ENOENT) {
+        uv_fs_req_cleanup(req);
         $RAISE(((B_BaseException)B_FileNotFoundErrorG_new(self->filename)));
     } else if (r < 0) {
         char errmsg[1024] = "Error opening file for reading: ";
         uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
+        uv_fs_req_cleanup(req);
         log_warn(errmsg);
         $RAISE(((B_BaseException)B_OSErrorG_new(to$str(errmsg))));
 
     }
     self->_fd = toB_int(r);
+    uv_fs_req_cleanup(req);
     return $R_CONT(c$cont, B_None);
 }
 
@@ -354,9 +372,11 @@ $R fileQ_ReadFileD_closeG_local (fileQ_ReadFile self, $Cont c$cont) {
     if (r < 0) {
         char errmsg[1024] = "Error closing file: ";
         uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
+        uv_fs_req_cleanup(req);
         log_warn(errmsg);
         $RAISE(((B_BaseException)B_OSErrorG_new(to$str(errmsg))));
     }
+    uv_fs_req_cleanup(req);
     return $R_CONT(c$cont, B_None);
 }
 
@@ -370,15 +390,18 @@ $R fileQ_ReadFileD_readG_local (fileQ_ReadFile self, $Cont c$cont) {
     res->length = 0;
     while (r > 0) {
         wit->$class->append(wit, res, to$bytesD_len(buf,r));
+        uv_fs_req_cleanup(req);
         iovec = uv_buf_init(buf, sizeof(buf));
         r = uv_fs_read(get_uv_loop(), req, (uv_file)fromB_int(self->_fd), &iovec, 1, -1, NULL);
     }
     if (r < 0) {
         char errmsg[1024] = "Error reading from file: ";
         uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
+        uv_fs_req_cleanup(req);
         log_warn(errmsg);
         $RAISE(((B_BaseException)B_OSErrorG_new(to$str(errmsg))));
     }
+    uv_fs_req_cleanup(req);
     B_bytes nullb = to$bytes("");
     B_Iterable wit2 = ((B_Iterable)((B_Collection)B_SequenceD_listG_new()->W_Collection));
     return $R_CONT(c$cont, nullb->$class->join(nullb,wit2,res));
@@ -392,11 +415,13 @@ $R fileQ_WriteFileD__open_fileG_local (fileQ_WriteFile self, $Cont c$cont) {
     if (r < 0) {
         char errmsg[1024] = "Error opening file for writing: ";
         uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
+        uv_fs_req_cleanup(req);
         log_warn(errmsg);
         $RAISE(((B_BaseException)B_OSErrorG_new(to$str(errmsg))));
 
     }
     self->_fd = toB_int(r);
+    uv_fs_req_cleanup(req);
     return $R_CONT(c$cont, B_None);
 }
 
@@ -422,9 +447,11 @@ $R fileQ_WriteFileD_closeG_local (fileQ_WriteFile self, $Cont c$cont) {
     if (r < 0) {
         char errmsg[1024] = "Error closing file: ";
         uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
+        uv_fs_req_cleanup(req);
         log_warn(errmsg);
         $RAISE(((B_BaseException)B_OSErrorG_new(to$str(errmsg))));
     }
+    uv_fs_req_cleanup(req);
     return $R_CONT(c$cont, B_None);
 }
 
@@ -436,9 +463,11 @@ $R fileQ_WriteFileD_writeG_local (fileQ_WriteFile self, $Cont c$cont, B_bytes da
     if (r < 0) {
         char errmsg[1024] = "Error writing to file: ";
         uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
+        uv_fs_req_cleanup(req);
         log_warn(errmsg);
         $RAISE(((B_BaseException)B_OSErrorG_new(to$str(errmsg))));
 
     }
+    uv_fs_req_cleanup(req);
     return $R_CONT(c$cont, B_None);
 }


### PR DESCRIPTION
Several synchronous file operations in file.ext.c returned or raised without calling uv_fs_req_cleanup(). On Linux this leaves libuv-owned request state allocated across normal file work.

Add cleanup calls on both success and error paths for the synchronous uv_fs_* operations in the file runtime, and clean up the reused read request between iterations before issuing the next read.