### PR TITLE
Isolate transitive zig dependency names

### DIFF
--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -2073,13 +2073,16 @@ genBuildZigFiles spec rootPins depOverrides paths depModuleOpts depPathOverrides
     homeDir <- getHomeDirectory
     depsRootAbs <- normalizePathSafe (joinPath [homeDir, ".cache", "acton", "deps"])
     normalizedSpec <- normalizeSpecPaths proj spec
-    let applyPins deps = M.mapWithKey (\n d -> M.findWithDefault d n rootPins) deps
-        mergedSpec0 = normalizedSpec { BuildSpec.dependencies     = applyPins (BuildSpec.dependencies normalizedSpec) `M.union` transPkgs
-                                     , BuildSpec.zig_dependencies = BuildSpec.zig_dependencies normalizedSpec `M.union` transZigs }
+    let directZigs = [ ZigDepRef depName (rebaseZigDep projAbs proj dep)
+                     | (depName, dep) <- M.toList (BuildSpec.zig_dependencies normalizedSpec)
+                     ]
+        applyPins deps = M.mapWithKey (\n d -> M.findWithDefault d n rootPins) deps
+        mergedSpec0 = normalizedSpec { BuildSpec.dependencies = applyPins (BuildSpec.dependencies normalizedSpec) `M.union` transPkgs }
         mergedSpec = applyPkgDepPathOverrides projAbs depPathOverrides mergedSpec0
+        resolvedZigs = resolveZigDepRefs (M.keys (BuildSpec.dependencies mergedSpec)) (directZigs ++ transZigs)
         zonWithFp = replace "{{fingerprint}}" fp . replace "{{name}}" zonName
-    writeFile buildZigPath (genBuildZig buildZigTemplate mergedSpec depModuleOpts)
-    writeFileAtomic buildZonPath (genBuildZigZon buildZonTemplate relSys depsRootAbs projAbs fp zonName mergedSpec)
+    writeFile buildZigPath (genBuildZig buildZigTemplate mergedSpec resolvedZigs depModuleOpts)
+    writeFileAtomic buildZonPath (genBuildZigZon buildZonTemplate relSys depsRootAbs projAbs fp zonName mergedSpec resolvedZigs)
 
 applyPkgDepPathOverrides :: FilePath -> M.Map String FilePath -> BuildSpec.BuildSpec -> BuildSpec.BuildSpec
 applyPkgDepPathOverrides projRoot depPathOverrides spec =
@@ -2091,15 +2094,104 @@ applyPkgDepPathOverrides projRoot depPathOverrides spec =
         Just depPath ->
           dep { BuildSpec.path = Just (collapseDots (makeRelativeOrAbsolute projRoot depPath)) }
 
-genBuildZig :: String -> BuildSpec.BuildSpec -> M.Map String String -> String
-genBuildZig template spec depModuleOpts =
-    let depsDefs = concatMap pkgDepDef (M.toList (BuildSpec.dependencies spec))
-        zigDefs  = concatMap zigDepDef (M.toList (BuildSpec.zig_dependencies spec))
+data ZigDepRef = ZigDepRef
+  { zigDepRefName :: String
+  , zigDepRefDep :: BuildSpec.ZigDep
+  }
+
+data ZigDepResolved = ZigDepResolved
+  { zigDepResolvedVarName :: String
+  , zigDepResolvedPkgName :: String
+  , zigDepResolvedDep :: BuildSpec.ZigDep
+  }
+
+data ZigDepIdentity
+  = ZigDepPathIdentity FilePath (M.Map String String)
+  | ZigDepHashIdentity String (M.Map String String)
+  | ZigDepUrlIdentity (Maybe String) (M.Map String String)
+  deriving (Eq, Ord, Show)
+
+zigDepIdentity :: BuildSpec.ZigDep -> ZigDepIdentity
+zigDepIdentity dep =
+  case BuildSpec.zpath dep of
+    Just p | not (null p) -> ZigDepPathIdentity p (BuildSpec.options dep)
+    _ -> case BuildSpec.zhash dep of
+           Just h | not (null h) -> ZigDepHashIdentity h (BuildSpec.options dep)
+           _ -> ZigDepUrlIdentity (BuildSpec.zurl dep) (BuildSpec.options dep)
+
+mergeUniqueStrings :: [String] -> [String] -> [String]
+mergeUniqueStrings xs ys =
+    xs ++ [ y | y <- ys, y `notElem` xs ]
+
+mergeZigDeps :: BuildSpec.ZigDep -> BuildSpec.ZigDep -> BuildSpec.ZigDep
+mergeZigDeps dep0 dep1 =
+    dep0 { BuildSpec.artifacts = mergeUniqueStrings (BuildSpec.artifacts dep0) (BuildSpec.artifacts dep1) }
+
+dedupZigDepRefs :: [ZigDepRef] -> [(String, BuildSpec.ZigDep)]
+dedupZigDepRefs refs =
+    let (orderRev, byIdentity) = foldl' step ([], M.empty) refs
+    in [ let ref = byIdentity M.! ident
+         in (zigDepRefName ref, zigDepRefDep ref)
+       | ident <- reverse orderRev
+       ]
+  where
+    step (orderRev, byIdentity) ref =
+      let ident = zigDepIdentity (zigDepRefDep ref)
+      in case M.lookup ident byIdentity of
+           Nothing ->
+             (ident : orderRev, M.insert ident ref byIdentity)
+           Just prevRef ->
+             let mergedRef = prevRef { zigDepRefDep = mergeZigDeps (zigDepRefDep prevRef) (zigDepRefDep ref) }
+             in (orderRev, M.insert ident mergedRef byIdentity)
+
+nextAvailableName :: Data.Set.Set String -> String -> String
+nextAvailableName usedNames baseName = go 0
+  where
+    go 0
+      | Data.Set.member baseName usedNames = go 2
+      | otherwise = baseName
+    go n =
+      let candidate = baseName ++ "_" ++ show n
+      in if Data.Set.member candidate usedNames
+           then go (n + 1)
+           else candidate
+
+-- | Zig and Acton package dependencies share one Zig package namespace at
+-- generation time. Keep generated zig package keys disjoint from package deps
+-- and reserved builder deps so a wrapper package and its underlying zig pkg can
+-- reuse the same logical dependency name.
+resolveZigDepRefs :: [String] -> [ZigDepRef] -> [ZigDepResolved]
+resolveZigDepRefs pkgDepNames refs =
+    reverse resolvedRev
+  where
+    reservedNames =
+      Data.Set.fromList (["actondb", "base"] ++ pkgDepNames)
+    uniqueRefs = dedupZigDepRefs refs
+    (_, _, resolvedRev) = foldl' assign (reservedNames, Data.Set.empty, []) uniqueRefs
+
+    assign (usedPkgNames, usedVarNames, acc) (depName, dep) =
+      let pkgName = nextAvailableName usedPkgNames ("acton_zig_" ++ depName)
+          varName = nextAvailableName usedVarNames depName
+          resolved = ZigDepResolved
+            { zigDepResolvedVarName = varName
+            , zigDepResolvedPkgName = pkgName
+            , zigDepResolvedDep = dep
+            }
+      in ( Data.Set.insert pkgName usedPkgNames
+         , Data.Set.insert varName usedVarNames
+         , resolved : acc
+         )
+
+genBuildZig :: String -> BuildSpec.BuildSpec -> [ZigDepResolved] -> M.Map String String -> String
+genBuildZig template spec zigDeps depModuleOpts =
+    let
+        depsDefs = concatMap pkgDepDef (M.toList (BuildSpec.dependencies spec))
+        zigDefs  = concatMap zigDepDef zigDeps
         depsAll  = depsDefs ++ zigDefs
         libLinks = concatMap pkgLibLink (M.toList (BuildSpec.dependencies spec))
-                ++ concatMap zigLibLink (M.toList (BuildSpec.zig_dependencies spec))
+                ++ concatMap zigLibLink zigDeps
         exeLinks = concatMap pkgExeLink (M.toList (BuildSpec.dependencies spec))
-                ++ concatMap zigExeLink (M.toList (BuildSpec.zig_dependencies spec))
+                ++ concatMap zigExeLink zigDeps
         header = [ "// AUTOMATICALLY GENERATED BY ACTON BUILD SYSTEM"
                  , "// DO NOT EDIT, CHANGES WILL BE OVERWRITTEN!!!!!"
                  , ""
@@ -2124,24 +2216,26 @@ genBuildZig template spec depModuleOpts =
     pkgLibLink (name, _) = "    libActonProject.linkLibrary(actdep_" ++ name ++ ".artifact(\"ActonProject\"));\n"
     pkgExeLink (name, _) = "            executable.linkLibrary(actdep_" ++ name ++ ".artifact(\"ActonProject\"));\n"
 
-    zigDepDef (name, dep)
+    zigDepDef resolved
       | null (BuildSpec.artifacts dep) = ""
       | otherwise =
           let opts = concat [ "        ." ++ k ++ " = " ++ v ++ ",\n" | (k, v) <- M.toList (BuildSpec.options dep) ]
-          in unlines [ "    const dep_" ++ name ++ " = b.dependency(\"" ++ name ++ "\", .{"
+          in unlines [ "    const dep_" ++ zigDepResolvedVarName resolved ++ " = b.dependency(\"" ++ zigDepResolvedPkgName resolved ++ "\", .{"
                      , "        .target = target,"
                      , "        .optimize = optimize,"
                      , opts ++ "    });"
                      ]
-    zigLibLink (name, dep) = concat [ "    libActonProject.linkLibrary(dep_" ++ name ++ ".artifact(\"" ++ art ++ "\"));\n"
-                                    | art <- BuildSpec.artifacts dep ]
-    zigExeLink (name, dep) = concat [ "            executable.linkLibrary(dep_" ++ name ++ ".artifact(\"" ++ art ++ "\"));\n"
-                                    | art <- BuildSpec.artifacts dep ]
+      where dep = zigDepResolvedDep resolved
+    zigLibLink resolved = concat [ "    libActonProject.linkLibrary(dep_" ++ zigDepResolvedVarName resolved ++ ".artifact(\"" ++ art ++ "\"));\n"
+                                 | art <- BuildSpec.artifacts (zigDepResolvedDep resolved) ]
+    zigExeLink resolved = concat [ "            executable.linkLibrary(dep_" ++ zigDepResolvedVarName resolved ++ ".artifact(\"" ++ art ++ "\"));\n"
+                                 | art <- BuildSpec.artifacts (zigDepResolvedDep resolved) ]
 
-genBuildZigZon :: String -> String -> FilePath -> FilePath -> String -> String -> BuildSpec.BuildSpec -> String
-genBuildZigZon template relSys depsRootAbs projAbs fingerprint zonName spec =
-    let pkgDeps = concatMap (pkgToZon projAbs depsRootAbs) (M.toList (BuildSpec.dependencies spec))
-        zigDeps = concatMap zigToZon (M.toList (BuildSpec.zig_dependencies spec))
+genBuildZigZon :: String -> String -> FilePath -> FilePath -> String -> String -> BuildSpec.BuildSpec -> [ZigDepResolved] -> String
+genBuildZigZon template relSys depsRootAbs projAbs fingerprint zonName spec zigDepsResolved =
+    let
+        pkgDeps = concatMap (pkgToZon projAbs depsRootAbs) (M.toList (BuildSpec.dependencies spec))
+        zigDeps = concatMap zigToZon zigDepsResolved
         deps = pkgDeps ++ zigDeps
         replaced = map (replace "{{fingerprint}}" fingerprint
                      . replace "{{syspath}}" relSys
@@ -2170,7 +2264,7 @@ genBuildZigZon template relSys depsRootAbs projAbs fingerprint zonName spec =
                  , "            .path = \"" ++ path ++ "\","
                  , "        },"
                  ]
-    zigToZon (name, dep) =
+    zigToZon resolved =
       case BuildSpec.zpath dep of
         Just p ->
           let absPath = collapseDots $
@@ -2178,15 +2272,17 @@ genBuildZigZon template relSys depsRootAbs projAbs fingerprint zonName spec =
                             then normalise p
                             else normalise (rebasePath projAbs p)
               relPath = relativeViaRoot projAbs absPath
-          in unlines [ "        ." ++ name ++ " = .{"
+          in unlines [ "        ." ++ zigDepResolvedPkgName resolved ++ " = .{"
                      , "            .path = \"" ++ relPath ++ "\","
                      , "        },"
                      ]
-        Nothing -> unlines [ "        ." ++ name ++ " = .{"
+        Nothing -> unlines [ "        ." ++ zigDepResolvedPkgName resolved ++ " = .{"
                            , "            .url = \"" ++ maybeEmpty (BuildSpec.zurl dep) ++ "\","
                            , "            .hash = \"" ++ maybeEmpty (BuildSpec.zhash dep) ++ "\","
                            , "        },"
                            ]
+      where
+        dep = zigDepResolvedDep resolved
     maybeEmpty (Just s) = s
     maybeEmpty Nothing  = ""
 
@@ -2339,10 +2435,11 @@ relativeViaRoot baseAbs targetAbs
     cleanParts = filter (\c -> not (null c) && c /= "/") . splitDirectories
 
 -- | Walk BuildSpec dependencies to collect transitive packages and zig deps.
-collectDepsRecursive :: BuildSpec.BuildSpec -> FilePath -> M.Map String BuildSpec.PkgDep -> [(String, FilePath)] -> IO (M.Map String BuildSpec.PkgDep, M.Map String BuildSpec.ZigDep)
+collectDepsRecursive :: BuildSpec.BuildSpec -> FilePath -> M.Map String BuildSpec.PkgDep -> [(String, FilePath)] -> IO (M.Map String BuildSpec.PkgDep, [ZigDepRef])
 collectDepsRecursive rootSpec projDir pins overrides = do
   root <- normalizePathSafe projDir
-  (\(_, pkgs, zigs) -> (pkgs, zigs)) <$> go root Data.Set.empty root (Just rootSpec)
+  spec <- applyDepOverrides root overrides rootSpec
+  (\(_, pkgs, zigs) -> (pkgs, zigs)) <$> foldM (step root root) (Data.Set.empty, M.empty, []) (M.toList (BuildSpec.dependencies spec))
   where
     go root seen dir mSpec = do
       spec0 <- case mSpec of
@@ -2350,7 +2447,9 @@ collectDepsRecursive rootSpec projDir pins overrides = do
                  Nothing -> loadBuildSpec dir
       spec <- applyDepOverrides dir overrides spec0
       let depsHere = BuildSpec.dependencies spec
-          zigsHere = M.map (rebaseZig root dir) (BuildSpec.zig_dependencies spec)
+          zigsHere = [ ZigDepRef depName (rebaseZigDep root dir dep)
+                     | (depName, dep) <- M.toList (BuildSpec.zig_dependencies spec)
+                     ]
       foldM (step root dir) (seen, M.empty, zigsHere) (M.toList depsHere)
 
     step root base (seen, pkgAcc, zigAcc) (depName, dep) = do
@@ -2372,15 +2471,16 @@ collectDepsRecursive rootSpec projDir pins overrides = do
         else do
           (seenNext, subPkgs, subZigs) <- go root seen' depBase Nothing
           let pkgAcc' = M.insertWith (\_ old -> old) depName dep' pkgAcc
-          return (seenNext, pkgAcc' `M.union` subPkgs, zigAcc `M.union` subZigs)
+          return (seenNext, pkgAcc' `M.union` subPkgs, zigAcc ++ subZigs)
 
-    rebaseZig root base dep =
-      case BuildSpec.zpath dep of
-        Just p | not (null p) ->
-          let absP = rebasePath base p
-              relP = makeRelativeOrAbsolute root absP
-          in dep { BuildSpec.zpath = Just (collapseDots relP) }
-        _ -> dep
+rebaseZigDep :: FilePath -> FilePath -> BuildSpec.ZigDep -> BuildSpec.ZigDep
+rebaseZigDep root base dep =
+  case BuildSpec.zpath dep of
+    Just p | not (null p) ->
+      let absP = rebasePath base p
+          relP = makeRelativeOrAbsolute root absP
+      in dep { BuildSpec.zpath = Just (collapseDots relP) }
+    _ -> dep
 
 -- | Normalize dependency paths in a BuildSpec.
 normalizeSpecPaths :: FilePath -> BuildSpec.BuildSpec -> IO BuildSpec.BuildSpec

--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -569,6 +569,193 @@ actonProjTests =
         expect ".dep_c = .{" depAZon "dep_a build.zig.zon should declare dep_c"
         expectAny ["dep_override/deps/dep_c", "dep_override\\deps\\dep_c", "../dep_c", "..\\dep_c"] depAZon "dep_a build.zig.zon should keep dep_c path"
         assertBool "dep_a build.zig.zon should not include undeclared ghost override" (not ("ghost" `isInfixOf` depAZon))
+  , testCase "zig deps do not collide with package deps in build.zig.zon" $ do
+        withSystemTempDirectory "acton-zig-dep-name-collision" $ \tmp -> do
+          actonExe <- canonicalizePath "../../dist/bin/acton"
+          let rootProj = tmp </> "root"
+              wrapperProj = rootProj </> "deps" </> "acton_lmdb"
+              zigProj = rootProj </> "deps" </> "lmdb_zig"
+              mkFp name = Fingerprint.formatFingerprint
+                (Fingerprint.updateFingerprintPrefix
+                  (Fingerprint.fingerprintPrefixForName name) 1)
+          createDirectoryIfMissing True (rootProj </> "src")
+          createDirectoryIfMissing True (wrapperProj </> "src")
+          createDirectoryIfMissing True (zigProj </> "src")
+          writeFile (rootProj </> "Build.act") $ unlines
+            [ "name = \"root_proj\""
+            , "fingerprint = " ++ mkFp "root_proj"
+            , "dependencies = {"
+            , "    \"lmdb\": (path=\"deps/acton_lmdb\")"
+            , "}"
+            , "zig_dependencies = {}"
+            ]
+          writeFile (rootProj </> "src" </> "main.act") $ unlines
+            [ "from lmdb import ready"
+            , ""
+            , "actor main(env):"
+            , "    if ready():"
+            , "        env.exit(0)"
+            , "    else:"
+            , "        env.exit(1)"
+            ]
+          writeFile (wrapperProj </> "Build.act") $ unlines
+            [ "name = \"acton_lmdb\""
+            , "fingerprint = " ++ mkFp "acton_lmdb"
+            , "dependencies = {}"
+            , "zig_dependencies = {"
+            , "    \"lmdb\": (path=\"../lmdb_zig\", artifacts=[\"lmdb\"])"
+            , "}"
+            ]
+          writeFile (wrapperProj </> "src" </> "lmdb.act") $ unlines
+            [ "def ready() -> bool:"
+            , "    return True"
+            ]
+          writeFile (zigProj </> "build.zig") $ unlines
+            [ "const std = @import(\"std\");"
+            , ""
+            , "pub fn build(b: *std.Build) void {"
+            , "    const target = b.standardTargetOptions(.{});"
+            , "    const optimize = b.standardOptimizeOption(.{});"
+            , "    const lib = b.addLibrary(.{"
+            , "        .name = \"lmdb\","
+            , "        .linkage = .static,"
+            , "        .root_module = b.createModule(.{"
+            , "            .root_source_file = b.path(\"src/root.zig\"),"
+            , "            .target = target,"
+            , "            .optimize = optimize,"
+            , "        }),"
+            , "    });"
+            , "    b.installArtifact(lib);"
+            , "}"
+            ]
+          writeFile (zigProj </> "build.zig.zon") $ unlines
+            [ ".{"
+            , "    .name = .lmdb_zig,"
+            , "    .version = \"0.0.0\","
+            , "    .fingerprint = 0xd571f8beb86c413e,"
+            , "    .minimum_zig_version = \"0.15.2\","
+            , "    .dependencies = .{},"
+            , "    .paths = .{\"\"},"
+            , "}"
+            ]
+          writeFile (zigProj </> "src" </> "root.zig") $ unlines
+            [ "pub export fn lmdb_test() void {}"
+            ]
+          (returnCode, _cmdOut, cmdErr) <- readCreateProcessWithExitCode (proc actonExe ["build"]){ cwd = Just rootProj } ""
+          assertEqual "acton should build when package and zig deps share a name" ExitSuccess returnCode
+          assertBool "acton should not report the old dependency option collision" (not ("invalid option: -Dacton_modules" `isInfixOf` cmdErr))
+          rootZon <- readFile (rootProj </> "build.zig.zon")
+          rootBuildZig <- readFile (rootProj </> "build.zig")
+          assertBool "root build.zig.zon should keep the package dep key" ("        .lmdb = .{" `isInfixOf` rootZon)
+          assertBool "root build.zig.zon should namespace the zig dep key" ("        .acton_zig_lmdb = .{" `isInfixOf` rootZon)
+          assertEqual "root build.zig.zon should emit the package dep key only once"
+            1
+            (length (filter (== "        .lmdb = .{") (lines rootZon)))
+          assertBool "root build.zig should keep the package dep lookup"
+            ("const actdep_lmdb = b.dependency(\"lmdb\"" `isInfixOf` rootBuildZig)
+          assertBool "root build.zig should namespace the zig dep lookup"
+            ("const dep_lmdb = b.dependency(\"acton_zig_lmdb\"" `isInfixOf` rootBuildZig)
+  , testCase "transitive zig deps deduplicate by identity and split on collision" $ do
+        withSystemTempDirectory "acton-zig-transitive-dedup" $ \tmp -> do
+          actonExe <- canonicalizePath "../../dist/bin/acton"
+          let rootProj = tmp </> "root"
+              depAProj = rootProj </> "deps" </> "dep_a"
+              depBProj = rootProj </> "deps" </> "dep_b"
+              depCProj = rootProj </> "deps" </> "dep_c"
+              zigCommonProj = rootProj </> "deps" </> "zig_common"
+              zigOtherProj = rootProj </> "deps" </> "zig_other"
+              mkFp name = Fingerprint.formatFingerprint
+                (Fingerprint.updateFingerprintPrefix
+                  (Fingerprint.fingerprintPrefixForName name) 1)
+              writeWrapper proj name zigPath moduleName = do
+                createDirectoryIfMissing True (proj </> "src")
+                writeFile (proj </> "Build.act") $ unlines
+                  [ "name = " ++ show name
+                  , "fingerprint = " ++ mkFp name
+                  , "dependencies = {}"
+                  , "zig_dependencies = {"
+                  , "    \"shared\": (path=" ++ show zigPath ++ ", artifacts=[\"shared\"])"
+                  , "}"
+                  ]
+                writeFile (proj </> "src" </> (moduleName ++ ".act")) $ unlines
+                  [ "def ready() -> bool:"
+                  , "    return True"
+                  ]
+              writeZigPkg proj = do
+                createDirectoryIfMissing True (proj </> "src")
+                writeFile (proj </> "build.zig") $ unlines
+                  [ "const std = @import(\"std\");"
+                  , ""
+                  , "pub fn build(b: *std.Build) void {"
+                  , "    const target = b.standardTargetOptions(.{});"
+                  , "    const optimize = b.standardOptimizeOption(.{});"
+                  , "    const lib = b.addLibrary(.{"
+                  , "        .name = \"shared\","
+                  , "        .linkage = .static,"
+                  , "        .root_module = b.createModule(.{"
+                  , "            .root_source_file = b.path(\"src/root.zig\"),"
+                  , "            .target = target,"
+                  , "            .optimize = optimize,"
+                  , "        }),"
+                  , "    });"
+                  , "    b.installArtifact(lib);"
+                  , "}"
+                  ]
+                writeFile (proj </> "build.zig.zon") $ unlines
+                  [ ".{"
+                  , "    .name = .lmdb_zig,"
+                  , "    .version = \"0.0.0\","
+                  , "    .fingerprint = 0xd571f8beb86c413e,"
+                  , "    .minimum_zig_version = \"0.15.2\","
+                  , "    .dependencies = .{},"
+                  , "    .paths = .{\"\"},"
+                  , "}"
+                  ]
+                writeFile (proj </> "src" </> "root.zig") $ unlines
+                  [ "pub export fn shared_test() void {}"
+                  ]
+          createDirectoryIfMissing True (rootProj </> "src")
+          writeFile (rootProj </> "Build.act") $ unlines
+            [ "name = \"root_proj\""
+            , "fingerprint = " ++ mkFp "root_proj"
+            , "dependencies = {"
+            , "    \"dep_a\": (path=\"deps/dep_a\"),"
+            , "    \"dep_b\": (path=\"deps/dep_b\"),"
+            , "    \"dep_c\": (path=\"deps/dep_c\")"
+            , "}"
+            , "zig_dependencies = {}"
+            ]
+          writeFile (rootProj </> "src" </> "main.act") $ unlines
+            [ "import dep_a"
+            , "import dep_b"
+            , "import dep_c"
+            , ""
+            , "actor main(env):"
+            , "    if dep_a.ready() and dep_b.ready() and dep_c.ready():"
+            , "        env.exit(0)"
+            , "    else:"
+            , "        env.exit(1)"
+            ]
+          writeWrapper depAProj "dep_a" "../zig_common" "dep_a"
+          writeWrapper depBProj "dep_b" "../zig_common" "dep_b"
+          writeWrapper depCProj "dep_c" "../zig_other" "dep_c"
+          writeZigPkg zigCommonProj
+          writeZigPkg zigOtherProj
+          (returnCode, _cmdOut, cmdErr) <- readCreateProcessWithExitCode (proc actonExe ["build"]){ cwd = Just rootProj } ""
+          assertEqual "acton should build with colliding transitive zig dep names" ExitSuccess returnCode
+          assertBool "acton should not report the old dependency option collision" (not ("invalid option: -Dacton_modules" `isInfixOf` cmdErr))
+          rootZon <- readFile (rootProj </> "build.zig.zon")
+          rootBuildZig <- readFile (rootProj </> "build.zig")
+          assertBool "root build.zig.zon should include the first local zig dep name"
+            ("        .acton_zig_shared = .{" `isInfixOf` rootZon)
+          assertBool "root build.zig.zon should include the second colliding zig dep name"
+            ("        .acton_zig_shared_2 = .{" `isInfixOf` rootZon)
+          assertBool "root build.zig.zon should not emit a third deduped copy"
+            (not ("        .acton_zig_shared_3 = .{" `isInfixOf` rootZon))
+          assertBool "root build.zig should bind the deduped zig dep once"
+            ("const dep_shared = b.dependency(\"acton_zig_shared\"" `isInfixOf` rootBuildZig)
+          assertBool "root build.zig should bind the colliding zig dep separately"
+            ("const dep_shared_2 = b.dependency(\"acton_zig_shared_2\"" `isInfixOf` rootBuildZig)
   , testCase "dep override path must be an Acton project root" $ do
         withSystemTempDirectory "acton-invalid-dep-override" $ \proj -> do
           let srcDir = proj </> "src"

--- a/docs/acton-dev-guide/src/SUMMARY.md
+++ b/docs/acton-dev-guide/src/SUMMARY.md
@@ -9,6 +9,7 @@
 - [Compiler](compiler/index.md)
   - [Incremental compilation](compiler/incremental_compilation.md)
   - [Imports and environments](compiler/imports_and_envs.md)
+  - [Project dependencies](compiler/project_dependencies.md)
   - [Test result cache](compiler/test_cache.md)
   - [Passes](compiler/passes/index.md)
     - [Parse](compiler/passes/parse.md)

--- a/docs/acton-dev-guide/src/compiler/index.md
+++ b/docs/acton-dev-guide/src/compiler/index.md
@@ -12,5 +12,9 @@ read and understand what each transformation does.
 See [Imports and environments](imports_and_envs.md) for how the scheduler,
 `.ty` headers, and the active type-checker environment fit together.
 
+See [Project dependencies](project_dependencies.md) for how Acton package
+dependencies and zig dependencies are discovered, fetched, and emitted into the
+generated Zig build files.
+
 See [Passes](passes/index.md) for the stage-by-stage pipeline and how front and
 back passes split the work.

--- a/docs/acton-dev-guide/src/compiler/project_dependencies.md
+++ b/docs/acton-dev-guide/src/compiler/project_dependencies.md
@@ -1,0 +1,167 @@
+# Project Dependencies
+
+Acton has two different dependency layers during a build:
+
+- Acton package dependencies from `Build.act` `dependencies`
+- Zig package dependencies from `Build.act` `zig_dependencies`
+
+They are related, but they do not participate in the build in the same way.
+
+## Discovery and fetch
+
+Project discovery in `Acton.Compile` only follows Acton package dependencies.
+Those edges determine the project graph used for module ordering, cache reuse,
+import visibility, and type-check planning.
+
+Zig dependencies are not Acton project edges. They do not contribute modules to
+the import graph and they are not used for project discovery.
+
+Fetch still needs them, though. For each reachable Acton project, the fetch
+phase downloads or copies both that project's package dependencies and its zig
+dependencies before later compile planning uses them.
+
+## Generated `build.zig` inputs
+
+`acton build` generates a `build.zig` and `build.zig.zon` for the current
+project in `compiler/acton/Main.hs`.
+
+At that point Acton combines:
+
+- direct package dependencies of the current project
+- transitive package dependencies reachable through package dependencies
+- direct zig dependencies of the current project
+- transitive zig dependencies from all reachable Acton projects
+
+Transitive zig dependencies are flattened into the consuming project's generated
+Zig manifest because the generated build may need to link their declared
+artifacts directly.
+
+### Example: one wrapper package
+
+Conceptually, a root project might look like this:
+
+```text
+root
+└── package dep "lmdb" -> acton-lmdb
+    └── zig dep "lmdb" -> raw LMDB zig package
+```
+
+That means the root project imports an Acton package named `lmdb`, while that
+package in turn links against a zig package also declared as `lmdb`.
+
+The generated root `build.zig.zon` needs both of them as sibling entries, so
+Acton emits separate local names:
+
+```zig
+.dependencies = .{
+    .lmdb = .{ ... },             // Acton package dep
+    .acton_zig_lmdb = .{ ... },   // underlying zig dep
+},
+```
+
+The Acton package keeps the user-facing name `lmdb`. The zig package gets a
+generated local alias because both entries live in the same Zig dependency
+table.
+
+## Local Zig names
+
+Zig dependency names are only local aliases inside one generated
+`build.zig.zon`. They are not global identities across the whole dependency
+tree.
+
+Acton therefore keeps package dependency names unchanged and assigns internal
+names to zig dependencies when rendering build metadata:
+
+- package dependencies keep their declared names
+- zig dependencies get generated names with an `acton_zig_` prefix
+- if multiple distinct zig dependencies would reuse the same local name, Acton
+  appends a numeric suffix
+
+This means an Acton package dependency named `lmdb` can coexist with a zig
+dependency also declared as `lmdb`, and two different transitive zig packages
+that both use the local name `shared` can still appear together in one
+generated manifest.
+
+### Example: colliding transitive zig names
+
+Consider this project graph:
+
+```text
+root
+├── package dep "dep_a"
+│   └── zig dep "shared" -> zig_common
+├── package dep "dep_b"
+│   └── zig dep "shared" -> zig_common
+└── package dep "dep_c"
+    └── zig dep "shared" -> zig_other
+```
+
+All three zig dependencies are named `shared` in their own local `Build.act`,
+but once they are flattened into the root manifest they become siblings.
+
+The generated root `build.zig.zon` therefore looks conceptually like:
+
+```zig
+.dependencies = .{
+    .dep_a = .{ ... },
+    .dep_b = .{ ... },
+    .dep_c = .{ ... },
+    .acton_zig_shared = .{ ... },     // zig_common
+    .acton_zig_shared_2 = .{ ... },   // zig_other
+},
+```
+
+There is no `.acton_zig_shared_3`, because `dep_a` and `dep_b` refer to the
+same zig package identity and are deduplicated before local names are assigned.
+
+## Deduplication
+
+Before assigning local zig names, Acton deduplicates zig dependency references
+by resolved identity plus Zig build options.
+
+Today that identity is derived from whichever source locator is present:
+
+- rebased path plus options
+- content hash plus options
+- URL plus options
+
+When two references resolve to the same identity, Acton emits one local zig
+dependency entry and merges the requested artifact names. When the identities
+differ, both dependencies stay present and receive separate local aliases.
+
+So collisions only matter among sibling entries in one generated
+`build.zig.zon`, and only after deduplication has decided whether two
+references are really the same package instance.
+
+### Example: same package, different options
+
+Options are part of the zig dependency identity. So this conceptual tree:
+
+```text
+root
+├── package dep "tls_a"
+│   └── zig dep "mbedtls" -> same package, options { .pic = true }
+└── package dep "tls_b"
+    └── zig dep "mbedtls" -> same package, options { .pic = false }
+```
+
+still produces two sibling zig entries in the root `build.zig.zon`, because
+the Zig build instances are not interchangeable:
+
+```zig
+.dependencies = .{
+    .tls_a = .{ ... },
+    .tls_b = .{ ... },
+    .acton_zig_mbedtls = .{ ... },     // options { .pic = true }
+    .acton_zig_mbedtls_2 = .{ ... },   // options { .pic = false }
+},
+```
+
+## Practical debugging rules
+
+- Import or type-check failures are usually about Acton package discovery, not
+  zig dependencies.
+- Linker or `b.dependency(...)` lookup failures are usually about generated
+  `build.zig` and `build.zig.zon` contents.
+- Root dependency pinning and `--dep` overrides apply to Acton package
+  dependencies, not zig dependencies.


### PR DESCRIPTION
Transitive zig dependencies were flattened into a map keyed by the declared dependency name. When wrapper packages or separate dependency branches reused the same zig dep name, one package could overwrite another before build.zig and build.zig.zon were rendered. The dev guide also did not explain how these names are resolved, which made collisions harder to debug.

This change keeps transitive zig dependency references separate until generation, deduplicates identical packages by resolved identity and options, merges artifact usage for shared packages, and assigns unique local zig package names only when emitting build metadata. The dev guide now documents the package graph, flattened transitive zig dependencies, local aliasing, and deduplication rules with concrete examples.

That keeps repeated references to the same zig package stable while allowing different zig packages that share a declared name to coexist in one consuming project manifest.