### PR TITLE
Support dependency-qualified package imports

### DIFF
--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -1004,14 +1004,21 @@ compileSigTarget gopts queryGopts opts paths rootProj sysAbs depOverrides target
     let targetCtx' = case M.lookup (projRoot targetCtx) (cpProjMap plan) of
                        Just ctx -> ctx
                        Nothing  -> targetCtx
-    targetPaths <- pathsForModule opts' (cpProjMap plan) targetCtx' mn
+    targetMods <- enumerateProjectModules (ccRootProj cctx') targetCtx'
+    let sourcePfx = case [ pfx | (path, _, canonMn, pfx) <- targetMods
+                               , path == srcPath || canonMn == mn
+                         ] of
+                      pfx:_ -> pfx
+                      [] -> []
+    targetPaths <- pathsForModule opts' (cpProjMap plan) targetCtx' sourcePfx mn
     return (outBase targetPaths mn ++ ".ty")
 
 resolveSigTarget :: C.CompileOptions -> Paths -> FilePath -> M.Map FilePath ProjCtx -> String -> IO SigTarget
 resolveSigTarget opts paths rootProj projMap rawTarget = do
     parts <- parseSigTarget rawTarget
     moduleIndex <- sigModuleIndex projMap rootProj
-    let fullMod = A.modName parts
+    fullParts <- sigRootLibAlias tySearchPath projMap rootProj parts
+    let fullMod = A.modName fullParts
     case lookup fullMod moduleIndex of
       Just (ctx, srcPath) ->
         return (SigSourceTarget ctx fullMod Nothing srcPath)
@@ -1029,8 +1036,8 @@ resolveSigTarget opts paths rootProj projMap rawTarget = do
       | length parts < 2 =
           printErrorAndExit ("Module not found: " ++ rawTarget)
       | otherwise = do
-          let modParts = init parts
-              namePart = last parts
+          modParts <- sigRootLibAlias tySearchPath projMap rootProj (init parts)
+          let namePart = last parts
               mn = A.modName modParts
               n = A.name namePart
           case lookup mn moduleIndex of
@@ -1052,6 +1059,22 @@ parseSigTarget rawTarget = do
       then printErrorAndExit ("Invalid signature target: " ++ rawTarget)
       else return parts
 
+sigRootLibAlias :: [FilePath] -> M.Map FilePath ProjCtx -> FilePath -> [String] -> IO [String]
+sigRootLibAlias tySearchPath projMap rootProj parts =
+    case (parts, M.lookup rootProj projMap) of
+      -- src/lib.act canonicalizes to the package name, but keep `acton sig lib`
+      -- as a source-file convenience without making `lib` importable.
+      (["lib"], Just ctx) | projHasPackageRoot ctx ->
+        return [BuildSpec.specName (projBuildSpec ctx)]
+      (["lib"], Just ctx) -> do
+        let pkgParts = [BuildSpec.specName (projBuildSpec ctx)]
+        mTy <- findSigTyFile tySearchPath (A.modName pkgParts)
+        return $ case mTy of
+          Just _  -> pkgParts
+          Nothing -> parts
+      _ ->
+        return parts
+
 sigModuleIndex :: M.Map FilePath ProjCtx -> FilePath -> IO [(A.ModName, (ProjCtx, FilePath))]
 sigModuleIndex projMap rootProj = do
     let roots = sigProjectSearchOrder projMap rootProj
@@ -1059,8 +1082,17 @@ sigModuleIndex projMap rootProj = do
       case M.lookup root projMap of
         Nothing -> return []
         Just ctx -> do
-          mods <- enumerateProjectModules ctx
-          return [ (mn, (ctx, srcPath)) | (srcPath, mn) <- mods ]
+          mods <- enumerateProjectModules rootProj ctx
+          let suppressLegacy =
+                any (\(_, rawMn, _, pfx) -> not (null pfx) && A.modPath rawMn == ["lib"]) mods
+          return $ concatMap (moduleEntries ctx suppressLegacy) mods
+  where
+    moduleEntries ctx suppressLegacy (srcPath, rawMn, canonMn, _) =
+      let canonical = [(canonMn, (ctx, srcPath))]
+          legacy
+            | rawMn == canonMn || suppressLegacy = []
+            | otherwise = [(rawMn, (ctx, srcPath))]
+      in canonical ++ legacy
 
 sigProjectSearchOrder :: M.Map FilePath ProjCtx -> FilePath -> [FilePath]
 sigProjectSearchOrder projMap rootProj =
@@ -1861,7 +1893,7 @@ runCliPostCompile cliHooks gopts plan env = do
           Just pctx -> do
             when (C.verbose gopts) $
               logLine ("Generating build.zig for dependency project " ++ p)
-            dummyPaths <- pathsForModule opts' projMap pctx (A.modName ["__gen_build__"])
+            dummyPaths <- pathsForModule opts' projMap pctx [] (A.modName ["__gen_build__"])
             let depOpts = M.findWithDefault M.empty p depModuleOptsByProj
                 depPathOverrides = projectDepPathOverrides projMap p
             genBuildZigFiles (projBuildSpec pctx) rootPins (ccDepOverrides cctx) dummyPaths depOpts depPathOverrides

--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -27,7 +27,9 @@ import Test.Tasty.HUnit
 
 import qualified PkgCommands
 import qualified Acton.CommandLineParser as C
+import qualified Acton.Env as Env
 import qualified Acton.Fingerprint as Fingerprint
+import qualified Acton.Syntax as A
 import qualified Options.Applicative as OA
 import qualified Paths_acton
 import qualified TestGolden
@@ -106,9 +108,642 @@ compilerTests =
   , testCase "deps" $ do
         (returnCode, cmdOut, cmdErr) <- readCreateProcessWithExitCode (shell $ "rm -rf ../../test/compiler/test_deps/build.zig*") ""
         (returnCode, cmdOut, cmdErr) <- readCreateProcessWithExitCode (shell $ "rm -rf ../../test/compiler/test_deps/out") ""
-        (returnCode, cmdOut, cmdErr) <- readCreateProcessWithExitCode (shell $ "rm -rf ../../test/compiler/test_deps/deps/a/build.zig*") ""
-        (returnCode, cmdOut, cmdErr) <- readCreateProcessWithExitCode (shell $ "rm -rf ../../test/compiler/test_deps/deps/a/out") ""
+        (returnCode, cmdOut, cmdErr) <- readCreateProcessWithExitCode (shell $ "rm -rf ../../test/compiler/test_deps/.acton") ""
+        (returnCode, cmdOut, cmdErr) <- readCreateProcessWithExitCode (shell $ "rm -rf ../../test/compiler/test_deps/deps/a-b/build.zig*") ""
+        (returnCode, cmdOut, cmdErr) <- readCreateProcessWithExitCode (shell $ "rm -rf ../../test/compiler/test_deps/deps/a-b/out") ""
         runActon "build" ExitSuccess False "../../test/compiler/test_deps/"
+  , testCase "deps hybrid import uses package-prefixed symbols" $ do
+        withSystemTempDirectory "acton-dep-hybrid" $ \tmp -> do
+            let depName = "foo"
+                appName = "app"
+                fpFor n seed =
+                  Fingerprint.formatFingerprint
+                    (Fingerprint.updateFingerprintPrefix
+                      (Fingerprint.fingerprintPrefixForName n) seed)
+                depDir = tmp </> "dep"
+                appDir = tmp </> "app"
+                depSrc = depDir </> "src"
+                appSrc = appDir </> "src"
+                depBuild = depDir </> "Build.act"
+                appBuild = appDir </> "Build.act"
+                appMain = appSrc </> "main.act"
+            createDirectoryIfMissing True depSrc
+            createDirectoryIfMissing True appSrc
+            writeFile depBuild $ unlines
+              [ "name = \"" ++ depName ++ "\""
+              , "fingerprint = " ++ fpFor depName 1
+              , ""
+              ]
+            writeFile (depSrc </> "a.act") $ unlines
+              [ "foo_val = 7"
+              ]
+            writeFile (appSrc </> "a.act") $ unlines
+              [ "foo_val = 5"
+              ]
+            writeFile appBuild $ unlines
+              [ "name = \"" ++ appName ++ "\""
+              , "fingerprint = " ++ fpFor appName 2
+              , ""
+              , "dependencies = {"
+              , "    \"bar\": ("
+              , "        path = \"../dep\""
+              , "    )"
+              , "}"
+              ]
+            writeFile appMain $ unlines
+              [ "import a"
+              , "import bar.a"
+              , ""
+              , "actor main(env):"
+              , "    print(a.foo_val + bar.a.foo_val)"
+              , "    env.exit(0)"
+              ]
+            runActon "build" ExitSuccess False appDir
+            cOut <- readFile (appDir </> "out" </> "types" </> "main.c")
+            hOut <- readFile (appDir </> "out" </> "types" </> "main.h")
+            assertBool "main.c should reference package-prefixed dep symbols"
+              ("fooQ_aQ_foo_val" `isInfixOf` cOut)
+            assertBool "main.c should reference the local a module separately"
+              ("aQ_foo_val" `isInfixOf` cOut)
+            assertBool "main.c should initialize canonical dep module"
+              ("fooQ_aQ___init__();" `isInfixOf` cOut)
+            assertBool "main.h should include canonical dep header"
+              ("#include \"out/types/foo/a.h\"" `isInfixOf` hOut)
+            assertBool "main.c should not call alias-prefixed init symbol"
+              (not ("barQ_aQ___init__();" `isInfixOf` cOut))
+  , testCase "findTyFile prefers package-root local module over stale raw type" $ do
+        withSystemTempDirectory "acton-findty-package-root-stale" $ \tmp -> do
+            let rootDir = tmp </> "pkg"
+                srcDir = rootDir </> "src"
+                typesDir = rootDir </> "out" </> "types"
+                fpFor n seed =
+                  Fingerprint.formatFingerprint
+                    (Fingerprint.updateFingerprintPrefix
+                      (Fingerprint.fingerprintPrefixForName n) seed)
+                freshTy = typesDir </> "foo" </> "transport.ty"
+                wrongTy = typesDir </> "bar" </> "transport.ty"
+                staleTy = typesDir </> "transport.ty"
+            createDirectoryIfMissing True srcDir
+            createDirectoryIfMissing True (takeDirectory freshTy)
+            createDirectoryIfMissing True (takeDirectory wrongTy)
+            writeFile (rootDir </> "Build.act") $ unlines
+              [ "name = \"foo\""
+              , "fingerprint = " ++ fpFor "foo" 23
+              , ""
+              ]
+            writeFile (srcDir </> "lib.act") ""
+            writeFile wrongTy "wrong package transport interface"
+            writeFile staleTy "stale raw transport interface"
+            writeFile freshTy "fresh package transport interface"
+            found <- Env.findTyFile [typesDir] (A.modName ["transport"])
+            assertEqual "package-root local module should outrank stale raw type"
+              (Just freshTy) found
+  , testCase "dep lib module acts as package root" $ do
+        withSystemTempDirectory "acton-dep-lib-root" $ \tmp -> do
+            let depName = "foo"
+                appName = "app"
+                fpFor n seed =
+                  Fingerprint.formatFingerprint
+                    (Fingerprint.updateFingerprintPrefix
+                      (Fingerprint.fingerprintPrefixForName n) seed)
+                depDir = tmp </> "dep"
+                appDir = tmp </> "app"
+                depSrc = depDir </> "src"
+                appSrc = appDir </> "src"
+            createDirectoryIfMissing True depSrc
+            createDirectoryIfMissing True appSrc
+            writeFile (depDir </> "Build.act") $ unlines
+              [ "name = \"" ++ depName ++ "\""
+              , "fingerprint = " ++ fpFor depName 3
+              , ""
+              ]
+            writeFile (depSrc </> "lib.act") $ unlines
+              [ "root_val = 7"
+              ]
+            writeFile (depSrc </> "a.act") $ unlines
+              [ "sub_val = 5"
+              ]
+            writeFile (appDir </> "Build.act") $ unlines
+              [ "name = \"" ++ appName ++ "\""
+              , "fingerprint = " ++ fpFor appName 4
+              , ""
+              , "dependencies = {"
+              , "    \"" ++ depName ++ "\": ("
+              , "        path = \"../dep\""
+              , "    )"
+              , "}"
+              ]
+            writeFile (appSrc </> "main.act") $ unlines
+              [ "import foo"
+              , "import foo.a"
+              , ""
+              , "actor main(env):"
+              , "    print(foo.root_val + foo.a.sub_val)"
+              , "    env.exit(0)"
+              ]
+            runActon "build" ExitSuccess False appDir
+            cOut <- readFile (appDir </> "out" </> "types" </> "main.c")
+            hOut <- readFile (appDir </> "out" </> "types" </> "main.h")
+            assertBool "main.h should include package root header from lib.act"
+              ("#include \"out/types/foo.h\"" `isInfixOf` hOut)
+            assertBool "main.h should include canonical submodule header"
+              ("#include \"out/types/foo/a.h\"" `isInfixOf` hOut)
+            assertBool "main.c should initialize the package root module"
+              ("fooQ___init__();" `isInfixOf` cOut)
+            assertBool "main.h should not treat lib.act as foo.lib"
+              (not ("out/types/foo/lib.h" `isInfixOf` hOut))
+  , testCase "root lib package keeps relative source imports" $ do
+        withSystemTempDirectory "acton-root-lib-relative-imports" $ \tmp -> do
+            let pkgName = "foo"
+                depName = "dep"
+                appName = "app"
+                fpFor n seed =
+                  Fingerprint.formatFingerprint
+                    (Fingerprint.updateFingerprintPrefix
+                      (Fingerprint.fingerprintPrefixForName n) seed)
+                depDir = tmp </> "dep"
+                pkgDir = tmp </> "pkg"
+                appDir = tmp </> "app"
+                depSrc = depDir </> "src"
+                pkgSrc = pkgDir </> "src"
+                appSrc = appDir </> "src"
+            createDirectoryIfMissing True depSrc
+            createDirectoryIfMissing True (pkgSrc </> "fixups")
+            createDirectoryIfMissing True appSrc
+            writeFile (depDir </> "Build.act") $ unlines
+              [ "name = \"" ++ depName ++ "\""
+              , "fingerprint = " ++ fpFor depName 22
+              , ""
+              ]
+            writeFile (depSrc </> "transport.act") $ unlines
+              [ "sub_val = \"dep\""
+              ]
+            writeFile (pkgDir </> "Build.act") $ unlines
+              [ "name = \"" ++ pkgName ++ "\""
+              , "fingerprint = " ++ fpFor pkgName 20
+              , ""
+              , "dependencies = {"
+              , "    \"" ++ depName ++ "\": ("
+              , "        path = \"../dep\""
+              , "    )"
+              , "}"
+              ]
+            writeFile (pkgSrc </> "lib.act") $ unlines
+              [ "import transport"
+              , "from fixups.base import Fixup"
+              , ""
+              , "root_val: int = transport.sub_val"
+              ]
+            writeFile (pkgSrc </> "transport.act") $ unlines
+              [ "from fixups.base import Fixup"
+              , ""
+              , "sub_val = 5"
+              ]
+            writeFile (pkgSrc </> "fixups" </> "base.act") $ unlines
+              [ "class Fixup(object):"
+              , "    pass"
+              ]
+            runActon "build --skip-build" ExitSuccess False pkgDir
+            rootTy <- doesFileExist (pkgDir </> "out" </> "types" </> "foo.ty")
+            transportTy <- doesFileExist (pkgDir </> "out" </> "types" </> "foo" </> "transport.ty")
+            rawTransportTy <- doesFileExist (pkgDir </> "out" </> "types" </> "transport.ty")
+            assertBool "lib.act should compile as the package root module" rootTy
+            assertBool "transport.act should compile as foo.transport" transportTy
+            assertBool "transport.act should not compile as a raw root module" (not rawTransportTy)
+            writeFile (pkgSrc </> "client.act") $ unlines
+              [ "import lib"
+              , ""
+              , "client_val = 1"
+              ]
+            runActon "build --skip-build src/client.act" (ExitFailure 1) True pkgDir
+            writeFile (appDir </> "Build.act") $ unlines
+              [ "name = \"" ++ appName ++ "\""
+              , "fingerprint = " ++ fpFor appName 21
+              , ""
+              , "dependencies = {"
+              , "    \"" ++ pkgName ++ "\": ("
+              , "        path = \"../pkg\""
+              , "    )"
+              , "}"
+              ]
+            writeFile (appSrc </> "main.act") $ unlines
+              [ "import foo"
+              , "import foo.transport"
+              , ""
+              , "actor main(env):"
+              , "    print(foo.root_val + foo.transport.sub_val)"
+              , "    env.exit(0)"
+              ]
+            runActon "build --skip-build" ExitSuccess False appDir
+  , testCase "dep lib module disables legacy dependency fallback" $ do
+        withSystemTempDirectory "acton-dep-lib-no-legacy-fallback" $ \tmp -> do
+            let depName = "ssh"
+                appName = "app"
+                fpFor n seed =
+                  Fingerprint.formatFingerprint
+                    (Fingerprint.updateFingerprintPrefix
+                      (Fingerprint.fingerprintPrefixForName n) seed)
+                depDir = tmp </> "dep"
+                appDir = tmp </> "app"
+                depSrc = depDir </> "src"
+                appSrc = appDir </> "src"
+                appMain = appSrc </> "main.act"
+            createDirectoryIfMissing True depSrc
+            createDirectoryIfMissing True appSrc
+            writeFile (depDir </> "Build.act") $ unlines
+              [ "name = \"" ++ depName ++ "\""
+              , "fingerprint = " ++ fpFor depName 18
+              , ""
+              ]
+            writeFile (depSrc </> "lib.act") $ unlines
+              [ "root_val = 1"
+              ]
+            writeFile (depSrc </> "client.act") $ unlines
+              [ "label = \"dep-client\""
+              ]
+            writeFile (appDir </> "Build.act") $ unlines
+              [ "name = \"" ++ appName ++ "\""
+              , "fingerprint = " ++ fpFor appName 19
+              , ""
+              , "dependencies = {"
+              , "    \"" ++ depName ++ "\": ("
+              , "        path = \"../dep\""
+              , "    )"
+              , "}"
+              ]
+            writeFile appMain $ unlines
+              [ "import ssh.client"
+              , "import client"
+              , ""
+              , "actor main(env):"
+              , "    print(ssh.client.label)"
+              , "    print(client.label)"
+              , "    env.exit(0)"
+              ]
+            actonExe <- canonicalizePath "../../dist/bin/acton"
+            (badCode, _badOut, badErr) <- readCreateProcessWithExitCode
+              (proc actonExe ["build", "--skip-build"]){ cwd = Just appDir } ""
+            assertBool ("legacy dependency fallback should reject import client, stderr:\n" ++ badErr)
+              (badCode /= ExitSuccess)
+            writeFile appMain $ unlines
+              [ "import ssh.client"
+              , ""
+              , "actor main(env):"
+              , "    print(ssh.client.label)"
+              , "    env.exit(0)"
+              ]
+            runActon "build --skip-build" ExitSuccess False appDir
+            (sigCode, sigOut, sigErr) <- readCreateProcessWithExitCode
+              (proc actonExe ["sig", "ssh.client"]){ cwd = Just appDir } ""
+            when (sigCode /= ExitSuccess) $
+              assertFailure ("qualified dependency sig failed:\nstdout:\n" ++ sigOut ++ "\nstderr:\n" ++ sigErr)
+            assertBool "qualified dependency sig should include the client value"
+              ("label : str" `isInfixOf` sigOut)
+            (badSigCode, _badSigOut, badSigErr) <- readCreateProcessWithExitCode
+              (proc actonExe ["sig", "client"]){ cwd = Just appDir } ""
+            assertBool ("legacy dependency sig fallback should reject client, stderr:\n" ++ badSigErr)
+              (badSigCode /= ExitSuccess)
+  , testCase "from dependency import does not bind module alias" $ do
+        withSystemTempDirectory "acton-from-dep-import-alias" $ \tmp -> do
+            let depName = "pipe"
+                appName = "app"
+                fpFor n seed =
+                  Fingerprint.formatFingerprint
+                    (Fingerprint.updateFingerprintPrefix
+                      (Fingerprint.fingerprintPrefixForName n) seed)
+                depDir = tmp </> "dep"
+                appDir = tmp </> "app"
+                depSrc = depDir </> "src"
+                appSrc = appDir </> "src"
+            createDirectoryIfMissing True depSrc
+            createDirectoryIfMissing True appSrc
+            writeFile (depDir </> "Build.act") $ unlines
+              [ "name = \"" ++ depName ++ "\""
+              , "fingerprint = " ++ fpFor depName 6
+              , ""
+              ]
+            writeFile (depSrc </> "pipe.act") $ unlines
+              [ "class Pipe(object):"
+              , "    close: proc() -> None"
+              ]
+            writeFile (appDir </> "Build.act") $ unlines
+              [ "name = \"" ++ appName ++ "\""
+              , "fingerprint = " ++ fpFor appName 7
+              , ""
+              , "dependencies = {"
+              , "    \"" ++ depName ++ "\": ("
+              , "        path = \"../dep\""
+              , "    )"
+              , "}"
+              ]
+            writeFile (appSrc </> "main.act") $ unlines
+              [ "from pipe import Pipe"
+              , ""
+              , "actor Client(pipe: ?Pipe):"
+              , "    def close():"
+              , "        if pipe is not None:"
+              , "            pipe.close()"
+              ]
+            runActon "build --skip-build" ExitSuccess False appDir
+  , testCase "from dependency import emits canonical headers" $ do
+        withSystemTempDirectory "acton-from-dep-canonical-headers" $ \tmp -> do
+            let depName = "acton_yang"
+                appName = "app"
+                fpFor n seed =
+                  Fingerprint.formatFingerprint
+                    (Fingerprint.updateFingerprintPrefix
+                      (Fingerprint.fingerprintPrefixForName n) seed)
+                depDir = tmp </> "dep"
+                appDir = tmp </> "app"
+                depSrc = depDir </> "src"
+                appSrc = appDir </> "src"
+            createDirectoryIfMissing True (depSrc </> "yang")
+            createDirectoryIfMissing True appSrc
+            writeFile (depDir </> "Build.act") $ unlines
+              [ "name = \"" ++ depName ++ "\""
+              , "fingerprint = " ++ fpFor depName 10
+              , ""
+              ]
+            writeFile (depSrc </> "yang" </> "type.act") $ unlines
+              [ "class Ranges(object):"
+              , "    def __init__(self):"
+              , "        pass"
+              ]
+            writeFile (depSrc </> "yang" </> "schema.act") $ unlines
+              [ "from yang.type import Ranges"
+              , ""
+              , "class DType(object):"
+              , "    length: ?Ranges"
+              , ""
+              , "    def __init__(self, length):"
+              , "        self.length = length"
+              ]
+            writeFile (appDir </> "Build.act") $ unlines
+              [ "name = \"" ++ appName ++ "\""
+              , "fingerprint = " ++ fpFor appName 11
+              , ""
+              , "dependencies = {"
+              , "    \"yang\": ("
+              , "        path = \"../dep\""
+              , "    )"
+              , "}"
+              ]
+            writeFile (appSrc </> "main.act") $ unlines
+              [ "import yang.schema"
+              , ""
+              , "actor main(env):"
+              , "    env.exit(0)"
+              ]
+            runActon "build --skip-build" ExitSuccess False appDir
+            hOut <- readFile (depDir </> "out" </> "types" </> "acton_yang" </> "yang" </> "schema.h")
+            assertBool "dependency header should include the canonical module path"
+              ("#include \"out/types/acton_yang/yang/type.h\"" `isInfixOf` hOut)
+            assertBool "dependency header should not include the legacy module path"
+              (not ("#include \"out/types/yang/type.h\"" `isInfixOf` hOut))
+  , testCase "dependency submodule aliases do not hide dependency root module" $ do
+        withSystemTempDirectory "acton-dep-root-after-submodule" $ \tmp -> do
+            let depName = "acton_yang"
+                appName = "app"
+                fpFor n seed =
+                  Fingerprint.formatFingerprint
+                    (Fingerprint.updateFingerprintPrefix
+                      (Fingerprint.fingerprintPrefixForName n) seed)
+                depDir = tmp </> "dep"
+                appDir = tmp </> "app"
+                depSrc = depDir </> "src"
+                appSrc = appDir </> "src"
+            createDirectoryIfMissing True (depSrc </> "yang")
+            createDirectoryIfMissing True appSrc
+            writeFile (depDir </> "Build.act") $ unlines
+              [ "name = \"" ++ depName ++ "\""
+              , "fingerprint = " ++ fpFor depName 12
+              , ""
+              ]
+            writeFile (depSrc </> "yang.act") $ unlines
+              [ "def compile() -> str:"
+              , "    return \"ok\""
+              ]
+            writeFile (depSrc </> "yang" </> "gdata.act") $ unlines
+              [ "item = \"sub\""
+              ]
+            writeFile (appDir </> "Build.act") $ unlines
+              [ "name = \"" ++ appName ++ "\""
+              , "fingerprint = " ++ fpFor appName 13
+              , ""
+              , "dependencies = {"
+              , "    \"yang\": ("
+              , "        path = \"../dep\""
+              , "    )"
+              , "}"
+              ]
+            writeFile (appSrc </> "main.act") $ unlines
+              [ "import yang.gdata"
+              , "import yang"
+              , ""
+              , "actor main(env):"
+              , "    print(yang.compile())"
+              , "    print(yang.gdata.item)"
+              , "    env.exit(0)"
+              ]
+            runActon "build --skip-build" ExitSuccess False appDir
+            hOut <- readFile (appDir </> "out" </> "types" </> "main.h")
+            assertBool "qualified root use should include the dependency root header"
+              ("#include \"out/types/acton_yang/yang.h\"" `isInfixOf` hOut)
+  , testCase "dependency root import wins over local package suffix fallback" $ do
+        withSystemTempDirectory "acton-dep-root-over-local-suffix" $ \tmp -> do
+            let depName = "acton_yang"
+                appName = "stratoweave"
+                fpFor n seed =
+                  Fingerprint.formatFingerprint
+                    (Fingerprint.updateFingerprintPrefix
+                      (Fingerprint.fingerprintPrefixForName n) seed)
+                depDir = tmp </> "dep"
+                appDir = tmp </> "app"
+                depSrc = depDir </> "src"
+                appSrc = appDir </> "src"
+            createDirectoryIfMissing True depSrc
+            createDirectoryIfMissing True (appSrc </> "stratoweave")
+            writeFile (depDir </> "Build.act") $ unlines
+              [ "name = \"" ++ depName ++ "\""
+              , "fingerprint = " ++ fpFor depName 16
+              , ""
+              ]
+            writeFile (depSrc </> "yang.act") $ unlines
+              [ "def compile() -> str:"
+              , "    return \"dep\""
+              ]
+            writeFile (appSrc </> "stratoweave" </> "yang.act") $ unlines
+              [ "label = \"local\""
+              ]
+            writeFile (appDir </> "Build.act") $ unlines
+              [ "name = \"" ++ appName ++ "\""
+              , "fingerprint = " ++ fpFor appName 17
+              , ""
+              , "dependencies = {"
+              , "    \"yang\": ("
+              , "        path = \"../dep\""
+              , "    )"
+              , "}"
+              ]
+            writeFile (appSrc </> "main.act") $ unlines
+              [ "import yang"
+              , "import stratoweave.yang as swyang"
+              , ""
+              , "actor main(env):"
+              , "    print(yang.compile())"
+              , "    print(swyang.label)"
+              , "    env.exit(0)"
+              ]
+            runActon "build --skip-build" ExitSuccess False appDir
+  , testCase "from dependency import resolves through module aliases" $ do
+        withSystemTempDirectory "acton-from-dep-module-alias" $ \tmp -> do
+            let depName = "netconf"
+                appName = "app"
+                fpFor n seed =
+                  Fingerprint.formatFingerprint
+                    (Fingerprint.updateFingerprintPrefix
+                      (Fingerprint.fingerprintPrefixForName n) seed)
+                depDir = tmp </> "dep"
+                appDir = tmp </> "app"
+                depSrc = depDir </> "src"
+                appSrc = appDir </> "src"
+            createDirectoryIfMissing True (depSrc </> "fixups")
+            createDirectoryIfMissing True appSrc
+            writeFile (depDir </> "Build.act") $ unlines
+              [ "name = \"" ++ depName ++ "\""
+              , "fingerprint = " ++ fpFor depName 14
+              , ""
+              ]
+            writeFile (depSrc </> "fixups" </> "base.act") $ unlines
+              [ "class Fixup(object):"
+              , "    name: str"
+              , ""
+              , "    def __init__(self, name: str):"
+              , "        self.name = name"
+              ]
+            writeFile (depSrc </> "fixups.act") $ unlines
+              [ "from fixups.base import Fixup"
+              , ""
+              , "def make_fixup() -> Fixup:"
+              , "    return Fixup(\"specific\")"
+              , ""
+              , "FIXUPS: list[proc() -> Fixup] = ["
+              , "    make_fixup,"
+              , "]"
+              ]
+            writeFile (depSrc </> "netconf.act") $ unlines
+              [ "from fixups import FIXUPS"
+              , "from fixups.base import Fixup"
+              , ""
+              , "actor Client(fixups: ?list[proc() -> Fixup]=FIXUPS):"
+              , "    pass"
+              ]
+            writeFile (appDir </> "Build.act") $ unlines
+              [ "name = \"" ++ appName ++ "\""
+              , "fingerprint = " ++ fpFor appName 15
+              , ""
+              , "dependencies = {"
+              , "    \"" ++ depName ++ "\": ("
+              , "        path = \"../dep\""
+              , "    )"
+              , "}"
+              ]
+            writeFile (appSrc </> "main.act") $ unlines
+              [ "import netconf"
+              , ""
+              , "actor main(env):"
+              , "    env.exit(0)"
+              ]
+            runActon "build --skip-build" ExitSuccess False appDir
+  , testCase "dependency ext.c can use legacy source module symbols" $ do
+        withSystemTempDirectory "acton-dep-ext-c-legacy" $ \tmp -> do
+            let depName = "extdep"
+                appName = "app"
+                fpFor n seed =
+                  Fingerprint.formatFingerprint
+                    (Fingerprint.updateFingerprintPrefix
+                      (Fingerprint.fingerprintPrefixForName n) seed)
+                depDir = tmp </> "dep"
+                appDir = tmp </> "app"
+                depSrc = depDir </> "src"
+                appSrc = appDir </> "src"
+            createDirectoryIfMissing True depSrc
+            createDirectoryIfMissing True appSrc
+            writeFile (depDir </> "Build.act") $ unlines
+              [ "name = \"" ++ depName ++ "\""
+              , "fingerprint = " ++ fpFor depName 8
+              , ""
+              ]
+            writeFile (depSrc </> "m.act") $ unlines
+              [ "class Box(object):"
+              , "    def __init__(self):"
+              , "        pass"
+              , ""
+              , "    def value(self) -> str:"
+              , "        NotImplemented"
+              , ""
+              , "def make() -> Box:"
+              , "    return Box()"
+              ]
+            writeFile (depSrc </> "m.ext.c") $ unlines
+              [ "void mQ___ext_init__() {"
+              , "}"
+              , ""
+              , "B_str mQ_BoxD_value(mQ_Box self) {"
+              , "    return to$str(\"ok\");"
+              , "}"
+              ]
+            writeFile (appDir </> "Build.act") $ unlines
+              [ "name = \"" ++ appName ++ "\""
+              , "fingerprint = " ++ fpFor appName 9
+              , ""
+              , "dependencies = {"
+              , "    \"" ++ depName ++ "\": ("
+              , "        path = \"../dep\""
+              , "    )"
+              , "}"
+              ]
+            writeFile (appSrc </> "main.act") $ unlines
+              [ "import extdep.m"
+              , ""
+              , "actor main(env):"
+              , "    print(extdep.m.make().value())"
+              , "    env.exit(0)"
+              ]
+            runActon "build" ExitSuccess False appDir
+            depC <- readFile (depDir </> "out" </> "types" </> "extdep" </> "m.c")
+            assertBool "dependency C output should alias legacy ext.c class symbols"
+              ("#define mQ_Box extdepQ_mQ_Box" `isInfixOf` depC)
+  , testCase "stdlib direct import wins over package-prefixed fallback" $ do
+        withSystemTempDirectory "acton-stdlib-direct-import" $ \tmp -> do
+            let appName = "app"
+                fp =
+                  Fingerprint.formatFingerprint
+                    (Fingerprint.updateFingerprintPrefix
+                      (Fingerprint.fingerprintPrefixForName appName) 5)
+                appDir = tmp </> "app"
+                appSrc = appDir </> "src"
+            createDirectoryIfMissing True (appSrc </> "yang")
+            writeFile (appDir </> "Build.act") $ unlines
+              [ "name = \"" ++ appName ++ "\""
+              , "fingerprint = " ++ fp
+              , ""
+              ]
+            writeFile (appSrc </> "yang" </> "xml.act") $ unlines
+              [ "import xml"
+              , ""
+              , "helper = 1"
+              ]
+            writeFile (appSrc </> "main.act") $ unlines
+              [ "import xml"
+              , "import yang.xml"
+              , ""
+              , "actor main(env):"
+              , "    n = xml.decode(\"<root/>\")"
+              , "    print(yang.xml.helper)"
+              , "    env.exit(0)"
+              ]
+            runActon "build --skip-build" ExitSuccess False appDir
   , testCase "path dependency fetches transitive cached deps before discovery" $ do
         withSystemTempDirectory "acton-transitive-path-fetch" $ \tmp -> do
           actonExe <- canonicalizePath "../../dist/bin/acton"

--- a/compiler/acton/test_incremental.hs
+++ b/compiler/acton/test_incremental.hs
@@ -2089,8 +2089,8 @@ p44_provider_import_rename_reruns_dependent_front =
       (typechecked out2 modMain)
     assertBool ("did not expect stale transitive import diagnostic\n" ++ T.unpack out2)
       (not (T.isInfixOf "Type interface file not found or unreadable for oldpkg.ttt" out2))
-    assertBool ("expected stale-cache log for missing transitive dep hash\n" ++ T.unpack out2)
-      (T.isInfixOf "missing dep hashes in" out2 && T.isInfixOf "oldpkg.ttt.TransformFunction" out2)
+    assertBool ("expected main to rerun after base public hash changed\n" ++ T.unpack out2)
+      (T.isInfixOf "Stale main: pub changes in base.Base" out2)
 
 -- Main -----------------------------------------------------------------------
 

--- a/compiler/lib/src/Acton/CodeGen.hs
+++ b/compiler/lib/src/Acton/CodeGen.hs
@@ -42,8 +42,9 @@ generate env srcbase srcText emitLines m hash = do return (n, h, c)
   where n                           = concat (Data.List.intersperse "." (modPath (modname m))) --render $ quotes $ gen env0 (modname m)
         hashComment                 = text "/* Acton impl hash:" <+> text hash <+> text "*/"
         h                           = render $ hashComment $+$ hModule env0 m
-        c                           = render $ hashComment $+$ cModule env0 srcbase srcText emitLines m
+        c                           = render $ hashComment $+$ cModule env0 legacyMod srcbase srcText emitLines m
         env0                        = genEnv $ setMod (modname m) env
+        legacyMod                   = legacyModName srcbase
 
 genRoot                            :: Acton.Env.Env0 -> QName -> IO String
 genRoot env0 qn@(GName m n)         = do return $ render (cInclude $+$ cIncludeMods $+$ cInit $+$ cRoot)
@@ -139,6 +140,13 @@ modNames (FromImportAll _ (ModRef (0,Just m)) : is)
                                     = m : modNames is
 modNames []                         = []
 
+legacyModName                       :: FilePath -> ModName
+legacyModName srcbase               = modName rel
+  where parts                       = splitDirectories (dropExtension srcbase)
+        rel                         = case parts of
+                                        "src":xs -> xs
+                                        xs       -> xs
+
 
 -- Header -------------------------------------------------------------------------------------------
 
@@ -147,11 +155,12 @@ hModule env (Module m imps _ stmts) = text "#pragma" <+> text "once" $+$
                                        then empty
                                        else text "#include \"builtin/builtin.h\"" $+$ -- TODO: can we include out/types/__builtin__.h instead?
                                             include env "rts" (modName ["rts"])) $+$
-                                      vcat (map (include env "out/types") $ modNames imps) $+$
+                                      vcat (map (include env "out/types") canonImps) $+$
                                       hSuite 1 env1 stmts $+$
                                       hSuite 2 env1 stmts $+$
                                       text "void" <+> genTopName env initKW <+> parens empty <> semi
   where env1                        = classdefine stmts env
+        canonImps                   = moduleRefs1 env
 
 
 hSuite phase env []                 = empty
@@ -313,11 +322,13 @@ primNEWTUPLE0                       = gPrim "NEWTUPLE0"
 
 -- Implementation -----------------------------------------------------------------------------------
 
-cModule env srcbase srcText emitLines (Module m imps _ stmts)
+cModule env legacyM srcbase srcText emitLines (Module m imps _ stmts)
                                     = (if inBuiltin env then text "#include \"builtin/builtin.c\"" else empty) $+$
                                       text "#include \"rts/common.h\"" $+$
                                       include env (if inBuiltin env then "" else "out/types") m $+$
+                                      ext_compat_open $+$
                                       ext_include $+$
+                                      ext_compat_close $+$
                                       declModule envWithLine stmts $+$
                                       text "int" <+> genTopName env initFlag <+> equals <+> text "0" <> semi $+$
                                       (text "void" <+> genTopName env initKW <+> parens empty <+> char '{') $+$
@@ -328,9 +339,11 @@ cModule env srcbase srcText emitLines (Module m imps _ stmts)
                                               initTables env1 stmts $+$
                                               initGlobals env1 stmts) $+$
                                       char '}'
-  where initImports                 = vcat [ gen env (GName m initKW) <> parens empty <> semi | m <- modNames imps ]
+  where initImports                 = vcat [ gen env (GName m initKW) <> parens empty <> semi | m <- canonImps ]
         external                    = notImpl && not (inBuiltin env)
         ext_include                 = if notImpl then text "#include" <+> doubleQuotes (text srcbase <> text ".ext.c") else empty
+        (ext_compat_open, ext_compat_close)
+                                    = legacyExtCompat env legacyM m stmts external
         ext_init                    = if notImpl then genTopName env (name "__ext_init__") <+> parens empty <> semi else empty
         notImpl                     = hasNotImpl stmts
         env1                        = classdefine stmts env
@@ -351,6 +364,43 @@ cModule env srcbase srcText emitLines (Module m imps _ stmts)
         emitLine (Loc startOffset _) =
             text "#line" <+> pretty (offsetToLine startOffset) <+> doubleQuotes (text actFile)
         envWithLine                 = if emitLines then setLineEmit emitLine env1 else env1
+        canonImps                   = moduleRefs1 env
+
+
+legacyExtCompat                    :: GenEnv -> ModName -> ModName -> Suite -> Bool -> (Doc, Doc)
+legacyExtCompat env legacyM canonM stmts external
+  | not external || legacyM == canonM = (empty, empty)
+  | otherwise                         = (defines, undefs)
+  where names                         = legacyExtNames stmts
+        legacy n                      = gen env (GName legacyM n)
+        canon n                       = gen env (GName canonM n)
+        defines                       = vcat [ text "#define" <+> legacy n <+> canon n | n <- names ]
+        undefs                        = vcat [ text "#undef" <+> legacy n | n <- names ]
+
+legacyExtNames                      :: Suite -> [Name]
+legacyExtNames stmts                = Data.List.nub $
+                                      [name "__ext_init__", initKW] ++
+                                      concatMap derivedNames (dom (envOf stmts)) ++
+                                      concatMap stmtMethodNames stmts
+
+derivedNames                        :: Name -> [Name]
+derivedNames n                      = [ n
+                                      , Derived n suffixClass
+                                      , Derived n suffixMethods
+                                      , Derived n suffixNew
+                                      , Derived n suffixWitness
+                                      ]
+
+stmtMethodNames                     :: Stmt -> [Name]
+stmtMethodNames (Decl _ ds)         = concatMap declMethodNames ds
+stmtMethodNames _                   = []
+
+declMethodNames                     :: Decl -> [Name]
+declMethodNames (Class _ n _ _ ss _)
+                                    = concatMap (derivedNames . methodname n) (dom (envOf ss))
+declMethodNames (Actor _ n _ _ _ ss _)
+                                    = concatMap (derivedNames . methodname n) (dom (envOf ss))
+declMethodNames _                   = []
 
 
 declModule env []                   = empty

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -228,7 +228,7 @@ import Data.Graph
 import Data.List (find, foldl', intercalate, intersperse, isPrefixOf, isSuffixOf, nub, partition)
 import qualified Data.List
 import Data.IORef
-import Data.Maybe (catMaybes, isJust, listToMaybe, mapMaybe)
+import Data.Maybe (catMaybes, isJust, listToMaybe, mapMaybe, maybeToList)
 import qualified Data.Map as M
 import Data.Ord (Down(..))
 import qualified Data.Set
@@ -608,6 +608,7 @@ prepareCompilePlanFromContext sp gopts ctx srcFiles allowPrune mChangedPaths = d
             , projSysPath = sysAbs
             , projSysTypes = joinPath [sysAbs, "base", "out", "types"]
             , projBuildSpec = scratchBuildSpec rootProj
+            , projHasPackageRoot = False
             , projDeps = []
             }
       return (M.singleton rootProj ctx')
@@ -616,9 +617,9 @@ prepareCompilePlanFromContext sp gopts ctx srcFiles allowPrune mChangedPaths = d
   -- For full builds, scan and prune all orphan outputs.
   -- For incremental builds, prune only modules whose changed .act paths are now missing.
   if incremental
-    then maybe (return ()) (pruneMissingChangedModuleOutputs (M.elems projMap)) mChangedPaths
-    else mapM_ pruneMissingModuleOutputs (M.elems projMap)
-  (globalTasks, _) <- buildGlobalTasks sp gopts opts' projMap
+    then maybe (return ()) (pruneMissingChangedModuleOutputs rootProj (M.elems projMap)) mChangedPaths
+    else mapM_ (pruneMissingModuleOutputs rootProj) (M.elems projMap)
+  (globalTasks, _) <- buildGlobalTasks sp gopts opts' rootProj projMap
     (if incremental || allowPrune then Nothing else Just srcFiles)
   neededTasks <- case mChangedPaths of
     Nothing -> selectNeededTasks pathsRoot rootProj globalTasks srcFiles
@@ -1057,11 +1058,63 @@ importsOf (ParseErrorTask _ _) = []
 -- | Resolve imports to in-graph providers using project search order.
 -- This chooses the first project in the search order that declares the module,
 -- producing TaskKeys for dependency edges.
-resolveProviders :: [FilePath] -> M.Map FilePath (Data.Set.Set A.ModName) -> [A.ModName] -> M.Map A.ModName TaskKey
-resolveProviders order modSets imps =
-    M.fromList $ catMaybes $ map (\mn -> fmap (\p -> (mn, TaskKey p mn)) (findProvider mn)) imps
+resolveProviders :: FilePath -> [String] -> [FilePath] -> M.Map FilePath (M.Map A.ModName A.ModName) -> [A.ModName] -> M.Map A.ModName TaskKey
+resolveProviders currentProj sourcePfx order modIndex imps =
+    M.fromList $ catMaybes $ map resolveOne imps
   where
-    findProvider mn = listToMaybe [ p | p <- order, maybe False (Data.Set.member mn) (M.lookup p modSets) ]
+    resolveOne mn = fmap (\(p, providerMn) -> (mn, TaskKey p providerMn)) (findProvider mn)
+
+    findProvider mn = findLocalQualified mn <|> findExact mn <|> findLegacy mn
+
+    findLocalQualified mn
+      | null sourcePfx = Nothing
+      | A.modPath mn == ["lib"] = Nothing
+      | sourcePfx `isPrefixOf` A.modPath mn = Nothing
+      | otherwise =
+          let (localMn, _) = qualifyModuleName sourcePfx mn
+          in fmap (\providerMn -> (currentProj, providerMn))
+               (M.lookup currentProj modIndex >>= M.lookup localMn)
+
+    findExact mn = listToMaybe
+      [ (p, providerMn)
+      | p <- order
+      , providerMn <- maybeToList (M.lookup p modIndex >>= M.lookup mn)
+      ]
+
+    findLegacy mn = do
+      raw <- dropFirstModName mn
+      listToMaybe
+        [ (p, providerMn)
+        | p <- drop 1 order
+        , providerMn <- maybeToList (M.lookup p modIndex >>= M.lookup raw)
+        ]
+
+dropFirstModName :: A.ModName -> Maybe A.ModName
+dropFirstModName (A.ModName (_:ns@(_:_))) = Just (A.ModName ns)
+dropFirstModName _ = Nothing
+
+isSystemProjectRoot :: ProjCtx -> Bool
+isSystemProjectRoot ctx =
+    let sysRoot = addTrailingPathSeparator (normalise (projSysPath ctx))
+        proj = addTrailingPathSeparator (normalise (projRoot ctx))
+    in sysRoot `isPrefixOf` proj
+
+hasProjectPackageRoot :: FilePath -> IO Bool
+hasProjectPackageRoot root =
+    doesFileExist (joinPath [root, "src", "lib.act"])
+
+projectModulePrefix :: FilePath -> ProjCtx -> [String]
+projectModulePrefix rootProj ctx
+  | isSystemProjectRoot ctx = []
+  | projRoot ctx == rootProj && not (projHasPackageRoot ctx) = []
+  | otherwise = [BuildSpec.specName (projBuildSpec ctx)]
+
+qualifyModuleName :: [String] -> A.ModName -> (A.ModName, [String])
+qualifyModuleName [] mn = (mn, [])
+qualifyModuleName pfx mn
+  | A.modPath mn == ["lib"] = (A.modName pfx, pfx)
+  | pfx `isPrefixOf` A.modPath mn = (mn, [])
+  | otherwise = (A.modName (pfx ++ A.modPath mn), pfx)
 
 
 -- | Build GlobalTasks for all discovered projects.
@@ -1070,46 +1123,71 @@ resolveProviders order modSets imps =
 buildGlobalTasks :: Source.SourceProvider
                  -> C.GlobalOptions
                  -> C.CompileOptions
+                 -> FilePath
                  -> M.Map FilePath ProjCtx
                  -> Maybe [String]                  -- optional seed source files; Nothing = all modules
                  -> IO ([GlobalTask], M.Map FilePath (Data.Set.Set A.ModName))
-buildGlobalTasks sp gopts opts projMap mSeeds = do
+buildGlobalTasks sp gopts opts rootProj projMap mSeeds = do
     perProj <- forM (M.elems projMap) $ \ctx -> do
-                  mods <- enumerateProjectModules ctx
+                  mods <- enumerateProjectModules rootProj ctx
                   return (ctx, mods)
-    let modMaps = M.fromList [ (projRoot ctx, M.fromList [ (mn, actFile) | (actFile, mn) <- mods ]) | (ctx, mods) <- perProj ]
+    let modMaps = M.fromList [ (projRoot ctx, M.fromList [ (mn, actFile) | (actFile, _, mn, _) <- mods ]) | (ctx, mods) <- perProj ]
         modSets = M.map Data.Set.fromList (M.map M.keys modMaps)
+        sourcePfxMaps = M.fromList
+          [ (projRoot ctx, M.fromList [ (mn, sourcePfx) | (_, _, mn, sourcePfx) <- mods ])
+          | (ctx, mods) <- perProj
+          ]
+        modIndex = M.fromList
+          [ ( projRoot ctx
+            , M.fromListWith (\old _ -> old) $
+                concatMap (providerNames (hasPackageRoot mods)) mods
+            )
+          | (ctx, mods) <- perProj
+          ]
         orderCache = M.fromList [ (projRoot ctx, projRoot ctx : projDepClosure projMap (projRoot ctx)) | (ctx, _) <- perProj ]
-        allKeys = [ TaskKey (projRoot ctx) mn | (ctx, mods) <- perProj, (_, mn) <- mods ]
+        allKeys = [ TaskKey (projRoot ctx) mn | (ctx, mods) <- perProj, (_, _, mn, _) <- mods ]
     seedKeys <- case mSeeds of
                   Nothing -> return allKeys
                   Just files -> do
                     absFiles <- mapM canonicalizePath files
-                    let pathIndex = M.fromList [ (actFile, TaskKey (projRoot ctx) mn) | (ctx, mods) <- perProj, (actFile, mn) <- mods ]
+                    let pathIndex = M.fromList [ (actFile, TaskKey (projRoot ctx) mn) | (ctx, mods) <- perProj, (actFile, _, mn, _) <- mods ]
                         found = mapMaybe (`M.lookup` pathIndex) absFiles
                     return (if null found then allKeys else found)
-    tasks <- go modMaps modSets orderCache Data.Set.empty seedKeys []
+    tasks <- go modMaps sourcePfxMaps modIndex orderCache Data.Set.empty seedKeys []
     return (reverse tasks, modSets)
   where
-    go modMaps modSets orderCache seen [] acc = return acc
-    go modMaps modSets orderCache seen (k:qs) acc
-      | Data.Set.member k seen = go modMaps modSets orderCache seen qs acc
+    hasPackageRoot mods =
+      any (\(_, rawMn, _, pfx) -> not (null pfx) && A.modPath rawMn == ["lib"]) mods
+
+    providerNames suppressLegacy (_, rawMn, mn, _) =
+      let canonical = (mn, mn)
+          legacy
+            | rawMn == mn || suppressLegacy = []
+            | otherwise = [(rawMn, mn)]
+      in canonical : legacy
+
+    go modMaps sourcePfxMaps modIndex orderCache seen [] acc = return acc
+    go modMaps sourcePfxMaps modIndex orderCache seen (k:qs) acc
+      | Data.Set.member k seen = go modMaps sourcePfxMaps modIndex orderCache seen qs acc
       | otherwise =
           case M.lookup (tkProj k) modMaps >>= M.lookup (tkMod k) of
-            Nothing -> go modMaps modSets orderCache (Data.Set.insert k seen) qs acc
+            Nothing -> go modMaps sourcePfxMaps modIndex orderCache (Data.Set.insert k seen) qs acc
             Just actFile -> do
               let ctx = projMap M.! tkProj k
-              paths <- pathsForModule opts projMap ctx (tkMod k)
+                  sourcePfx =
+                    M.findWithDefault [] (tkMod k)
+                      (M.findWithDefault M.empty (tkProj k) sourcePfxMaps)
+              paths <- pathsForModule opts projMap ctx sourcePfx (tkMod k)
               task  <- readModuleTask sp gopts opts paths actFile
               let order = M.findWithDefault [tkProj k] (tkProj k) orderCache
-                  providers = resolveProviders order modSets (importsOf task)
+                  providers = resolveProviders (tkProj k) sourcePfx order modIndex (importsOf task)
                   newKeys = M.elems providers
                   acc' = GlobalTask { gtKey = k
                                     , gtPaths = paths
                                     , gtTask = task
                                     , gtImportProviders = providers
                                     } : acc
-              go modMaps modSets orderCache (Data.Set.insert k seen) (qs ++ newKeys) acc'
+              go modMaps sourcePfxMaps modIndex orderCache (Data.Set.insert k seen) (qs ++ newKeys) acc'
 
 
 -- | Select the subgraph needed for a given build request.
@@ -2869,6 +2947,7 @@ data Paths      = Paths {
                     projTypes   :: FilePath,
                     binDir      :: FilePath,
                     srcDir      :: FilePath,
+                    sourcePrefix :: [String],
                     isTmp       :: Bool,
                     fileExt     :: String,
                     modName     :: A.ModName
@@ -2884,6 +2963,7 @@ data ProjCtx = ProjCtx {
                      projSysPath :: FilePath,
                      projSysTypes:: FilePath,
                      projBuildSpec :: BuildSpec.BuildSpec,
+                     projHasPackageRoot :: Bool,
                      projDeps     :: [(String, FilePath)]          -- resolved dependency roots (abs paths)
                    } deriving (Show)
 
@@ -2949,6 +3029,8 @@ discoverProjects gopts sysAbs rootProj depOverrides = do
           let outDir   = joinPath [dirAbs, "out"]
               typesDir = joinPath [outDir, "types"]
               srcDir'  = joinPath [dirAbs, "src"]
+          hasPackageRoot <- hasProjectPackageRoot dirAbs
+          let
               ctx = ProjCtx { projRoot = dirAbs
                             , projOutDir = outDir
                             , projTypesDir = typesDir
@@ -2956,6 +3038,7 @@ discoverProjects gopts sysAbs rootProj depOverrides = do
                             , projSysPath = sysAbs
                             , projSysTypes = joinPath [sysAbs, "base", "out", "types"]
                             , projBuildSpec = spec
+                            , projHasPackageRoot = hasPackageRoot
                             , projDeps = [ (n, p) | (n, p, _) <- reverse deps ]
                             }
               acc' = M.insert dirAbs ctx acc
@@ -3005,9 +3088,17 @@ discoverProjects gopts sysAbs rootProj depOverrides = do
 -- 'fileExt' is file suffix of FILE.
 -- 'modName' is the module name of FILE (its path after 'src' except 'fileExt', split at every '/')
 
+sourcePathForModule :: Paths -> A.ModName -> [String]
+sourcePathForModule paths mn =
+    let path = A.modPath mn
+        relPath = maybe path id (Data.List.stripPrefix (sourcePrefix paths) path)
+    in case relPath of
+         [] | not (null (sourcePrefix paths)) -> ["lib"]
+         _ -> relPath
+
 -- | Compute the source file path for a module under its project src dir.
 srcFile                 :: Paths -> A.ModName -> FilePath
-srcFile paths mn        = joinPath (srcDir paths : A.modPath mn) ++ ".act"
+srcFile paths mn        = joinPath (srcDir paths : sourcePathForModule paths mn) ++ ".act"
 
 -- | Compute the output base path (without extension) for a module.
 -- Used to locate .ty/.c/.h output under the project's types directory.
@@ -3017,7 +3108,7 @@ outBase paths mn        = joinPath (projTypes paths : A.modPath mn)
 -- | Compute the module path without extension under the project's src dir.
 -- Used to derive the .act path or related per-module files.
 srcBase                 :: Paths -> A.ModName -> FilePath
-srcBase paths mn        = joinPath (srcDir paths : A.modPath mn)
+srcBase paths mn        = joinPath (srcDir paths : sourcePathForModule paths mn)
 
 
 -- | Walk upward from a path to find a project root.
@@ -3117,7 +3208,17 @@ findPaths actFile opts  = do execDir <- takeDirectory <$> getExecutablePath
                                  projOut = joinPath [projPath, "out"]
                                  projTypes = joinPath [projOut, "types"]
                                  binDir  = if isTmp then srcDir else joinPath [projOut, "bin"]
-                                 modName = A.modName $ dirInSrc ++ [fileBody]
+                                 rawModName = A.modName $ dirInSrc ++ [fileBody]
+                             sourcePfx <- if isTmp
+                                            then return []
+                                            else do
+                                              hasPackageRoot <- hasProjectPackageRoot projPath
+                                              if hasPackageRoot
+                                                then do
+                                                  spec <- loadBuildSpec projPath
+                                                  return [BuildSpec.specName spec]
+                                                else return []
+                             let (modName, _) = qualifyModuleName sourcePfx rawModName
                              -- join the search paths from command line options with the ones found in the deps directory
                              depOverrides <- normalizeDepOverrides projPath (C.dep_overrides opts)
                              depTypePaths <- if isTmp then return [] else collectDepTypePaths projPath depOverrides
@@ -3126,7 +3227,7 @@ findPaths actFile opts  = do execDir <- takeDirectory <$> getExecutablePath
                              createDirectoryIfMissing True projOut
                              createDirectoryIfMissing True projTypes
                              createDirectoryIfMissing True (getModPath projTypes modName)
-                             return $ Paths sPaths sysPath sysTypes projPath projOut projTypes binDir srcDir isTmp fileExt modName
+                             return $ Paths sPaths sysPath sysTypes projPath projOut projTypes binDir srcDir sourcePfx isTmp fileExt modName
   where (fileBody,fileExt) = splitExtension $ takeFileName actFile
 
         analyze "/" ds  = do tmp <- canonicalizePath (C.tempdir opts)
@@ -3142,7 +3243,7 @@ findPaths actFile opts  = do execDir <- takeDirectory <$> getExecutablePath
 
 -- Module helpers for multi-project builds ---------------------------------------------------------
 
--- | Derive a module name from a file path under a project's src root.
+-- | Derive a raw module name from a file path under a project's src root.
 -- The result uses path segments and strips the .act extension.
 moduleNameFromFile :: FilePath -> FilePath -> IO A.ModName
 moduleNameFromFile srcBase actFile = do
@@ -3151,10 +3252,17 @@ moduleNameFromFile srcBase actFile = do
     let rel = dropExtension (makeRelative base file)
     return $ A.modName (splitDirectories rel)
 
+-- | Pair a project source file with its raw and canonical module names.
+moduleInfoFromFile :: FilePath -> ProjCtx -> FilePath -> IO (A.ModName, A.ModName, [String])
+moduleInfoFromFile rootProj ctx actFile = do
+    rawMn <- moduleNameFromFile (projSrcDir ctx) actFile
+    let (canonMn, sourcePfx) = qualifyModuleName (projectModulePrefix rootProj ctx) rawMn
+    return (rawMn, canonMn, sourcePfx)
+
 -- | Enumerate all .act files in a project and pair them with module names.
 -- Used to seed the project module index for graph construction.
-enumerateProjectModules :: ProjCtx -> IO [(FilePath, A.ModName)]
-enumerateProjectModules ctx = do
+enumerateProjectModules :: FilePath -> ProjCtx -> IO [(FilePath, A.ModName, A.ModName, [String])]
+enumerateProjectModules rootProj ctx = do
     exists <- doesDirectoryExist (projSrcDir ctx)
     if not exists
       then return []
@@ -3162,14 +3270,14 @@ enumerateProjectModules ctx = do
         files <- getFilesRecursive (projSrcDir ctx)
         let actFiles = filter (\f -> takeExtension f == ".act") files
         forM actFiles $ \f -> do
-          mn <- moduleNameFromFile (projSrcDir ctx) f
-          return (f, mn)
+          (rawMn, canonMn, sourcePfx) <- moduleInfoFromFile rootProj ctx f
+          return (f, rawMn, canonMn, sourcePfx)
 
 -- | Remove stale generated module artifacts when source modules disappear.
 -- Prunes orphan .ty/.c/.h outputs under out/types before task planning so
 -- cached headers cannot mask deleted .act modules.
-pruneMissingModuleOutputs :: ProjCtx -> IO ()
-pruneMissingModuleOutputs ctx = do
+pruneMissingModuleOutputs :: FilePath -> ProjCtx -> IO ()
+pruneMissingModuleOutputs rootProj ctx = do
     let srcRoot = projSrcDir ctx
         typesRoot = projTypesDir ctx
     typesExists <- doesDirectoryExist typesRoot
@@ -3177,9 +3285,11 @@ pruneMissingModuleOutputs ctx = do
       srcExists <- doesDirectoryExist srcRoot
       srcMods <- if srcExists
                    then do
-                     srcFiles <- getFilesRecursive srcRoot
-                     let actFiles = filter (\f -> takeExtension f == ".act") srcFiles
-                         modBases = map (normalise . dropExtension . makeRelative srcRoot) actFiles
+                     mods <- enumerateProjectModules rootProj ctx
+                     let modBases =
+                           [ normalise (joinPath (A.modPath canonMn))
+                           | (_, _, canonMn, _) <- mods
+                           ]
                      return (Data.Set.fromList modBases)
                    else return Data.Set.empty
       outFiles <- getFilesRecursive typesRoot
@@ -3206,8 +3316,8 @@ pruneMissingModuleOutputs ctx = do
     ignoreNotExists _ = return ()
 
 -- | Incremental variant: prune only modules whose changed .act file no longer exists.
-pruneMissingChangedModuleOutputs :: [ProjCtx] -> [FilePath] -> IO ()
-pruneMissingChangedModuleOutputs ctxs changedPaths = do
+pruneMissingChangedModuleOutputs :: FilePath -> [ProjCtx] -> [FilePath] -> IO ()
+pruneMissingChangedModuleOutputs rootProj ctxs changedPaths = do
     absChanged <- mapM normalizePathSafe changedPaths
     let actPaths = filter (\p -> takeExtension p == ".act") absChanged
     forM_ actPaths $ \actPath -> do
@@ -3220,7 +3330,9 @@ pruneMissingChangedModuleOutputs ctxs changedPaths = do
       let srcRoot' = addTrailingPathSeparator (normalise srcRoot)
           actPath' = normalise actPath
       when (Data.List.isPrefixOf srcRoot' actPath') $ do
-        let modBase = normalise (dropExtension (makeRelative srcRoot actPath'))
+        rawMn <- moduleNameFromFile srcRoot actPath'
+        let (canonMn, _) = qualifyModuleName (projectModulePrefix rootProj ctx) rawMn
+            modBase = normalise (joinPath (A.modPath canonMn))
             outBase = projTypesDir ctx </> modBase
         mapM_ (\ext -> removeFile (outBase ++ ext) `catch` ignoreNotExists) [".ty", ".c", ".h"]
 
@@ -3237,12 +3349,12 @@ searchPathForProject opts projMap ctx =
 
 -- | Construct a Paths record for a module within a project context.
 -- Creates output directories and ensures the types directory exists.
-pathsForModule :: C.CompileOptions -> M.Map FilePath ProjCtx -> ProjCtx -> A.ModName -> IO Paths
-pathsForModule opts projMap ctx mn = do
+pathsForModule :: C.CompileOptions -> M.Map FilePath ProjCtx -> ProjCtx -> [String] -> A.ModName -> IO Paths
+pathsForModule opts projMap ctx sourcePfx mn = do
     let sPaths = searchPathForProject opts projMap ctx
         bin = joinPath [projOutDir ctx, "bin"]
         src = projSrcDir ctx
-        p = Paths sPaths (projSysPath ctx) (projSysTypes ctx) (projRoot ctx) (projOutDir ctx) (projTypesDir ctx) bin src False ".act" mn
+        p = Paths sPaths (projSysPath ctx) (projSysTypes ctx) (projRoot ctx) (projOutDir ctx) (projTypesDir ctx) bin src sourcePfx False ".act" mn
     createDirectoryIfMissing True bin
     createDirectoryIfMissing True (projOutDir ctx)
     createDirectoryIfMissing True (projTypesDir ctx)

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -19,15 +19,18 @@ import qualified Data.Binary
 import GHC.Generics (Generic)
 import Data.Typeable
 import Data.Char
-import System.FilePath.Posix (joinPath,takeDirectory)
-import System.Directory (doesFileExist)
+import System.FilePath.Posix (joinPath,takeDirectory,takeFileName)
+import System.Directory (doesDirectoryExist, doesFileExist, listDirectory)
 import System.Environment (getExecutablePath)
+import qualified System.IO as IO
 import Control.Monad
 import Control.Monad.Except
 import qualified Data.HashMap.Strict as M
+import qualified Data.List as List
 import qualified Data.Set as S
 
 import Acton.Syntax
+import qualified Acton.BuildSpec as BuildSpec
 import Acton.Builtin
 import Acton.Prim
 import Acton.Printer
@@ -154,10 +157,12 @@ instance (Unalias a) => Unalias (Maybe a) where
 instance Unalias ModName where
     unalias env m@(ModName ns)
       | inBuiltin env               = m
-      | otherwise                   = case lookup (head ns) (names env) of
-                                        Just (NMAlias m') -> m'
-                                        Nothing | m `elem` imports env  -> m
-                                        _ -> noModule m
+      | otherwise                   = case ns of
+                                        [] -> m
+                                        n:ns' -> case lookup n (names env) of
+                                                   Just (NMAlias (ModName ms)) -> ModName (ms ++ ns')
+                                                   _ | m `elem` imports env -> m
+                                                   _ -> noModule m
 instance Unalias QName where
     unalias env n0@(QName m n)      = case findHMod m env of
                                         Just te -> case M.lookup n te of
@@ -333,6 +338,30 @@ addMod m newte mdoc env     = env{ modules = addM ns (modules env) }
     update n ns (ni:te)     = ni : update n ns te
     update n ns []          = (n, NModule (addM ns []) mdoc) : []
 
+addModAlias                :: ModName -> ModName -> EnvF x -> EnvF x
+addModAlias m target env    = env{ modules = addA ns (modules env) }
+  where
+    ModName ns              = m
+    addA [] te              = te
+    addA [n] te             = updateLeaf n te
+    addA (n:ns) te          = updateNode n ns te
+
+    updateLeaf n ((x,i):te)
+      | n == x              = case i of
+                                NModule{} -> (x,i) : te
+                                NMAlias{} -> (x,NMAlias target) : te
+                                _         -> (x,i) : te
+    updateLeaf n (ni:te)    = ni : updateLeaf n te
+    updateLeaf n []         = [(n, NMAlias target)]
+
+    updateNode n ns ((x,i):te)
+      | n == x              = case i of
+                                NModule te1 doc -> (n, NModule (addA ns te1) doc) : te
+                                NMAlias{}       -> (x,i) : te
+                                _               -> (x,i) : te
+    updateNode n ns (ni:te) = ni : updateNode n ns te
+    updateNode n ns []      = (n, NModule (addA ns []) Nothing) : []
+
 
 -- General Env queries -----------------------------------------------------------------------------------------------------------
 
@@ -404,38 +433,42 @@ lookupVar n env             = case lookup n (names env) of
 findHMod                    :: ModName -> EnvF x -> Maybe HTEnv  -- m is modname part of a QName, so we must check for aliasing
 findHMod m env | inBuiltin env, m==mBuiltin
                             = Just (convTEnv2HTEnv (names env))
-findHMod m@(ModName ns) env = case lookup (head ns) (names env) of
-                                Just (NMAlias (ModName m')) -> lookupHMod (ModName $ m'++tail ns) env
-                                Nothing | m `elem` imports env  -> lookupHMod m env
-                                _ -> Nothing
+findHMod m@(ModName ns) env = case ns of
+                                [] -> Nothing
+                                n:ns' -> case lookup n (names env) of
+                                           Just (NMAlias (ModName ms)) -> lookupHMod (ModName (ms ++ ns')) env
+                                           _ | m `elem` imports env -> lookupHMod m env
+                                           _ -> Nothing
 
 lookupHMod                  :: ModName -> EnvF x -> Maybe HTEnv -- m is modname part of a GName, so search directly for module
 lookupHMod m env | inBuiltin env, m==mBuiltin
                             = Just (convTEnv2HTEnv (names env))
 lookupHMod (ModName ns) env = f ns (hmodules env)
   where f [] te
-          | not (all isHNModule (M.toList te)) = Just te
+          | not (all isHModChild (M.toList te)) = Just te
           | otherwise              = Nothing
         f (n:ns) te         = case M.lookup n te of
                                 Just (HNModule te' _) -> f ns te'
                                 Just (HNMAlias (ModName m)) -> lookupHMod (ModName $ m++ns) env
                                 _ -> Nothing
-        isHNModule (_, HNModule{}) = True
-        isHNModule _               = False
+        isHModChild (_, HNModule{}) = True
+        isHModChild (_, HNMAlias{}) = True
+        isHModChild _               = False
 
 lookupMod                  :: ModName -> EnvF x -> Maybe TEnv 
 lookupMod m env | inBuiltin env, m==mBuiltin
                             = Just (names env)
 lookupMod (ModName ns) env  = f ns (modules env)
   where f [] te
-          | not (all isNModule te) = Just te
+          | not (all isModChild te) = Just te
           | otherwise              = Nothing
         f (n:ns) te         = case lookup n te of
                                 Just (NModule te' _) -> f ns te'
                                 Just (NMAlias (ModName m)) -> lookupMod (ModName $ m++ns) env
                                 _ -> Nothing
-        isNModule (_, NModule{})  = True
-        isNModule _               = False
+        isModChild (_, NModule{}) = True
+        isModChild (_, NMAlias{}) = True
+        isModChild _              = False
 
 
 isMod                       :: EnvF x -> [Name] -> Bool
@@ -1016,70 +1049,230 @@ impModule spath env (Import _ ms)
                                 = imp env ms
   where imp env []              = return env
         imp env (ModuleItem m as : is)
-                                = do (env1,te) <- doImp spath env m
-                                     let env2 = maybe (addImport m) (\n->define [(n, NMAlias m)]) as env1
-                                     imp (importWits m te env2) is
+                                = do (env1,m',te) <- doImp spath env m
+                                     let env2 = addImport m' env1
+                                         env3 = case as of
+                                                  Just n -> define [(n, NMAlias m')] env2
+                                                  Nothing | m == m' -> env2
+                                                  Nothing ->
+                                                    case aliasBindingForImport m m' of
+                                                      Just (n, target) -> define [(n, NMAlias target)] env2
+                                                      Nothing -> env2
+                                     imp (importWits m' te env3) is
 impModule spath env (FromImport _ (ModRef (0,Just m)) items)
-                                = do (env1,te) <- doImp spath env m
-                                     return $ importSome items m te $ importWits m te $ env1
+                                = do (env1,m',te) <- doImp spath env m
+                                     return $ importSome items m' te $ importWits m' te $ env1
 impModule spath env (FromImportAll _ (ModRef (0,Just m)))
-                                = do (env1,te) <- doImp spath env m
-                                     return $ importAll m te $ importWits m te $ env1
+                                = do (env1,m',te) <- doImp spath env m
+                                     return $ importAll m' te $ importWits m' te $ env1
 impModule _ _ i                 = illegalImport (loc i)
 
 
-moduleRefs env                  = nub $ imports env ++ [ m | (_,NMAlias m) <- names env ] ++ [ m | (_,NAlias (GName m _)) <- names env ]
+moduleRefs env                  = nub $ map canonicalRef refs
+  where
+    realMods                    = realModuleRefs (modules env)
+    refs                        = imports env ++
+                                  [ m | (_,NAlias (GName m _)) <- names env ] ++
+                                  [ m | (_,NMAlias m) <- names env, m `elem` realMods ]
+    canonicalRef m
+      | m `elem` realMods       = m
+      | otherwise               = case [ m' | m' <- realMods
+                                            , length (modPath m') > length (modPath m)
+                                            , modPath m `List.isSuffixOf` modPath m' ] of
+                                    [m'] -> m'
+                                    _    -> m
+
+realModuleRefs                :: TEnv -> [ModName]
+realModuleRefs te              = go [] te
+  where
+    go prefix                  = concatMap (one prefix)
+    one prefix (n, NModule te' _)
+      | all isModChild te'     = children
+      | otherwise              = ModName path : children
+      where
+        path                   = prefix ++ [n]
+        children               = go path te'
+    one _ _                    = []
+
+    isModChild (_, NModule{})  = True
+    isModChild (_, NMAlias{})  = True
+    isModChild _               = False
 
 moduleRefs1 env                 = moduleRefs env \\ [mPrim, mBuiltin]
 
 subImp spath env []          = return env
-subImp spath env (m:ms)      = do (env',_) <- doImp spath env m
+subImp spath env (m:ms)      = do (env',_,_) <- doImp spath env m
                                   subImp spath env' ms
 
 findTyFile spaths mn = go spaths
   where
-    go []     = return Nothing
-    go (p:ps) = do
-      let fullPath = joinPath (p : modPath mn) ++ ".ty"
-      exists <- doesFileExist fullPath
-      --traceM ("findTyFile: " ++ fullPath ++ " " ++ show exists)
-      if exists
-        then return (Just fullPath)
-        else go ps
+    segs = modPath mn
+    tails = case segs of
+              (_:rest) | not (null rest) -> [rest]
+              _ -> []
+
+    firstExisting [] = return Nothing
+    firstExisting (f:fs) = do
+      exists <- doesFileExist f
+      if exists then return (Just f) else firstExisting fs
+
+    projectRootForTypes p =
+      let outDir = takeDirectory p
+          root = takeDirectory outDir
+      in if takeFileName p == "types" && takeFileName outDir == "out"
+           then Just root
+           else Nothing
+
+    hasPackageRootSource p =
+      case projectRootForTypes p of
+        Just root -> doesFileExist (joinPath [root, "src", "lib.act"])
+        Nothing -> return False
+
+    packageRootName p =
+      case projectRootForTypes p of
+        Just root -> do
+          hasRoot <- doesFileExist (joinPath [root, "src", "lib.act"])
+          if not hasRoot
+            then return Nothing
+            else do
+              let buildAct = joinPath [root, "Build.act"]
+              hasBuild <- doesFileExist buildAct
+              if not hasBuild
+                then return Nothing
+                else do
+                  content <- IO.readFile buildAct
+                  return $ case BuildSpec.parseBuildActDetailed content of
+                    Right (spec, _, _) -> Just (BuildSpec.specName spec)
+                    Left _ -> Nothing
+        Nothing -> return Nothing
+
+    prefixedSearch _ _ [] = return Nothing
+    prefixedSearch skipPackageRoots p rels = do
+      exists <- doesDirectoryExist p
+      if not exists
+        then return Nothing
+        else do
+          blocked <- if skipPackageRoots then hasPackageRootSource p else return False
+          if blocked
+            then return Nothing
+            else do
+              entries <- List.sort <$> listDirectory p
+              dirs <- filterM (\d -> doesDirectoryExist (joinPath [p,d])) entries
+              let candidates = [ joinPath ([p,d] ++ rel) ++ ".ty" | d <- dirs, rel <- rels ]
+              firstExisting candidates
+
+    prefixedSearchPaths _ [] = return Nothing
+    prefixedSearchPaths skipPackageRoots (p:ps) = do
+      found <- prefixedSearch skipPackageRoots p (segs : tails)
+      case found of
+        Just f -> return (Just f)
+        Nothing -> prefixedSearchPaths skipPackageRoots ps
+
+    go [] = return Nothing
+    go paths@(p:ps) = do
+      currentHasPackageRoot <- hasPackageRootSource p
+      currentPackageName <- packageRootName p
+      currentPackage <- case currentPackageName of
+                          Just pkg -> firstExisting [joinPath ([p, pkg] ++ segs) ++ ".ty"]
+                          Nothing -> return Nothing
+      case currentPackage of
+        Just f -> return (Just f)
+        Nothing -> do
+          directCurrent <- firstExisting [joinPath (p : segs) ++ ".ty"]
+          case directCurrent of
+            Just f -> return (Just f)
+            Nothing -> do
+              directRest <- firstExisting [ joinPath (p' : segs) ++ ".ty" | p' <- ps ]
+              case directRest of
+                Just f -> return (Just f)
+                Nothing -> do
+                  depFallback <- prefixedSearchPaths True ps
+                  case depFallback of
+                    Just f -> return (Just f)
+                    Nothing ->
+                      if currentHasPackageRoot
+                        then return Nothing
+                        else prefixedSearchPaths False [p]
+
+aliasBindingForImport :: ModName -> ModName -> Maybe (Name, ModName)
+aliasBindingForImport (ModName (n:ns)) realM =
+    let suffix = map nstr ns
+        target0 = modPath realM
+        target = case stripSuffix suffix target0 of
+                   Just pfx | not (null pfx) -> pfx
+                   _ -> target0
+    in Just (n, modName target)
+  where
+    stripSuffix suffix xs = reverse <$> List.stripPrefix (reverse suffix) (reverse xs)
+aliasBindingForImport _ _ = Nothing
+
+resolveHeadAlias :: EnvF x -> ModName -> Maybe ModName
+resolveHeadAlias env (ModName (n:ns)) =
+  case lookup n (names env) of
+    Just (NMAlias (ModName ms)) -> Just (ModName (ms ++ ns))
+    _ -> Nothing
+resolveHeadAlias _ _ = Nothing
+
+resolveModuleAlias :: EnvF x -> ModName -> ModName
+resolveModuleAlias env m =
+  case resolveModuleAlias1 env m of
+    Just m' | m' /= m -> resolveModuleAlias env m'
+    _                 -> m
+
+resolveModuleAlias1 :: EnvF x -> ModName -> Maybe ModName
+resolveModuleAlias1 env (ModName ns) = go ns (modules env)
+  where
+    go [] _             = Nothing
+    go (n:ns) te        = case lookup n te of
+                            Just (NMAlias (ModName ms)) -> Just (ModName (ms ++ ns))
+                            Just (NModule te' _)        -> go ns te'
+                            _                           -> Nothing
 
 -- | Import a module, loading its .ty and extending the environment.
-doImp                        :: [FilePath] -> EnvF x -> ModName -> IO (EnvF x, TEnv)
+doImp                        :: [FilePath] -> EnvF x -> ModName -> IO (EnvF x, ModName, TEnv)
 doImp spath env m            = do
-                                  (env', te, _) <- doImpSeen S.empty env m
-                                  return (env', te)
+                                  (env', m', te, _) <- doImpSeen S.empty env m
+                                  return (env', m', te)
   where
+    lookupLoaded req canon env =
+      case lookupMod canon env of
+        Just te -> Just te
+        Nothing | canon /= req -> lookupMod req env
+        Nothing -> Nothing
+
     -- A cached module still needs its recorded import closure available in the
     -- environment. Otherwise later imports of that cached module can miss
     -- transitive dependencies that were never added to the shared module cache.
     doImpSeen seen env m
-      | S.member m seen      =
-          case lookupMod m env of
-            Just te -> return (env, te, seen)
+      | S.member canon seen  =
+          case lookupLoaded m canon env of
+            Just te -> return (env, canon, te, seen)
             Nothing -> fileNotFound m
       | otherwise            =
-          let seen' = S.insert m seen in
-          case lookupMod m env of
+          let seen' = S.insert canon seen in
+          case lookupLoaded m canon env of
             Just te -> do
-              hdr <- readFoundTy InterfaceFiles.readHeaderMaybe m
+              hdr <- readFoundTy InterfaceFiles.readHeaderMaybe canon
               case hdr of
-                Nothing -> return (env, te, seen')
+                Nothing -> return (env, canon, te, seen')
                 Just (_sourceMeta, _, _, _, imps, _, _, _, _) -> do
                   (env', seen'') <- subImpSeen seen' env (map fst imps)
-                  return (env', te, seen'')
+                  return (env', canon, te, seen'')
             Nothing -> do
               ty <- readFoundTy InterfaceFiles.readFileMaybe m
               case ty of
                 Nothing -> fileNotFound m
-                Just (ms,nmod,_,_,_,_,_,_,_,_,_,_) -> do
-                  (env', seen'') <- subImpSeen seen' env ms
+                Just (ms,nmod,tmod,_,_,_,_,_,_,_,_,_) -> do
+                  let m' = modname tmod
+                      seen'' = S.insert m' seen'
+                  (env', seen''') <- subImpSeen seen'' env ms
                   let NModule teFull mdoc = nmod
                       te = publicTEnv teFull
-                  return (addMod m te mdoc env', te, seen'')
+                      env1 = addMod m' te mdoc env'
+                      env2 = if m == m' then env1 else addModAlias m m' env1
+                  return (env2, m', te, seen''')
+      where
+        canon = resolveModuleAlias env (maybe m id (resolveHeadAlias env m))
 
     readFoundTy readTy m = do
       tyFile <- findTyFile spath m
@@ -1089,7 +1282,7 @@ doImp spath env m            = do
 
     subImpSeen seen env []   = return (env, seen)
     subImpSeen seen env (m:ms) = do
-      (env', _, seen') <- doImpSeen seen env m
+      (env', _, _, seen') <- doImpSeen seen env m
       subImpSeen seen' env' ms
 
 importSome                  :: [ImportItem] -> ModName -> TEnv -> EnvF x -> EnvF x

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -93,7 +93,7 @@ main = do
               ( (map (+ 1) S.version, sourceMeta, srcHash, pubHash, implHash)
               , imps, nameHashes, roots, tests, mdoc, nmod, tmod
               )
-          (_env2, te) <- Acton.Env.doImp [dir] env1 directMod
+          (_env2, _directMod, te) <- Acton.Env.doImp [dir] env1 directMod
           map fst te `shouldBe` [valueName]
 
     describe "Pass 1: Parser" $ do


### PR DESCRIPTION
This adds dependency-qualified imports so modules from dependencies can be addressed through the dependency name. A dependency named `foo` can expose its package root as `import foo` when it has `src/lib.act`, and other source modules can be imported as `foo.bar`, `foo.client`, and so on.

`src/lib.act` is treated as the package root module for new-style packages. Inside such a package, local modules can still use relative imports like `import transport`, so packages do not need to refer to themselves through their dependency-qualified external name.

Dependencies that have a package root are excluded from the legacy unqualified dependency fallback. That keeps common module names such as `client`, `transport`, and `config` from colliding across dependencies as packages migrate to the new import style, while old packages without `src/lib.act` continue to work through the existing lookup behavior.

The compiler keeps canonical module names through planning, import loading, signature lookup, interface lookup, and code generation. Interface lookup is tied to the package name from `Build.act`, stale raw outputs cannot shadow package-root modules, `from` imports avoid binding the dependency head as a module alias, and dependency `.ext.c` sources get compatibility macros so existing legacy C symbol references continue to compile.