### PR TITLE
Describe root actor env parameter

### DIFF
--- a/docs/acton-guide/src/actors/root.md
+++ b/docs/acton-guide/src/actors/root.md
@@ -1,6 +1,8 @@
 # Root Actor
 
-Every Acton program has a root actor. To compile a binary executable, there must be a root actor. Per default, if a source (`.act`) file contains an actor named `main`, it will be used as the root actor. You can specify which actor should be the root using the `--root` argument. While the convention is to call the root actor `main`, you are free to name it anything.
+Every Acton program has a root actor. To compile a binary executable, there must be a root actor. Per default, if a source (`.act`) file contains an actor named `main` with a single `Env` type parameter, it will be used as the root actor. You can specify which actor should be the root using the `--root` argument. While the convention is to call the root actor `main`, you are free to name it anything.
+
+The `env` parameter is not an arbitrary actor reference, it is the builtin environment actor `Env`. The Acton run time system (RTS) constructs this actor and passes it to the root actor when the program starts. In guide examples this is usually written as `actor main(env):`, but you can also write the type explicitly as `actor main(env: Env):`.
 
 Given this Acton program:
 ```python
@@ -40,3 +42,5 @@ A normal Acton program consists of many actors that are structured in a hierarch
 ```
 
 Any executable Acton program must have a root actor defined. Acton libraries (that are included in an another Acton program), do not need a root actor.
+
+Because the root actor receives `Env`, it is also where access to the builtin environment actor begins. See [Environment](/environment.md) for an overview of `Env` and links to the relevant guide pages for arguments, capabilities, environment variables, and stdin handling.

--- a/docs/acton-guide/src/environment.md
+++ b/docs/acton-guide/src/environment.md
@@ -2,3 +2,14 @@
 
 The environment of an Acton application is the outside world. Any useful application typically needs to interact with the environment in some way, like reading arguments or taking input from stdin and printing output.
 
+The root actor receives the builtin environment actor `Env` as its `env` parameter. This is the primary way the root actor, and other actors it enables, access the outside world.
+
+The builtin `Env` actor provides, among other things:
+
+- `env.argv` for command-line arguments, see [Program Arguments](/hello/args.md)
+- `env.cap` for the root `WorldCap` capability, see [Capabilities](/security/capabilities.md)
+- `env.syscap` for low-level RTS/system access used by some runtime-facing libraries
+- `env.getenv`, `env.setenv`, and `env.unsetenv` for environment variables, see [Environment Variables](/environment/variables.md)
+- `env.stdin_install`, `env.set_stdin`, `env.stdout_write`, and `env.is_tty` for terminal I/O, see [Reading stdin input](/environment/stdin.md) and [Interactive stdin input](/environment/interactive_stdin.md)
+- `env.exit(n)` to terminate the program
+- `env.nr_wthreads` for the number of RTS worker threads


### PR DESCRIPTION
If the parameter of the candidate root actor (defualt main) is not of type Env, then the actor is an eligible root actor.