### PR TITLE
Add release mode aliases

### DIFF
--- a/compiler/acton/package.yaml.in
+++ b/compiler/acton/package.yaml.in
@@ -38,6 +38,7 @@ dependencies:
   - http-client
   - http-client-tls
   - http-types
+  - optparse-applicative
   - megaparsec
   - prettyprinter
   - pretty-show

--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -26,7 +26,9 @@ import Test.Tasty.Golden (goldenVsString)
 import Test.Tasty.HUnit
 
 import qualified PkgCommands
+import qualified Acton.CommandLineParser as C
 import qualified Acton.Fingerprint as Fingerprint
+import qualified Options.Applicative as OA
 import qualified Paths_acton
 
 -- The default is to build and run each test program with the expectation that
@@ -426,6 +428,25 @@ parseFlagTests =
   , flagGolden "cgen flag prints c" "test/parse/simple.cgen.golden" ["--quiet", "--dbg-no-lines", "--cgen"]
   , flagGolden "all flags combined" "test/parse/simple.all.golden"
         ["--quiet", "--parse", "--kinds", "--types", "--sigs", "--norm", "--deact", "--cps", "--llift", "--box", "--dbg-no-lines", "--hgen"]
+  , testCase "optimize parser accepts release aliases" $ do
+      assertParsedBuildOptimize ["build", "--release"] C.ReleaseSafe
+      assertParsedBuildOptimize ["build", "--release=safe"] C.ReleaseSafe
+      assertParsedBuildOptimize ["build", "--release=SmAlL"] C.ReleaseSmall
+      assertParsedBuildOptimize ["build", "--release=FAST"] C.ReleaseFast
+      assertParsedBuildOptimize ["build", "--optimize=release"] C.ReleaseSafe
+      assertParsedBuildOptimize ["build", "--optimize=ReLeAsE"] C.ReleaseSafe
+      assertParsedBuildOptimize ["build", "--optimize=dEbUg"] C.Debug
+      assertParsedBuildOptimize ["build", "--optimize=reLeAsEsMaLl"] C.ReleaseSmall
+      assertParsedBuildOptimize ["build", "--optimize=RELEASEFAST"] C.ReleaseFast
+  , testCase "explicit --optimize overrides --release alias" $ do
+      assertParsedBuildOptimize ["build", "--release", "--optimize=releasesmall"] C.ReleaseSmall
+      assertParsedBuildOptimize ["build", "--release=fast", "--optimize=debug"] C.Debug
+      assertParsedBuildOptimize ["build", "--optimize=debug", "--release"] C.Debug
+  , testCase "build parser help includes --release alias" $ do
+      helpText <- renderParserHelp ["build", "--help"]
+      assertBool "help text should include --release" ("--release" `isInfixOf` helpText)
+      assertBool "help text should mention release variants" ("=small or =fast" `isInfixOf` helpText)
+      assertBool "help text should mention default release mode" ("same as --release=safe" `isInfixOf` helpText)
   , testCase "acton test --help includes --no-cache and --tag" $ do
       acton <- canonicalizePath "../../dist/bin/acton"
       (returnCode, cmdOut, cmdErr) <- readCreateProcessWithExitCode (proc acton ["test", "--help"]) ""
@@ -492,6 +513,34 @@ parseFlagTests =
           (not ("Using cached results for 1 tests" `isInfixOf` out3))
   ]
   where
+    parserInfo = OA.info (C.cmdLineParser OA.<**> OA.helper) C.descr
+
+    parseArgs args =
+      case OA.execParserPure OA.defaultPrefs parserInfo args of
+        OA.Success result -> return result
+        OA.Failure failure -> do
+          let (msg, _) = OA.renderFailure failure "acton"
+          assertFailure ("parser failed for " ++ unwords args ++ ":\n" ++ msg)
+        OA.CompletionInvoked _ ->
+          assertFailure ("parser requested shell completion for " ++ unwords args)
+
+    assertParsedBuildOptimize args expected = do
+      parsed <- parseArgs args
+      case parsed of
+        C.CmdOpt _ (C.Build buildOpts) ->
+          assertEqual ("unexpected optimize mode for " ++ unwords args)
+            expected
+            (C.optimize (C.buildCompile buildOpts))
+        _ ->
+          assertFailure ("expected build command for " ++ unwords args)
+
+    renderParserHelp args =
+      case OA.execParserPure OA.defaultPrefs parserInfo args of
+        OA.Failure failure -> pure (fst (OA.renderFailure failure "acton"))
+        OA.Success _ -> assertFailure ("expected parser help for " ++ unwords args)
+        OA.CompletionInvoked _ ->
+          assertFailure ("parser requested shell completion for " ++ unwords args)
+
     flagGolden label golden flags =
       goldenVsString label golden $ do
         acton <- canonicalizePath "../../dist/bin/acton"

--- a/compiler/lib/src/Acton/CommandLineParser.hs
+++ b/compiler/lib/src/Acton/CommandLineParser.hs
@@ -2,6 +2,7 @@
 module Acton.CommandLineParser where
 
 import Options.Applicative
+import Data.Char (toLower)
 import Data.Maybe (fromMaybe, isJust)
 
 #if defined(darwin_HOST_OS) && defined(aarch64_HOST_ARCH)
@@ -224,12 +225,21 @@ globalOptions = GlobalOptions
 
 optimizeReader :: ReadM OptimizeMode
 optimizeReader = eitherReader $ \s ->
-    case s of
-        "Debug"        -> Right Debug
-        "ReleaseSafe"  -> Right ReleaseSafe
-        "ReleaseSmall" -> Right ReleaseSmall
-        "ReleaseFast"  -> Right ReleaseFast
-        _              -> Left $ "Invalid optimize option: " ++ s ++ " (expected: Debug, ReleaseSafe, ReleaseSmall, ReleaseFast)"
+    case map toLower s of
+        "debug"        -> Right Debug
+        "release"      -> Right ReleaseSafe
+        "releasesafe"  -> Right ReleaseSafe
+        "releasesmall" -> Right ReleaseSmall
+        "releasefast"  -> Right ReleaseFast
+        _              -> Left $ "Invalid optimize option: " ++ s ++ " (expected: Debug, Release, ReleaseSafe, ReleaseSmall, ReleaseFast)"
+
+releaseModeReader :: ReadM OptimizeMode
+releaseModeReader = eitherReader $ \s ->
+    case map toLower s of
+        "safe"  -> Right ReleaseSafe
+        "small" -> Right ReleaseSmall
+        "fast"  -> Right ReleaseFast
+        _       -> Left $ "Invalid release option: " ++ s ++ " (expected: safe, small, fast)"
 
 
 {-
@@ -359,12 +369,28 @@ docOptions = DocOptions
         )
 
 optimizeOption :: Parser OptimizeMode
-optimizeOption = option optimizeReader
-    (long "optimize"
-     <> metavar "MODE"
-     <> value Debug
-     <> help "Optimization mode (Debug, ReleaseSafe, ReleaseSmall, ReleaseFast)"
-    )
+optimizeOption = resolveOptimizeOption
+    <$> optional releaseOption
+    <*> optional
+        (option optimizeReader
+            (long "optimize"
+             <> metavar "MODE"
+             <> help "Optimization mode (case-insensitive: Debug, Release/ReleaseSafe, ReleaseSmall, ReleaseFast)"
+            ))
+  where
+    releaseOption =
+        flag' ReleaseSafe
+            (long "release"
+             <> help "Release build mode; same as --release=safe and also accepts =small or =fast"
+            )
+        <|> option releaseModeReader
+            (long "release"
+             <> internal
+            )
+
+    resolveOptimizeOption _ (Just mode) = mode
+    resolveOptimizeOption (Just mode) _ = mode
+    resolveOptimizeOption Nothing Nothing = Debug
 
 data TestModeTag = ModeList | ModePerf | ModeStress deriving Show
 

--- a/docs/acton-guide/src/compilation.md
+++ b/docs/acton-guide/src/compilation.md
@@ -6,6 +6,19 @@ While compiled languages are often associated with long compilation times that s
 
 It is possible to influence the compilation process and the output in various ways.
 
+## Optimization modes
+
+Acton defaults to `Debug` builds. Debug builds compile fast and include
+debug symbols, which makes them the right default during development.
+
+For release builds, use `acton build --release` to better optimize the
+final executable. For standalone files, use `acton --release foo.act`.
+
+`--release` and `--release=safe` select the normal release mode.
+`--release=small` optimizes for a smaller binary size. `--release=fast`
+can result in a faster program, but it is generally discouraged because
+it disables safety checks and alters language semantics.
+
 ## Optimized for native CPU features
 
 The default target is somewhat conservative to ensure a reasonable amount of compatibility. On Linux, the default target is GNU Libc version 2.27 which makes it possible to run Acton programs on Ubuntu 18.04 and similar old operating systems. Similarly, a generic x86_64 CPU is assumed which means that newer extra CPU instruction sets are not used.


### PR DESCRIPTION
Acton's release guidance and CLI were awkward. Users had to reach for --optimize mode names directly, and the parser only accepted exact-cased mode names. That made the recommended release path harder to discover and left the guide speaking in terms of lower-level optimization flags.

Add a dedicated --release option that defaults to ReleaseSafe and also accepts safe, small, and fast variants. Keep --optimize available, make its release mode names case-insensitive, and let explicit --optimize override any release shortcut. Update the guide to present Debug as the default development build and describe the release modes through --release.