### PR TITLE
Use source metadata to validate .ty

### DIFF
--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -701,7 +701,7 @@ readModuleImports paths mn = do
         hdrE <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readHeader tyFile
         case hdrE of
           Left _ -> return []
-          Right (_hash, _ih, _implH, imps, _nameHashes, _roots, _tests, _doc) -> return (map fst imps)
+          Right (_sourceMeta, _hash, _ih, _implH, imps, _nameHashes, _roots, _tests, _doc) -> return (map fst imps)
 
 dependentTestModulesFromHeaders :: Paths -> [FilePath] -> [String] -> IO [String]
 dependentTestModulesFromHeaders paths srcFiles changedModules = do
@@ -1699,7 +1699,7 @@ generateProjectDocIndex sp gopts opts paths srcFiles = do
         createDirectoryIfMissing True docDir
         tasks <- mapM (\f -> findPaths f opts >>= \p -> readModuleTask sp gopts opts p f) srcFiles
         entries <- catMaybes <$> forM tasks (\t -> case t of
-                          ActonTask mn _src _bytes m -> return (Just (mn, DocP.extractDocstring (A.mbody m)))
+                          ActonTask mn _src _bytes _sourceMeta m -> return (Just (mn, DocP.extractDocstring (A.mbody m)))
                           TyTask { name = mn, tyDoc = mdoc } -> return (Just (mn, mdoc))
                           ParseErrorTask{} -> return Nothing)
         DocP.generateDocIndex docDir entries
@@ -1818,7 +1818,7 @@ expectedRootStubs paths tasks = do
             tyPath = outbase ++ ".ty"
         hdrE <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readHeader tyPath
         case hdrE of
-          Right (_, _, _implH, _imps, _nameHashes, rs, _tests, _) -> return (map (mkStub outbase) rs)
+          Right (_sourceMeta, _, _, _implH, _imps, _nameHashes, rs, _tests, _) -> return (map (mkStub outbase) rs)
           _ -> return []
     return (concat roots)
   where
@@ -1869,12 +1869,20 @@ High-level Steps
 1) Discover and read tasks using header-first strategy (readModuleTask)
    - For each module, try to use its .ty header to avoid parsing:
      - If .ty is missing/unreadable → parse .act to obtain imports (ActonTask).
-     - If .ty exists and both .act and the acton executable mtime <= .ty mtime
+     - If the compiler compatibility guard says the cache is stale
+       → parse .act now to get accurate imports (ActonTask).
+     - If source metadata in the .ty header still matches the current .act and
+       the source mtime is strictly older than the .ty mtime
        → trust .ty header imports and create a TyTask stub (no heavy decode)
-       for graph building. Use --ignore-compiler-version to skip the acton part.
-     - If .act appears newer than .ty → verify by content hash:
-       – If stored moduleSrcBytesHash == current bytes hash → header is still valid (TyTask)
+       for graph building.
+     - If metadata differs, or source/.ty mtimes are equal, verify by content
+       hash:
+       – If stored moduleSrcBytesHash == current bytes hash → header is still
+         valid (TyTask) and refresh cached source metadata.
        – Else → parse .act now to get accurate imports (ActonTask)
+     - Equal source/.ty mtimes are treated as ambiguous because coarse-mtime
+       filesystems can assign the same visible timestamp to a changed source
+       and the cached .ty written from an earlier version of that source.
    - This ensures that .ty is up to date with the .act source and lets us
      read module imports/roots/docstring from the header, which is much faster
      than parsing the .act file.
@@ -1942,7 +1950,7 @@ writeRootC env gopts opts paths tasks binTask = do
         -- was rebuilt during this run.
         tyPath <- Acton.Env.findTyFile (searchPath paths) m
         rootsHeader <- case tyPath of
-                         Just ty -> do (_, _, _implH, _imps, _nameHashes, roots, _tests, _) <- InterfaceFiles.readHeader ty; return roots
+                         Just ty -> do (_sourceMeta, _, _, _implH, _imps, _nameHashes, roots, _tests, _) <- InterfaceFiles.readHeader ty; return roots
                          Nothing -> return []
         let rootsEnv = case Acton.Env.lookupMod m env of
                          Nothing -> []
@@ -2527,7 +2535,7 @@ filterMainActor env paths binTask = do
       Just ty -> do
         hdrE <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readHeader ty
         case hdrE of
-          Right (_, _, _implH, _imps, _nameHashes, roots, _tests, _) | n `elem` roots -> return (Just binTask)
+          Right (_sourceMeta, _, _, _implH, _imps, _nameHashes, roots, _tests, _) | n `elem` roots -> return (Just binTask)
           _ -> checkEnv
       Nothing -> checkEnv
 

--- a/compiler/acton/TestRunner.hs
+++ b/compiler/acton/TestRunner.hs
@@ -560,7 +560,7 @@ readModuleTests paths mn = do
         hdrE <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readHeader tyFile
         case hdrE of
           Left _ -> return []
-          Right (_srcH, _ih, _implH, _imps, _nameHashes, _roots, tests, _doc) ->
+          Right (_sourceMeta, _srcH, _ih, _implH, _imps, _nameHashes, _roots, tests, _doc) ->
             return tests
 
 modNameFromString :: String -> A.ModName

--- a/compiler/acton/test_incremental.hs
+++ b/compiler/acton/test_incremental.hs
@@ -15,12 +15,15 @@ import qualified Acton.Fingerprint as Fingerprint
 import qualified Crypto.Hash.SHA256 as SHA256
 import           Data.List (find, partition, sort)
 import qualified Data.Map.Strict as M
+import           Data.Maybe (isJust)
 import           System.Directory
 import           System.Exit
 import           System.FilePath
 import           System.IO (Handle)
+import           System.Posix.Files (deviceID, fileID, fileSize, getFileStatus, modificationTimeHiRes, statusChangeTimeHiRes)
 import           System.Process
-import           Data.Time.Clock        (getCurrentTime)
+import           Data.Time.Clock        (addUTCTime, getCurrentTime)
+import           Data.Time.Clock.POSIX  (posixSecondsToUTCTime)
 import           System.Directory       (setModificationTime)
 import qualified Control.Exception as E
 import           Control.Concurrent     (threadDelay)
@@ -457,7 +460,7 @@ buildProject = do
 -- | Read name hashes from a .ty file.
 readTyNameHashes :: FilePath -> IO [InterfaceFiles.NameHashInfo]
 readTyNameHashes tyPath = do
-  (_, _, _, _, _, _, _, nameHashes, _, _, _) <- InterfaceFiles.readFile tyPath
+  (_, _, _, _, _, _, _, _, nameHashes, _, _, _) <- InterfaceFiles.readFile tyPath
   pure nameHashes
 
 -- | Read pub/impl dependency names for a binding in a .ty file.
@@ -477,8 +480,35 @@ readTyDeps tyPath nameLabel = do
 -- | Rewrite source hash and name-hash section of a .ty file.
 rewriteTySrcHashAndNameHashes :: FilePath -> B.ByteString -> ([InterfaceFiles.NameHashInfo] -> [InterfaceFiles.NameHashInfo]) -> IO ()
 rewriteTySrcHashAndNameHashes tyPath srcHash' f = do
-  (_mods, nmod, tmod, _srcHash, pubHash, implHash, imps, nameHashes, roots, tests, mdoc) <- InterfaceFiles.readFile tyPath
-  InterfaceFiles.writeFile tyPath srcHash' pubHash implHash imps (f nameHashes) roots tests mdoc nmod tmod
+  (_mods, nmod, tmod, sourceMeta, _srcHash, pubHash, implHash, imps, nameHashes, roots, tests, mdoc) <- InterfaceFiles.readFile tyPath
+  InterfaceFiles.writeFile tyPath srcHash' pubHash implHash sourceMeta imps (f nameHashes) roots tests mdoc nmod tmod
+
+rewriteTySourceMeta :: FilePath -> Maybe InterfaceFiles.SourceFileMeta -> IO ()
+rewriteTySourceMeta tyPath sourceMeta' = do
+  (_mods, nmod, tmod, _sourceMeta, srcHash, pubHash, implHash, imps, nameHashes, roots, tests, mdoc) <- InterfaceFiles.readFile tyPath
+  InterfaceFiles.writeFile tyPath srcHash pubHash implHash sourceMeta' imps nameHashes roots tests mdoc nmod tmod
+
+readTySourceMeta :: FilePath -> IO (Maybe InterfaceFiles.SourceFileMeta)
+readTySourceMeta tyPath = do
+  (sourceMeta, _srcHash, _pubHash, _implHash, _imps, _nameHashes, _roots, _tests, _doc) <- InterfaceFiles.readHeader tyPath
+  pure sourceMeta
+
+sourceFileMetaForPath :: FilePath -> IO InterfaceFiles.SourceFileMeta
+sourceFileMetaForPath path = do
+  st <- getFileStatus path
+  let mtimeNs = floor (toRational (modificationTimeHiRes st) * 1000000000)
+      ctimeNs = floor (toRational (statusChangeTimeHiRes st) * 1000000000)
+  pure InterfaceFiles.SourceFileMeta
+    { InterfaceFiles.sfmMTimeNs = mtimeNs
+    , InterfaceFiles.sfmCTimeNs = ctimeNs
+    , InterfaceFiles.sfmSize = fromIntegral (fileSize st)
+    , InterfaceFiles.sfmDevice = Just (fromIntegral (deviceID st))
+    , InterfaceFiles.sfmInode = Just (fromIntegral (fileID st))
+    }
+
+setFileMTimeNs :: FilePath -> Integer -> IO ()
+setFileMTimeNs path mtimeNs =
+  setModificationTime path (posixSecondsToUTCTime (fromRational (toRational mtimeNs / 1000000000)))
 
 -- | Drop a qualified dependency label from all stored pub/impl dep lists.
 dropTyDepByLabel :: String -> [InterfaceFiles.NameHashInfo] -> [InterfaceFiles.NameHashInfo]
@@ -1260,7 +1290,7 @@ p28_protocol_extension_deps = testCase "28-protocol/extension deps are recorded 
   let namesA = sort (map (prstr . InterfaceFiles.nhName) nameHashesA)
   assertBool "expected generated protocol sibling name" ("BazProtoD_BarProto" `elem` namesA)
   assertBool "expected generated extension name" ("BarProtoD_Widget" `elem` namesA)
-  (_, nmod, _, _, _, _, _, _, _, _, _) <- InterfaceFiles.readFile tyA
+  (_, nmod, _, _, _, _, _, _, _, _, _, _) <- InterfaceFiles.readFile tyA
   let I.NModule iface _ = nmod
       extMatch (n, _) = prstr n == "BarProtoD_Widget"
   case find extMatch iface of
@@ -1844,6 +1874,133 @@ p40_background_lock_blocks_watch =
           _ <- waitForProcess ph
           pure ()
 
+p41_stale_header_missing_import_reparses_source :: TestTree
+p41_stale_header_missing_import_reparses_source =
+  testCase "41-stale header missing import reparses source" $ do
+    let proj = casesProjDir
+        src = casesSrcDir
+        actA = src </> "a.act"
+        actB = src </> "b.act"
+        tyB = proj </> "out" </> "types" </> "b.ty"
+        outA = proj </> "out" </> "types" </> "a"
+        modB = modLabel proj "b"
+    ensureCasesProject
+    writeFileUtf8 actA "aaa = 1\n"
+    writeFileUtf8 actB $ T.unlines
+      [ "import a"
+      , ""
+      , "def bar() -> int:"
+      , "    return a.aaa"
+      ]
+    writeFileUtf8 (src </> "main.act") $ T.unlines
+      [ "import b"
+      , ""
+      , "actor main(env: Env):"
+      , "    print(b.bar())"
+      , "    env.exit(0)"
+      ]
+    _ <- buildOutIn proj
+    writeFileUtf8 actB $ T.unlines
+      [ "def bar() -> int:"
+      , "    return 7"
+      ]
+    tyTime <- getModificationTime tyB
+    setModificationTime actB (addUTCTime (-10) tyTime)
+    removeFile actA
+    res@(_ec, out) <- runActonIn proj ["build", "--color", "never", "--verbose"]
+    assertExitSuccess "build after stale header import removal" res
+    mapM_ (\ext -> do
+      exists <- doesFileExist (outA ++ ext)
+      assertBool ("did not expect stale generated " ++ outA ++ ext) (not exists))
+      [".ty", ".c", ".h"]
+    assertBool "expected b.act to type check after stale header reparse"
+      (typechecked out modB)
+    assertBool ("did not expect stale import diagnostic\n" ++ T.unpack out)
+      (not (T.isInfixOf "Type interface file not found or unreadable for a" out))
+
+p42_metadata_drift_refreshes_header :: TestTree
+p42_metadata_drift_refreshes_header =
+  testCase "42-metadata drift refreshes header" $ do
+    let proj = casesProjDir
+        src = casesSrcDir
+        actA = src </> "a.act"
+        tyA = proj </> "out" </> "types" </> "a.ty"
+        modA = modLabel proj "a"
+    ensureCasesProject
+    writeFileUtf8 actA "aaa = 1\n"
+    writeFileUtf8 (src </> "main.act") $ T.unlines
+      [ "import a"
+      , ""
+      , "actor main(env: Env):"
+      , "    print(a.aaa)"
+      , "    env.exit(0)"
+      ]
+    _ <- buildOutIn proj
+    metaBefore <- readTySourceMeta tyA
+    threadDelay 1000000
+    touch actA
+    out <- buildOutIn proj
+    metaAfter <- readTySourceMeta tyA
+    currentMeta <- sourceFileMetaForPath actA
+    assertBool "did not expect a.act to type check after metadata-only drift"
+      (not (typechecked out modA))
+    assertBool "expected .ty header to carry source metadata"
+      (isJust metaAfter)
+    assertBool "expected metadata drift to update cached source metadata"
+      (metaBefore /= metaAfter)
+    metaAfter @?= Just currentMeta
+
+p43_equal_act_ty_mtime_hashes_source :: TestTree
+p43_equal_act_ty_mtime_hashes_source =
+  testCase "43-equal act/ty mtimes still hash source" $ do
+    let proj = casesProjDir
+        src = casesSrcDir
+        actA = src </> "a.act"
+        actB = src </> "b.act"
+        tyB = proj </> "out" </> "types" </> "b.ty"
+        outA = proj </> "out" </> "types" </> "a"
+        modB = modLabel proj "b"
+    ensureCasesProject
+    writeFileUtf8 actA "aaa = 1\n"
+    writeFileUtf8 actB $ T.unlines
+      [ "import a"
+      , ""
+      , "def bar() -> int:"
+      , "    return a.aaa"
+      ]
+    writeFileUtf8 (src </> "main.act") $ T.unlines
+      [ "import b"
+      , ""
+      , "actor main(env: Env):"
+      , "    print(b.bar())"
+      , "    env.exit(0)"
+      ]
+    _ <- buildOutIn proj
+    writeFileUtf8 actB $ T.unlines
+      [ "def bar() -> int:"
+      , "    return 7"
+      ]
+    rewriteTySourceMeta tyB Nothing
+    tyStatus <- getFileStatus tyB
+    let tyMTimeNs = floor (toRational (modificationTimeHiRes tyStatus) * 1000000000)
+    setFileMTimeNs actB tyMTimeNs
+    currentMeta <- sourceFileMetaForPath actB
+    rewriteTySourceMeta tyB (Just currentMeta)
+    setFileMTimeNs tyB tyMTimeNs
+    metaAfter <- readTySourceMeta tyB
+    metaAfter @?= Just currentMeta
+    removeFile actA
+    res@(_ec, out) <- runActonIn proj ["build", "--color", "never", "--verbose"]
+    assertExitSuccess "build after equal act/ty mtime stale header" res
+    mapM_ (\ext -> do
+      exists <- doesFileExist (outA ++ ext)
+      assertBool ("did not expect stale generated " ++ outA ++ ext) (not exists))
+      [".ty", ".c", ".h"]
+    assertBool "expected b.act to type check after equal-mtime hash check"
+      (typechecked out modB)
+    assertBool ("did not expect stale import diagnostic\n" ++ T.unpack out)
+      (not (T.isInfixOf "Type interface file not found or unreadable for a" out))
+
 -- Main -----------------------------------------------------------------------
 
 -- | Tasty entry point for incremental tests.
@@ -1904,5 +2061,10 @@ main = defaultMain $ localOption (NumThreads 1) $ testGroup "incremental"
       , p38_project_lock_blocks_build
       , p39_background_lock_does_not_block_build
       , p40_background_lock_blocks_watch
+      ]
+  , sequentialTestGroup "incremental-cache-cases" AllSucceed
+      [ p41_stale_header_missing_import_reparses_source
+      , p42_metadata_drift_refreshes_header
+      , p43_equal_act_ty_mtime_hashes_source
       ]
   ]

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -249,6 +249,7 @@ import System.FilePath.Posix
 import System.Exit (ExitCode(..))
 import System.IO hiding (readFile, writeFile)
 import System.IO.Unsafe (unsafePerformIO)
+import System.Posix.Files (FileStatus, deviceID, fileID, fileSize, getFileStatus, modificationTimeHiRes, statusChangeTimeHiRes)
 import System.Process (readCreateProcessWithExitCode, proc)
 import System.Random (randomRIO)
 import Text.PrettyPrint (renderStyle, style, Style(..), Mode(PageMode))
@@ -807,7 +808,7 @@ getPubHashCached paths mn = modifyMVar pubHashCache $ \m -> do
         Just ty -> do
           hdrE <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readHeader ty
           case hdrE of
-            Right (_srcH, ih, _implH, _impsH, _nameHashesH, _rootsH, _testsH, _docH) -> return (M.insert mn ih m, Just ih)
+            Right (_sourceMetaH, _srcH, ih, _implH, _impsH, _nameHashesH, _rootsH, _testsH, _docH) -> return (M.insert mn ih m, Just ih)
             _ -> return (m, Nothing)
         Nothing -> return (m, Nothing)
 
@@ -831,7 +832,7 @@ getNameHashMapCached paths mn = modifyMVar nameHashCache $ \m -> do
         Just ty -> do
           hdrE <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readHeader ty
           case hdrE of
-            Right (_srcH, _ih, _implH, _impsH, nameHashes, _rootsH, _testsH, _docH) -> do
+            Right (_sourceMetaH, _srcH, _ih, _implH, _impsH, nameHashes, _rootsH, _testsH, _docH) -> do
               let hm = nameHashMapFromList nameHashes
               return (M.insert mn hm m, Just hm)
             _ -> return (m, Nothing)
@@ -909,6 +910,25 @@ parseActFile sp mn actFile = do
   emod <- parseActSnapshot mn actFile snap
   return $ fmap (\m -> (snap, m)) emod
 
+-- | Read stable source metadata used for quick .ty reuse checks.
+-- Device/inode act as file identity on POSIX so metadata drift from copies or
+-- restores falls back to content hashing instead of blindly trusting mtimes.
+readSourceFileMeta :: FilePath -> IO InterfaceFiles.SourceFileMeta
+readSourceFileMeta path = do
+  st <- getFileStatus path
+  let mtimeNs = fileStatusMTimeNs st
+      ctimeNs = fileStatusCTimeNs st
+  return InterfaceFiles.SourceFileMeta
+    { InterfaceFiles.sfmMTimeNs = mtimeNs
+    , InterfaceFiles.sfmCTimeNs = ctimeNs
+    , InterfaceFiles.sfmSize = fromIntegral (fileSize st)
+    , InterfaceFiles.sfmDevice = Just (fromIntegral (deviceID st))
+    , InterfaceFiles.sfmInode = Just (fromIntegral (fileID st))
+    }
+  where
+    fileStatusMTimeNs st = floor (toRational (modificationTimeHiRes st) * 1000000000)
+    fileStatusCTimeNs st = floor (toRational (statusChangeTimeHiRes st) * 1000000000)
+
 
 -- Compilation tasks, chasing imported modules, compilation and building executables -----------------
 
@@ -935,7 +955,7 @@ data FrontResult = FrontResult
   , frBackJob  :: Maybe BackJob
   }
 
-data CompileTask        = ActonTask { name :: A.ModName, src :: String, srcBytes :: B.ByteString, atree:: A.Module }
+data CompileTask        = ActonTask { name :: A.ModName, src :: String, srcBytes :: B.ByteString, sourceMeta :: Maybe InterfaceFiles.SourceFileMeta, atree:: A.Module }
                         | TyTask    { name :: A.ModName
                                     , tyHash :: B.ByteString               -- raw source bytes hash
                                     , tyPubHash :: B.ByteString          -- module public hash
@@ -976,7 +996,7 @@ data GlobalTask = GlobalTask
 -- TyTask uses header imports, ActonTask uses the parsed AST, and parse errors
 -- yield no imports.
 importsOf :: CompileTask -> [A.ModName]
-importsOf (ActonTask _ _ _ m) = A.importsOf m
+importsOf (ActonTask _ _ _ _ m) = A.importsOf m
 importsOf (TyTask { tyImports = ms }) = map fst ms
 importsOf (ParseErrorTask _ _) = []
 
@@ -1133,18 +1153,22 @@ selectAffectedTasks globalTasks changedFiles = do
 -- Prefer reading imports from .ty header; if no .ty, parse the source.
 -- Decide how to represent a module for the graph:
 -- 1) If .ty is missing/unreadable -> parse .act to obtain imports (ActonTask).
--- 2) If .ty exists and .act mtime < .ty mtime (and the acton binary isn't newer
---    than the .ty unless --ignore-compiler-version is set) -> trust header imports (TyTask).
--- 2b) If an in-memory overlay exists, skip source mtime and compare its hash to header
---     (unless the compiler is newer and --ignore-compiler-version is not set).
--- 3) If .act appears newer than .ty -> verify by content hash:
---      - If stored moduleSrcBytesHash == current hash -> header is still valid (TyTask)
+-- 2) If .ty exists but the compiler compatibility guard says it is stale ->
+--    parse .act to obtain fresh imports.
+-- 3) If an in-memory overlay exists, skip filesystem metadata and compare the
+--    overlay bytes hash to the stored moduleSrcBytesHash.
+-- 4) Otherwise compare current source metadata against the cached sourceMeta:
+--      - If metadata matches and the source mtime is strictly older than the
+--        .ty mtime -> reuse the cached header (TyTask)
+--      - If metadata differs, or source/.ty mtimes are equal, and stored
+--        moduleSrcBytesHash == current bytes hash
+--        -> header is still valid (TyTask) and refresh source metadata in .ty
 --      - Else -> parse .act to obtain accurate imports (ActonTask)
 -- Returns either a header-only TyTask stub or an ActonTask; no heavy decoding.
 --
 -- This is the core of incremental graph construction: it avoids parsing when
--- cached interfaces are reliable, while still falling back to parsing when
--- source changes are detected.
+-- cached interfaces are reliable, while treating source content hash as the
+-- correctness authority when metadata alone is inconclusive.
 readModuleTask :: Source.SourceProvider -> C.GlobalOptions -> C.CompileOptions -> Paths -> String -> IO CompileTask
 readModuleTask sp gopts opts paths actFile = do
     let mn      = modName paths
@@ -1153,31 +1177,34 @@ readModuleTask sp gopts opts paths actFile = do
     if not tyExists
       then parseForImports mn
       else do
-        -- .ty exists: read header for hashes/imports and compare timestamps
+        -- .ty exists: read the cached header and validate it against compiler
+        -- compatibility plus source metadata/content as needed.
         hdrE <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readHeader tyFile
         case hdrE of
           Left _ -> parseForImports mn
-          Right (moduleSrcBytesHash, modulePubHash, moduleImplHash, imps, nameHashes, roots, tests, mdoc) -> do
-            tyTime <- getModificationTime tyFile
-            newCompiler <- compilerNewerThan tyTime
+          Right (cachedSourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash, imps, nameHashes, roots, tests, mdoc) -> do
+            tyStatus <- getFileStatus tyFile
+            let tyMTimeNs = fileStatusMTimeNs tyStatus
+            newCompiler <- compilerNewerThan tyMTimeNs
             mOverlay <- Source.spReadOverlay sp actFile
             case mOverlay of
               Just snap ->
                 if newCompiler
                   then parseFromSnapshot mn snap
-                  else verifyOrParse mn snap moduleSrcBytesHash modulePubHash moduleImplHash imps nameHashes roots tests mdoc
+                  else verifyOrParse mn snap moduleSrcBytesHash modulePubHash moduleImplHash cachedSourceMeta Nothing imps nameHashes roots tests mdoc
               Nothing -> do
-                actTime <- Source.spGetModTime sp actFile
-                -- Equal mtimes are ambiguous with coarse timestamp resolution,
-                -- so treat them as stale and re-hash the source.
                 if newCompiler
                   then parseForImports mn
-                  else if actTime < tyTime
-                    then return (mkTyTask mn moduleSrcBytesHash modulePubHash moduleImplHash imps nameHashes roots tests mdoc)
-                    else do
-                      snap <- Source.spReadFile sp actFile
-                      verifyOrParse mn snap moduleSrcBytesHash modulePubHash moduleImplHash imps nameHashes roots tests mdoc
+                  else do
+                    currentSourceMeta <- readSourceFileMeta actFile
+                    if canReuseHeader cachedSourceMeta currentSourceMeta tyMTimeNs
+                      then return (mkTyTask mn moduleSrcBytesHash modulePubHash moduleImplHash imps nameHashes roots tests mdoc)
+                      else do
+                        snap <- Source.spReadFile sp actFile
+                        verifyOrParse mn snap moduleSrcBytesHash modulePubHash moduleImplHash cachedSourceMeta (Just currentSourceMeta) imps nameHashes roots tests mdoc
   where
+    fileStatusMTimeNs st = floor (toRational (modificationTimeHiRes st) * 1000000000)
+
     mkTyTask mn moduleSrcBytesHash modulePubHash moduleImplHash imps nameHashes roots tests mdoc =
       let nmodStub = I.NModule [] mdoc
           tmodStub = A.Module mn [] []
@@ -1193,31 +1220,56 @@ readModuleTask sp gopts opts paths actFile = do
                 , iface     = nmodStub
                 , typed     = tmodStub }
 
+    metadataMatches cached current =
+      case cached of
+        Nothing -> False
+        Just meta -> meta == current
+
+    canReuseHeader cached current tyMTimeNs =
+      metadataMatches cached current
+      && InterfaceFiles.sfmMTimeNs current < tyMTimeNs
+
     parseForImports mn = do
       parsedRes <- parseActFile sp mn actFile
       case parsedRes of
         Left diags -> return $ ParseErrorTask mn diags
-        Right (snap, m) -> return $ ActonTask mn (Source.ssText snap) (Source.ssBytes snap) m
+        Right (snap, m) -> do
+          mSourceMeta <- snapshotSourceMeta snap
+          return $ ActonTask mn (Source.ssText snap) (Source.ssBytes snap) mSourceMeta m
 
     parseFromSnapshot mn snap = do
       emod <- parseActSnapshot mn actFile snap
       case emod of
         Left diags -> return $ ParseErrorTask mn diags
-        Right m -> return $ ActonTask mn (Source.ssText snap) (Source.ssBytes snap) m
+        Right m -> do
+          mSourceMeta <- snapshotSourceMeta snap
+          return $ ActonTask mn (Source.ssText snap) (Source.ssBytes snap) mSourceMeta m
 
-    compilerNewerThan tyTime
+    snapshotSourceMeta snap
+      | Source.ssIsOverlay snap = return Nothing
+      | otherwise = Just <$> readSourceFileMeta actFile
+
+    compilerNewerThan tyMTimeNs
       | C.ignore_compiler_version opts = return False
       | otherwise = do
           exePathE <- (try getExecutablePath :: IO (Either SomeException FilePath))
           case exePathE of
             Left _ -> return False
             Right exePath -> do
-              exeTimeE <- (try (getModificationTime exePath) :: IO (Either SomeException UTCTime))
-              case exeTimeE of
+              exeStatusE <- (try (getFileStatus exePath) :: IO (Either SomeException FileStatus))
+              case exeStatusE of
                 Left _ -> return False
-                Right exeTime -> return (exeTime > tyTime)
+                Right exeStatus -> return (fileStatusMTimeNs exeStatus > tyMTimeNs)
 
-    verifyOrParse mn snap moduleSrcBytesHash modulePubHash moduleImplHash imps nameHashes roots tests mdoc = do
+    refreshCachedSourceMeta currentSourceMeta = do
+      let tyFilePath = outBase paths (modName paths) ++ ".ty"
+      tyRes <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readFile tyFilePath
+      case tyRes of
+        Left _ -> return ()
+        Right (_ms, nmod, tmod, _oldSourceMeta, srcHash, pubHash, implHash, imps, nameHashes, roots, tests, mdoc) ->
+          InterfaceFiles.writeFile tyFilePath srcHash pubHash implHash currentSourceMeta imps nameHashes roots tests mdoc nmod tmod
+
+    verifyOrParse mn snap moduleSrcBytesHash modulePubHash moduleImplHash cachedSourceMeta currentSourceMeta imps nameHashes roots tests mdoc = do
       let curHash = SHA256.hash (Source.ssBytes snap)
           short8 bs = take 8 (B.unpack $ Base16.encode bs)
           same = curHash == moduleSrcBytesHash
@@ -1233,7 +1285,10 @@ readModuleTask sp gopts opts paths actFile = do
                   ++ " len=" ++ show len
                   ++ if same then " (match)" else " (diff)")
       if same
-        then return (mkTyTask mn moduleSrcBytesHash modulePubHash moduleImplHash imps nameHashes roots tests mdoc)
+        then do
+          when (currentSourceMeta /= Nothing && currentSourceMeta /= cachedSourceMeta) $
+            refreshCachedSourceMeta currentSourceMeta
+          return (mkTyTask mn moduleSrcBytesHash modulePubHash moduleImplHash imps nameHashes roots tests mdoc)
         else parseFromSnapshot mn snap
 
 
@@ -1288,14 +1343,14 @@ readIfaceFromTy paths mn src mHash = do
         fileRes <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readFile tyF
         case fileRes of
           Left _ -> return $ Left (missingIfaceDiagnostics mn src mn)
-          Right (_ms, nmod, _tmod, _si, _ti, _implH, _ni, _nameHashes, _te, _tests, _tm) -> do
+          Right (_ms, nmod, _tmod, _sourceMeta, _srcH, _pubH, _implH, _imps, _nameHashes, _roots, _tests, _tm) -> do
             let I.NModule te mdoc = nmod
             ih <- case mHash of
                     Just h -> return h
                     Nothing -> do
                       hdrE <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readHeader tyF
                       case hdrE of
-                        Right (_srcH, ihash, _implH, _impsH, _nameHashesH, _rootsH, _testsH, _docH) -> return ihash
+                        Right (_sourceMetaH, _srcH, ihash, _implH, _impsH, _nameHashesH, _rootsH, _testsH, _docH) -> return ihash
                         _ -> return B.empty
             return $ Right (te, mdoc, ih)
 
@@ -1369,11 +1424,12 @@ runFrontPasses :: C.GlobalOptions
                -> A.Module
                -> String
                -> B.ByteString
+               -> Maybe InterfaceFiles.SourceFileMeta
                -> (A.ModName -> IO (Maybe B.ByteString))
                -> (A.ModName -> IO (Maybe (M.Map A.Name InterfaceFiles.NameHashInfo)))
                -> (FrontPassProgress -> IO ())
                -> IO (Either [Diagnostic String] FrontResult)
-runFrontPasses gopts opts paths env0 parsed srcContent srcBytes resolveImportHash resolveNameHashMap onFrontProgress = do
+runFrontPasses gopts opts paths env0 parsed srcContent srcBytes sourceMeta resolveImportHash resolveNameHashMap onFrontProgress = do
   createDirectoryIfMissing True (getModPath (projTypes paths) mn)
   core
     `catch` handleGeneral
@@ -1596,7 +1652,7 @@ runFrontPasses gopts opts paths env0 parsed srcContent srcBytes resolveImportHas
                   let modulePubHash = Hashing.modulePubHashFromIface nmod nameHashes
                       moduleImplHash = Hashing.moduleImplHashFromNameHashes nameHashes
                   -- Write .ty now so later builds can reuse this front-pass work.
-                  InterfaceFiles.writeFile (outbase ++ ".ty") moduleSrcBytesHash modulePubHash moduleImplHash impsWithHash nameHashes roots tests mdoc nmod tchecked
+                  InterfaceFiles.writeFile (outbase ++ ".ty") moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta impsWithHash nameHashes roots tests mdoc nmod tchecked
 
                   iff (C.types opts && isRoot) $ dump mn "types" (Pretty.print tchecked)
                   iff (C.sigs opts && isRoot) $ dump mn "sigs" (Acton.Types.prettySigs env mn iface)
@@ -1908,14 +1964,16 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
               parsedRes <- parseActFile sp mn actFile
               case parsedRes of
                 Left diags -> return (ParseErrorTask mn diags)
-                Right (snap, m) -> return $ ActonTask mn (Source.ssText snap) (Source.ssBytes snap) m
+                Right (snap, m) -> do
+                  mSourceMeta <- if Source.ssIsOverlay snap then return Nothing else Just <$> readSourceFileMeta actFile
+                  return $ ActonTask mn (Source.ssText snap) (Source.ssBytes snap) mSourceMeta m
             _ -> return (gtTask t)
           case t' of
             ParseErrorTask{ parseDiagnostics = diags } -> do
               ccOnDiagnostics callbacks t optsBuiltin diags
               return (Left CompileBuiltinFailure)
             TyTask{} -> return (Right ())
-            ActonTask{ src = srcContent, srcBytes = srcBytes, atree = m } -> do
+            ActonTask{ src = srcContent, srcBytes = srcBytes, sourceMeta = mSourceMeta, atree = m } -> do
               ccOnFrontStart callbacks t optsBuiltin
               builtinEnv0 <- Acton.Env.initEnv (projTypes bPaths) True
               res <- runFrontPasses
@@ -1926,6 +1984,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
                 m
                 srcContent
                 srcBytes
+                mSourceMeta
                 (getPubHashCached bPaths)
                 (getNameHashMapCached bPaths)
                 (\p -> ccOnFrontProgress callbacks t optsBuiltin p)
@@ -2290,10 +2349,12 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
                               parsedRes <- parseActFile sp mn actFile
                               case parsedRes of
                                 Left diags -> return (ParseErrorTask mn diags)
-                                Right (snap, m) -> return $ ActonTask mn (Source.ssText snap) (Source.ssBytes snap) m
+                                Right (snap, m) -> do
+                                  mSourceMeta <- if Source.ssIsOverlay snap then return Nothing else Just <$> readSourceFileMeta actFile
+                                  return $ ActonTask mn (Source.ssText snap) (Source.ssBytes snap) mSourceMeta m
                     case t' of
                       ParseErrorTask{ parseDiagnostics = diags } -> return (key, Left diags)
-                      ActonTask{ src = srcContent, srcBytes = srcBytes, atree = m } -> do
+                      ActonTask{ src = srcContent, srcBytes = srcBytes, sourceMeta = mSourceMeta, atree = m } -> do
                         res <- runFrontPasses
                           gopts
                           optsT
@@ -2302,6 +2363,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
                           m
                           srcContent
                           srcBytes
+                          mSourceMeta
                           resolveImportHash
                           resolveNameHashMap'
                           (\p -> ccOnFrontProgress callbacks t optsT p)
@@ -2333,7 +2395,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
                       tyRes <- readTyFile
                       case tyRes of
                         Left diags -> return (key, Left diags)
-                        Right (_ms, nmod, tmod, moduleSrcBytesHash, modulePubHash, _moduleImplHash, imps, nameHashes, roots, tests, mdoc) -> do
+                        Right (_ms, nmod, tmod, sourceMeta, moduleSrcBytesHash, modulePubHash, _moduleImplHash, imps, nameHashes, roots, tests, mdoc) -> do
                           parsedRes <- parseActFile sp mn actFile
                           case parsedRes of
                             Left diags -> return (key, Left diags)
@@ -2373,7 +2435,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
                                       let updatedNameHashes =
                                             Hashing.refreshImplHashes nameHashes nameImplHashes implLocalDeps implExtHashes
                                           moduleImplHash = Hashing.moduleImplHashFromNameHashes updatedNameHashes
-                                      InterfaceFiles.writeFile tyFile moduleSrcBytesHash modulePubHash moduleImplHash imps updatedNameHashes roots tests mdoc nmod tmod
+                                      InterfaceFiles.writeFile tyFile moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta imps updatedNameHashes roots tests mdoc nmod tmod
                                       let I.NModule ifaceTE _mdoc = nmod
                                           backJob = Just (mkBackJob env1 tmod (Source.ssText snap) moduleImplHash)
                                           fr = mkFrontResult ifaceTE mdoc modulePubHash updatedNameHashes backJob
@@ -2386,7 +2448,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
                     tyRes <- readTyFile
                     case tyRes of
                       Left diags -> return (key, Left diags)
-                      Right (_ms, nmod, tmod, _moduleSrcBytesHash, modulePubHash, moduleImplHashStored, _imps, nameHashes, _roots, _tests, mdoc) -> do
+                      Right (_ms, nmod, tmod, _sourceMeta, _moduleSrcBytesHash, modulePubHash, moduleImplHashStored, _imps, nameHashes, _roots, _tests, mdoc) -> do
                         snap <- Source.readSource sp actFile
                         env1 <- Acton.Env.mkEnv (searchPath paths) envSnap tmod
                         let I.NModule ifaceTE _mdoc = nmod

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -243,7 +243,7 @@ initEnv path True          = return $ EnvF{ names = [(nPrim,NMAlias mPrim)],
                                             context = [],
                                             qlevel = 0,
                                             envX = () }
-initEnv path False         = do (_,nmod,_,_,_,_,_,_,_,_,_) <- InterfaceFiles.readFile (joinPath [path,"__builtin__.ty"])
+initEnv path False         = do (_,nmod,_,_,_,_,_,_,_,_,_,_) <- InterfaceFiles.readFile (joinPath [path,"__builtin__.ty"])
                                 let NModule envBuiltin builtinDocstring = nmod
                                     env0 = EnvF{ names = [(nPrim,NMAlias mPrim), (nBuiltin,NMAlias mBuiltin)],
                                                  imports = [mPrim,mBuiltin],
@@ -1065,7 +1065,7 @@ doImp spath env m            = do
               case tyFile of
                 Nothing -> return (env, te, seen')
                 Just tyF -> do
-                  (_, _, _, imps, _, _, _, _) <- InterfaceFiles.readHeader tyF
+                  (_sourceMeta, _, _, _, imps, _, _, _, _) <- InterfaceFiles.readHeader tyF
                   (env', seen'') <- subImpSeen seen' env (map fst imps)
                   return (env', te, seen'')
             Nothing -> do
@@ -1073,7 +1073,7 @@ doImp spath env m            = do
               case tyFile of
                 Nothing -> fileNotFound m
                 Just tyF -> do
-                  (ms,nmod,_,_,_,_,_,_,_,_,_) <- InterfaceFiles.readFile tyF
+                  (ms,nmod,_,_,_,_,_,_,_,_,_,_) <- InterfaceFiles.readFile tyF
                   (env', seen'') <- subImpSeen seen' env ms
                   let NModule te mdoc = nmod
                   return (addMod m te mdoc env', te, seen'')

--- a/compiler/lib/src/Acton/Syntax.hs
+++ b/compiler/lib/src/Acton/Syntax.hs
@@ -25,7 +25,7 @@ import Control.DeepSeq
 import Prelude hiding((<>))
 
 version :: [Int]
-version = [0,12]
+version = [0,13]
 
 data Module     = Module        { modname::ModName, imps::[Import], mbody::Suite } deriving (Eq,Show,Generic,NFData)
 

--- a/compiler/lib/src/Acton/Testing.hs
+++ b/compiler/lib/src/Acton/Testing.hs
@@ -453,7 +453,7 @@ readModuleNameHashesByModName paths mn = do
         hdrE <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readHeader tyFile
         case hdrE of
           Left _ -> return M.empty
-          Right (_srcH, _ih, _implH, _imps, nameHashes, _roots, _tests, _doc) ->
+          Right (_sourceMeta, _srcH, _ih, _implH, _imps, nameHashes, _roots, _tests, _doc) ->
             return $ M.fromList [ (A.nstr (InterfaceFiles.nhName nh), nh) | nh <- nameHashes ]
 
 -- | Cache-aware wrapper for reading name hashes.

--- a/compiler/lib/src/Acton/Types.hs
+++ b/compiler/lib/src/Acton/Types.hs
@@ -111,7 +111,7 @@ reconstruct progressCb env0 (Module m i ss)         = do --traceM ("############
 
 -- | Print a .ty file header and interface; include name hashes when verbose.
 showTyFile env0 m fname verbose = do
-                                     (ms,nmod,_,srcH,pubH,implH,imps,nameHashes,roots,tests,mdocH) <- InterfaceFiles.readFile fname
+                                     (ms,nmod,_,sourceMeta,srcH,pubH,implH,imps,nameHashes,roots,tests,mdocH) <- InterfaceFiles.readFile fname
                                      putStrLn ("\n############### Header ###############")
                                      putStrLn ("Imports: " ++ (show [ (prstr mn, take 16 (B.unpack $ Base16.encode h)) | (mn,h) <- imps ]))
                                      putStrLn ("Roots  : " ++ (show (map prstr roots)))
@@ -124,6 +124,15 @@ showTyFile env0 m fname verbose = do
                                      putStrLn ("ModuleImplHash    : 0x" ++ (B.unpack $ Base16.encode implH))
 
                                      when verbose $ do
+                                       putStrLn ("\n############### Source Meta ############")
+                                       case sourceMeta of
+                                         Nothing -> putStrLn "None"
+                                         Just meta -> do
+                                           putStrLn ("mtimeNs: " ++ show (InterfaceFiles.sfmMTimeNs meta))
+                                           putStrLn ("ctimeNs: " ++ show (InterfaceFiles.sfmCTimeNs meta))
+                                           putStrLn ("size   : " ++ show (InterfaceFiles.sfmSize meta))
+                                           putStrLn ("device : " ++ maybe "-" show (InterfaceFiles.sfmDevice meta))
+                                           putStrLn ("inode  : " ++ maybe "-" show (InterfaceFiles.sfmInode meta))
                                        putStrLn ("\n############### Name Hashes ############")
                                        forM_ nameHashes $ \nh -> do
                                          let formatHash h =

--- a/compiler/lib/src/InterfaceFiles.hs
+++ b/compiler/lib/src/InterfaceFiles.hs
@@ -22,22 +22,23 @@
 --
 -- On-disk layout (Binary, in this exact order)
 --   1) version            :: [Int]                         -- Acton.Syntax.version
---   2) moduleHashes       :: (ByteString, ByteString, ByteString)
---      - moduleSrcBytesHash :: ByteString                  -- SHA-256 of raw source bytes
---      - modulePubHash      :: ByteString                  -- SHA-256 of public NameInfo (doc-free)
+--   2) sourceMeta         :: Maybe SourceFileMeta          -- cached source stat metadata
+--   3) moduleSrcBytesHash :: ByteString                    -- SHA-256 of raw source bytes
+--   4) modulePubHash      :: ByteString                    -- SHA-256 of public NameInfo (doc-free)
 --                                                       -- augmented with imports' pub hashes
---      - moduleImplHash     :: ByteString                  -- SHA-256 of per-name impl hashes
---   3) imports            :: [(A.ModName, ByteString)]     -- imported module and pub hash used
---   4) nameHashes         :: [NameHashInfo]                -- per-name src/pub/impl hashes + deps
---   5) roots              :: [A.Name]                      -- root actors (e.g., main or test_main)
---   6) tests              :: [String]                      -- discovered test names
---   7) docstring          :: Maybe String                  -- module docstring
---   8) nameInfo           :: I.NameInfo                    -- type/name environment
---   9) typedModule        :: A.Module                      -- typed module
+--   5) moduleImplHash     :: ByteString                    -- SHA-256 of per-name impl hashes
+--   6) imports            :: [(A.ModName, ByteString)]     -- imported module and pub hash used
+--   7) nameHashes         :: [NameHashInfo]                -- per-name src/pub/impl hashes + deps
+--   8) roots              :: [A.Name]                      -- root actors (e.g., main or test_main)
+--   9) tests              :: [String]                      -- discovered test names
+--  10) docstring          :: Maybe String                  -- module docstring
+--  11) nameInfo           :: I.NameInfo                    -- type/name environment
+--  12) typedModule        :: A.Module                      -- typed module
 --
 -- Rationale for ordering
--- - Put small, fixed/cheap fields up front (version, moduleSrcBytesHash) to enable fast
---   header-only reads for freshness checks and dependency discovery.
+-- - Put cache validity fields first so callers can validate and reuse a cache
+--   entry without decoding the large NameInfo and typed Module sections.
+-- - Follow with the remaining module hashes used for dependency checks.
 -- - Follow with small variable fields (imports, roots, docstring).
 -- - Put heavy sections last (NameInfo, typed Module) to preserve laziness.
 
@@ -51,8 +52,8 @@ import qualified System.Exit
 import qualified Acton.Syntax as A
 import qualified Acton.NameInfo as I
 import GHC.Generics (Generic)
-import System.IO
 import System.Directory (renameFile)
+import System.IO
 import System.Posix.Process (getProcessID)
 
 data NameHashInfo = NameHashInfo
@@ -66,57 +67,97 @@ data NameHashInfo = NameHashInfo
 
 instance Binary NameHashInfo
 
+data SourceFileMeta = SourceFileMeta
+  { sfmMTimeNs :: Integer
+  , sfmCTimeNs :: Integer
+  , sfmSize    :: Integer
+  , sfmDevice  :: Maybe Integer
+  , sfmInode   :: Maybe Integer
+  } deriving (Show, Eq, Generic)
+
+instance Binary SourceFileMeta
+
 -- Note: tests are stored in the header to support listing without compiling
 --       or executing test binaries.
 
-writeFile :: FilePath -> BS.ByteString -> BS.ByteString -> BS.ByteString -> [(A.ModName, BS.ByteString)] -> [NameHashInfo] -> [A.Name] -> [String] -> Maybe String -> I.NameInfo -> A.Module -> IO ()
-writeFile f moduleSrcBytesHash modulePubHash moduleImplHash imps nameHashes roots tests mdoc nmod tchecked = do
-    -- Use PID for unique temp file name
+readTyBytes :: FilePath -> IO BL.ByteString
+readTyBytes f = do
+    h <- openBinaryFile f ReadMode
+    size <- hFileSize h
+    bs <- BS.hGet h (fromIntegral size)
+    hClose h
+    return (BL.fromStrict bs)
+
+versionMismatch :: [Int] -> IO a
+versionMismatch vs = do
+    hPutStrLn stderr ("Interface file has version " ++ show vs ++ "; current version is " ++ show A.version)
+    System.Exit.exitFailure
+
+readTyVersion :: BL.ByteString -> IO BL.ByteString
+readTyVersion bsLazy =
+    case BinaryGet.runGetOrFail (get :: BinaryGet.Get [Int]) bsLazy of
+      Left _ -> ioError (userError "Failed to decode .ty version")
+      Right (rest, _, vs)
+        | vs == A.version -> return rest
+        | otherwise -> versionMismatch vs
+
+decodeTyPrefix :: BL.ByteString -> IO (Maybe SourceFileMeta, BS.ByteString, BS.ByteString, BS.ByteString, BL.ByteString)
+decodeTyPrefix bsLazy =
+    case BinaryGet.runGetOrFail getPrefix bsLazy of
+      Left _ -> ioError (userError "Failed to decode .ty prefix")
+      Right (rest, _, (sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash)) ->
+        return (sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash, rest)
+  where
+    getPrefix = do
+      sourceMeta <- get :: BinaryGet.Get (Maybe SourceFileMeta)
+      moduleSrcBytesHash <- get :: BinaryGet.Get BS.ByteString
+      modulePubHash <- get :: BinaryGet.Get BS.ByteString
+      moduleImplHash <- get :: BinaryGet.Get BS.ByteString
+      return (sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash)
+
+writeFile :: FilePath -> BS.ByteString -> BS.ByteString -> BS.ByteString -> Maybe SourceFileMeta -> [(A.ModName, BS.ByteString)] -> [NameHashInfo] -> [A.Name] -> [String] -> Maybe String -> I.NameInfo -> A.Module -> IO ()
+writeFile f moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta imps nameHashes roots tests mdoc nmod tchecked = do
     pid <- getProcessID
     let tmpFile = f ++ "." ++ show pid
-    BL.writeFile tmpFile (encode (A.version, (moduleSrcBytesHash, modulePubHash, moduleImplHash), imps, nameHashes, roots, tests, mdoc, nmod, tchecked))
-    -- Atomically rename to final location
-    -- This is atomic on POSIX systems and prevents partial writes or conflicts
+    BL.writeFile tmpFile (encode ((A.version, sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash), imps, nameHashes, roots, tests, mdoc, nmod, tchecked))
     renameFile tmpFile f
 
-readFile :: FilePath -> IO ([A.ModName], I.NameInfo, A.Module, BS.ByteString, BS.ByteString, BS.ByteString, [(A.ModName, BS.ByteString)], [NameHashInfo], [A.Name], [String], Maybe String)
+readFile :: FilePath -> IO ([A.ModName], I.NameInfo, A.Module, Maybe SourceFileMeta, BS.ByteString, BS.ByteString, BS.ByteString, [(A.ModName, BS.ByteString)], [NameHashInfo], [A.Name], [String], Maybe String)
 readFile f = do
-    h <- openBinaryFile f ReadMode
-    size <- hFileSize h
-    bs <- BS.hGet h (fromIntegral size)
-    hClose h
-    let bsLazy = BL.fromStrict bs
-    let (vs, (moduleSrcBytesHash, modulePubHash, moduleImplHash), imps, nameHashes, roots, tests, mdoc, nmod, tmod)
-          = decode bsLazy :: ([Int], (BS.ByteString, BS.ByteString, BS.ByteString), [(A.ModName, BS.ByteString)], [NameHashInfo], [A.Name], [String], Maybe String, I.NameInfo, A.Module)
-    if vs == A.version
-      then return (map fst imps, nmod, tmod, moduleSrcBytesHash, modulePubHash, moduleImplHash, imps, nameHashes, roots, tests, mdoc)
-      else do
-        hPutStrLn stderr ("Interface file has version " ++ show vs ++ "; current version is " ++ show A.version)
-        System.Exit.exitFailure
+    bsLazy <- readTyBytes f
+    body0 <- readTyVersion bsLazy
+    (sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash, body1) <- decodeTyPrefix body0
+    let getBody = do
+          imps <- get :: BinaryGet.Get [(A.ModName, BS.ByteString)]
+          nameHashes <- get :: BinaryGet.Get [NameHashInfo]
+          roots <- get :: BinaryGet.Get [A.Name]
+          tests <- get :: BinaryGet.Get [String]
+          mdoc <- get :: BinaryGet.Get (Maybe String)
+          nmod <- get :: BinaryGet.Get I.NameInfo
+          tmod <- get :: BinaryGet.Get A.Module
+          return (imps, nameHashes, roots, tests, mdoc, nmod, tmod)
+    case BinaryGet.runGetOrFail getBody body1 of
+      Left _ -> ioError (userError "Failed to decode .ty file")
+      Right (_, _, (imps, nameHashes, roots, tests, mdoc, nmod, tmod)) ->
+        return (map fst imps, nmod, tmod, sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash, imps, nameHashes, roots, tests, mdoc)
 
--- Read only small header fields from .ty: (moduleSrcBytesHash, modulePubHash,
--- moduleImplHash, imports, nameHashes, roots, tests, docstring)
--- This avoids loading large fields and is much faster than readFile which
--- decodes everything.
-readHeader :: FilePath -> IO (BS.ByteString, BS.ByteString, BS.ByteString, [(A.ModName, BS.ByteString)], [NameHashInfo], [A.Name], [String], Maybe String)
+-- Read only the cached header fields from .ty: source metadata, module hashes,
+-- imports, name hashes, roots, tests, and docstring.
+-- This avoids decoding the large NameInfo and typed Module sections and is
+-- much faster than readFile for freshness checks and dependency discovery.
+readHeader :: FilePath -> IO (Maybe SourceFileMeta, BS.ByteString, BS.ByteString, BS.ByteString, [(A.ModName, BS.ByteString)], [NameHashInfo], [A.Name], [String], Maybe String)
 readHeader f = do
-    h <- openBinaryFile f ReadMode
-    size <- hFileSize h
-    bs <- BS.hGet h (fromIntegral size)
-    hClose h
-    let bsLazy = BL.fromStrict bs
-        getHdr :: BinaryGet.Get ([Int], (BS.ByteString, BS.ByteString, BS.ByteString), [(A.ModName, BS.ByteString)], [NameHashInfo], [A.Name], [String], Maybe String)
-        getHdr = do
-          vs    <- get :: BinaryGet.Get [Int]
-          hashes <- get :: BinaryGet.Get (BS.ByteString, BS.ByteString, BS.ByteString)
+    bsLazy <- readTyBytes f
+    body0 <- readTyVersion bsLazy
+    (sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash, body1) <- decodeTyPrefix body0
+    let getHdr = do
           imps  <- get :: BinaryGet.Get [(A.ModName, BS.ByteString)]
           nameHashes <- get :: BinaryGet.Get [NameHashInfo]
           roots <- get :: BinaryGet.Get [A.Name]
           tests <- get :: BinaryGet.Get [String]
           doc   <- get :: BinaryGet.Get (Maybe String)
-          return (vs, hashes, imps, nameHashes, roots, tests, doc)
-    case BinaryGet.runGetOrFail getHdr bsLazy of
+          return (imps, nameHashes, roots, tests, doc)
+    case BinaryGet.runGetOrFail getHdr body1 of
       Left _ -> ioError (userError "Failed to decode .ty header")
-      Right (_, _, (vs, (moduleSrcBytesHash, modulePubHash, moduleImplHash), imps, nameHashes, roots, tests, doc)) ->
-        if vs == A.version then return (moduleSrcBytesHash, modulePubHash, moduleImplHash, imps, nameHashes, roots, tests, doc)
-        else ioError (userError (".ty version mismatch: file has " ++ show vs ++ ", expected " ++ show A.version))
+      Right (_, _, (imps, nameHashes, roots, tests, doc)) ->
+        return (sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash, imps, nameHashes, roots, tests, doc)

--- a/docs/acton-guide/src/compilation/incremental.md
+++ b/docs/acton-guide/src/compilation/incremental.md
@@ -4,7 +4,7 @@ Acton tracks changes at a finer level than whole modules so builds stay fast as 
 
 ## What gets hashed and tracked
 
-- **moduleSrcBytesHash**: hash of the raw bytes for a whole `.act` file. It is very cheap to read and hash a .act file from disk (GB/s). This is stored in the .ty file, so we can quickly determine if the .ty file is up to date with the .act. If not, we re-parse the .act and re-run front passes for that module. Parsing is not incremental, it only supports re-parsing a complete module, which is also why a single hash for the entire `.act` module file makes sense.
+- **moduleSrcBytesHash**: hash of the raw bytes for a whole `.act` file. It is very cheap to read and hash a `.act` file from disk (GB/s). This is stored in the `.ty` file and is the authority for deciding whether a cached typed module still matches the source. Parsing is not incremental, it only supports re-parsing a complete module, which is also why a single hash for the entire `.act` module file makes sense.
 - **per-name srcHash**: hash of a name's source code. Since this is only the hash of the source code, it can be computed after the parser and before type checking in order to determine what functions we need to rerun through later passes, including type checking which is typically a relatively expensive pass. Note how the next pubHash and implHash are after type checking, so they cannot be used in order to determine if type-checking should be rerun for a function.
 - **per-name pubHash**: hash of a name's public interface (its type signature). Downstream modules only need to re-typecheck if a pubHash they depend on changes. The pubHash also contains the hashes of dependencies, and if those change, our pubHash will change, thus causing re-typecheck.
 - **per-name implHash**: hash of a name's implementation plus the impl hashes it depends on. If an implHash changes, we re-run back passes and tests.
@@ -12,6 +12,48 @@ Acton tracks changes at a finer level than whole modules so builds stay fast as 
 - **per-name implsDeps**: the hashes of the implementation of other names that we depend on. If the hashes of any deps change, we must rerun back passes.
 
 Most names have both a pubHash and implHash. Some derived internal names only have implHash.
+
+## How `.ty` cache validity is decided
+
+Each module gets a cached typed interface file in `out/types/<module>.ty`.
+That cache stores:
+
+- the module source content hash (`moduleSrcBytesHash`)
+- fast-path source metadata such as modification time, change time, and file size
+- file identity metadata where available, such as inode/device on POSIX
+- the compiler/cache schema version
+
+The important rule is:
+
+- **content hash is the correctness authority**
+- **filesystem metadata is only a fast path**
+
+In practice, Acton decides reuse like this:
+
+1. If the `.ty` file is missing, unreadable, or from an incompatible cache
+   schema version, Acton reparses the `.act` file and rebuilds the `.ty`.
+2. If the cached source metadata still matches the current source file and the
+   source mtime is strictly older than the `.ty` mtime, Acton reuses the `.ty`
+   header immediately without reading and hashing the source.
+3. If the metadata differs, or the source and `.ty` mtimes are equal, Acton
+   reads the `.act` file and compares its content hash to the stored
+   `moduleSrcBytesHash`.
+4. If the hash matches, the source content is unchanged, so Acton reuses the
+   cached `.ty` and refreshes the stored source metadata.
+5. If the hash differs, the source really changed, so Acton reparses and
+   recompiles that module.
+
+This means harmless metadata drift, like a `touch`, checkout, restore, copy,
+or cross-machine sync, does not by itself force a front-end rebuild. It also
+means misleading timestamps cannot cause stale typed-module reuse, because
+Acton falls back to the source content hash before trusting the cache.
+
+The strict `source mtime < .ty mtime` check matters on filesystems with coarse
+mtime resolution. If a source edit and `.ty` write land in the same timestamp
+tick, equal mtimes are ambiguous: the source may already have changed even
+though the cached source metadata still looks identical. Acton therefore treats
+equal source and `.ty` mtimes as a signal to hash the current source instead of
+taking the metadata-only fast path.
 
 ## What changes cause what work
 

--- a/docs/acton-guide/src/projects/directory_structure.md
+++ b/docs/acton-guide/src/projects/directory_structure.md
@@ -30,6 +30,9 @@ Output goes into `out/`, most importantly, executable binaries are placed in
 specified root actor.  In the example above, the root actor is `foo.main`, i.e.
 actor `main` in the module `foo` and consequently, the executable name is `foo`.
 
-`out/types` contain generated code, which is to be considered internal. Don't
-touch it.  All other output files, like object files and archives, are placed
-out-of-tree in the cache directory (`~/.cache/acton/`).
+`out/types` contains internal compiler output. In particular, `.ty` files are
+cached typed-module interfaces and `.c` / `.h` files are generated code derived
+from them. Acton validates and regenerates these files as needed, so they
+should be treated as internal build artifacts. Don't touch them. All other
+output files, like object files and archives, are placed out-of-tree in the
+cache directory (`~/.cache/acton/`).


### PR DESCRIPTION
Incremental reuse already compared source content hashes, but only after mtime checks had decided that a module looked stale. When a checkout, restore, copy, or cross-machine sync left a changed .act file with metadata that still made the cached .ty look newer, the compiler could reuse a stale header and keep imports that were no longer present in source.

This change stores source metadata in the .ty header and uses it to validate cached reuse. When the current source metadata still matches, readModuleTask reuses the cached header immediately. When the metadata drifts, it reads and hashes the current .act and compares that hash to moduleSrcBytesHash. A hash match reuses the cached .ty and refreshes its stored metadata, while a hash change reparses and recompiles the module.

This keeps source metadata as the cheap validation path while making source content hash the correctness check when metadata is inconclusive. Metadata-only churn no longer forces front-end rebuilds, and misleading timestamps no longer allow stale typed interfaces to be reused.

Fixes #2712 