### PR TITLE
Make .ty version mismatches recoverable

### DIFF
--- a/compiler/lib/src/InterfaceFiles.hs
+++ b/compiler/lib/src/InterfaceFiles.hs
@@ -48,7 +48,6 @@ import Data.Binary
 import qualified Data.Binary.Get as BinaryGet
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
-import qualified System.Exit
 import qualified Acton.Syntax as A
 import qualified Acton.NameInfo as I
 import GHC.Generics (Generic)
@@ -89,9 +88,8 @@ readTyBytes f = do
     return (BL.fromStrict bs)
 
 versionMismatch :: [Int] -> IO a
-versionMismatch vs = do
-    hPutStrLn stderr ("Interface file has version " ++ show vs ++ "; current version is " ++ show A.version)
-    System.Exit.exitFailure
+versionMismatch vs =
+    ioError (userError (".ty version mismatch: file has " ++ show vs ++ ", expected " ++ show A.version))
 
 readTyVersion :: BL.ByteString -> IO BL.ByteString
 readTyVersion bsLazy =


### PR DESCRIPTION
InterfaceFiles treated a .ty version mismatch as a process-level failure and printed directly to stderr before exiting. That was too aggressive for normal cache probing, where callers routinely use readHeader or readFile under try and expect an old or unreadable .ty to be treated as stale.

This change makes version mismatch raise a normal IO error instead of printing and exiting. That keeps the recovery decision with the caller, so incremental builds can silently discard stale .ty files while commands that explicitly inspect interface files still fail in the usual way.