### PR TITLE
Add URI quote and unquote

### DIFF
--- a/base/src/uri.act
+++ b/base/src/uri.act
@@ -1,4 +1,70 @@
 
+_UNRESERVED = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~"
+_HEX_DIGITS = "0123456789ABCDEF"
+
+
+def quote(text: str, safe: str="/") -> str:
+    """Percent-encode a string for use in a URI.
+
+    Unreserved characters defined by RFC 3986 are preserved. Characters in
+    the safe set are also preserved when they are ASCII bytes.
+    """
+    allowed = set(_UNRESERVED + safe)
+    encoded = text.encode()
+    parts: list[str] = []
+
+    for i in range(len(encoded)):
+        byte = encoded[i]
+        if byte < 128 and chr(byte) in allowed:
+            parts.append(chr(byte))
+        else:
+            parts.append(_quote_byte(byte))
+
+    return "".join(parts)
+
+
+def unquote(text: str) -> str:
+    """Decode percent-escaped bytes in a URI string as UTF-8."""
+    result = bytearray(b"")
+    i = 0
+
+    while i < len(text):
+        if text[i] != "%":
+            _append_bytes(result, text[i].encode())
+            i += 1
+            continue
+
+        if i + 2 >= len(text):
+            raise ValueError("Incomplete percent escape: {text[i:]}")
+
+        escape = text[i:i+3]
+        hi = _hex_value(text[i+1])
+        lo = _hex_value(text[i+2])
+        result.append(hi * 16 + lo)
+        i += 3
+
+    try:
+        return result.decode()
+    except ValueError:
+        raise ValueError("Invalid UTF-8 in percent-escaped text")
+
+
+def _append_bytes(result: bytearray, data: bytes) -> None:
+    for i in range(len(data)):
+        result.append(data[i])
+
+
+def _quote_byte(byte: int) -> str:
+    return "%" + _HEX_DIGITS[byte // 16] + _HEX_DIGITS[byte % 16]
+
+
+def _hex_value(char: str) -> int:
+    idx = _HEX_DIGITS.find(char.upper())
+    if idx == -1:
+        raise ValueError("Invalid percent escape: %%{char}")
+    return idx
+
+
 class URI(object):
     """A class representing a Uniform Resource Identifier (URI).
 

--- a/test/stdlib_tests/src/test_uri.act
+++ b/test/stdlib_tests/src/test_uri.act
@@ -1,6 +1,6 @@
 import testing
 
-from uri import URI
+from uri import URI, quote, unquote
 
 def _test_basic_uri():
     """Test basic URI parsing"""
@@ -123,5 +123,48 @@ def _test_scheme_validation():
         try:
             URI(uri_str)
             testing.error("Expected ValueError for invalid scheme: " + uri_str)
+        except ValueError:
+            pass
+
+def _test_quote_preserves_unreserved_and_safe():
+    testing.assertEqual(
+        quote("alpha-._~/beta gamma?delta=1&epsilon=2"),
+        "alpha-._~/beta%20gamma%3Fdelta%3D1%26epsilon%3D2"
+    )
+
+def _test_quote_custom_safe():
+    testing.assertEqual(quote("a/b+c", safe=""), "a%2Fb%2Bc")
+    testing.assertEqual(quote("a/b+c", safe="+"), "a%2Fb+c")
+
+def _test_quote_unicode_utf8():
+    testing.assertEqual(
+        quote("räksmörgås"),
+        "r%C3%A4ksm%C3%B6rg%C3%A5s"
+    )
+
+def _test_unquote_decodes_percent_escapes():
+    testing.assertEqual(
+        unquote("alpha-._~/beta%20gamma%3Fdelta%3D1%26epsilon%3D2"),
+        "alpha-._~/beta gamma?delta=1&epsilon=2"
+    )
+    testing.assertEqual(unquote("a+b%20c"), "a+b c")
+    testing.assertEqual(unquote("r%C3%A4ksm%C3%B6rg%C3%A5s"), "räksmörgås")
+
+def _test_quote_unquote_roundtrip():
+    raw = "Hello Acton 🫡 / räksmörgås?"
+    testing.assertEqual(unquote(quote(raw)), raw)
+
+def _test_unquote_invalid_escapes():
+    invalid_inputs = [
+        "%",
+        "%2",
+        "%GG",
+        "%C3%28"
+    ]
+
+    for raw in invalid_inputs:
+        try:
+            unquote(raw)
+            testing.error("Expected ValueError for invalid escape: " + raw)
         except ValueError:
             pass


### PR DESCRIPTION
This adds quote() and unquote() to the stdlib uri module. quote() preserves RFC 3986 unreserved characters and an explicit safe set, defaulting to keeping "/" unescaped so path-oriented use stays practical. unquote() decodes percent escapes as UTF-8 and rejects incomplete escapes and invalid UTF-8 with ValueError.

Keeping the logic in uri makes quoting behavior consistent with the rest of the module and ensures invalid escape sequences fail at decode time instead of being silently passed through.

Fixes #2711 