### PR TITLE
added forced unwrapping

### DIFF
--- a/base/builtin/exceptions.c
+++ b/base/builtin/exceptions.c
@@ -149,3 +149,9 @@ struct $RETG_class $RETG_methods = {
     .__serialize__      = $RETD___serialize__,
     .__deserialize__    = $RETD___deserialize__
 };
+
+
+$WORD $raiseValueError(B_str msg) {
+    $RAISE((B_BaseException)$NEW(B_ValueError,msg));
+    return ($WORD)0;
+}

--- a/base/builtin/exceptions.h
+++ b/base/builtin/exceptions.h
@@ -175,3 +175,6 @@ $SEQ $SEQG_new();
 $BRK $BRKG_new();
 $CNT $CNTG_new();
 $RET $RETG_new(B_value);
+
+$WORD $raiseValueError(B_str str);
+    

--- a/compiler/lib/src/Acton/CPS.hs
+++ b/compiler/lib/src/Acton/CPS.hs
@@ -410,7 +410,9 @@ instance PreCPS Expr where
       where t                           = typeOf env e0
     pre env (Async l e)                 = Async l <$> pre env e
     pre env (TApp l e ts)               = TApp l <$> pre env e <*> pure ts
-    pre env (Let l ss e)                = Let l <$> pre env1 ss <*> pre env1 e
+    pre env (Let l ss e)                = do ss' <- preSuite env ss
+                                             (prefixes,e') <- withPrefixes $ pre env1 e
+                                             return $ Let l (ss' ++ prefixes) e'
        where env1                       = define (envOf ss) env
     pre env (Cond l e1 e e2)            = do (pre1,e1') <- withPrefixes $ pre env e1
                                              (pre2,e2') <- withPrefixes $ pre env e2

--- a/compiler/lib/src/Acton/Kinds.hs
+++ b/compiler/lib/src/Acton/Kinds.hs
@@ -375,7 +375,7 @@ instance KCheck Expr where
     kchk env (Rest l e n)           = Rest l <$> kchk env e <*> return n
     kchk env (DotI l e i)           = DotI l <$> kchk env e <*> return i
     kchk env (RestI l e i)          = RestI l <$> kchk env e <*> return i
-    kchk env (Opt l e)              = Opt l <$> kchk env e
+    kchk env (Opt l e b)            = Opt l <$> kchk env e <*> return b
     kchk env (OptChain l e)         = OptChain l <$> kchk env e
     kchk env (Lambda l p k e x)     = Lambda l <$> (kchk env =<< convTWild env p) <*> (kchk env =<< convTWild env k) <*>
                                                    kchk env e <*> (kfx env =<< convTWild env x)
@@ -698,7 +698,7 @@ instance KSubst Expr where
     ksubst g (Rest l e n)           = Rest l <$> ksubst g e <*> return n
     ksubst g (DotI l e i)           = DotI l <$> ksubst g e <*> return i
     ksubst g (RestI l e i)          = RestI l <$> ksubst g e <*> return i
-    ksubst g (Opt l e)              = Opt l <$> ksubst g e
+    ksubst g (Opt l e b)            = Opt l <$> ksubst g e <*> return b
     ksubst g (OptChain l e)         = OptChain l <$> ksubst g e
     ksubst g (Lambda l ps ks e fx)  = Lambda l <$> ksubst g ps <*> ksubst g ks <*> ksubst g e <*> ksubst g fx
     ksubst g (Yield l e)            = Yield l <$> ksubst g e

--- a/compiler/lib/src/Acton/LambdaLifter.hs
+++ b/compiler/lib/src/Acton/LambdaLifter.hs
@@ -246,15 +246,15 @@ instance Lift Branch where
     ll env (Branch e ss)                = Branch <$> ll env e <*> llSuite env ss
 
 freefun env e@(Var l qn@(NoQ n))
-  | Just vts <- findFree n env          = Just (tApp (Var l (NoQ $ liftedName env n)) (map tVar tvs), vts)
+  | Just vts <- findFree n env          = Just (Var l (NoQ $ liftedName env n), map tVar tvs, vts)
   where Just tvs                        = lookup n (quantmap env)
 freefun env (Var l n)
-  | isDefOrClass env n                  = Just (Var l (primSubst n), [])
+  | isDefOrClass env n                  = Just (Var l (primSubst n), [], [])
 freefun env (TApp l e@(Var l' qn@(NoQ n)) ts)
-  | Just vts <- findFree n env          = Just (TApp l (Var l' (NoQ $ liftedName env n)) (map tVar tvs ++ conv ts), vts)
+  | Just vts <- findFree n env          = Just (Var l' (NoQ $ liftedName env n), map tVar tvs ++ conv ts, vts)
   where Just tvs                        = lookup n (quantmap env)
 freefun env (TApp l (Var l' n) ts)
-  | isDefOrClass env n                  = Just (TApp l (Var l' (primSubst n)) (conv ts), [])
+  | isDefOrClass env n                  = Just (Var l' (primSubst n), conv ts, [])
 freefun env e                           = Nothing
 
 closureConvert env lambda t0 vts0 es    = do n <- newName (nstr $ noq basename)
@@ -320,14 +320,16 @@ instance Lift Expr where
     ll env e@(Var l (NoQ n))
       | n `elem` dom (locals env)       = pure e
     ll env e
-      | Just (e',vts) <- freefun env e  = closureConvert env (Lambda l0 par KwdNIL (call e' vts) fx) t vts (map (eVar . fst) vts )
+      | Just (e',tvs,vts) <- freefun env e    -- e' is a Var, tvs is a (possibly empty) list of TVar, vts a list of (Name,Type) pairs (free vars in function body)
+                                        = closureConvert env (Lambda l0 par KwdNIL (call (tApp e' tvs) vts) fx) t vts (map (eVar . fst) vts )
       where par                         = pPar paramNames p
             call e' vts                 = Call l0 e' (addArgs vts $ pArg par) KwdNil
             TFun _ fx p _ t             = typeOf env e
 
     ll env (Call l e p KwdNil)
-      | Just (e',vts) <- freefun env e  = do p' <- ll env p
-                                             return $ Call l e' (addArgs vts p') KwdNil
+      | Just (e',tvs,vts) <- freefun env e
+                                        = do p' <- ll env p
+                                             return $ Call l (tApp e' tvs) (addArgs vts p') KwdNil
       | Async _ e' <- e,
         closedType env e'               = do e' <- ll env e'
                                              p' <- ll env p

--- a/compiler/lib/src/Acton/LambdaLifter.hs
+++ b/compiler/lib/src/Acton/LambdaLifter.hs
@@ -246,15 +246,15 @@ instance Lift Branch where
     ll env (Branch e ss)                = Branch <$> ll env e <*> llSuite env ss
 
 freefun env e@(Var l qn@(NoQ n))
-  | Just vts <- findFree n env          = Just (Var l (NoQ $ liftedName env n), map tVar tvs, vts)
+  | Just vts <- findFree n env          = Just (tApp (Var l (NoQ $ liftedName env n)) (map tVar tvs), vts)
   where Just tvs                        = lookup n (quantmap env)
 freefun env (Var l n)
-  | isDefOrClass env n                  = Just (Var l (primSubst n), [], [])
+  | isDefOrClass env n                  = Just (Var l (primSubst n), [])
 freefun env (TApp l e@(Var l' qn@(NoQ n)) ts)
-  | Just vts <- findFree n env          = Just (Var l' (NoQ $ liftedName env n), map tVar tvs ++ conv ts, vts)
+  | Just vts <- findFree n env          = Just (TApp l (Var l' (NoQ $ liftedName env n)) (map tVar tvs ++ conv ts), vts)
   where Just tvs                        = lookup n (quantmap env)
 freefun env (TApp l (Var l' n) ts)
-  | isDefOrClass env n                  = Just (Var l' (primSubst n), conv ts, [])
+  | isDefOrClass env n                  = Just (TApp l (Var l' (primSubst n)) (conv ts), [])
 freefun env e                           = Nothing
 
 closureConvert env lambda t0 vts0 es    = do n <- newName (nstr $ noq basename)
@@ -320,16 +320,14 @@ instance Lift Expr where
     ll env e@(Var l (NoQ n))
       | n `elem` dom (locals env)       = pure e
     ll env e
-      | Just (e',tvs,vts) <- freefun env e    -- e' is a Var, tvs is a (possibly empty) list of TVar, vts a list of (Name,Type) pairs (free vars in function body)
-                                        = closureConvert env (Lambda l0 par KwdNIL (call (tApp e' tvs) vts) fx) t vts (map (eVar . fst) vts )
+      | Just (e',vts) <- freefun env e  = closureConvert env (Lambda l0 par KwdNIL (call e' vts) fx) t vts (map (eVar . fst) vts )
       where par                         = pPar paramNames p
             call e' vts                 = Call l0 e' (addArgs vts $ pArg par) KwdNil
             TFun _ fx p _ t             = typeOf env e
 
     ll env (Call l e p KwdNil)
-      | Just (e',tvs,vts) <- freefun env e
-                                        = do p' <- ll env p
-                                             return $ Call l (tApp e' tvs) (addArgs vts p') KwdNil
+      | Just (e',vts) <- freefun env e  = do p' <- ll env p
+                                             return $ Call l e' (addArgs vts p') KwdNil
       | Async _ e' <- e,
         closedType env e'               = do e' <- ll env e'
                                              p' <- ll env p

--- a/compiler/lib/src/Acton/Names.hs
+++ b/compiler/lib/src/Acton/Names.hs
@@ -273,7 +273,7 @@ instance Vars Expr where
     freeQ (CompOp _ e ops)          = freeQ e ++ freeQ ops
     freeQ (UnOp _ o e)              = freeQ e
     freeQ (Dot _ e n)               = freeQ e  
-    freeQ (Opt _ e)                 = freeQ e
+    freeQ (Opt _ e _)               = freeQ e
     freeQ (OptChain _ e)            = freeQ e
     freeQ (Rest _ e n)              = freeQ e
     freeQ (DotI _ e i)              = freeQ e

--- a/compiler/lib/src/Acton/Parser.hs
+++ b/compiler/lib/src/Acton/Parser.hs
@@ -1803,7 +1803,11 @@ atom_expr = do
                      (l,(kind,f)) <- withLoc (
                          (do
                             (l,_) <- withLoc(symbol "?")
-                            return (COpt,\a -> S.Opt (loc a `upto` l) a))
+                            return (COpt,\a -> S.Opt (loc a `upto` l) a True))
+                        <|>
+                          (do
+                            (l,_) <- withLoc(opPref "!")
+                            return (COpt,\a -> S.Opt (loc a `upto` l) a False))
                         <|>
                          (do
                            f <- brackets sliceOrIndex

--- a/compiler/lib/src/Acton/Prim.hs
+++ b/compiler/lib/src/Acton/Prim.hs
@@ -148,6 +148,7 @@ primMkSet           = gPrim "mkSet"
 primMkDict          = gPrim "mkDict"
 primAnnot           = gPrim "annot"
 
+primRaiseValueError = gPrim "raiseValueError"
 primUGetItem        = gPrim "listD_U__getitem__"
 primUNext           = gPrim "rangeD_U__next__"
 
@@ -236,6 +237,7 @@ primEnv             = [     (noq primASYNCf,        NDef scASYNCf NoDec Nothing)
                             (noq primMkSet,         NDef scMkSet NoDec Nothing),
                             (noq primMkDict,        NDef scMkDict NoDec Nothing),
                             (noq primAnnot,         NDef scAnnot NoDec Nothing),
+                            (noq primRaiseValueError,NDef scRaiseValueError NoDec Nothing), 
                             (noq primUGetItem,      NDef scUGetItem NoDec Nothing),
                             (noq primUNext,         NDef scUNext NoDec Nothing)
                       ]
@@ -561,6 +563,10 @@ scUGetItem          = tSchema [qbind a] tUGetItem
   where tUGetItem   = tFun fxPure (posRow (tList (tVar a)) (posRow tInt posNil)) kwdNil (tVar a)
         a           = TV KType $ name "A"
 
+scRaiseValueError   = tSchema [qbind a] tRaiseValErr
+  where tRaiseValErr= tFun fxPure (posRow tStr posNil) kwdNil (tVar a)
+        a           = TV KType (name "A")
+        
 -- $rangeD_U__next__ : [A] => (Iterator[A]) -> A   will only be used to replace B_IteratorD_range.__next__
 scUNext             = tSchema [] tUNext
   where tUNext      = tFun fxMut (posRow (tIterator (tInt)) posNil) kwdNil tInt

--- a/compiler/lib/src/Acton/Printer.hs
+++ b/compiler/lib/src/Acton/Printer.hs
@@ -179,7 +179,8 @@ instance Pretty Expr where
     pretty (Rest _ e n)             = prettyAtom e <> dot <> text "~" <> pretty n
     pretty (DotI _ e i)             = prettyAtom e <> dot <> pretty i
     pretty (RestI _ e i)            = prettyAtom e <> dot <> text "~" <> pretty i
-    pretty (Opt _ e)                = pretty e <> text "?"
+    pretty (Opt _ e True)           = pretty e <> text "?"
+    pretty (Opt _ e False)          = pretty e <> text "!"
     pretty (OptChain _ e)           = pretty e
     pretty (Lambda _ ps ks e fx)    = prettyFXnoWild fx <+> text "lambda" <+> prettyLambdaPar ps ks <> colon <+> pretty e
     pretty (Yield _ e)              = text "yield" <+> pretty e

--- a/compiler/lib/src/Acton/Syntax.hs
+++ b/compiler/lib/src/Acton/Syntax.hs
@@ -93,7 +93,7 @@ data Expr       = Var           { eloc::SrcLoc, var::QName }
                 | Rest          { eloc::SrcLoc, exp1::Expr, attr::Name }
                 | DotI          { eloc::SrcLoc, exp1::Expr, ival::Integer }
                 | RestI         { eloc::SrcLoc, exp1::Expr, ival::Integer }
-                | Opt           { eloc::SrcLoc, exp1::Expr }
+                | Opt           { eloc::SrcLoc, exp1::Expr, optVal::Bool }
                 | OptChain      { eloc::SrcLoc, exp1::Expr }
                 | Lambda        { eloc::SrcLoc, ppar::PosPar, kpar::KwdPar, exp1::Expr, efx::TFX }
                 | Yield         { eloc::SrcLoc, yexp1::Maybe Expr }
@@ -658,7 +658,7 @@ instance Eq Expr where
     x@Rest{}            ==  y@Rest{}            = exp1 x == exp1 y && attr x == attr y
     x@DotI{}            ==  y@DotI{}            = exp1 x == exp1 y && ival x == ival y
     x@RestI{}           ==  y@RestI{}           = exp1 x == exp1 y && ival x == ival y
-    x@Opt{}             ==  y@Opt{}             = exp1 x == exp1 y
+    x@Opt{}             ==  y@Opt{}             = exp1 x == exp1 y && optVal x == optVal y
     x@OptChain{}        ==  y@OptChain{}        = exp1 x == exp1 y
     x@Lambda{}          ==  y@Lambda{}          = ppar x == ppar y && kpar x == kpar y && exp1 x == exp1 y && efx x == efx y
     x@Yield{}           ==  y@Yield{}           = yexp1 x == yexp1 y

--- a/compiler/lib/src/Acton/Transform.hs
+++ b/compiler/lib/src/Acton/Transform.hs
@@ -163,7 +163,6 @@ instance Transform Expr where
       | Tuple{} <- e'                   = kwditem n $ kargs e'                              -- TODO: outrule side-effects in e
       | otherwise                       = Dot l e' n
       where e'                          = trans env e
-    trans env (Opt l e)                 = Opt l (trans env e)
     trans env (OptChain l e)            = OptChain l (trans env e)
     trans env (Rest l e n)
       | Tuple{} <- e'                   = Tuple NoLoc PosNil (kwdrest n $ kargs e')         -- TODO: outrule side-effects in e

--- a/compiler/lib/src/Acton/Types.hs
+++ b/compiler/lib/src/Acton/Types.hs
@@ -1938,30 +1938,30 @@ instance Infer Expr where
 
                                          -- The parser inserts Opt nodes only within OptChain nodes (which each contains exactly one Opt node).
                                          -- The Opt nodes are handled and eliminated by infer on an OptChain node.
---    infer env (Opt l e)                = do (cs, t, e') <- infer env e
---                                            return (cs, tOpt t, Opt l e')
-                                            
                                          -- e is an atomic expression (atom_expr in the parser) which contains exactly one ? in its sequence of trailers
     infer env (OptChain l e)           = do x <- newTmp                                                                                      -- Example: a s1 s2 ? t1 t2
-                                            let (e1,e2) = split x e                                                                          -- e1 = a s1 s2, e2 = x t1 t2
+                                            let (b,e1,e2) = split x e                                                                          -- e1 = a s1 s2, e2 = x t1 t2
                                             te <- newUnivar env
                                             (cs1,e1') <- inferSub env (tOpt te) e1
                                             let env1 = define [(x,NVar te)] env
                                             (cs2,t,e2') <- infer env1 e2
                                             y <- newTmp
-                                            w <- newWitness
-                                            w1 <- newWitness
-                                            t1 <- newUnivar env
-                                            return (Sub (noinfo 444) env w tNone t1 : Sub (noinfo 555) env w1 t t1 : cs1++cs2,
-                                                     t1, eLet [sAssign (pVar y (tOpt te)) e1']
+                                            (cs3,t',e3) <- alt t te b
+                                            return (cs1++cs2++cs3,
+                                                     t', eLet [sAssign (pVar y (tOpt te)) e1']
                                                                            (eCond (termsubst [(x,eCAST (tOpt te) te (eVar y))] e2')
                                                                                   (eCall (tApp (eQVar primISNOTNONE) [te]) [eVar y])
-                                                                                  eNone))
-      where split x (Opt l e)           = (e, eVar x)
-            split x (Dot l e n)         = (e1,Dot l e2 n) where (e1,e2) = split x e
-            split x (Call l f ps ks)    = (e1,Call l e2 ps ks) where (e1,e2) = split x f
-            split x (Index l e ix)      = (e1,Index l e2 ix) where (e1,e2) = split x e
-            split x (Slice l e sz)      = (e1,Slice l e2 sz) where (e1,e2) = split x e
+                                                                                  e3))
+      where split x (Opt l e b)         = (b, e, eVar x)
+            split x (Dot l e n)         = (b, e1,Dot l e2 n) where (b,e1,e2) = split x e
+            split x (Call l f ps ks)    = (b, e1,Call l e2 ps ks) where (b,e1,e2) = split x f
+            split x (Index l e ix)      = (b, e1,Index l e2 ix) where (b,e1,e2) = split x e
+            split x (Slice l e sz)      = (b, e1,Slice l e2 sz) where (b,e1,e2) = split x e
+            alt t te True               = do w <- newWitness
+                                             w1 <- newWitness
+                                             t1 <- newUnivar env
+                                             return ([Sub (noinfo 444) env w tNone t1, Sub (noinfo 555) env w1 t t1],t1,eNone)
+            alt t te False              = return ([],t,eCall (tApp (eQVar primRaiseValueError) [te]) [Strings NoLoc ["Forced unwrapping applied to None"]] )
  
     infer env e@(Rest _ _ _)            = notYetExpr e
 --    infer env (Rest l e n)              = do p <- newUnivarOfKind PRow env

--- a/test/core_lang_auto/optchain6.act
+++ b/test/core_lang_auto/optchain6.act
@@ -1,0 +1,40 @@
+class Alpha:
+    def __init__(self, b: ?Beta):
+        self.b = b
+
+class Beta(object):
+    def __init__(self, c: ?Gamma):
+        self.c = c
+
+class Gamma:
+    def __init__(self, s: str):
+        self.s = s
+
+def new_opt(a: ?Alpha):
+    # Using ? will shortcut and return None if any accessed field is None
+    part: ?str = a?.b?.c?.s
+    if part is not None:
+        print("Got a part:", part)
+    else:
+        print("Got None")
+
+def new_nonopt(a: ?Alpha):
+    # Using ! will check each field and if it is None we will get an exception. If all fields are not-None then we can proceed and thus the return value is a non-optional str
+    part: str = a!.b!.c!.s
+    print("Got a part:", part)
+
+actor main(env):
+    c = Gamma("hello")
+    b = Beta(c)
+    a = Alpha(b)
+    new_opt(a)
+    new_nonopt(a)
+    b.c = None
+    new_opt(a)
+    try:
+        new_nonopt(a)
+    except ValueError:
+        print("ValueError")
+    env.exit(0)
+    
+        

--- a/test/core_lang_auto/optchain7.act
+++ b/test/core_lang_auto/optchain7.act
@@ -1,0 +1,21 @@
+actor main(env):
+   d: ?dict[str,list[int]] = { "a": list(range(20)), "c": list(range(30)) }
+
+   a1 = d ?.get("a") ? [1::2] [5] # a1 has type ?int; last !/? operation decides type.
+   a2 = d !.get("a") ! [1::2] [5] # a2 has type int
+   a3 = d ?.get("a") ! [1::2] [5] # a3 has type int
+   a4 = d !.get("a") ? [1::2] [5] # a4 has type ?int
+  
+   print(a1,a2,a3,a4)
+   
+   print(d ?.get("b") ? [1::2])  # prints None; failure in ? operation
+   print(d !.get("b") ? [1::2])  # prints None; failure in ? operation
+   try:
+        print(d ?.get("b") ! [1::2])  # raises ValueError; failure in ! operation
+        print(d !.get("b") ! [1::2])  # Never executed; would raise ValueError
+   except ValueError:
+        print("ValueError")
+   env.exit(0)
+
+
+   


### PR DESCRIPTION
This PR implements forced unwrapping and should complete #1859.

We take the approach to parse the postfix operator ! as yet an alternative trailer in atomic expressions, together with ? and indexing, slicing, selection and calls. The operators ! and ? are thus interchangable and expect an expression of optional type as left operand and a sequence of trailers as right operand. It is debatable how useful it is to mix ! and ? in the same sequence, but the following is valid code:
````
actor main(env):
   d: ?dict[str,list[int]] = { "a": list(range(20)), "c": list(range(30)) }

   a1 = d ?.get("a") ? [1::2] [5] # a1 has type ?int; last !/? operation decides type.
   a2 = d !.get("a") ! [1::2] [5] # a2 has type int
   a3 = d ?.get("a") ! [1::2] [5] # a3 has type int
   a4 = d !.get("a") ? [1::2] [5] # a4 has type ?int
  
   print(a1,a2,a3,a4)
   
   print(d ?.get("b") ? [1::2])  # prints None; failure in ? operation
   print(d !.get("b") ? [1::2])  # prints None; failure in ? operation
   try:
        print(d ?.get("b") ! [1::2])  # raises ValueError; failure in ! operation
        print(d !.get("b") ! [1::2])  # Never executed; would raise ValueError
   except ValueError:
        print("ValueError")
   env.exit(0)
````
Note that for a successful sequence of operations, the last ?/! operator decides the type of the result. For a failed operation (None encountered in one !/? operation), the failing operation decides the effect: ? gives a None result and ! raises a ValueError.
