### PR TITLE
Restrict module top-level statements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ endif
 BUILTIN_HFILES=$(wildcard base/builtin/*.h)
 
 DIST_BINS=$(ACTONC) dist/bin/actondb dist/bin/runacton dist/bin/lsp-server-acton
-DIST_ZIG=dist/zig
+DIST_ZIG=$(ZIG)
 
 .PHONY: test-backend
 test-backend: $(BACKEND_TESTS)
@@ -434,11 +434,14 @@ dist/completion/acton.bash-completion: completion/acton.bash-completion
 	mkdir -p "$(dir $@)"
 	cp "$<" "$@"
 
-dist/zig: deps-download/zig-$(ARCH)-$(OS)-$(ZIG_VERSION).tar.xz
-	mkdir -p "$@"
-	cd "$@" && tar Jx --strip-components=1 -f "../../$^"
-	rm -rf "$@/doc"
-	cp -a deps/zig-extras/* "$@"
+$(ZIG): deps-download/zig-$(ARCH)-$(OS)-$(ZIG_VERSION).tar.xz
+	mkdir -p "$(dir $@)"
+	cd "$(dir $@)" && tar Jx --strip-components=1 -f "../../$<"
+	rm -rf "$(dir $@)/doc"
+	cp -a deps/zig-extras/* "$(dir $@)"
+
+.PHONY: dist/zig
+dist/zig: $(ZIG)
 
 
 # Check if ZIG_VERSION contains -dev, in which case we pull down a nightly,

--- a/base/src/buildy.act
+++ b/base/src/buildy.act
@@ -1,12 +1,12 @@
-import file
-import json
-import re
-
 """Buildy stuff
 
 Our projects have a built.act and it collides with this module if it would be
 called just 'build', so it's buildy for buildy stuff.
 """
+
+import file
+import json
+import re
 
 class BuildSpecError(ValueError):
     pass

--- a/base/src/logging.act
+++ b/base/src/logging.act
@@ -1,6 +1,3 @@
-import file
-import time
-
 r"""Advanced actor based logging
 
 There are three main components to the logging system:
@@ -82,6 +79,9 @@ vvvvvvvvvv vvvvvvvvvvvvvvvvvv vv vvvvv
                        log message --------------------------------------------------------'                |
                    structured data -------------------------------------------------------------------------'
 """
+
+import file
+import time
 
 # Log levels
 UNSET, OFF, EMERGENCY, ALERT, CRITICAL, ERR, WARNING, INFO, NOTICE, DEBUG, VERBOSE, TRACE, ALL : int

--- a/compiler/acton/test/typeerrors/ex23.act
+++ b/compiler/acton/test/typeerrors/ex23.act
@@ -4,24 +4,19 @@ def f(x,s : str):
     else:
        return x+x
 
-'''
-This gives a misleading error message; the last constraint is
-
-
-  |
-2 |    if s==7:
-  |       ^^^^
-The type of s == 7 (which we call t1) must implement __builtin__.Eq
-
-
-Instead of "The type of s == 7" one wants "a common supertype of s and 7" (?)
-
-Fix should be done in the 
-
-    infer env e@(CompOp l e1 [OpArg op e2])
-
-case in Types.hs.
-
-
-Similar problems show up for other binary operators.
-'''
+# This gives a misleading error message; the last constraint is
+#
+#   |
+# 2 |    if s==7:
+#   |       ^^^^
+# The type of s == 7 (which we call t1) must implement __builtin__.Eq
+#
+# Instead of "The type of s == 7" one wants "a common supertype of s and 7" (?)
+#
+# Fix should be done in the
+#
+#     infer env e@(CompOp l e1 [OpArg op e2])
+#
+# case in Types.hs.
+#
+# Similar problems show up for other binary operators.

--- a/compiler/lib/src/Acton/Diagnostics.hs
+++ b/compiler/lib/src/Acton/Diagnostics.hs
@@ -48,6 +48,14 @@ customParseErrorToDiagnostic (TooManyQuotesError quote)        = ("Too many quot
                                                                    Hint "Use escape sequences for quotes inside strings, e.g. \"\"\"text \\\"with quotes\\\"\"\" -> text \"with quotes\""])
 customParseErrorToDiagnostic (MissingClosingQuote quote)       = ("Missing closing " ++ quote,
                                                                   [Hint $ "Add a closing quote (" ++ quote ++ ") to match the opening one"])
+customParseErrorToDiagnostic InvalidModuleStatement            = ("Only declarations and assignments are allowed at the module top level",
+                                                                  [Hint "Assign the value to a name or move runtime work into an actor or function"])
+customParseErrorToDiagnostic InvalidTopLevelAssignmentPattern  = ("Module top-level assignments must bind at least one name",
+                                                                  [Note "Module top-level assignments define constants by name",
+                                                                   Hint "Bind the value to a name or move the computation into an actor or function"])
+customParseErrorToDiagnostic (DuplicateTopLevelAssignment name) = ("Module top-level name '" ++ name ++ "' cannot be assigned more than once",
+                                                                   [Note "Module top-level assignments define constants",
+                                                                    Hint "Use a fresh name or move mutable state into an actor"])
 -- String interpolation errors
 customParseErrorToDiagnostic EmptyInterpolationExpression       = ("Empty expression in string interpolation",
                                                                   [Hint "Add an expression between the braces, e.g. {name}"])

--- a/compiler/lib/src/Acton/Parser.hs
+++ b/compiler/lib/src/Acton/Parser.hs
@@ -26,7 +26,7 @@ import Data.Maybe (fromMaybe)
 import Data.Void
 import Data.Char
 import qualified Data.List.NonEmpty as N
-import qualified Data.Set as S
+import qualified Data.Set as Set
 import Numeric
 import Text.Megaparsec
 import Text.Megaparsec.Char
@@ -48,6 +48,9 @@ data CustomParseError = TypeVariableNameError String  -- Name that looks like ty
                       | InvalidFormatSpecifier String
                       | MissingClosingQuote String  -- String is the quote type (e.g., "\"\"\"" or "'")
                       | TooManyQuotesError String
+                      | InvalidModuleStatement
+                      | InvalidTopLevelAssignmentPattern
+                      | DuplicateTopLevelAssignment String
                       -- String interpolation errors
                       | EmptyInterpolationExpression
                       | MissingExpressionBeforeFormat
@@ -72,6 +75,12 @@ instance ShowErrorComponent CustomParseError where
   showErrorComponent (InvalidFormatSpecifier spec) = "Invalid format specifier" ++ if null spec then "" else ": " ++ spec
   showErrorComponent (MissingClosingQuote quote) = "missing closing " ++ quote
   showErrorComponent (TooManyQuotesError quote) = "too many quote characters"
+  showErrorComponent InvalidModuleStatement =
+    "Only declarations and assignments are allowed at the module top level"
+  showErrorComponent InvalidTopLevelAssignmentPattern =
+    "Module top-level assignments must bind at least one name"
+  showErrorComponent (DuplicateTopLevelAssignment name) =
+    "Module top-level name '" ++ name ++ "' cannot be assigned more than once"
   -- String interpolation errors
   showErrorComponent EmptyInterpolationExpression = "Empty expression in string interpolation"
   showErrorComponent MissingExpressionBeforeFormat = "Missing expression before format specifier"
@@ -1011,14 +1020,14 @@ identifier = (lexeme . try) $ do
     cs <- hidden (takeWhileP Nothing (\c -> isAlphaNum c || c=='_'))
     let x = c:cs
     if S.isKeyword x
-      then parseError (TrivialError off (Just (Tokens (N.fromList x))) (S.fromList [Label (N.fromList "identifier")]))
+      then parseError (TrivialError off (Just (Tokens (N.fromList x))) (Set.fromList [Label (N.fromList "identifier")]))
       else return x
 
 name, escname, tvarname :: Parser S.Name
 name = do off <- getOffset
           x <- identifier
           if isUpper (head x) && all isDigit (tail x)
-            then parseError (FancyError off (S.fromList [ErrorCustom (TypeVariableNameError x)]))
+            then parseError (FancyError off (Set.fromList [ErrorCustom (TypeVariableNameError x)]))
             else return $ S.Name (Loc off (off+length x)) x
 
 escname = name <|> addLoc (S.Name NoLoc . head <$> plainstrLiteral)  -- Assumes an escname cannot contain hex escape sequences
@@ -1027,7 +1036,7 @@ tvarname = do off <- getOffset
               x <- identifier
               if isUpper (head x) && all isDigit (tail x)
                then return $ S.Name (Loc off (off+length x)) x
-               else parseError (TrivialError off (Just (Tokens (N.fromList x))) (S.fromList [Label (N.fromList ("type variable (upper case letter optionally followed by digits)"))]))
+               else parseError (TrivialError off (Just (Tokens (N.fromList x))) (Set.fromList [Label (N.fromList ("type variable (upper case letter optionally followed by digits)"))]))
 
 module_name :: Parser S.ModName
 module_name = do
@@ -1069,6 +1078,7 @@ file_input = sc2 *>  do
     mbDocstring <- optional (try (L.nonIndented sc2 docstring_stmt <* eol <* sc2))
     is <- imports
     s <-  withCtx TOP top_suite
+    validateModuleSuite s
     eof
     -- Prepend docstring to suite if present
     let suite = case mbDocstring of
@@ -1083,6 +1093,25 @@ imports = many (L.nonIndented sc2 import_stmt <* eol <* sc2)
 
 top_suite :: Parser S.Suite
 top_suite = concat <$> (many (L.nonIndented sc2 stmt <|> newline1))
+
+validateModuleSuite :: S.Suite -> Parser ()
+validateModuleSuite stmts = do
+  assigned <- concat <$> mapM validateModuleStmt stmts
+  case duplicates assigned of
+    n:_ -> parseException (loc n) (DuplicateTopLevelAssignment (S.rawstr n))
+    []  -> return ()
+
+validateModuleStmt :: S.Stmt -> Parser [S.Name]
+validateModuleStmt stmt =
+  case stmt of
+    S.Assign _ pats _ ->
+      let names = Names.bound pats
+      in if null names
+         then parseException (loc pats) InvalidTopLevelAssignmentPattern
+         else return names
+    S.Signature{} -> return []
+    S.Decl{}      -> return []
+    _             -> parseException (S.sloc stmt) InvalidModuleStatement
 
 -- Row parsers ----------------------------------------------------------------------
 

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -94,6 +94,56 @@ main = do
           testModuleParseError "module_func_before_import" "def foo():\n    pass\nimport math\n"
           testModuleParseError "module_actor_before_import" "actor Foo():\n    pass\nimport math\n"
 
+        describe "Module-level constants" $ do
+          it "allows top-level declarations, signatures, and assignments" $ do
+            expectModuleParseSuccess $ unlines
+              [ "value : int"
+              , "def helper() -> int:"
+              , "    return 41"
+              , "value = helper()"
+              ]
+
+          it "rejects top-level expression statements" $ do
+            err <- expectModuleParseFailure $ unlines
+              [ "value = 1"
+              , "1 + 2"
+              ]
+            err `shouldContain` "Only declarations and assignments are allowed at the module top level"
+
+          it "rejects top-level control flow" $ do
+            err <- expectModuleParseFailure $ unlines
+              [ "import math"
+              , "if True:"
+              , "    value = 1"
+              ]
+            err `shouldContain` "Only declarations and assignments are allowed at the module top level"
+
+          it "rejects top-level reassignment" $ do
+            err <- expectModuleParseFailure $ unlines
+              [ "value = 1"
+              , "value = 2"
+              ]
+            err `shouldContain` "Module top-level name 'value' cannot be assigned more than once"
+
+          it "allows top-level destructuring with at least one bound name" $ do
+            expectModuleParseSuccess "left, _ = (1, 2)\n"
+
+          it "rejects duplicate names within one top-level assignment" $ do
+            err <- expectModuleParseFailure "left, left = (1, 2)\n"
+            err `shouldContain` "Module top-level name 'left' cannot be assigned more than once"
+
+          it "rejects top-level wildcard-only assignment" $ do
+            _ <- expectModuleParseFailure "_ = 1\n"
+            return ()
+
+          it "rejects top-level assignments with no bound names" $ do
+            err <- expectModuleParseFailure "[] = []\n"
+            err `shouldContain` "Module top-level assignments must bind at least one name"
+
+          it "rejects top-level wildcard-only destructuring assignment" $ do
+            err <- expectModuleParseFailure "[_, _] = [1, 2]\n"
+            err `shouldContain` "Module top-level assignments must bind at least one name"
+
       describe "Numeric literals" $ do
         it "parses INT64_MIN as a single literal" $ do
           case parseStmtAst "a = -9223372036854775808" of
@@ -1048,6 +1098,18 @@ parseModuleTest input =
     handleCustomParseException :: P.CustomParseException -> IO (Either String String)
     handleCustomParseException (P.CustomParseException loc err) =
       return $ Left $ formatCustomParseError "test.act" inputWithNewline loc err
+
+expectModuleParseSuccess :: String -> IO ()
+expectModuleParseSuccess input =
+  case parseModuleTest input of
+    Left err -> expectationFailure $ "Parse failed: " ++ err
+    Right _ -> return ()
+
+expectModuleParseFailure :: String -> IO String
+expectModuleParseFailure input =
+  case parseModuleTest input of
+    Left err -> return err
+    Right result -> expectationFailure $ "Expected parse failure, got: " ++ result
 
 parseStmtAst :: String -> Either String [S.Stmt]
 parseStmtAst input =

--- a/compiler/lib/test/parser_golden/module_call_before_import.golden
+++ b/compiler/lib/test/parser_golden/module_call_before_import.golden
@@ -1,11 +1,9 @@
-ERROR: [error Parse error]: unexpected 'i'
-                     expecting end of input, end of line, or statement
-
-     ╭──▶ test.act@2:1-2:2
+ERROR: [error Syntax error]: Only declarations and assignments are allowed at the module top level
+     ╭──▶ test.act@1:1-1:15
      │
-   2 │ import math
-     • ┬ 
-     • ╰╸ unexpected 'i'
-     •    expecting end of input, end of line, or statement
-     •    
+   1 │ print("hello")
+     • ┬─────────────
+     • ╰╸ Only declarations and assignments are allowed at the module top level
+     •
+     │ Hint: Assign the value to a name or move runtime work into an actor or function
 ─────╯

--- a/compiler/lib/test/parser_golden/module_dict_before_import.golden
+++ b/compiler/lib/test/parser_golden/module_dict_before_import.golden
@@ -1,11 +1,9 @@
-ERROR: [error Parse error]: unexpected 'i'
-                     expecting end of input, end of line, or statement
-
-     ╭──▶ test.act@2:1-2:2
+ERROR: [error Syntax error]: Only declarations and assignments are allowed at the module top level
+     ╭──▶ test.act@1:1-1:17
      │
-   2 │ import math
-     • ┬ 
-     • ╰╸ unexpected 'i'
-     •    expecting end of input, end of line, or statement
-     •    
+   1 │ {"key": "value"}
+     • ┬───────────────
+     • ╰╸ Only declarations and assignments are allowed at the module top level
+     •
+     │ Hint: Assign the value to a name or move runtime work into an actor or function
 ─────╯

--- a/compiler/lib/test/parser_golden/module_for_before_import.golden
+++ b/compiler/lib/test/parser_golden/module_for_before_import.golden
@@ -1,11 +1,9 @@
-ERROR: [error Parse error]: unexpected 'i'
-                     expecting "else", end of input, end of line, or statement
-
-     ╭──▶ test.act@3:1-3:2
+ERROR: [error Syntax error]: Only declarations and assignments are allowed at the module top level
+     ╭──▶ test.act@1:1-1:1
      │
-   3 │ import math
-     • ┬ 
-     • ╰╸ unexpected 'i'
-     •    expecting "else", end of input, end of line, or statement
-     •    
+   1 │ for i in range(10):
+     •  
+     • ╰╸ Only declarations and assignments are allowed at the module top level
+     •
+     │ Hint: Assign the value to a name or move runtime work into an actor or function
 ─────╯

--- a/compiler/lib/test/parser_golden/module_if_before_import.golden
+++ b/compiler/lib/test/parser_golden/module_if_before_import.golden
@@ -1,11 +1,9 @@
-ERROR: [error Parse error]: unexpected 'i'
-                     expecting "elif", "else", end of input, end of line, or statement
-
-     ╭──▶ test.act@3:1-3:2
+ERROR: [error Syntax error]: Only declarations and assignments are allowed at the module top level
+     ╭──▶ test.act@1:1-1:1
      │
-   3 │ import math
-     • ┬ 
-     • ╰╸ unexpected 'i'
-     •    expecting "elif", "else", end of input, end of line, or statement
-     •    
+   1 │ if True:
+     •  
+     • ╰╸ Only declarations and assignments are allowed at the module top level
+     •
+     │ Hint: Assign the value to a name or move runtime work into an actor or function
 ─────╯

--- a/compiler/lib/test/parser_golden/module_list_before_import.golden
+++ b/compiler/lib/test/parser_golden/module_list_before_import.golden
@@ -1,11 +1,9 @@
-ERROR: [error Parse error]: unexpected 'i'
-                     expecting end of input, end of line, or statement
-
-     ╭──▶ test.act@2:1-2:2
+ERROR: [error Syntax error]: Only declarations and assignments are allowed at the module top level
+     ╭──▶ test.act@1:1-1:10
      │
-   2 │ import math
-     • ┬ 
-     • ╰╸ unexpected 'i'
-     •    expecting end of input, end of line, or statement
-     •    
+   1 │ [1, 2, 3]
+     • ┬────────
+     • ╰╸ Only declarations and assignments are allowed at the module top level
+     •
+     │ Hint: Assign the value to a name or move runtime work into an actor or function
 ─────╯

--- a/compiler/lib/test/parser_golden/module_number_before_import.golden
+++ b/compiler/lib/test/parser_golden/module_number_before_import.golden
@@ -1,11 +1,9 @@
-ERROR: [error Parse error]: unexpected 'i'
-                     expecting end of input, end of line, or statement
-
-     ╭──▶ test.act@2:1-2:2
+ERROR: [error Syntax error]: Only declarations and assignments are allowed at the module top level
+     ╭──▶ test.act@1:1-1:3
      │
-   2 │ import math
-     • ┬ 
-     • ╰╸ unexpected 'i'
-     •    expecting end of input, end of line, or statement
-     •    
+   1 │ 42
+     • ┬─
+     • ╰╸ Only declarations and assignments are allowed at the module top level
+     •
+     │ Hint: Assign the value to a name or move runtime work into an actor or function
 ─────╯

--- a/compiler/lib/test/src/bar.act
+++ b/compiler/lib/test/src/bar.act
@@ -6,10 +6,10 @@ that are used across the application.
 
 # Module constants
 VERSION: str = "1.0.0"
-"""Current version of the bar module"""
+# Current version of the bar module
 
 MAX_ITEMS: int = 1000
-"""Maximum number of items allowed in a container"""
+# Maximum number of items allowed in a container
 
 # Basic data class
 class Data(object):
@@ -312,5 +312,3 @@ def process_items[T](items: list[Processable[T]]) -> list[T]:
 def gt(a, b, c, d):
     """Function that takes generic types"""
     return (a + b, a - b, c + d)
-
-gt(1, 2, "a", "b")

--- a/compiler/lib/test/src/foo.act
+++ b/compiler/lib/test/src/foo.act
@@ -1,14 +1,14 @@
-import bar
-
 """Foo module - demonstrates cross-module type usage
 
 This module extensively uses types from the bar module
 to demonstrate documentation of cross-module references.
 """
 
+import bar
+
 # Module constants
 DEFAULT_PREFIX: str = "AUTO_"
-"""Default prefix for auto-generated labels"""
+# Default prefix for auto-generated labels
 
 # Functions using bar.Data
 def create_data(value: str) -> bar.Data:

--- a/test/builtins_auto/list.act
+++ b/test/builtins_auto/list.act
@@ -1,7 +1,7 @@
-import testing
-
 """Test lists
 """
+
+import testing
 
 def test_list_index():
     l = [1, 2, 3, 1, 2, 5, 1]

--- a/test/test_doc_printing/src/bar.act
+++ b/test/test_doc_printing/src/bar.act
@@ -6,10 +6,10 @@ that are used across the application.
 
 # Module constants
 VERSION: str = "1.0.0"
-"""Current version of the bar module"""
+# Current version of the bar module
 
 MAX_ITEMS: int = 1000
-"""Maximum number of items allowed in a container"""
+# Maximum number of items allowed in a container
 
 # Basic data class
 class Data(object):
@@ -312,5 +312,3 @@ def process_items[T](items: list[Processable[T]]) -> list[T]:
 def gt(a, b, c, d):
     """Function that takes generic types"""
     return (a + b, a - b, c + d)
-
-gt(1, 2, "a", "b")

--- a/test/test_doc_printing/src/foo.act
+++ b/test/test_doc_printing/src/foo.act
@@ -1,14 +1,14 @@
-import bar
-
 """Foo module - demonstrates cross-module type usage
 
 This module extensively uses types from the bar module
 to demonstrate documentation of cross-module references.
 """
 
+import bar
+
 # Module constants
 DEFAULT_PREFIX: str = "AUTO_"
-"""Default prefix for auto-generated labels"""
+# Default prefix for auto-generated labels
 
 # Functions using bar.Data
 def create_data(value: str) -> bar.Data:


### PR DESCRIPTION
The parser has a consistent statement grammar across module bodies and nestes suites so the syntax remains simple with uniform parsing. However, we do in fact want a somewhat stricter grammar on the module top level.

This change keeps the shared parsing structure and validates parsed module suites afterwards. Only declarations, signatures, and assignments are accepted at the module top level, and top-level assignment names are tracked so rebinding a module constant is rejected early. Explicit module docstrings before imports still work, while stray bare strings in module bodies no longer do.

This makes the parser more restrictive only where the language requires it, without splitting module parsing off into a separate statement grammar.