### PR TITLE
Split constructor attribute envs

### DIFF
--- a/compiler/acton/test_incremental.hs
+++ b/compiler/acton/test_incremental.hs
@@ -1294,7 +1294,7 @@ p28_protocol_extension_deps = testCase "28-protocol/extension deps are recorded 
   let I.NModule iface _ = nmod
       extMatch (n, _) = prstr n == "BarProtoD_Widget"
   case find extMatch iface of
-    Just (_, I.NExt _ _ ps _ _ _) -> do
+    Just (_, I.NExt _ _ ps _ _ _ _) -> do
       let protoNames = sort [ prstr (A.tcname p) | (_, p) <- ps ]
       assertEqual "extension protocol mro" (sort ["a.BarProto", "a.BazProto", "a.FooProto"]) protoNames
     _ -> assertFailure "missing extension NameInfo for BarProtoD_Widget"

--- a/compiler/lib/src/Acton/CPS.hs
+++ b/compiler/lib/src/Acton/CPS.hs
@@ -517,7 +517,7 @@ instance (Conv a) => Conv (Name, a) where
     conv env (n, x)                     = (n, conv env x)
 
 instance Conv NameInfo where
-    conv env (NClass q ps te doc)       = NClass q (conv env ps) (conv env te) doc
+    conv env (NClass q ps sigs defs doc)= NClass q (conv env ps) (conv env sigs) (conv env defs) doc
     conv env (NSig sc dec doc)          = NSig (conv env sc) dec doc
     conv env (NDef sc dec doc)          = NDef (conv env sc) dec doc
     conv env (NVar t)                   = NVar (conv env t)

--- a/compiler/lib/src/Acton/CodeGen.hs
+++ b/compiler/lib/src/Acton/CodeGen.hs
@@ -857,7 +857,7 @@ acton_malloc env n                  = text "acton_malloc" <> parens (text "sizeo
 comma' x                            = if isEmpty x then empty else comma <+> x
 
 genDotCall env ts dec e@(Var _ x) n p
-  | NClass q _ _ _ <- info,
+  | NClass q _ _ _ _ <- info,
     Just _ <- dec                   = classCast env ts x q n (methodtable' env x <> text "." <> gen env n) <> parens (gen env p)
   where info                        = findQName x env
 genDotCall env ts dec e n p
@@ -866,7 +866,7 @@ genDotCall env ts dec e n p
 
 
 genDot env ts e@(Var _ x) n
-  | NClass q _ _ _ <- findQName x env = classCast env ts x q n $ methodtable' env x <> text "." <> gen env n
+  | NClass q _ _ _ _ <- findQName x env = classCast env ts x q n $ methodtable' env x <> text "." <> gen env n
 genDot env ts e n                   = dotCast env False ts e n $ gen env e <> text "->" <> gen env n
 -- NOTE: all method references are eta-expanded by the lambda-lifter at this point, so n cannot be a method (i.e., require methodtable lookup) here
 

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -3633,7 +3633,7 @@ nameToString (A.Name _ s) = s
 -- | Check whether a NameInfo represents a root-eligible actor.
 -- Used to decide which roots to include in .ty headers and root generation.
 rootEligible :: I.NameInfo -> Bool
-rootEligible (I.NAct [] p k _ _) = case (p,k) of
+rootEligible (I.NAct [] p k _ _ _) = case (p,k) of
                                       (A.TNil{}, A.TRow _ _ _ t A.TNil{}) ->
                                         prstr t == "Env" || prstr t == "None" ||
                                         prstr t == "__builtin__.Env" || prstr t == "__builtin__.None"

--- a/compiler/lib/src/Acton/Converter.hs
+++ b/compiler/lib/src/Acton/Converter.hs
@@ -242,18 +242,25 @@ convEnvProtos env                       = mapModules conv env
   where
     conv env1 m (n, NDef sc d doc)      = [(n, NDef (convS sc) d doc)]
     conv env1 m (n, NSig sc d doc)      = [(n, NSig (convS sc) d doc)]
-    conv env1 m (n, NAct q p k te doc)  = [(n, NAct (noqual env q) (qualWRow env q p) k (concat $ map (conv env m) te) doc)]
-    conv env1 m ni@(n, NProto q us te doc)
+    conv env1 m (n, NAct q p k sigs defs doc)
+                                        = [(n, NAct (noqual env q) (qualWRow env q p) k
+                                                (concat $ map (conv env m) sigs)
+                                                (concat $ map (conv env m) defs) doc)]
+    conv env1 m ni@(n, NProto q us sigs defs doc)
                                         = map (fromClass env) $ convProtocol (define [ni] env) n q us [] [] (fromTEnv te)
-    conv env1 m ni@(n, NExt q c us te opts doc)
+      where te                          = attrTEnv sigs defs
+    conv env1 m ni@(n, NExt q c us sigs defs opts doc)
                                         = map (fromClass env) $ convExtension (define [ni] env) n c q us [] [] (fromTEnv te) opts
-    conv env1 m (n, NClass q us te doc) = [(n, NClass (noqual env q) us (convClassTEnv env q te) doc)]
+      where te                          = attrTEnv sigs defs
+    conv env1 m (n, NClass q us sigs defs doc)
+                                        = [(n, NClass (noqual env q) us (convClassTEnv env q sigs) (convClassTEnv env q defs) doc)]
     conv env1 m ni                      = [ni]
     convS (TSchema l q t)               = TSchema l (noqual env q) (convT q t)
     convT q (TFun l x p k t)            = TFun l x (qualWRow env q p) k t
     convT q t                           = t
 
-fromClass env (Class _ n q us b ddoc)   = (n, NClass q (leftpath us) (fromStmts env b) ddoc)
+fromClass env (Class _ n q us b ddoc)   = (n, NClass q (leftpath us) (attrSigs te) (attrDefs te) ddoc)
+  where te                              = fromStmts env b
 
 fromStmts env (Signature _ ns sc d : ss)= [ (n, NSig (convS sc) d Nothing) | n <- ns ] ++ fromStmts env ss
   where convS (TSchema l q t)           = TSchema l (noqual env q) (convT q t)

--- a/compiler/lib/src/Acton/Deactorizer.hs
+++ b/compiler/lib/src/Acton/Deactorizer.hs
@@ -361,10 +361,12 @@ instance LambdaFree Elem where
 
 -- Convert types and environments -----------------------------------------------------------------------
 
-conv env m (n, NAct q p k te' doc)  = (n, NClass q (leftpath [TC primActor [], cValue]) (convActorEnv q p k te') doc) :
+conv env m (n, NAct q p k sigs defs doc)
+                                    = (n, NClass q (leftpath [TC primActor [], cValue]) (attrSigs te) (attrDefs te) doc) :
                                       (newactName n, NDef (tSchema q (tFun fxProc p k t)) NoDec Nothing) :
                                       []
-  where convActorEnv q0 p k te'     = (initKW, NDef t0 NoDec Nothing) : te'
+  where te                          = convActorEnv q p k (attrTEnv sigs defs)
+        convActorEnv q0 p k te'     = (initKW, NDef t0 NoDec Nothing) : te'
           where t0                  = tSchema q0 (tFun fxProc p k tNone)
         t                           = tCon $ TC (GName m n) (map tVar $ qbound q)
 conv env m ni                       = [ni]

--- a/compiler/lib/src/Acton/DocPrinter.hs
+++ b/compiler/lib/src/Acton/DocPrinter.hs
@@ -88,10 +88,10 @@ extractTopLevelWithTypes _ _ = []
 extractNameDocstring :: NameInfo -> Maybe String
 extractNameDocstring (NDef _ _ mdoc) = mdoc
 extractNameDocstring (NSig _ _ mdoc) = mdoc
-extractNameDocstring (NAct _ _ _ _ mdoc) = mdoc
-extractNameDocstring (NClass _ _ _ mdoc) = mdoc
-extractNameDocstring (NProto _ _ _ mdoc) = mdoc
-extractNameDocstring (NExt _ _ _ _ _ mdoc) = mdoc
+extractNameDocstring (NAct _ _ _ _ _ mdoc) = mdoc
+extractNameDocstring (NClass _ _ _ _ mdoc) = mdoc
+extractNameDocstring (NProto _ _ _ _ mdoc) = mdoc
+extractNameDocstring (NExt _ _ _ _ _ _ mdoc) = mdoc
 extractNameDocstring (NModule _ mdoc) = mdoc
 extractNameDocstring _ = Nothing
 
@@ -718,7 +718,7 @@ docDeclUnified useStyle tenv decl@(Def _ n q p k a b d x ddoc) =
 
 docDeclUnified useStyle tenv (Actor _ n q p k b ddoc) =
     let (paramsWithTypes, docstringFromTEnv) = case lookup n tenv of
-            Just info@(NAct _ posRow kwdRow _ mdoc) ->
+            Just info@(NAct _ posRow kwdRow _ _ mdoc) ->
                 (enrichParamsStyledAsciiActr useStyle posRow kwdRow p k, mdoc)
             _ -> (docParamsStyledAscii useStyle useStyle p k, Nothing)
         -- Use docstring from AST declaration
@@ -809,8 +809,9 @@ docDeclUnified useStyle tenv (Class _ n q a b ddoc) =
         let (paramsWithTypes, inferredRetType) =
                 -- Try to get type info from TEnv
                 case lookup className tenv of
-                    Just (NClass _ _ methods _) ->
-                        case lookup methodName methods of
+                    Just (NClass _ _ sigs defs _) ->
+                        let methods = attrTEnv sigs defs
+                        in case lookup methodName methods of
                             Just info ->
                                 case extractTypeFromNameInfo info of
                                     Just (TFun _ _ posRow kwdRow resType) ->
@@ -1584,7 +1585,7 @@ collectClassInfos currentModule tenv stmts =
         importedClasses = Set.fromList $ concatMap extractClassFromTEnv tenv
     in Set.union localClasses importedClasses
   where
-    extractClassFromTEnv (n, NClass _ _ _ _) = [ClassInfo n currentModule False]  -- Mark as imported
+    extractClassFromTEnv (n, NClass _ _ _ _ _) = [ClassInfo n currentModule False]  -- Mark as imported
     extractClassFromTEnv _ = []
 
 -- | Collect all class names defined in the module
@@ -2505,7 +2506,7 @@ docDeclHtmlWithTypesAndClassesAndModule tenv currentModule classNames decl =
         let explicitGenerics = extractGenerics q
             -- Look up inferred type information for actors
             (paramsWithTypes, allGenerics, constraints) = case lookup n tenv of
-                Just (NAct qConstraints posRow kwdRow _ _) ->
+                Just (NAct qConstraints posRow kwdRow _ _ _) ->
                     let inferredGenerics = extractGenerics qConstraints
                         combinedGenerics = Set.union explicitGenerics inferredGenerics
                     in (enrichParamsWithTypesHtmlAndClassesModule curMod combinedGenerics qConstraints classNames posRow kwdRow p k, combinedGenerics, qConstraints)
@@ -2642,7 +2643,7 @@ docDeclHtmlWithTypesAndClasses tenv classNames (Actor _ n q p k b ddoc) =
     let explicitGenerics = extractGenerics q
         -- Look up inferred type information for actors
         (paramsWithTypes, allGenerics, constraints) = case lookup n tenv of
-            Just (NAct qConstraints posRow kwdRow _ _) ->
+            Just (NAct qConstraints posRow kwdRow _ _ _) ->
                 let inferredGenerics = extractGenerics qConstraints
                     combinedGenerics = Set.union explicitGenerics inferredGenerics
                 in (enrichParamsWithTypesHtmlAndClasses combinedGenerics qConstraints classNames posRow kwdRow p k, combinedGenerics, qConstraints)

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -208,10 +208,12 @@ instance Unalias NameInfo where
     unalias env (NSVar t)           = NSVar (unalias env t)
     unalias env (NDef t d doc)      = NDef (unalias env t) d doc
     unalias env (NSig t d doc)      = NSig (unalias env t) d doc
-    unalias env (NAct q p k te doc) = NAct (unalias env q) (unalias env p) (unalias env k) (unalias env te) doc
-    unalias env (NClass q us te doc)= NClass (unalias env q) (unalias env us) (unalias env te) doc
-    unalias env (NProto q us te doc)= NProto (unalias env q) (unalias env us) (unalias env te) doc
-    unalias env (NExt q c ps te opts doc)= NExt (unalias env q) (unalias env c) (unalias env ps) (unalias env te) opts doc
+    unalias env (NAct q p k sigs defs doc)
+                                    = NAct (unalias env q) (unalias env p) (unalias env k)
+                                      (unalias env sigs) (unalias env defs) doc
+    unalias env (NClass q us sigs defs doc)= NClass (unalias env q) (unalias env us) (unalias env sigs) (unalias env defs) doc
+    unalias env (NProto q us sigs defs doc)= NProto (unalias env q) (unalias env us) (unalias env sigs) (unalias env defs) doc
+    unalias env (NExt q c ps sigs defs opts doc)= NExt (unalias env q) (unalias env c) (unalias env ps) (unalias env sigs) (unalias env defs) opts doc
     unalias env (NTVar k c ps)      = NTVar k (unalias env c) (unalias env ps)
     unalias env (NAlias qn)         = NAlias (unalias env qn)
     unalias env (NMAlias m)         = NMAlias (unalias env m)
@@ -277,7 +279,7 @@ define te env
   | not $ null badSelf      = selfParamError (loc $ head badSelf)
   | otherwise               = foldl addWit env1 ws
   where env1                = env{ names = reverse te ++ names env }
-        ws                  = [ WClass q (tCon c) p (NoQ w) ws (length opts) | (w, NExt q c ps te' opts _) <- te, (ws,p) <- ps ]
+        ws                  = [ WClass q (tCon c) p (NoQ w) ws (length opts) | (w, NExt q c ps _ _ opts _) <- te, (ws,p) <- ps ]
         badSelf             = if inAct env then dom te `intersect` [selfKW] else []
 
 
@@ -458,9 +460,9 @@ kindOf env TFX{}            = KFX
 
 tconKind                    :: QName -> EnvF x -> Kind
 tconKind n env              = case findQName n env of
-                                NAct q _ _ _ _ -> kind KType q
-                                NClass q _ _ _ -> kind KType q
-                                NProto q _ _ _ -> kind KProto q
+                                NAct q _ _ _ _ _ -> kind KType q
+                                NClass q _ _ _ _ -> kind KType q
+                                NProto q _ _ _ _ -> kind KProto q
                                 NReserved    -> nameReserved n
                                 _            -> notClassOrProto n
   where kind k []           = k
@@ -523,17 +525,18 @@ findAttr' env tc n          = case findAttr env tc n of
 
 splitTC                     :: EnvF x -> TCon -> (Substitution, TCon)
 splitTC env (TC n ts)       = (qbound q `zip` ts, TC n $ map tVar $ qbound q)
-  where (q,_,_)             = findConName n env
+  where (q,_,_,_)           = findConName n env
 
 findAncestry                :: EnvF x -> TCon -> [WTCon]
-findAncestry env tc         = ([],tc) : fst (findCon env tc)
+findAncestry env tc         = ([],tc) : us
+  where (us,_,_)            = findCon env tc
 
 findAncestor                :: EnvF x -> TCon -> QName -> Maybe (Expr->Expr,TCon)
 findAncestor env p qn       = listToMaybe [ (wexpr ws, p') | (ws,p') <- findAncestry env p, tcname p' == qn ]
 
 hasAncestor'                :: EnvF x -> QName -> QName -> Bool
 hasAncestor' env qn qn'     = qn' `elem` [ tcname c' | (w,c') <- us ]
-  where (_,us,_)            = findConName qn env
+  where (_,us,_,_)          = findConName qn env
 
 hasAncestor                 :: EnvF x -> TCon -> TCon -> Bool
 hasAncestor env c c'        = hasAncestor' env (tcname c) (tcname c')
@@ -544,46 +547,50 @@ commonAncestors env c1 c2   = filter ((`elem` ns) . tcname) $ map snd (findAnces
 
 directAncestors             :: EnvF x -> QName -> [QName]
 directAncestors env qn      = [ tcname p | (ws,p) <- us, null $ catRight ws ]
-  where (q,us,te)           = findConName qn env
+  where (q,us,_,_)          = findConName qn env
 
 allAncestors                :: EnvF x -> TCon -> [TCon]
 allAncestors env tc         = reverse [ schematic' c | (_, c) <- us ]
-  where (us,te)             = findCon env tc
+  where (us,_,_)            = findCon env tc
 
 allDescendants              :: EnvF x -> TCon -> [TCon]
 allDescendants env tc       = [ schematic' c | c <- allCons env, hasAncestor' env (tcname c) (tcname tc) ]
 
-findCon                     :: EnvF x -> TCon -> ([WTCon],TEnv)
+findCon                     :: EnvF x -> TCon -> ([WTCon],TEnv,TEnv)
 findCon env (TC n ts)
-  | map tVar tvs == ts      = (us, te)
-  | otherwise               = (vsubst s us, vsubst s te)
-  where (q,us,te)           = findConName n env
+  | map tVar tvs == ts      = (us, sigs, defs)
+  | otherwise               = (vsubst s us, vsubst s sigs, vsubst s defs)
+  where (q,us,sigs,defs)    = findConName n env
         tvs                 = qbound q
         s                   = tvs `zip` ts
 
 findConName n env           = case findQName n env of
-                                NAct q p k te _  -> (q,[],te)
-                                NClass q us te _ -> (q,us,te)
-                                NProto q us te _ -> (q,us,te)
-                                NExt q c us te _ _ -> (q,us,te)
+                                NAct q p k sigs defs _ -> (q,[],sigs,defs)
+                                NClass q us sigs defs _ -> (q,us,sigs,defs)
+                                NProto q us sigs defs _ -> (q,us,sigs,defs)
+                                NExt q c us sigs defs _ _ -> (q,us,sigs,defs)
                                 NReserved -> nameReserved n
                                 i -> err1 n ("findConName: Class or protocol name expected, got " ++ show i ++ " --- ")
 
 conAttrs                    :: EnvF x -> QName -> [Name]
-conAttrs env qn             = dom te
-  where (_,_,te)            = findConName qn env
+conAttrs env qn             = dom (attrTEnv sigs defs)
+  where (_,_,sigs,defs)     = findConName qn env
 
 attributes                  :: (WPath -> NameInfo -> Name -> Maybe a) -> EnvF x -> TCon -> [a]
 attributes f env tc         = catMaybes [ f wp i n | n <- ns, let Just (wp,i) = lookup n aenv ]
   where ns                  = nub $ reverse $ dom aenv                                                                                  -- in offset order
-        aenv                = [ (n,(wp,i)) | (wp,c) <- findAncestry env tc, let (_,te) = findCon env c, (n,i) <- reverse te ]           -- in override order
+        aenv                = [ (n,(wp,i)) | (wp,c) <- findAncestry env tc, (n,i) <- reverse $ conTEnv c ]                              -- in override order
+        conTEnv c           = attrTEnv sigs defs
+          where (_,sigs,defs) = findCon env c
 
 fullAttrEnv                 :: EnvF x -> TCon -> TEnv
 fullAttrEnv                 = attributes f
   where f wp i n            = Just (n,i)
 
 parentTEnv                  :: EnvF x -> [WTCon] -> TEnv
-parentTEnv env us           = [ (n,i) | (_,c) <- us, let (_,te) = findCon env c, (n,i) <- reverse te ]                                  -- in override order
+parentTEnv env us           = [ (n,i) | (_,c) <- us, (n,i) <- reverse $ conTEnv c ]                                                     -- in override order
+  where conTEnv c           = attrTEnv sigs defs
+          where (_,sigs,defs) = findCon env c
 
 findAttr                    :: EnvF x -> TCon -> Name -> Maybe (Expr->Expr, TSchema, Maybe Deco)
 findAttr env tc n           = listToMaybe $ attributes f env tc
@@ -596,9 +603,11 @@ findAttr env tc n           = listToMaybe $ attributes f env tc
 attributes'                 :: (WPath -> NameInfo -> Name -> Maybe a) -> EnvF x -> QName -> [a]
 attributes' f env qn        = catMaybes [ f wp i n | n <- ns, let Just (wp,i) = lookup n aenv ]
   where ns                  = nub $ reverse $ dom aenv                                                                                  -- in offset order
-        aenv                = [ (n,(wp,i)) | (wp,c) <- ([],tc) : us, let (_,_,te) = findConName (tcname c) env, (n,i) <- reverse te ]   -- in override order
-        (q,us,_)            = findConName qn env
+        aenv                = [ (n,(wp,i)) | (wp,c) <- ([],tc) : us, (n,i) <- reverse $ conTEnv c ]                                     -- in override order
+        (q,us,_,_)          = findConName qn env
         tc                  = TC qn [ tVar v | QBind v _ <- q ]
+        conTEnv c           = attrTEnv sigs defs
+          where (_,_,sigs,defs) = findConName (tcname c) env
 
 inheritedAttrs              :: EnvF x -> QName -> [(QName,Name)]
 inheritedAttrs              = attributes' f
@@ -712,7 +721,7 @@ mro env us                              = merge [] $ map lin us' ++ [us']
 
     lin                                 :: WTCon -> [WTCon]
     lin (w,u)                           = (w,u) : [ (w++w',u') | (w',u') <- us' ]
-      where (us',_)                     = findCon env u
+      where (us',_,_)                   = findCon env u
 
     merge                               :: [WTCon] -> [[WTCon]] -> [WTCon]
     merge out lists
@@ -1097,10 +1106,10 @@ importAll m te env          = define (impNames m te) env
 impNames                    :: ModName -> TEnv -> TEnv
 impNames m te               = mapMaybe imp te
   where
-    imp (n, NAct _ _ _ _ _)   = Just (n, NAlias (GName m n))
-    imp (n, NClass _ _ _ _)   = Just (n, NAlias (GName m n))
-    imp (n, NProto _ _ _ _)   = Just (n, NAlias (GName m n))
-    imp (n, NExt _ _ _ _ _ _) = Nothing
+    imp (n, NAct _ _ _ _ _ _) = Just (n, NAlias (GName m n))
+    imp (n, NClass _ _ _ _ _) = Just (n, NAlias (GName m n))
+    imp (n, NProto _ _ _ _ _) = Just (n, NAlias (GName m n))
+    imp (n, NExt _ _ _ _ _ _ _) = Nothing
     imp (n, NAlias _)       = Just (n, NAlias (GName m n))
     imp (n, NVar t)         = Just (n, NAlias (GName m n))
     imp (n, NDef t d _)       = Just (n, NAlias (GName m n))
@@ -1108,7 +1117,7 @@ impNames m te               = mapMaybe imp te
 
 importWits                  :: ModName -> TEnv -> EnvF x -> EnvF x
 importWits m te env         = foldl addWit env ws
-  where ws                  = [ WClass q (tCon c) p (GName m n) ws (length opts) | (n, NExt q c ps te' opts _) <- te, (ws,p) <- ps ]
+  where ws                  = [ WClass q (tCon c) p (GName m n) ws (length opts) | (n, NExt q c ps _ _ opts _) <- te, (ws,p) <- ps ]
 
 
 
@@ -1254,15 +1263,17 @@ instance Simp (Name, NameInfo) where
     simp env (n, NDef sc dec doc)   = (n, NDef (simp env sc) dec doc)
     simp env (n, NVar t)            = (n, NVar (simp env t))
     simp env (n, NSVar t)           = (n, NSVar (simp env t))
-    simp env (n, NClass q us te doc)= (n, NClass (simp env' q) (simp env' us) (simp env' te) doc)
+    simp env (n, NClass q us sigs defs doc)= (n, NClass (simp env' q) (simp env' us) (simp env' sigs) (simp env' defs) doc)
       where env'                    = defineTVars (stripQual q) env
-    simp env (n, NProto q us te doc)= (n, NProto (simp env' q) (simp env' us) (simp env' te) doc)
+    simp env (n, NProto q us sigs defs doc)= (n, NProto (simp env' q) (simp env' us) (simp env' sigs) (simp env' defs) doc)
       where env'                    = defineTVars (stripQual q) env
-    simp env (n, NExt q c us te opts doc)
-                                    = (n, NExt q' (vsubst s $ simp env' c) (vsubst s $ simp env' us) (vsubst s $ simp env' te) opts doc)
-      where (q', s)                 = simpQuant env (simp env' q) (vfree c ++ vfree us ++ vfree te)
+    simp env (n, NExt q c us sigs defs opts doc)
+                                    = (n, NExt q' (vsubst s $ simp env' c) (vsubst s $ simp env' us) (vsubst s $ simp env' sigs) (vsubst s $ simp env' defs) opts doc)
+      where (q', s)                 = simpQuant env (simp env' q) (vfree c ++ vfree us ++ vfree sigs ++ vfree defs)
             env'                    = defineTVars (stripQual q) env
-    simp env (n, NAct q p k te doc) = (n, NAct (simp env' q) (simp env' p) (simp env' k) (simp env' te) doc)
+    simp env (n, NAct q p k sigs defs doc)
+                                    = (n, NAct (simp env' q) (simp env' p) (simp env' k)
+                                      (simp env' sigs) (simp env' defs) doc)
       where env'                    = defineTVars (stripQual q) env
     simp env (n, i)                 = (n, i)
 

--- a/compiler/lib/src/Acton/Kinds.hs
+++ b/compiler/lib/src/Acton/Kinds.hs
@@ -269,9 +269,9 @@ kchkSuite env (Decl l ds : ss)      = do ds <- instKWild (map (autoQuantD env) d
                                          ds <- kchk env1 ds
                                          ss <- kchkSuite env1 ss
                                          return (Decl l ds : ss)
-  where kinds (Actor _ n q _ _ _ _) = [(n, NAct q posNil kwdNil [] Nothing)]
-        kinds (Class _ n q _ _ _)   = [(n, NClass q [] [] Nothing)]
-        kinds (Protocol _ n q _ _ _)= [(n, NProto q [] [] Nothing)]
+  where kinds (Actor _ n q _ _ _ _) = [(n, NAct q posNil kwdNil [] [] Nothing)]
+        kinds (Class _ n q _ _ _)   = [(n, NClass q [] [] [] Nothing)]
+        kinds (Protocol _ n q _ _ _)= [(n, NProto q [] [] [] Nothing)]
         kinds _                     = []
         kind k []                   = k
         kind k q                    = KFun [ tvkind v | QBind v _ <- q ] k
@@ -776,4 +776,3 @@ instance KSubst Assoc where
 
 instance KSubst Sliz where
     ksubst g (Sliz l e1 e2 e3)      = Sliz l <$> ksubst g e1 <*> ksubst g e2 <*> ksubst g e3
-

--- a/compiler/lib/src/Acton/LambdaLifter.hs
+++ b/compiler/lib/src/Acton/LambdaLifter.hs
@@ -453,7 +453,7 @@ instance (Conv a) => Conv (Name, a) where
     conv (n, x)                         = (n, conv x)
 
 instance Conv NameInfo where
-    conv (NClass q ps te doc)           = NClass (conv q) (conv ps) (conv te) doc
+    conv (NClass q ps sigs defs doc)    = NClass (conv q) (conv ps) (conv sigs) (conv defs) doc
     conv (NSig sc Property doc)         = NSig (conv sc) Property doc
     conv (NSig sc dec doc)              = NSig (convTop sc) dec doc
     conv (NDef sc dec doc)              = NDef (convTop sc) dec doc

--- a/compiler/lib/src/Acton/NameInfo.hs
+++ b/compiler/lib/src/Acton/NameInfo.hs
@@ -33,7 +33,8 @@ import Acton.Printer
 {-  TEnv principles:
     -   A TEnv is an association of NameInfo details to a list of names.
     -   NSig holds the schema of an explicit Signature, while NDef and NVar give schemas and types to names created by Defs and assignments.
-    -   NClass, NProto, NExt and NAct represent class, protocol, extension and actor declarations. They each contain a TEnv of visible local attributes.
+    -   NClass, NProto, NExt and NAct represent class, protocol, extension and actor declarations.
+        These declarations keep signature and definition attributes separate.
     -   Signatures must appear before the defs/assignments they describe, and every TEnv respects the order of the syntactic constructs binding each name.
     -   The attribute TEnvs of NClass, NProto, NExt and NAct are searched left-to-right, thus favoring (explicit) NSigs over (inferred) NDefs/NVars.
     -   The global inference TEnv (names env) is searched right-to-left, thereby prioritizing NDefs/NVars over NSigs, as well as any inner bindings in scope.
@@ -51,10 +52,10 @@ data NameInfo           = NVar      Type
                         | NSVar     Type
                         | NDef      TSchema Deco (Maybe String)
                         | NSig      TSchema Deco (Maybe String)
-                        | NAct      QBinds PosRow KwdRow TEnv (Maybe String)
-                        | NClass    QBinds [WTCon] TEnv (Maybe String)
-                        | NProto    QBinds [WTCon] TEnv (Maybe String)
-                        | NExt      QBinds TCon [WTCon] TEnv [Name] (Maybe String)
+                        | NAct      QBinds PosRow KwdRow TEnv TEnv (Maybe String)
+                        | NClass    QBinds [WTCon] TEnv TEnv (Maybe String)
+                        | NProto    QBinds [WTCon] TEnv TEnv (Maybe String)
+                        | NExt      QBinds TCon [WTCon] TEnv TEnv [Name] (Maybe String)
                         | NTVar     Kind CCon [PCon]
                         | NAlias    QName
                         | NMAlias   ModName
@@ -71,10 +72,10 @@ data HNameInfo          = HNVar      Type
                         | HNSVar     Type
                         | HNDef      TSchema Deco (Maybe String)
                         | HNSig      TSchema Deco (Maybe String)
-                        | HNAct      QBinds PosRow KwdRow TEnv (Maybe String)
-                        | HNClass    QBinds [WTCon] TEnv (Maybe String)
-                        | HNProto    QBinds [WTCon] TEnv (Maybe String)
-                        | HNExt      QBinds TCon [WTCon] TEnv [Name] (Maybe String)
+                        | HNAct      QBinds PosRow KwdRow TEnv TEnv (Maybe String)
+                        | HNClass    QBinds [WTCon] TEnv TEnv (Maybe String)
+                        | HNProto    QBinds [WTCon] TEnv TEnv (Maybe String)
+                        | HNExt      QBinds TCon [WTCon] TEnv TEnv [Name] (Maybe String)
                         | HNTVar     Kind CCon [PCon]
                         | HNAlias    QName
                         | HNMAlias   ModName
@@ -90,10 +91,14 @@ convNameInfo2HNameInfo (NVar t)               = HNVar t
 convNameInfo2HNameInfo (NSVar t)              = HNSVar t
 convNameInfo2HNameInfo (NDef sc dec mdoc)     = HNDef sc dec mdoc
 convNameInfo2HNameInfo (NSig sc dec mdoc)     = HNSig sc dec mdoc
-convNameInfo2HNameInfo (NAct q p k te mdoc)   = HNAct q p k te mdoc
-convNameInfo2HNameInfo (NClass q ws te mdoc)  = HNClass q ws te mdoc
-convNameInfo2HNameInfo (NProto q ws te mdoc)  = HNProto q ws te mdoc
-convNameInfo2HNameInfo (NExt q tc ws te ns mdoc) = HNExt q tc ws te ns mdoc
+convNameInfo2HNameInfo (NAct q p k sigs defs mdoc)
+                                               = HNAct q p k sigs defs mdoc
+convNameInfo2HNameInfo (NClass q ws sigs defs mdoc)
+                                               = HNClass q ws sigs defs mdoc
+convNameInfo2HNameInfo (NProto q ws sigs defs mdoc)
+                                               = HNProto q ws sigs defs mdoc
+convNameInfo2HNameInfo (NExt q tc ws sigs defs ns mdoc)
+                                               = HNExt q tc ws sigs defs ns mdoc
 convNameInfo2HNameInfo (NTVar k c ps)         = HNTVar k c ps
 convNameInfo2HNameInfo (NAlias qn)            = HNAlias qn
 convNameInfo2HNameInfo (NMAlias mn)           = HNMAlias mn
@@ -105,10 +110,14 @@ convHNameInfo2NameInfo (HNVar t)               = NVar t
 convHNameInfo2NameInfo (HNSVar t)              = NSVar t
 convHNameInfo2NameInfo (HNDef sc dec mdoc)     = NDef sc dec mdoc
 convHNameInfo2NameInfo (HNSig sc dec mdoc)     = NSig sc dec mdoc
-convHNameInfo2NameInfo (HNAct q p k te mdoc)   = NAct q p k te mdoc
-convHNameInfo2NameInfo (HNClass q ws te mdoc)  = NClass q ws te mdoc
-convHNameInfo2NameInfo (HNProto q ws te mdoc)  = NProto q ws te mdoc
-convHNameInfo2NameInfo (HNExt q tc ws te ns mdoc) = NExt q tc ws te ns mdoc
+convHNameInfo2NameInfo (HNAct q p k sigs defs mdoc)
+                                               = NAct q p k sigs defs mdoc
+convHNameInfo2NameInfo (HNClass q ws sigs defs mdoc)
+                                               = NClass q ws sigs defs mdoc
+convHNameInfo2NameInfo (HNProto q ws sigs defs mdoc)
+                                               = NProto q ws sigs defs mdoc
+convHNameInfo2NameInfo (HNExt q tc ws sigs defs ns mdoc)
+                                               = NExt q tc ws sigs defs ns mdoc
 convHNameInfo2NameInfo (HNTVar k c ps)         = NTVar k c ps
 convHNameInfo2NameInfo (HNAlias qn)            = NAlias qn
 convHNameInfo2NameInfo (HNMAlias mn)           = NMAlias mn
@@ -130,10 +139,14 @@ convHTEnv2TEnv te                     = map convPair (M.toList te)
 stripDocsNI :: NameInfo -> NameInfo
 stripDocsNI ni = case ni of
   NModule te _        -> NModule (map stripBind te) Nothing
-  NAct q p k te _     -> NAct q p k (map stripBind te) Nothing
-  NClass q cs te _    -> NClass q cs (map stripBind te) Nothing
-  NProto q ps te _    -> NProto q ps (map stripBind te) Nothing
-  NExt q c ps te o _  -> NExt q c ps (map stripBind te) o Nothing
+  NAct q p k sigs defs _
+                       -> NAct q p k (map stripBind sigs) (map stripBind defs) Nothing
+  NClass q cs sigs defs _
+                       -> NClass q cs (map stripBind sigs) (map stripBind defs) Nothing
+  NProto q ps sigs defs _
+                       -> NProto q ps (map stripBind sigs) (map stripBind defs) Nothing
+  NExt q c ps sigs defs o _
+                       -> NExt q c ps (map stripBind sigs) (map stripBind defs) o Nothing
   NDef sc dec _       -> NDef sc dec Nothing
   NSig sc dec _       -> NSig sc dec Nothing
   other               -> other
@@ -141,10 +154,14 @@ stripDocsNI ni = case ni of
     stripBind (n, info) = (n, stripDocsNI info)
 
 instance Leaves NameInfo where
-    leaves (NClass q cs te _) = leaves q ++ leaves cs ++ leaves te
-    leaves (NProto q ps te _) = leaves q ++ leaves ps ++ leaves te
-    leaves (NAct q p k te _)  = leaves q ++ leaves [p,k] ++ leaves te
-    leaves (NExt q c ps te _ _) = leaves q ++ leaves c ++ leaves ps ++ leaves te
+    leaves (NClass q cs sigs defs _)
+                                = leaves q ++ leaves cs ++ leaves sigs ++ leaves defs
+    leaves (NProto q ps sigs defs _)
+                                = leaves q ++ leaves ps ++ leaves sigs ++ leaves defs
+    leaves (NAct q p k sigs defs _)
+                                = leaves q ++ leaves [p,k] ++ leaves sigs ++ leaves defs
+    leaves (NExt q c ps sigs defs _ _)
+                                = leaves q ++ leaves c ++ leaves ps ++ leaves sigs ++ leaves defs
     leaves (NDef sc dec _)    = leaves sc
     leaves _                  = []
 
@@ -163,23 +180,28 @@ instance Pretty (Name,NameInfo) where
     pretty (n, NSVar t)         = text "var" <+> pretty n <+> colon <+> pretty t
     pretty (n, NDef t d doc)    = prettyDec d $ pretty n <+> colon <+> pretty t $+$ nest 4 (prettyDocstring doc)
     pretty (n, NSig t d doc)    = prettyDec d $ pretty n <+> colon <+> pretty t $+$ nest 4 (prettyDocstring doc)
-    pretty (n, NAct q p k te doc)
+    pretty (n, NAct q p k sigs defs doc)
                                 = text "actor" <+> pretty n <> nonEmpty brackets commaList q <+>
-                                  parens (prettyFunRow p k) <> colon $+$ nest 4 (prettyDocstring doc) $+$ (nest 4 $ prettyOrPass te)
-    pretty (n, NClass q us te doc)
+                                  parens (prettyFunRow p k) <> colon $+$ nest 4 (prettyDocstring doc) $+$
+                                  nest 4 (prettyOrPass $ attrTEnv sigs defs)
+    pretty (n, NClass q us sigs defs doc)
                                 = text "class" <+> pretty n <> nonEmpty brackets commaList q <+>
-                                  nonEmpty parens commaList us <> colon $+$ nest 4 (prettyDocstring doc) $+$ (nest 4 $ prettyOrPass te)
-    pretty (n, NProto q us te doc)
+                                  nonEmpty parens commaList us <> colon $+$ nest 4 (prettyDocstring doc) $+$
+                                  nest 4 (prettyOrPass $ attrTEnv sigs defs)
+    pretty (n, NProto q us sigs defs doc)
                                 = text "protocol" <+> pretty n <> nonEmpty brackets commaList q <+>
-                                  nonEmpty parens commaList us <> colon $+$ nest 4 (prettyDocstring doc) $+$ (nest 4 $ prettyOrPass te)
-    pretty (w, NExt [] c ps te opts doc)
+                                  nonEmpty parens commaList us <> colon $+$ nest 4 (prettyDocstring doc) $+$
+                                  nest 4 (prettyOrPass $ attrTEnv sigs defs)
+    pretty (w, NExt [] c ps sigs defs opts doc)
                                 = {-pretty w  <+> colon <+> -}
                                   text "extension" <+> pretty c <+> parens (commaList ps) <>
-                                  colon $+$ nest 4 (prettyDocstring doc) $+$ (nest 4 $ prettyOrPass te)
-    pretty (w, NExt q c ps te opts doc)
+                                  colon $+$ nest 4 (prettyDocstring doc) $+$
+                                  nest 4 (prettyOrPass $ attrTEnv sigs defs)
+    pretty (w, NExt q c ps sigs defs opts doc)
                                 = {-pretty w  <+> colon <+> -}
                                   text "extension" <+> pretty q <+> text "=>" <+> pretty c <+> parens (commaList ps) <>
-                                  colon $+$ nest 4 (prettyDocstring doc) $+$ (nest 4 $ prettyOrPass te)
+                                  colon $+$ nest 4 (prettyDocstring doc) $+$
+                                  nest 4 (prettyOrPass $ attrTEnv sigs defs)
     pretty (n, NTVar k c ps)    = pretty n <> parens (commaList (c:ps))
     pretty (n, NAlias qn)       = text "alias" <+> pretty n <+> equals <+> pretty qn
     pretty (n, NMAlias m)       = text "module" <+> pretty n <+> equals <+> pretty m
@@ -200,10 +222,14 @@ instance VFree NameInfo where
     vfree (NSVar t)             = vfree t
     vfree (NDef t d _)          = vfree t
     vfree (NSig t d _)          = vfree t
-    vfree (NAct q p k te _)     = (vfree q ++ vfree p ++ vfree k ++ vfree te) \\ (tvSelf : qbound q)
-    vfree (NClass q us te _)    = (vfree q ++ vfree us ++ vfree te) \\ (tvSelf : qbound q)
-    vfree (NProto q us te _)    = (vfree q ++ vfree us ++ vfree te) \\ (tvSelf : qbound q)
-    vfree (NExt q c ps te _ _)  = (vfree q ++ vfree c ++ vfree ps ++ vfree te) \\ (tvSelf : qbound q)
+    vfree (NAct q p k sigs defs _)
+                                = (vfree q ++ vfree p ++ vfree k ++ vfree sigs ++ vfree defs) \\ (tvSelf : qbound q)
+    vfree (NClass q us sigs defs _)
+                                = (vfree q ++ vfree us ++ vfree sigs ++ vfree defs) \\ (tvSelf : qbound q)
+    vfree (NProto q us sigs defs _)
+                                = (vfree q ++ vfree us ++ vfree sigs ++ vfree defs) \\ (tvSelf : qbound q)
+    vfree (NExt q c ps sigs defs _ _)
+                                = (vfree q ++ vfree c ++ vfree ps ++ vfree sigs ++ vfree defs) \\ (tvSelf : qbound q)
     vfree (NTVar k c ps)        = vfree c ++ vfree ps
     vfree (NAlias qn)           = []
     vfree (NMAlias qn)          = []
@@ -215,10 +241,14 @@ instance VSubst NameInfo where
     vsubst s (NSVar t)          = NSVar (vsubst s t)
     vsubst s (NDef t d x)       = NDef (vsubst s t) d x
     vsubst s (NSig t d x)       = NSig (vsubst s t) d x
-    vsubst s (NAct q p k te x)  = NAct (vsubst s q) (vsubst s p) (vsubst s k) (vsubst s te) x
-    vsubst s (NClass q us te x) = NClass (vsubst s q) (vsubst s us) (vsubst s te) x
-    vsubst s (NProto q us te x) = NProto (vsubst s q) (vsubst s us) (vsubst s te) x
-    vsubst s (NExt q c ps te opts x) = NExt (vsubst s q) (vsubst s c) (vsubst s ps) (vsubst s te) opts x
+    vsubst s (NAct q p k sigs defs x)
+                                = NAct (vsubst s q) (vsubst s p) (vsubst s k) (vsubst s sigs) (vsubst s defs) x
+    vsubst s (NClass q us sigs defs x)
+                                = NClass (vsubst s q) (vsubst s us) (vsubst s sigs) (vsubst s defs) x
+    vsubst s (NProto q us sigs defs x)
+                                = NProto (vsubst s q) (vsubst s us) (vsubst s sigs) (vsubst s defs) x
+    vsubst s (NExt q c ps sigs defs opts x)
+                                = NExt (vsubst s q) (vsubst s c) (vsubst s ps) (vsubst s sigs) (vsubst s defs) opts x
     vsubst s (NTVar k c ps)        = NTVar k (vsubst s c) (vsubst s ps)
     vsubst s (NAlias qn)        = NAlias qn
     vsubst s (NMAlias m)        = NMAlias m
@@ -230,10 +260,14 @@ instance UFree NameInfo where
     ufree (NSVar t)             = ufree t
     ufree (NDef t d _)          = ufree t
     ufree (NSig t d _)          = ufree t
-    ufree (NAct q p k te _)     = ufree q ++ ufree p ++ ufree k ++ ufree te
-    ufree (NClass q us te _)    = ufree q ++ ufree us ++ ufree te
-    ufree (NProto q us te _)    = ufree q ++ ufree us ++ ufree te
-    ufree (NExt q c ps te _ _)  = ufree q ++ ufree c ++ ufree ps ++ ufree te
+    ufree (NAct q p k sigs defs _)
+                                = ufree q ++ ufree p ++ ufree k ++ ufree sigs ++ ufree defs
+    ufree (NClass q us sigs defs _)
+                                = ufree q ++ ufree us ++ ufree sigs ++ ufree defs
+    ufree (NProto q us sigs defs _)
+                                = ufree q ++ ufree us ++ ufree sigs ++ ufree defs
+    ufree (NExt q c ps sigs defs _ _)
+                                = ufree q ++ ufree c ++ ufree ps ++ ufree sigs ++ ufree defs
     ufree (NTVar k c ps)        = ufree c ++ ufree ps
     ufree (NAlias qn)           = []
     ufree (NMAlias qn)          = []
@@ -248,10 +282,15 @@ instance Polarity NameInfo where
     polvars (NSVar t)           = invvars t
     polvars (NDef t d _)        = polvars t
     polvars (NSig t d _)        = polvars t
-    polvars (NAct q p k te _)   = polvars q `polcat` polneg (polvars p `polcat` polvars k) `polcat` polvars te
-    polvars (NClass q us te _)  = polvars q `polcat` polvars us `polcat` polvars te
-    polvars (NProto q us te _)  = polvars q `polcat` polvars us `polcat` polvars te
-    polvars (NExt q c ps te _ _) = polvars q `polcat` polvars c `polcat` polvars ps `polcat` polvars te
+    polvars (NAct q p k sigs defs _)
+                                = polvars q `polcat` polneg (polvars p `polcat` polvars k) `polcat`
+                                  polvars sigs `polcat` polvars defs
+    polvars (NClass q us sigs defs _)
+                                = polvars q `polcat` polvars us `polcat` polvars sigs `polcat` polvars defs
+    polvars (NProto q us sigs defs _)
+                                = polvars q `polcat` polvars us `polcat` polvars sigs `polcat` polvars defs
+    polvars (NExt q c ps sigs defs _ _)
+                                = polvars q `polcat` polvars c `polcat` polvars ps `polcat` polvars sigs `polcat` polvars defs
     polvars (NTVar k c ps)      = polvars c `polcat` polvars ps
     polvars _                   = ([],[])
 
@@ -263,12 +302,25 @@ instance Tailvars (Name, NameInfo) where
 
 wildargs i                      = [ tWild | _ <- nbinds i ]
   where
-    nbinds (NAct q _ _ _ _)     = q
-    nbinds (NClass q _ _ _)     = q
-    nbinds (NProto q _ _ _)     = q
-    nbinds (NExt q _ _ _ _ _)   = q
+    nbinds (NAct q _ _ _ _ _)   = q
+    nbinds (NClass q _ _ _ _)   = q
+    nbinds (NProto q _ _ _ _)   = q
+    nbinds (NExt q _ _ _ _ _ _) = q
 
 -- TEnv filters --------------------------------------------------------------------------------------------------------
+
+attrTEnv                    :: TEnv -> TEnv -> TEnv
+attrTEnv sigs defs          = sigs ++ defs
+
+attrSigs                    :: TEnv -> TEnv
+attrSigs te                 = [ (n,i) | (n, i@NSig{}) <- te ]
+
+attrDefs                    :: TEnv -> TEnv
+attrDefs te                 = [ (n,i) | (n, i) <- te, not $ isNSig i ]
+
+isNSig                      :: NameInfo -> Bool
+isNSig NSig{}               = True
+isNSig _                    = False
 
 nSigs                       :: TEnv -> TEnv
 nSigs te                    = [ (n,i) | (n, i@(NSig sc dec _)) <- te, not $ isProp dec sc ]
@@ -359,10 +411,10 @@ instance Vars NameInfo where
       NSVar t -> freeQ t
       NDef sc _ _ -> freeQ sc
       NSig sc _ _ -> freeQ sc
-      NAct q p k te _ -> freeQ q ++ freeQ p ++ freeQ k ++ freeQTEnv te
-      NClass q ws te _ -> freeQ q ++ freeQWTCons ws ++ freeQTEnv te
-      NProto q ws te _ -> freeQ q ++ freeQWTCons ws ++ freeQTEnv te
-      NExt q c ws te _ _ -> freeQ q ++ freeQ c ++ freeQWTCons ws ++ freeQTEnv te
+      NAct q p k sigs defs _ -> freeQ q ++ freeQ p ++ freeQ k ++ freeQTEnv sigs ++ freeQTEnv defs
+      NClass q ws sigs defs _ -> freeQ q ++ freeQWTCons ws ++ freeQTEnv sigs ++ freeQTEnv defs
+      NProto q ws sigs defs _ -> freeQ q ++ freeQWTCons ws ++ freeQTEnv sigs ++ freeQTEnv defs
+      NExt q c ws sigs defs _ _ -> freeQ q ++ freeQ c ++ freeQWTCons ws ++ freeQTEnv sigs ++ freeQTEnv defs
       NTVar _ c ps -> freeQ c ++ freeQ ps
       NAlias qn -> freeQ qn
       NMAlias _ -> []

--- a/compiler/lib/src/Acton/Normalizer.hs
+++ b/compiler/lib/src/Acton/Normalizer.hs
@@ -672,8 +672,8 @@ instance (Conv a) => Conv (Name, a) where
     conv (n, x)                     = (n, conv x)
 
 instance Conv NameInfo where
-    conv (NAct q p k te doc)        = NAct q (joinRow p k) kwdNil (conv te) doc
-    conv (NClass q ps te doc)       = NClass q (conv ps) (conv te) doc
+    conv (NAct q p k sigs defs doc) = NAct q (joinRow p k) kwdNil (conv sigs) (conv defs) doc
+    conv (NClass q ps sigs defs doc)= NClass q (conv ps) (conv sigs) (conv defs) doc
     conv (NSig sc dec doc)          = NSig (conv sc) dec doc
     conv (NDef sc dec doc)          = NDef (conv sc) dec doc
     conv (NVar t)                   = NVar (conv t)

--- a/compiler/lib/src/Acton/Prim.hs
+++ b/compiler/lib/src/Acton/Prim.hs
@@ -244,14 +244,14 @@ primEnv             = [     (noq primASYNCf,        NDef scASYNCf NoDec Nothing)
 
 --  class $Cont[T] (value): pass
 --      __call__    : proc(T) -> $R
-clCont              = NClass [qbind t] (leftpath [cValue]) te Nothing
+clCont              = NClass [qbind t] (leftpath [cValue]) (attrSigs te) (attrDefs te) Nothing
   where te          = [ (attr_call_, NSig (monotype $ tFun fxProc (posRow (tVar t) posNil) kwdNil tR) NoDec Nothing) ]
         t           = TV KType (name "T")
 
 --  class $proc[R,T] (value):
 --      __call__    : proc($Cont[T], *R) -> $R
 --      __exec__    : proc($Cont[value], *R) -> $R
-clProc              = NClass [qbind r, qbind t] (leftpath [cValue]) te Nothing
+clProc              = NClass [qbind r, qbind t] (leftpath [cValue]) (attrSigs te) (attrDefs te) Nothing
   where te          = [ (attr_call_, NSig (monotype $ tFun fxProc (posRow (tVar t) (tVar r)) kwdNil tR) NoDec Nothing),
                         (attr_exec_, NSig (monotype $ tFun fxProc (posRow tValue (tVar r)) kwdNil tR) NoDec Nothing) ]
         r           = TV PRow (name "R")
@@ -259,7 +259,7 @@ clProc              = NClass [qbind r, qbind t] (leftpath [cValue]) te Nothing
 
 --  class $action[R,T] ($proc[R,T], value):
 --      __asyn__    : action(*R) -> T
-clAction            = NClass [qbind r, qbind t] (leftpath [ cProc (tVar r) (tVar t), cValue]) te Nothing
+clAction            = NClass [qbind r, qbind t] (leftpath [ cProc (tVar r) (tVar t), cValue]) (attrSigs te) (attrDefs te) Nothing
   where te          = [ (attr_asyn_, NSig (monotype $ tFun fxAction (tVar r) kwdNil (tVar t)) NoDec Nothing) ]
         r           = TV PRow (name "R")
         t           = TV KType (name "T")
@@ -267,14 +267,14 @@ clAction            = NClass [qbind r, qbind t] (leftpath [ cProc (tVar r) (tVar
 
 --  class $mut[R,T] ($proc[R,T], value):
 --      __eval__    : mut(*R) -> T
-clMut               = NClass [qbind r, qbind t] (leftpath [ cProc (tVar r) (tVar t), cValue]) te Nothing
+clMut               = NClass [qbind r, qbind t] (leftpath [ cProc (tVar r) (tVar t), cValue]) (attrSigs te) (attrDefs te) Nothing
   where te          = [ (attr_eval_, NSig (monotype $ tFun fxMut (tVar r) kwdNil (tVar t)) NoDec Nothing) ]
         r           = TV PRow (name "R")
         t           = TV KType (name "T")
 
 --  class $pure[R,T] ($mut[R,T], $proc[R,T], value):
 --      __eval__    : pure(*R) -> T
-clPure              = NClass [qbind r, qbind t] (leftpath [ cMut (tVar r) (tVar t), cProc (tVar r) (tVar t), cValue]) te Nothing
+clPure              = NClass [qbind r, qbind t] (leftpath [ cMut (tVar r) (tVar t), cProc (tVar r) (tVar t), cValue]) (attrSigs te) (attrDefs te) Nothing
   where te          = [ (attr_eval_, NSig (monotype $ tFun fxPure (tVar r) kwdNil (tVar t)) NoDec Nothing) ]
         r           = TV PRow (name "R")
         t           = TV KType (name "T")
@@ -282,14 +282,14 @@ clPure              = NClass [qbind r, qbind t] (leftpath [ cMut (tVar r) (tVar 
 --  class $Box[A] (object, value):
 --      ref         : A
 --      __init__    : (A) -> None
-clBox               = NClass [qbind a] (leftpath [cObject, cValue]) te Nothing
+clBox               = NClass [qbind a] (leftpath [cObject, cValue]) (attrSigs te) (attrDefs te) Nothing
   where te          = [ (valKW,  NSig (monotype $ tVar a) Property Nothing),
                         (initKW, NDef (monotype $ tFun fxPure (posRow (tVar a) posNil) kwdNil tNone) NoDec Nothing) ]
         a           = TV KType (name "A")
 
 
 --  class $Actor (): pass
-clActor             = NClass [] (leftpath [cValue]) te Nothing
+clActor             = NClass [] (leftpath [cValue]) (attrSigs te) (attrDefs te) Nothing
   where te          = [ (primKW "next",       NSig (monotype tActor) Property Nothing),
                         (primKW "msg",        NSig (monotype (tMsg tWild)) Property Nothing),
                         (primKW "msg_tail",   NSig (monotype (tMsg tWild)) Property Nothing),
@@ -309,30 +309,30 @@ clActor             = NClass [] (leftpath [cValue]) te Nothing
 
 --  class $SEQ (BaseException, value):
 --      __init__ : () -> None
-clSEQ               = NClass [] (leftpath [cBaseException, cValue]) te Nothing
+clSEQ               = NClass [] (leftpath [cBaseException, cValue]) (attrSigs te) (attrDefs te) Nothing
   where te          = [ (initKW, NSig (monotype $ tFun fxPure posNil kwdNil tNone) NoDec Nothing) ]
 
 --  class $BRK (BaseException, value):
 --      __init__ : () -> None
-clBRK               = NClass [] (leftpath [cBaseException, cValue]) te Nothing
+clBRK               = NClass [] (leftpath [cBaseException, cValue]) (attrSigs te) (attrDefs te) Nothing
   where te          = [ (initKW, NSig (monotype $ tFun fxPure posNil kwdNil tNone) NoDec Nothing) ]
 
 --  class $CNT (BaseException, value):
 --      __init__ : () -> None
-clCNT               = NClass [] (leftpath [cBaseException, cValue]) te Nothing
+clCNT               = NClass [] (leftpath [cBaseException, cValue]) (attrSigs te) (attrDefs te) Nothing
   where te          = [ (initKW, NSig (monotype $ tFun fxPure posNil kwdNil tNone) NoDec Nothing) ]
 
 --  class $RET (BaseException, value):
 --      @property
 --      val      : value
 --      __init__ : (value) -> None
-clRET               = NClass [] (leftpath [cBaseException, cValue]) te Nothing
+clRET               = NClass [] (leftpath [cBaseException, cValue]) (attrSigs te) (attrDefs te) Nothing
   where te          = [ (attrVal, NSig (monotype tValue) Property Nothing),
                         (initKW,  NSig (monotype $ tFun fxPure (posRow tValue posNil) kwdNil tNone) NoDec Nothing) ]
 
 
 --  class $R (): pass
-clR                 = NClass [] [] [] Nothing
+clR                 = NClass [] [] [] [] Nothing
 
 --  $ASYNCf         : [A] => action($Actor, proc()->A) -> A
 scASYNCf            = tSchema [qbind a] tASYNC
@@ -496,13 +496,13 @@ scRFail             = tSchema [] tRFail
 
 
 --  class $EqOpt[A] (Eq[?A]): pass
-clEqOpt             = NClass [qbind a] (leftpath [TC qnEq [tOpt $ tVar a]]) clTEnv Nothing
+clEqOpt             = NClass [qbind a] (leftpath [TC qnEq [tOpt $ tVar a]]) (attrSigs clTEnv) (attrDefs clTEnv) Nothing
   where clTEnv      = [ (initKW, NDef scInit NoDec Nothing) ]
         scInit      = tSchema [] $ tFun fxPure (posRow (tCon $ TC qnEq [tVar a]) posNil) kwdNil tNone
         a           = TV KType (name "A")
 
 --  class $IdentityActor (Identity[$Actor]): pass
-clIdentityActor     = NClass [] (leftpath [TC qnIdentity [tActor]]) [] Nothing                 -- methods not modelled
+clIdentityActor     = NClass [] (leftpath [TC qnIdentity [tActor]]) [] [] Nothing              -- methods not modelled
 
 --  w$EqNone        : Eq[None]
 tEqNone             = tCon $ TC qnEq [tNone]
@@ -584,7 +584,7 @@ scWRAP              = tSchema [qbind a, qbind b, qbind c] tWRAP
 --      wrap        : [A,B,C] => ($Actor, X(*A,**B)->C) -> Self(*A,**B)->C
 --      @static
 --      unwrap      : [A,B,C] => (Self(*A,**B)->C) -> Y(*A,**B)->C
-proWrapped          = NProto [qbind x, qbind y] [] te Nothing
+proWrapped          = NProto [qbind x, qbind y] [] te [] Nothing
   where te          = [(attrWrap,scWrap), (attrUnwrap,scUnwrap)]
         scWrap      = NSig (tSchema q (tFun0 [tActor, fxFun tX] (fxFun tSelf)))  Static Nothing
         scUnwrap    = NSig (tSchema q (tFun0 [fxFun tSelf] (fxFun tY))) Static Nothing
@@ -602,7 +602,7 @@ proWrapped          = NProto [qbind x, qbind y] [] te Nothing
 --  class $WrappedC[S,X,Y]: pass
 --      wrap        : [A,B,C] => ($Actor, X(*A,**B)->C) -> S(*A,**B)->C
 --      unwrap      : [A,B,C] => (S(*A,**B)->C) -> X(*A,**B)->C
-clWrapped           = NClass [qbind s, qbind x, qbind y] [] te Nothing
+clWrapped           = NClass [qbind s, qbind x, qbind y] [] (attrSigs te) (attrDefs te) Nothing
   where te          = [(attrWrap,scWrap), (attrUnwrap,scUnwrap)]
         scWrap      = NDef (tSchema q (tFun0 [tActor, fxFun tX] (fxFun tS))) NoDec Nothing
         scUnwrap    = NDef (tSchema q (tFun0 [fxFun tS] (fxFun tY))) NoDec Nothing
@@ -636,5 +636,4 @@ isPUSHF _                       = False
 
 isRAISE (Call _ (Var _ x) _ _)  = x == primRAISE
 isRAISE _                       = False
-
 

--- a/compiler/lib/src/Acton/QuickType.hs
+++ b/compiler/lib/src/Acton/QuickType.hs
@@ -53,7 +53,7 @@ schemaOf env e                      = (sc, dec)
 closedType                          :: EnvF x -> Expr -> Bool
 closedType env (Var _ n)            = isClosed $ findQName n env
 closedType env (Dot _ (Var _ x) n)
-  | NClass q _ _ _ <- findQName x env = closedAttr env (TC x (map tVar $ qbound q)) n
+  | NClass q _ _ _ _ <- findQName x env = closedAttr env (TC x (map tVar $ qbound q)) n
 closedType env (Dot _ e n)          = case typeOf env e of
                                         TCon _ c -> closedAttr env c n
                                         TVar _ v  -> closedAttr env (findTVBound env v) n
@@ -80,16 +80,16 @@ qSchema env f e@(Var _ n)           = case findQName n env of
                                             (sc, fxPure, Just dec, e)
                                         NSig sc dec _ ->
                                             (sc, fxPure, Just dec, e)
-                                        NClass q _ _ _ ->
+                                        NClass q _ _ _ _ ->
                                             let tc = TC (unalias env n) (map tVar $ qbound q)
                                                 (TSchema _ q' t, _) = findAttr' env tc initKW
                                                 t' = if restype t == tR then t else t{ restype = tSelf }
                                             in (tSchema (q++q') $ vsubst [(tvSelf,tCon tc)] t', fxPure, Just NoDec, e)
-                                        NAct q p k _ _ ->
+                                        NAct q p k _ _ _ ->
                                             (tSchema q (tFun fxProc p k (tCon0 n q)), fxPure, Just NoDec, e)
                                         i -> error ("### qSchema Var unexpected " ++ prstr (noq n,i))
 qSchema env f e@(Dot _ (Var _ x) n)
-  | NClass q _ _ _ <- info          = let tc = TC x (map tVar $ qbound q)
+  | NClass q _ _ _ _ <- info        = let tc = TC x (map tVar $ qbound q)
                                           (TSchema _ q' t, mbdec) = findAttr' env tc n
                                       in (tSchema (q++q') $ vsubst [(tvSelf,tCon tc)] (addSelf t mbdec), fxPure, mbdec, e)
   where info                        = findQName x env
@@ -368,10 +368,12 @@ commonEnvOf suites
 instance EnvOf Decl where
     envOf (Def _ n q p k (Just t) b dec fx doc)
                                     = [(n, NDef (TSchema NoLoc q $ TFun NoLoc fx (prowOf p) (krowOf k) t) dec doc)]
-    envOf (Class _ n q as ss doc)   = [(n, NClass q (leftpath as) (map dropDefSelf $ envOf ss) doc)]
+    envOf (Class _ n q as ss doc)   = [(n, NClass q (leftpath as) (attrSigs te) (attrDefs te) doc)]
+      where te                      = map dropDefSelf $ envOf ss
 
-    envOf (Actor _ n q p k ss doc)  = [(n, NAct q (prowOf p) (krowOf k) (map wrap te) doc)]
+    envOf (Actor _ n q p k ss doc)  = [(n, NAct q (prowOf p) (krowOf k) (attrSigs te') (attrDefs te') doc)]
       where te                      = filter (not . isHidden . fst) $ envOf ss `exclude` statevars ss
+            te'                     = map wrap te
             wrap (n, NDef sc dec doc) = (n, NDef (wrapFX sc) dec doc)
             wrap (n, i)             = (n, i)
             wrapFX (TSchema l q t)  = TSchema l q (if effect t == fxProc then t{ effect = fxAction } else t)

--- a/compiler/lib/src/Acton/Syntax.hs
+++ b/compiler/lib/src/Acton/Syntax.hs
@@ -25,7 +25,7 @@ import Control.DeepSeq
 import Prelude hiding((<>))
 
 version :: [Int]
-version = [0,14]
+version = [0,15]
 
 data Module     = Module        { modname::ModName, imps::[Import], mdoc::Maybe String, mbody::Suite } deriving (Eq,Show,Generic,NFData)
 

--- a/compiler/lib/src/Acton/TypeEnv.hs
+++ b/compiler/lib/src/Acton/TypeEnv.hs
@@ -612,10 +612,12 @@ instance USubst NameInfo where
     usubst (NSVar t)            = NSVar <$> usubst t
     usubst (NDef t d doc)       = NDef <$> usubst t <*> return d <*> return doc
     usubst (NSig t d doc)       = NSig <$> usubst t <*> return d <*> return doc
-    usubst (NAct q p k te doc)  = NAct <$> usubst q <*> usubst p <*> usubst k <*> usubst te <*> return doc
-    usubst (NClass q us te doc) = NClass <$> usubst q <*> usubst us <*> usubst te <*> return doc
-    usubst (NProto q us te doc) = NProto <$> usubst q <*> usubst us <*> usubst te <*> return doc
-    usubst (NExt q c ps te opts doc) = NExt <$> usubst q <*> usubst c <*> usubst ps <*> usubst te <*> return opts <*> return doc
+    usubst (NAct q p k sigs defs doc)
+                                = NAct <$> usubst q <*> usubst p <*> usubst k <*>
+                                  usubst sigs <*> usubst defs <*> return doc
+    usubst (NClass q us sigs defs doc) = NClass <$> usubst q <*> usubst us <*> usubst sigs <*> usubst defs <*> return doc
+    usubst (NProto q us sigs defs doc) = NProto <$> usubst q <*> usubst us <*> usubst sigs <*> usubst defs <*> return doc
+    usubst (NExt q c ps sigs defs opts doc) = NExt <$> usubst q <*> usubst c <*> usubst ps <*> usubst sigs <*> usubst defs <*> return opts <*> return doc
     usubst (NTVar k c ps)       = NTVar k <$> usubst c <*> usubst ps
     usubst (NAlias qn)          = NAlias <$> return qn
     usubst (NMAlias m)          = NMAlias <$> return m
@@ -653,9 +655,9 @@ instance (WellFormed a) => WellFormed [a] where
 instance WellFormed TCon where
     wf env (TC n ts)        = wf env ts ++ [ constr (vsubst s u) (vsubst s $ tVar v) | QBind v us <- q, u <- us ]
       where q               = case findQName n env of
-                                NAct q p k te _ -> q
-                                NClass q us te _ -> q
-                                NProto q us te _ -> q
+                                NAct q p k sigs defs _ -> q
+                                NClass q us sigs defs _ -> q
+                                NProto q us sigs defs _ -> q
                                 NReserved -> nameReserved n
                                 i -> err1 n ("wf: Class or protocol name expected, got " ++ show i)
             s               = qbound q `zip` ts
@@ -667,7 +669,7 @@ wfProto                     :: Env -> TCon -> TypeM (Constraints, Constraints)
 wfProto env (TC n ts)       = do cs <- instQuals env q ts
                                  return (wf env ts, cs)
   where q                   = case findQName n env of
-                                NProto q us te _ -> q
+                                NProto q us sigs defs _ -> q
                                 NReserved -> nameReserved n
                                 i -> err1 n ("wfProto: Protocol name expected, got " ++ show i)
 

--- a/compiler/lib/src/Acton/Types.hs
+++ b/compiler/lib/src/Acton/Types.hs
@@ -785,8 +785,10 @@ instance InfEnv Decl where
                                                  te <- infActorEnv env b
                                                  let prow = prowOf p
                                                      krow = krowOf k
-                                                 --traceM ("\n## infEnv actor " ++ prstr (n, NAct q prow krow te ddoc))
-                                                 return ([], [(n, NAct q prow krow te ddoc)], d)
+                                                     sigs = attrSigs te
+                                                     defs = attrDefs te
+                                                 --traceM ("\n## infEnv actor " ++ prstr (n, NAct q prow krow sigs defs ddoc))
+                                                 return ([], [(n, NAct q prow krow sigs defs ddoc)], d)
                                              _ ->
                                                  illegalRedef n
 
@@ -805,7 +807,8 @@ instance InfEnv Decl where
                                                  let (te2,b2) = if notImplBody b then let te1 = unSig asigs in (te++te1, addImpl te1 b1)
                                                                 else if null asigs && initKW `notElem` dom te then relayInit te b1
                                                                 else (te,b1)
-                                                 return ([], [(n, NClass q as' (te0++te2) ddoc)], Class l n q us (props te0 ++ b2) ddoc)
+                                                 let te3 = te0++te2
+                                                 return ([], [(n, NClass q as' (attrSigs te3) (attrDefs te3) ddoc)], Class l n q us (props te0 ++ b2) ddoc)
                                              _ -> illegalRedef n
       where env1                        = define (exclude (toSigs te') [initKW]) $ reserve (assigned b0) $ defineTVars (stripQual q') $ setInClass env
             (as,ps)                     = mro2 env us
@@ -839,7 +842,7 @@ instance InfEnv Decl where
                                                  when (not $ null nterms) $ err2 (dom nterms) "Method/attribute lacks signature:"
                                                  when (initKW `elem` sigs) $ err2 (filter (==initKW) sigs) "A protocol cannot define __init__"
                                                  when (not $ null noself) $ err2 noself "A static protocol signature must mention Self"
-                                                 return ([], [(n, NProto q ps te ddoc)], Protocol l n q us b' ddoc)
+                                                 return ([], [(n, NProto q ps (attrSigs te) (attrDefs te) ddoc)], Protocol l n q us b' ddoc)
                                              _ -> illegalRedef n
       where env1                        = define (toSigs te') $ reserve (assigned b) $ defineTVars (stripQual q') $ setInClass env
             ps                          = mro1 env us
@@ -862,7 +865,7 @@ instance InfEnv Decl where
                                              let te1 = unSig $ selfSubst n q asigs
                                                  te2 = te ++ te1
                                                  b2 = addImpl te1 b1
-                                             return ([], [(extensionName us c, NExt q c ps te2 [] ddoc)], Extension l q c us b2 ddoc)
+                                             return ([], [(extensionName us c, NExt q c ps extsigs (attrDefs te2) [] ddoc)], Extension l q c us b2 ddoc)
       where TC n ts                     = c
             env1                        = define (toSigs te') $ reserve (assigned b) $ defineTVars (stripQual q') $ setInClass env
             witsearch                   = findWitness env (tCon c) u
@@ -870,6 +873,7 @@ instance InfEnv Decl where
             ps                          = selfSubst n q $ mro1 env us -- TODO: check that ps doesn't contradict any previous extension mro for c
             final                       = concat [ conAttrs env (tcname p) | (_,p) <- tail ps, hasWitness env (tCon c) p ]
             te'                         = parentTEnv env ps
+            extsigs                     = attrSigs $ selfSubst n q te'
             q'                          = selfQuant n q
 
 --------------------------------------------------------------------------------------------------------------------------
@@ -936,8 +940,8 @@ checkClassAttributesInitialized className classLoc env ancestors inferredProps b
                                                              let parentInfo = findAttributeParent prop
                                                                  isInferred = prop `elem` inferred && prop `notElem` explicit && prop `notElem` inherited
                                                              in Control.Exception.throw $ UninitializedAttribute (loc prop) prop isInferred initLoc classLoc className parentInfo
-  where getPropertiesFromClass env qn   = let (_,_,te) = findConName qn env
-                                          in [ n | (n, NSig _ Property _) <- te ]
+  where getPropertiesFromClass env qn   = let (_,_,sigs,_) = findConName qn env
+                                          in [ n | (n, NSig _ Property _) <- sigs ]
 
         -- Helper to look up class location in environment
         getClassLoc env qname           = case [ className | (className, NClass{}) <- names env, className == noq qname ] of
@@ -989,14 +993,16 @@ instance (Check a) => Check [a] where
 
 infActorEnv env ss                      = do dsigs <- mapM mkNDef dvars                                 -- exposed defs without sigs
                                              bsigs <- mapM mkNVar pvars                                 -- exposed assigns without sigs
-                                             return (abssigs ++ unSig concsigs ++ dsigs ++ bsigs)       -- abstract sigs ++ exposed sigs + the above
+                                             return (abssigs ++ unSig concsigs ++ dsigs ++ bsigs)       -- abstract sigs ++ exposed sigs + inferred defs/fields
   where sigs                            = [ (n, NSig sc dec Nothing) | Signature _ ns sc dec <- ss, n <- ns, not $ isHidden n ]
-        (concsigs, abssigs)             = partition ((`elem`(dvars++pvars)) . fst) sigs
-        dvars                           = notHidden $ methods ss \\ dom sigs
+        (concsigs, abssigs)             = partition ((`elem`(mvars++pvarTerms)) . fst) sigs
+        mvars                           = notHidden $ methods ss
+        dvars                           = mvars \\ dom sigs
         mkNDef n                        = do t <- newUnivar env
                                              return (n, NDef (monotype $ t) NoDec Nothing)
         svars                           = statevars ss
-        pvars                           = pvarsF ss \\ dom (sigs) \\ dvars
+        pvarTerms                       = pvarsF ss
+        pvars                           = pvarTerms \\ dom (sigs) \\ dvars
         pvarsF ss                       = nub $ concat $ map pvs ss
           where pvs (Assign _ pats _)   = notHidden $ bound pats \\ svars   -- svars only excluded until we move stateful actor cmds to __init__
                 pvs (If _ bs els)       = foldr intersect (pvarsF els) [ pvarsF ss | Branch _ ss <- bs ]
@@ -1010,7 +1016,8 @@ matchActorAssumption env n0 p k te      = do --traceM ("## matchActorAssumption 
                                                        Seal (locinfo p 112) env p0, Seal (locinfo k 113) env k0]
                                              (cs,eq) <- oldSimplify env obs (cs ++ concat css)
                                              return (cs, eq ++ concat eqs)
-  where NAct q p0 k0 te0 _              = findName n0 env
+  where NAct q p0 k0 sigs0 defs0 _      = findName n0 env
+        te0                             = attrTEnv sigs0 defs0
         ns                              = dom te0
         obs                             = te0 ++ te
         te1                             = nTerms $ te `restrict` ns
@@ -1401,12 +1408,12 @@ getInitializedByParent :: Env -> QName -> [Name]
 getInitializedByParent env qn           = -- When calling ParentClass.__init__(self), we assume it initializes:
                                           -- 1. All attributes declared in ParentClass
                                           -- 2. All attributes ParentClass inherited (since it should call its parent's __init__)
-                                          let (_,ancestors,te) = findConName qn env
+                                          let (_,ancestors,sigs,_) = findConName qn env
                                               inherited = concatMap (getPropertiesFromClass env . tcname . snd) ancestors
-                                              declared = [ n | (n, NSig _ Property _) <- te ]
+                                              declared = [ n | (n, NSig _ Property _) <- sigs ]
                                           in nub $ inherited ++ declared
-  where getPropertiesFromClass env qn   = let (_,_,te) = findConName qn env
-                                          in [ n | (n, NSig _ Property _) <- te ]
+  where getPropertiesFromClass env qn   = let (_,_,sigs,_) = findConName qn env
+                                          in [ n | (n, NSig _ Property _) <- sigs ]
 
 
 
@@ -1518,7 +1525,8 @@ instance Check Decl where
                                              (cs1,eq1) <- markScoped env n q' te csb
                                              return (cs1, [Class l n (noqual env q) (map snd as) (bindWits eq1 ++ abstractDefs env q b') ddoc])
       where env1                        = defineTVars q' $ setInClass env
-            NClass _ as te _            = findName n env
+            NClass _ as sigs defs _     = findName n env
+            te                          = attrTEnv sigs defs
             te'                         = selfSubst n' q te
             q'                          = selfQuant n' q
             n'                          = NoQ n
@@ -1534,7 +1542,8 @@ instance Check Decl where
                                              b' <- usubst b'
                                              return (cs1, convProtocol env n q ps eq1 wmap b')
       where env1                        = defineTVars q' $ setInClass env
-            NProto _ ps te _            = findName n env
+            NProto _ ps sigs defs _     = findName n env
+            te                          = attrTEnv sigs defs
             te'                         = selfSubst n' q te
             q'                          = selfQuant n' q
             n'                          = NoQ n
@@ -1554,7 +1563,8 @@ instance Check Decl where
       where env1                        = defineInst c ps thisKW' $ defineTVars q' $ setInClass env
             n                           = tcname c
             n'                          = extensionName us c
-            NExt _ _ ps te _ _          = findName n' env
+            NExt _ _ ps sigs defs _ _   = findName n' env
+            te                          = attrTEnv sigs defs
             te'                         = selfSubst n q te
             q'                          = selfQuant n q
             tc                          = TC n (map tVar $ qbound q)
@@ -1658,7 +1668,7 @@ instance Infer Expr where
                                                 if actorSelf env
                                                     then wrapped l attrWrap env cs1 [tActor,t] [eVar selfKW,e]
                                                     else return (cs1, t, e)
-                                            NClass q _ _ _ -> do
+                                            NClass q _ _ _ _ -> do
                                                 (cs0,ts) <- instQBinds env q
                                                 --traceM ("## Instantiating " ++ prstr n)
                                                 let ns = abstractAttrs env n
@@ -1669,7 +1679,7 @@ instance Infer Expr where
                                                         let t0 = tCon $ TC (unalias env n) ts
                                                             t' = vsubst [(tvSelf,t0)] t{ restype = tSelf }
                                                         return (cs0++cs1, t', app t' (tApp x (ts++tvs)) $ protoWitsOf (cs0++cs1))
-                                            NAct q p k _ _ -> do
+                                            NAct q p k _ _ _ -> do
 --                                                when (abstractActor env n) (err1 n "Abstract actor cannot be instantiated:")
                                                 (cs,tvs,t) <- instantiate env (tSchema q (tFun fxProc p k (tCon0 (unalias env n) q)))
                                                 return (cs, t, app t (tApp x tvs) $ protoWitsOf cs)
@@ -1730,7 +1740,7 @@ instance Infer Expr where
                                              (cs2,e2') <- inferSub env t0 e2
                                              return (cs0++cs1++cs2, t0, Cond l (termsubst s e1') e' e2')
     infer env (IsInstance l e c)        = case findQName c env of
-                                             NClass q _ _ _ -> do
+                                             NClass q _ _ _ _ -> do
                                                 (cs,t,e') <- infer env e
                                                 ts <- newUnivars env [ tvkind v | v <- qbound q ]
                                                 return (cs, tBool, IsInstance l e' c)
@@ -1872,7 +1882,8 @@ instance Infer Expr where
     infer env (CompOp l e1 ops)         = notYet l "Comparison chaining"
 
     infer env (Dot l x@(Var _ c) n)
-      | NClass q us te _ <- cinfo       = do (cs0,ts) <- instQBinds env q
+      | NClass q us sigs defs _ <- cinfo
+                                        = do (cs0,ts) <- instQBinds env q
                                              let tc = TC c' ts
                                              case findAttr env tc n of
                                                 Just (_,sc,dec)
@@ -1893,7 +1904,8 @@ instance Infer Expr where
                                                             let t' = vsubst [(tvSelf,tCon tc)] $ addSelf t dec
                                                             return (cs2, t', app t' (tApp (eDot (wf we) n) tvs) $ protoWitsOf cs2)
                                                         Nothing -> err1 l "Attribute not found"
-      | NProto q us te _ <- cinfo       = do (_,ts) <- instQBinds env q
+      | NProto q us sigs defs _ <- cinfo
+                                        = do (_,ts) <- instQBinds env q
                                              let tc = TC c' ts
                                              case findAttr env tc n of
                                                 Just (wf,sc,dec) -> do
@@ -2103,7 +2115,7 @@ inferTest env (CompOp l e [OpArg Is None{}])
                                              return (cs1, env, [], tBool, eCall (tApp (eQVar primISNONE) [t]) [e'])
 inferTest env (IsInstance l e@(Var _ (NoQ n)) c)
                                         = case findQName c env of
-                                             NClass q _ _ _ -> do
+                                             NClass q _ _ _ _ -> do
                                                 (cs,t,e') <- infer env e
                                                 ts <- newUnivars env [ tvkind v | v <- qbound q ]
                                                 let tc = tCon (TC c ts)
@@ -2311,7 +2323,7 @@ testStmts env m ss                      = (stmts, tests)
         assocName _                     = Nothing
 
 testEnv                                 = [ (name n, NVar (tDict tStr (testing cl))) | (n,cl) <- testDicts ] ++
-                                          [ (name "test_main", NAct [] posNil (kwdRow (name "env") tEnv kwdNil) [] Nothing) ]
+                                          [ (name "test_main", NAct [] posNil (kwdRow (name "env") tEnv kwdNil) [] [] Nothing) ]
 
 gname ns n                              = GName (ModName ns) n
 dername a b                             = Derived (name a) (name b)

--- a/compiler/lib/src/Acton/WitKnots.hs
+++ b/compiler/lib/src/Acton/WitKnots.hs
@@ -153,9 +153,9 @@ depsof w cycledeps              = case lookup w cycledeps of
                                     _ -> []
 
 
-addopts cycledeps (n, NExt q c us te _ doc)
+addopts cycledeps (n, NExt q c us sigs defs _ doc)
                                 = --trace ("#### Extending " ++ prstr n ++ " with opts " ++ prstrs opts) $
-                                  (n, NExt q c us te opts doc)
+                                  (n, NExt q c us sigs defs opts doc)
   where opts                    = depsof n cycledeps
 addopts cycledeps ni            = ni
 

--- a/test/regression_auto/abstract_actor_from_type_signature.act
+++ b/test/regression_auto/abstract_actor_from_type_signature.act
@@ -1,7 +1,6 @@
 
 actor Foo():
-    # acton will interpret this type signature to mean the actor is abstract - clearly wrong
-    # If we remove the type signature, this program works
+    # A signature paired with a definition must not make the actor abstract.
     hello : action() -> None
     def hello():
         print("Hello World!")


### PR DESCRIPTION
Classes, protocols, extensions, and actors stored their attribute environment as a single TEnv. That made it hard to distinguish declared signatures from concrete definitions, even though later phases need to know whether an attribute is part of the public interface or part of the implementation.

This change represents those bindings as separate signature and definition environments in NClass, NProto, NExt, NAct, and their serialized counterparts. Consumers that need the combined view rebuild it explicitly with attrTEnv, while lookup and interface code can preserve the distinction.

The interface file version is bumped because NameInfo is part of the serialized .ty format. Keeping the distinction in NameInfo gives a future syntactic pre-pass a stable place to publish complete interfaces before full body checking, while implementation declarations remain available for the typed AST.