### PR TITLE
Defer full parsing past discovery

### DIFF
--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -1326,6 +1326,7 @@ initCliCompileHooks progressUI progressState gopts sched gen plan = do
         termEnabled = termProgressEnabled termProgress
         modLabel mn = modNameToString mn
         timeSep = "    "
+        parseDoneStatus = "Parse done"
         frontDoneStatus = "Type check done"
         backDoneStatus = "Compilation done"
         backFailStatus msg = "Compilation failed: " ++ msg
@@ -1435,6 +1436,8 @@ initCliCompileHooks progressUI progressState gopts sched gen plan = do
           ++ ", boxing " ++ fmtTimePrecise (btBoxing bt)
           ++ ", codegen " ++ fmtTimePrecise (btCodeGen bt)
           ++ maybe "" (\t -> ", write " ++ fmtTimePrecise t) (btWriteCode bt)
+        parseDoneRenderer =
+          staticStatusRenderer parseDoneStatus "Parsed"
         frontDoneRenderer =
           staticStatusRenderer frontDoneStatus "Typed"
         backDoneRenderer =
@@ -1446,6 +1449,10 @@ initCliCompileHooks progressUI progressState gopts sched gen plan = do
               else Just (abbreviateRight budget (backFailStatus msg))
         finalDoneRenderer =
           staticStatusRenderer finalDoneStatus "Final"
+        parseDoneLine width proj mn t =
+          if puWidthAware progressUI
+            then doneStatusLine width (projectModuleLabel proj mn) parseDoneRenderer "Parsed" (Just t)
+            else plainDoneTimedLine (projectModuleLabel proj mn) parseDoneStatus t
         frontDoneLine width proj mn t =
           if puWidthAware progressUI
             then doneStatusLine width (projectModuleLabel proj mn) frontDoneRenderer "Typed" (Just t)
@@ -1471,6 +1478,8 @@ initCliCompileHooks progressUI progressState gopts sched gen plan = do
         renderProjectLine proj mn statusRender width =
           let modLbl = projectModuleLabel proj mn
           in fitBuildLineLayout width labelWidth statusWidth False modLbl statusRender
+        parseActiveLine proj mn =
+          renderProjectLine proj mn (staticStatusRenderer "Parsing" "Parse")
         frontInitialLine proj mn =
           renderProjectLine proj mn (staticStatusRenderer "Kinds check" "Kinds")
         backActiveLine proj mn =
@@ -1563,6 +1572,18 @@ initCliCompileHooks progressUI progressState gopts sched gen plan = do
           { chOnDiagnostics = \t optsT diags -> do
               gate (progressDoneTask progressUI progressState (gtKey t))
               logDiagnostics optsT diags
+          , chOnParseStart = \t ->
+              let key = gtKey t
+                  proj = tkProj key
+                  mn = tkMod key
+              in gate (progressStartTask progressUI progressState key (parseActiveLine proj mn) Nothing)
+          , chOnParseDone = \t mtime -> do
+              gate (progressDoneTask progressUI progressState (gtKey t))
+              when (not (quiet gopts optsPlan)) $
+                forM_ mtime $ \tParse -> do
+                  let proj = tkProj (gtKey t)
+                      mn = tkMod (gtKey t)
+                  logRendered (\cols -> parseDoneLine cols proj mn tParse)
           , chOnFrontResult = \t fr -> do
               forM_ (frFrontTime fr) $ \tFront -> do
                 let proj = tkProj (gtKey t)
@@ -1682,19 +1703,16 @@ runCliPostCompile cliHooks gopts plan env = do
           else do
             unless (altOutput opts') $
               runFinal (compileBins gopts opts' pathsRoot env rootSpec rootTasks preBinTasks allowPrune' rootModuleEntries rootDepModuleOpts rootDepPathOverrides (Just (cchProgressUI cliHooks)))
--- Generate documentation index for a project build by reading module docstrings
--- from the current tasks. Uses TyTask header docs when available to avoid
--- parsing/decoding; falls back to extracting from ActonTask ASTs.
+-- Generate documentation index for a project build by reading module names and
+-- docstrings from cached .ty headers or source headers.
 generateProjectDocIndex :: Source.SourceProvider -> C.GlobalOptions -> C.CompileOptions -> Paths -> [String] -> IO ()
 generateProjectDocIndex sp gopts opts paths srcFiles = do
     unless (C.skip_build opts || C.only_build opts || isTmp paths) $ do
         let docDir = joinPath [projPath paths, "out", "doc"]
         createDirectoryIfMissing True docDir
-        tasks <- mapM (\f -> findPaths f opts >>= \p -> readModuleTask sp gopts opts p f) srcFiles
-        entries <- catMaybes <$> forM tasks (\t -> case t of
-                          ActonTask mn _src _bytes _sourceMeta m -> return (Just (mn, A.mdoc m))
-                          TyTask { name = mn, tyDoc = mdoc } -> return (Just (mn, mdoc))
-                          ParseErrorTask{} -> return Nothing)
+        entries <- catMaybes <$> forM srcFiles (\f -> do
+                     p <- findPaths f opts
+                     readModuleDoc sp gopts opts p f)
         DocP.generateDocIndex docDir entries
 
 -- | Relative C source paths for selected tasks in one project.
@@ -1853,7 +1871,9 @@ files so we can skip back passes when codegen is already up to date, and we use
 it (with impl deps) to drive the test cache.
 
 Terminology
-- ActonTask: a module parsed from source (.act) and that needs to be compiled
+- ParseTask: a source-backed module whose imports are known but whose full AST
+  has not been materialized yet
+- ActonTask: a fully parsed source module ready for front passes
 - TyTask: a module loaded from the cached .ty file on disk. Note how there are
   two variants, a stubbed TyTask where only header fields are loaded and the
   full TyTask where all module content is available.
@@ -1861,9 +1881,10 @@ Terminology
 High-level Steps
 1) Discover and read tasks using header-first strategy (readModuleTask)
    - For each module, try to use its .ty header to avoid parsing:
-     - If .ty is missing/unreadable → parse .act to obtain imports (ActonTask).
+     - If .ty is missing/unreadable → read source and parse only the import
+       header (ParseTask).
      - If the compiler compatibility guard says the cache is stale
-       → parse .act now to get accurate imports (ActonTask).
+       → read source and parse the import header now (ParseTask).
      - If source metadata in the .ty header still matches the current .act and
        the source mtime is strictly older than the .ty mtime
        → trust .ty header imports and create a TyTask stub (no heavy decode)
@@ -1872,13 +1893,13 @@ High-level Steps
        hash:
        – If stored moduleSrcBytesHash == current bytes hash → header is still
          valid (TyTask) and refresh cached source metadata.
-       – Else → parse .act now to get accurate imports (ActonTask)
+       – Else → read source and parse the import header now (ParseTask)
      - Equal source/.ty mtimes are treated as ambiguous because coarse-mtime
        filesystems can assign the same visible timestamp to a changed source
        and the cached .ty written from an earlier version of that source.
    - This ensures that .ty is up to date with the .act source and lets us
      read module imports/roots/docstring from the header, which is much faster
-     than parsing the .act file.
+     than parsing the full .act file.
 
 2) Expand to include transitive project imports (readImports)
    - For project builds, we enumerate all modules under src/ upfront, so chasing
@@ -1888,9 +1909,12 @@ High-level Steps
      headers to avoid parsing; we parse only when a .ty is missing/unreadable.
 
 3) Compile and build
-   - compileTasks orders modules in dependency (topological) order and decides
-     rebuilds as it goes:
-     - Source changed (ActonTask) → run front passes
+   - compileTasks builds a stage graph and prefers front work over parse work:
+     - ParseTask stages have no dependencies and can run opportunistically.
+     - Front stages depend on the module's parse stage (if any) plus provider
+       front stages.
+   - Front-stage rebuild decisions are then made per module:
+     - Source changed (ParseTask/ActonTask) → run front passes
      - Otherwise, compare each used pub dependency hash from the dependent’s
        .ty header with the provider’s current pub hash. If any differ → front.
      - Otherwise, compare each used impl dependency hash from the dependent’s

--- a/compiler/acton/TestGolden.hs
+++ b/compiler/acton/TestGolden.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module TestGolden
+  ( normalizeProgressTimingLine
+  , normalizeProgressTimings
+  ) where
+
+import           Data.Char (isDigit)
+import qualified Data.Text as T
+
+-- | Replace trailing durations like "12.345 s" with a stable token
+-- "0.000 s", preserving the original field width for alignment.
+normalizeProgressTimingLine :: T.Text -> T.Text
+normalizeProgressTimingLine t =
+  case T.stripSuffix " s" t of
+    Nothing -> t
+    Just pre ->
+      let field = T.takeWhileEnd (\c -> isDigit c || c == '.') pre
+          pre' = T.dropEnd (T.length field) pre
+      in case T.splitOn "." field of
+           [intPart, frac]
+             | not (T.null intPart)
+               && T.length frac == 3
+               && T.all isDigit intPart
+               && T.all isDigit frac ->
+                 let base = "0.000"
+                     padding = T.replicate (max 0 (T.length field - T.length base)) " "
+                 in pre' <> padding <> base <> " s"
+           _ -> t
+
+normalizeProgressTimings :: String -> String
+normalizeProgressTimings =
+    unlines . map (T.unpack . normalizeProgressTimingLine . T.pack) . lines

--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -30,6 +30,7 @@ import qualified Acton.CommandLineParser as C
 import qualified Acton.Fingerprint as Fingerprint
 import qualified Options.Applicative as OA
 import qualified Paths_acton
+import qualified TestGolden
 
 -- The default is to build and run each test program with the expectation that
 -- both compilation and running the program is successful as determined by exit
@@ -1046,7 +1047,7 @@ createGoldenErrorAutoTest dir file = do
 getCompileError file = do
     (returnCode, cmdOut, cmdErr) <- buildThing "" file
     assertEqual "compile error retCode" (ExitFailure 1) returnCode
-    return (LBS.pack cmdOut)
+    return (LBS.pack (TestGolden.normalizeProgressTimings cmdOut))
 
 findThings dir = do
     items <- listDirectory dir

--- a/compiler/acton/test/rebuild/golden/file_02-initial-build.golden
+++ b/compiler/acton/test/rebuild/golden/file_02-initial-build.golden
@@ -1,9 +1,12 @@
 Building file src/c.act in project .
 Resolving dependencies (fetching if missing)...
+   a  Parse done                                                            0.000 s
   Stale a: source changed
    a  Type check done                                                       0.000 s
+   b  Parse done                                                            0.000 s
   Stale b: source changed
    b  Type check done                                                       0.000 s
+   c  Parse done                                                            0.000 s
   Stale c: source changed
    c  Type check done                                                       0.000 s
    a  Compilation done                                                      0.000 s

--- a/compiler/acton/test/rebuild/golden/file_06-change-a-impl.golden
+++ b/compiler/acton/test/rebuild/golden/file_06-change-a-impl.golden
@@ -1,5 +1,6 @@
 Building file src/c.act in project .
 Resolving dependencies (fetching if missing)...
+   a  Parse done                                                            0.000 s
   Stale a: source changed
   Hash deltas a: ~aaa{src HASH1 -> HASH2, impl HASH1 -> HASH2}
    a  Type check done                                                       0.000 s

--- a/compiler/acton/test/rebuild/golden/file_08-change-b-impl.golden
+++ b/compiler/acton/test/rebuild/golden/file_08-change-b-impl.golden
@@ -1,6 +1,7 @@
 Building file src/c.act in project .
 Resolving dependencies (fetching if missing)...
   Fresh a: using cached .ty
+   b  Parse done                                                            0.000 s
   Stale b: source changed
   Hash deltas b: +DocInfo, ~baa{src HASH1 -> HASH2, impl HASH1 -> HASH2}
    b  Type check done                                                       0.000 s

--- a/compiler/acton/test/rebuild/golden/project_02-initial-build.golden
+++ b/compiler/acton/test/rebuild/golden/project_02-initial-build.golden
@@ -1,8 +1,11 @@
 Resolving dependencies (fetching if missing)...
+   a  Parse done                                                            0.000 s
   Stale a: source changed
    a  Type check done                                                       0.000 s
+   b  Parse done                                                            0.000 s
   Stale b: source changed
    b  Type check done                                                       0.000 s
+   c  Parse done                                                            0.000 s
   Stale c: source changed
    c  Type check done                                                       0.000 s
    a  Compilation done                                                      0.000 s

--- a/compiler/acton/test/rebuild/golden/project_06-change-a-impl.golden
+++ b/compiler/acton/test/rebuild/golden/project_06-change-a-impl.golden
@@ -1,4 +1,5 @@
 Resolving dependencies (fetching if missing)...
+   a  Parse done                                                            0.000 s
   Stale a: source changed
   Hash deltas a: ~aaa{src HASH1 -> HASH2, impl HASH1 -> HASH2}
    a  Type check done                                                       0.000 s

--- a/compiler/acton/test/rebuild/golden/project_08-change-b-impl.golden
+++ b/compiler/acton/test/rebuild/golden/project_08-change-b-impl.golden
@@ -1,5 +1,6 @@
 Resolving dependencies (fetching if missing)...
   Fresh a: using cached .ty
+   b  Parse done                                                            0.000 s
   Stale b: source changed
   Hash deltas b: ~baa{src HASH1 -> HASH2, impl HASH1 -> HASH2}
    b  Type check done                                                       0.000 s

--- a/compiler/acton/test/rebuild/golden/project_10-change-a-iface.golden
+++ b/compiler/acton/test/rebuild/golden/project_10-change-a-iface.golden
@@ -1,4 +1,5 @@
 Resolving dependencies (fetching if missing)...
+   a  Parse done                                                            0.000 s
   Stale a: source changed
   Hash deltas a: -W_aaa_3, ~aaa{src HASH1 -> HASH2, pub HASH1 -> HASH2, impl HASH1 -> HASH2}
    a  Type check done                                                       0.000 s

--- a/compiler/acton/test/rebuild/golden/project_11-change-b-doc.golden
+++ b/compiler/acton/test/rebuild/golden/project_11-change-b-doc.golden
@@ -1,5 +1,6 @@
 Resolving dependencies (fetching if missing)...
   Fresh a: using cached .ty
+   b  Parse done                                                            0.000 s
   Stale b: source changed
   Hash deltas b: ~DocInfo{src HASH1 -> HASH2, impl HASH1 -> HASH2}
    b  Type check done                                                       0.000 s

--- a/compiler/acton/test/typeerrors/actor_self_reserved_assignment.golden
+++ b/compiler/acton/test/typeerrors/actor_self_reserved_assignment.golden
@@ -1,4 +1,5 @@
 Building file test/typeerrors/actor_self_reserved_assignment.act using temporary scratch directory
+   actor_self_reserved_assignment  Parse done                                                            0.000 s
 [error Compilation error]: 'self' cannot be used as a parameter name in actors.
      +--> actor_self_reserved_assignment.act@2:5-2:9
      |

--- a/compiler/acton/test/typeerrors/actor_self_reserved_constructor_param.golden
+++ b/compiler/acton/test/typeerrors/actor_self_reserved_constructor_param.golden
@@ -1,4 +1,5 @@
 Building file test/typeerrors/actor_self_reserved_constructor_param.act using temporary scratch directory
+   actor_self_reserved_constructor_param  Parse done                                                            0.000 s
 [error Compilation error]: 'self' cannot be used as a parameter name in actors.
      +--> actor_self_reserved_constructor_param.act@1:19-1:23
      |

--- a/compiler/acton/test/typeerrors/actor_self_reserved_except_as.golden
+++ b/compiler/acton/test/typeerrors/actor_self_reserved_except_as.golden
@@ -1,4 +1,5 @@
 Building file test/typeerrors/actor_self_reserved_except_as.act using temporary scratch directory
+   actor_self_reserved_except_as  Parse done                                                            0.000 s
 [error Compilation error]: 'self' cannot be used as a parameter name in actors.
      +--> actor_self_reserved_except_as.act@4:26-4:30
      |

--- a/compiler/acton/test/typeerrors/actor_self_reserved_loop_var.golden
+++ b/compiler/acton/test/typeerrors/actor_self_reserved_loop_var.golden
@@ -1,4 +1,5 @@
 Building file test/typeerrors/actor_self_reserved_loop_var.act using temporary scratch directory
+   actor_self_reserved_loop_var  Parse done                                                            0.000 s
 [error Compilation error]: 'self' cannot be used as a parameter name in actors.
      +--> actor_self_reserved_loop_var.act@2:9-2:13
      |

--- a/compiler/acton/test/typeerrors/actor_self_reserved_method_name.golden
+++ b/compiler/acton/test/typeerrors/actor_self_reserved_method_name.golden
@@ -1,4 +1,5 @@
 Building file test/typeerrors/actor_self_reserved_method_name.act using temporary scratch directory
+   actor_self_reserved_method_name  Parse done                                                            0.000 s
 [error Compilation error]: 'self' cannot be used as a parameter name in actors.
      +--> actor_self_reserved_method_name.act@2:9-2:13
      |

--- a/compiler/acton/test/typeerrors/actor_self_reserved_method_param.golden
+++ b/compiler/acton/test/typeerrors/actor_self_reserved_method_param.golden
@@ -1,4 +1,5 @@
 Building file test/typeerrors/actor_self_reserved_method_param.act using temporary scratch directory
+   actor_self_reserved_method_param  Parse done                                                            0.000 s
 [error Compilation error]: 'self' cannot be used as a parameter name in actors.
      +--> actor_self_reserved_method_param.act@2:28-2:32
      |

--- a/compiler/acton/test/typeerrors/actor_self_reserved_method_param2.golden
+++ b/compiler/acton/test/typeerrors/actor_self_reserved_method_param2.golden
@@ -1,4 +1,5 @@
 Building file test/typeerrors/actor_self_reserved_method_param2.act using temporary scratch directory
+   actor_self_reserved_method_param2  Parse done                                                            0.000 s
 [error Compilation error]: 'self' cannot be used as a parameter name in actors.
      +--> actor_self_reserved_method_param2.act@3:32-3:36
      |

--- a/compiler/acton/test/typeerrors/actor_self_reserved_variable.golden
+++ b/compiler/acton/test/typeerrors/actor_self_reserved_variable.golden
@@ -1,4 +1,5 @@
 Building file test/typeerrors/actor_self_reserved_variable.act using temporary scratch directory
+   actor_self_reserved_variable  Parse done                                                            0.000 s
 [error Compilation error]: 'self' cannot be used as a parameter name in actors.
      +--> actor_self_reserved_variable.act@2:9-2:13
      |

--- a/compiler/acton/test/typeerrors/ex1.golden
+++ b/compiler/acton/test/typeerrors/ex1.golden
@@ -1,4 +1,5 @@
 Building file test/typeerrors/ex1.act using temporary scratch directory
+   ex1  Parse done                                                            0.000 s
 [error]: Incompatible types
      +--> ex1.act@4:5-4:9
      |

--- a/compiler/acton/test/typeerrors/ex10.golden
+++ b/compiler/acton/test/typeerrors/ex10.golden
@@ -1,4 +1,5 @@
 Building file test/typeerrors/ex10.act using temporary scratch directory
+   ex10  Parse done                                                            0.000 s
 [error]: Constraint violation
      +--> ex10.act@4:5-4:15
      |

--- a/compiler/acton/test/typeerrors/ex11.golden
+++ b/compiler/acton/test/typeerrors/ex11.golden
@@ -1,4 +1,5 @@
 Building file test/typeerrors/ex11.act using temporary scratch directory
+   ex11  Parse done                                                            0.000 s
 [error]: Constraint violation
      +--> ex11.act@4:5-4:11
      |

--- a/compiler/acton/test/typeerrors/ex13.golden
+++ b/compiler/acton/test/typeerrors/ex13.golden
@@ -1,4 +1,5 @@
 Building file test/typeerrors/ex13.act using temporary scratch directory
+   ex13  Parse done                                                            0.000 s
 [error]: Incompatible types
      +--> ex13.act@2:7-2:13
      |

--- a/compiler/acton/test/typeerrors/ex14.golden
+++ b/compiler/acton/test/typeerrors/ex14.golden
@@ -1,4 +1,5 @@
 Building file test/typeerrors/ex14.act using temporary scratch directory
+   ex14  Parse done                                                            0.000 s
 [error]: Incompatible types
      +--> ex14.act@2:12-2:16
      |

--- a/compiler/acton/test/typeerrors/ex15.golden
+++ b/compiler/acton/test/typeerrors/ex15.golden
@@ -1,4 +1,5 @@
 Building file test/typeerrors/ex15.act using temporary scratch directory
+   ex15  Parse done                                                            0.000 s
 [error]: Cannot satisfy the following simultaneous constraints for the unknown types
      +--> ex15.act@2:9-2:10
      |

--- a/compiler/acton/test/typeerrors/ex16.golden
+++ b/compiler/acton/test/typeerrors/ex16.golden
@@ -1,4 +1,5 @@
 Building file test/typeerrors/ex16.act using temporary scratch directory
+   ex16  Parse done                                                            0.000 s
 [error]: Constraint violation
      +--> ex16.act@6:9-6:22
      |

--- a/compiler/acton/test/typeerrors/ex17.golden
+++ b/compiler/acton/test/typeerrors/ex17.golden
@@ -1,4 +1,5 @@
 Building file test/typeerrors/ex17.act using temporary scratch directory
+   ex17  Parse done                                                            0.000 s
 [error]: Cannot satisfy the following simultaneous constraints for the unknown types
      +--> ex17.act@2:9-2:10
      |

--- a/compiler/acton/test/typeerrors/ex18.golden
+++ b/compiler/acton/test/typeerrors/ex18.golden
@@ -1,4 +1,5 @@
 Building file test/typeerrors/ex18.act using temporary scratch directory
+   ex18  Parse done                                                            0.000 s
 [error]: Cannot satisfy the following simultaneous constraints for the unknown type t0
      +--> ex18.act@2:12-2:27
      |

--- a/compiler/acton/test/typeerrors/ex19.golden
+++ b/compiler/acton/test/typeerrors/ex19.golden
@@ -1,4 +1,5 @@
 Building file test/typeerrors/ex19.act using temporary scratch directory
+   ex19  Parse done                                                            0.000 s
 [error]: Cannot satisfy the following simultaneous constraints for the unknown types
      +--> ex19.act@1:5-1:6
      |

--- a/compiler/acton/test/typeerrors/ex2.golden
+++ b/compiler/acton/test/typeerrors/ex2.golden
@@ -1,4 +1,5 @@
 Building file test/typeerrors/ex2.act using temporary scratch directory
+   ex2  Parse done                                                            0.000 s
 [error]: Incompatible types
      +--> ex2.act@4:5-4:13
      |

--- a/compiler/acton/test/typeerrors/ex20.golden
+++ b/compiler/acton/test/typeerrors/ex20.golden
@@ -1,4 +1,5 @@
 Building file test/typeerrors/ex20.act using temporary scratch directory
+   ex20  Parse done                                                            0.000 s
 [error]: Constraint violation
      +--> ex20.act@1:1-1:2
      |

--- a/compiler/acton/test/typeerrors/ex21.golden
+++ b/compiler/acton/test/typeerrors/ex21.golden
@@ -1,4 +1,5 @@
 Building file test/typeerrors/ex21.act using temporary scratch directory
+   ex21  Parse done                                                            0.000 s
 [error]: Constraint violation
      +--> ex21.act@4:10-4:25
      |

--- a/compiler/acton/test/typeerrors/ex22.golden
+++ b/compiler/acton/test/typeerrors/ex22.golden
@@ -1,4 +1,5 @@
 Building file test/typeerrors/ex22.act using temporary scratch directory
+   ex22  Parse done                                                            0.000 s
 [error]: Incompatible types
      +--> ex22.act@1:1-1:2
      |

--- a/compiler/acton/test/typeerrors/ex23.golden
+++ b/compiler/acton/test/typeerrors/ex23.golden
@@ -1,4 +1,5 @@
 Building file test/typeerrors/ex23.act using temporary scratch directory
+   ex23  Parse done                                                            0.000 s
 [error]: Cannot satisfy the following simultaneous constraints for the unknown types
      +--> ex23.act@2:11-2:12
      |

--- a/compiler/acton/test/typeerrors/ex24.golden
+++ b/compiler/acton/test/typeerrors/ex24.golden
@@ -1,4 +1,5 @@
 Building file test/typeerrors/ex24.act using temporary scratch directory
+   ex24  Parse done                                                            0.000 s
 [error]: Type unification error
      +--> ex24.act@5:13-5:16
      |

--- a/compiler/acton/test/typeerrors/ex25.golden
+++ b/compiler/acton/test/typeerrors/ex25.golden
@@ -1,4 +1,5 @@
 Building file test/typeerrors/ex25.act using temporary scratch directory
+   ex25  Parse done                                                            0.000 s
 [error]: Incompatible types
      +--> ex25.act@8:9-8:16
      |

--- a/compiler/acton/test/typeerrors/ex26.golden
+++ b/compiler/acton/test/typeerrors/ex26.golden
@@ -1,4 +1,5 @@
 Building file test/typeerrors/ex26.act using temporary scratch directory
+   ex26  Parse done                                                            0.000 s
 [error]: Constraint violation
      +--> ex26.act@15:5-15:33
      |

--- a/compiler/acton/test/typeerrors/ex27.golden
+++ b/compiler/acton/test/typeerrors/ex27.golden
@@ -1,4 +1,5 @@
 Building file test/typeerrors/ex27.act using temporary scratch directory
+   ex27  Parse done                                                            0.000 s
 [error]: Type unification error
      +--> ex27.act@5:5-6:1
      |

--- a/compiler/acton/test/typeerrors/ex4.golden
+++ b/compiler/acton/test/typeerrors/ex4.golden
@@ -1,4 +1,5 @@
 Building file test/typeerrors/ex4.act using temporary scratch directory
+   ex4  Parse done                                                            0.000 s
 [error]: Incompatible types
      +--> ex4.act@5:22-5:26
      |

--- a/compiler/acton/test/typeerrors/ex5.golden
+++ b/compiler/acton/test/typeerrors/ex5.golden
@@ -1,4 +1,5 @@
 Building file test/typeerrors/ex5.act using temporary scratch directory
+   ex5  Parse done                                                            0.000 s
 [error]: Incompatible types
      +--> ex5.act@7:5-7:15
      |

--- a/compiler/acton/test/typeerrors/ex6.golden
+++ b/compiler/acton/test/typeerrors/ex6.golden
@@ -1,4 +1,5 @@
 Building file test/typeerrors/ex6.act using temporary scratch directory
+   ex6  Parse done                                                            0.000 s
 [error]: Incompatible types
      +--> ex6.act@1:9-1:16
      |

--- a/compiler/acton/test/typeerrors/ex7.golden
+++ b/compiler/acton/test/typeerrors/ex7.golden
@@ -1,4 +1,5 @@
 Building file test/typeerrors/ex7.act using temporary scratch directory
+   ex7  Parse done                                                            0.000 s
 [error]: Constraint violation
      +--> ex7.act@4:16-4:17
      |

--- a/compiler/acton/test/typeerrors/ex8.golden
+++ b/compiler/acton/test/typeerrors/ex8.golden
@@ -1,4 +1,5 @@
 Building file test/typeerrors/ex8.act using temporary scratch directory
+   ex8  Parse done                                                            0.000 s
 [error]: Cannot satisfy the following simultaneous constraints for the unknown type t0
      +--> ex8.act@3:14-3:15
      |

--- a/compiler/acton/test/typeerrors/ex9.golden
+++ b/compiler/acton/test/typeerrors/ex9.golden
@@ -1,4 +1,5 @@
 Building file test/typeerrors/ex9.act using temporary scratch directory
+   ex9  Parse done                                                            0.000 s
 [error]: Cannot satisfy the following simultaneous constraints for the unknown types
      +--> ex9.act@1:5-1:6
      |

--- a/compiler/acton/test/typeerrors/funargs1.golden
+++ b/compiler/acton/test/typeerrors/funargs1.golden
@@ -1,4 +1,5 @@
 Building file test/typeerrors/funargs1.act using temporary scratch directory
+   funargs1  Parse done                                                            0.000 s
 [error]: Unexpected keyword argument
      +--> funargs1.act@4:9-4:10
      |

--- a/compiler/acton/test/typeerrors/funargs2.golden
+++ b/compiler/acton/test/typeerrors/funargs2.golden
@@ -1,4 +1,5 @@
 Building file test/typeerrors/funargs2.act using temporary scratch directory
+   funargs2  Parse done                                                            0.000 s
 [error]: Unexpected keyword argument
      +--> funargs2.act@4:9-4:10
      |

--- a/compiler/acton/test/typeerrors/funargs4.golden
+++ b/compiler/acton/test/typeerrors/funargs4.golden
@@ -1,4 +1,5 @@
 Building file test/typeerrors/funargs4.act using temporary scratch directory
+   funargs4  Parse done                                                            0.000 s
 [error]: Unexpected keyword argument
      +--> funargs4.act@4:9-4:10
      |

--- a/compiler/acton/test/typeerrors/funargs5.golden
+++ b/compiler/acton/test/typeerrors/funargs5.golden
@@ -1,4 +1,5 @@
 Building file test/typeerrors/funargs5.act using temporary scratch directory
+   funargs5  Parse done                                                            0.000 s
 [error]: Incompatible types
      +--> funargs5.act@4:5-4:15
      |

--- a/compiler/acton/test/typeerrors/funargs6.golden
+++ b/compiler/acton/test/typeerrors/funargs6.golden
@@ -1,4 +1,5 @@
 Building file test/typeerrors/funargs6.act using temporary scratch directory
+   funargs6  Parse done                                                            0.000 s
 [error]: Incompatible types
      +--> funargs6.act@4:5-4:13
      |

--- a/compiler/acton/test_incremental.hs
+++ b/compiler/acton/test_incremental.hs
@@ -8,7 +8,7 @@ import qualified Data.ByteString as B
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import qualified Data.Text.Encoding as TE
-import           Data.Char (isDigit, isHexDigit, isSpace)
+import           Data.Char (isHexDigit, isSpace)
 import           Data.Bits (shiftL, (.|.))
 import           Data.Word (Word64)
 import qualified Acton.Fingerprint as Fingerprint
@@ -33,6 +33,7 @@ import           Test.Tasty.Runners (NumThreads(..))
 import           Test.Tasty (DependencyType(..), after, TestName)
 import           Test.Tasty.Golden (goldenVsString)
 import           Test.Tasty.HUnit
+import           TestGolden (normalizeProgressTimingLine)
 import qualified Acton.Compile as Compile
 import qualified Acton.CommandLineParser as C
 import qualified Acton.SourceProvider as Source
@@ -79,7 +80,7 @@ sanitize = LBS.fromStrict
         . T.unlines
         . reorderBackLines
         . map censorHashes
-        . map redact
+        . map normalizeProgressTimingLine
         . dropPaths
         . filter (not . isVolatile)
         . T.lines
@@ -89,26 +90,6 @@ sanitize = LBS.fromStrict
       T.isInfixOf "zigCmd" t ||
       T.isInfixOf "Building project in" t ||
       T.isInfixOf "Building [cap" t
-
-    -- Replace trailing durations like "12.345 s" with a stable token "0.000 s",
-    -- preserving the original field width for alignment.
-    redact :: T.Text -> T.Text
-    redact t =
-      case T.stripSuffix " s" t of
-        Nothing -> t
-        Just pre ->
-          let field = T.takeWhileEnd (\c -> isDigit c || c == '.') pre
-              pre' = T.dropEnd (T.length field) pre
-          in case T.splitOn "." field of
-               [intPart, frac]
-                 | not (T.null intPart)
-                   && T.length frac == 3
-                   && T.all isDigit intPart
-                   && T.all isDigit frac ->
-                     let base = "0.000"
-                         padding = T.replicate (max 0 (T.length field - T.length base)) " "
-                     in pre' <> padding <> base <> " s"
-               _ -> t
 
     -- Rewrite volatile hash literals in log lines to stable placeholders.
     -- We keep semantic position in deltas:
@@ -1222,19 +1203,26 @@ p27_overlay_source_provider = testCase "27-overlay snapshots drive readModuleTas
   case taskSame of
     Compile.TyTask{} -> pure ()
     _ -> assertFailure "expected TyTask when overlay matches header"
-  let bytesDiff = TE.encodeUtf8 (T.pack "aaa = 2\n")
+  let textDiff = "\"\"\"Overlay doc\"\"\"\naaa = 2\n"
+      bytesDiff = TE.encodeUtf8 (T.pack textDiff)
       snapDiff = Source.SourceSnapshot
-        { Source.ssText = "aaa = 2\n"
+        { Source.ssText = textDiff
         , Source.ssBytes = bytesDiff
         , Source.ssIsOverlay = True
         }
       spDiff = disk { Source.spReadOverlay = \path -> return (if path == actAAbs then Just snapDiff else Nothing) }
   taskDiff <- Compile.readModuleTask spDiff gopts Compile.defaultCompileOptions paths actAAbs
   case taskDiff of
-    Compile.ActonTask{ Compile.src = srcText, Compile.srcBytes = srcBytes } -> do
-      srcText @?= "aaa = 2\n"
+    Compile.ParseTask{ Compile.src = srcText, Compile.srcBytes = srcBytes } -> do
+      srcText @?= textDiff
       srcBytes @?= bytesDiff
-    _ -> assertFailure "expected ActonTask when overlay differs from header"
+    _ -> assertFailure "expected ParseTask when overlay differs from header"
+  docDiff <- Compile.readModuleDoc spDiff gopts Compile.defaultCompileOptions paths actAAbs
+  case docDiff of
+    Just (mn, Just doc) -> do
+      mn @?= A.modName ["a"]
+      doc @?= "Overlay doc"
+    _ -> assertFailure "expected module doc from overlay header"
 
 p28_protocol_extension_deps :: TestTree
 p28_protocol_extension_deps = testCase "28-protocol/extension deps are recorded by name" $ do
@@ -1418,6 +1406,19 @@ p30_only_build = testCase "30-only-build skips front passes" $ do
   assertBool "did not expect c.act to type check" (not (typechecked out2 modC))
   assertBool "did not expect b.act to compile codegen" (not (compiled out2 modB))
   assertBool "did not expect c.act to compile codegen" (not (compiled out2 modC))
+
+  writeFileUtf8 (src </> "b.act") $ T.unlines
+    [ "import a"
+    , ""
+    , "def bar() -> int:"
+    , "    return a.aaa"
+    , ")"
+    ]
+  res3@(ec3, out3) <- runActonIn proj ["build", "--color", "never", "--verbose", "--only-build"]
+  assertExitSuccess "only-build with invalid body" res3
+  assertBool "did not expect invalid b.act to type check in only-build" (not (typechecked out3 modB))
+  assertBool "did not expect c.act to type check after invalid b.act in only-build" (not (typechecked out3 modC))
+  assertBool "did not expect parse diagnostics in only-build" (not ("Syntax error" `T.isInfixOf` out3))
 
 p31_always_build :: TestTree
 p31_always_build = testCase "31-always-build forces front passes" $ do

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -130,6 +130,7 @@ module Acton.Compile
   , parseActSnapshot
   , parseActFile
   , readModuleTask
+  , readModuleDoc
   , readImports
   , buildGlobalTasks
   , selectNeededTasks
@@ -224,7 +225,7 @@ import Data.Bits (shiftL, shiftR, (.|.))
 import Data.Char (isAlpha, isDigit, isHexDigit, isSpace, toLower)
 import Data.Either (partitionEithers)
 import Data.Graph
-import Data.List (find, foldl', intercalate, intersperse, isPrefixOf, isSuffixOf, nub)
+import Data.List (find, foldl', intercalate, intersperse, isPrefixOf, isSuffixOf, nub, partition)
 import qualified Data.List
 import Data.IORef
 import Data.Maybe (catMaybes, isJust, listToMaybe, mapMaybe)
@@ -340,6 +341,8 @@ data BackTiming = BackTiming
 
 data CompileCallbacks = CompileCallbacks
   { ccOnDiagnostics :: GlobalTask -> C.CompileOptions -> [Diagnostic String] -> IO ()
+  , ccOnParseStart :: GlobalTask -> C.CompileOptions -> IO ()
+  , ccOnParseDone :: GlobalTask -> C.CompileOptions -> Maybe TimeSpec -> IO ()
   , ccOnFrontResult :: GlobalTask -> C.CompileOptions -> FrontResult -> IO ()
   , ccOnFrontStart :: GlobalTask -> C.CompileOptions -> IO ()
   , ccOnFrontDone :: GlobalTask -> C.CompileOptions -> IO ()
@@ -353,6 +356,8 @@ data CompileCallbacks = CompileCallbacks
 defaultCompileCallbacks :: CompileCallbacks
 defaultCompileCallbacks = CompileCallbacks
   { ccOnDiagnostics = \_ _ _ -> return ()
+  , ccOnParseStart = \_ _ -> return ()
+  , ccOnParseDone = \_ _ _ -> return ()
   , ccOnFrontResult = \_ _ _ -> return ()
   , ccOnFrontStart = \_ _ -> return ()
   , ccOnFrontDone = \_ _ -> return ()
@@ -635,6 +640,8 @@ prepareCompilePlanFromContext sp gopts ctx srcFiles allowPrune mChangedPaths = d
 
 data CompileHooks = CompileHooks
   { chOnDiagnostics :: GlobalTask -> C.CompileOptions -> [Diagnostic String] -> IO ()
+  , chOnParseStart :: GlobalTask -> IO ()
+  , chOnParseDone :: GlobalTask -> Maybe TimeSpec -> IO ()
   , chOnFrontStart :: GlobalTask -> IO ()
   , chOnFrontDone :: GlobalTask -> IO ()
   , chOnFrontProgress :: GlobalTask -> FrontPassProgress -> IO ()
@@ -649,6 +656,8 @@ defaultCompileHooks :: CompileHooks
 defaultCompileHooks =
   CompileHooks
     { chOnDiagnostics = \_ _ _ -> return ()
+    , chOnParseStart = \_ -> return ()
+    , chOnParseDone = \_ _ -> return ()
     , chOnFrontStart = \_ -> return ()
     , chOnFrontDone = \_ -> return ()
     , chOnFrontProgress = \_ _ -> return ()
@@ -678,6 +687,8 @@ runCompilePlan sp gopts plan sched gen hooks = do
         }
       callbacks = defaultCompileCallbacks
         { ccOnDiagnostics = \t optsT diags -> chOnDiagnostics hooks t optsT diags
+        , ccOnParseStart = \t _ -> chOnParseStart hooks t
+        , ccOnParseDone = \t _ mtime -> chOnParseDone hooks t mtime
         , ccOnFrontResult = \t _ fr -> chOnFrontResult hooks t fr
         , ccOnFrontStart = \t _ -> chOnFrontStart hooks t
         , ccOnFrontDone = \t _ -> chOnFrontDone hooks t
@@ -894,6 +905,35 @@ parseActSource mn actFile srcContent = do
     handleIndentationError err =
       return $ Left (errsToDiagnostics "Indentation error" (modNameToFilename mn) srcContent (Acton.Parser.indentationError err))
 
+-- | Parse only the module header from a SourceSnapshot.
+parseActHeaderSnapshot :: A.ModName
+                       -> FilePath
+                       -> Source.SourceSnapshot
+                       -> IO (Either [Diagnostic String] ([A.ModName], Maybe String))
+parseActHeaderSnapshot mn actFile snap = do
+  cwd <- getCurrentDirectory
+  let displayFile = makeRelative cwd actFile
+      srcContent = Source.ssText snap
+  (Right <$> do
+      (imps, mdoc) <- Acton.Parser.parseModuleHeader displayFile srcContent
+      return (A.importsOf (A.Module mn imps Nothing []), mdoc))
+    `catch` handleParseBundle displayFile srcContent
+    `catch` handleCustomParse displayFile srcContent
+    `catch` handleContextError srcContent
+    `catch` handleIndentationError srcContent
+  where
+    handleParseBundle file srcContent bundle =
+      return $ Left [Diag.parseDiagnosticFromBundle file srcContent bundle]
+
+    handleCustomParse file srcContent err =
+      return $ Left [Diag.customParseExceptionToDiagnostic file srcContent err]
+
+    handleContextError srcContent err =
+      return $ Left (errsToDiagnostics "Context error" (modNameToFilename mn) srcContent (Acton.Parser.contextError err))
+
+    handleIndentationError srcContent err =
+      return $ Left (errsToDiagnostics "Indentation error" (modNameToFilename mn) srcContent (Acton.Parser.indentationError err))
+
 -- | Parse a SourceSnapshot with a display path relative to cwd.
 -- Keeps diagnostics stable regardless of absolute paths or overlays.
 parseActSnapshot :: A.ModName -> FilePath -> Source.SourceSnapshot -> IO (Either [Diagnostic String] A.Module)
@@ -955,7 +995,8 @@ data FrontResult = FrontResult
   , frBackJob  :: Maybe BackJob
   }
 
-data CompileTask        = ActonTask { name :: A.ModName, src :: String, srcBytes :: B.ByteString, sourceMeta :: Maybe InterfaceFiles.SourceFileMeta, atree:: A.Module }
+data CompileTask        = ParseTask { name :: A.ModName, src :: String, srcBytes :: B.ByteString, sourceMeta :: Maybe InterfaceFiles.SourceFileMeta, parseImports :: [A.ModName] }
+                        | ActonTask { name :: A.ModName, src :: String, srcBytes :: B.ByteString, sourceMeta :: Maybe InterfaceFiles.SourceFileMeta, atree:: A.Module }
                         | TyTask    { name :: A.ModName
                                     , tyHash :: B.ByteString               -- raw source bytes hash
                                     , tyPubHash :: B.ByteString          -- module public hash
@@ -971,6 +1012,7 @@ data CompileTask        = ActonTask { name :: A.ModName, src :: String, srcBytes
                         | ParseErrorTask { name :: A.ModName, parseDiagnostics :: [Diagnostic String] }
 
 instance Show CompileTask where
+  show ParseTask{ name = mn } = "ParseTask " ++ modNameToString mn
   show ActonTask{ name = mn } = "ActonTask " ++ modNameToString mn
   show TyTask{ name = mn } = "TyTask " ++ modNameToString mn
   show ParseErrorTask{ name = mn, parseDiagnostics = ds } =
@@ -985,6 +1027,10 @@ instance Show CompileTask where
 
 data TaskKey = TaskKey { tkProj :: FilePath, tkMod :: A.ModName } deriving (Eq, Ord, Show)
 
+data StageKey = ParseStage TaskKey | FrontStage TaskKey deriving (Eq, Ord, Show)
+
+data StageSuccess = StageParsed CompileTask (Maybe TimeSpec) | StageFronted FrontResult
+
 data GlobalTask = GlobalTask
   { gtKey             :: TaskKey
   , gtPaths           :: Paths
@@ -996,6 +1042,7 @@ data GlobalTask = GlobalTask
 -- TyTask uses header imports, ActonTask uses the parsed AST, and parse errors
 -- yield no imports.
 importsOf :: CompileTask -> [A.ModName]
+importsOf (ParseTask _ _ _ _ imps) = imps
 importsOf (ActonTask _ _ _ _ m) = A.importsOf m
 importsOf (TyTask { tyImports = ms }) = map fst ms
 importsOf (ParseErrorTask _ _) = []
@@ -1149,39 +1196,52 @@ selectAffectedTasks globalTasks changedFiles = do
           in go seen' (ks ++ new)
 
 
--- | Prepare a task for dependency graph construction.
--- Prefer reading imports from .ty header; if no .ty, parse the source.
--- Decide how to represent a module for the graph:
--- 1) If .ty is missing/unreadable -> parse .act to obtain imports (ActonTask).
--- 2) If .ty exists but the compiler compatibility guard says it is stale ->
---    parse .act to obtain fresh imports.
--- 3) If an in-memory overlay exists, skip filesystem metadata and compare the
---    overlay bytes hash to the stored moduleSrcBytesHash.
--- 4) Otherwise compare current source metadata against the cached sourceMeta:
---      - If metadata matches and the source mtime is strictly older than the
---        .ty mtime -> reuse the cached header (TyTask)
---      - If metadata differs, or source/.ty mtimes are equal, and stored
---        moduleSrcBytesHash == current bytes hash
---        -> header is still valid (TyTask) and refresh source metadata in .ty
---      - Else -> parse .act to obtain accurate imports (ActonTask)
--- Returns either a header-only TyTask stub or an ActonTask; no heavy decoding.
---
--- This is the core of incremental graph construction: it avoids parsing when
--- cached interfaces are reliable, while treating source content hash as the
--- correctness authority when metadata alone is inconclusive.
-readModuleTask :: Source.SourceProvider -> C.GlobalOptions -> C.CompileOptions -> Paths -> String -> IO CompileTask
-readModuleTask sp gopts opts paths actFile = do
+data ModuleHead
+  = TyHead
+      { mhName       :: A.ModName
+      , mhSrcHash    :: B.ByteString
+      , mhPubHash    :: B.ByteString
+      , mhImplHash   :: B.ByteString
+      , mhTyImports  :: [(A.ModName, B.ByteString)]
+      , mhNameHashes :: [InterfaceFiles.NameHashInfo]
+      , mhRoots      :: [A.Name]
+      , mhTests      :: [String]
+      , mhDoc        :: Maybe String
+      }
+  | SrcHead
+      { mhName       :: A.ModName
+      , mhSrc        :: String
+      , mhBytes      :: B.ByteString
+      , mhSourceMeta :: Maybe InterfaceFiles.SourceFileMeta
+      , mhSrcImports :: [A.ModName]
+      , mhDoc        :: Maybe String
+      }
+  | HeadError
+      { mhName        :: A.ModName
+      , mhDiagnostics :: [Diagnostic String]
+      }
+
+-- | Read the cheap module header used by discovery and doc indexing.
+-- Reuse a valid .ty header when possible; otherwise read the source snapshot
+-- and parse only the module docstring plus imports.
+readModuleHeader :: Source.SourceProvider
+                 -> C.GlobalOptions
+                 -> C.CompileOptions
+                 -> Paths
+                 -> String
+                 -> IO ModuleHead
+readModuleHeader sp gopts opts paths actFile = do
     let mn      = modName paths
         tyFile  = outBase paths mn ++ ".ty"
     tyExists <- doesFileExist tyFile
     if not tyExists
-      then parseForImports mn
+      then readSourceHead mn
       else do
         -- .ty exists: read the cached header and validate it against compiler
         -- compatibility plus source metadata/content as needed.
         hdrE <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readHeader tyFile
         case hdrE of
-          Left _ -> parseForImports mn
+          Left _ -> readSourceHead mn
           Right (cachedSourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash, imps, nameHashes, roots, tests, mdoc) -> do
             tyStatus <- getFileStatus tyFile
             let tyMTimeNs = fileStatusMTimeNs tyStatus
@@ -1190,35 +1250,33 @@ readModuleTask sp gopts opts paths actFile = do
             case mOverlay of
               Just snap ->
                 if newCompiler
-                  then parseFromSnapshot mn snap
+                  then sourceHeadFromSnapshot mn snap
                   else verifyOrParse mn snap moduleSrcBytesHash modulePubHash moduleImplHash cachedSourceMeta Nothing imps nameHashes roots tests mdoc
               Nothing -> do
                 if newCompiler
-                  then parseForImports mn
+                  then readSourceHead mn
                   else do
                     currentSourceMeta <- readSourceFileMeta actFile
                     if canReuseHeader cachedSourceMeta currentSourceMeta tyMTimeNs
-                      then return (mkTyTask mn moduleSrcBytesHash modulePubHash moduleImplHash imps nameHashes roots tests mdoc)
+                      then return (mkTyHead mn moduleSrcBytesHash modulePubHash moduleImplHash imps nameHashes roots tests mdoc)
                       else do
                         snap <- Source.spReadFile sp actFile
                         verifyOrParse mn snap moduleSrcBytesHash modulePubHash moduleImplHash cachedSourceMeta (Just currentSourceMeta) imps nameHashes roots tests mdoc
   where
     fileStatusMTimeNs st = floor (toRational (modificationTimeHiRes st) * 1000000000)
 
-    mkTyTask mn moduleSrcBytesHash modulePubHash moduleImplHash imps nameHashes roots tests mdoc =
-      let nmodStub = I.NModule [] mdoc
-          tmodStub = A.Module mn [] mdoc []
-      in TyTask { name      = mn
-                , tyHash     = moduleSrcBytesHash
-                , tyPubHash  = modulePubHash
-                , tyImplHash = moduleImplHash
-                , tyImports  = imps
-                , tyNameHashes = nameHashes
-                , tyRoots   = roots
-                , tyTests   = tests
-                , tyDoc     = mdoc
-                , iface     = nmodStub
-                , typed     = tmodStub }
+    mkTyHead mn moduleSrcBytesHash modulePubHash moduleImplHash imps nameHashes roots tests mdoc =
+      TyHead
+        { mhName       = mn
+        , mhSrcHash    = moduleSrcBytesHash
+        , mhPubHash    = modulePubHash
+        , mhImplHash   = moduleImplHash
+        , mhTyImports  = imps
+        , mhNameHashes = nameHashes
+        , mhRoots      = roots
+        , mhTests      = tests
+        , mhDoc        = mdoc
+        }
 
     metadataMatches cached current =
       case cached of
@@ -1229,21 +1287,17 @@ readModuleTask sp gopts opts paths actFile = do
       metadataMatches cached current
       && InterfaceFiles.sfmMTimeNs current < tyMTimeNs
 
-    parseForImports mn = do
-      parsedRes <- parseActFile sp mn actFile
-      case parsedRes of
-        Left diags -> return $ ParseErrorTask mn diags
-        Right (snap, m) -> do
-          mSourceMeta <- snapshotSourceMeta snap
-          return $ ActonTask mn (Source.ssText snap) (Source.ssBytes snap) mSourceMeta m
+    readSourceHead mn = do
+      snap <- Source.readSource sp actFile
+      sourceHeadFromSnapshot mn snap
 
-    parseFromSnapshot mn snap = do
-      emod <- parseActSnapshot mn actFile snap
-      case emod of
-        Left diags -> return $ ParseErrorTask mn diags
-        Right m -> do
+    sourceHeadFromSnapshot mn snap = do
+      headerRes <- parseActHeaderSnapshot mn actFile snap
+      case headerRes of
+        Left diags -> return $ HeadError mn diags
+        Right (imps, mdoc) -> do
           mSourceMeta <- snapshotSourceMeta snap
-          return $ ActonTask mn (Source.ssText snap) (Source.ssBytes snap) mSourceMeta m
+          return $ SrcHead mn (Source.ssText snap) (Source.ssBytes snap) mSourceMeta imps mdoc
 
     snapshotSourceMeta snap
       | Source.ssIsOverlay snap = return Nothing
@@ -1277,7 +1331,7 @@ readModuleTask sp gopts opts paths actFile = do
         actTime <- Source.spGetModTime sp actFile
         tyTime <- getModificationTime (outBase paths mn ++ ".ty")
         let len = B.length (Source.ssBytes snap)
-        putStrLn ("[debug] readModuleTask " ++ modNameToString mn
+        putStrLn ("[debug] readModuleHeader " ++ modNameToString mn
                   ++ " act=" ++ show actTime
                   ++ " ty=" ++ show tyTime
                   ++ " hash=" ++ short8 curHash
@@ -1288,8 +1342,87 @@ readModuleTask sp gopts opts paths actFile = do
         then do
           when (currentSourceMeta /= Nothing && currentSourceMeta /= cachedSourceMeta) $
             refreshCachedSourceMeta currentSourceMeta
-          return (mkTyTask mn moduleSrcBytesHash modulePubHash moduleImplHash imps nameHashes roots tests mdoc)
-        else parseFromSnapshot mn snap
+          return (mkTyHead mn moduleSrcBytesHash modulePubHash moduleImplHash imps nameHashes roots tests mdoc)
+        else sourceHeadFromSnapshot mn snap
+
+-- | Prepare a task for dependency graph construction.
+-- The full source parse is deferred for modules whose .ty header cannot be
+-- reused, but discovery still gets accurate imports from the source header.
+readModuleTask :: Source.SourceProvider -> C.GlobalOptions -> C.CompileOptions -> Paths -> String -> IO CompileTask
+readModuleTask sp gopts opts paths actFile = do
+  h <- readModuleHeader sp gopts opts paths actFile
+  return $ case h of
+    TyHead{ mhName = mn
+          , mhSrcHash = srcHash
+          , mhPubHash = pubHash
+          , mhImplHash = implHash
+          , mhTyImports = imps
+          , mhNameHashes = nameHashes
+          , mhRoots = roots
+          , mhTests = tests
+          , mhDoc = mdoc
+          } ->
+      let nmodStub = I.NModule [] mdoc
+          tmodStub = A.Module mn [] mdoc []
+      in TyTask { name      = mn
+                , tyHash     = srcHash
+                , tyPubHash  = pubHash
+                , tyImplHash = implHash
+                , tyImports  = imps
+                , tyNameHashes = nameHashes
+                , tyRoots   = roots
+                , tyTests   = tests
+                , tyDoc     = mdoc
+                , iface     = nmodStub
+                , typed     = tmodStub }
+    SrcHead{ mhName = mn
+           , mhSrc = srcContent
+           , mhBytes = bytes
+           , mhSourceMeta = mSourceMeta
+           , mhSrcImports = imps
+           } ->
+      ParseTask mn srcContent bytes mSourceMeta imps
+    HeadError{ mhName = mn, mhDiagnostics = diags } ->
+      ParseErrorTask mn diags
+
+readModuleDoc :: Source.SourceProvider
+              -> C.GlobalOptions
+              -> C.CompileOptions
+              -> Paths
+              -> String
+              -> IO (Maybe (A.ModName, Maybe String))
+readModuleDoc sp gopts opts paths actFile = do
+  h <- readModuleHeader sp gopts opts paths actFile
+  return $ case h of
+    TyHead{ mhName = mn, mhDoc = mdoc } -> Just (mn, mdoc)
+    SrcHead{ mhName = mn, mhDoc = mdoc } -> Just (mn, mdoc)
+    HeadError{} -> Nothing
+
+-- | Materialize a source-backed task into a fully parsed ActonTask.
+-- ParseTask reuses the snapshot captured during graph discovery; TyTask reparses
+-- from the current source file because the cached header was deemed stale.
+materializeTask :: Source.SourceProvider -> A.ModName -> FilePath -> CompileTask -> IO CompileTask
+materializeTask sp mn actFile task =
+  case task of
+    ActonTask{} -> return task
+    ParseErrorTask{} -> return task
+    ParseTask{ src = srcContent, srcBytes = bytes, sourceMeta = mSourceMeta } -> do
+      emod <- parseStoredSource mn actFile srcContent
+      case emod of
+        Left diags -> return (ParseErrorTask mn diags)
+        Right m -> return (ActonTask mn srcContent bytes mSourceMeta m)
+    TyTask{} -> do
+      parsedRes <- parseActFile sp mn actFile
+      case parsedRes of
+        Left diags -> return (ParseErrorTask mn diags)
+        Right (snap, m) -> do
+          mSourceMeta <- if Source.ssIsOverlay snap then return Nothing else Just <$> readSourceFileMeta actFile
+          return $ ActonTask mn (Source.ssText snap) (Source.ssBytes snap) mSourceMeta m
+  where
+    parseStoredSource mn' file srcContent = do
+      cwd <- getCurrentDirectory
+      let displayFile = makeRelative cwd file
+      parseActSource mn' displayFile srcContent
 
 
 -- | Recursively read imports for a set of tasks within the same project.
@@ -1832,6 +1965,8 @@ runBackPasses gopts opts paths backInput shouldWrite = do
 --   - TyTask is lightweight, read from the .ty header: moduleSrcBytesHash, modulePubHash,
 --     moduleImplHash, imports annotated with the pub hash used, per-name hashes (src/pub/impl
 --     + deps), roots, tests, and docstring. It avoids decoding heavy sections.
+--   - ParseTask carries source text plus discovered imports; full parsing is
+--     deferred until front passes are needed.
 --   - ActonTask carries parsed source and must be compiled.
 --   - pubMap :: Map TaskKey ByteString and nameMap :: Map TaskKey (Map Name NameHashInfo) are
 --     maintained during the run. TyTask compares recorded dependency hashes against current
@@ -1887,7 +2022,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
       nCaps <- getNumCapabilities
       let maxParallel = max 1 (if C.jobs gopts > 0 then C.jobs gopts else nCaps)
 
-      (envFinal, hadErrors) <- loop runningRef initialReady [] M.empty M.empty indeg pending0 baseEnv False maxParallel cwMap
+      (envFinal, hadErrors) <- loop runningRef stageInitialReady [] M.empty M.empty M.empty stageIndeg stagePending0 baseEnv False maxParallel cwMap
       return (Right (envFinal, hadErrors))
 
     -- Basic maps/sets ----------------------------------------------------
@@ -1911,11 +2046,48 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
     depMap :: M.Map TaskKey [TaskKey]
     depMap = M.fromList [ (gtKey t, depsOf t) | t <- order ]
     indeg  = M.map length depMap
-    initialReady = [ k | (k,d) <- M.toList indeg, d == 0 ]
-    pending0 = Data.Set.fromList (M.keys indeg)
 
     depOpts = opts { C.skip_build = True, C.test = False }
     optsFor k = if tkProj k == rootProj then opts else depOpts
+
+    needsParseStage t =
+      case gtTask t of
+        ParseTask{} -> not (C.only_build (optsFor (gtKey t)))
+        _ -> False
+
+    stageDepsOf t =
+      let k = gtKey t
+          parseDeps = [ParseStage k | needsParseStage t]
+          frontDeps = map FrontStage (depsOf t)
+      in (parseDeps ++ frontDeps)
+
+    stageDepMap :: M.Map StageKey [StageKey]
+    stageDepMap =
+      M.fromList $
+        [ (ParseStage (gtKey t), [])
+        | t <- order
+        , needsParseStage t
+        ] ++
+        [ (FrontStage (gtKey t), stageDepsOf t)
+        | t <- order
+        ]
+
+    stageRevMap :: M.Map StageKey [StageKey]
+    stageRevMap =
+      foldl'
+        (\acc (k, ds) -> foldl' (\a d -> M.insertWith (++) d [k] a) acc ds)
+        M.empty
+        (M.toList stageDepMap)
+
+    stageIndeg :: M.Map StageKey Int
+    stageIndeg = M.map length stageDepMap
+
+    stageInitialReady :: [StageKey]
+    stageInitialReady = [ k | (k, d) <- M.toList stageIndeg, d == 0 ]
+
+    stagePending0 :: Data.Set.Set StageKey
+    stagePending0 = Data.Set.fromList (M.keys stageIndeg)
+
     rootAlt = modName rootPaths
 
     builtinPath =
@@ -1960,19 +2132,15 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
         then return (Right ())
         else do
           t' <- case gtTask t of
-            TyTask{} | forceAlt -> do
-              parsedRes <- parseActFile sp mn actFile
-              case parsedRes of
-                Left diags -> return (ParseErrorTask mn diags)
-                Right (snap, m) -> do
-                  mSourceMeta <- if Source.ssIsOverlay snap then return Nothing else Just <$> readSourceFileMeta actFile
-                  return $ ActonTask mn (Source.ssText snap) (Source.ssBytes snap) mSourceMeta m
+            TyTask{} | forceAlt -> materializeTask sp mn actFile (gtTask t)
+            ParseTask{} -> materializeTask sp mn actFile (gtTask t)
             _ -> return (gtTask t)
           case t' of
             ParseErrorTask{ parseDiagnostics = diags } -> do
               ccOnDiagnostics callbacks t optsBuiltin diags
               return (Left CompileBuiltinFailure)
             TyTask{} -> return (Right ())
+            ParseTask{} -> error ("Internal error: unmaterialized ParseTask " ++ modNameToString mn)
             ActonTask{ src = srcContent, srcBytes = srcBytes, sourceMeta = mSourceMeta, atree = m } -> do
               ccOnFrontStart callbacks t optsBuiltin
               builtinEnv0 <- Acton.Env.initEnv (projTypes bPaths) True
@@ -2005,13 +2173,15 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
     doOne :: Acton.Env.Env0
           -> M.Map TaskKey B.ByteString
           -> M.Map TaskKey (M.Map A.Name InterfaceFiles.NameHashInfo)
+          -> M.Map TaskKey CompileTask
           -> TaskKey
           -> IO (TaskKey, Either [Diagnostic String] FrontResult)
-    doOne envSnap pubMap nameMap key = do
+    doOne envSnap pubMap nameMap parsedTasks key = do
       t <- case M.lookup key taskMap of
              Just x -> return x
              Nothing -> error ("Internal error: missing task for key " ++ show key)
-      let paths = gtPaths t
+      let taskCurrent = M.findWithDefault (gtTask t) key parsedTasks
+          paths = gtPaths t
           mn    = name (gtTask t)
           optsT = optsFor key
           providers = gtImportProviders t
@@ -2256,15 +2426,16 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
                 in (deltas, missing))
               resolved)
 
-      case gtTask t of
+      case taskCurrent of
         ParseErrorTask{ parseDiagnostics = diags } -> return (key, Left diags)
         _ | C.only_build optsT -> do
-              ifaceRes <- case gtTask t of
+              ifaceRes <- case taskCurrent of
                             TyTask{ tyPubHash = h } -> readIfaceFromTy paths mn "" (Just h)
+                            ParseTask{ src = srcContent } -> readIfaceFromTy paths mn srcContent Nothing
                             ActonTask{ src = srcContent } -> readIfaceFromTy paths mn srcContent Nothing
               case ifaceRes of
                 Right (ifaceTE, mdoc, ih) -> do
-                  let cachedNameHashes = case gtTask t of
+                  let cachedNameHashes = case taskCurrent of
                         TyTask{ tyNameHashes = nhs } -> nhs
                         _ -> []
                       fr = mkFrontResult ifaceTE mdoc ih cachedNameHashes Nothing
@@ -2277,7 +2448,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
           -- any implDeps have changed we need to rerun out back passes and if
           -- any pubDeps have changed we need to rerun front passes (and back
           -- passes)
-          needByDepsRes <- case gtTask t of
+          needByDepsRes <- case taskCurrent of
             TyTask{ tyImports = imps, tyNameHashes = nameHashes } -> do
               missingImportsRes <- checkMissingImports imps
               case missingImportsRes of
@@ -2302,7 +2473,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
           case needByDepsRes of
             Left diags -> return (key, Left diags)
             Right (pubDeltas, implDeltas, pubMissing, implMissing, pubUsers, implUsers) -> do
-              let needBySource = case gtTask t of { ActonTask{} -> True; _ -> False }
+              let needBySource = case taskCurrent of { ParseTask{} -> True; ActonTask{} -> True; _ -> False }
                   -- Public deltas require front passes; impl deltas only need back jobs.
                   needByPub = not (null pubDeltas)
                   needByMissing = not (null pubMissing) || not (null implMissing)
@@ -2311,7 +2482,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
                   forceAlways = C.alwaysbuild optsT
                   -- Front passes run on source or API changes, or when forced.
                   needFront = needBySource || needByPub || needByMissing || forceAlt || forceAlways
-                  mModuleImplHash = case gtTask t of
+                  mModuleImplHash = case taskCurrent of
                     TyTask{ tyImplHash = implHash } -> Just implHash
                     _ -> Nothing
               let canCheckCodegen = not needFront && not needByImpl && not (altOutput optsT)
@@ -2321,7 +2492,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
               let needByCodegen = maybe False (not . codegenUpToDate) mCodegenStatus
               let runFront = do
                     prevNameHashes <- if C.verbose gopts
-                      then case gtTask t of
+                      then case taskCurrent of
                         TyTask{ tyNameHashes = nhs } -> return (Just (nameHashMapFromList nhs))
                         _ -> getNameHashMapCached paths mn
                       else return Nothing
@@ -2343,15 +2514,9 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
                                   | qn <- Data.List.sortOn Hashing.qnameKey implMissing
                                   ]
                             ccOnInfo callbacks ("  Stale " ++ modNameToString mn ++ ": missing dep hashes in " ++ Data.List.intercalate ", " (pubMissingItems ++ implMissingItems))
-                    t' <- case gtTask t of
-                            ActonTask{} -> return (gtTask t)
-                            TyTask{}    -> do
-                              parsedRes <- parseActFile sp mn actFile
-                              case parsedRes of
-                                Left diags -> return (ParseErrorTask mn diags)
-                                Right (snap, m) -> do
-                                  mSourceMeta <- if Source.ssIsOverlay snap then return Nothing else Just <$> readSourceFileMeta actFile
-                                  return $ ActonTask mn (Source.ssText snap) (Source.ssBytes snap) mSourceMeta m
+                    t' <- case taskCurrent of
+                            ActonTask{} -> return taskCurrent
+                            _ -> materializeTask sp mn actFile taskCurrent
                     case t' of
                       ParseErrorTask{ parseDiagnostics = diags } -> return (key, Left diags)
                       ActonTask{ src = srcContent, srcBytes = srcBytes, sourceMeta = mSourceMeta, atree = m } -> do
@@ -2375,6 +2540,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
                                 forM_ (nameHashSummary prevMap (frNameHashes fr)) $ \summary ->
                                   ccOnInfo callbacks ("  Hash deltas " ++ modNameToString mn ++ ": " ++ summary)
                             cacheFrontResult fr
+                      ParseTask{} -> error ("Internal error: unmaterialized ParseTask " ++ modNameToString mn)
                       _ -> error ("Internal error: unexpected task " ++ show t')
                   runImplRefresh = do
                     let rerunFront = do
@@ -2458,13 +2624,13 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
                   runReuse = do
                     when (C.verbose gopts) $
                       ccOnInfo callbacks ("  Fresh " ++ modNameToString mn ++ ": using cached .ty")
-                    ifaceRes <- case gtTask t of
+                    ifaceRes <- case taskCurrent of
                                   TyTask{ tyPubHash = h } -> readIfaceFromTy paths mn "" (Just h)
                                   _ -> readIfaceFromTy paths mn "" Nothing
                     case ifaceRes of
                       Left diags -> return (key, Left diags)
                       Right (ifaceTE, mdoc, ih) -> do
-                        let cachedNameHashes = case gtTask t of
+                        let cachedNameHashes = case taskCurrent of
                               TyTask{ tyNameHashes = nhs } -> nhs
                               _ -> []
                             fr = mkFrontResult ifaceTE mdoc ih cachedNameHashes Nothing
@@ -2475,41 +2641,98 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
                 _ | needByCodegen -> runCodegenRefresh
                 _ -> runReuse
 
-    scheduleMore :: Int -> [TaskKey]
-                 -> [(Async (TaskKey, Either [Diagnostic String] FrontResult), TaskKey)]
+    stageTaskKey :: StageKey -> TaskKey
+    stageTaskKey sk =
+      case sk of
+        ParseStage k -> k
+        FrontStage k -> k
+
+    stagePriority :: M.Map TaskKey Integer -> StageKey -> (Int, Integer)
+    stagePriority cw sk =
+      let phase = case sk of
+                    FrontStage _ -> 1
+                    ParseStage _ -> 0
+      in (phase, M.findWithDefault 0 (stageTaskKey sk) cw)
+
+    runParseStage :: TaskKey -> IO (StageKey, Either [Diagnostic String] StageSuccess)
+    runParseStage key = do
+      t <- case M.lookup key taskMap of
+             Just x -> return x
+             Nothing -> error ("Internal error: missing task for key " ++ show key)
+      let optsT = optsFor key
+          mn = name (gtTask t)
+          actFile = srcFile (gtPaths t) mn
+      timeStart <- getTime Monotonic
+      parsed <- if C.only_build optsT
+                  then return (gtTask t)
+                  else case gtTask t of
+                         ParseTask{} -> materializeTask sp mn actFile (gtTask t)
+                         _ -> return (gtTask t)
+      case parsed of
+        ParseTask{} -> return (ParseStage key, Right (StageParsed parsed Nothing))
+        ActonTask{ atree = m } -> do
+          _ <- evaluate (rnf m)
+          timeEnd <- getTime Monotonic
+          let parseTime = if not (quiet gopts optsT) then Just (timeEnd - timeStart) else Nothing
+          return (ParseStage key, Right (StageParsed parsed parseTime))
+        ParseErrorTask{} -> return (ParseStage key, Right (StageParsed parsed Nothing))
+        _ -> error ("Internal error: parse stage did not materialize " ++ modNameToString mn)
+
+    runFrontStage :: Acton.Env.Env0
+                  -> M.Map TaskKey B.ByteString
+                  -> M.Map TaskKey (M.Map A.Name InterfaceFiles.NameHashInfo)
+                  -> M.Map TaskKey CompileTask
+                  -> TaskKey
+                  -> IO (StageKey, Either [Diagnostic String] StageSuccess)
+    runFrontStage envSnap res nameRes parsedTasks key = do
+      (doneKey, outcome) <- doOne envSnap res nameRes parsedTasks key
+      return (FrontStage doneKey, fmap StageFronted outcome)
+
+    scheduleMore :: Int -> [StageKey]
+                 -> [(Async (StageKey, Either [Diagnostic String] StageSuccess), StageKey)]
                  -> M.Map TaskKey B.ByteString
                  -> M.Map TaskKey (M.Map A.Name InterfaceFiles.NameHashInfo)
+                 -> M.Map TaskKey CompileTask
                  -> Acton.Env.Env0
                  -> M.Map TaskKey Integer
-                 -> IO ([TaskKey]
-                       , [(Async (TaskKey, Either [Diagnostic String] FrontResult), TaskKey)])
-    scheduleMore k rdy running res nameRes envSnap cw = do
-      let prio m = M.findWithDefault 0 m cw
-          rdySorted = Data.List.sortOn (Down . prio) rdy
+                 -> IO ([StageKey]
+                       , [(Async (StageKey, Either [Diagnostic String] StageSuccess), StageKey)])
+    scheduleMore k rdy running res nameRes parsedTasks envSnap cw = do
+      let rdySorted = Data.List.sortOn (Down . stagePriority cw) rdy
           (toStart, rdy') = splitAt k rdySorted
-      new <- forM toStart $ \mn -> do
-                case M.lookup mn taskMap of
-                  Just t -> ccOnFrontStart callbacks t (optsFor mn)
-                  Nothing -> return ()
-                a <- async (doOne envSnap res nameRes mn)
-                return (a, mn)
+      new <- forM toStart $ \sk -> do
+                case sk of
+                  FrontStage key ->
+                    case M.lookup key taskMap of
+                      Just t -> ccOnFrontStart callbacks t (optsFor key)
+                      Nothing -> return ()
+                  ParseStage key ->
+                    case M.lookup key taskMap of
+                      Just t -> ccOnParseStart callbacks t (optsFor key)
+                      Nothing -> return ()
+                a <- async $
+                  case sk of
+                    ParseStage key -> runParseStage key
+                    FrontStage key -> runFrontStage envSnap res nameRes parsedTasks key
+                return (a, sk)
       return (rdy', new ++ running)
 
-    loop :: IORef [Async (TaskKey, Either [Diagnostic String] FrontResult)]
-         -> [TaskKey]
-         -> [(Async (TaskKey, Either [Diagnostic String] FrontResult), TaskKey)]
+    loop :: IORef [Async (StageKey, Either [Diagnostic String] StageSuccess)]
+         -> [StageKey]
+         -> [(Async (StageKey, Either [Diagnostic String] StageSuccess), StageKey)]
          -> M.Map TaskKey B.ByteString
          -> M.Map TaskKey (M.Map A.Name InterfaceFiles.NameHashInfo)
-         -> M.Map TaskKey Int
-         -> Data.Set.Set TaskKey
+         -> M.Map TaskKey CompileTask
+         -> M.Map StageKey Int
+         -> Data.Set.Set StageKey
          -> Acton.Env.Env0
          -> Bool
          -> Int
          -> M.Map TaskKey Integer
          -> IO (Acton.Env.Env0, Bool)
-    loop runningRef rdy running res nameRes ind pend envAcc hadErrors maxPar cw = do
+    loop runningRef rdy running res nameRes parsedTasks ind pend envAcc hadErrors maxPar cw = do
       (rdy1, running1) <- mask_ $ do
-        res@(rdy1', running1') <- scheduleMore (maxPar - length running) rdy running res nameRes envAcc cw
+        res@(rdy1', running1') <- scheduleMore (maxPar - length running) rdy running res nameRes parsedTasks envAcc cw
         writeIORef runningRef (map fst running1')
         return res
       if null running1 && null rdy1
@@ -2519,36 +2742,57 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
                  return (envAcc, hadErrors)
                else return (envAcc, True)
         else do
-          (doneA, (mnDone, outcome)) <- waitAny $ map fst running1
+          (doneA, (stageDone, outcome)) <- waitAny $ map fst running1
           let running2 = filter ((/= doneA) . fst) running1
           writeIORef runningRef (map fst running2)
-          let tDone = taskMap M.! mnDone
-              optsDone = optsFor mnDone
-          ccOnFrontDone callbacks tDone optsDone
+          let keyDone = stageTaskKey stageDone
+              tDone = taskMap M.! keyDone
+              optsDone = optsFor keyDone
           case outcome of
             Left diags -> do
+              case stageDone of
+                FrontStage _ -> ccOnFrontDone callbacks tDone optsDone
+                ParseStage _ -> ccOnParseDone callbacks tDone optsDone Nothing
               ccOnDiagnostics callbacks tDone optsDone diags
-              let blocked = dependentClosure mnDone
-                  pend2 = Data.Set.delete mnDone (pend `Data.Set.difference` blocked)
-                  rdy2 = filter (`Data.Set.notMember` blocked) rdy1
-              loop runningRef rdy2 running2 res nameRes ind pend2 envAcc True maxPar cw
-            Right fr -> do
-              ccOnFrontResult callbacks tDone optsDone fr
-              forM_ (frBackJob fr) $ ccOnBackJob callbacks
-              let res2  = M.insert mnDone (frPubHash fr) res
-                  nameRes2 = M.insert mnDone (nameHashMapFromList (frNameHashes fr)) nameRes
-                  pend2 = Data.Set.delete mnDone pend
-                  ind2  = case M.lookup mnDone revMap of
+              let blockedMods = dependentClosure keyDone
+                  blockedStages =
+                    Data.Set.fromList $
+                      concatMap (\m -> [ParseStage m, FrontStage m]) (Data.Set.toList blockedMods)
+                  (blockedRunning, running3) =
+                    partition (\(_, sk) -> Data.Set.member sk blockedStages) running2
+              mapM_ (cancel . fst) blockedRunning
+              writeIORef runningRef (map fst running3)
+              let pend2 = Data.Set.delete stageDone (pend `Data.Set.difference` blockedStages)
+                  rdy2 = filter (`Data.Set.notMember` blockedStages) rdy1
+                  dropKeys = keyDone : Data.Set.toList blockedMods
+                  parsedTasks2 = foldl' (flip M.delete) parsedTasks dropKeys
+              loop runningRef rdy2 running3 res nameRes parsedTasks2 ind pend2 envAcc True maxPar cw
+            Right success -> do
+              let pend2 = Data.Set.delete stageDone pend
+                  ind2  = case M.lookup stageDone stageRevMap of
                             Nothing -> ind
                             Just ds -> foldl' (\m d -> M.adjust (\x -> x-1) d m) ind ds
-                  newlyReady = [ m | m <- Data.Set.toList pend2
-                                   , M.findWithDefault 0 m ind2 == 0
-                                   , not (m `elem` rdy1)
-                                   , not (m `elem` map snd running2)
-                                   ]
+                  runningKeys = map snd running2
+                  newlyReady = [ sk | sk <- Data.Set.toList pend2
+                                    , M.findWithDefault 0 sk ind2 == 0
+                                    , not (sk `elem` rdy1)
+                                    , not (sk `elem` runningKeys)
+                                    ]
                   rdy2 = rdy1 ++ newlyReady
-                  envAcc' = Acton.Env.addMod (tkMod mnDone) (frIfaceTE fr) (frDoc fr) envAcc
-              loop runningRef rdy2 running2 res2 nameRes2 ind2 pend2 envAcc' hadErrors maxPar cw
+              case success of
+                StageParsed parsed mParseTime -> do
+                  ccOnParseDone callbacks tDone optsDone mParseTime
+                  let parsedTasks2 = M.insert keyDone parsed parsedTasks
+                  loop runningRef rdy2 running2 res nameRes parsedTasks2 ind2 pend2 envAcc hadErrors maxPar cw
+                StageFronted fr -> do
+                  ccOnFrontDone callbacks tDone optsDone
+                  ccOnFrontResult callbacks tDone optsDone fr
+                  forM_ (frBackJob fr) $ ccOnBackJob callbacks
+                  let res2  = M.insert keyDone (frPubHash fr) res
+                      nameRes2 = M.insert keyDone (nameHashMapFromList (frNameHashes fr)) nameRes
+                      parsedTasks2 = M.delete keyDone parsedTasks
+                      envAcc' = Acton.Env.addMod (tkMod keyDone) (frIfaceTE fr) (frDoc fr) envAcc
+                  loop runningRef rdy2 running2 res2 nameRes2 parsedTasks2 ind2 pend2 envAcc' hadErrors maxPar cw
 
 
 -- | Execute back-pass jobs in parallel while keeping output order stable.

--- a/compiler/lib/src/Acton/Parser.hs
+++ b/compiler/lib/src/Acton/Parser.hs
@@ -124,6 +124,18 @@ parseModule qn fileName fileContent =
         Left err -> Control.Exception.throw err
         Right (i,mdoc,s) -> return $ S.Module qn i mdoc s
 
+parseModuleImports :: String -> String -> IO [S.Import]
+parseModuleImports fileName fileContent = fst <$> parseModuleHeader fileName fileContent
+
+parseModuleHeader :: String -> String -> IO ([S.Import], Maybe String)
+parseModuleHeader fileName fileContent =
+    let contentWithNewline = if null fileContent || last fileContent == '\n'
+                             then fileContent
+                             else fileContent ++ "\n"
+    in case runParser (St.evalStateT import_input initState) fileName contentWithNewline of
+        Left err -> Control.Exception.throw err
+        Right res -> return res
+
 -- parseTest file = snd (unsafePerformIO (do cont <- readFile file; parseModule (S.modName ["test"]) file cont))
 
 parseTestStr p str = case runParser (St.evalStateT p initState) "" str of
@@ -1082,6 +1094,12 @@ file_input = sc2 *>  do
     return (is, mbDocstring, s)
 
 -- (((,) <$> imports <*> withCtx TOP top_suite) <* eof)
+
+import_input :: Parser ([S.Import], Maybe String)
+import_input = sc2 *> do
+    mbDocstring <- optional (try (L.nonIndented sc2 module_docstring <* eol <* sc2))
+    is <- imports
+    return (is, mbDocstring)
 
 imports :: Parser [S.Import]
 imports = many (L.nonIndented sc2 import_stmt <* eol <* sc2)


### PR DESCRIPTION
Modules without a usable .ty were fully parsed during task planning. The planner only needs the module header to build the dependency graph, so parsing entire source files up front made discovery expensive and left large builds sitting before progress reporting could start.

This change makes the parser expose the cheap module header, including imports and the module docstring. readModuleTask converts that header state into ParseTask when the cached .ty cannot be trusted, and compileTasks materializes the source only when front passes are actually needed.

The documentation index now consumes the same header reader through a dedicated readModuleDoc path instead of matching on CompileTask. That keeps the docs pass independent of scheduler variants while still using cached .ty docstrings when they are valid and source header docstrings when they are not.

This preserves discovery correctness because import resolution sees the same module graph and any source-backed module is fully parsed before later compiler passes depend on its AST. Stale or missing cached headers no longer force a full parse during planning, and non-compile consumers do not need to know about ParseTask.