### PR TITLE
Restore Zig dist target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ endif
 BUILTIN_HFILES=$(wildcard base/builtin/*.h)
 
 DIST_BINS=$(ACTONC) dist/bin/actondb dist/bin/runacton dist/bin/lsp-server-acton
-DIST_ZIG=$(ZIG)
+DIST_ZIG=dist/zig
 
 .PHONY: test-backend
 test-backend: $(BACKEND_TESTS)
@@ -434,14 +434,11 @@ dist/completion/acton.bash-completion: completion/acton.bash-completion
 	mkdir -p "$(dir $@)"
 	cp "$<" "$@"
 
-$(ZIG): deps-download/zig-$(ARCH)-$(OS)-$(ZIG_VERSION).tar.xz
-	mkdir -p "$(dir $@)"
-	cd "$(dir $@)" && tar Jx --strip-components=1 -f "../../$<"
-	rm -rf "$(dir $@)/doc"
-	cp -a deps/zig-extras/* "$(dir $@)"
-
-.PHONY: dist/zig
-dist/zig: $(ZIG)
+dist/zig: deps-download/zig-$(ARCH)-$(OS)-$(ZIG_VERSION).tar.xz
+	mkdir -p "$@"
+	cd "$@" && tar Jx --strip-components=1 -f "../../$^"
+	rm -rf "$@/doc"
+	cp -a deps/zig-extras/* "$@"
 
 
 # Check if ZIG_VERSION contains -dev, in which case we pull down a nightly,


### PR DESCRIPTION
The Zig extraction rule was changed to build the dist/zig/zig binary directly. That made make compare the downloaded tarball against the executable timestamp restored from the archive, so the target could appear stale on every invocation after the tarball was downloaded.

Use the dist/zig directory as the distribution target again. Its timestamp reflects the local extraction, while the ZIG variable still points callers at the executable inside that directory.