### PR TITLE
Add 'acton sig'

### DIFF
--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -122,6 +122,7 @@ main = do
               in if null files
                  then buildProject gopts opts
                  else buildFiles gopts opts files
+          C.CmdOpt gopts (C.Sig opts)          -> sigCommand gopts opts
           C.CmdOpt gopts (C.Test tcmd)        -> runTests gopts tcmd
           C.CmdOpt gopts C.Fetch             -> fetchCommand gopts
           C.CmdOpt gopts C.PkgShow           -> pkgShow gopts
@@ -932,6 +933,182 @@ fetchCommand gopts = do
       Right () ->
         unless (C.quiet gopts) $
           putStrLn "Dependencies fetched"
+
+data SigTarget
+    = SigSourceTarget ProjCtx A.ModName (Maybe A.Name) FilePath
+    | SigTyTarget A.ModName (Maybe A.Name) FilePath
+
+sigCommand :: C.GlobalOptions -> C.SigOptions -> IO ()
+sigCommand gopts sigOpts = do
+    let opts0 = (C.sigCompile sigOpts)
+          { C.skip_build = True
+          , C.only_build = False
+          , C.sigs = False
+          }
+        queryGopts = if C.verbose gopts then gopts else gopts { C.quiet = True }
+    paths0 <- loadProjectPaths opts0
+    depOverrides <- normalizeDepOverrides (projPath paths0) (C.dep_overrides opts0)
+    let opts = opts0 { C.dep_overrides = depOverrides }
+    paths <- loadProjectPaths opts
+    rootProj <- normalizePathSafe (projPath paths)
+    sysAbs <- normalizePathSafe (sysPath paths)
+    withProjectLockNotice queryGopts rootProj $ do
+      fetchDependencies queryGopts paths depOverrides
+      projMap <- discoverProjects queryGopts sysAbs rootProj depOverrides
+      target <- resolveSigTarget opts paths rootProj projMap (C.sigTarget sigOpts)
+      tyFile <- case target of
+        SigSourceTarget ctx mn _ srcPath ->
+          compileSigTarget gopts queryGopts opts paths rootProj sysAbs depOverrides ctx mn srcPath
+        SigTyTarget _ _ tyPath ->
+          return tyPath
+      case target of
+        SigSourceTarget _ mn mName _ -> printSigInterface paths mn mName tyFile
+        SigTyTarget mn mName _       -> printSigInterface paths mn mName tyFile
+
+compileSigTarget :: C.GlobalOptions
+                 -> C.GlobalOptions
+                 -> C.CompileOptions
+                 -> Paths
+                 -> FilePath
+                 -> FilePath
+                 -> [(String, FilePath)]
+                 -> ProjCtx
+                 -> A.ModName
+                 -> FilePath
+                 -> IO FilePath
+compileSigTarget gopts queryGopts opts paths rootProj sysAbs depOverrides targetCtx mn srcPath = do
+    buildStamp <- readBuildSpecStamp (projPath paths)
+    let sp = Source.diskSourceProvider
+        cctx = CompileContext
+          { ccOpts = opts
+          , ccDepOverrides = depOverrides
+          , ccPathsRoot = paths
+          , ccRootProj = rootProj
+          , ccSysAbs = sysAbs
+          , ccBuildStamp = buildStamp
+          }
+    plan <- prepareCompilePlanFromContext sp queryGopts cctx [srcPath] False Nothing
+    let cctx' = cpContext plan
+        opts' = ccOpts cctx'
+        callbacks = defaultCompileCallbacks
+          { ccOnDiagnostics = \_ optsT diags -> printDiagnostics gopts optsT diags
+          , ccOnInfo = \msg -> when (C.verbose gopts) $ putStrLn msg
+          , ccOnBackJob = \_ -> return ()
+          }
+    compileRes <- compileTasks sp queryGopts opts' (ccPathsRoot cctx') (ccRootProj cctx') (cpNeededTasks plan) callbacks
+    case compileRes of
+      Left err -> printErrorAndExit (compileFailureMessage err)
+      Right (_, hadErrors) -> when hadErrors System.Exit.exitFailure
+    let targetCtx' = case M.lookup (projRoot targetCtx) (cpProjMap plan) of
+                       Just ctx -> ctx
+                       Nothing  -> targetCtx
+    targetPaths <- pathsForModule opts' (cpProjMap plan) targetCtx' mn
+    return (outBase targetPaths mn ++ ".ty")
+
+resolveSigTarget :: C.CompileOptions -> Paths -> FilePath -> M.Map FilePath ProjCtx -> String -> IO SigTarget
+resolveSigTarget opts paths rootProj projMap rawTarget = do
+    parts <- parseSigTarget rawTarget
+    moduleIndex <- sigModuleIndex projMap rootProj
+    let fullMod = A.modName parts
+    case lookup fullMod moduleIndex of
+      Just (ctx, srcPath) ->
+        return (SigSourceTarget ctx fullMod Nothing srcPath)
+      Nothing -> do
+        mFullTy <- findSigTyFile tySearchPath fullMod
+        case mFullTy of
+          Just tyPath ->
+            return (SigTyTarget fullMod Nothing tyPath)
+          Nothing ->
+            resolveNameTarget parts moduleIndex
+  where
+    tySearchPath = sigTySearchPath opts paths rootProj projMap
+
+    resolveNameTarget parts moduleIndex
+      | length parts < 2 =
+          printErrorAndExit ("Module not found: " ++ rawTarget)
+      | otherwise = do
+          let modParts = init parts
+              namePart = last parts
+              mn = A.modName modParts
+              n = A.name namePart
+          case lookup mn moduleIndex of
+            Just (ctx, srcPath) ->
+              return (SigSourceTarget ctx mn (Just n) srcPath)
+            Nothing -> do
+              mTy <- findSigTyFile tySearchPath mn
+              case mTy of
+                Just tyPath ->
+                  return (SigTyTarget mn (Just n) tyPath)
+                Nothing ->
+                  printErrorAndExit ("Module not found: " ++ intercalate "." modParts
+                                     ++ " (while resolving " ++ rawTarget ++ ")")
+
+parseSigTarget :: String -> IO [String]
+parseSigTarget rawTarget = do
+    let parts = splitOn "." rawTarget
+    if null rawTarget || any null parts
+      then printErrorAndExit ("Invalid signature target: " ++ rawTarget)
+      else return parts
+
+sigModuleIndex :: M.Map FilePath ProjCtx -> FilePath -> IO [(A.ModName, (ProjCtx, FilePath))]
+sigModuleIndex projMap rootProj = do
+    let roots = sigProjectSearchOrder projMap rootProj
+    fmap concat $ forM roots $ \root ->
+      case M.lookup root projMap of
+        Nothing -> return []
+        Just ctx -> do
+          mods <- enumerateProjectModules ctx
+          return [ (mn, (ctx, srcPath)) | (srcPath, mn) <- mods ]
+
+sigProjectSearchOrder :: M.Map FilePath ProjCtx -> FilePath -> [FilePath]
+sigProjectSearchOrder projMap rootProj =
+    rootProj : snd (go (Data.Set.singleton rootProj) rootProj)
+  where
+    go seen root =
+      case M.lookup root projMap of
+        Nothing -> (seen, [])
+        Just ctx -> foldl' step (seen, []) (projDeps ctx)
+
+    step (seen, acc) (_, depRoot)
+      | Data.Set.member depRoot seen = (seen, acc)
+      | otherwise =
+          let seen' = Data.Set.insert depRoot seen
+              (seenNext, sub) = go seen' depRoot
+          in (seenNext, acc ++ [depRoot] ++ sub)
+
+sigTySearchPath :: C.CompileOptions -> Paths -> FilePath -> M.Map FilePath ProjCtx -> [FilePath]
+sigTySearchPath opts paths rootProj projMap =
+    case M.lookup rootProj projMap of
+      Just rootCtx -> searchPathForProject opts projMap rootCtx
+      Nothing      -> searchPath paths
+
+findSigTyFile :: [FilePath] -> A.ModName -> IO (Maybe FilePath)
+findSigTyFile = Acton.Env.findTyFile
+
+printSigInterface :: Paths -> A.ModName -> Maybe A.Name -> FilePath -> IO ()
+printSigInterface paths mn mName tyFile = do
+    exists <- doesFileExist tyFile
+    unless exists $
+      printErrorAndExit ("Type interface not found for " ++ modNameToString mn)
+    tyRes <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readFile tyFile
+    case tyRes of
+      Left err ->
+        printErrorAndExit ("Could not read type interface for " ++ modNameToString mn ++ ": " ++ show err)
+      Right (ms, nmod, _, _, _, _, _, _, _, _, _, _) -> do
+        env0 <- Acton.Env.initEnv (sysTypes paths) False
+        let I.NModule te _ = nmod
+            envImports = foldr Acton.Env.addImport env0 ms
+            selected = case mName of
+              Nothing -> te
+              Just n  -> filter ((== n) . fst) te
+            envForPrint = case mName of
+              Nothing -> envImports
+              Just _  -> define te (setMod mn envImports)
+        case mName of
+          Just n | null selected ->
+            printErrorAndExit ("Public name not found: " ++ modNameToString mn ++ "." ++ nameToString n)
+          _ ->
+            putStrLn (Acton.Types.prettySigs envForPrint mn selected)
 
 -- Show dependency tree with overrides applied from root pins
 pkgShow :: C.GlobalOptions -> IO ()

--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -448,6 +448,83 @@ parseFlagTests =
       assertBool "help text should include --release" ("--release" `isInfixOf` helpText)
       assertBool "help text should mention release variants" ("=small or =fast" `isInfixOf` helpText)
       assertBool "help text should mention default release mode" ("same as --release=safe" `isInfixOf` helpText)
+  , testCase "sig parser accepts target and project options" $ do
+      parsed <- parseArgs ["sig", "--always-build", "--dep", "dep=../dep", "--searchpath", "out/types", "foo.bar"]
+      case parsed of
+        C.CmdOpt _ (C.Sig sigOpts) -> do
+          let opts = C.sigCompile sigOpts
+          assertEqual "sig target" "foo.bar" (C.sigTarget sigOpts)
+          assertBool "sig should force rebuild when requested" (C.alwaysbuild opts)
+          assertEqual "sig searchpath" ["out/types"] (C.searchpath opts)
+          assertEqual "sig dep overrides" [("dep", "../dep")] (C.dep_overrides opts)
+          assertBool "sig should skip final build" (C.skip_build opts)
+        _ ->
+          assertFailure "expected sig command"
+  , testCase "sig finds prebuilt dependency interfaces" $ do
+      withSystemTempDirectory "acton-sig-prebuilt-dep" $ \tmp -> do
+        actonBinDir <- Paths_acton.getBinDir
+        let actonCandidate = actonBinDir </> "acton"
+            distActon = "../../dist/bin/acton"
+        hasActonCandidate <- doesFileExist actonCandidate
+        actonExe <- canonicalizePath $
+          if hasActonCandidate then actonCandidate else distActon
+        sysPath <- canonicalizePath "../../dist"
+        env0 <- getEnvironment
+        let homeDir = tmp </> "home"
+            rootProj = tmp </> "root"
+            depProj = tmp </> "dep"
+            envWithHome = ("HOME", homeDir) : filter ((/= "HOME") . fst) env0
+            mkFp name = Fingerprint.formatFingerprint
+              (Fingerprint.updateFingerprintPrefix
+                (Fingerprint.fingerprintPrefixForName name) 1)
+            writeBuildActAt :: FilePath -> String -> [(String, FilePath)] -> IO ()
+            writeBuildActAt dir name deps = do
+              createDirectoryIfMissing True (dir </> "src")
+              let depsBody = intercalate ",\n"
+                    [ "    \"" ++ depName ++ "\": (\n"
+                      ++ "        path=" ++ show depPath ++ "\n"
+                      ++ "    )"
+                    | (depName, depPath) <- deps
+                    ]
+                  depsSection =
+                    if null deps
+                      then "dependencies = {}"
+                      else "dependencies = {\n" ++ depsBody ++ "\n}"
+              writeFile (dir </> "Build.act") $ unlines
+                [ "name = " ++ show name
+                , "fingerprint = " ++ mkFp name
+                , ""
+                , depsSection
+                , ""
+                , "zig_dependencies = {}"
+                ]
+        createDirectoryIfMissing True homeDir
+
+        writeBuildActAt depProj "sig_dep" []
+        writeFile (depProj </> "src" </> "prebuilt.act") $ unlines
+          [ "def count() -> int:"
+          , "    return 1"
+          ]
+        (buildCode, buildOut, buildErr) <- readCreateProcessWithExitCode
+          (proc actonExe ["build", "--syspath", sysPath, "--skip-build", "src/prebuilt.act"])
+            { cwd = Just depProj, env = Just envWithHome } ""
+        when (buildCode /= ExitSuccess) $
+          assertFailure ("dependency build failed:\nstdout:\n" ++ buildOut ++ "\nstderr:\n" ++ buildErr)
+
+        removeFile (depProj </> "src" </> "prebuilt.act")
+        writeBuildActAt rootProj "sig_root" [("sig_dep", depProj)]
+        writeFile (rootProj </> "src" </> "main.act") $ unlines
+          [ "actor main(env):"
+          , "    env.exit(0)"
+          ]
+
+        (sigCode, sigOut, sigErr) <- readCreateProcessWithExitCode
+          (proc actonExe ["sig", "--syspath", sysPath, "prebuilt"])
+            { cwd = Just rootProj, env = Just envWithHome } ""
+        when (sigCode /= ExitSuccess) $
+          assertFailure ("acton sig failed:\nstdout:\n" ++ sigOut ++ "\nstderr:\n" ++ sigErr)
+        assertBool "sig output should include the dependency function"
+          ("count : () -> int" `isInfixOf` sigOut)
   , testCase "acton test --help includes --no-cache and --tag" $ do
       acton <- canonicalizePath "../../dist/bin/acton"
       (returnCode, cmdOut, cmdErr) <- readCreateProcessWithExitCode (proc acton ["test", "--help"]) ""

--- a/compiler/lib/src/Acton/CommandLineParser.hs
+++ b/compiler/lib/src/Acton/CommandLineParser.hs
@@ -41,6 +41,7 @@ data GlobalOptions = GlobalOptions {
 
 data Command        = New NewOptions
                     | Build BuildOptions
+                    | Sig SigOptions
                     | Test TestCommand
                     | Fetch
                     | PkgShow
@@ -100,6 +101,11 @@ data CompileOptions   = CompileOptions {
 data BuildOptions = BuildOptions
     { buildCompile :: CompileOptions
     , buildFiles   :: [String]
+    } deriving Show
+
+data SigOptions = SigOptions
+    { sigCompile :: CompileOptions
+    , sigTarget  :: String
     } deriving Show
 
 
@@ -188,6 +194,7 @@ cmdLineParser       :: Parser CmdLineOptions
 cmdLineParser       = hsubparser
                         (  command "new"     (info (CmdOpt <$> globalOptions <*> (New <$> newOptions)) (progDesc "Create a new Acton project"))
                         <> command "build"   (info (CmdOpt <$> globalOptions <*> (Build <$> buildOptions)) (progDesc "Build an Acton project"))
+                        <> command "sig"     (info (CmdOpt <$> globalOptions <*> (Sig <$> sigOptions)) (progDesc "Show inferred type signatures"))
                         <> command "test"    (info (CmdOpt <$> globalOptions <*> (Test <$> testCommand)) (progDesc "Build and run project tests"))
                         <> command "fetch"   (info (CmdOpt <$> globalOptions <*> pure Fetch) (progDesc "Fetch project dependencies (offline prep)"))
                         <> command "pkg"     (info (CmdOpt <$> globalOptions <*> pkgSubcommands) (progDesc "Package/dependency commands"))
@@ -255,6 +262,58 @@ buildOptions :: Parser BuildOptions
 buildOptions = BuildOptions
         <$> compileOptions
         <*> many (argument str (metavar "ACTONFILE" <> help "Specific .act file(s) to build"))
+
+sigOptions :: Parser SigOptions
+sigOptions = SigOptions
+        <$> sigCompileOptions
+        <*> argument str (metavar "TARGET" <> help "Module or module.name to show, e.g. foo.bar")
+
+sigCompileOptions :: Parser CompileOptions
+sigCompileOptions = mkSigCompileOptions
+        <$> switch (long "always-build" <> help "Recompute signatures instead of reusing fresh cached interfaces")
+        <*> switch (long "ignore-compiler-version" <> help "Ignore acton version when checking .ty freshness")
+        <*> strOption (long "syspath"   <> metavar "TARGETDIR" <> value "" <> help "Set syspath")
+        <*> many (strOption (long "searchpath" <> metavar "DIR" <> help "Add search path"))
+        <*> many (option depOverrideReader
+               (long "dep"
+                <> metavar "NAME=PATH"
+                <> help "Override dependency NAME with local PATH"))
+  where
+    mkSigCompileOptions always ignore syspath' search depOverrides =
+      CompileOptions
+        { alwaysbuild = always
+        , ignore_compiler_version = ignore
+        , db = False
+        , parse = False
+        , parse_ast = False
+        , kinds = False
+        , types = False
+        , sigs = False
+        , norm = False
+        , deact = False
+        , cps = False
+        , llift = False
+        , box = False
+        , hgen = False
+        , cgen = False
+        , ccmd = False
+        , ty = False
+        , cpedantic = False
+        , dbg_no_lines = False
+        , optimize = Debug
+        , only_build = False
+        , skip_build = True
+        , watch = False
+        , no_threads = False
+        , root = ""
+        , tempdir = ""
+        , syspath = syspath'
+        , target = defTarget
+        , cpu = ""
+        , test = False
+        , searchpath = search
+        , dep_overrides = depOverrides
+        }
 
 compileOptions = CompileOptions
         <$> switch (long "always-build" <> help "Show the result of parsing")

--- a/docs/acton-guide/src/SUMMARY.md
+++ b/docs/acton-guide/src/SUMMARY.md
@@ -46,6 +46,7 @@
     - [Explicit types](types/explicit.md)
     - [Generics](types/generics.md)
     - [Effects (`pure`, `mut`, `proc`, `action`)](types/effects.md)
+    - [Troubleshooting type errors](types/troubleshooting.md)
   - [Actors & concurrency](language/state_concurrency.md)
     - [Actors](actors.md)
     - [Root Actor](actors/root.md)

--- a/docs/acton-guide/src/types/intro.md
+++ b/docs/acton-guide/src/types/intro.md
@@ -54,6 +54,32 @@ Use `--sigs` when you want the compiler to show the types it inferred.
 acton types.act --sigs
 ```
 
+In a project, use `acton sig` when you want signatures by import path
+instead of by source file path:
+
+```sh
+acton sig foo.bar
+```
+
+The target is resolved like an import path. Acton first looks for a
+module named `foo.bar`. If that module does not exist, it treats the
+target as the public name `bar` inside module `foo` and prints only that
+signature.
+
+This is useful when a type error mentions an imported module or name,
+especially one that comes from a dependency. `acton sig` uses the
+project's normal build resolution, so it reads `Build.act`, honors
+dependency overrides such as `--dep name=path`, fetches missing
+dependencies, and compiles the module interfaces it needs before
+printing the signatures. It does not perform the final executable build.
+
+For example:
+
+```sh
+acton sig collections.list
+acton sig mylib.parser.parse
+```
+
 <div class="advanced-content">
 <p>Acton's inferred signatures include more than argument and return
 types. You will see generic binders, protocol constraints, optional
@@ -79,5 +105,7 @@ This is especially useful when:
   concrete types without losing safety
 - [Effects (`pure`, `mut`, `proc`, `action`)](effects.md) when you want
   to treat side effects as part of the type information
+- [Troubleshooting type errors](troubleshooting.md) when you want to
+  inspect imported signatures and compare them with an error
 - [Optionals](optionals.md) when you want the deeper type-system view of
   values that may be absent

--- a/docs/acton-guide/src/types/troubleshooting.md
+++ b/docs/acton-guide/src/types/troubleshooting.md
@@ -1,0 +1,96 @@
+# Troubleshooting type errors with signatures
+
+When a type error mentions a value from another module, first check the
+interface that the compiler sees. `acton sig` prints inferred signatures
+by import path, so you can compare the error against the imported API
+instead of searching for generated files or guessing from memory.
+
+Use this workflow:
+
+1. Read the type error and find the module or type name involved.
+2. Run `acton sig` for that module or public name.
+3. Compare the available attributes and methods with the failing code.
+4. Fix the source and rebuild.
+
+## Example: singular vs plural attribute
+
+Suppose one module defines a contact value:
+
+```python
+# src/directory.act
+class Contact(object):
+    display_name: str
+    email_addresses: list[str]
+
+    def __init__(self, display_name: str, email_addresses: list[str]):
+        self.display_name = display_name
+        self.email_addresses = email_addresses
+```
+
+Another module imports the class and uses the right concept, but the
+wrong singular form of the attribute name:
+
+```python
+# src/main.act
+from directory import Contact
+
+def email_count(contact: Contact) -> int:
+    return len(contact.email_address)
+```
+
+Running `acton build` points at the attribute selection:
+
+```text
+[error]: Attribute not found email_address
+     +--> main.act@4:24-4:37
+     |
+   4 |     return len(contact.email_address)
+     :                        ^------------
+     :                        `- Attribute not found email_address
+-----+
+```
+
+The error is in `main`, but the shape of `Contact` is defined in
+`directory`. Ask the compiler for the imported type:
+
+```sh
+acton sig directory.Contact
+```
+
+`acton sig` first looks for a module named `directory.Contact`. If no
+such module exists, it treats the target as the public name `Contact`
+inside module `directory`. The output shows the public interface for the
+class:
+
+```python
+class Contact (object, value):
+    G_init : () -> None
+    @property
+    display_name : str
+    @property
+    email_addresses : list[str]
+    __init__ : (display_name: str, email_addresses: list[str]) -> None
+```
+
+The `@property` entries are the readable part for this error. They say
+the class has `email_addresses`, not `email_address`. That is not
+obvious from the local `main.act` file, but it is clear from the
+compiler-visible interface. The fix is in the selecting code:
+
+```python
+def email_count(contact: Contact) -> int:
+    return len(contact.email_addresses)
+```
+
+This same approach works for dependencies. If `directory` comes from a
+package dependency, `acton sig directory.Contact` still uses the
+project's normal build resolution: it reads `Build.act`, fetches missing
+dependencies, compiles the interface files it needs, and skips the final
+executable build.
+
+If you are testing a local checkout of a dependency, pass the same
+override you would pass to `acton build`:
+
+```sh
+acton sig --dep directory=../directory directory.Contact
+```


### PR DESCRIPTION
Users could only inspect inferred signatures by running a build with --sigs against a source file path. That works for modules in the current project, but it is awkward for dependency imports because the user has to know the provider's filesystem path and ensure the interface has already been built.

This change adds acton sig TARGET as a project-aware query. The command fetches dependencies, discovers the same reachable project graph as build, resolves TARGET as a module first and then as a public name in the parent module, and compiles the needed front-end graph with the final build disabled before printing the selected interface.

Reusing the existing fetch, discovery, planning, and .ty interface machinery keeps the displayed signatures aligned with normal imports. It also lets the command work from a clean project checkout without requiring users to translate import paths into source paths.