### PR TITLE
Preserve source locations in caches

### DIFF
--- a/compiler/acton/test/parse/simple.all.golden
+++ b/compiler/acton/test/parse/simple.all.golden
@@ -66,7 +66,7 @@ pure def main () -> None:
     return None
 ===============================================
 
-/* Acton impl hash: d9f9cff347fdb461e47f52afc75c341b9f014d057f3a2808aecbce8f1e0a05c6 */
+/* Acton impl hash: 90d154672dec39acdfe73f54da1124538a944a4989833b41555c4693f4283455 */
 #pragma once
 #include "builtin/builtin.h"
 #include "rts/rts.h"

--- a/compiler/acton/test/parse/simple.cgen.golden
+++ b/compiler/acton/test/parse/simple.cgen.golden
@@ -1,4 +1,4 @@
-/* Acton impl hash: d9f9cff347fdb461e47f52afc75c341b9f014d057f3a2808aecbce8f1e0a05c6 */
+/* Acton impl hash: 90d154672dec39acdfe73f54da1124538a944a4989833b41555c4693f4283455 */
 #include "rts/common.h"
 #include "out/types/simple.h"
 B_NoneType simpleQ_main () {

--- a/compiler/acton/test/parse/simple.hgen.golden
+++ b/compiler/acton/test/parse/simple.hgen.golden
@@ -1,4 +1,4 @@
-/* Acton impl hash: d9f9cff347fdb461e47f52afc75c341b9f014d057f3a2808aecbce8f1e0a05c6 */
+/* Acton impl hash: 90d154672dec39acdfe73f54da1124538a944a4989833b41555c4693f4283455 */
 #pragma once
 #include "builtin/builtin.h"
 #include "rts/rts.h"

--- a/compiler/lib/src/Acton/Hashing.hs
+++ b/compiler/lib/src/Acton/Hashing.hs
@@ -182,7 +182,7 @@ buildNameHashes :: Data.Set.Set A.Name
                 -> M.Map A.Name [(A.QName, B.ByteString)]
                 -> [InterfaceFiles.NameHashInfo]
 buildNameHashes nameKeys nameSrcHashes nameImplHashes nameInfoMap pubSigLocalDeps pubSigExtHashes implLocalDeps implExtHashes pubExtHashes =
-  let hashNameInfo info = SHA256.hash (BL.toStrict $ encode (I.stripDocsNI info))
+  let hashNameInfo info = SHA256.hash (BL.toStrict $ encode (I.stripLocsNI (I.stripDocsNI info)))
       selfPubHashes = M.map hashNameInfo nameInfoMap
       selfImplHashes = nameImplHashes
       pubHashes = computeHashes selfPubHashes pubSigLocalDeps pubSigExtHashes
@@ -227,14 +227,14 @@ modulePubHashFromIface nmod nameHashes =
         | nh <- nameHashes
         ]
       pubNamesSorted = Data.List.sortOn nameKey (map fst iface)
-      pubEntries = [ (n, M.findWithDefault B.empty n pubHashMap) | n <- pubNamesSorted ]
+      pubEntries = [ (nameKey n, M.findWithDefault B.empty n pubHashMap) | n <- pubNamesSorted ]
   in SHA256.hash (BL.toStrict $ encode pubEntries)
 
 -- | Hash the module impl entries from per-name impl hashes.
 moduleImplHashFromNameHashes :: [InterfaceFiles.NameHashInfo] -> B.ByteString
 moduleImplHashFromNameHashes infos =
   let items =
-        [ (InterfaceFiles.nhName nh, InterfaceFiles.nhImplHash nh)
+        [ (nameKey (InterfaceFiles.nhName nh), InterfaceFiles.nhImplHash nh)
         | nh <- Data.List.sortOn (nameKey . InterfaceFiles.nhName) infos
         ]
   in SHA256.hash (BL.toStrict (encode items))

--- a/compiler/lib/src/Acton/NameInfo.hs
+++ b/compiler/lib/src/Acton/NameInfo.hs
@@ -140,6 +140,81 @@ stripDocsNI ni = case ni of
   where
     stripBind (n, info) = (n, stripDocsNI info)
 
+-- | Strip source locations from NameInfo (and nested syntax fragments).
+-- This keeps public interface hashes independent from whitespace-only source
+-- edits while preserving locations in the cached .ty payload itself.
+stripLocsNI :: NameInfo -> NameInfo
+stripLocsNI ni = case ni of
+  NVar t             -> NVar (stripLocsType t)
+  NSVar t            -> NSVar (stripLocsType t)
+  NDef sc dec doc    -> NDef (stripLocsTSchema sc) dec doc
+  NSig sc dec doc    -> NSig (stripLocsTSchema sc) dec doc
+  NAct q p k te doc  -> NAct (stripLocsQBinds q) (stripLocsType p) (stripLocsType k) (stripLocsTEnv te) doc
+  NClass q cs te doc -> NClass (stripLocsQBinds q) (map stripLocsWTCon cs) (stripLocsTEnv te) doc
+  NProto q ps te doc -> NProto (stripLocsQBinds q) (map stripLocsWTCon ps) (stripLocsTEnv te) doc
+  NExt q c ps te o doc ->
+    NExt (stripLocsQBinds q) (stripLocsTCon c) (map stripLocsWTCon ps) (stripLocsTEnv te) (map stripLocsName o) doc
+  NTVar k c ps       -> NTVar k (stripLocsTCon c) (map stripLocsTCon ps)
+  NAlias qn          -> NAlias (stripLocsQName qn)
+  NMAlias mn         -> NMAlias (stripLocsModName mn)
+  NModule te doc     -> NModule (stripLocsTEnv te) doc
+  NReserved          -> NReserved
+  where
+    stripLocsTEnv :: TEnv -> TEnv
+    stripLocsTEnv = map $ \(n, info) -> (stripLocsName n, stripLocsNI info)
+
+    stripLocsTSchema :: TSchema -> TSchema
+    stripLocsTSchema (TSchema _ q t) = TSchema NoLoc (stripLocsQBinds q) (stripLocsType t)
+
+    stripLocsQBinds :: QBinds -> QBinds
+    stripLocsQBinds = map stripLocsQBind
+
+    stripLocsQBind :: QBind -> QBind
+    stripLocsQBind (QBind tv cs) = QBind (stripLocsTVar tv) (map stripLocsTCon cs)
+
+    stripLocsTVar :: TVar -> TVar
+    stripLocsTVar (TV k n) = TV k (stripLocsName n)
+
+    stripLocsTCon :: TCon -> TCon
+    stripLocsTCon (TC qn ts) = TC (stripLocsQName qn) (map stripLocsType ts)
+
+    stripLocsWTCon :: WTCon -> WTCon
+    stripLocsWTCon (wpath, pcon) = (map stripLocsWStep wpath, stripLocsTCon pcon)
+
+    stripLocsWStep :: Either QName QName -> Either QName QName
+    stripLocsWStep (Left qn) = Left (stripLocsQName qn)
+    stripLocsWStep (Right qn) = Right (stripLocsQName qn)
+
+    stripLocsType :: Type -> Type
+    stripLocsType t = case t of
+      TUni _ u          -> TUni NoLoc u
+      TVar _ tv         -> TVar NoLoc (stripLocsTVar tv)
+      TCon _ tc         -> TCon NoLoc (stripLocsTCon tc)
+      TFun _ fx p k r   -> TFun NoLoc (stripLocsType fx) (stripLocsType p) (stripLocsType k) (stripLocsType r)
+      TTuple _ p k      -> TTuple NoLoc (stripLocsType p) (stripLocsType k)
+      TOpt _ opt        -> TOpt NoLoc (stripLocsType opt)
+      TNone _           -> TNone NoLoc
+      TWild _           -> TWild NoLoc
+      TNil _ k          -> TNil NoLoc k
+      TRow _ k n ty row -> TRow NoLoc k (stripLocsName n) (stripLocsType ty) (stripLocsType row)
+      TStar _ k row     -> TStar NoLoc k (stripLocsType row)
+      TFX _ fx          -> TFX NoLoc fx
+
+    stripLocsQName :: QName -> QName
+    stripLocsQName qn = case qn of
+      QName mn n -> QName (stripLocsModName mn) (stripLocsName n)
+      NoQ n      -> NoQ (stripLocsName n)
+      GName mn n -> GName (stripLocsModName mn) (stripLocsName n)
+
+    stripLocsModName :: ModName -> ModName
+    stripLocsModName (ModName ns) = ModName (map stripLocsName ns)
+
+    stripLocsName :: Name -> Name
+    stripLocsName n = case n of
+      Name _ s       -> Name NoLoc s
+      Derived n1 n2  -> Derived (stripLocsName n1) (stripLocsName n2)
+      Internal{}     -> n
+
 instance Leaves NameInfo where
     leaves (NClass q cs te _) = leaves q ++ leaves cs ++ leaves te
     leaves (NProto q ps te _) = leaves q ++ leaves ps ++ leaves te

--- a/compiler/lib/src/Acton/Syntax.hs
+++ b/compiler/lib/src/Acton/Syntax.hs
@@ -25,7 +25,7 @@ import Control.DeepSeq
 import Prelude hiding((<>))
 
 version :: [Int]
-version = [0,14]
+version = [0,15]
 
 data Module     = Module        { modname::ModName, imps::[Import], mdoc::Maybe String, mbody::Suite } deriving (Eq,Show,Generic,NFData)
 

--- a/compiler/lib/src/Acton/Syntax.hs
+++ b/compiler/lib/src/Acton/Syntax.hs
@@ -25,7 +25,7 @@ import Control.DeepSeq
 import Prelude hiding((<>))
 
 version :: [Int]
-version = [0,15]
+version = [0,16]
 
 data Module     = Module        { modname::ModName, imps::[Import], mdoc::Maybe String, mbody::Suite } deriving (Eq,Show,Generic,NFData)
 

--- a/compiler/lib/src/Utils.hs
+++ b/compiler/lib/src/Utils.hs
@@ -33,8 +33,13 @@ import System.IO.Error (catchIOError)
 data SrcLoc                     = Loc Int Int | NoLoc deriving (Eq,Ord,Show,Read,Generic,NFData)
 
 instance Data.Binary.Binary SrcLoc where
-    put _ = return ()
-    get   = return NoLoc
+    put NoLoc                    = Data.Binary.put False
+    put (Loc l r)                = Data.Binary.put True >> Data.Binary.put l >> Data.Binary.put r
+    get                          = do
+        hasLoc <- Data.Binary.get
+        if hasLoc
+            then Loc <$> Data.Binary.get <*> Data.Binary.get
+            else return NoLoc
 
 instance Pretty SrcLoc where
     pretty (Loc l r)            = pretty l <> text "-" <> pretty r


### PR DESCRIPTION
Serialized typed modules currently discard every SrcLoc value. The parser records offsets in the AST, but writing a .ty file drops them and reading the file reconstructs every location as NoLoc. Any later diagnostic that comes from cached typed data therefore loses the position it originally had.

Write a small presence tag for SrcLoc and store the start and end offsets for real locations. NoLoc remains compact, while Loc survives the round trip through the interface cache.

The .ty format version is bumped.