### PR TITLE
Store private names in interfaces

### DIFF
--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -1106,7 +1106,7 @@ printSigInterface paths mn mName tyFile = do
               Just _  -> define te (setMod mn envImports)
         case mName of
           Just n | null selected ->
-            printErrorAndExit ("Public name not found: " ++ modNameToString mn ++ "." ++ nameToString n)
+            printErrorAndExit ("Name not found: " ++ modNameToString mn ++ "." ++ nameToString n)
           _ ->
             putStrLn (Acton.Types.prettySigs envForPrint mn selected)
 

--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -525,6 +525,97 @@ parseFlagTests =
           assertFailure ("acton sig failed:\nstdout:\n" ++ sigOut ++ "\nstderr:\n" ++ sigErr)
         assertBool "sig output should include the dependency function"
           ("count : () -> int" `isInfixOf` sigOut)
+  , testCase "sig prints private names without importing them" $ do
+      withSystemTempDirectory "acton-sig-private-names" $ \tmp -> do
+        actonExe <- canonicalizePath "../../dist/bin/acton"
+        sysPath <- canonicalizePath "../../dist"
+        env0 <- getEnvironment
+        let homeDir = tmp </> "home"
+            proj = tmp </> "proj"
+            srcDir = proj </> "src"
+            rootProj = tmp </> "root"
+            rootSrcDir = rootProj </> "src"
+            envWithHome = ("HOME", homeDir) : filter ((/= "HOME") . fst) env0
+            mkFp name = Fingerprint.formatFingerprint
+              (Fingerprint.updateFingerprintPrefix
+                (Fingerprint.fingerprintPrefixForName name) 1)
+            writeBuildActAt :: FilePath -> String -> [(String, FilePath)] -> IO ()
+            writeBuildActAt dir pkgName deps = do
+              createDirectoryIfMissing True (dir </> "src")
+              let depsBody = intercalate ",\n"
+                    [ "    \"" ++ depName ++ "\": (\n"
+                      ++ "        path=" ++ show depPath ++ "\n"
+                      ++ "    )"
+                    | (depName, depPath) <- deps
+                    ]
+                  depsSection =
+                    if null deps
+                      then "dependencies = {}"
+                      else "dependencies = {\n" ++ depsBody ++ "\n}"
+              writeFile (dir </> "Build.act") $ unlines
+                [ "name = " ++ show pkgName
+                , "fingerprint = " ++ mkFp pkgName
+                , depsSection
+                , "zig_dependencies = {}"
+                ]
+        createDirectoryIfMissing True homeDir
+        writeBuildActAt proj "sig_private" []
+        writeFile (srcDir </> "lib.act") $ unlines
+          [ "def _private() -> int:"
+          , "    return 1"
+          , ""
+          , "def public() -> int:"
+          , "    return _private()"
+          ]
+        (buildCode, buildOut, buildErr) <- readCreateProcessWithExitCode
+          (proc actonExe ["build", "--syspath", sysPath, "--skip-build", "src/lib.act"])
+            { cwd = Just proj, env = Just envWithHome } ""
+        when (buildCode /= ExitSuccess) $
+          assertFailure ("library build failed:\nstdout:\n" ++ buildOut ++ "\nstderr:\n" ++ buildErr)
+
+        (sigCode, sigOut, sigErr) <- readCreateProcessWithExitCode
+          (proc actonExe ["sig", "--syspath", sysPath, "lib"])
+            { cwd = Just proj, env = Just envWithHome } ""
+        when (sigCode /= ExitSuccess) $
+          assertFailure ("acton sig failed:\nstdout:\n" ++ sigOut ++ "\nstderr:\n" ++ sigErr)
+        assertBool "sig output should include private function"
+          ("_private : () -> int" `isInfixOf` sigOut)
+        assertBool "sig output should include public function"
+          ("public : () -> int" `isInfixOf` sigOut)
+
+        writeFile (srcDir </> "main.act") $ unlines
+          [ "from lib import _private"
+          , ""
+          , "actor main(env):"
+          , "    env.exit(0)"
+          ]
+        (importCode, _importOut, importErr) <- readCreateProcessWithExitCode
+          (proc actonExe ["build", "--syspath", sysPath, "--skip-build", "src/main.act"])
+            { cwd = Just proj, env = Just envWithHome } ""
+        assertBool ("private import should fail, stderr:\n" ++ importErr)
+          (importCode /= ExitSuccess)
+
+        removeFile (srcDir </> "lib.act")
+        (cachedSigCode, cachedSigOut, cachedSigErr) <- readCreateProcessWithExitCode
+          (proc actonExe ["sig", "--syspath", sysPath, "lib._private"])
+            { cwd = Just proj, env = Just envWithHome } ""
+        when (cachedSigCode /= ExitSuccess) $
+          assertFailure ("cached acton sig failed:\nstdout:\n" ++ cachedSigOut ++ "\nstderr:\n" ++ cachedSigErr)
+        assertBool "cached sig output should include private function"
+          ("_private : () -> int" `isInfixOf` cachedSigOut)
+
+        writeBuildActAt rootProj "sig_private_root" [("sig_private", proj)]
+        writeFile (rootSrcDir </> "main.act") $ unlines
+          [ "from lib import _private"
+          , ""
+          , "actor main(env):"
+          , "    env.exit(0)"
+          ]
+        (cachedImportCode, _cachedImportOut, cachedImportErr) <- readCreateProcessWithExitCode
+          (proc actonExe ["build", "--syspath", sysPath, "--skip-build", "src/main.act"])
+            { cwd = Just rootProj, env = Just envWithHome } ""
+        assertBool ("cached private import should fail, stderr:\n" ++ cachedImportErr)
+          (cachedImportCode /= ExitSuccess)
   , testCase "acton test --help includes --no-cache and --tag" $ do
       acton <- canonicalizePath "../../dist/bin/acton"
       (returnCode, cmdOut, cmdErr) <- readCreateProcessWithExitCode (proc acton ["test", "--help"]) ""

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -832,6 +832,12 @@ updatePubHashCache mn ih = modifyMVar_ pubHashCache $ \m -> return (M.insert mn 
 nameHashMapFromList :: [InterfaceFiles.NameHashInfo] -> M.Map A.Name InterfaceFiles.NameHashInfo
 nameHashMapFromList infos = M.fromList [ (InterfaceFiles.nhName i, i) | i <- infos ]
 
+publicIfaceTE :: [(A.Name, I.NameInfo)] -> [(A.Name, I.NameInfo)]
+publicIfaceTE = filter (Names.isPublicName . fst)
+
+publicNameHashes :: [InterfaceFiles.NameHashInfo] -> [InterfaceFiles.NameHashInfo]
+publicNameHashes = filter (Names.isPublicName . InterfaceFiles.nhName)
+
 -- | Read a module's per-name hash map using the cache and .ty header.
 getNameHashMapCached :: Paths -> A.ModName -> IO (Maybe (M.Map A.Name InterfaceFiles.NameHashInfo))
 getNameHashMapCached paths mn = modifyMVar nameHashCache $ \m -> do
@@ -844,7 +850,7 @@ getNameHashMapCached paths mn = modifyMVar nameHashCache $ \m -> do
           hdrE <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readHeader ty
           case hdrE of
             Right (_sourceMetaH, _srcH, _ih, _implH, _impsH, nameHashes, _rootsH, _testsH, _docH) -> do
-              let hm = nameHashMapFromList nameHashes
+              let hm = nameHashMapFromList (publicNameHashes nameHashes)
               return (M.insert mn hm m, Just hm)
             _ -> return (m, Nothing)
         Nothing -> return (m, Nothing)
@@ -1477,7 +1483,8 @@ readIfaceFromTy paths mn src mHash = do
         case fileRes of
           Left _ -> return $ Left (missingIfaceDiagnostics mn src mn)
           Right (_ms, nmod, _tmod, _sourceMeta, _srcH, _pubH, _implH, _imps, _nameHashes, _roots, _tests, _tm) -> do
-            let I.NModule te mdoc = nmod
+            let I.NModule teFull mdoc = nmod
+                te = publicIfaceTE teFull
             ih <- case mHash of
                     Just h -> return h
                     Nothing -> do
@@ -1703,8 +1710,9 @@ runFrontPasses gopts opts paths env0 parsed srcContent srcBytes sourceMeta resol
       -- Module-level src hash uses raw bytes so any source edit forces re-parse.
       let moduleSrcBytesHash = SHA256.hash srcBytes
       -- Store roots so later builds can discover entry points without reparse.
-      let I.NModule iface mdoc = nmod
-      let roots = [ n | (n,i) <- iface, rootEligible i ]
+      let I.NModule fullIface mdoc = nmod
+          publicIface = publicIfaceTE fullIface
+      let roots = [ n | (n,i) <- fullIface, rootEligible i ]
       -- Import hashes are recorded in the .ty header so dep changes can be detected.
       impsRes <- resolveImportHashes mrefs
       case impsRes of
@@ -1718,8 +1726,8 @@ runFrontPasses gopts opts paths env0 parsed srcContent srcBytes sourceMeta resol
               -- impl hashes are derived from the typed AST bodies. this is the
               -- local function hash, implDeps are added later
               nameImplHashes = Hashing.nameHashesFromItems implItems
-              -- NameInfo defines the public interface (signatures, classes, protocols).
-              nameInfoMap = M.fromList iface
+              -- NameInfo defines the full local environment for this module.
+              nameInfoMap = M.fromList fullIface
               nameSrcKeys = M.keysSet nameSrcHashes
               nameImplKeys = M.keysSet nameImplHashes
               nameKeys = Data.Set.union nameSrcKeys nameImplKeys
@@ -1788,7 +1796,7 @@ runFrontPasses gopts opts paths env0 parsed srcContent srcBytes sourceMeta resol
                   InterfaceFiles.writeFile (outbase ++ ".ty") moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta impsWithHash nameHashes roots tests mdoc nmod tchecked
 
                   iff (C.types opts && isRoot) $ dump mn "types" (Pretty.print tchecked)
-                  iff (C.sigs opts && isRoot) $ dump mn "sigs" (Acton.Types.prettySigs env mn iface)
+                  iff (C.sigs opts && isRoot) $ dump mn "sigs" (Acton.Types.prettySigs env mn fullIface)
 
                   -- Generate documentation, if building for a project
                   when (not (C.skip_build opts) && not (isTmp paths)) $ do
@@ -1801,9 +1809,9 @@ runFrontPasses gopts opts paths env0 parsed srcContent srcBytes sourceMeta resol
                         -- Get the type environment for this module
                         modTypeEnv = case Acton.Env.lookupMod mn typeEnv of
                           Just te -> te
-                          Nothing -> iface
+                          Nothing -> publicIface
                         -- Apply the same simplification as --sigs uses
-                        env1 = define iface $ setMod mn env
+                        env1 = define publicIface $ setMod mn env
                         simplifiedTypeEnv = simp env1 modTypeEnv
                     createDirectoryIfMissing True docFileDir
                     -- Use parsed (original AST) to preserve docstrings
@@ -1835,10 +1843,10 @@ runFrontPasses gopts opts paths env0 parsed srcContent srcBytes sourceMeta resol
                                                                   , biImplHash = moduleImplHash
                                                                   }
                                              }
-                  return $ Right FrontResult { frIfaceTE = iface
+                  return $ Right FrontResult { frIfaceTE = publicIface
                                              , frDoc = mdoc
                                              , frPubHash = modulePubHash
-                                             , frNameHashes = nameHashes
+                                             , frNameHashes = publicNameHashes nameHashes
                                              , frFrontTime = frontTimeMaybe
                                              , frFrontTiming = frontTimingMaybe
                                              , frBackJob = backJob
@@ -2436,7 +2444,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
               case ifaceRes of
                 Right (ifaceTE, mdoc, ih) -> do
                   let cachedNameHashes = case taskCurrent of
-                        TyTask{ tyNameHashes = nhs } -> nhs
+                        TyTask{ tyNameHashes = nhs } -> publicNameHashes nhs
                         _ -> []
                       fr = mkFrontResult ifaceTE mdoc ih cachedNameHashes Nothing
                   cacheFrontResult fr
@@ -2493,7 +2501,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
               let runFront = do
                     prevNameHashes <- if C.verbose gopts
                       then case taskCurrent of
-                        TyTask{ tyNameHashes = nhs } -> return (Just (nameHashMapFromList nhs))
+                        TyTask{ tyNameHashes = nhs } -> return (Just (nameHashMapFromList (publicNameHashes nhs)))
                         _ -> getNameHashMapCached paths mn
                       else return Nothing
                     when (C.verbose gopts) $ do
@@ -2602,9 +2610,10 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
                                             Hashing.refreshImplHashes nameHashes nameImplHashes implLocalDeps implExtHashes
                                           moduleImplHash = Hashing.moduleImplHashFromNameHashes updatedNameHashes
                                       InterfaceFiles.writeFile tyFile moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta imps updatedNameHashes roots tests mdoc nmod tmod
-                                      let I.NModule ifaceTE _mdoc = nmod
+                                      let I.NModule ifaceFull _mdoc = nmod
+                                          ifaceTE = publicIfaceTE ifaceFull
                                           backJob = Just (mkBackJob env1 tmod (Source.ssText snap) moduleImplHash)
-                                          fr = mkFrontResult ifaceTE mdoc modulePubHash updatedNameHashes backJob
+                                          fr = mkFrontResult ifaceTE mdoc modulePubHash (publicNameHashes updatedNameHashes) backJob
                                       cacheFrontResult fr
                       ) `catch` handleImplRefreshException
                   runCodegenRefresh = do
@@ -2617,9 +2626,10 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
                       Right (_ms, nmod, tmod, _sourceMeta, _moduleSrcBytesHash, modulePubHash, moduleImplHashStored, _imps, nameHashes, _roots, _tests, mdoc) -> do
                         snap <- Source.readSource sp actFile
                         env1 <- Acton.Env.mkEnv (searchPath paths) envSnap tmod
-                        let I.NModule ifaceTE _mdoc = nmod
+                        let I.NModule ifaceFull _mdoc = nmod
+                            ifaceTE = publicIfaceTE ifaceFull
                             backJob = Just (mkBackJob env1 tmod (Source.ssText snap) moduleImplHashStored)
-                            fr = mkFrontResult ifaceTE mdoc modulePubHash nameHashes backJob
+                            fr = mkFrontResult ifaceTE mdoc modulePubHash (publicNameHashes nameHashes) backJob
                         cacheFrontResult fr
                   runReuse = do
                     when (C.verbose gopts) $
@@ -2631,7 +2641,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
                       Left diags -> return (key, Left diags)
                       Right (ifaceTE, mdoc, ih) -> do
                         let cachedNameHashes = case taskCurrent of
-                              TyTask{ tyNameHashes = nhs } -> nhs
+                              TyTask{ tyNameHashes = nhs } -> publicNameHashes nhs
                               _ -> []
                             fr = mkFrontResult ifaceTE mdoc ih cachedNameHashes Nothing
                         cacheFrontResult fr

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -233,6 +233,9 @@ instance Unalias (Either QName QName) where
 
 -- | Initialize the base environment; the builtin mode skips interface loading.
 -- first variant is special case for compiling __builtin__.act
+publicTEnv                 :: TEnv -> TEnv
+publicTEnv                 = filter (isPublicName . fst)
+
 initEnv                    :: FilePath -> Bool -> IO Env0
 initEnv path True          = return $ EnvF{ names = [(nPrim,NMAlias mPrim)],
                                             imports = [mPrim],
@@ -245,16 +248,17 @@ initEnv path True          = return $ EnvF{ names = [(nPrim,NMAlias mPrim)],
                                             envX = () }
 initEnv path False         = do (_,nmod,_,_,_,_,_,_,_,_,_,_) <- InterfaceFiles.readFile (joinPath [path,"__builtin__.ty"])
                                 let NModule envBuiltin builtinDocstring = nmod
+                                    envBuiltinPublic = publicTEnv envBuiltin
                                     env0 = EnvF{ names = [(nPrim,NMAlias mPrim), (nBuiltin,NMAlias mBuiltin)],
                                                  imports = [mPrim,mBuiltin],
-                                                 modules = [(nPrim,NModule primEnv Nothing), (nBuiltin,NModule envBuiltin builtinDocstring)],
+                                                 modules = [(nPrim,NModule primEnv Nothing), (nBuiltin,NModule envBuiltinPublic builtinDocstring)],
                                                  hmodules = M.empty,
                                                  witnesses = primWits,
                                                  thismod = Nothing,
                                                  context = [],
                                                  qlevel = 0,
                                                  envX = () }
-                                    env = importAll mBuiltin envBuiltin $ importWits mBuiltin envBuiltin $ env0
+                                    env = importAll mBuiltin envBuiltinPublic $ importWits mBuiltin envBuiltinPublic $ env0
                                 return env
 
 withModulesFrom             :: EnvF x -> EnvF x -> EnvF x
@@ -1075,7 +1079,8 @@ doImp spath env m            = do
                 Just tyF -> do
                   (ms,nmod,_,_,_,_,_,_,_,_,_,_) <- InterfaceFiles.readFile tyF
                   (env', seen'') <- subImpSeen seen' env ms
-                  let NModule te mdoc = nmod
+                  let NModule teFull mdoc = nmod
+                      te = publicTEnv teFull
                   return (addMod m te mdoc env', te, seen'')
 
     subImpSeen seen env []   = return (env, seen)
@@ -1095,7 +1100,7 @@ importAll                   :: ModName -> TEnv -> EnvF x -> EnvF x
 importAll m te env          = define (impNames m te) env
 
 impNames                    :: ModName -> TEnv -> TEnv
-impNames m te               = mapMaybe imp te
+impNames m te               = mapMaybe imp (publicTEnv te)
   where
     imp (n, NAct _ _ _ _ _)   = Just (n, NAlias (GName m n))
     imp (n, NClass _ _ _ _)   = Just (n, NAlias (GName m n))

--- a/compiler/lib/src/Acton/Hashing.hs
+++ b/compiler/lib/src/Acton/Hashing.hs
@@ -226,7 +226,8 @@ modulePubHashFromIface nmod nameHashes =
         [ (InterfaceFiles.nhName nh, InterfaceFiles.nhPubHash nh)
         | nh <- nameHashes
         ]
-      pubNamesSorted = Data.List.sortOn nameKey (map fst iface)
+      pubNamesSorted = Data.List.sortOn nameKey
+        [ n | (n, _) <- iface, Names.isPublicName n ]
       pubEntries = [ (nameKey n, M.findWithDefault B.empty n pubHashMap) | n <- pubNamesSorted ]
   in SHA256.hash (BL.toStrict $ encode pubEntries)
 

--- a/compiler/lib/src/Acton/Types.hs
+++ b/compiler/lib/src/Acton/Types.hs
@@ -65,12 +65,11 @@ reconstruct progressCb env0 (Module m i mdoc ss)    = do --traceM ("############
             then let (testSs, discovered) = testStmts env2 (modNameStr m) ss1
                  in (te ++ testEnv, ss1 ++ testSs, discovered)
             else (te, ss1, [])
-        iface                           = filterIface (unalias env2 teT)
+        iface                           = unalias env2 teT
 
         mrefs                           = moduleRefs1 env0
         env0'                           = convEnvProtos env0
         hasTesting i                    = Import NoLoc [ModuleItem (ModName [name "testing"]) Nothing] `elem` i
-        filterIface                     = filter (isPublicName . fst)
         rmTests (Assign _ [PVar _ n _] _ : ss)
           | nstr n `elem` ["__unit_tests","__simple_sync_tests","__sync_tests","__async_tests","__env_tests"]
                                         = rmTests ss

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -569,7 +569,8 @@ main = do
         kcheckedA <- liftIO $ Acton.Kinds.check envA parsedA
         (nmodA, _, _, _, _) <- liftIO $ Acton.Types.reconstruct Nothing envA kcheckedA
         let I.NModule tenvA mdocA = nmodA
-            env1 = Acton.Env.addMod (S.modname parsedA) tenvA mdocA env0
+            publicTEnvA = Acton.Env.publicTEnv tenvA
+            env1 = Acton.Env.addMod (S.modname parsedA) publicTEnvA mdocA env0
 
         (envB, parsedB) <- parseAct env1 "import_private_qualified"
         kcheckedB <- liftIO $ Acton.Kinds.check envB parsedB


### PR DESCRIPTION
The .ty interface files were primarily meant for other consuming modules to be able to view the names visible in a module and their type signature for type checking. Since _private names are not exported, we stripped those before writing the .ty file. However, we are now looking to use the .ty file for other purposes as well, like incremental compilation and simply inspecting the content of a module. For this purpose, it is better to keep all names, including private ones. Instead we filter away private names on the import side.