### PR TITLE
Completion

### DIFF
--- a/compiler/lib/package.yaml.in
+++ b/compiler/lib/package.yaml.in
@@ -66,6 +66,7 @@ library:
     - Acton.Builtin
     - Acton.CPS
     - Acton.CodeGen
+    - Acton.Completion
     - Acton.Compile
     - Acton.CommandLineParser
     - Acton.Deactorizer

--- a/compiler/lib/src/Acton/Completion.hs
+++ b/compiler/lib/src/Acton/Completion.hs
@@ -7,7 +7,10 @@ module Acton.Completion
   , HoverInfo(..)
   , SignatureParameter(..)
   , CallRequest(..)
+  , ArgumentRequest(..)
   , MemberRequest(..)
+  , argumentCompletions
+  , argumentCompletionsWithEnv
   , callContextAt
   , callSignatures
   , callSignaturesWithEnv
@@ -40,6 +43,7 @@ data CompletionKind
   | CompletionMethod
   | CompletionProperty
   | CompletionValue
+  | CompletionKeyword
   deriving (Eq, Show)
 
 data Completion = Completion
@@ -56,6 +60,13 @@ data MemberRequest = MemberRequest
 data CallRequest = CallRequest
   { callTarget :: [String]
   , callActiveParameter :: Int
+  , callArgumentText :: String
+  } deriving (Eq, Show)
+
+data ArgumentRequest = ArgumentRequest
+  { argumentTarget :: [String]
+  , argumentPrefix :: String
+  , argumentSuppliedKeywords :: [String]
   } deriving (Eq, Show)
 
 data SignatureParameter = SignatureParameter
@@ -117,6 +128,11 @@ data HoverTarget = HoverTarget
   , hoverResolvedDoc :: Maybe String
   } deriving (Eq, Show)
 
+data KeywordParameter = KeywordParameter
+  { keywordParameterName :: String
+  , keywordParameterType :: S.Type
+  } deriving (Eq, Show)
+
 data Scope = ScopeClass ClassContext | ScopeDef DefContext deriving (Eq, Show)
 
 data ScanState = ScanState
@@ -145,6 +161,28 @@ memberCompletionsWithEnv env src cursor =
     Just req ->
       let ctx = scanSourceContext src cursor
       in completeMember env ctx req
+
+argumentCompletions :: Env.Env0 -> [FilePath] -> S.ModName -> FilePath -> String -> Int -> IO [Completion]
+argumentCompletions baseEnv searchPath modName fileName src cursor = do
+  res <- E.try $ do
+    case argumentContextAt src cursor of
+      Nothing -> return []
+      Just req -> do
+        env <- prepareCompletionEnv baseEnv searchPath modName fileName src
+        let ctx = scanSourceContext src cursor
+            comps = completeArguments env ctx req
+        E.evaluate (forceCompletions comps)
+  case res of
+    Left (_ :: E.SomeException) -> return []
+    Right comps -> return comps
+
+argumentCompletionsWithEnv :: Env.Env0 -> String -> Int -> [Completion]
+argumentCompletionsWithEnv env src cursor =
+  case argumentContextAt src cursor of
+    Nothing -> []
+    Just req ->
+      let ctx = scanSourceContext src cursor
+      in completeArguments env ctx req
 
 callSignatures :: Env.Env0 -> [FilePath] -> S.ModName -> FilePath -> String -> Int -> IO [CallSignature]
 callSignatures baseEnv searchPath modName fileName src cursor = do
@@ -260,10 +298,101 @@ callContextAt src cursor = do
     else Just CallRequest
       { callTarget = target
       , callActiveParameter = activeArgIndex args
+      , callArgumentText = args
       }
   where
     before = take (max 0 (min cursor (length src))) src
     callPathChar c = identChar c || c == '.' || c == '?'
+
+argumentContextAt :: String -> Int -> Maybe ArgumentRequest
+argumentContextAt src cursor = do
+  req <- callContextAt src cursor
+  prefix <- activeKeywordPrefix (callArgumentText req)
+  return ArgumentRequest
+    { argumentTarget = callTarget req
+    , argumentPrefix = prefix
+    , argumentSuppliedKeywords = suppliedKeywordNames (callArgumentText req)
+    }
+
+activeKeywordPrefix :: String -> Maybe String
+activeKeywordPrefix args = do
+  current <- lastMaybe (splitArgSegments args)
+  if topLevelContains '=' current
+    then Nothing
+    else
+      let prefix = reverse (takeWhile identChar (reverse current))
+          beforePrefix = take (length current - length prefix) current
+      in if all isSpace beforePrefix
+           then Just prefix
+           else Nothing
+
+suppliedKeywordNames :: String -> [String]
+suppliedKeywordNames args =
+  mapMaybe keywordName (splitArgSegments args)
+  where
+    keywordName segment =
+      let (lhs, eqPart) = breakArgTopLevel '=' segment
+          nm = trim lhs
+      in case eqPart of
+           '=':_ | validIdent nm -> Just nm
+           _ -> Nothing
+
+splitArgSegments :: String -> [String]
+splitArgSegments = reverse . map reverse . go 0 0 0 Nothing [[]]
+  where
+    go _ _ _ _ acc [] = acc
+    go p b c str (x:xs) (ch:chs)
+      | Just q <- str =
+          let str' = if ch == q then Nothing else str
+          in go p b c str' ((ch:x):xs) chs
+      | ch == '"' || ch == '\'' = go p b c (Just ch) ((ch:x):xs) chs
+      | ch == ',' && p == 0 && b == 0 && c == 0 = go p b c str ([]:x:xs) chs
+      | ch == '(' = go (p + 1) b c str ((ch:x):xs) chs
+      | ch == ')' = go (max 0 (p - 1)) b c str ((ch:x):xs) chs
+      | ch == '[' = go p (b + 1) c str ((ch:x):xs) chs
+      | ch == ']' = go p (max 0 (b - 1)) c str ((ch:x):xs) chs
+      | ch == '{' = go p b (c + 1) str ((ch:x):xs) chs
+      | ch == '}' = go p b (max 0 (c - 1)) str ((ch:x):xs) chs
+      | otherwise = go p b c str ((ch:x):xs) chs
+    go _ _ _ _ [] _ = []
+
+topLevelContains :: Char -> String -> Bool
+topLevelContains needle = go 0 0 0 Nothing
+  where
+    go _ _ _ _ [] = False
+    go p b c str (ch:chs)
+      | Just q <- str =
+          go p b c (if ch == q then Nothing else str) chs
+      | ch == '"' || ch == '\'' = go p b c (Just ch) chs
+      | ch == needle && p == 0 && b == 0 && c == 0 = True
+      | ch == '(' = go (p + 1) b c str chs
+      | ch == ')' = go (max 0 (p - 1)) b c str chs
+      | ch == '[' = go p (b + 1) c str chs
+      | ch == ']' = go p (max 0 (b - 1)) c str chs
+      | ch == '{' = go p b (c + 1) str chs
+      | ch == '}' = go p b (max 0 (c - 1)) str chs
+      | otherwise = go p b c str chs
+
+breakArgTopLevel :: Char -> String -> (String, String)
+breakArgTopLevel needle = go 0 0 0 Nothing []
+  where
+    go _ _ _ _ acc [] = (reverse acc, [])
+    go p b c str acc s@(ch:chs)
+      | Just q <- str =
+          go p b c (if ch == q then Nothing else str) (ch:acc) chs
+      | ch == '"' || ch == '\'' = go p b c (Just ch) (ch:acc) chs
+      | ch == needle && p == 0 && b == 0 && c == 0 = (reverse acc, s)
+      | ch == '(' = go (p + 1) b c str (ch:acc) chs
+      | ch == ')' = go (max 0 (p - 1)) b c str (ch:acc) chs
+      | ch == '[' = go p (b + 1) c str (ch:acc) chs
+      | ch == ']' = go p (max 0 (b - 1)) c str (ch:acc) chs
+      | ch == '{' = go p b (c + 1) str (ch:acc) chs
+      | ch == '}' = go p b (max 0 (c - 1)) str (ch:acc) chs
+      | otherwise = go p b c str (ch:acc) chs
+
+lastMaybe :: [a] -> Maybe a
+lastMaybe [] = Nothing
+lastMaybe xs = Just (last xs)
 
 activeOpenParen :: String -> Maybe Int
 activeOpenParen before = go (length before - 1) 0 (reverse before)
@@ -299,6 +428,23 @@ completeMember env ctx req =
   case resolveReceiverType env ctx (receiverParts (memberReceiver req)) of
     Nothing -> []
     Just typ -> attrsForType env typ (memberPrefix req)
+
+completeArguments :: Env.Env0 -> SourceContext -> ArgumentRequest -> [Completion]
+completeArguments env ctx req =
+  case resolveCallableInfo env ctx (argumentTarget req) >>= typeOfInfo of
+    Just typ ->
+      case Env.unalias env typ of
+        S.TFun _ _ _ kw _ ->
+          [ Completion
+              (keywordParameterName param ++ "=")
+              CompletionKeyword
+              (Just (displayType (keywordParameterType param)))
+          | param <- keywordParameterRows kw
+          , argumentPrefix req `isPrefixOf` keywordParameterName param
+          , keywordParameterName param `notElem` argumentSuppliedKeywords req
+          ]
+        _ -> []
+    _ -> []
 
 callSignature :: Env.Env0 -> SourceContext -> CallRequest -> Maybe CallSignature
 callSignature env ctx req = do
@@ -403,6 +549,13 @@ keywordParameters row =
       SignatureParameter (S.rawstr name ++ ": " ++ displayType typ) : keywordParameters rest
     S.TStar _ S.KRow rest ->
       [SignatureParameter ("**kwargs: " ++ displayType (S.tTupleK rest))]
+    _ -> []
+
+keywordParameterRows :: S.Type -> [KeywordParameter]
+keywordParameterRows row =
+  case row of
+    S.TRow _ S.KRow name typ rest ->
+      KeywordParameter (S.rawstr name) typ : keywordParameterRows rest
     _ -> []
 
 completionEnv :: [FilePath] -> Env.Env0 -> S.ModName -> [S.Import] -> IO Env.Env0
@@ -993,6 +1146,7 @@ forceCompletions xs =
     kindCode CompletionMethod = 2
     kindCode CompletionProperty = 3
     kindCode CompletionValue = 4
+    kindCode CompletionKeyword = 5
 
 forceSignatures :: [CallSignature] -> [CallSignature]
 forceSignatures xs =

--- a/compiler/lib/src/Acton/Completion.hs
+++ b/compiler/lib/src/Acton/Completion.hs
@@ -86,6 +86,8 @@ data HoverInfo = HoverInfo
   , hoverDocumentation :: Maybe String
   } deriving (Eq, Show)
 
+data StringState = StringState Char Bool deriving (Eq, Show)
+
 data SourceContext = SourceContext
   { sourceClass :: Maybe ClassContext
   , sourceDef :: Maybe DefContext
@@ -343,10 +345,9 @@ splitArgSegments = reverse . map reverse . go 0 0 0 Nothing [[]]
   where
     go _ _ _ _ acc [] = acc
     go p b c str (x:xs) (ch:chs)
-      | Just q <- str =
-          let str' = if ch == q then Nothing else str
-          in go p b c str' ((ch:x):xs) chs
-      | ch == '"' || ch == '\'' = go p b c (Just ch) ((ch:x):xs) chs
+      | Just st <- str =
+          go p b c (advanceString st ch) ((ch:x):xs) chs
+      | isStringQuote ch = go p b c (Just (StringState ch False)) ((ch:x):xs) chs
       | ch == ',' && p == 0 && b == 0 && c == 0 = go p b c str ([]:x:xs) chs
       | ch == '(' = go (p + 1) b c str ((ch:x):xs) chs
       | ch == ')' = go (max 0 (p - 1)) b c str ((ch:x):xs) chs
@@ -362,9 +363,9 @@ topLevelContains needle = go 0 0 0 Nothing
   where
     go _ _ _ _ [] = False
     go p b c str (ch:chs)
-      | Just q <- str =
-          go p b c (if ch == q then Nothing else str) chs
-      | ch == '"' || ch == '\'' = go p b c (Just ch) chs
+      | Just st <- str =
+          go p b c (advanceString st ch) chs
+      | isStringQuote ch = go p b c (Just (StringState ch False)) chs
       | ch == needle && p == 0 && b == 0 && c == 0 = True
       | ch == '(' = go (p + 1) b c str chs
       | ch == ')' = go (max 0 (p - 1)) b c str chs
@@ -379,9 +380,9 @@ breakArgTopLevel needle = go 0 0 0 Nothing []
   where
     go _ _ _ _ acc [] = (reverse acc, [])
     go p b c str acc s@(ch:chs)
-      | Just q <- str =
-          go p b c (if ch == q then Nothing else str) (ch:acc) chs
-      | ch == '"' || ch == '\'' = go p b c (Just ch) (ch:acc) chs
+      | Just st <- str =
+          go p b c (advanceString st ch) (ch:acc) chs
+      | isStringQuote ch = go p b c (Just (StringState ch False)) (ch:acc) chs
       | ch == needle && p == 0 && b == 0 && c == 0 = (reverse acc, s)
       | ch == '(' = go (p + 1) b c str (ch:acc) chs
       | ch == ')' = go (max 0 (p - 1)) b c str (ch:acc) chs
@@ -396,25 +397,29 @@ lastMaybe [] = Nothing
 lastMaybe xs = Just (last xs)
 
 activeOpenParen :: String -> Maybe Int
-activeOpenParen before = go (length before - 1) 0 (reverse before)
+activeOpenParen = listToMaybe . go 0 Nothing []
   where
-    go _ _ [] = Nothing
-    go ix depth (c:cs)
-      | c == ')' = go (ix - 1) (depth + 1) cs
-      | c == '(' && depth == 0 = Just ix
-      | c == '(' = go (ix - 1) (depth - 1) cs
-      | otherwise = go (ix - 1) depth cs
+    go _ _ stack [] = stack
+    go ix str stack (ch:chs)
+      | Just st <- str =
+          go (ix + 1) (advanceString st ch) stack chs
+      | isStringQuote ch =
+          go (ix + 1) (Just (StringState ch False)) stack chs
+      | ch == '(' =
+          go (ix + 1) str (ix:stack) chs
+      | ch == ')' =
+          go (ix + 1) str (drop 1 stack) chs
+      | otherwise =
+          go (ix + 1) str stack chs
 
 activeArgIndex :: String -> Int
 activeArgIndex = go 0 0 0 0 Nothing
   where
     go arg _ _ _ _ [] = arg
     go arg p b c str (x:xs)
-      | Just q <- str =
-          if x == q
-            then go arg p b c Nothing xs
-            else go arg p b c str xs
-      | x == '"' || x == '\'' = go arg p b c (Just x) xs
+      | Just st <- str =
+          go arg p b c (advanceString st x) xs
+      | isStringQuote x = go arg p b c (Just (StringState x False)) xs
       | x == '(' = go arg (p + 1) b c str xs
       | x == ')' = go arg (max 0 (p - 1)) b c str xs
       | x == '[' = go arg p (b + 1) c str xs
@@ -423,6 +428,16 @@ activeArgIndex = go 0 0 0 0 Nothing
       | x == '}' = go arg p b (max 0 (c - 1)) str xs
       | x == ',' && p == 0 && b == 0 && c == 0 = go (arg + 1) p b c str xs
       | otherwise = go arg p b c str xs
+
+isStringQuote :: Char -> Bool
+isStringQuote ch = ch == '"' || ch == '\''
+
+advanceString :: StringState -> Char -> Maybe StringState
+advanceString (StringState quote escaped) ch
+  | escaped = Just (StringState quote False)
+  | ch == '\\' = Just (StringState quote True)
+  | ch == quote = Nothing
+  | otherwise = Just (StringState quote False)
 
 completeMember :: Env.Env0 -> SourceContext -> MemberRequest -> [Completion]
 completeMember env ctx req =

--- a/compiler/lib/src/Acton/Completion.hs
+++ b/compiler/lib/src/Acton/Completion.hs
@@ -29,6 +29,7 @@ import qualified Control.Monad.Trans.State.Strict as St
 import Data.Char (isAlpha, isAlphaNum, isSpace)
 import Data.List (find, findIndex, intercalate, isPrefixOf, nubBy)
 import Data.Maybe (listToMaybe, mapMaybe)
+import qualified Data.HashMap.Strict as HM
 import qualified InterfaceFiles as IF
 import Text.Megaparsec (eof, runParser)
 
@@ -766,12 +767,36 @@ callResultType env ctx parts = do
 lookupPathInfo :: Env.Env0 -> [String] -> Maybe I.NameInfo
 lookupPathInfo _ [] = Nothing
 lookupPathInfo env [n] =
-  fmap I.convHNameInfo2NameInfo (Env.tryQName (S.NoQ (S.name n)) env)
+  lookupQNameInfo env (S.NoQ (S.name n))
 lookupPathInfo env parts =
   let modPart = init parts
       n = last parts
       qn = S.QName (S.ModName (map S.name modPart)) (S.name n)
-  in fmap I.convHNameInfo2NameInfo (Env.tryQName qn env)
+  in lookupQNameInfo env qn
+
+lookupQNameInfo :: Env.Env0 -> S.QName -> Maybe I.NameInfo
+lookupQNameInfo env qn =
+  case qn of
+    S.NoQ n ->
+      case lookup n (Env.names env) of
+        Just (I.NAlias qn') -> lookupQNameInfo env qn'
+        Just info -> Just info
+        Nothing -> Nothing
+    S.QName m n ->
+      lookupModuleItem env (Env.findHMod m env) n
+    S.GName m n
+      | Just m == Env.thismod env ->
+          lookupQNameInfo env (S.NoQ n)
+      | otherwise ->
+          lookupModuleItem env (Env.lookupHMod m env) n
+
+lookupModuleItem :: Env.Env0 -> Maybe I.HTEnv -> S.Name -> Maybe I.NameInfo
+lookupModuleItem env mtenv n = do
+  tenv <- mtenv
+  info <- HM.lookup n tenv
+  case info of
+    I.HNAlias qn -> lookupQNameInfo env qn
+    _ -> Just (I.convHNameInfo2NameInfo info)
 
 functionReturnType :: Env.Env0 -> I.NameInfo -> Maybe S.Type
 functionReturnType env info = do
@@ -823,7 +848,7 @@ typeDoc env typ = do
 
 lookupTConInfo :: Env.Env0 -> S.TCon -> Maybe I.NameInfo
 lookupTConInfo env tc =
-  fmap I.convHNameInfo2NameInfo (Env.tryQName (S.tcname tc) env)
+  lookupQNameInfo env (S.tcname tc)
 
 cleanDoc :: Maybe String -> Maybe String
 cleanDoc Nothing = Nothing

--- a/compiler/lib/src/Acton/Completion.hs
+++ b/compiler/lib/src/Acton/Completion.hs
@@ -9,8 +9,12 @@ module Acton.Completion
   , MemberRequest(..)
   , callContextAt
   , callSignatures
+  , callSignaturesWithEnv
+  , completionImportKey
   , memberContextAt
   , memberCompletions
+  , memberCompletionsWithEnv
+  , prepareCompletionEnv
   ) where
 
 import qualified Control.Exception as E
@@ -112,8 +116,7 @@ memberCompletions baseEnv searchPath modName fileName src cursor = do
     case memberContextAt src cursor of
       Nothing -> return []
       Just req -> do
-        imps <- parseImports fileName src
-        env <- completionEnv searchPath baseEnv modName imps
+        env <- prepareCompletionEnv baseEnv searchPath modName fileName src
         let ctx = scanSourceContext src cursor
             comps = completeMember env ctx req
         E.evaluate (forceCompletions comps)
@@ -121,20 +124,45 @@ memberCompletions baseEnv searchPath modName fileName src cursor = do
     Left (_ :: E.SomeException) -> return []
     Right comps -> return comps
 
+memberCompletionsWithEnv :: Env.Env0 -> String -> Int -> [Completion]
+memberCompletionsWithEnv env src cursor =
+  case memberContextAt src cursor of
+    Nothing -> []
+    Just req ->
+      let ctx = scanSourceContext src cursor
+      in completeMember env ctx req
+
 callSignatures :: Env.Env0 -> [FilePath] -> S.ModName -> FilePath -> String -> Int -> IO [CallSignature]
 callSignatures baseEnv searchPath modName fileName src cursor = do
   res <- E.try $ do
     case callContextAt src cursor of
       Nothing -> return []
       Just req -> do
-        imps <- parseImports fileName src
-        env <- completionEnv searchPath baseEnv modName imps
+        env <- prepareCompletionEnv baseEnv searchPath modName fileName src
         let ctx = scanSourceContext src cursor
             sigs = maybe [] (:[]) (callSignature env ctx req)
         E.evaluate (forceSignatures sigs)
   case res of
     Left (_ :: E.SomeException) -> return []
     Right sigs -> return sigs
+
+callSignaturesWithEnv :: Env.Env0 -> String -> Int -> [CallSignature]
+callSignaturesWithEnv env src cursor =
+  case callContextAt src cursor of
+    Nothing -> []
+    Just req ->
+      let ctx = scanSourceContext src cursor
+      in maybe [] (:[]) (callSignature env ctx req)
+
+prepareCompletionEnv :: Env.Env0 -> [FilePath] -> S.ModName -> FilePath -> String -> IO Env.Env0
+prepareCompletionEnv baseEnv searchPath modName fileName src = do
+  imps <- parseImports fileName src
+  completionEnv searchPath baseEnv modName imps
+
+completionImportKey :: FilePath -> String -> IO String
+completionImportKey fileName src = do
+  imps <- parseImports fileName src
+  return (show imps)
 
 memberContextAt :: String -> Int -> Maybe MemberRequest
 memberContextAt src cursor =

--- a/compiler/lib/src/Acton/Completion.hs
+++ b/compiler/lib/src/Acton/Completion.hs
@@ -1,0 +1,832 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Acton.Completion
+  ( Completion(..)
+  , CompletionKind(..)
+  , CallSignature(..)
+  , SignatureParameter(..)
+  , CallRequest(..)
+  , MemberRequest(..)
+  , callContextAt
+  , callSignatures
+  , memberContextAt
+  , memberCompletions
+  ) where
+
+import qualified Control.Exception as E
+import Control.Monad (foldM)
+import qualified Control.Monad.Trans.State.Strict as St
+import Data.Char (isAlpha, isAlphaNum, isSpace)
+import Data.List (find, findIndex, intercalate, isPrefixOf, nubBy)
+import Data.Maybe (listToMaybe, mapMaybe)
+import qualified InterfaceFiles as IF
+import Text.Megaparsec (eof, runParser)
+
+import qualified Acton.Env as Env
+import qualified Acton.NameInfo as I
+import qualified Acton.Parser as P
+import qualified Acton.Syntax as S
+import Utils (prstr)
+
+data CompletionKind
+  = CompletionField
+  | CompletionMethod
+  | CompletionProperty
+  | CompletionValue
+  deriving (Eq, Show)
+
+data Completion = Completion
+  { completionLabel :: String
+  , completionKind :: CompletionKind
+  , completionDetail :: Maybe String
+  } deriving (Eq, Show)
+
+data MemberRequest = MemberRequest
+  { memberReceiver :: String
+  , memberPrefix :: String
+  } deriving (Eq, Show)
+
+data CallRequest = CallRequest
+  { callTarget :: [String]
+  , callActiveParameter :: Int
+  } deriving (Eq, Show)
+
+data SignatureParameter = SignatureParameter
+  { signatureParameterLabel :: String
+  } deriving (Eq, Show)
+
+data CallSignature = CallSignature
+  { callSignatureLabel :: String
+  , callSignatureParameters :: [SignatureParameter]
+  , callSignatureActiveParameter :: Int
+  } deriving (Eq, Show)
+
+data SourceContext = SourceContext
+  { sourceClass :: Maybe ClassContext
+  , sourceDef :: Maybe DefContext
+  , sourceLocalBindings :: [LocalBinding]
+  } deriving (Eq, Show)
+
+data ClassContext = ClassContext
+  { className :: String
+  , classParents :: [String]
+  , classIndent :: Int
+  } deriving (Eq, Show)
+
+data DefContext = DefContext
+  { defName :: String
+  , defParams :: [Param]
+  , defIndent :: Int
+  } deriving (Eq, Show)
+
+data Param = Param
+  { paramName :: String
+  , paramAnn :: Maybe String
+  } deriving (Eq, Show)
+
+data LocalBinding = LocalBinding
+  { localName :: String
+  , localClassName :: Maybe String
+  , localClassIndent :: Maybe Int
+  , localDefName :: String
+  , localDefIndent :: Int
+  , localKind :: LocalKind
+  } deriving (Eq, Show)
+
+data LocalKind
+  = LocalAnnotated String
+  | LocalCallResult [String]
+  | LocalMemberPath [String]
+  deriving (Eq, Show)
+
+data Scope = ScopeClass ClassContext | ScopeDef DefContext deriving (Eq, Show)
+
+data ScanState = ScanState
+  { scanScopes :: [Scope]
+  , scanLocals :: [LocalBinding]
+  } deriving (Eq, Show)
+
+memberCompletions :: Env.Env0 -> [FilePath] -> S.ModName -> FilePath -> String -> Int -> IO [Completion]
+memberCompletions baseEnv searchPath modName fileName src cursor = do
+  res <- E.try $ do
+    case memberContextAt src cursor of
+      Nothing -> return []
+      Just req -> do
+        imps <- parseImports fileName src
+        env <- completionEnv searchPath baseEnv modName imps
+        let ctx = scanSourceContext src cursor
+            comps = completeMember env ctx req
+        E.evaluate (forceCompletions comps)
+  case res of
+    Left (_ :: E.SomeException) -> return []
+    Right comps -> return comps
+
+callSignatures :: Env.Env0 -> [FilePath] -> S.ModName -> FilePath -> String -> Int -> IO [CallSignature]
+callSignatures baseEnv searchPath modName fileName src cursor = do
+  res <- E.try $ do
+    case callContextAt src cursor of
+      Nothing -> return []
+      Just req -> do
+        imps <- parseImports fileName src
+        env <- completionEnv searchPath baseEnv modName imps
+        let ctx = scanSourceContext src cursor
+            sigs = maybe [] (:[]) (callSignature env ctx req)
+        E.evaluate (forceSignatures sigs)
+  case res of
+    Left (_ :: E.SomeException) -> return []
+    Right sigs -> return sigs
+
+memberContextAt :: String -> Int -> Maybe MemberRequest
+memberContextAt src cursor =
+  case restAfterPrefix of
+    '.':rest ->
+      let receiver = reverse (takeWhile receiverChar rest)
+          receiver' = trimDots receiver
+      in if null receiver'
+           then Nothing
+           else Just MemberRequest
+                  { memberReceiver = receiver'
+                  , memberPrefix = reverse prefixRev
+                  }
+    _ -> Nothing
+  where
+    before = take (max 0 (min cursor (length src))) src
+    (prefixRev, restAfterPrefix) = span identChar (reverse before)
+
+    identChar c = isAlphaNum c || c == '_'
+    receiverChar c = identChar c || c == '.' || c == '?'
+    trimDots = reverse . dropWhile (== '.') . reverse . dropWhile (== '.')
+
+callContextAt :: String -> Int -> Maybe CallRequest
+callContextAt src cursor = do
+  openIx <- activeOpenParen before
+  let args = drop (openIx + 1) before
+      calleeBeforeParen = take openIx before
+      callee = reverse $
+        takeWhile callPathChar $
+        dropWhile isSpace $
+        reverse calleeBeforeParen
+      target = receiverParts callee
+  if null target
+    then Nothing
+    else Just CallRequest
+      { callTarget = target
+      , callActiveParameter = activeArgIndex args
+      }
+  where
+    before = take (max 0 (min cursor (length src))) src
+    callPathChar c = identChar c || c == '.' || c == '?'
+
+activeOpenParen :: String -> Maybe Int
+activeOpenParen before = go (length before - 1) 0 (reverse before)
+  where
+    go _ _ [] = Nothing
+    go ix depth (c:cs)
+      | c == ')' = go (ix - 1) (depth + 1) cs
+      | c == '(' && depth == 0 = Just ix
+      | c == '(' = go (ix - 1) (depth - 1) cs
+      | otherwise = go (ix - 1) depth cs
+
+activeArgIndex :: String -> Int
+activeArgIndex = go 0 0 0 0 Nothing
+  where
+    go arg _ _ _ _ [] = arg
+    go arg p b c str (x:xs)
+      | Just q <- str =
+          if x == q
+            then go arg p b c Nothing xs
+            else go arg p b c str xs
+      | x == '"' || x == '\'' = go arg p b c (Just x) xs
+      | x == '(' = go arg (p + 1) b c str xs
+      | x == ')' = go arg (max 0 (p - 1)) b c str xs
+      | x == '[' = go arg p (b + 1) c str xs
+      | x == ']' = go arg p (max 0 (b - 1)) c str xs
+      | x == '{' = go arg p b (c + 1) str xs
+      | x == '}' = go arg p b (max 0 (c - 1)) str xs
+      | x == ',' && p == 0 && b == 0 && c == 0 = go (arg + 1) p b c str xs
+      | otherwise = go arg p b c str xs
+
+completeMember :: Env.Env0 -> SourceContext -> MemberRequest -> [Completion]
+completeMember env ctx req =
+  case resolveReceiverType env ctx (receiverParts (memberReceiver req)) of
+    Nothing -> []
+    Just typ -> attrsForType env typ (memberPrefix req)
+
+callSignature :: Env.Env0 -> SourceContext -> CallRequest -> Maybe CallSignature
+callSignature env ctx req = do
+  info <- resolveCallableInfo env ctx (callTarget req)
+  typ <- typeOfInfo info
+  case Env.unalias env typ of
+    S.TFun _ _ pos kw ret ->
+      let params = signatureParameters pos kw
+          active = if null params
+                     then 0
+                     else min (callActiveParameter req) (length params - 1)
+          label = intercalate "." (callTarget req)
+            ++ "("
+            ++ intercalate ", " (map signatureParameterLabel params)
+            ++ ") -> "
+            ++ prstr ret
+      in Just CallSignature
+        { callSignatureLabel = label
+        , callSignatureParameters = params
+        , callSignatureActiveParameter = active
+        }
+    _ -> Nothing
+
+resolveCallableInfo :: Env.Env0 -> SourceContext -> [String] -> Maybe I.NameInfo
+resolveCallableInfo env ctx parts =
+  memberCallableInfo env ctx parts <|> lookupPathInfo env parts
+
+memberCallableInfo :: Env.Env0 -> SourceContext -> [String] -> Maybe I.NameInfo
+memberCallableInfo env ctx parts = do
+  (receiver, attr) <- unsnoc parts
+  typ <- resolveReceiverType env ctx receiver
+  tc <- typeTCon env typ
+  attrInfo env tc (S.name attr)
+
+unsnoc :: [a] -> Maybe ([a], a)
+unsnoc [] = Nothing
+unsnoc xs = Just (init xs, last xs)
+
+signatureParameters :: S.Type -> S.Type -> [SignatureParameter]
+signatureParameters pos kw =
+  zipWith positional [1..] (positionalTypes pos) ++ keywordParameters kw
+  where
+    positional ix typ =
+      SignatureParameter ("arg" ++ show (ix :: Int) ++ ": " ++ prstr typ)
+
+positionalTypes :: S.Type -> [S.Type]
+positionalTypes row =
+  case row of
+    S.TRow _ S.PRow _ typ rest -> typ : positionalTypes rest
+    S.TStar _ S.PRow rest -> [S.tTupleP rest]
+    _ -> []
+
+keywordParameters :: S.Type -> [SignatureParameter]
+keywordParameters row =
+  case row of
+    S.TRow _ S.KRow name typ rest ->
+      SignatureParameter (S.rawstr name ++ ": " ++ prstr typ) : keywordParameters rest
+    S.TStar _ S.KRow rest ->
+      [SignatureParameter ("**kwargs: " ++ prstr (S.tTupleK rest))]
+    _ -> []
+
+completionEnv :: [FilePath] -> Env.Env0 -> S.ModName -> [S.Import] -> IO Env.Env0
+completionEnv searchPath baseEnv modName imps =
+  Env.mkEnv searchPath baseEnv mod `E.catch` \(_ :: E.SomeException) ->
+    shallowCompletionEnv searchPath baseEnv imps
+  where
+    mod = S.Module modName imps Nothing []
+
+-- Completion should still work when an otherwise usable direct import records
+-- stale transitive interfaces. Load only the imported modules themselves as a
+-- fallback, which is enough for generated base classes and typed constructors.
+shallowCompletionEnv :: [FilePath] -> Env.Env0 -> [S.Import] -> IO Env.Env0
+shallowCompletionEnv searchPath baseEnv imps =
+  refreshHModules <$> foldM (shallowImport searchPath) baseEnv imps
+
+refreshHModules :: Env.Env0 -> Env.Env0
+refreshHModules env =
+  env { Env.hmodules = I.convTEnv2HTEnv (Env.modules env) }
+
+shallowImport :: [FilePath] -> Env.Env0 -> S.Import -> IO Env.Env0
+shallowImport searchPath env imp =
+  case imp of
+    S.Import _ items ->
+      foldM (shallowModuleItem searchPath) env items
+    S.FromImport _ (S.ModRef (0, Just m)) items ->
+      shallowModule searchPath env m $ \te env' ->
+        Env.importSome items m te (Env.importWits m te env')
+    S.FromImportAll _ (S.ModRef (0, Just m)) ->
+      shallowModule searchPath env m $ \te env' ->
+        Env.importAll m te (Env.importWits m te env')
+    _ ->
+      return env
+
+shallowModuleItem :: [FilePath] -> Env.Env0 -> S.ModuleItem -> IO Env.Env0
+shallowModuleItem searchPath env (S.ModuleItem m as) =
+  shallowModule searchPath env m $ \te env' ->
+    let env'' =
+          case as of
+            Nothing -> Env.addImport m env'
+            Just n -> Env.define [(n, I.NMAlias m)] env'
+    in Env.importWits m te env''
+
+shallowModule
+  :: [FilePath]
+  -> Env.Env0
+  -> S.ModName
+  -> (I.TEnv -> Env.Env0 -> Env.Env0)
+  -> IO Env.Env0
+shallowModule searchPath env m applyImport = do
+  loaded <- readModuleInterface searchPath m
+  case loaded of
+    Nothing -> return env
+    Just (te, mdoc) ->
+      return $ applyImport te (Env.addMod m te mdoc env)
+
+readModuleInterface :: [FilePath] -> S.ModName -> IO (Maybe (I.TEnv, Maybe String))
+readModuleInterface searchPath m = do
+  mty <- Env.findTyFile searchPath m
+  case mty of
+    Nothing -> return Nothing
+    Just ty -> do
+      res <- (Just <$> IF.readFile ty) `E.catch` \(_ :: E.SomeException) ->
+        return Nothing
+      case res of
+        Just (_, I.NModule te mdoc, _, _, _, _, _, _, _, _, _, _) ->
+          return (Just (te, mdoc))
+        _ ->
+          return Nothing
+
+resolveReceiverType :: Env.Env0 -> SourceContext -> [String] -> Maybe S.Type
+resolveReceiverType _ _ [] = Nothing
+resolveReceiverType env ctx (base:attrs) = do
+  baseType <- resolveBaseType env ctx base
+  foldl step (Just baseType) attrs
+  where
+    step Nothing _ = Nothing
+    step (Just typ) attr = do
+      tc <- typeTCon env typ
+      attrType env tc (S.name attr)
+
+resolveBaseType :: Env.Env0 -> SourceContext -> String -> Maybe S.Type
+resolveBaseType env ctx name =
+  localBindingType env ctx name
+  <|> explicitParamType env ctx name
+  <|> inheritedParamType env ctx name
+
+localBindingType :: Env.Env0 -> SourceContext -> String -> Maybe S.Type
+localBindingType env ctx name =
+  listToMaybe $ mapMaybe bindingType matching
+  where
+    matching =
+      case sourceDef ctx of
+        Nothing -> []
+        Just def ->
+          filter (sameDef def) $
+            filter ((== name) . localName) (sourceLocalBindings ctx)
+
+    sameDef def binding =
+      localDefName binding == defName def &&
+      localDefIndent binding == defIndent def &&
+      localClassKey binding == sourceClassKey
+
+    sourceClassKey =
+      fmap (\cls -> (className cls, classIndent cls)) (sourceClass ctx)
+
+    localClassKey binding =
+      (,) <$> localClassName binding <*> localClassIndent binding
+
+    bindingType binding =
+      case localKind binding of
+        LocalAnnotated ann -> parseTypeText env ann
+        LocalCallResult callee -> callResultType env ctx callee
+        LocalMemberPath path -> resolveReceiverType env ctx path
+
+explicitParamType :: Env.Env0 -> SourceContext -> String -> Maybe S.Type
+explicitParamType env ctx name = do
+  def <- sourceDef ctx
+  param <- find ((== name) . paramName) (defParams def)
+  ann <- paramAnn param
+  parseTypeText env ann
+
+inheritedParamType :: Env.Env0 -> SourceContext -> String -> Maybe S.Type
+inheritedParamType env ctx name = do
+  cls <- sourceClass ctx
+  def <- sourceDef ctx
+  paramIx <- methodParamIndex name (defParams def)
+  listToMaybe $ mapMaybe (parentParamType paramIx name (defName def)) (classParents cls)
+  where
+    parentParamType ix pname method parentText = do
+      parentType <- parseTypeText env parentText
+      parentTc <- typeTCon env parentType
+      (_, schema, _) <- Env.findAttr env parentTc (S.name method)
+      parentMod <- qnameModule (S.tcname parentTc)
+      Env.unalias (Env.setMod parentMod env) <$> paramTypeFromSchema ix pname schema
+
+    qnameModule qn =
+      case qn of
+        S.QName mn _ -> Just mn
+        S.GName mn _ -> Just mn
+        S.NoQ _ -> Nothing
+
+methodParamIndex :: String -> [Param] -> Maybe Int
+methodParamIndex name params = do
+  ix <- findIndex ((== name) . paramName) params
+  let selfOffset = case params of
+                     Param "self" _ : _ -> 1
+                     _ -> 0
+      ix' = ix - selfOffset
+  if ix' < 0 then Nothing else Just ix'
+
+paramTypeFromSchema :: Int -> String -> S.TSchema -> Maybe S.Type
+paramTypeFromSchema ix pname (S.TSchema _ _ typ) =
+  case typ of
+    S.TFun _ _ pos kwd _ ->
+      positionalType ix pos <|> keywordType (S.name pname) kwd
+    _ -> Nothing
+
+positionalType :: Int -> S.Type -> Maybe S.Type
+positionalType ix row =
+  case row of
+    S.TRow _ S.PRow _ typ rest
+      | ix == 0 -> Just typ
+      | otherwise -> positionalType (ix - 1) rest
+    _ -> Nothing
+
+keywordType :: S.Name -> S.Type -> Maybe S.Type
+keywordType name row =
+  case row of
+    S.TRow _ S.KRow n typ rest
+      | S.rawstr n == S.rawstr name -> Just typ
+      | otherwise -> keywordType name rest
+    _ -> Nothing
+
+attrsForType :: Env.Env0 -> S.Type -> String -> [Completion]
+attrsForType env typ prefix =
+  case typeTCon env typ of
+    Nothing -> []
+    Just tc ->
+      dedup $
+        [ Completion (S.rawstr n) (kindOf info) (detailOf info)
+        | (n, info) <- Env.fullAttrEnv env tc
+        , prefix `isPrefixOf` S.rawstr n
+        ]
+
+attrType :: Env.Env0 -> S.TCon -> S.Name -> Maybe S.Type
+attrType env tc attr =
+  attrInfo env tc attr >>= typeOfInfo
+
+attrInfo :: Env.Env0 -> S.TCon -> S.Name -> Maybe I.NameInfo
+attrInfo env tc attr =
+  snd <$> find ((== S.rawstr attr) . S.rawstr . fst) (Env.fullAttrEnv env tc)
+
+typeOfInfo :: I.NameInfo -> Maybe S.Type
+typeOfInfo info =
+  case info of
+    I.NVar t -> Just t
+    I.NSVar t -> Just t
+    I.NDef schema _ _ -> Just (S.sctype schema)
+    I.NSig schema _ _ -> Just (S.sctype schema)
+    _ -> Nothing
+
+callResultType :: Env.Env0 -> SourceContext -> [String] -> Maybe S.Type
+callResultType env ctx parts = do
+  info <- resolveCallableInfo env ctx parts
+  functionReturnType env info
+
+lookupPathInfo :: Env.Env0 -> [String] -> Maybe I.NameInfo
+lookupPathInfo _ [] = Nothing
+lookupPathInfo env [n] =
+  fmap I.convHNameInfo2NameInfo (Env.tryQName (S.NoQ (S.name n)) env)
+lookupPathInfo env parts =
+  let modPart = init parts
+      n = last parts
+      qn = S.QName (S.ModName (map S.name modPart)) (S.name n)
+  in fmap I.convHNameInfo2NameInfo (Env.tryQName qn env)
+
+functionReturnType :: Env.Env0 -> I.NameInfo -> Maybe S.Type
+functionReturnType env info = do
+  typ <- typeOfInfo info
+  case typ of
+    S.TFun _ _ _ _ ret -> Just (Env.unalias env ret)
+    _ -> Nothing
+
+kindOf :: I.NameInfo -> CompletionKind
+kindOf info =
+  case info of
+    I.NSig schema dec _
+      | dec == S.Property -> CompletionProperty
+      | isFun (S.sctype schema) -> CompletionMethod
+      | otherwise -> CompletionField
+    I.NDef schema dec _
+      | dec == S.Property -> CompletionProperty
+      | isFun (S.sctype schema) -> CompletionMethod
+      | otherwise -> CompletionValue
+    I.NVar{} -> CompletionField
+    I.NSVar{} -> CompletionField
+    _ -> CompletionValue
+  where
+    isFun S.TFun{} = True
+    isFun _ = False
+
+detailOf :: I.NameInfo -> Maybe String
+detailOf info =
+  fmap prstr (typeOfInfo info)
+
+typeTCon :: Env.Env0 -> S.Type -> Maybe S.TCon
+typeTCon env typ =
+  case typ of
+    S.TCon _ tc -> Just tc
+    S.TOpt _ inner -> typeTCon env inner
+    S.TVar _ tv -> Just (Env.findTVBound env tv)
+    _ -> Nothing
+
+parseTypeText :: Env.Env0 -> String -> Maybe S.Type
+parseTypeText env raw =
+  case runParser (St.evalStateT (P.ttype <* eof) P.initState) "" raw of
+    Left _ -> Nothing
+    Right typ -> Just (Env.unalias env typ)
+
+parseImports :: FilePath -> String -> IO [S.Import]
+parseImports fileName src = do
+  res <- E.try (P.parseModuleHeader fileName src)
+  case res of
+    Left (_ :: E.SomeException) -> return []
+    Right (imps, _) -> return imps
+
+scanSourceContext :: String -> Int -> SourceContext
+scanSourceContext src cursor =
+  let st = foldl scanLine (ScanState [] []) (contextLines src cursor)
+      scopes = scanScopes st
+  in SourceContext
+       { sourceClass = listToMaybe [ c | ScopeClass c <- scopes ]
+       , sourceDef = listToMaybe [ d | ScopeDef d <- scopes ]
+       , sourceLocalBindings = scanLocals st
+       }
+
+scanLine :: ScanState -> String -> ScanState
+scanLine st line
+  | null stripped = st
+  | "#" `isPrefixOf` stripped = st
+  | otherwise =
+      let indent = lineIndent line
+          scopes' = popClosed indent (scanScopes st)
+      in case parseClass indent stripped of
+           Just cls -> st { scanScopes = ScopeClass cls : scopes' }
+           Nothing ->
+             case parseDef indent stripped of
+               Just def -> st { scanScopes = ScopeDef def : scopes' }
+               Nothing ->
+                 st { scanScopes = scopes'
+                    , scanLocals = scanLocal scopes' stripped (scanLocals st)
+                    }
+  where
+    stripped = trimLeft line
+
+scanLocal :: [Scope] -> String -> [LocalBinding] -> [LocalBinding]
+scanLocal scopes stripped locals
+  | Just def <- activeDef =
+      case parseLocalBinding stripped of
+        Just (nm, kind) ->
+          LocalBinding
+            { localName = nm
+            , localClassName = className <$> activeClass
+            , localClassIndent = classIndent <$> activeClass
+            , localDefName = defName def
+            , localDefIndent = defIndent def
+            , localKind = kind
+            } : locals
+        Nothing -> locals
+  | otherwise = locals
+  where
+    activeDef = listToMaybe [ d | ScopeDef d <- scopes ]
+    activeClass = listToMaybe [ c | ScopeClass c <- scopes ]
+
+popClosed :: Int -> [Scope] -> [Scope]
+popClosed indent = dropWhile ((>= indent) . scopeIndent)
+
+scopeIndent :: Scope -> Int
+scopeIndent (ScopeClass cls) = classIndent cls
+scopeIndent (ScopeDef def) = defIndent def
+
+parseClass :: Int -> String -> Maybe ClassContext
+parseClass indent line
+  | "class " `isPrefixOf` line = do
+      let rest = dropWhile isSpace (drop (length "class ") line)
+          (nm, afterName) = span identChar rest
+      if null nm
+        then Nothing
+        else Just ClassContext
+               { className = nm
+               , classParents = parseParents (skipTypeBinder afterName)
+               , classIndent = indent
+               }
+  | otherwise = Nothing
+
+parseParents :: String -> [String]
+parseParents afterName =
+  case dropWhile isSpace afterName of
+    '(':rest ->
+      case balancedContent '(' ')' rest of
+        Just inside -> filter (not . null) (map trim (splitTopLevel ',' inside))
+        Nothing -> []
+    _ -> []
+
+parseDef :: Int -> String -> Maybe DefContext
+parseDef indent line = do
+  afterDef <- afterDefKeyword line
+  let (nm, afterName) = span identChar (dropWhile isSpace afterDef)
+  paramsText <- case skipTypeBinder afterName of
+                  '(':rest -> balancedContent '(' ')' rest
+                  _ -> Nothing
+  return DefContext
+    { defName = nm
+    , defParams = mapMaybe parseParam (splitTopLevel ',' paramsText)
+    , defIndent = indent
+    }
+
+afterDefKeyword :: String -> Maybe String
+afterDefKeyword line
+  | "def " `isPrefixOf` line = Just (drop 4 line)
+  | otherwise =
+      case stripEffect line of
+        Just rest | "def " `isPrefixOf` rest -> Just (drop 4 rest)
+        _ -> Nothing
+  where
+    stripEffect s =
+      case words s of
+        w:_ | w `elem` ["mut", "proc", "pure", "action"] ->
+              Just (dropWhile isSpace (drop (length w) s))
+        _ -> Nothing
+
+parseParam :: String -> Maybe Param
+parseParam raw
+  | null nm = Nothing
+  | otherwise = Just Param { paramName = nm, paramAnn = ann }
+  where
+    s0 = trim raw
+    s = dropWhile (== '*') s0
+    (beforeDefault, _) = breakTopLevel '=' s
+    (namePart, annPart) = breakTopLevel ':' beforeDefault
+    nm = trim namePart
+    ann = case annPart of
+            ':' : rest ->
+              let a = trim rest
+              in if null a then Nothing else Just a
+            _ -> Nothing
+
+parseLocalBinding :: String -> Maybe (String, LocalKind)
+parseLocalBinding line = do
+  let (lhs, eqPart) = breakTopLevel '=' line
+  rhs <- case eqPart of
+           '=' : rest -> Just rest
+           _ -> Nothing
+  let (namePart, annPart) = breakTopLevel ':' lhs
+      nm = trim namePart
+  if not (validIdent nm)
+    then Nothing
+    else case annPart of
+           ':' : annRaw ->
+             let ann = trim annRaw
+             in if null ann
+                  then Nothing
+                  else Just (nm, LocalAnnotated ann)
+           _ ->
+             case parseCallTarget rhs of
+               Just callee -> Just (nm, LocalCallResult callee)
+               Nothing -> do
+                 path <- parseMemberPath rhs
+                 return (nm, LocalMemberPath path)
+
+parseCallTarget :: String -> Maybe [String]
+parseCallTarget raw =
+  let s = trim raw
+      (callee, rest) = span callPathChar s
+  in case (strictReceiverParts callee, dropWhile isSpace rest) of
+       (Just parts, '(' : _) | validCallPath parts -> Just parts
+       _ -> Nothing
+  where
+    callPathChar c = identChar c || c == '.' || c == '?'
+    validCallPath parts = all validIdent parts && not (null parts)
+
+parseMemberPath :: String -> Maybe [String]
+parseMemberPath raw =
+  let s = trim raw
+      (path, rest) = span memberPathChar s
+  in case strictReceiverParts path of
+       Just parts | all isSpace rest && validMemberPath parts -> Just parts
+       _ -> Nothing
+  where
+    memberPathChar c = identChar c || c == '.' || c == '?'
+    validMemberPath parts = length parts > 1 && all validIdent parts
+
+validIdent :: String -> Bool
+validIdent [] = False
+validIdent (c:cs) = (isAlpha c || c == '_') && all identChar cs
+
+contextLines :: String -> Int -> [String]
+contextLines src cursor =
+  let before = take (max 0 (min cursor (length src))) src
+      ls = lines before
+  in case reverse before of
+       '\n':_ -> ls
+       _ -> case ls of
+              [] -> []
+              _ -> init ls
+
+receiverParts :: String -> [String]
+receiverParts =
+  filter (not . null) . map stripOptionalMarker . splitOn '.'
+
+strictReceiverParts :: String -> Maybe [String]
+strictReceiverParts raw =
+  let parts = map stripOptionalMarker (splitOn '.' raw)
+  in if any null parts then Nothing else Just parts
+
+stripOptionalMarker :: String -> String
+stripOptionalMarker = reverse . dropWhile (== '?') . reverse
+
+lineIndent :: String -> Int
+lineIndent = go 0
+  where
+    go n (' ':xs) = go (n + 1) xs
+    go n ('\t':xs) = go (n + 8) xs
+    go n _ = n
+
+identChar :: Char -> Bool
+identChar c = isAlphaNum c || c == '_'
+
+splitOn :: Char -> String -> [String]
+splitOn sep = splitTopLevel sep
+
+splitTopLevel :: Char -> String -> [String]
+splitTopLevel sep = reverse . map reverse . go 0 0 0 [[]]
+  where
+    go _ _ _ acc [] = acc
+    go p b c (x:xs) (ch:chs)
+      | ch == sep && p == 0 && b == 0 && c == 0 = go p b c ([]:x:xs) chs
+      | ch == '(' = go (p + 1) b c ((ch:x):xs) chs
+      | ch == ')' = go (max 0 (p - 1)) b c ((ch:x):xs) chs
+      | ch == '[' = go p (b + 1) c ((ch:x):xs) chs
+      | ch == ']' = go p (max 0 (b - 1)) c ((ch:x):xs) chs
+      | ch == '{' = go p b (c + 1) ((ch:x):xs) chs
+      | ch == '}' = go p b (max 0 (c - 1)) ((ch:x):xs) chs
+      | otherwise = go p b c ((ch:x):xs) chs
+    go _ _ _ [] _ = []
+
+breakTopLevel :: Char -> String -> (String, String)
+breakTopLevel needle = go 0 0 0 []
+  where
+    go _ _ _ acc [] = (reverse acc, [])
+    go p b c acc s@(ch:chs)
+      | ch == needle && p == 0 && b == 0 && c == 0 = (reverse acc, s)
+      | ch == '(' = go (p + 1) b c (ch:acc) chs
+      | ch == ')' = go (max 0 (p - 1)) b c (ch:acc) chs
+      | ch == '[' = go p (b + 1) c (ch:acc) chs
+      | ch == ']' = go p (max 0 (b - 1)) c (ch:acc) chs
+      | ch == '{' = go p b (c + 1) (ch:acc) chs
+      | ch == '}' = go p b (max 0 (c - 1)) (ch:acc) chs
+      | otherwise = go p b c (ch:acc) chs
+
+skipTypeBinder :: String -> String
+skipTypeBinder raw =
+  case dropWhile isSpace raw of
+    '[':rest ->
+      case balancedContentRest '[' ']' rest of
+        Just (_, after) -> dropWhile isSpace after
+        Nothing -> dropWhile isSpace raw
+    rest -> rest
+
+balancedContent :: Char -> Char -> String -> Maybe String
+balancedContent open close src =
+  fst <$> balancedContentRest open close src
+
+balancedContentRest :: Char -> Char -> String -> Maybe (String, String)
+balancedContentRest open close = go 1 []
+  where
+    go 0 acc rest = Just (reverse acc, rest)
+    go _ _ [] = Nothing
+    go n acc (ch:chs)
+      | ch == open = go (n + 1) (ch:acc) chs
+      | ch == close =
+          if n == 1
+            then Just (reverse acc, chs)
+            else go (n - 1) (ch:acc) chs
+      | otherwise = go n (ch:acc) chs
+
+trimLeft :: String -> String
+trimLeft = dropWhile isSpace
+
+trim :: String -> String
+trim = reverse . dropWhile isSpace . reverse . dropWhile isSpace
+
+dedup :: [Completion] -> [Completion]
+dedup = nubBy (\a b -> completionLabel a == completionLabel b)
+
+forceCompletions :: [Completion] -> [Completion]
+forceCompletions xs =
+  sum [ length (completionLabel c)
+      + maybe 0 length (completionDetail c)
+      + kindCode (completionKind c)
+      | c <- xs
+      ] `seq` xs
+  where
+    kindCode CompletionField = 1
+    kindCode CompletionMethod = 2
+    kindCode CompletionProperty = 3
+    kindCode CompletionValue = 4
+
+forceSignatures :: [CallSignature] -> [CallSignature]
+forceSignatures xs =
+  sum [ length (callSignatureLabel sig)
+      + callSignatureActiveParameter sig
+      + sum (map (length . signatureParameterLabel) (callSignatureParameters sig))
+      | sig <- xs
+      ] `seq` xs
+
+(<|>) :: Maybe a -> Maybe a -> Maybe a
+Nothing <|> b = b
+a <|> _ = a

--- a/compiler/lib/src/Acton/Completion.hs
+++ b/compiler/lib/src/Acton/Completion.hs
@@ -4,6 +4,7 @@ module Acton.Completion
   ( Completion(..)
   , CompletionKind(..)
   , CallSignature(..)
+  , HoverInfo(..)
   , SignatureParameter(..)
   , CallRequest(..)
   , MemberRequest(..)
@@ -11,6 +12,8 @@ module Acton.Completion
   , callSignatures
   , callSignaturesWithEnv
   , completionImportKey
+  , hoverInfo
+  , hoverInfoWithEnv
   , memberContextAt
   , memberCompletions
   , memberCompletionsWithEnv
@@ -65,6 +68,12 @@ data CallSignature = CallSignature
   , callSignatureActiveParameter :: Int
   } deriving (Eq, Show)
 
+data HoverInfo = HoverInfo
+  { hoverLabel :: String
+  , hoverDetail :: String
+  , hoverDocumentation :: Maybe String
+  } deriving (Eq, Show)
+
 data SourceContext = SourceContext
   { sourceClass :: Maybe ClassContext
   , sourceDef :: Maybe DefContext
@@ -102,6 +111,11 @@ data LocalKind
   | LocalCallResult [String]
   | LocalMemberPath [String]
   deriving (Eq, Show)
+
+data HoverTarget = HoverTarget
+  { hoverResolvedType :: S.Type
+  , hoverResolvedDoc :: Maybe String
+  } deriving (Eq, Show)
 
 data Scope = ScopeClass ClassContext | ScopeDef DefContext deriving (Eq, Show)
 
@@ -154,6 +168,26 @@ callSignaturesWithEnv env src cursor =
       let ctx = scanSourceContext src cursor
       in maybe [] (:[]) (callSignature env ctx req)
 
+hoverInfo :: Env.Env0 -> [FilePath] -> S.ModName -> FilePath -> String -> Int -> IO (Maybe HoverInfo)
+hoverInfo baseEnv searchPath modName fileName src cursor = do
+  res <- E.try $ do
+    case hoverTargetAt src cursor of
+      Nothing -> return Nothing
+      Just parts -> do
+        env <- prepareCompletionEnv baseEnv searchPath modName fileName src
+        let ctx = scanSourceContext src cursor
+            info = hoverInfoForParts env ctx parts
+        E.evaluate (forceMaybeHover info)
+  case res of
+    Left (_ :: E.SomeException) -> return Nothing
+    Right info -> return info
+
+hoverInfoWithEnv :: Env.Env0 -> String -> Int -> Maybe HoverInfo
+hoverInfoWithEnv env src cursor = do
+  parts <- hoverTargetAt src cursor
+  let ctx = scanSourceContext src cursor
+  hoverInfoForParts env ctx parts
+
 prepareCompletionEnv :: Env.Env0 -> [FilePath] -> S.ModName -> FilePath -> String -> IO Env.Env0
 prepareCompletionEnv baseEnv searchPath modName fileName src = do
   imps <- parseImports fileName src
@@ -184,6 +218,32 @@ memberContextAt src cursor =
     identChar c = isAlphaNum c || c == '_'
     receiverChar c = identChar c || c == '.' || c == '?'
     trimDots = reverse . dropWhile (== '.') . reverse . dropWhile (== '.')
+
+hoverTargetAt :: String -> Int -> Maybe [String]
+hoverTargetAt src cursor = do
+  let cursor' = max 0 (min cursor (length src))
+      before = take cursor' src
+      after = drop cursor' src
+      identPrefix = reverse (takeWhile identChar (reverse before))
+      identSuffix = takeWhile identChar after
+      ident = identPrefix ++ identSuffix
+      identStart = cursor' - length identPrefix
+  if not (validIdent ident)
+    then Nothing
+    else do
+      let beforeIdent = take identStart src
+          target =
+            case reverse beforeIdent of
+              '.':rest ->
+                let receiver = reverse (takeWhile receiverChar rest)
+                in receiver ++ "." ++ ident
+              _ -> ident
+          parts = receiverParts target
+      if all validIdent parts && not (null parts)
+        then Just parts
+        else Nothing
+  where
+    receiverChar c = identChar c || c == '.' || c == '?'
 
 callContextAt :: String -> Int -> Maybe CallRequest
 callContextAt src cursor = do
@@ -254,13 +314,58 @@ callSignature env ctx req = do
             ++ "("
             ++ intercalate ", " (map signatureParameterLabel params)
             ++ ") -> "
-            ++ prstr ret
+            ++ displayType ret
       in Just CallSignature
         { callSignatureLabel = label
         , callSignatureParameters = params
         , callSignatureActiveParameter = active
         }
     _ -> Nothing
+
+hoverInfoForParts :: Env.Env0 -> SourceContext -> [String] -> Maybe HoverInfo
+hoverInfoForParts env ctx parts = do
+  target <- hoverTarget env ctx parts
+  let label = intercalate "." parts
+  return HoverInfo
+    { hoverLabel = label
+    , hoverDetail = label ++ ": " ++ displayType (hoverResolvedType target)
+    , hoverDocumentation = hoverResolvedDoc target
+    }
+
+hoverTarget :: Env.Env0 -> SourceContext -> [String] -> Maybe HoverTarget
+hoverTarget env ctx parts =
+  memberHoverTarget env ctx parts
+  <|> baseHoverTarget env ctx parts
+  <|> globalHoverTarget env parts
+
+memberHoverTarget :: Env.Env0 -> SourceContext -> [String] -> Maybe HoverTarget
+memberHoverTarget env ctx parts = do
+  (receiver, attr) <- unsnoc parts
+  typ <- resolveReceiverType env ctx receiver
+  tc <- typeTCon env typ
+  info <- attrInfo env tc (S.name attr)
+  attrTyp <- Env.unalias env <$> typeOfInfo info
+  return HoverTarget
+    { hoverResolvedType = attrTyp
+    , hoverResolvedDoc = docOfInfo info <|> typeDoc env attrTyp
+    }
+
+baseHoverTarget :: Env.Env0 -> SourceContext -> [String] -> Maybe HoverTarget
+baseHoverTarget env ctx parts = do
+  typ <- resolveReceiverType env ctx parts
+  return HoverTarget
+    { hoverResolvedType = typ
+    , hoverResolvedDoc = typeDoc env typ
+    }
+
+globalHoverTarget :: Env.Env0 -> [String] -> Maybe HoverTarget
+globalHoverTarget env parts = do
+  info <- lookupPathInfo env parts
+  typ <- Env.unalias env <$> typeOfInfo info
+  return HoverTarget
+    { hoverResolvedType = typ
+    , hoverResolvedDoc = docOfInfo info <|> typeDoc env typ
+    }
 
 resolveCallableInfo :: Env.Env0 -> SourceContext -> [String] -> Maybe I.NameInfo
 resolveCallableInfo env ctx parts =
@@ -282,7 +387,7 @@ signatureParameters pos kw =
   zipWith positional [1..] (positionalTypes pos) ++ keywordParameters kw
   where
     positional ix typ =
-      SignatureParameter ("arg" ++ show (ix :: Int) ++ ": " ++ prstr typ)
+      SignatureParameter ("arg" ++ show (ix :: Int) ++ ": " ++ displayType typ)
 
 positionalTypes :: S.Type -> [S.Type]
 positionalTypes row =
@@ -295,9 +400,9 @@ keywordParameters :: S.Type -> [SignatureParameter]
 keywordParameters row =
   case row of
     S.TRow _ S.KRow name typ rest ->
-      SignatureParameter (S.rawstr name ++ ": " ++ prstr typ) : keywordParameters rest
+      SignatureParameter (S.rawstr name ++ ": " ++ displayType typ) : keywordParameters rest
     S.TStar _ S.KRow rest ->
-      [SignatureParameter ("**kwargs: " ++ prstr (S.tTupleK rest))]
+      [SignatureParameter ("**kwargs: " ++ displayType (S.tTupleK rest))]
     _ -> []
 
 completionEnv :: [FilePath] -> Env.Env0 -> S.ModName -> [S.Import] -> IO Env.Env0
@@ -542,7 +647,49 @@ kindOf info =
 
 detailOf :: I.NameInfo -> Maybe String
 detailOf info =
-  fmap prstr (typeOfInfo info)
+  fmap displayType (typeOfInfo info)
+
+docOfInfo :: I.NameInfo -> Maybe String
+docOfInfo info =
+  cleanDoc $
+    case info of
+      I.NDef _ _ doc -> doc
+      I.NSig _ _ doc -> doc
+      I.NAct _ _ _ _ doc -> doc
+      I.NClass _ _ _ doc -> doc
+      I.NProto _ _ _ doc -> doc
+      I.NExt _ _ _ _ _ doc -> doc
+      I.NModule _ doc -> doc
+      _ -> Nothing
+
+typeDoc :: Env.Env0 -> S.Type -> Maybe String
+typeDoc env typ = do
+  tc <- typeTCon env typ
+  info <- lookupTConInfo env tc
+  docOfInfo info
+
+lookupTConInfo :: Env.Env0 -> S.TCon -> Maybe I.NameInfo
+lookupTConInfo env tc =
+  fmap I.convHNameInfo2NameInfo (Env.tryQName (S.tcname tc) env)
+
+cleanDoc :: Maybe String -> Maybe String
+cleanDoc Nothing = Nothing
+cleanDoc (Just doc) =
+  let doc' = trim doc
+  in if null doc' then Nothing else Just doc'
+
+displayType :: S.Type -> String
+displayType = stripBuiltinPrefix . prstr
+
+stripBuiltinPrefix :: String -> String
+stripBuiltinPrefix [] = []
+stripBuiltinPrefix s
+  | builtinPrefix `isPrefixOf` s =
+      stripBuiltinPrefix (drop (length builtinPrefix) s)
+  | otherwise =
+      head s : stripBuiltinPrefix (tail s)
+  where
+    builtinPrefix = "__builtin__."
 
 typeTCon :: Env.Env0 -> S.Type -> Maybe S.TCon
 typeTCon env typ =
@@ -854,6 +1001,15 @@ forceSignatures xs =
       + sum (map (length . signatureParameterLabel) (callSignatureParameters sig))
       | sig <- xs
       ] `seq` xs
+
+forceMaybeHover :: Maybe HoverInfo -> Maybe HoverInfo
+forceMaybeHover info =
+  case info of
+    Nothing -> Nothing
+    Just hover ->
+      length (hoverLabel hover)
+      + length (hoverDetail hover)
+      + maybe 0 length (hoverDocumentation hover) `seq` info
 
 (<|>) :: Maybe a -> Maybe a -> Maybe a
 Nothing <|> b = b

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -7,6 +7,7 @@ import Data.Char (toLower, isAlphaNum)
 
 import qualified Acton.Parser as P
 import qualified Acton.Syntax as S
+import qualified Acton.Builtin as Builtin
 import qualified Acton.NameInfo as I
 import qualified Acton.Printer as AP
 import qualified Acton.DocPrinter as DocP
@@ -24,6 +25,8 @@ import qualified Acton.CodeGen
 import qualified Acton.Diagnostics as Diag
 import qualified Acton.Compile as Compile
 import qualified Acton.Fingerprint as Fingerprint
+import qualified Acton.Completion as Completion
+import qualified InterfaceFiles
 import Pretty (print, prettyText)
 import qualified Pretty
 import Test.Syd
@@ -38,7 +41,7 @@ import Error.Diagnose.Report (Report(..))
 import Prettyprinter (unAnnotate, layoutPretty, defaultLayoutOptions)
 import Prettyprinter.Render.Text (renderStrict)
 import System.FilePath ((</>), joinPath, takeFileName, takeBaseName, takeDirectory, splitDirectories)
-import System.Directory (getCurrentDirectory, setCurrentDirectory)
+import System.Directory (createDirectoryIfMissing, getCurrentDirectory, setCurrentDirectory)
 import System.IO.Temp (withSystemTempDirectory)
 import Control.Monad (forM_, when, foldM)
 import qualified Control.Exception as E
@@ -197,6 +200,182 @@ main = do
             Left err -> expectationFailure $ "Parse failed: " ++ err
             Right [S.Expr _ expr@S.OptChain{}] -> loc expr `shouldNotBe` NoLoc
             Right other -> expectationFailure $ "Unexpected AST: " ++ show other
+
+      describe "Completion" $ do
+        it "completes inherited transform input attributes" $ do
+          let env = completionFixtureEnv env0
+              (src, cursor) = cursorSource $ unlines
+                [ "import mini.layers.base_1 as base"
+                , "import mini.layers.y_1 as y1"
+                , ""
+                , "class L3vpnEndpoint(base.L3vpnEndpoint):"
+                , "    def transform(self, i, di):"
+                , "        i.<CURSOR>"
+                ]
+          items <- Completion.memberCompletions env [] (S.modName ["rfs"]) "rfs.act" src cursor
+          let labels = map Completion.completionLabel items
+          forM_ ["interface_name", "vpn_name", "ipv4_address"] $ \label ->
+            labels `shouldSatisfy` elem label
+
+        it "completes explicitly typed transform input attributes" $ do
+          let env = completionFixtureEnv env0
+              inputTypeName = "y1.stratoweave_rfs__rfs__l3vpn_endpoint_entry"
+              (src, cursor) = cursorSource $ unlines
+                [ "import mini.layers.base_1 as base"
+                , "import mini.layers.y_1 as y1"
+                , ""
+                , "class L3vpnEndpoint(base.L3vpnEndpoint):"
+                , "    def transform(self, i: " ++ inputTypeName ++ ", di):"
+                , "        i.v<CURSOR>"
+                ]
+          items <- Completion.memberCompletions env [] (S.modName ["rfs"]) "rfs.act" src cursor
+          map Completion.completionLabel items `shouldBe` ["vpn_name"]
+
+        it "completes annotated parameters inside generic functions" $ do
+          let env = completionFixtureEnv env0
+              inputTypeName = "y1.stratoweave_rfs__rfs__l3vpn_endpoint_entry"
+              (src, cursor) = cursorSource $ unlines
+                [ "import mini.layers.y_1 as y1"
+                , ""
+                , "def helper [T](i: " ++ inputTypeName ++ "):"
+                , "    i.v<CURSOR>"
+                ]
+          items <- Completion.memberCompletions env [] (S.modName ["rfs"]) "rfs.act" src cursor
+          map Completion.completionLabel items `shouldBe` ["vpn_name"]
+
+        it "completes local values assigned from typed calls" $ do
+          let env = completionFixtureEnv env0
+              (src, cursor) = cursorSource $ unlines
+                [ "import mini.layers.base_1 as base"
+                , ""
+                , "class L3vpnEndpoint(base.L3vpnEndpoint):"
+                , "    def transform(self, i, di):"
+                , "        o = base.o_root()"
+                , "        o.<CURSOR>"
+                ]
+          items <- Completion.memberCompletions env [] (S.modName ["rfs"]) "rfs.act" src cursor
+          map Completion.completionLabel items `shouldSatisfy` elem "netinfra"
+
+        it "completes local values assigned from nested member calls" $ do
+          let env = completionFixtureEnv env0
+              (src, cursor) = cursorSource $ unlines
+                [ "import mini.layers.base_1 as base"
+                , ""
+                , "class L3vpnEndpoint(base.L3vpnEndpoint):"
+                , "    def transform(self, i, di):"
+                , "        o = base.o_root()"
+                , "        o_router = o.netinfra.router.create(i.name, id=i.id)"
+                , "        o_router.<CURSOR>"
+                ]
+          items <- Completion.memberCompletions env [] (S.modName ["rfs"]) "rfs.act" src cursor
+          map Completion.completionLabel items `shouldSatisfy` elem "router_id"
+
+        it "completes local values assigned from member paths" $ do
+          let env = completionFixtureEnv env0
+              (src, cursor) = cursorSource $ unlines
+                [ "import mini.layers.base_1 as base"
+                , ""
+                , "class L3vpnEndpoint(base.L3vpnEndpoint):"
+                , "    def transform(self, i, di):"
+                , "        o = base.o_root()"
+                , "        o_router = o.netinfra.router.create(i.name, id=i.id)"
+                , "        bc = o_router.base_config"
+                , "        bc.<CURSOR>"
+                ]
+          items <- Completion.memberCompletions env [] (S.modName ["rfs"]) "rfs.act" src cursor
+          map Completion.completionLabel items `shouldSatisfy` elem "asn"
+
+        it "uses inherited parameter types inside generic classes" $ do
+          let env = completionFixtureEnv env0
+              (src, cursor) = cursorSource $ unlines
+                [ "import mini.layers.base_1 as base"
+                , ""
+                , "class L3vpnEndpoint[T](base.L3vpnEndpoint):"
+                , "    def transform(self, i, di):"
+                , "        i.<CURSOR>"
+                ]
+          items <- Completion.memberCompletions env [] (S.modName ["rfs"]) "rfs.act" src cursor
+          map Completion.completionLabel items `shouldSatisfy` elem "interface_name"
+
+        it "resolves inherited parameter types in the parent module" $ do
+          let env = completionFixtureEnv env0
+              (src, cursor) = cursorSource $ unlines
+                [ "import mini.layers.base_1 as base"
+                , ""
+                , "class LocalEndpoint(base.LocalEndpoint):"
+                , "    def transform(self, i):"
+                , "        a = i.<CURSOR>"
+                ]
+          items <- Completion.memberCompletions env [] (S.modName ["rfs"]) "rfs.act" src cursor
+          map Completion.completionLabel items `shouldSatisfy` elem "local_field"
+
+        it "uses direct imports when transitive interfaces are stale" $ do
+          withSystemTempDirectory "acton-completion" $ \dir -> do
+            let directMod = S.modName ["direct"]
+                staleMod = S.modName ["stale"]
+                directTy = dir </> "direct.ty"
+                staleTy = dir </> "stale.ty"
+                inputName = S.name "LocalInput"
+                routerName = S.name "Router"
+                inputType = S.tCon (S.TC (S.NoQ inputName) [])
+                transformType =
+                  S.tFun S.fxMut
+                    (S.posRow inputType S.posNil)
+                    S.kwdNil
+                    S.tWild
+                transformInfo = I.NSig (S.tSchema [] transformType) S.NoDec Nothing
+                inputClass = I.NClass [] [] [(S.name "local_field", I.NVar S.tWild)] Nothing
+                routerClass = I.NClass [] [] [(S.name "transform", transformInfo)] Nothing
+                directIface = I.NModule
+                  [ (routerName, routerClass)
+                  , (inputName, inputClass)
+                  ] Nothing
+                directModule = S.Module directMod [] Nothing []
+                (src, cursor) = cursorSource $ unlines
+                  [ "import direct as base"
+                  , ""
+                  , "class Router(base.Router):"
+                  , "    def transform(self, i):"
+                  , "        i.<CURSOR>"
+                  ]
+            createDirectoryIfMissing True dir
+            B8.writeFile staleTy "not a current ty file"
+            InterfaceFiles.writeFile
+              directTy
+              B8.empty
+              B8.empty
+              B8.empty
+              Nothing
+              [(staleMod, B8.empty)]
+              []
+              []
+              []
+              Nothing
+              directIface
+              directModule
+            items <- Completion.memberCompletions env0 [dir] (S.modName ["rfs"]) "rfs.act" src cursor
+            map Completion.completionLabel items `shouldSatisfy` elem "local_field"
+
+        it "shows signatures for nested member calls" $ do
+          let env = completionFixtureEnv env0
+              (src, cursor) = cursorSource $ unlines
+                [ "import mini.layers.base_1 as base"
+                , ""
+                , "class L3vpnEndpoint(base.L3vpnEndpoint):"
+                , "    def transform(self, i, di):"
+                , "        o = base.o_root()"
+                , "        o.netinfra.router.create(\"r1\", <CURSOR>)"
+                ]
+          sigs <- Completion.callSignatures env [] (S.modName ["rfs"]) "rfs.act" src cursor
+          case sigs of
+            [sig] -> do
+              Completion.callSignatureLabel sig `shouldSatisfy` isPrefixOf "o.netinfra.router.create("
+              Completion.callSignatureActiveParameter sig `shouldBe` 1
+              let params = map Completion.signatureParameterLabel (Completion.callSignatureParameters sig)
+              params `shouldSatisfy` any (isPrefixOf "arg1:")
+              params `shouldSatisfy` any (isPrefixOf "id:")
+            other ->
+              expectationFailure $ "Unexpected signatures: " ++ show other
 
       describe "String Interpolation" $ do
         -- Note: In these tests, we use Haskell string literals which require escaping.
@@ -1152,6 +1331,97 @@ expectModuleParseFailure input =
   case parseModuleTest input of
     Left err -> return err
     Right result -> expectationFailure $ "Expected parse failure, got: " ++ result
+
+completionFixtureEnv :: Acton.Env.Env0 -> Acton.Env.Env0
+completionFixtureEnv env0 =
+  let y1Mod = S.modName ["mini", "layers", "y_1"]
+      baseMod = S.modName ["mini", "layers", "base_1"]
+      inputName = S.name "stratoweave_rfs__rfs__l3vpn_endpoint_entry"
+      inputType = S.tCon (S.TC (S.GName y1Mod inputName) [])
+      localInputName = S.name "LocalInput"
+      localInputType = S.tCon (S.TC (S.NoQ localInputName) [])
+      transformType =
+        S.tFun S.fxMut
+          (S.posRow inputType (S.posRow S.tWild S.posNil))
+          S.kwdNil
+          S.tWild
+      transformInfo = I.NSig (S.tSchema [] transformType) S.NoDec Nothing
+      localTransformType =
+        S.tFun S.fxMut
+          (S.posRow localInputType S.posNil)
+          S.kwdNil
+          S.tWild
+      localTransformInfo = I.NSig (S.tSchema [] localTransformType) S.NoDec Nothing
+      outputRootName = S.name "OutputRoot"
+      outputRootType = S.tCon (S.TC (S.GName baseMod outputRootName) [])
+      netinfraName = S.name "Netinfra"
+      netinfraType = S.tCon (S.TC (S.GName baseMod netinfraName) [])
+      routerCollectionName = S.name "RouterCollection"
+      routerCollectionType = S.tCon (S.TC (S.GName baseMod routerCollectionName) [])
+      routerEntryName = S.name "RouterEntry"
+      routerEntryType = S.tCon (S.TC (S.GName baseMod routerEntryName) [])
+      baseConfigName = S.name "BaseConfig"
+      baseConfigType = S.tCon (S.TC (S.GName baseMod baseConfigName) [])
+      oRootType = S.tFun S.fxPure S.posNil S.kwdNil outputRootType
+      oRootInfo = I.NDef (S.tSchema [] oRootType) S.NoDec Nothing
+      createType =
+        S.tFun S.fxMut
+          (S.posRow Builtin.tStr S.posNil)
+          (S.kwdRow (S.name "id") Builtin.tInt S.kwdNil)
+          routerEntryType
+      createInfo = I.NDef (S.tSchema [] createType) S.NoDec Nothing
+      baseClass = I.NClass [] [] [(S.name "transform", transformInfo)] Nothing
+      localBaseClass = I.NClass [] [] [(S.name "transform", localTransformInfo)] Nothing
+      outputRootClass = I.NClass [] []
+        [ fieldOf "netinfra" netinfraType
+        , field "l3vpns"
+        ] Nothing
+      netinfraClass = I.NClass [] []
+        [ fieldOf "router" routerCollectionType
+        ] Nothing
+      routerCollectionClass = I.NClass [] []
+        [ (S.name "create", createInfo)
+        ] Nothing
+      routerEntryClass = I.NClass [] []
+        [ field "router_id"
+        , field "hostname"
+        , fieldOf "base_config" baseConfigType
+        ] Nothing
+      baseConfigClass = I.NClass [] []
+        [ field "asn"
+        , field "ipv4_address"
+        ] Nothing
+      localInputClass = I.NClass [] []
+        [ field "local_field"
+        ] Nothing
+      inputClass = I.NClass [] []
+        [ field "interface_name"
+        , field "vpn_name"
+        , field "customer_name"
+        , field "ipv4_address"
+        ] Nothing
+      field n = fieldOf n S.tWild
+      fieldOf n typ = (S.name n, I.NVar typ)
+  in Acton.Env.addMod baseMod
+       [ (S.name "L3vpnEndpoint", baseClass)
+       , (S.name "LocalEndpoint", localBaseClass)
+       , (localInputName, localInputClass)
+       , (outputRootName, outputRootClass)
+       , (netinfraName, netinfraClass)
+       , (routerCollectionName, routerCollectionClass)
+       , (routerEntryName, routerEntryClass)
+       , (baseConfigName, baseConfigClass)
+       , (S.name "o_root", oRootInfo)
+       ] Nothing $
+     Acton.Env.addMod y1Mod [(inputName, inputClass)] Nothing env0
+
+cursorSource :: String -> (String, Int)
+cursorSource src =
+  let marker = T.pack "<CURSOR>"
+      (before, after) = T.breakOn marker (T.pack src)
+  in if T.null after
+       then (src, length src)
+       else (T.unpack before ++ T.unpack (T.drop (T.length marker) after), T.length before)
 
 parseStmtAst :: String -> Either String [S.Stmt]
 parseStmtAst input =

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -284,6 +284,10 @@ main = do
                 ]
           items <- Completion.memberCompletions env [] (S.modName ["rfs"]) "rfs.act" src cursor
           map Completion.completionLabel items `shouldSatisfy` elem "asn"
+          [ Completion.completionDetail item
+            | item <- items
+            , Completion.completionLabel item == "asn"
+            ] `shouldBe` [Just "int"]
 
         it "uses inherited parameter types inside generic classes" $ do
           let env = completionFixtureEnv env0
@@ -370,12 +374,74 @@ main = do
           case sigs of
             [sig] -> do
               Completion.callSignatureLabel sig `shouldSatisfy` isPrefixOf "o.netinfra.router.create("
+              Completion.callSignatureLabel sig `shouldSatisfy` not . isInfixOf "__builtin__."
               Completion.callSignatureActiveParameter sig `shouldBe` 1
               let params = map Completion.signatureParameterLabel (Completion.callSignatureParameters sig)
               params `shouldSatisfy` any (isPrefixOf "arg1:")
               params `shouldSatisfy` any (isPrefixOf "id:")
+              params `shouldSatisfy` all (not . isInfixOf "__builtin__.")
             other ->
               expectationFailure $ "Unexpected signatures: " ++ show other
+
+        it "hovers local values assigned from member paths" $ do
+          let env = completionFixtureEnv env0
+              (src, cursor) = cursorSource $ unlines
+                [ "import mini.layers.base_1 as base"
+                , ""
+                , "class L3vpnEndpoint(base.L3vpnEndpoint):"
+                , "    def transform(self, i, di):"
+                , "        o = base.o_root()"
+                , "        o_router = o.netinfra.router.create(i.name, id=i.id)"
+                , "        bc = o_router.base_config"
+                , "        bc<CURSOR>.asn = 1"
+                ]
+          info <- Completion.hoverInfo env [] (S.modName ["rfs"]) "rfs.act" src cursor
+          case info of
+            Just hover -> do
+              Completion.hoverDetail hover `shouldSatisfy` isInfixOf "BaseConfig"
+              Completion.hoverDocumentation hover `shouldBe` Just "Base router configuration."
+            Nothing ->
+              expectationFailure "Expected hover info for bc"
+
+        it "hovers nested member fields" $ do
+          let env = completionFixtureEnv env0
+              (src, cursor) = cursorSource $ unlines
+                [ "import mini.layers.base_1 as base"
+                , ""
+                , "class L3vpnEndpoint(base.L3vpnEndpoint):"
+                , "    def transform(self, i, di):"
+                , "        o = base.o_root()"
+                , "        o_router = o.netinfra.router.create(i.name, id=i.id)"
+                , "        bc = o_router.base_config"
+                , "        bc.<CURSOR>asn = 1"
+                ]
+          info <- Completion.hoverInfo env [] (S.modName ["rfs"]) "rfs.act" src cursor
+          case info of
+            Just hover -> do
+              Completion.hoverDetail hover `shouldBe` "bc.asn: int"
+              Completion.hoverDocumentation hover `shouldBe` Just "Autonomous system number."
+            Nothing ->
+              expectationFailure "Expected hover info for bc.asn"
+
+        it "hovers methods resolved through local call results" $ do
+          let env = completionFixtureEnv env0
+              (src, cursor) = cursorSource $ unlines
+                [ "import mini.layers.base_1 as base"
+                , ""
+                , "class L3vpnEndpoint(base.L3vpnEndpoint):"
+                , "    def transform(self, i, di):"
+                , "        o = base.o_root()"
+                , "        o.netinfra.router.<CURSOR>create(\"r1\", id=1)"
+                ]
+          info <- Completion.hoverInfo env [] (S.modName ["rfs"]) "rfs.act" src cursor
+          case info of
+            Just hover -> do
+              Completion.hoverDetail hover `shouldSatisfy` isPrefixOf "o.netinfra.router.create:"
+              Completion.hoverDetail hover `shouldSatisfy` isInfixOf "RouterEntry"
+              Completion.hoverDetail hover `shouldSatisfy` not . isInfixOf "__builtin__."
+              Completion.hoverDocumentation hover `shouldBe` Just "Create a router entry."
+            Nothing ->
+              expectationFailure "Expected hover info for create"
 
       describe "String Interpolation" $ do
         -- Note: In these tests, we use Haskell string literals which require escaping.
@@ -1369,8 +1435,8 @@ completionFixtureEnv env0 =
           (S.posRow Builtin.tStr S.posNil)
           (S.kwdRow (S.name "id") Builtin.tInt S.kwdNil)
           routerEntryType
-      createInfo = I.NDef (S.tSchema [] createType) S.NoDec Nothing
-      baseClass = I.NClass [] [] [(S.name "transform", transformInfo)] Nothing
+      createInfo = I.NDef (S.tSchema [] createType) S.NoDec (Just "Create a router entry.")
+      baseClass = I.NClass [] [] [(S.name "transform", transformInfo)] (Just "Base transform class.")
       localBaseClass = I.NClass [] [] [(S.name "transform", localTransformInfo)] Nothing
       outputRootClass = I.NClass [] []
         [ fieldOf "netinfra" netinfraType
@@ -1388,9 +1454,9 @@ completionFixtureEnv env0 =
         , fieldOf "base_config" baseConfigType
         ] Nothing
       baseConfigClass = I.NClass [] []
-        [ field "asn"
-        , field "ipv4_address"
-        ] Nothing
+        [ docFieldOf "asn" Builtin.tInt "Autonomous system number."
+        , fieldOf "ipv4_address" Builtin.tStr
+        ] (Just "Base router configuration.")
       localInputClass = I.NClass [] []
         [ field "local_field"
         ] Nothing
@@ -1399,9 +1465,10 @@ completionFixtureEnv env0 =
         , field "vpn_name"
         , field "customer_name"
         , field "ipv4_address"
-        ] Nothing
+        ] (Just "L3VPN endpoint input.")
       field n = fieldOf n S.tWild
       fieldOf n typ = (S.name n, I.NVar typ)
+      docFieldOf n typ doc = (S.name n, I.NSig (S.tSchema [] typ) S.NoDec (Just doc))
   in Acton.Env.addMod baseMod
        [ (S.name "L3vpnEndpoint", baseClass)
        , (S.name "LocalEndpoint", localBaseClass)

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -383,6 +383,24 @@ main = do
             other ->
               expectationFailure $ "Unexpected signatures: " ++ show other
 
+        it "ignores string parentheses when finding call signatures" $ do
+          let env = completionFixtureEnv env0
+          forM_ ["\"(\"", "\"x)\""] $ \arg -> do
+            let (src, cursor) = cursorSource $ unlines
+                  [ "import mini.layers.base_1 as base"
+                  , ""
+                  , "class L3vpnEndpoint(base.L3vpnEndpoint):"
+                  , "    def transform(self, i, di):"
+                  , "        o = base.o_root()"
+                  , "        o.netinfra.router.create(" ++ arg ++ ", <CURSOR>)"
+                  ]
+            sigs <- Completion.callSignatures env [] (S.modName ["rfs"]) "rfs.act" src cursor
+            case sigs of
+              [sig] ->
+                Completion.callSignatureActiveParameter sig `shouldBe` 1
+              other ->
+                expectationFailure $ "Unexpected signatures: " ++ show other
+
         it "completes keyword arguments for nested member calls" $ do
           let env = completionFixtureEnv env0
               (src, cursor) = cursorSource $ unlines
@@ -423,6 +441,19 @@ main = do
                 ]
           items <- Completion.argumentCompletions env [] (S.modName ["rfs"]) "rfs.act" src cursor
           map Completion.completionLabel items `shouldBe` ["role="]
+
+        it "keeps escaped commas inside string arguments" $ do
+          let env = completionFixtureEnv env0
+              (src, cursor) = cursorSource $ unlines
+                [ "import mini.layers.base_1 as base"
+                , ""
+                , "class L3vpnEndpoint(base.L3vpnEndpoint):"
+                , "    def transform(self, i, di):"
+                , "        o = base.o_root()"
+                , "        o.netinfra.router.create(\"r1\", id=1, role=\"a\\\",b\", m<CURSOR>)"
+                ]
+          items <- Completion.argumentCompletions env [] (S.modName ["rfs"]) "rfs.act" src cursor
+          map Completion.completionLabel items `shouldBe` ["mock="]
 
         it "does not complete keyword names inside argument values" $ do
           let env = completionFixtureEnv env0

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -497,6 +497,16 @@ main = do
             Nothing ->
               expectationFailure "Expected hover info for create"
 
+        it "ignores imported module path hovers" $ do
+          let env = completionFixtureEnv env0
+              (src, cursor) = cursorSource "import mini.layers.y_1<CURSOR>\n"
+          result <- E.try (E.evaluate (Completion.hoverInfoWithEnv env src cursor))
+          case result of
+            Left (err :: E.SomeException) ->
+              expectationFailure $ "Unexpected hover exception: " ++ E.displayException err
+            Right info ->
+              info `shouldBe` Nothing
+
       describe "String Interpolation" $ do
         -- Note: In these tests, we use Haskell string literals which require escaping.
         -- The test format is: testParseOutput <Haskell literal> <expected parser output>

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -383,6 +383,60 @@ main = do
             other ->
               expectationFailure $ "Unexpected signatures: " ++ show other
 
+        it "completes keyword arguments for nested member calls" $ do
+          let env = completionFixtureEnv env0
+              (src, cursor) = cursorSource $ unlines
+                [ "import mini.layers.base_1 as base"
+                , ""
+                , "class L3vpnEndpoint(base.L3vpnEndpoint):"
+                , "    def transform(self, i, di):"
+                , "        o = base.o_root()"
+                , "        o.netinfra.router.create(\"r1\", <CURSOR>)"
+                ]
+          items <- Completion.argumentCompletions env [] (S.modName ["rfs"]) "rfs.act" src cursor
+          map Completion.completionLabel items `shouldBe` ["id=", "role=", "mock="]
+          map Completion.completionKind items `shouldBe` replicate 3 Completion.CompletionKeyword
+          map Completion.completionDetail items `shouldBe` map Just ["int", "str", "bool"]
+
+        it "filters supplied keyword argument completions" $ do
+          let env = completionFixtureEnv env0
+              (src, cursor) = cursorSource $ unlines
+                [ "import mini.layers.base_1 as base"
+                , ""
+                , "class L3vpnEndpoint(base.L3vpnEndpoint):"
+                , "    def transform(self, i, di):"
+                , "        o = base.o_root()"
+                , "        o.netinfra.router.create(\"r1\", id=1, <CURSOR>)"
+                ]
+          items <- Completion.argumentCompletions env [] (S.modName ["rfs"]) "rfs.act" src cursor
+          map Completion.completionLabel items `shouldBe` ["role=", "mock="]
+
+        it "prefixes keyword argument completions" $ do
+          let env = completionFixtureEnv env0
+              (src, cursor) = cursorSource $ unlines
+                [ "import mini.layers.base_1 as base"
+                , ""
+                , "class L3vpnEndpoint(base.L3vpnEndpoint):"
+                , "    def transform(self, i, di):"
+                , "        o = base.o_root()"
+                , "        o.netinfra.router.create(\"r1\", id=1, r<CURSOR>)"
+                ]
+          items <- Completion.argumentCompletions env [] (S.modName ["rfs"]) "rfs.act" src cursor
+          map Completion.completionLabel items `shouldBe` ["role="]
+
+        it "does not complete keyword names inside argument values" $ do
+          let env = completionFixtureEnv env0
+              (src, cursor) = cursorSource $ unlines
+                [ "import mini.layers.base_1 as base"
+                , ""
+                , "class L3vpnEndpoint(base.L3vpnEndpoint):"
+                , "    def transform(self, i, di):"
+                , "        o = base.o_root()"
+                , "        o.netinfra.router.create(\"r1\", id=<CURSOR>)"
+                ]
+          items <- Completion.argumentCompletions env [] (S.modName ["rfs"]) "rfs.act" src cursor
+          items `shouldBe` []
+
         it "hovers local values assigned from member paths" $ do
           let env = completionFixtureEnv env0
               (src, cursor) = cursorSource $ unlines
@@ -1433,7 +1487,9 @@ completionFixtureEnv env0 =
       createType =
         S.tFun S.fxMut
           (S.posRow Builtin.tStr S.posNil)
-          (S.kwdRow (S.name "id") Builtin.tInt S.kwdNil)
+          (S.kwdRow (S.name "id") Builtin.tInt
+            (S.kwdRow (S.name "role") Builtin.tStr
+              (S.kwdRow (S.name "mock") Builtin.tBool S.kwdNil)))
           routerEntryType
       createInfo = I.NDef (S.tSchema [] createType) S.NoDec (Just "Create a router entry.")
       baseClass = I.NClass [] [] [(S.name "transform", transformInfo)] (Just "Base transform class.")

--- a/compiler/lsp-server/Main.hs
+++ b/compiler/lsp-server/Main.hs
@@ -1,16 +1,24 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeOperators #-}
 
-import Control.Exception (finally, try)
-import Control.Monad (forM_, void, when)
+import Control.Exception (SomeException, finally, try)
+import Control.Concurrent (ThreadId, forkIO, killThread, threadDelay)
+import Control.Concurrent.MVar (MVar, newEmptyMVar, takeMVar, tryPutMVar)
+import Control.Monad (forM, forM_, forever, void, when)
 import Control.Monad.IO.Class
+import Data.Aeson (toJSON)
+import Data.Char (ord)
 import Data.IORef
 import qualified Data.HashMap.Strict as HM
 import Data.Maybe (fromMaybe, listToMaybe)
+import Data.Sequence (Seq, ViewL(..), (|>))
+import qualified Data.Sequence as Seq
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import GHC.Conc (getNumCapabilities)
+import System.FilePath (takeFileName)
 import System.IO.Unsafe (unsafePerformIO)
 
 import Language.LSP.Protocol.Message
@@ -20,7 +28,10 @@ import Language.LSP.Server
 
 import qualified Acton.Compile as Compile
 import qualified Acton.CommandLineParser as C
+import qualified Acton.Completion as Completion
+import qualified Acton.Env as Env
 import qualified Acton.SourceProvider as Source
+import qualified Acton.Syntax as S
 
 import Error.Diagnose (Diagnostic)
 import Error.Diagnose.Diagnostic (reportsOf)
@@ -32,10 +43,30 @@ type OverlayMap = HM.HashMap FilePath Source.SourceSnapshot
 type UriMap = HM.HashMap FilePath Uri
 type BackgroundCompilerLockMap = HM.HashMap FilePath Compile.BackgroundCompilerLock
 type BackgroundCompilerWarned = HM.HashMap FilePath ()
+type CompletionStateMap = HM.HashMap FilePath CompletionState
+
+data CompletionState = CompletionState
+  { completionEnv :: Env.Env0
+  , completionSearchPath :: [FilePath]
+  , completionModuleName :: S.ModName
+  }
+
+data LspProgress = LspProgress
+  { lspProgressToken :: ProgressToken
+  , lspProgressQueue :: IORef (Seq T.Text)
+  , lspProgressSignal :: MVar ()
+  , lspProgressWorker :: ThreadId
+  }
 
 -- | Debounce delay (microseconds) before recompiling on edits.
 debounceMicros :: Int
 debounceMicros = 200000
+
+progressIntervalMicros :: Int
+progressIntervalMicros = 250000
+
+progressQueueLimit :: Int
+progressQueueLimit = 100
 
 {-# NOINLINE overlaysRef #-}
 -- | Global in-memory buffer map used as a source overlay.
@@ -56,6 +87,11 @@ backgroundCompilerLocksRef = unsafePerformIO (newIORef HM.empty)
 -- | Remember which projects have already warned about another background compiler.
 backgroundCompilerWarnedRef :: IORef BackgroundCompilerWarned
 backgroundCompilerWarnedRef = unsafePerformIO (newIORef HM.empty)
+
+{-# NOINLINE completionStatesRef #-}
+-- | Latest successful front-end environment for member completion.
+completionStatesRef :: IORef CompletionStateMap
+completionStatesRef = unsafePerformIO (newIORef HM.empty)
 
 {-# NOINLINE compileScheduler #-}
 -- | Shared compile scheduler for LSP events and back jobs.
@@ -152,6 +188,158 @@ releaseBackgroundCompilerLocks = do
   forM_ (HM.elems locks) Compile.releaseBackgroundCompilerLock
   writeIORef backgroundCompilerLocksRef HM.empty
 
+rememberCompletionStates :: Compile.CompilePlan -> Env.Env0 -> IO ()
+rememberCompletionStates plan env = do
+  entries <- forM (Compile.cpGlobalTasks plan) $ \t -> do
+    let key = Compile.gtKey t
+        paths = Compile.gtPaths t
+        mn = Compile.tkMod key
+    path <- Compile.normalizePathSafe (Compile.srcFile paths mn)
+    return (path, CompletionState env (Compile.searchPath paths) mn)
+  atomicModifyIORef' completionStatesRef $ \m ->
+    (foldr (uncurry HM.insert) m entries, ())
+
+lookupCompletionState :: FilePath -> IO (Maybe CompletionState)
+lookupCompletionState path = HM.lookup path <$> readIORef completionStatesRef
+
+cacheCompletionState :: FilePath -> CompletionState -> IO ()
+cacheCompletionState path state =
+  atomicModifyIORef' completionStatesRef $ \m -> (HM.insert path state m, ())
+
+loadDiskCompletionState :: FilePath -> IO CompletionState
+loadDiskCompletionState path = do
+  paths <- Compile.findPaths path lspCompileOpts
+  env <- Env.initEnv (Compile.sysTypes paths) False
+  return CompletionState
+    { completionEnv = env
+    , completionSearchPath = Compile.searchPath paths
+    , completionModuleName = Compile.modName paths
+    }
+
+loadCompletionStateFor :: FilePath -> IO (Maybe CompletionState)
+loadCompletionStateFor path = do
+  mstate <- lookupCompletionState path
+  case mstate of
+    Just state -> return (Just state)
+    Nothing -> do
+      res <- (try (loadDiskCompletionState path) :: IO (Either SomeException CompletionState))
+      case res of
+        Right state -> do
+          cacheCompletionState path state
+          return (Just state)
+        Left _ ->
+          return Nothing
+
+progressToken :: Int -> FilePath -> ProgressToken
+progressToken gen path =
+  ProgressToken (InR (T.pack ("acton-lsp-" ++ show gen ++ "-" ++ takeFileName path)))
+
+startLspProgress :: Int -> FilePath -> LspM () LspProgress
+startLspProgress gen path = do
+  env <- getLspEnv
+  queue <- liftIO $ newIORef Seq.empty
+  signal <- liftIO newEmptyMVar
+  let token = progressToken gen path
+      title = T.pack ("Acton: " ++ takeFileName path)
+      dequeue = atomicModifyIORef' queue $ \msgs ->
+        case Seq.viewl msgs of
+          EmptyL -> (msgs, Nothing)
+          msg :< rest -> (rest, Just msg)
+      drain = do
+        mmsg <- dequeue
+        case mmsg of
+          Nothing -> return ()
+          Just msg -> do
+            runLspT env $ progressReportToken token msg Nothing
+            threadDelay progressIntervalMicros
+            drain
+      loop = forever $ takeMVar signal >> drain
+  worker <- liftIO $ forkIO loop
+  let progress = LspProgress token queue signal worker
+  void $ sendRequest SMethod_WindowWorkDoneProgressCreate
+    (WorkDoneProgressCreateParams token)
+    (\_ -> pure ())
+  progressBegin progress title "Preparing diagnostics and completion"
+  return progress
+
+progressBegin :: LspProgress -> T.Text -> T.Text -> LspM () ()
+progressBegin progress title msg =
+  sendNotification SMethod_Progress $
+    ProgressParams (lspProgressToken progress) $
+      toJSON (WorkDoneProgressBegin AString title (Just False) (Just msg) Nothing)
+
+progressReportToken :: ProgressToken -> T.Text -> Maybe Int -> LspM () ()
+progressReportToken token msg pct =
+  sendNotification SMethod_Progress $
+    ProgressParams token $
+      toJSON (WorkDoneProgressReport AString (Just False) (Just msg) (fromIntegral <$> pct))
+
+progressReport :: LspProgress -> T.Text -> Maybe Int -> LspM () ()
+progressReport progress =
+  progressReportToken (lspProgressToken progress)
+
+clearProgressQueue :: LspProgress -> LspM () ()
+clearProgressQueue progress =
+  liftIO $ writeIORef (lspProgressQueue progress) Seq.empty
+
+progressReportImmediate :: LspProgress -> T.Text -> Maybe Int -> LspM () ()
+progressReportImmediate progress msg pct = do
+  clearProgressQueue progress
+  progressReport progress msg pct
+
+progressReportQueued :: LspProgress -> T.Text -> LspM () ()
+progressReportQueued progress msg =
+  liftIO $ do
+    atomicModifyIORef' (lspProgressQueue progress) $ \msgs ->
+      let msgs' = msgs |> msg
+      in (dropOldestProgress msgs', ())
+    void $ tryPutMVar (lspProgressSignal progress) ()
+
+dropOldestProgress :: Seq T.Text -> Seq T.Text
+dropOldestProgress msgs =
+  Seq.drop (max 0 (Seq.length msgs - progressQueueLimit)) msgs
+
+progressEnd :: LspProgress -> T.Text -> LspM () ()
+progressEnd progress msg =
+  sendNotification SMethod_Progress $
+    ProgressParams (lspProgressToken progress) $
+      toJSON (WorkDoneProgressEnd AString (Just msg))
+
+finishProgressOnce :: IORef Bool -> LspProgress -> T.Text -> LspM () ()
+finishProgressOnce finished progress msg = do
+  alreadyFinished <- liftIO $
+    atomicModifyIORef' finished $ \done -> (True, done)
+  when (not alreadyFinished) $ do
+    clearProgressQueue progress
+    liftIO $ killThread (lspProgressWorker progress)
+    progressEnd progress msg
+
+moduleLabel :: Compile.GlobalTask -> String
+moduleLabel task = Compile.modNameToString (Compile.tkMod (Compile.gtKey task))
+
+backJobLabel :: Compile.BackJob -> String
+backJobLabel job =
+  Compile.modNameToString (S.modname (Compile.biTypedMod (Compile.bjInput job)))
+
+frontProgressMessage :: Compile.GlobalTask -> Compile.FrontPassProgress -> T.Text
+frontProgressMessage task p =
+  T.pack $
+    passName (Compile.fppPass p) ++ " " ++ moduleLabel task ++ current
+  where
+    current =
+      case Compile.fppCurrent p of
+        Nothing -> ""
+        Just label -> " (" ++ label ++ ")"
+    passName Compile.FrontPassKinds = "Checking kinds for"
+    passName Compile.FrontPassTypes = "Typechecking"
+
+backProgressMessage :: Compile.BackJob -> Compile.BackJobResult -> T.Text
+backProgressMessage job result =
+  T.pack $
+    case result of
+      Compile.BackJobOk{} -> "Generated " ++ backJobLabel job
+      Compile.BackJobFailed{} -> "Codegen failed for " ++ backJobLabel job
+
 warnBackgroundCompilerLocked :: FilePath -> LspM () ()
 warnBackgroundCompilerLocked projRoot = do
   first <- liftIO $ atomicModifyIORef' backgroundCompilerWarnedRef $ \m ->
@@ -230,12 +418,29 @@ lspDiagnosticsFrom diags = concatMap (map reportToLsp . reportsOf) diags
 -- | Prepare a compile plan for a file, run it, and publish diagnostics.
 runCompile :: Int -> FilePath -> LspM () ()
 runCompile gen path = do
-  let gopts = lspGlobalOpts
-      opts = lspCompileOpts
-      sp = overlaySourceProvider overlaysRef
-  rootProj <- liftIO $ resolveCompileRoot path opts
-  withBackgroundCompilerLock gen rootProj $
-    runCompilePlanWithHooks gen rootProj path sp gopts opts
+  env <- getLspEnv
+  progress <- startLspProgress gen path
+  finished <- liftIO $ newIORef False
+  let finish = finishProgressOnce finished progress
+      body = do
+        let gopts = lspGlobalOpts
+            opts = lspCompileOpts
+            sp = overlaySourceProvider overlaysRef
+        rootProj <- liftIO $ resolveCompileRoot path opts
+        lockOk <- liftIO $ ensureBackgroundCompilerLock rootProj
+        if lockOk
+          then do
+            progressReportImmediate progress "Running Acton front passes" Nothing
+            ok <- runCompilePlanWithHooks gen rootProj path sp gopts opts progress
+            if ok
+              then finish "Acton ready"
+              else finish "Acton failed"
+          else do
+            progressReportImmediate progress "Waiting for another Acton compiler for this project" Nothing
+            whenCurrentGen gen $ warnBackgroundCompilerLocked rootProj
+            finish "Acton blocked by another compiler"
+  liftIO $
+    runLspT env body `finally` runLspT env (finish "Acton stopped")
 
 -- | Resolve the project root used for compile locking.
 resolveCompileRoot :: FilePath -> C.CompileOptions -> IO FilePath
@@ -248,20 +453,40 @@ resolveCompileRoot path opts = do
       Compile.normalizePathSafe (Compile.projPath paths)
 
 -- | Prepare and run a compile while holding the per-run project work lock.
-runCompilePlanWithHooks :: Int -> FilePath -> FilePath -> Source.SourceProvider -> C.GlobalOptions -> C.CompileOptions -> LspM () ()
-runCompilePlanWithHooks gen rootProj path sp gopts opts = do
+runCompilePlanWithHooks :: Int -> FilePath -> FilePath -> Source.SourceProvider -> C.GlobalOptions -> C.CompileOptions -> LspProgress -> LspM () Bool
+runCompilePlanWithHooks gen rootProj path sp gopts opts progress = do
   env <- getLspEnv
   let taskPath t = Compile.srcFile (Compile.gtPaths t) (Compile.tkMod (Compile.gtKey t))
       publishFor t diags =
         runLspT env $ whenCurrentGen gen $
           publishDiagnosticsFor (taskPath t) diags
+      progressFor msg =
+        runLspT env $ whenCurrentGen gen $
+          progressReportImmediate progress msg Nothing
+      progressForQueued msg =
+        runLspT env $ whenCurrentGen gen $
+          progressReportQueued progress msg
       hooks = Compile.defaultCompileHooks
         { Compile.chOnDiagnostics = \t _ diags ->
             publishFor t (lspDiagnosticsFrom diags)
+        , Compile.chOnParseStart = \t ->
+            progressForQueued (T.pack ("Parsing " ++ moduleLabel t))
+        , Compile.chOnParseDone = \t _ ->
+            progressForQueued (T.pack ("Parsed " ++ moduleLabel t))
+        , Compile.chOnFrontStart = \t ->
+            progressFor (T.pack ("Checking " ++ moduleLabel t))
+        , Compile.chOnFrontProgress = \t p ->
+            progressForQueued (frontProgressMessage t p)
         , Compile.chOnFrontResult = \t _ ->
-            publishFor t []
+            publishFor t [] >>
+            progressForQueued (T.pack ("Checked " ++ moduleLabel t))
+        , Compile.chOnBackStart = \job ->
+            progressForQueued (T.pack ("Generating " ++ backJobLabel job))
+        , Compile.chOnBackDone = \job result ->
+            progressForQueued (backProgressMessage job result)
         , Compile.chOnInfo = \_ -> return ()
         }
+  progressReportImmediate progress "Discovering Acton project" Nothing
   compileRes <- liftIO $
     Compile.withProjectLock rootProj $
       do
@@ -272,11 +497,14 @@ runCompilePlanWithHooks gen rootProj path sp gopts opts = do
           Left (Compile.ProjectError msg) ->
             return (Left msg)
           Right plan -> do
+            progressFor "Acton compile plan ready"
             runRes <- Compile.runCompilePlan sp gopts plan compileScheduler gen hooks
             case runRes of
               Left err ->
                 return (Left (Compile.compileFailureMessage err))
-              Right _ -> do
+              Right (envAcc, _) -> do
+                rememberCompletionStates plan envAcc
+                progressFor "Completion ready"
                 let opts' = Compile.ccOpts (Compile.cpContext plan)
                 backFailure <-
                   if C.only_build opts'
@@ -288,16 +516,8 @@ runCompilePlanWithHooks gen rootProj path sp gopts opts = do
                   Nothing ->
                     return (Right ())
   case compileRes of
-    Left msg -> notifyCompileError gen msg
-    Right () -> return ()
-
--- | Execute an action only when we own the long-running compiler lock.
-withBackgroundCompilerLock :: Int -> FilePath -> LspM () () -> LspM () ()
-withBackgroundCompilerLock gen rootProj action = do
-  lockOk <- liftIO $ ensureBackgroundCompilerLock rootProj
-  if lockOk
-    then action
-    else whenCurrentGen gen $ warnBackgroundCompilerLocked rootProj
+    Left msg -> notifyCompileError gen msg >> return False
+    Right () -> return True
 
 -- | Schedule a compile run with a debounce delay.
 scheduleCompile :: Int -> FilePath -> LspM () ()
@@ -305,6 +525,169 @@ scheduleCompile delay path = do
   env <- getLspEnv
   void $ liftIO $ Compile.startCompile compileScheduler delay $ \gen ->
     runLspT env (runCompile gen path)
+
+-- | Convert an LSP position to a source offset. LSP columns are UTF-16 code
+-- units; parser/source offsets are Haskell character offsets.
+positionToOffset :: String -> LSP.Position -> Int
+positionToOffset src (LSP.Position line character) =
+  goLine (fromIntegral line) 0 src
+  where
+    targetCol = fromIntegral character
+
+    goLine 0 off rest = off + columnOffset targetCol rest
+    goLine _ off [] = off
+    goLine n off (c:cs)
+      | c == '\n' = goLine (n - 1) (off + 1) cs
+      | otherwise = goLine n (off + 1) cs
+
+    columnOffset 0 _ = 0
+    columnOffset _ [] = 0
+    columnOffset col (c:cs)
+      | c == '\n' = 0
+      | units > col = 0
+      | otherwise = 1 + columnOffset (col - units) cs
+      where units = if ord c > 0xffff then 2 else 1
+
+completionKindToLsp :: Completion.CompletionKind -> CompletionItemKind
+completionKindToLsp kind =
+  case kind of
+    Completion.CompletionField -> CompletionItemKind_Field
+    Completion.CompletionMethod -> CompletionItemKind_Method
+    Completion.CompletionProperty -> CompletionItemKind_Property
+    Completion.CompletionValue -> CompletionItemKind_Value
+
+lspCompletionItem :: Completion.Completion -> CompletionItem
+lspCompletionItem item =
+  CompletionItem
+    { _label = T.pack (Completion.completionLabel item)
+    , _labelDetails = Nothing
+    , _kind = Just (completionKindToLsp (Completion.completionKind item))
+    , _tags = Nothing
+    , _detail = T.pack <$> Completion.completionDetail item
+    , _documentation = Nothing
+    , _deprecated = Nothing
+    , _preselect = Nothing
+    , _sortText = Nothing
+    , _filterText = Nothing
+    , _insertText = completionInsertText item
+    , _insertTextFormat = completionInsertTextFormat item
+    , _insertTextMode = Nothing
+    , _textEdit = Nothing
+    , _textEditText = Nothing
+    , _additionalTextEdits = Nothing
+    , _commitCharacters = Nothing
+    , _command = completionCommand item
+    , _data_ = Nothing
+    }
+
+completionInsertText :: Completion.Completion -> Maybe T.Text
+completionInsertText item =
+  case Completion.completionKind item of
+    Completion.CompletionMethod ->
+      Just (T.pack (Completion.completionLabel item ++ "($0)"))
+    _ -> Nothing
+
+completionInsertTextFormat :: Completion.Completion -> Maybe InsertTextFormat
+completionInsertTextFormat item =
+  case Completion.completionKind item of
+    Completion.CompletionMethod -> Just InsertTextFormat_Snippet
+    _ -> Nothing
+
+completionCommand :: Completion.Completion -> Maybe Command
+completionCommand item =
+  case Completion.completionKind item of
+    Completion.CompletionMethod ->
+      Just Command
+        { _title = "Trigger parameter hints"
+        , _command = "editor.action.triggerParameterHints"
+        , _arguments = Nothing
+        }
+    _ -> Nothing
+
+signatureHelpFor :: FilePath -> LSP.Position -> LspM () (SignatureHelp |? Null)
+signatureHelpFor path pos = do
+  mstate <- liftIO $ loadCompletionStateFor path
+  case mstate of
+    Nothing -> return (InR Null)
+    Just state -> do
+      snapRes <- liftIO $
+        (try (Source.readSource (overlaySourceProvider overlaysRef) path) :: IO (Either IOError Source.SourceSnapshot))
+      case snapRes of
+        Left _ -> return (InR Null)
+        Right snap -> do
+          let src = Source.ssText snap
+              cursor = positionToOffset src pos
+          sigs <- liftIO $
+            Completion.callSignatures
+              (completionEnv state)
+              (completionSearchPath state)
+              (completionModuleName state)
+              path
+              src
+              cursor
+          return $
+            case sigs of
+              [] -> InR Null
+              sig:_ -> InL (lspSignatureHelp sig)
+
+lspSignatureHelp :: Completion.CallSignature -> SignatureHelp
+lspSignatureHelp sig =
+  SignatureHelp
+    { _signatures = [lspSignatureInformation sig]
+    , _activeSignature = Just 0
+    , _activeParameter = active
+    }
+  where
+    params = Completion.callSignatureParameters sig
+    active =
+      if null params
+        then Nothing
+        else Just (InL (fromIntegral (Completion.callSignatureActiveParameter sig)))
+
+lspSignatureInformation :: Completion.CallSignature -> SignatureInformation
+lspSignatureInformation sig =
+  SignatureInformation
+    { _label = T.pack (Completion.callSignatureLabel sig)
+    , _documentation = Nothing
+    , _parameters = Just (map lspParameterInformation (Completion.callSignatureParameters sig))
+    , _activeParameter = active
+    }
+  where
+    params = Completion.callSignatureParameters sig
+    active =
+      if null params
+        then Nothing
+        else Just (InL (fromIntegral (Completion.callSignatureActiveParameter sig)))
+
+lspParameterInformation :: Completion.SignatureParameter -> ParameterInformation
+lspParameterInformation param =
+  ParameterInformation
+    { _label = InL (T.pack (Completion.signatureParameterLabel param))
+    , _documentation = Nothing
+    }
+
+completionItemsFor :: FilePath -> LSP.Position -> LspM () [CompletionItem]
+completionItemsFor path pos = do
+  mstate <- liftIO $ loadCompletionStateFor path
+  case mstate of
+    Nothing -> return []
+    Just state -> do
+      snapRes <- liftIO $
+        (try (Source.readSource (overlaySourceProvider overlaysRef) path) :: IO (Either IOError Source.SourceSnapshot))
+      case snapRes of
+        Left _ -> return []
+        Right snap -> do
+          let src = Source.ssText snap
+              cursor = positionToOffset src pos
+          items <- liftIO $
+            Completion.memberCompletions
+              (completionEnv state)
+              (completionSearchPath state)
+              (completionModuleName state)
+              path
+              src
+              cursor
+          return (map lspCompletionItem items)
 
 -- | Resolve and normalize a document URI to a file path.
 resolvePath :: Uri -> LspM () (Maybe FilePath)
@@ -319,6 +702,18 @@ handlers =
   mconcat
     [ notificationHandler SMethod_Initialized $ \_ -> pure ()
     , notificationHandler SMethod_WorkspaceDidChangeConfiguration $ \_ -> pure ()
+    , requestHandler SMethod_TextDocumentCompletion $ \(TRequestMessage _ _ _ params) respond -> do
+        let CompletionParams (TextDocumentIdentifier uri) pos _ _ _ = params
+        items <- resolvePath uri >>= \case
+          Nothing -> return []
+          Just path -> completionItemsFor path pos
+        respond (Right (InL items))
+    , requestHandler SMethod_TextDocumentSignatureHelp $ \(TRequestMessage _ _ _ params) respond -> do
+        let SignatureHelpParams (TextDocumentIdentifier uri) pos _ _ = params
+        help <- resolvePath uri >>= \case
+          Nothing -> return (InR Null)
+          Just path -> signatureHelpFor path pos
+        respond (Right help)
     , notificationHandler SMethod_TextDocumentDidOpen $ \(TNotificationMessage _ _ (DidOpenTextDocumentParams doc)) -> do
         let TextDocumentItem{_uri=uri,_text=txt} = doc
         resolvePath uri >>= \case
@@ -365,7 +760,12 @@ main =
         , doInitialize = \env _req -> pure $ Right env
         , staticHandlers = \_caps -> handlers
         , interpretHandler = \env -> Iso (runLspT env) liftIO
-        , options = defaultOptions { optTextDocumentSync = Just syncOptions }
+        , options = defaultOptions
+            { optTextDocumentSync = Just syncOptions
+            , optCompletionTriggerCharacters = Just ['.']
+            , optSignatureHelpTriggerCharacters = Just ['(', ',']
+            , optSignatureHelpRetriggerCharacters = Just [',']
+            }
         }
     syncOptions = TextDocumentSyncOptions
       { _openClose = Just True

--- a/compiler/lsp-server/Main.hs
+++ b/compiler/lsp-server/Main.hs
@@ -3,22 +3,26 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeOperators #-}
 
-import Control.Exception (SomeException, finally, try)
+import Control.Exception (SomeException, displayException, finally, fromException, try)
 import Control.Concurrent (ThreadId, forkIO, killThread, threadDelay)
 import Control.Concurrent.MVar (MVar, newEmptyMVar, takeMVar, tryPutMVar)
 import Control.Monad (forM, forM_, forever, void, when)
 import Control.Monad.IO.Class
 import Data.Aeson (toJSON)
 import Data.Char (ord)
+import Data.List (find)
 import Data.IORef
 import qualified Data.HashMap.Strict as HM
+import qualified Data.Map.Strict as M
 import Data.Maybe (fromMaybe, listToMaybe)
 import Data.Sequence (Seq, ViewL(..), (|>))
 import qualified Data.Sequence as Seq
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import GHC.Conc (getNumCapabilities)
-import System.FilePath (takeFileName)
+import System.Directory (doesDirectoryExist)
+import System.FilePath ((</>), takeExtension, takeFileName)
+import qualified System.FSNotify as FS
 import System.IO.Unsafe (unsafePerformIO)
 
 import Language.LSP.Protocol.Message
@@ -26,6 +30,7 @@ import Language.LSP.Protocol.Types hiding (Diagnostic, Position)
 import qualified Language.LSP.Protocol.Types as LSP
 import Language.LSP.Server
 
+import qualified Acton.BuildSpec as BuildSpec
 import qualified Acton.Compile as Compile
 import qualified Acton.CommandLineParser as C
 import qualified Acton.Completion as Completion
@@ -44,12 +49,32 @@ type UriMap = HM.HashMap FilePath Uri
 type BackgroundCompilerLockMap = HM.HashMap FilePath Compile.BackgroundCompilerLock
 type BackgroundCompilerWarned = HM.HashMap FilePath ()
 type CompletionStateMap = HM.HashMap FilePath CompletionState
+type CompletionEnvCacheMap = HM.HashMap FilePath CompletionEnvCache
+type ProjectBuildCacheMap = HM.HashMap FilePath ProjectBuildCache
+type ProjectWatcherMap = HM.HashMap (FilePath, FilePath) ThreadId
 
 data CompletionState = CompletionState
   { completionEnv :: Env.Env0
   , completionSearchPath :: [FilePath]
   , completionModuleName :: S.ModName
+  , completionStateGen :: Int
   }
+
+data CompletionEnvCache = CompletionEnvCache
+  { cachedCompletionStateGen :: Int
+  , cachedCompletionImportKey :: String
+  , cachedCompletionEnv :: Env.Env0
+  }
+
+data ProjectBuildCache = ProjectBuildCache
+  { cachedCompileContext :: Compile.CompileContext
+  , cachedProjectMap :: M.Map FilePath Compile.ProjCtx
+  , cachedGlobalTasks :: [Compile.GlobalTask]
+  , cachedRootPins :: M.Map String BuildSpec.PkgDep
+  , cachedImportKeys :: HM.HashMap FilePath String
+  }
+
+data PlanOrigin = PlanFromCache | PlanFromDiscovery deriving (Eq, Show)
 
 data LspProgress = LspProgress
   { lspProgressToken :: ProgressToken
@@ -92,6 +117,18 @@ backgroundCompilerWarnedRef = unsafePerformIO (newIORef HM.empty)
 -- | Latest successful front-end environment for member completion.
 completionStatesRef :: IORef CompletionStateMap
 completionStatesRef = unsafePerformIO (newIORef HM.empty)
+
+{-# NOINLINE completionEnvCacheRef #-}
+completionEnvCacheRef :: IORef CompletionEnvCacheMap
+completionEnvCacheRef = unsafePerformIO (newIORef HM.empty)
+
+{-# NOINLINE projectBuildCachesRef #-}
+projectBuildCachesRef :: IORef ProjectBuildCacheMap
+projectBuildCachesRef = unsafePerformIO (newIORef HM.empty)
+
+{-# NOINLINE projectWatchersRef #-}
+projectWatchersRef :: IORef ProjectWatcherMap
+projectWatchersRef = unsafePerformIO (newIORef HM.empty)
 
 {-# NOINLINE compileScheduler #-}
 -- | Shared compile scheduler for LSP events and back jobs.
@@ -188,14 +225,14 @@ releaseBackgroundCompilerLocks = do
   forM_ (HM.elems locks) Compile.releaseBackgroundCompilerLock
   writeIORef backgroundCompilerLocksRef HM.empty
 
-rememberCompletionStates :: Compile.CompilePlan -> Env.Env0 -> IO ()
-rememberCompletionStates plan env = do
+rememberCompletionStates :: Int -> Compile.CompilePlan -> Env.Env0 -> IO ()
+rememberCompletionStates gen plan env = do
   entries <- forM (Compile.cpGlobalTasks plan) $ \t -> do
     let key = Compile.gtKey t
         paths = Compile.gtPaths t
         mn = Compile.tkMod key
     path <- Compile.normalizePathSafe (Compile.srcFile paths mn)
-    return (path, CompletionState env (Compile.searchPath paths) mn)
+    return (path, CompletionState env (Compile.searchPath paths) mn gen)
   atomicModifyIORef' completionStatesRef $ \m ->
     (foldr (uncurry HM.insert) m entries, ())
 
@@ -214,6 +251,7 @@ loadDiskCompletionState path = do
     { completionEnv = env
     , completionSearchPath = Compile.searchPath paths
     , completionModuleName = Compile.modName paths
+    , completionStateGen = 0
     }
 
 loadCompletionStateFor :: FilePath -> IO (Maybe CompletionState)
@@ -229,6 +267,163 @@ loadCompletionStateFor path = do
           return (Just state)
         Left _ ->
           return Nothing
+
+cacheCompilePlan :: Compile.CompilePlan -> IO ()
+cacheCompilePlan plan = do
+  importKeys <- globalTaskImportKeys (Compile.cpGlobalTasks plan)
+  let ctx = Compile.cpContext plan
+      rootProj = Compile.ccRootProj ctx
+      cache = ProjectBuildCache
+        { cachedCompileContext = ctx
+        , cachedProjectMap = Compile.cpProjMap plan
+        , cachedGlobalTasks = Compile.cpGlobalTasks plan
+        , cachedRootPins = Compile.cpRootPins plan
+        , cachedImportKeys = importKeys
+        }
+  atomicModifyIORef' projectBuildCachesRef $ \m ->
+    (HM.insert rootProj cache m, ())
+  ensureProjectWatchers rootProj (M.keys (Compile.cpProjMap plan))
+
+globalTaskImportKeys :: [Compile.GlobalTask] -> IO (HM.HashMap FilePath String)
+globalTaskImportKeys tasks =
+  HM.fromList <$> mapM taskImportKeyEntry tasks
+
+taskImportKeyEntry :: Compile.GlobalTask -> IO (FilePath, String)
+taskImportKeyEntry task = do
+  path <- Compile.normalizePathSafe $
+    Compile.srcFile (Compile.gtPaths task) (Compile.tkMod (Compile.gtKey task))
+  return (path, taskImportKey task)
+
+taskImportKey :: Compile.GlobalTask -> String
+taskImportKey task =
+  show (Compile.importsOf (Compile.gtTask task))
+
+invalidateProjectCache :: FilePath -> IO ()
+invalidateProjectCache rootProj = do
+  atomicModifyIORef' projectBuildCachesRef $ \m ->
+    (HM.delete rootProj m, ())
+  invalidateCompletionEnvCache
+
+ensureProjectWatchers :: FilePath -> [FilePath] -> IO ()
+ensureProjectWatchers rootProj roots =
+  forM_ roots $ \watchedRoot -> do
+    let key = (rootProj, watchedRoot)
+    existing <- HM.lookup key <$> readIORef projectWatchersRef
+    case existing of
+      Just _ -> return ()
+      Nothing -> do
+        tid <- forkIO (watchProjectShape rootProj watchedRoot)
+        atomicModifyIORef' projectWatchersRef $ \m ->
+          (HM.insert key tid m, ())
+
+watchProjectShape :: FilePath -> FilePath -> IO ()
+watchProjectShape rootProj watchedRoot =
+  FS.withManager $ \mgr -> do
+    let srcRoot = watchedRoot </> "src"
+        invalidate _ = invalidateProjectCache rootProj
+        isActEvent ev = takeExtension (FS.eventPath ev) == ".act"
+        isBuildActEvent ev = takeFileName (FS.eventPath ev) == "Build.act"
+    srcExists <- doesDirectoryExist srcRoot
+    when srcExists $
+      void $ FS.watchTree mgr srcRoot isActEvent invalidate
+    void $ FS.watchDir mgr watchedRoot isBuildActEvent invalidate
+    forever $ threadDelay maxBound
+
+prepareLspCompilePlan
+  :: Source.SourceProvider
+  -> C.GlobalOptions
+  -> C.CompileOptions
+  -> FilePath
+  -> LspM () (Either String (PlanOrigin, Compile.CompilePlan))
+prepareLspCompilePlan sp gopts opts path = do
+  planE <- liftIO ((try $ do
+    ctx <- Compile.prepareCompileContext opts [path]
+    path' <- Compile.normalizePathSafe path
+    mcache <- HM.lookup (Compile.ccRootProj ctx) <$> readIORef projectBuildCachesRef
+    case mcache of
+      Just cache
+        | Compile.ccBuildStamp (cachedCompileContext cache) == Compile.ccBuildStamp ctx -> do
+            mplan <- compilePlanFromCache ctx path' cache
+            case mplan of
+              Just plan -> return (PlanFromCache, plan)
+              Nothing -> freshPlan
+      _ -> freshPlan
+    ) :: IO (Either SomeException (PlanOrigin, Compile.CompilePlan)))
+  case planE of
+    Left err ->
+      case fromException err of
+        Just (Compile.ProjectError msg) -> return (Left msg)
+        Nothing -> return (Left (displayException err))
+    Right plan -> return (Right plan)
+  where
+    freshPlan = do
+      plan <- Compile.prepareCompilePlan sp gopts compileScheduler opts [path] False (Just [path])
+      cacheCompilePlan plan
+      return (PlanFromDiscovery, plan)
+
+compilePlanFromCache :: Compile.CompileContext -> FilePath -> ProjectBuildCache -> IO (Maybe Compile.CompilePlan)
+compilePlanFromCache ctx changedPath cache = do
+  refreshed <- refreshChangedGlobalTask changedPath (Compile.ccOpts ctx) cache
+  case refreshed of
+    Nothing -> return Nothing
+    Just (globalTasks, importKeys) -> do
+      neededTasks <- Compile.selectAffectedTasks globalTasks [changedPath]
+      let rootProj = Compile.ccRootProj ctx
+          rootTasks =
+            [ Compile.gtTask t
+            | t <- neededTasks
+            , Compile.tkProj (Compile.gtKey t) == rootProj
+            ]
+          cache' = cache
+            { cachedCompileContext = ctx
+            , cachedGlobalTasks = globalTasks
+            , cachedImportKeys = importKeys
+            }
+      atomicModifyIORef' projectBuildCachesRef $ \m ->
+        (HM.insert rootProj cache' m, ())
+      return $ Just Compile.CompilePlan
+        { Compile.cpContext = ctx
+        , Compile.cpProjMap = cachedProjectMap cache
+        , Compile.cpGlobalTasks = globalTasks
+        , Compile.cpNeededTasks = neededTasks
+        , Compile.cpRootTasks = rootTasks
+        , Compile.cpRootPins = cachedRootPins cache
+        , Compile.cpIncremental = True
+        , Compile.cpAllowPrune = False
+        , Compile.cpChangedPaths = Just [changedPath]
+        , Compile.cpSrcFiles = [changedPath]
+        }
+
+refreshChangedGlobalTask
+  :: FilePath
+  -> C.CompileOptions
+  -> ProjectBuildCache
+  -> IO (Maybe ([Compile.GlobalTask], HM.HashMap FilePath String))
+refreshChangedGlobalTask changedPath opts cache =
+  case find isChanged (cachedGlobalTasks cache) of
+    Nothing -> return Nothing
+    Just old -> do
+      newTask <- Compile.readModuleTask
+        (overlaySourceProvider overlaysRef)
+        lspGlobalOpts
+        opts
+        (Compile.gtPaths old)
+        changedPath
+      let new = old { Compile.gtTask = newTask }
+          newKey = taskImportKey new
+      case HM.lookup changedPath (cachedImportKeys cache) of
+        Just oldKey | oldKey /= newKey ->
+          return Nothing
+        _ -> do
+          let tasks' =
+                [ if Compile.gtKey t == Compile.gtKey old then new else t
+                | t <- cachedGlobalTasks cache
+                ]
+              importKeys' = HM.insert changedPath newKey (cachedImportKeys cache)
+          return (Just (tasks', importKeys'))
+  where
+    isChanged t =
+      Compile.srcFile (Compile.gtPaths t) (Compile.tkMod (Compile.gtKey t)) == changedPath
 
 progressToken :: Int -> FilePath -> ProgressToken
 progressToken gen path =
@@ -486,24 +681,26 @@ runCompilePlanWithHooks gen rootProj path sp gopts opts progress = do
             progressForQueued (backProgressMessage job result)
         , Compile.chOnInfo = \_ -> return ()
         }
-  progressReportImmediate progress "Discovering Acton project" Nothing
+  progressReportImmediate progress "Preparing Acton project" Nothing
   compileRes <- liftIO $
     Compile.withProjectLock rootProj $
       do
-        planE <- (try $ do
-          Compile.prepareCompilePlan sp gopts compileScheduler opts [path] False (Just [path])
-          ) :: IO (Either Compile.ProjectError Compile.CompilePlan)
+        planE <- runLspT env $
+          prepareLspCompilePlan sp gopts opts path
         case planE of
-          Left (Compile.ProjectError msg) ->
+          Left msg ->
             return (Left msg)
-          Right plan -> do
-            progressFor "Acton compile plan ready"
+          Right (origin, plan) -> do
+            progressFor $
+              case origin of
+                PlanFromCache -> "Acton cached project ready"
+                PlanFromDiscovery -> "Acton compile plan ready"
             runRes <- Compile.runCompilePlan sp gopts plan compileScheduler gen hooks
             case runRes of
               Left err ->
                 return (Left (Compile.compileFailureMessage err))
               Right (envAcc, _) -> do
-                rememberCompletionStates plan envAcc
+                rememberCompletionStates gen plan envAcc
                 progressFor "Completion ready"
                 let opts' = Compile.ccOpts (Compile.cpContext plan)
                 backFailure <-
@@ -617,14 +814,8 @@ signatureHelpFor path pos = do
         Right snap -> do
           let src = Source.ssText snap
               cursor = positionToOffset src pos
-          sigs <- liftIO $
-            Completion.callSignatures
-              (completionEnv state)
-              (completionSearchPath state)
-              (completionModuleName state)
-              path
-              src
-              cursor
+          env <- liftIO $ completionEnvFor state path src
+          let sigs = Completion.callSignaturesWithEnv env src cursor
           return $
             case sigs of
               [] -> InR Null
@@ -666,6 +857,35 @@ lspParameterInformation param =
     , _documentation = Nothing
     }
 
+completionEnvFor :: CompletionState -> FilePath -> String -> IO Env.Env0
+completionEnvFor state path src = do
+  importKey <- Completion.completionImportKey path src
+  mcache <- HM.lookup path <$> readIORef completionEnvCacheRef
+  case mcache of
+    Just cache
+      | cachedCompletionStateGen cache == completionStateGen state
+      , cachedCompletionImportKey cache == importKey ->
+          return (cachedCompletionEnv cache)
+    _ -> do
+      env <- Completion.prepareCompletionEnv
+        (completionEnv state)
+        (completionSearchPath state)
+        (completionModuleName state)
+        path
+        src
+      let cache = CompletionEnvCache
+            { cachedCompletionStateGen = completionStateGen state
+            , cachedCompletionImportKey = importKey
+            , cachedCompletionEnv = env
+            }
+      atomicModifyIORef' completionEnvCacheRef $ \m ->
+        (HM.insert path cache m, ())
+      return env
+
+invalidateCompletionEnvCache :: IO ()
+invalidateCompletionEnvCache =
+  writeIORef completionEnvCacheRef HM.empty
+
 completionItemsFor :: FilePath -> LSP.Position -> LspM () [CompletionItem]
 completionItemsFor path pos = do
   mstate <- liftIO $ loadCompletionStateFor path
@@ -679,14 +899,8 @@ completionItemsFor path pos = do
         Right snap -> do
           let src = Source.ssText snap
               cursor = positionToOffset src pos
-          items <- liftIO $
-            Completion.memberCompletions
-              (completionEnv state)
-              (completionSearchPath state)
-              (completionModuleName state)
-              path
-              src
-              cursor
+          env <- liftIO $ completionEnvFor state path src
+          let items = Completion.memberCompletionsWithEnv env src cursor
           return (map lspCompletionItem items)
 
 -- | Resolve and normalize a document URI to a file path.

--- a/compiler/lsp-server/Main.hs
+++ b/compiler/lsp-server/Main.hs
@@ -821,6 +821,46 @@ signatureHelpFor path pos = do
               [] -> InR Null
               sig:_ -> InL (lspSignatureHelp sig)
 
+hoverFor :: FilePath -> LSP.Position -> LspM () (Hover |? Null)
+hoverFor path pos = do
+  mstate <- liftIO $ loadCompletionStateFor path
+  case mstate of
+    Nothing -> return (InR Null)
+    Just state -> do
+      snapRes <- liftIO $
+        (try (Source.readSource (overlaySourceProvider overlaysRef) path) :: IO (Either IOError Source.SourceSnapshot))
+      case snapRes of
+        Left _ -> return (InR Null)
+        Right snap -> do
+          let src = Source.ssText snap
+              cursor = positionToOffset src pos
+          env <- liftIO $ completionEnvFor state path src
+          return $
+            case Completion.hoverInfoWithEnv env src cursor of
+              Nothing -> InR Null
+              Just info -> InL (lspHover info)
+
+lspHover :: Completion.HoverInfo -> Hover
+lspHover info =
+  Hover
+    { _contents = InL MarkupContent
+        { _kind = MarkupKind_Markdown
+        , _value = T.pack (hoverMarkdown info)
+        }
+    , _range = Nothing
+    }
+  where
+    hoverMarkdown hover =
+      "```acton\n"
+      ++ Completion.hoverDetail hover
+      ++ "\n```"
+      ++ hoverDoc hover
+
+    hoverDoc hover =
+      case Completion.hoverDocumentation hover of
+        Nothing -> ""
+        Just doc -> "\n\n" ++ doc
+
 lspSignatureHelp :: Completion.CallSignature -> SignatureHelp
 lspSignatureHelp sig =
   SignatureHelp
@@ -928,6 +968,12 @@ handlers =
           Nothing -> return (InR Null)
           Just path -> signatureHelpFor path pos
         respond (Right help)
+    , requestHandler SMethod_TextDocumentHover $ \(TRequestMessage _ _ _ params) respond -> do
+        let HoverParams (TextDocumentIdentifier uri) pos _ = params
+        hover <- resolvePath uri >>= \case
+          Nothing -> return (InR Null)
+          Just path -> hoverFor path pos
+        respond (Right hover)
     , notificationHandler SMethod_TextDocumentDidOpen $ \(TNotificationMessage _ _ (DidOpenTextDocumentParams doc)) -> do
         let TextDocumentItem{_uri=uri,_text=txt} = doc
         resolvePath uri >>= \case

--- a/compiler/lsp-server/Main.hs
+++ b/compiler/lsp-server/Main.hs
@@ -752,6 +752,7 @@ completionKindToLsp kind =
     Completion.CompletionMethod -> CompletionItemKind_Method
     Completion.CompletionProperty -> CompletionItemKind_Property
     Completion.CompletionValue -> CompletionItemKind_Value
+    Completion.CompletionKeyword -> CompletionItemKind_Keyword
 
 lspCompletionItem :: Completion.Completion -> CompletionItem
 lspCompletionItem item =
@@ -782,12 +783,15 @@ completionInsertText item =
   case Completion.completionKind item of
     Completion.CompletionMethod ->
       Just (T.pack (Completion.completionLabel item ++ "($0)"))
+    Completion.CompletionKeyword ->
+      Just (T.pack (Completion.completionLabel item ++ "$0"))
     _ -> Nothing
 
 completionInsertTextFormat :: Completion.Completion -> Maybe InsertTextFormat
 completionInsertTextFormat item =
   case Completion.completionKind item of
     Completion.CompletionMethod -> Just InsertTextFormat_Snippet
+    Completion.CompletionKeyword -> Just InsertTextFormat_Snippet
     _ -> Nothing
 
 completionCommand :: Completion.Completion -> Maybe Command
@@ -940,7 +944,9 @@ completionItemsFor path pos = do
           let src = Source.ssText snap
               cursor = positionToOffset src pos
           env <- liftIO $ completionEnvFor state path src
-          let items = Completion.memberCompletionsWithEnv env src cursor
+          let items =
+                Completion.memberCompletionsWithEnv env src cursor ++
+                Completion.argumentCompletionsWithEnv env src cursor
           return (map lspCompletionItem items)
 
 -- | Resolve and normalize a document URI to a file path.
@@ -1022,7 +1028,7 @@ main =
         , interpretHandler = \env -> Iso (runLspT env) liftIO
         , options = defaultOptions
             { optTextDocumentSync = Just syncOptions
-            , optCompletionTriggerCharacters = Just ['.']
+            , optCompletionTriggerCharacters = Just ['.', '(', ',']
             , optSignatureHelpTriggerCharacters = Just ['(', ',']
             , optSignatureHelpRetriggerCharacters = Just [',']
             }

--- a/compiler/lsp-server/Main.hs
+++ b/compiler/lsp-server/Main.hs
@@ -1,9 +1,10 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators #-}
 
-import Control.Exception (SomeException, displayException, finally, fromException, try)
+import Control.Exception (AsyncException, SomeException, displayException, evaluate, finally, fromException, throwIO, try)
 import Control.Concurrent (ThreadId, forkIO, killThread, threadDelay)
 import Control.Concurrent.MVar (MVar, newEmptyMVar, takeMVar, tryPutMVar)
 import Control.Monad (forM, forM_, forever, void, when)
@@ -805,6 +806,51 @@ completionCommand item =
         }
     _ -> Nothing
 
+forceLspCompletions :: [Completion.Completion] -> [Completion.Completion]
+forceLspCompletions items =
+  sum [ length (Completion.completionLabel item)
+      + maybe 0 length (Completion.completionDetail item)
+      + completionKindCode (Completion.completionKind item)
+      | item <- items
+      ] `seq` items
+
+forceLspSignatures :: [Completion.CallSignature] -> [Completion.CallSignature]
+forceLspSignatures sigs =
+  sum [ length (Completion.callSignatureLabel sig)
+      + Completion.callSignatureActiveParameter sig
+      + sum (map (length . Completion.signatureParameterLabel) (Completion.callSignatureParameters sig))
+      | sig <- sigs
+      ] `seq` sigs
+
+forceLspHover :: Maybe Completion.HoverInfo -> Maybe Completion.HoverInfo
+forceLspHover info =
+  case info of
+    Nothing -> Nothing
+    Just hover ->
+      length (Completion.hoverLabel hover)
+      + length (Completion.hoverDetail hover)
+      + maybe 0 length (Completion.hoverDocumentation hover) `seq` info
+
+completionKindCode :: Completion.CompletionKind -> Int
+completionKindCode kind =
+  case kind of
+    Completion.CompletionField -> 1
+    Completion.CompletionMethod -> 2
+    Completion.CompletionProperty -> 3
+    Completion.CompletionValue -> 4
+    Completion.CompletionKeyword -> 5
+
+tryLspIO :: IO a -> IO (Maybe a)
+tryLspIO action = do
+  res <- try action
+  case res of
+    Left err
+      | Just (_ :: AsyncException) <- fromException err ->
+          throwIO err
+      | otherwise ->
+          return Nothing
+    Right value -> return (Just value)
+
 signatureHelpFor :: FilePath -> LSP.Position -> LspM () (SignatureHelp |? Null)
 signatureHelpFor path pos = do
   mstate <- liftIO $ loadCompletionStateFor path
@@ -818,12 +864,14 @@ signatureHelpFor path pos = do
         Right snap -> do
           let src = Source.ssText snap
               cursor = positionToOffset src pos
-          env <- liftIO $ completionEnvFor state path src
-          let sigs = Completion.callSignaturesWithEnv env src cursor
+          msigs <- liftIO $
+            tryLspIO $ do
+              env <- completionEnvFor state path src
+              evaluate (forceLspSignatures (Completion.callSignaturesWithEnv env src cursor))
           return $
-            case sigs of
-              [] -> InR Null
-              sig:_ -> InL (lspSignatureHelp sig)
+            case msigs of
+              Just (sig:_) -> InL (lspSignatureHelp sig)
+              _ -> InR Null
 
 hoverFor :: FilePath -> LSP.Position -> LspM () (Hover |? Null)
 hoverFor path pos = do
@@ -838,11 +886,14 @@ hoverFor path pos = do
         Right snap -> do
           let src = Source.ssText snap
               cursor = positionToOffset src pos
-          env <- liftIO $ completionEnvFor state path src
+          minfo <- liftIO $
+            tryLspIO $ do
+              env <- completionEnvFor state path src
+              evaluate (forceLspHover (Completion.hoverInfoWithEnv env src cursor))
           return $
-            case Completion.hoverInfoWithEnv env src cursor of
-              Nothing -> InR Null
-              Just info -> InL (lspHover info)
+            case minfo of
+              Just (Just info) -> InL (lspHover info)
+              _ -> InR Null
 
 lspHover :: Completion.HoverInfo -> Hover
 lspHover info =
@@ -943,18 +994,22 @@ completionItemsFor path pos = do
         Right snap -> do
           let src = Source.ssText snap
               cursor = positionToOffset src pos
-          env <- liftIO $ completionEnvFor state path src
-          let items =
-                Completion.memberCompletionsWithEnv env src cursor ++
-                Completion.argumentCompletionsWithEnv env src cursor
-          return (map lspCompletionItem items)
+          mitems <- liftIO $
+            tryLspIO $ do
+              env <- completionEnvFor state path src
+              let items =
+                    Completion.memberCompletionsWithEnv env src cursor ++
+                    Completion.argumentCompletionsWithEnv env src cursor
+              evaluate (forceLspCompletions items)
+          return (maybe [] (map lspCompletionItem) mitems)
 
 -- | Resolve and normalize a document URI to a file path.
 resolvePath :: Uri -> LspM () (Maybe FilePath)
 resolvePath uri =
   case uriToFilePath uri of
     Nothing -> return Nothing
-    Just path -> liftIO $ Just <$> Compile.normalizePathSafe path
+    Just path -> liftIO $ do
+      tryLspIO (Compile.normalizePathSafe path)
 
 -- | LSP notification handlers for open/change/close events.
 handlers :: Handlers (LspM ())

--- a/compiler/lsp-server/package.yaml.in
+++ b/compiler/lsp-server/package.yaml.in
@@ -27,6 +27,7 @@ executables:
       - containers
       - directory
       - filepath
+      - fsnotify
       - mtl
       - megaparsec
       - aeson


### PR DESCRIPTION
This adds completion / suggestion support to the LSP-server. It is based on syntactic completion, producing completions based on explicit types or those that can be syntactically derived via inheritance chains and similar.

I've been thinking about tab completion for quite some time now and I generally think that the first steps to a proper solution is to add error handling and fault tolerance to the front passes so we that we can parse incomplete files and do kinds + type checking on those modules to the furthest extent possible. However, that is a long journey, so I decided to see if it was possible to do something half-baked today. Turns out it is. This now uses custom parsers that can handle some specific subsets of lines that we are interested in doing completion on - it seems to work rather well for the primary completion cases we have in mind right now and I think it will serve as a fantastic foundation, since we now have the complete chain in place for completions including a test suite, so now we can get to work on replacing these parts with a fault tolerant parser etc.

It quickly become obvious that we needed better caching in this, so that we can return completions in milliseconds, not hundreds of milliseconds, and so now we do cache the build graph and keep all dependency modules for a project loaded in memory. This reduces typical time from ~250-350ms to < 1ms for completing something and the difference in snappiness in an editor is noticeable! We use fsnotify to register for file change events so we can invalidate this cache.

There's also on-hover info showing up with types and docstrings now.