### PR TITLE
Set DEVELOPER_DIR=/dev/null for actondb on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -413,6 +413,13 @@ dist/base: base base/.build base/__root.zig base/acton.zig base/build.zig base/b
 # the file and modify it, which the Linux kernel (and perhaps others?) will
 # prevent if the file to be modified is an executable program that is currently
 # running.  We work around it by moving / renaming the file in place instead!
+ifeq ($(OS),macos)
+# Workaround for macOS 26.4 CLI tools breaking Zig: point DEVELOPER_DIR to
+# /dev/null to prevent Zig from trying to use them and instead falling back to
+# its own implementation.
+# See https://codeberg.org/ziglang/zig/issues/31658.
+dist/bin/actondb: export DEVELOPER_DIR := $(or $(DEVELOPER_DIR),/dev/null)
+endif
 dist/bin/actondb: $(DIST_ZIG) $(DEPS)
 	@mkdir -p $(dir $@)
 	cd dist/backend && "$(ZIG)" build -Donly_actondb --prefix "$(TD)/dist"


### PR DESCRIPTION
Mirror the workaround in Main.hs for avoiding Zig picking up broken Xcode SDK headers on macOS 26.4. In this case we invoke Zig outside of the Acton compiler.