### PR TITLE
Restrict pkg commands to libraries

### DIFF
--- a/compiler/acton/PkgCommands.hs
+++ b/compiler/acton/PkgCommands.hs
@@ -53,10 +53,11 @@ data PackageEntry = PackageEntry
     , pkgRepoUrl     :: String
     } deriving (Eq, Show)
 
-data PackageEntryRaw = PackageEntryRaw
-    { rawName        :: Maybe String
-    , rawDescription :: Maybe String
-    , rawRepoUrl     :: Maybe String
+data PackageIndexEntry = PackageIndexEntry
+    { indexName        :: String
+    , indexKinds       :: [String]
+    , indexDescription :: String
+    , indexRepoUrl     :: String
     } deriving (Eq, Show)
 
 data RepoInfo = RepoInfo
@@ -341,42 +342,54 @@ lookupRepoUrlFromIndex depName pkgNameArg = do
     unless exists $
       throwProjectError ("ERROR: Package index not found at " ++ indexPath ++ "\nHINT: Run: acton pkg update")
     content <- readIndexFile indexPath
-    entries <- requireRight (decodePackageIndexRaw content)
+    entries <- requireRight (decodePackageIndexEntries content)
     let pkgName = if null pkgNameArg then depName else pkgNameArg
-        matchEntry e = rawName e == Just pkgName
+        matchEntry e = indexName e == pkgName
     case filter matchEntry entries of
       [] -> throwProjectError ("ERROR: Package " ++ pkgName ++ " not found in package index")
-      (entry:_) ->
-        case rawRepoUrl entry of
-          Just url | not (null url) -> return url
-          _ -> throwProjectError ("ERROR: Package " ++ pkgName ++ " in index is missing 'repo_url'")
+      entriesForName ->
+        case filter (elem "library" . indexKinds) entriesForName of
+          (entry:_) -> return (indexRepoUrl entry)
+          [] -> throwProjectError ("ERROR: Package " ++ pkgName ++ " is not an acton-library package")
 
 decodePackageIndex :: BL.ByteString -> Either String [PackageEntry]
 decodePackageIndex content = do
-    raws <- decodePackageIndexRaw content
+    entries <- decodePackageIndexEntries content
     let pkgs = [ PackageEntry n d r
-               | PackageEntryRaw (Just n) (Just d) (Just r) <- raws
+               | PackageIndexEntry n ks d r <- entries
+               , "library" `elem` ks
                ]
     return pkgs
 
-decodePackageIndexRaw :: BL.ByteString -> Either String [PackageEntryRaw]
-decodePackageIndexRaw content =
+decodePackageIndexEntries :: BL.ByteString -> Either String [PackageIndexEntry]
+decodePackageIndexEntries content =
     case Aeson.eitherDecode content of
       Left err -> Left ("ERROR: Failed to parse package index JSON: " ++ err)
       Right (Aeson.Object obj) ->
         case AesonKM.lookup (AesonKey.fromString "packages") obj of
-          Just (Aeson.Array arr) -> Right (map parseEntry (toList arr))
+          Just (Aeson.Array arr) -> mapM parseEntry (zip [0 :: Int ..] (toList arr))
           _ -> Left "ERROR: Invalid package index: top-level 'packages' list missing or wrong type"
       Right _ ->
         Left "ERROR: Invalid package index: top-level 'packages' list missing or wrong type"
   where
-    parseEntry (Aeson.Object o) =
-      PackageEntryRaw
-        { rawName = lookupString "name" o
-        , rawDescription = lookupString "description" o
-        , rawRepoUrl = lookupString "repo_url" o
-        }
-    parseEntry _ = PackageEntryRaw Nothing Nothing Nothing
+    parseEntry (idx, Aeson.Object o) =
+      case ( lookupString "name" o
+           , lookupStringList "kinds" o
+           , lookupString "description" o
+           , lookupString "repo_url" o
+           ) of
+        (Just n, Just ks, Just d, Just r)
+          | null ks ->
+              Left ("ERROR: Invalid package index entry " ++ show idx ++ ": expected at least one kind")
+          | all validPackageKind ks -> Right (PackageIndexEntry n ks d r)
+          | otherwise ->
+              Left ("ERROR: Invalid package index entry " ++ show idx ++ ": unsupported kind in 'kinds'")
+        _ ->
+          Left ("ERROR: Invalid package index entry " ++ show idx ++ ": expected name, kinds, description, and repo_url")
+    parseEntry (idx, _) =
+      Left ("ERROR: Invalid package index entry " ++ show idx ++ ": expected object")
+
+    validPackageKind k = k == "library" || k == "app"
 
 matchesAllTerms :: [String] -> PackageEntry -> IO Bool
 matchesAllTerms terms pkg = do
@@ -539,6 +552,15 @@ lookupString key obj =
     case AesonKM.lookup (AesonKey.fromString key) obj of
       Just (Aeson.String s) -> Just (T.unpack s)
       _ -> Nothing
+
+lookupStringList :: String -> Aeson.Object -> Maybe [String]
+lookupStringList key obj =
+    case AesonKM.lookup (AesonKey.fromString key) obj of
+      Just (Aeson.Array arr) -> mapM valueString (toList arr)
+      _ -> Nothing
+  where
+    valueString (Aeson.String s) = Just (T.unpack s)
+    valueString _ = Nothing
 
 lookupMessage :: Aeson.Object -> Maybe String
 lookupMessage = lookupString "message"

--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -1153,13 +1153,27 @@ pkgCliTests =
         assertBool "prefix matches" ok
         ok2 <- PkgCommands.matchesAllTerms ["bar"] pkg
         assertBool "non-prefix does not match" (not ok2)
-  , testCase "decode package index filters invalid entries" $ do
-        let body = "{\"packages\":[{\"name\":\"foo\",\"description\":\"desc\",\"repo_url\":\"https://github.com/actonlang/foo\"},{\"name\":\"bad\"}]}"
+  , testCase "decode package index returns only libraries" $ do
+        let body = concat
+              [ "{\"packages\":["
+              , "{\"name\":\"foo\",\"kinds\":[\"library\",\"app\"],\"description\":\"desc\",\"repo_url\":\"https://github.com/actonlang/foo\"}"
+              , ",{\"name\":\"bar\",\"kinds\":[\"app\"],\"description\":\"app\",\"repo_url\":\"https://github.com/actonlang/bar\"}"
+              , "]}"
+              ]
         case PkgCommands.decodePackageIndex (LBS.pack body) of
           Left err -> assertFailure err
           Right pkgs -> do
             assertEqual "one package" 1 (length pkgs)
             assertEqual "name" "foo" (PkgCommands.pkgName (head pkgs))
+  , testCase "decode package index requires kinds" $ do
+        let body = concat
+              [ "{\"packages\":["
+              , "{\"name\":\"foo\",\"description\":\"desc\",\"repo_url\":\"https://github.com/actonlang/foo\"}"
+              , "]}"
+              ]
+        case PkgCommands.decodePackageIndex (LBS.pack body) of
+          Left _ -> return ()
+          Right _ -> assertFailure "package index entry without kinds should fail"
   ]
 
 -- Creates testgroup from .act files found in specified directory

--- a/compiler/lib/src/Acton/CommandLineParser.hs
+++ b/compiler/lib/src/Acton/CommandLineParser.hs
@@ -197,7 +197,7 @@ cmdLineParser       = hsubparser
                         <> command "sig"     (info (CmdOpt <$> globalOptions <*> (Sig <$> sigOptions)) (progDesc "Show inferred type signatures"))
                         <> command "test"    (info (CmdOpt <$> globalOptions <*> (Test <$> testCommand)) (progDesc "Build and run project tests"))
                         <> command "fetch"   (info (CmdOpt <$> globalOptions <*> pure Fetch) (progDesc "Fetch project dependencies (offline prep)"))
-                        <> command "pkg"     (info (CmdOpt <$> globalOptions <*> pkgSubcommands) (progDesc "Package/dependency commands"))
+                        <> command "pkg"     (info (CmdOpt <$> globalOptions <*> pkgSubcommands) (progDesc "Library package/dependency commands"))
                         <> command "zig-pkg" (info (CmdOpt <$> globalOptions <*> zigPkgSubcommands) (progDesc "Zig package dependency commands"))
                         <> command "spec"    (info (CmdOpt <$> globalOptions <*> (BuildSpecCmd <$> buildSpecCommand)) (progDesc "Inspect or update build specification"))
                         <> command "cloud"   (info (CmdOpt <$> globalOptions <*> (Cloud <$> cloudOptions)) (progDesc "Run an Acton project in the cloud"))
@@ -355,11 +355,11 @@ compileOptions = CompileOptions
 pkgSubcommands :: Parser Command
 pkgSubcommands = hsubparser
   (  command "show"    (info (pure PkgShow) (progDesc "Show dependency tree with overrides"))
-  <> command "add"     (info (PkgAdd <$> pkgAddOptions) (progDesc "Add package dependency"))
-  <> command "remove"  (info (PkgRemove <$> pkgRemoveOptions) (progDesc "Remove package dependency"))
-  <> command "upgrade" (info (PkgUpgrade <$> pkgUpgradeOptions) (progDesc "Upgrade (or downgrade) package dependency"))
+  <> command "add"     (info (PkgAdd <$> pkgAddOptions) (progDesc "Add library package dependency"))
+  <> command "remove"  (info (PkgRemove <$> pkgRemoveOptions) (progDesc "Remove library package dependency"))
+  <> command "upgrade" (info (PkgUpgrade <$> pkgUpgradeOptions) (progDesc "Upgrade (or downgrade) library package dependency"))
   <> command "update"  (info (pure PkgUpdate) (progDesc "Update package index"))
-  <> command "search"  (info (PkgSearch <$> pkgSearchOptions) (progDesc "Search package index"))
+  <> command "search"  (info (PkgSearch <$> pkgSearchOptions) (progDesc "Search library package index"))
   )
 
 githubTokenOption :: Parser String

--- a/docs/acton-guide/src/SUMMARY.md
+++ b/docs/acton-guide/src/SUMMARY.md
@@ -92,6 +92,7 @@
 - [Build System](compilation.md)
   - [Incremental compilation](compilation/incremental.md)
 - [Package Management](package_management.md)
+  - [Package Index](pkg/package_index.md)
   - [Fingerprint and Lineage](pkg/fingerprint.md)
   - [Add Dependency](pkg/add_dependency.md)
   - [Local Dependencies](pkg/local_dependencies.md)

--- a/docs/acton-guide/src/package_management.md
+++ b/docs/acton-guide/src/package_management.md
@@ -1,34 +1,37 @@
 # Package Management
 
-`acton` offers integrated package management to declare dependencies on
-other Acton packages and automatically download them from their sources
-on the Internet.
+`acton` offers integrated package management for adding library dependencies to
+a project. At build time, dependencies are automatically fetched and validated.
 
-This sits next to the project tree, not instead of it. See
-[Projects](projects.md) for how local source discovery works and
-[Modules](modules.md) for how files under `src/` become module names.
+Acton pins dependencies by content, via a content hash, rather than by mutable
+package version labels. Therefore, builds are entirely deterministic so that the
+same compilation result can be reproduced on another machine.
 
-The guiding principle behind Acton's package management is to strive
-for determinism, robustness, and safety. This is primarily achieved by
-only resolving dependencies at design time. That is, the developer of a
-particular Acton package determines its exact dependencies, not
-whomever might be downloading and building it. The identity of a
-package at a particular point in time, which you can think of as the
-version of a package, is the hash of its content. That is the
-foundation of Acton's package management. Each dependency has a hash of
-its content. A URL is just one place from which this particular version
-of a package can be downloaded. The hash of packages is determined and
-recorded at design time. Anyone pulling down and building dependencies
-will have the hash verified to ensure a deterministic build.
+The guiding principle behind Acton's package management is to strive for
+determinism, robustness, and safety. Dependencies are resolved at design time by
+the package developer and written into `Build.act` as archive URLs plus content
+hashes. Later builds fetch those recorded archives and verify the hashes; they
+do not pick newer compatible versions or rely on a name to mean the same thing
+forever.
 
-There is no central package repository. Instead, dependencies are
-defined as URLs from which the dependency package can be downloaded.
-This is typically a tar.gz file from GitHub, GitLab, or a similar
-source hosting site. Again, the identity of a version of a package is
-the content hash. The URL is only where to get it.
+Acton's public package index is a discovery index. Packages are hosted
+by their owners, and dependencies are recorded as URLs from which a
+specific package archive can be downloaded. This is typically a tar.gz
+or zip archive from GitHub, GitLab, or a similar source hosting site.
+The index helps find packages; `Build.act` records the exact archive and
+hash used by a project.
 
-Acton is statically compiled. All dependencies are fetched and
-included at compile time, so there are no runtime dependencies.
+The public index is decentralized in the sense that package authors opt
+in from their own GitHub repositories. The index collects repositories
+tagged with an `acton-library` or `acton-app` topic and records their
+metadata for search and resolution. `acton pkg` commands work with
+library packages only: `acton pkg search` shows libraries and
+`acton pkg add` resolves libraries as dependencies. App packages are
+installable applications and are kept separate from dependency
+resolution.
+
+All dependencies are fetched and included, linked statically, at compile time,
+so there are no runtime dependencies.
 
 ## Project lineage fingerprint
 

--- a/docs/acton-guide/src/pkg/add_dependency.md
+++ b/docs/acton-guide/src/pkg/add_dependency.md
@@ -1,17 +1,33 @@
 # Add Dependency
 
-Add a dependency to your project by using `acton pkg add` and providing the URL to the project and a local reference name.
+Add a dependency to your project by using `acton pkg add`. The usual
+flow is to refresh the public package index first:
+
+```console
+acton pkg update
+```
+
+Then add the dependency by package name:
+
+```console
+acton pkg add foo
+```
+
+You can also provide a GitHub repository URL directly. The first
+argument is still the local dependency name:
 
 In this case we add the example `foo` package as a dependency.
 ```console
-acton pkg add https://github.com/actonlang/foo/archive/refs/heads/main.zip foo
+acton pkg add foo --repo-url https://github.com/actonlang/foo --repo-ref main
 ```
 
 This will fetch the dependency and add it to the `dependencies` block in `Build.act`, resulting in something like:
 ```python
 dependencies = {
   "foo": (
-        url="https://github.com/actonlang/foo/archive/refs/heads/main.zip",
+        repo_url="https://github.com/actonlang/foo",
+        repo_ref="main",
+        url="https://github.com/actonlang/foo/archive/0123456789abcdef0123456789abcdef01234567.zip",
         hash="1220cd47344f8a1e7fe86741c7b0257a63567b4c17ad583bddf690eedd672032abdd",
     ),
 }

--- a/docs/acton-guide/src/pkg/package_index.md
+++ b/docs/acton-guide/src/pkg/package_index.md
@@ -1,0 +1,47 @@
+# Package Index
+
+The public package index is built from GitHub repository topics. A
+repository can opt in as a library, an app, or both. The generated
+index records this as a `kinds` list:
+
+- `acton-library` marks an importable library package.
+- `acton-app` marks an installable application package.
+
+Use `acton-library` for packages that other projects import and add as
+dependencies. These are the only packages used by `acton pkg add` and
+shown by `acton pkg search`.
+
+Use `acton-app` for projects that produce executable tools. App packages
+are intended for commands that install binaries, for example into
+`~/.acton/bin`.
+
+Add both topics when a repository provides useful importable modules and
+also builds executable tools. `acton pkg` still uses only the library
+entry for dependency resolution.
+
+## Add your package
+
+To have a package discovered by the public index:
+
+1. Put `Build.act` at the root of the repository.
+2. Declare the mandatory `name` and `fingerprint` fields in `Build.act`.
+3. Publish the repository on GitHub.
+4. Add the `acton-library` topic, the `acton-app` topic, or both.
+
+After the public index has refreshed, users can update their local copy:
+
+```console
+acton pkg update
+```
+
+Libraries can then be found with:
+
+```console
+acton pkg search PACKAGE
+```
+
+and added as dependencies with:
+
+```console
+acton pkg add PACKAGE
+```


### PR DESCRIPTION
The package index now describes library and application capabilities, while the pkg commands still treated every valid index entry as a dependency candidate. That made app-only packages visible in dependency search and left index-based add resolution unaware of package kind.

This change makes the index parser require name, kinds, description, and repo_url for every entry, accepts library and app capabilities, and exposes only entries containing library through acton pkg search and index-based acton pkg add. The command help now describes pkg as library dependency management.

The guide now documents acton-library and acton-app topics, explains how repositories are discovered, and keeps the dependency page focused on the normal package-index flow. Repositories may use both topics when they provide importable modules and executable tools; acton pkg still resolves only the library capability as a dependency.