### PR TITLE
Treat stale .ty interfaces as cache misses

### DIFF
--- a/compiler/acton/test_incremental.hs
+++ b/compiler/acton/test_incremental.hs
@@ -3,6 +3,7 @@
 module Main (main) where
 
 import           Control.Monad (unless, when)
+import qualified Data.Binary as Binary
 import qualified Data.ByteString.Lazy.Char8 as LBS
 import qualified Data.ByteString as B
 import qualified Data.Text as T
@@ -468,6 +469,12 @@ rewriteTySourceMeta :: FilePath -> Maybe InterfaceFiles.SourceFileMeta -> IO ()
 rewriteTySourceMeta tyPath sourceMeta' = do
   (_mods, nmod, tmod, _sourceMeta, srcHash, pubHash, implHash, imps, nameHashes, roots, tests, mdoc) <- InterfaceFiles.readFile tyPath
   InterfaceFiles.writeFile tyPath srcHash pubHash implHash sourceMeta' imps nameHashes roots tests mdoc nmod tmod
+
+rewriteTyVersion :: FilePath -> [Int] -> IO ()
+rewriteTyVersion tyPath version' = do
+  (_mods, nmod, tmod, sourceMeta, srcHash, pubHash, implHash, imps, nameHashes, roots, tests, mdoc) <- InterfaceFiles.readFile tyPath
+  LBS.writeFile tyPath $
+    Binary.encode ((version', sourceMeta, srcHash, pubHash, implHash), imps, nameHashes, roots, tests, mdoc, nmod, tmod)
 
 readTySourceMeta :: FilePath -> IO (Maybe InterfaceFiles.SourceFileMeta)
 readTySourceMeta tyPath = do
@@ -1162,6 +1169,28 @@ p26_corrupt_ty_header = testCase "26-corrupt .ty header forces re-parse" $ do
   writeFileUtf8 tyA "garbage\n"
   out <- buildOutIn proj
   assertBool "expected a.act to type check after corrupt .ty" (typechecked out modA)
+
+p26_ty_version_mismatch :: TestTree
+p26_ty_version_mismatch = testCase "26b-.ty version mismatch forces re-parse" $ do
+  let proj = casesProjDir
+      src = casesSrcDir
+      modA = modLabel proj "a"
+      tyA = proj </> "out" </> "types" </> "a.ty"
+  ensureCasesProject
+  writeFileUtf8 (src </> "a.act") "aaa = 1\n"
+  writeFileUtf8 (src </> "c.act") $ T.unlines
+    [ "import a"
+    , ""
+    , "actor main(env: Env):"
+    , "    print(a.aaa)"
+    , "    env.exit(0)"
+    ]
+  _ <- buildOutIn proj
+  rewriteTyVersion tyA (map (+ 1) A.version)
+  out <- buildOutIn proj
+  assertBool "expected a.act to type check after .ty version mismatch" (typechecked out modA)
+  assertBool "did not expect raw .ty version mismatch" $
+    not (".ty version mismatch" `T.isInfixOf` out)
 
 p27_overlay_source_provider :: TestTree
 p27_overlay_source_provider = testCase "27-overlay snapshots drive readModuleTask" $ do
@@ -2109,6 +2138,7 @@ main = defaultMain $ localOption (NumThreads 1) $ testGroup "incremental"
       , p24_codegen_equal_hash
       , p25_whitespace_change
       , p26_corrupt_ty_header
+      , p26_ty_version_mismatch
       , p27_overlay_source_provider
       , p28_protocol_extension_deps
       , p29_protocol_impl_rebuild

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -1065,23 +1065,27 @@ doImp spath env m            = do
           let seen' = S.insert m seen in
           case lookupMod m env of
             Just te -> do
-              tyFile <- findTyFile spath m
-              case tyFile of
+              hdr <- readFoundTy InterfaceFiles.readHeaderMaybe m
+              case hdr of
                 Nothing -> return (env, te, seen')
-                Just tyF -> do
-                  (_sourceMeta, _, _, _, imps, _, _, _, _) <- InterfaceFiles.readHeader tyF
+                Just (_sourceMeta, _, _, _, imps, _, _, _, _) -> do
                   (env', seen'') <- subImpSeen seen' env (map fst imps)
                   return (env', te, seen'')
             Nothing -> do
-              tyFile <- findTyFile spath m
-              case tyFile of
+              ty <- readFoundTy InterfaceFiles.readFileMaybe m
+              case ty of
                 Nothing -> fileNotFound m
-                Just tyF -> do
-                  (ms,nmod,_,_,_,_,_,_,_,_,_,_) <- InterfaceFiles.readFile tyF
+                Just (ms,nmod,_,_,_,_,_,_,_,_,_,_) -> do
                   (env', seen'') <- subImpSeen seen' env ms
                   let NModule teFull mdoc = nmod
                       te = publicTEnv teFull
                   return (addMod m te mdoc env', te, seen'')
+
+    readFoundTy readTy m = do
+      tyFile <- findTyFile spath m
+      case tyFile of
+        Nothing -> return Nothing
+        Just tyF -> readTy tyF
 
     subImpSeen seen env []   = return (env, seen)
     subImpSeen seen env (m:ms) = do

--- a/compiler/lib/src/InterfaceFiles.hs
+++ b/compiler/lib/src/InterfaceFiles.hs
@@ -44,7 +44,9 @@
 
 module InterfaceFiles where
 
+import Prelude hiding (readFile, writeFile)
 import Data.Binary
+import qualified Control.Exception as E
 import qualified Data.Binary.Get as BinaryGet
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
@@ -52,7 +54,7 @@ import qualified Acton.Syntax as A
 import qualified Acton.NameInfo as I
 import GHC.Generics (Generic)
 import System.Directory (renameFile)
-import System.IO
+import System.IO (IOMode(ReadMode), hClose, hFileSize, openBinaryFile)
 import System.Posix.Process (getProcessID)
 
 data NameHashInfo = NameHashInfo
@@ -75,6 +77,33 @@ data SourceFileMeta = SourceFileMeta
   } deriving (Show, Eq, Generic)
 
 instance Binary SourceFileMeta
+
+type TyFile =
+  ( [A.ModName]
+  , I.NameInfo
+  , A.Module
+  , Maybe SourceFileMeta
+  , BS.ByteString
+  , BS.ByteString
+  , BS.ByteString
+  , [(A.ModName, BS.ByteString)]
+  , [NameHashInfo]
+  , [A.Name]
+  , [String]
+  , Maybe String
+  )
+
+type TyHeader =
+  ( Maybe SourceFileMeta
+  , BS.ByteString
+  , BS.ByteString
+  , BS.ByteString
+  , [(A.ModName, BS.ByteString)]
+  , [NameHashInfo]
+  , [A.Name]
+  , [String]
+  , Maybe String
+  )
 
 -- Note: tests are stored in the header to support listing without compiling
 --       or executing test binaries.
@@ -120,7 +149,7 @@ writeFile f moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta imps name
     BL.writeFile tmpFile (encode ((A.version, sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash), imps, nameHashes, roots, tests, mdoc, nmod, tchecked))
     renameFile tmpFile f
 
-readFile :: FilePath -> IO ([A.ModName], I.NameInfo, A.Module, Maybe SourceFileMeta, BS.ByteString, BS.ByteString, BS.ByteString, [(A.ModName, BS.ByteString)], [NameHashInfo], [A.Name], [String], Maybe String)
+readFile :: FilePath -> IO TyFile
 readFile f = do
     bsLazy <- readTyBytes f
     body0 <- readTyVersion bsLazy
@@ -143,7 +172,7 @@ readFile f = do
 -- imports, name hashes, roots, tests, and docstring.
 -- This avoids decoding the large NameInfo and typed Module sections and is
 -- much faster than readFile for freshness checks and dependency discovery.
-readHeader :: FilePath -> IO (Maybe SourceFileMeta, BS.ByteString, BS.ByteString, BS.ByteString, [(A.ModName, BS.ByteString)], [NameHashInfo], [A.Name], [String], Maybe String)
+readHeader :: FilePath -> IO TyHeader
 readHeader f = do
     bsLazy <- readTyBytes f
     body0 <- readTyVersion bsLazy
@@ -159,3 +188,18 @@ readHeader f = do
       Left _ -> ioError (userError "Failed to decode .ty header")
       Right (_, _, (imps, nameHashes, roots, tests, doc)) ->
         return (sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash, imps, nameHashes, roots, tests, doc)
+
+-- Interface files are caches for most callers. If a file is missing,
+-- unreadable, corrupt, or from a different compiler interface version, the
+-- cache entry is not usable.
+readFileMaybe :: FilePath -> IO (Maybe TyFile)
+readFileMaybe = readTyMaybe readFile
+
+readHeaderMaybe :: FilePath -> IO (Maybe TyHeader)
+readHeaderMaybe = readTyMaybe readHeader
+
+readTyMaybe :: (FilePath -> IO a) -> FilePath -> IO (Maybe a)
+readTyMaybe readTy f = (Just <$> readTy f) `E.catch` tyCacheMiss
+
+tyCacheMiss :: E.IOException -> IO (Maybe a)
+tyCacheMiss _ = return Nothing

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -48,6 +48,7 @@ import qualified Control.Exception as E
 import Control.DeepSeq (rnf)
 import Utils (SrcLoc(..), loc, prstr)
 import qualified Acton.BuildSpec as BuildSpec
+import qualified Data.Binary as Binary
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.Aeson as Ae
@@ -62,6 +63,39 @@ main = do
   env0 <- Acton.Env.initEnv sysTypesPath False
 
   sydTest $ do
+    describe "Environment" $ do
+      it "treats mismatched .ty headers for loaded modules as stale" $ do
+        withSystemTempDirectory "acton-env" $ \dir -> do
+          let directMod = S.modName ["direct"]
+              directTy = dir </> "direct.ty"
+              valueName = S.name "value"
+              iface = [(valueName, I.NVar S.tWild)]
+              directIface = I.NModule iface Nothing
+              directModule = S.Module directMod [] Nothing []
+              env1 = Acton.Env.addMod directMod iface Nothing env0
+          InterfaceFiles.writeFile
+            directTy
+            B8.empty
+            B8.empty
+            B8.empty
+            Nothing
+            []
+            []
+            []
+            []
+            Nothing
+            directIface
+            directModule
+          (_mods, nmod, tmod, sourceMeta, srcHash, pubHash, implHash, imps, nameHashes, roots, tests, mdoc) <-
+            InterfaceFiles.readFile directTy
+          BL.writeFile directTy $
+            Binary.encode
+              ( (map (+ 1) S.version, sourceMeta, srcHash, pubHash, implHash)
+              , imps, nameHashes, roots, tests, mdoc, nmod, tmod
+              )
+          (_env2, te) <- Acton.Env.doImp [dir] env1 directMod
+          map fst te `shouldBe` [valueName]
+
     describe "Pass 1: Parser" $ do
 
       describe "Basic Syntax" $ do


### PR DESCRIPTION
Interface files are cache entries, but import environment loading still read cached headers and full interfaces as mandatory data. A version mismatch from that path escaped as a raw user error, making an otherwise recoverable stale .ty file fatal during compilation.

This change gives InterfaceFiles explicit Maybe-returning readers for cache use. Missing, unreadable, corrupt, or version-mismatched .ty files become cache misses for callers that choose those readers, while the existing readFile and readHeader APIs keep their fatal behavior for places that require a valid interface.

Environment import loading now uses those cache readers and keeps the policy local to doImp: already-loaded modules can keep their in-memory interface when their recorded import closure cannot be read, while unloaded modules still fall back to the normal missing-interface diagnostic. That keeps stale .ty data from becoming authoritative without hiding real imports that cannot be satisfied.