### PR TITLE
Map release aliases to fast mode

### DIFF
--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -430,12 +430,12 @@ parseFlagTests =
   , flagGolden "all flags combined" "test/parse/simple.all.golden"
         ["--quiet", "--parse", "--kinds", "--types", "--sigs", "--norm", "--deact", "--cps", "--llift", "--box", "--dbg-no-lines", "--hgen"]
   , testCase "optimize parser accepts release aliases" $ do
-      assertParsedBuildOptimize ["build", "--release"] C.ReleaseSafe
+      assertParsedBuildOptimize ["build", "--release"] C.ReleaseFast
       assertParsedBuildOptimize ["build", "--release=safe"] C.ReleaseSafe
       assertParsedBuildOptimize ["build", "--release=SmAlL"] C.ReleaseSmall
       assertParsedBuildOptimize ["build", "--release=FAST"] C.ReleaseFast
-      assertParsedBuildOptimize ["build", "--optimize=release"] C.ReleaseSafe
-      assertParsedBuildOptimize ["build", "--optimize=ReLeAsE"] C.ReleaseSafe
+      assertParsedBuildOptimize ["build", "--optimize=release"] C.ReleaseFast
+      assertParsedBuildOptimize ["build", "--optimize=ReLeAsE"] C.ReleaseFast
       assertParsedBuildOptimize ["build", "--optimize=dEbUg"] C.Debug
       assertParsedBuildOptimize ["build", "--optimize=reLeAsEsMaLl"] C.ReleaseSmall
       assertParsedBuildOptimize ["build", "--optimize=RELEASEFAST"] C.ReleaseFast
@@ -446,8 +446,8 @@ parseFlagTests =
   , testCase "build parser help includes --release alias" $ do
       helpText <- renderParserHelp ["build", "--help"]
       assertBool "help text should include --release" ("--release" `isInfixOf` helpText)
-      assertBool "help text should mention release variants" ("=small or =fast" `isInfixOf` helpText)
-      assertBool "help text should mention default release mode" ("same as --release=safe" `isInfixOf` helpText)
+      assertBool "help text should mention release variants" ("=safe or =small" `isInfixOf` helpText)
+      assertBool "help text should mention default release mode" ("same as --release=fast" `isInfixOf` helpText)
   , testCase "sig parser accepts target and project options" $ do
       parsed <- parseArgs ["sig", "--always-build", "--dep", "dep=../dep", "--searchpath", "out/types", "foo.bar"]
       case parsed of

--- a/compiler/lib/src/Acton/CommandLineParser.hs
+++ b/compiler/lib/src/Acton/CommandLineParser.hs
@@ -250,7 +250,7 @@ optimizeReader :: ReadM OptimizeMode
 optimizeReader = eitherReader $ \s ->
     case map toLower s of
         "debug"        -> Right Debug
-        "release"      -> Right ReleaseSafe
+        "release"      -> Right ReleaseFast
         "releasesafe"  -> Right ReleaseSafe
         "releasesmall" -> Right ReleaseSmall
         "releasefast"  -> Right ReleaseFast
@@ -462,13 +462,13 @@ optimizeOption = resolveOptimizeOption
         (option optimizeReader
             (long "optimize"
              <> metavar "MODE"
-             <> help "Optimization mode (case-insensitive: Debug, Release/ReleaseSafe, ReleaseSmall, ReleaseFast)"
+             <> help "Optimization mode (case-insensitive: Debug, Release/ReleaseFast, ReleaseSafe, ReleaseSmall)"
             ))
   where
     releaseOption =
-        flag' ReleaseSafe
+        flag' ReleaseFast
             (long "release"
-             <> help "Release build mode; same as --release=safe and also accepts =small or =fast"
+             <> help "Release build mode; same as --release=fast and also accepts =safe or =small"
             )
         <|> option releaseModeReader
             (long "release"

--- a/docs/acton-guide/src/compilation.md
+++ b/docs/acton-guide/src/compilation.md
@@ -14,10 +14,9 @@ debug symbols, which makes them the right default during development.
 For release builds, use `acton build --release` to better optimize the
 final executable. For standalone files, use `acton --release foo.act`.
 
-`--release` and `--release=safe` select the normal release mode.
-`--release=small` optimizes for a smaller binary size. `--release=fast`
-can result in a faster program, but it is generally discouraged because
-it disables safety checks and alters language semantics.
+`--release` and `--release=fast` select the fastest release mode.
+`--release=safe` enables release optimizations with safety checks.
+`--release=small` optimizes for a smaller binary size.
 
 ## Optimized for native CPU features
 


### PR DESCRIPTION
The release shortcut currently selected ReleaseSafe, which makes the recommended release path hit a known crashing profile on Linux. Users could ask for --release=fast explicitly, but bare --release and --optimize=release still steered them toward the problematic mode.

Make the unqualified release aliases select ReleaseFast instead. Keep the explicit safe, small, and fast variants unchanged so callers that need a specific Zig optimization mode can still request it directly. The CLI help and guide now describe fast as the shortcut target, which keeps the documented behavior aligned with the parser.