### PR TITLE
Document container image usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,19 @@ sudo apt-get install -qy acton
 brew install actonlang/acton/acton
 ```
 
+### Container image
+
+Use the container image to try Acton without installing it locally, or to run
+Acton builds in CI:
+
+```sh
+docker run --rm ghcr.io/actonlang/acton:latest version
+docker run --rm -v "$PWD":/work -w /work ghcr.io/actonlang/acton:latest build
+```
+
+For day-to-day development, the native APT and Homebrew packages are usually
+more convenient. For CI, pin a version tag instead of using `latest`.
+
 ## Writing and compiling your first Acton program
 
 Edit the program source file, let's call it `helloworld.act`, and enter the

--- a/docs/acton-guide/src/install.md
+++ b/docs/acton-guide/src/install.md
@@ -18,3 +18,24 @@ brew install actonlang/acton/acton
 ```
 {{#endtab }}
 {{#endtabs }}
+
+## Container image
+
+Acton also publishes a container image for trying Acton without installing it
+locally, running builds in CI, or pinning a reproducible toolchain for examples
+and tutorials. For day-to-day development, the native APT and Homebrew packages
+are usually more convenient.
+
+Check the installed Acton version in the image:
+
+```console
+docker run --rm ghcr.io/actonlang/acton:latest version
+```
+
+Build the Acton project in the current directory:
+
+```console
+docker run --rm -v "$PWD":/work -w /work ghcr.io/actonlang/acton:latest build
+```
+
+For CI and long-lived examples, pin a version tag instead of using `latest`.


### PR DESCRIPTION
Explain when to use the Acton container image and add copy-pastable Docker commands for checking the compiler version and building the current project.

Position the image as useful for CI, tutorials, and reproducible builds while keeping native packages as the normal local development path.