### PR TITLE
[codex] Link Linux acton with Zig glibc target

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -216,7 +216,7 @@ jobs:
         run: |
           export DEBIAN_FRONTEND=noninteractive
           apt-get update
-          apt-get install -qy bzip2 curl g++ haskell-stack libtinfo-dev make procps zlib1g-dev
+          apt-get install -qy bzip2 curl g++ haskell-stack libncurses-dev make procps zlib1g-dev
           apt-get install -qy gdb
       - name: "locale en_US.UTF-8"
         run: |
@@ -226,14 +226,28 @@ jobs:
           echo "locales locales/locales_to_be_generated multiselect en_US.UTF-8 UTF-8" | debconf-set-selections
           rm "/etc/locale.gen"
           dpkg-reconfigure --frontend noninteractive locales
-      - name: "Upgrade stack on old distributions"
-        if: ${{ matrix.os == 'ubuntu' && matrix.version == '22.04' }}
+      - name: "Install newer stack"
         run: |
-          stack upgrade
-          echo "PATH=~/.local/bin:$PATH" >> $GITHUB_ENV
+          STACK_VERSION=3.9.3
+          ARCH="$(uname -m)"
+          case "${ARCH}" in
+            x86_64) STACK_ARCH="x86_64" ;;
+            aarch64|arm64) STACK_ARCH="aarch64" ;;
+            *) echo "Unsupported arch: ${ARCH}" >&2; exit 1 ;;
+          esac
+          STACK_TAR="stack-${STACK_VERSION}-linux-${STACK_ARCH}.tar.gz"
+          STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK_VERSION}/${STACK_TAR}"
+          mkdir -p "${HOME}/.local/bin"
+          curl -fsSL "${STACK_URL}" -o /tmp/stack.tgz
+          tar -xzf /tmp/stack.tgz -C /tmp
+          install -m 0755 "/tmp/stack-${STACK_VERSION}-linux-${STACK_ARCH}/stack" "${HOME}/.local/bin/stack"
+          echo "${HOME}/.local/bin" >> "$GITHUB_PATH"
+          "${HOME}/.local/bin/stack" --version
       - name: "Build Acton"
         run: |
           make -j2 -C ${GITHUB_WORKSPACE} BUILD_RELEASE=${{ env.BUILD_RELEASE }} BUILD_TIME=${BUILD_TIME}
+      - name: "Show Acton linkage"
+        run: make -C ${GITHUB_WORKSPACE} ldd
       - name: "Build a release"
         run: make -C ${GITHUB_WORKSPACE} release BUILD_TIME=${BUILD_TIME}
       - name: "Upload artifact"
@@ -285,7 +299,7 @@ jobs:
       - name: "Install build prerequisites"
         run: |
           apt-get update
-          apt-get install -qy bzip2 curl g++ haskell-stack libtinfo-dev make procps zlib1g-dev
+          apt-get install -qy bzip2 curl g++ haskell-stack libncurses-dev make procps zlib1g-dev
           apt-get install -qy bash-completion build-essential debhelper devscripts
       - name: "Prepare stack directories"
         run: |
@@ -328,6 +342,16 @@ jobs:
         run: |
           set -euo pipefail
           make -C "${GITHUB_WORKSPACE}" debs BUILD_RELEASE=${{ env.BUILD_RELEASE }} BUILD_TIME=${BUILD_TIME}
+      - name: "Show packaged Acton linkage"
+        shell: bash
+        run: |
+          set -euo pipefail
+          make -C "${GITHUB_WORKSPACE}" ldd
+          deb="$(ls "${GITHUB_WORKSPACE}"/../acton_*.deb | head -n1)"
+          dpkg-deb -I "$deb"
+          tmp="$(mktemp -d)"
+          dpkg-deb -x "$deb" "$tmp"
+          make -C "${GITHUB_WORKSPACE}" ldd ACTON_LINKAGE_BINS="$tmp/usr/lib/acton/bin/acton $tmp/usr/lib/acton/bin/lsp-server-acton"
       - name: "Compute variables"
         id: vars
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ builder/zig-cache
 compiler/package.yaml
 compiler/acton/acton.cabal
 compiler/acton/package.yaml
+compiler/lib/libacton.cabal
 compiler/lib/package.yaml
 compiler/lsp-server/package.yaml
 compiler/lsp-server/lsp-server-acton.cabal

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ CC=$(ZIG) cc
 CXX=$(ZIG) c++
 export CC
 export CXX
+ACTON_STACK_CC=$(TD)/compiler/tools/zig-cc.sh
+ACTON_STACK_CXX=$(TD)/compiler/tools/zig-cxx.sh
+ACTON_STACK_NEEDS_ZIG=
+STACK=unset CC && unset CXX && unset CFLAGS && unset ACTON_REAL_LD && stack
 
 # Determine which xargs we have. BSD xargs does not have --no-run-if-empty,
 # rather, it is the default behavior so the argument is superfluous. We check if
@@ -72,6 +76,10 @@ endif
 # -- Linux ---------------------------------------------------------------------
 ifeq ($(shell uname -s),Linux)
 OS:=linux
+ACTON_ZIG_GLIBC_VERSION ?= 2.27
+export ACTON_ZIG_GLIBC_VERSION
+ACTON_STACK_NEEDS_ZIG=1
+STACK=CC="$(ACTON_STACK_CC)" CXX="$(ACTON_STACK_CXX)" CFLAGS= ACTON_REAL_LD="$(ACTON_STACK_CC)" stack --with-gcc="$(ACTON_STACK_CC)"
 ifeq ($(shell uname -m),x86_64)
 ACTONC_TARGET := --target x86_64-linux-gnu.2.27
 else ifeq ($(shell uname -m),aarch64)
@@ -113,6 +121,11 @@ BUILTIN_HFILES=$(wildcard base/builtin/*.h)
 
 DIST_BINS=$(ACTONC) dist/bin/actondb dist/bin/runacton dist/bin/lsp-server-acton
 DIST_ZIG=dist/zig
+ifeq ($(ACTON_STACK_NEEDS_ZIG),1)
+ACTON_STACK_PREREQS=$(DIST_ZIG)
+else
+ACTON_STACK_PREREQS=
+endif
 
 .PHONY: test-backend
 test-backend: $(BACKEND_TESTS)
@@ -126,17 +139,16 @@ test-backend: $(BACKEND_TESTS)
 # /compiler ----------------------------------------------
 ACTONC_HS=$(wildcard compiler/lib/src/*.hs compiler/lib/src/*/*.hs compiler/acton/*.hs compiler/acton/*/*.hs)
 ACTONLSP_HS=$(wildcard compiler/lsp-server/*.hs)
-# NOTE: we're unsetting CC & CXX to avoid using zig cc & zig c++ for stack /
-# ghc, which doesn't seem to work properly
-dist/bin/acton: compiler/lib/package.yaml.in compiler/acton/package.yaml.in compiler/lsp-server/package.yaml.in compiler/stack.yaml $(ACTONC_HS) $(ACTONLSP_HS) version.mk dist/builder
+dist/bin/acton: compiler/lib/package.yaml.in compiler/acton/package.yaml.in compiler/lsp-server/package.yaml.in compiler/stack.yaml $(ACTONC_HS) $(ACTONLSP_HS) version.mk dist/builder $(ACTON_STACK_PREREQS)
 	mkdir -p dist/bin
 	rm -f dist/bin/actonc
 	cd compiler && sed 's,^version: BUILD_VERSION,version: "$(VERSION)",' < lib/package.yaml.in > lib/package.yaml
-	cd compiler && unset CC && unset CXX && unset CFLAGS && stack build acton lsp-server-acton $(ACTON_STACK_BUILD_OPTS) --ghc-options='-j4 $(ACTC_GHC_OPTS)' --dry-run 2>&1 | grep "Nothing to build" || \
-		(sed 's,^version: BUILD_VERSION,version: "$(VERSION_INFO)",' < acton/package.yaml.in > acton/package.yaml \
-		&& sed 's,^version: BUILD_VERSION,version: "$(VERSION_INFO)",' < lsp-server/package.yaml.in > lsp-server/package.yaml \
-		&& stack build acton lsp-server-acton $(ACTON_STACK_BUILD_OPTS) --ghc-options='-j4 $(ACTC_GHC_OPTS)')
-	cd compiler && unset CC && unset CXX && unset CFLAGS && stack --local-bin-path=../dist/bin install acton lsp-server-acton $(ACTON_STACK_BUILD_OPTS) --ghc-options='-j4 $(ACTC_GHC_OPTS)'
+	cd compiler && sed 's,^version: BUILD_VERSION,version: "$(VERSION_INFO)",' < acton/package.yaml.in > acton/package.yaml
+	cd compiler && sed 's,^version: BUILD_VERSION,version: "$(VERSION_INFO)",' < lsp-server/package.yaml.in > lsp-server/package.yaml
+	cd compiler && unset CC && unset CXX && unset CFLAGS && unset ACTON_REAL_LD && stack setup
+	cd compiler && $(STACK) build acton lsp-server-acton $(ACTON_STACK_BUILD_OPTS) --ghc-options='-j4 $(ACTC_GHC_OPTS)' --dry-run 2>&1 | grep "Nothing to build" || \
+		$(STACK) build acton lsp-server-acton $(ACTON_STACK_BUILD_OPTS) --ghc-options='-j4 $(ACTC_GHC_OPTS)'
+	cd compiler && $(STACK) --local-bin-path=../dist/bin install acton lsp-server-acton $(ACTON_STACK_BUILD_OPTS) --ghc-options='-j4 $(ACTC_GHC_OPTS)'
 	# Keep actonc as a symlink for compatibility
 	ln -sf acton dist/bin/actonc
 
@@ -153,6 +165,35 @@ clean-compiler:
 	rm -f dist/bin/acton dist/bin/actonc compiler/package.yaml compiler/acton.cabal \
 		compiler/acton/package.yaml compiler/acton/acton.cabal \
 		compiler/lib/*.cabal compiler/acton/*.cabal compiler/lsp-server/*.cabal
+
+ACTON_LINKAGE_BINS ?= dist/bin/acton dist/bin/lsp-server-acton
+ACTON_ALLOWED_NEEDED_RE ?= ^(libc\.so\.6|libm\.so\.6|libdl\.so\.2|libpthread\.so\.0|librt\.so\.1|libutil\.so\.1)$$
+.PHONY: ldd
+ldd: $(ACTON_LINKAGE_BINS)
+ifeq ($(OS),linux)
+	@for bin in $(ACTON_LINKAGE_BINS); do \
+		echo "== $$bin =="; \
+		ldd "$$bin"; \
+		if command -v readelf >/dev/null 2>&1; then \
+			unexpected_needed=$$(readelf -d "$$bin" | sed -n 's/.*Shared library: \[\(.*\)\].*/\1/p' | grep -Ev '$(ACTON_ALLOWED_NEEDED_RE)' || true); \
+			if [ -n "$$unexpected_needed" ]; then \
+				echo "unexpected dynamic libraries:" >&2; \
+				echo "$$unexpected_needed" >&2; \
+				exit 1; \
+			fi; \
+			max_glibc=$$(readelf --version-info "$$bin" | grep -o 'GLIBC_[0-9][.0-9]*' | sed 's/GLIBC_//' | sort -Vu | tail -n 1); \
+			if [ -n "$$max_glibc" ]; then \
+				echo "max GLIBC version required: $$max_glibc"; \
+				if [ "$$(printf '%s\n%s\n' "$$max_glibc" "$(ACTON_ZIG_GLIBC_VERSION)" | sort -V | tail -n 1)" != "$(ACTON_ZIG_GLIBC_VERSION)" ]; then \
+					echo "ERROR: $$bin requires GLIBC $$max_glibc, newer than target $(ACTON_ZIG_GLIBC_VERSION)" >&2; \
+					exit 1; \
+				fi; \
+			fi; \
+		fi; \
+	done
+else
+	@echo "ldd target is only meaningful on Linux"
+endif
 
 # /deps --------------------------------------------------
 DEPS += dist/deps/mbedtls
@@ -517,7 +558,7 @@ debian/changelog: debian/changelog.in CHANGELOG.md
 
 .PHONY: debs
 debs: debian/changelog
-	debuild --preserve-envvar VERSION_INFO --preserve-envvar PATH --preserve-envvar STACK_ROOT --preserve-envvar ZIG_DOWNLOAD_BASE_URL -i -us -uc -nc -b
+	debuild --preserve-envvar VERSION_INFO --preserve-envvar PATH --preserve-envvar STACK_ROOT --preserve-envvar ZIG_DOWNLOAD_BASE_URL --preserve-envvar ACTON_ZIG_GLIBC_VERSION -i -us -uc -nc -b
 
 .PHONY: container-image image image-deb push-image
 container-image: all

--- a/compiler/acton/package.yaml.in
+++ b/compiler/acton/package.yaml.in
@@ -78,14 +78,11 @@ executables:
       - -with-rtsopts=-N
       - -with-rtsopts=-A64M
     when:
-    - condition: os(linux) && arch(aarch64)
+    - condition: os(linux)
       ghc-options:
         - -no-pie
         - -optl-no-pie
         - -pgml=../tools/ld-wrapper.sh
-    - condition: os(linux) && !arch(aarch64)
-      ld-options:
-        - -static
 
 tests:
   test_acton:

--- a/compiler/lsp-server/package.yaml.in
+++ b/compiler/lsp-server/package.yaml.in
@@ -43,11 +43,8 @@ executables:
       - -with-rtsopts=-N
       - -with-rtsopts=-A64M
     when:
-      - condition: os(linux) && arch(aarch64)
+      - condition: os(linux)
         ghc-options:
           - -no-pie
           - -optl-no-pie
           - -pgml=../tools/ld-wrapper.sh
-      - condition: os(linux) && !arch(aarch64)
-        ld-options:
-          - -static

--- a/compiler/stack.yaml
+++ b/compiler/stack.yaml
@@ -47,7 +47,9 @@ extra-deps:
   - unix-2.8.2.1
 
 # Override default flag values for local packages and extra-deps
-# flags: {}
+flags:
+  text:
+    simdutf: false
 
 # Extra package databases containing global packages
 # extra-package-dbs: []

--- a/compiler/tools/ld-wrapper.sh
+++ b/compiler/tools/ld-wrapper.sh
@@ -6,17 +6,35 @@ state="static"
 arch="$(uname -m 2>/dev/null || true)"
 allow_dynamic_glibc=false
 case "$arch" in
-  aarch64|arm64)
+  aarch64|arm64|x86_64|amd64)
     allow_dynamic_glibc=true
     ;;
 esac
 
 args=()
 args+=("-Wl,-Bstatic")
-gcc_lib="$(gcc -print-file-name=libgcc_s.so 2>/dev/null || true)"
-if [[ -n "$gcc_lib" && "$gcc_lib" != "libgcc_s.so" ]]; then
-  args+=("-L$(dirname "$gcc_lib")")
-fi
+
+gcc_lib_path() {
+  local lib="$1"
+  local lib_path
+  lib_path="$(gcc -print-file-name="$lib" 2>/dev/null || true)"
+  if [[ -n "$lib_path" && "$lib_path" != "$lib" ]]; then
+    echo "$lib_path"
+    return 0
+  fi
+  return 1
+}
+
+add_static_gcc_lib() {
+  local archive="$1"
+  local fallback="$2"
+  local archive_path
+  if archive_path="$(gcc_lib_path "$archive")"; then
+    args+=("$archive_path")
+  else
+    args+=("-l:$fallback")
+  fi
+}
 
 normalize_lib() {
   local lib="$1"
@@ -43,7 +61,7 @@ handle_lib() {
       args+=("-Wl,-Bstatic")
       state="static"
     fi
-    args+=("-l:libz.a")
+    add_static_gcc_lib libz.a libz.a
     return
   fi
   if [[ "$lib_key" == "gmp" ]]; then
@@ -51,7 +69,7 @@ handle_lib() {
       args+=("-Wl,-Bstatic")
       state="static"
     fi
-    args+=("-l:libgmp.a")
+    add_static_gcc_lib libgmp.a libgmp.a
     return
   fi
   if [[ "$lib_key" == "stdc++" ]]; then
@@ -59,12 +77,20 @@ handle_lib() {
       args+=("-Wl,-Bstatic")
       state="static"
     fi
-    args+=("-l:libstdc++.a")
+    add_static_gcc_lib libstdc++.a libstdc++.a
+    return
+  fi
+  if [[ "$lib_key" == "tinfo" ]]; then
+    if [[ "$state" != "static" ]]; then
+      args+=("-Wl,-Bstatic")
+      state="static"
+    fi
+    add_static_gcc_lib libtinfo.a libtinfo.a
     return
   fi
   if [[ "$allow_dynamic_glibc" == true ]]; then
     case "$lib_key" in
-      c|m|dl|pthread|rt|util|gcc_s)
+      c|m|dl|pthread|rt|util)
         if [[ "$state" != "dynamic" ]]; then
           args+=("-Wl,-Bdynamic")
           state="dynamic"
@@ -73,6 +99,14 @@ handle_lib() {
         return
         ;;
     esac
+  fi
+  if [[ "$lib_key" == "gcc_s" ]]; then
+    if [[ "$state" != "static" ]]; then
+      args+=("-Wl,-Bstatic")
+      state="static"
+    fi
+    add_static_gcc_lib libgcc_eh.a libgcc_eh.a
+    return
   fi
   if [[ "$state" != "static" ]]; then
     args+=("-Wl,-Bstatic")

--- a/compiler/tools/zig-cc.sh
+++ b/compiler/tools/zig-cc.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+ZIG="${ROOT}/dist/zig/zig"
+
+gcc_lib_path() {
+  local lib="$1"
+  local lib_path
+  lib_path="$(gcc -print-file-name="$lib" 2>/dev/null || true)"
+  if [[ -n "$lib_path" && "$lib_path" != "$lib" ]]; then
+    echo "$lib_path"
+    return 0
+  fi
+  return 1
+}
+
+add_system_include_dirs() {
+  local multiarch
+  args+=("-idirafter" "/usr/include")
+  multiarch="$(gcc -print-multiarch 2>/dev/null || true)"
+  if [[ -n "$multiarch" && -d "/usr/include/$multiarch" ]]; then
+    args+=("-idirafter" "/usr/include/$multiarch")
+  fi
+}
+
+rewrite_lib_arg() {
+  local arg="$1"
+  local lib_path
+  case "$arg" in
+    -lgmp|-l:libgmp.a)
+      if lib_path="$(gcc_lib_path libgmp.a)"; then
+        echo "$lib_path"
+      else
+        echo "$arg"
+      fi
+      ;;
+    -lz|-l:libz.a)
+      if lib_path="$(gcc_lib_path libz.a)"; then
+        echo "$lib_path"
+      else
+        echo "$arg"
+      fi
+      ;;
+    -lstdc++|-l:libstdc++.a)
+      if lib_path="$(gcc_lib_path libstdc++.a)"; then
+        echo "$lib_path"
+      else
+        echo "$arg"
+      fi
+      ;;
+    -ltinfo|-l:libtinfo.a)
+      if lib_path="$(gcc_lib_path libtinfo.a)"; then
+        echo "$lib_path"
+      else
+        echo "$arg"
+      fi
+      ;;
+    *)
+      echo "$arg"
+      ;;
+  esac
+}
+
+process_arg() {
+  local arg="$1"
+  case "$arg" in
+    @*)
+      local rsp="${arg#@}"
+      if [[ -f "$rsp" ]]; then
+        local line
+        while IFS= read -r line || [[ -n "$line" ]]; do
+          [[ -z "$line" ]] && continue
+          if [[ "$line" == \"*\" && "$line" == *\" ]]; then
+            line="${line:1:${#line}-2}"
+            line="${line//\\\\/\\}"
+            line="${line//\\\"/\"}"
+          fi
+          process_arg "$line"
+        done < "$rsp"
+      else
+        args+=("$(rewrite_lib_arg "$arg")")
+      fi
+      ;;
+    *)
+      args+=("$(rewrite_lib_arg "$arg")")
+      ;;
+  esac
+}
+
+case "$(uname -s)" in
+  Linux)
+    ARCH="$(uname -m)"
+    case "${ARCH}" in
+      x86_64) ZIG_ARCH=x86_64 ;;
+      aarch64|arm64) ZIG_ARCH=aarch64 ;;
+      *) echo "Unsupported architecture for Linux: ${ARCH}" >&2; exit 1 ;;
+    esac
+    GLIBC_VERSION="${ACTON_ZIG_GLIBC_VERSION:-2.27}"
+    args=()
+    add_system_include_dirs
+    for arg in "$@"; do
+      process_arg "$arg"
+    done
+    exec "${ZIG}" cc -target "${ZIG_ARCH}-linux-gnu.${GLIBC_VERSION}" "${args[@]}"
+    ;;
+  *)
+    exec "${ZIG}" cc "$@"
+    ;;
+esac

--- a/compiler/tools/zig-cxx.sh
+++ b/compiler/tools/zig-cxx.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+ZIG="${ROOT}/dist/zig/zig"
+
+gcc_lib_path() {
+  local lib="$1"
+  local lib_path
+  lib_path="$(gcc -print-file-name="$lib" 2>/dev/null || true)"
+  if [[ -n "$lib_path" && "$lib_path" != "$lib" ]]; then
+    echo "$lib_path"
+    return 0
+  fi
+  return 1
+}
+
+add_system_include_dirs() {
+  local multiarch
+  args+=("-idirafter" "/usr/include")
+  multiarch="$(gcc -print-multiarch 2>/dev/null || true)"
+  if [[ -n "$multiarch" && -d "/usr/include/$multiarch" ]]; then
+    args+=("-idirafter" "/usr/include/$multiarch")
+  fi
+}
+
+rewrite_lib_arg() {
+  local arg="$1"
+  local lib_path
+  case "$arg" in
+    -lgmp|-l:libgmp.a)
+      if lib_path="$(gcc_lib_path libgmp.a)"; then
+        echo "$lib_path"
+      else
+        echo "$arg"
+      fi
+      ;;
+    -lz|-l:libz.a)
+      if lib_path="$(gcc_lib_path libz.a)"; then
+        echo "$lib_path"
+      else
+        echo "$arg"
+      fi
+      ;;
+    -lstdc++|-l:libstdc++.a)
+      if lib_path="$(gcc_lib_path libstdc++.a)"; then
+        echo "$lib_path"
+      else
+        echo "$arg"
+      fi
+      ;;
+    -ltinfo|-l:libtinfo.a)
+      if lib_path="$(gcc_lib_path libtinfo.a)"; then
+        echo "$lib_path"
+      else
+        echo "$arg"
+      fi
+      ;;
+    *)
+      echo "$arg"
+      ;;
+  esac
+}
+
+process_arg() {
+  local arg="$1"
+  case "$arg" in
+    @*)
+      local rsp="${arg#@}"
+      if [[ -f "$rsp" ]]; then
+        local line
+        while IFS= read -r line || [[ -n "$line" ]]; do
+          [[ -z "$line" ]] && continue
+          if [[ "$line" == \"*\" && "$line" == *\" ]]; then
+            line="${line:1:${#line}-2}"
+            line="${line//\\\\/\\}"
+            line="${line//\\\"/\"}"
+          fi
+          process_arg "$line"
+        done < "$rsp"
+      else
+        args+=("$(rewrite_lib_arg "$arg")")
+      fi
+      ;;
+    *)
+      args+=("$(rewrite_lib_arg "$arg")")
+      ;;
+  esac
+}
+
+case "$(uname -s)" in
+  Linux)
+    ARCH="$(uname -m)"
+    case "${ARCH}" in
+      x86_64) ZIG_ARCH=x86_64 ;;
+      aarch64|arm64) ZIG_ARCH=aarch64 ;;
+      *) echo "Unsupported architecture for Linux: ${ARCH}" >&2; exit 1 ;;
+    esac
+    GLIBC_VERSION="${ACTON_ZIG_GLIBC_VERSION:-2.27}"
+    args=()
+    add_system_include_dirs
+    for arg in "$@"; do
+      process_arg "$arg"
+    done
+    exec "${ZIG}" c++ -target "${ZIG_ARCH}-linux-gnu.${GLIBC_VERSION}" "${args[@]}"
+    ;;
+  *)
+    exec "${ZIG}" c++ "$@"
+    ;;
+esac

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends:
  debhelper-compat (= 13),
  g++,
  haskell-stack,
- libtinfo-dev,
+ libncurses-dev,
  make,
  zlib1g-dev
 Standards-Version: 4.6.0
@@ -18,6 +18,7 @@ Package: acton
 Architecture: any
 Depends:
  libc6 (>= 2.27),
+ ${shlibs:Depends},
  ${misc:Depends}
 Description: Acton Programming Language
  An awesome programming language.

--- a/docs/acton-dev-guide/src/getting_started/build.md
+++ b/docs/acton-dev-guide/src/getting_started/build.md
@@ -32,4 +32,5 @@ dist/bin/actonc path/to/file.act   # compatibility alias
 
 - `ZIG_LOCAL_CACHE_DIR` controls Zig's cache location (defaults to `~/.cache/acton/zig-local-cache` when `HOME` is set).
 - `BUILD_RELEASE=1 make` stamps release versions; default builds get a timestamped version suffix.
-- On Linux, the Makefile pins the default target to glibc 2.27 for compatibility.
+- On Linux, the Makefile uses Zig for the Stack/GHC C compiler path and pins the default glibc target to 2.27 for compatibility.
+- `ACTON_ZIG_GLIBC_VERSION` overrides the glibc version used for Stack/GHC linking on Linux.


### PR DESCRIPTION
## Summary

Switch the Linux Stack/GHC compiler path to Zig so the release binaries target an explicit glibc version, defaulting to glibc 2.27.

Keep the final Linux binaries dynamically linked only against glibc-family libraries while resolving GMP, zlib, tinfo, stdc++, and gcc unwinder inputs statically. Add linkage checks for both source-tree binaries and binaries extracted from the Debian package.

## Validation

- `make -B dist/bin/acton` on macOS arm64
- `dist/bin/acton version`
- Linux arm64 Docker container: forced relink, `make ldd`, and `./dist/bin/acton version`
- Actual Linux `dist/bin/acton` and `dist/bin/lsp-server-acton` only need `libm`, `libpthread`, `libc`, `libdl`, and the loader, with max GLIBC `2.27`
- `git diff --check`
- `bash -n compiler/tools/ld-wrapper.sh compiler/tools/zig-cc.sh compiler/tools/zig-cxx.sh`

## Notes

This intentionally keeps glibc dynamic and the other native dependencies static. CI now fails if unexpected dynamic dependencies appear in the built or packaged Acton binaries.