### PR TITLE
Implement concurrent top-level type checking

### DIFF
--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -1260,7 +1260,7 @@ printDocs gopts opts = do
             env0 <- Acton.Env.initEnv (sysTypes paths) False
             env <- Acton.Env.mkEnv (searchPath paths) env0 parsed
             kchecked <- Acton.Kinds.check env parsed
-            (nmod, _, env', _, _) <- Acton.Types.reconstruct Nothing env kchecked
+            (nmod, _, env', _, _) <- Acton.Types.reconstruct Nothing Nothing env kchecked
             let I.NModule tenv mdoc = nmod
 
             -- 1. If format is explicitly set (via -t, --html, --markdown), use it
@@ -1607,6 +1607,8 @@ initCliCompileHooks progressUI progressState gopts sched gen plan = do
           "Type stmt " ++ show (tstCompleted st) ++ "/" ++ show (tstTotal st)
         typeStmtBindsLine st =
           "binds: " ++ intercalate ", " (tstNames st)
+        inferredSignatureLine sig =
+          "Non-total inferred signature: " ++ intercalate ", " (isigNames sig)
         backTimingLine bt =
           "Back timing: normalize " ++ fmtTimePrecise (btNormalize bt)
           ++ ", deactorize " ++ fmtTimePrecise (btDeactorize bt)
@@ -1774,6 +1776,11 @@ initCliCompileHooks progressUI progressState gopts sched gen plan = do
                     forM_ (ftTypeStmtTimings ft) $ \st -> do
                       logRendered (\cols -> detailTimedLine cols detailStmtIndentWide detailStmtIndentNarrow (typeStmtTimingLine st) (tstTime st))
                       logRendered (\cols -> detailLine cols detailBindsIndentWide detailBindsIndentNarrow (typeStmtBindsLine st))
+                when (C.timing gopts || C.verbose gopts) $
+                  forM_ (frInferredSigs fr) $ \sig -> do
+                    logRendered (\cols -> detailLine cols detailStmtIndentWide detailStmtIndentNarrow (inferredSignatureLine sig))
+                    forM_ (lines (isigSignature sig)) $ \line ->
+                      logRendered (\cols -> detailLine cols detailBindsIndentWide detailBindsIndentNarrow line)
               case frBackJob fr of
                 Nothing -> creditBack (gtKey t)
                 Just _ -> return ()

--- a/compiler/acton/package.yaml.in
+++ b/compiler/acton/package.yaml.in
@@ -75,8 +75,7 @@ executables:
     ghc-options:
       - -threaded
       - -rtsopts
-      - -with-rtsopts=-N
-      - -with-rtsopts=-A64M
+      - '"-with-rtsopts=-N -A64M"'
     when:
     - condition: os(linux) && arch(aarch64)
       ghc-options:

--- a/compiler/acton/test/rebuild/golden/file_02-initial-build.golden
+++ b/compiler/acton/test/rebuild/golden/file_02-initial-build.golden
@@ -3,9 +3,13 @@ Resolving dependencies (fetching if missing)...
    a  Parse done                                                            0.000 s
   Stale a: source changed
    a  Type check done                                                       0.000 s
+     Non-total inferred signature: aaa
+       aaa : int
    b  Parse done                                                            0.000 s
   Stale b: source changed
    b  Type check done                                                       0.000 s
+     Non-total inferred signature: baa
+       baa : () -> int
    c  Parse done                                                            0.000 s
   Stale c: source changed
    c  Type check done                                                       0.000 s

--- a/compiler/acton/test/rebuild/golden/file_06-change-a-impl.golden
+++ b/compiler/acton/test/rebuild/golden/file_06-change-a-impl.golden
@@ -4,6 +4,8 @@ Resolving dependencies (fetching if missing)...
   Stale a: source changed
   Hash deltas a: ~aaa{src HASH1 -> HASH2, impl HASH1 -> HASH2}
    a  Type check done                                                       0.000 s
+     Non-total inferred signature: aaa
+       aaa : int
   Stale b: impl changes in a.aaa HASH1 → HASH2 (used by baa)
   Stale c: impl changes in b.baa HASH1 → HASH2 (used by main)
    a  Compilation done                                                      0.000 s

--- a/compiler/acton/test/rebuild/golden/file_08-change-b-impl.golden
+++ b/compiler/acton/test/rebuild/golden/file_08-change-b-impl.golden
@@ -5,6 +5,12 @@ Resolving dependencies (fetching if missing)...
   Stale b: source changed
   Hash deltas b: +DocInfo, ~baa{src HASH1 -> HASH2, impl HASH1 -> HASH2}
    b  Type check done                                                       0.000 s
+     Non-total inferred signature: baa
+       baa : () -> int
+     Non-total inferred signature: DocInfo
+       class DocInfo (value):
+           G_init : () -> None
+           get : () -> int
   Stale c: impl changes in b.baa HASH1 → HASH2 (used by main)
    b  Compilation done                                                      0.000 s
    c  Compilation done                                                      0.000 s

--- a/compiler/acton/test/rebuild/golden/project_02-initial-build.golden
+++ b/compiler/acton/test/rebuild/golden/project_02-initial-build.golden
@@ -2,9 +2,17 @@ Resolving dependencies (fetching if missing)...
    a  Parse done                                                            0.000 s
   Stale a: source changed
    a  Type check done                                                       0.000 s
+     Non-total inferred signature: aaa
+       aaa : int
    b  Parse done                                                            0.000 s
   Stale b: source changed
    b  Type check done                                                       0.000 s
+     Non-total inferred signature: baa
+       baa : () -> int
+     Non-total inferred signature: DocInfo
+       class DocInfo (value):
+           G_init : () -> None
+           get : () -> int
    c  Parse done                                                            0.000 s
   Stale c: source changed
    c  Type check done                                                       0.000 s

--- a/compiler/acton/test/rebuild/golden/project_06-change-a-impl.golden
+++ b/compiler/acton/test/rebuild/golden/project_06-change-a-impl.golden
@@ -3,6 +3,8 @@ Resolving dependencies (fetching if missing)...
   Stale a: source changed
   Hash deltas a: ~aaa{src HASH1 -> HASH2, impl HASH1 -> HASH2}
    a  Type check done                                                       0.000 s
+     Non-total inferred signature: aaa
+       aaa : int
   Stale b: impl changes in a.aaa HASH1 → HASH2 (used by baa)
   Stale c: impl changes in b.baa HASH1 → HASH2 (used by main)
    a  Compilation done                                                      0.000 s

--- a/compiler/acton/test/rebuild/golden/project_08-change-b-impl.golden
+++ b/compiler/acton/test/rebuild/golden/project_08-change-b-impl.golden
@@ -4,6 +4,12 @@ Resolving dependencies (fetching if missing)...
   Stale b: source changed
   Hash deltas b: ~baa{src HASH1 -> HASH2, impl HASH1 -> HASH2}
    b  Type check done                                                       0.000 s
+     Non-total inferred signature: baa
+       baa : () -> int
+     Non-total inferred signature: DocInfo
+       class DocInfo (value):
+           G_init : () -> None
+           get : () -> int
   Stale c: impl changes in b.baa HASH1 → HASH2 (used by main)
    b  Compilation done                                                      0.000 s
    c  Compilation done                                                      0.000 s

--- a/compiler/acton/test/rebuild/golden/project_10-change-a-iface.golden
+++ b/compiler/acton/test/rebuild/golden/project_10-change-a-iface.golden
@@ -3,9 +3,17 @@ Resolving dependencies (fetching if missing)...
   Stale a: source changed
   Hash deltas a: -W_aaa_3, ~aaa{src HASH1 -> HASH2, pub HASH1 -> HASH2, impl HASH1 -> HASH2}
    a  Type check done                                                       0.000 s
+     Non-total inferred signature: aaa
+       aaa : str
   Stale b: pub changes in a.aaa HASH1 → HASH2 (used by baa)
   Hash deltas b: ~baa{pub HASH1 -> HASH2, impl HASH1 -> HASH2}
    b  Type check done                                                       0.000 s
+     Non-total inferred signature: baa
+       baa : () -> str
+     Non-total inferred signature: DocInfo
+       class DocInfo (value):
+           G_init : () -> None
+           get : () -> int
   Stale c: pub changes in b.baa HASH1 → HASH2 (used by main)
   Hash deltas c: ~main{impl HASH1 -> HASH2}
    c  Type check done                                                       0.000 s

--- a/compiler/acton/test/rebuild/golden/project_11-change-b-doc.golden
+++ b/compiler/acton/test/rebuild/golden/project_11-change-b-doc.golden
@@ -4,6 +4,12 @@ Resolving dependencies (fetching if missing)...
   Stale b: source changed
   Hash deltas b: ~DocInfo{src HASH1 -> HASH2, impl HASH1 -> HASH2}
    b  Type check done                                                       0.000 s
+     Non-total inferred signature: baa
+       baa : () -> str
+     Non-total inferred signature: DocInfo
+       class DocInfo (value):
+           G_init : () -> None
+           get : () -> int
   Fresh c: using cached .ty
    b  Compilation done                                                      0.000 s
       Final compilation done                                                0.000 s

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -91,6 +91,7 @@ module Acton.Compile
   , FrontResult(..)
   , FrontTiming(..)
   , TypeStmtTiming(..)
+  , InferredSignature(..)
   , BackTiming(..)
   , FrontPass(..)
   , FrontPassProgress(..)
@@ -319,6 +320,11 @@ data TypeStmtTiming = TypeStmtTiming
   , tstLabel :: String
   , tstNames :: [String]
   , tstTime :: TimeSpec
+  } deriving (Eq, Show)
+
+data InferredSignature = InferredSignature
+  { isigNames :: [String]
+  , isigSignature :: String
   } deriving (Eq, Show)
 
 data FrontTiming = FrontTiming
@@ -998,6 +1004,7 @@ data FrontResult = FrontResult
   , frNameHashes :: [InterfaceFiles.NameHashInfo]
   , frFrontTime :: Maybe TimeSpec
   , frFrontTiming :: Maybe FrontTiming
+  , frInferredSigs :: [InferredSignature]
   , frBackJob  :: Maybe BackJob
   }
 
@@ -1574,6 +1581,7 @@ runFrontPasses gopts opts paths env0 parsed srcContent srcBytes sourceMeta resol
   core
     `catch` handleGeneral
     `catch` handleCompilation
+    `catch` handleTypeErrors
     `catch` handleTypeError
   where
     mn = A.modname parsed
@@ -1594,6 +1602,12 @@ runFrontPasses gopts opts paths env0 parsed srcContent srcBytes sourceMeta resol
     handleTypeError :: Acton.TypeEnv.TypeError -> IO (Either [Diagnostic String] FrontResult)
     handleTypeError err =
       return $ Left [Acton.TypeEnv.mkErrorDiagnostic filename srcContent (Acton.TypeEnv.typeReport err filename srcContent)]
+
+    handleTypeErrors :: Acton.Types.TypeErrors -> IO (Either [Diagnostic String] FrontResult)
+    handleTypeErrors (Acton.Types.TypeErrors errs) =
+      return $ Left [ Acton.TypeEnv.mkErrorDiagnostic filename srcContent (Acton.TypeEnv.typeReport err filename srcContent)
+                    | err <- errs
+                    ]
 
     resolveImportHashes :: [A.ModName] -> IO (Either [Diagnostic String] [(A.ModName, B.ByteString)])
     resolveImportHashes mrefs = do
@@ -1677,6 +1691,7 @@ runFrontPasses gopts opts paths env0 parsed srcContent srcBytes sourceMeta resol
         dump mn "parse-ast" (renderStyle prettyAstStyle (ppDoc parsed))
 
       typeStmtTimingsRef <- newIORef ([] :: [TypeStmtTiming])
+      inferredSigsRef <- newIORef ([] :: [InferredSignature])
       typeActiveRef <- newIORef Nothing
       let onTypeProgress total completed current names _weight = do
             now <- getTime Monotonic
@@ -1695,6 +1710,12 @@ runFrontPasses gopts opts paths env0 parsed srcContent srcBytes sourceMeta resol
               Just label -> writeIORef typeActiveRef (Just (label, names, total, now))
               Nothing -> writeIORef typeActiveRef Nothing
             emitFrontProgress FrontPassTypes completed total current
+          onInferredSignature names sig =
+            modifyIORef' inferredSigsRef (InferredSignature names sig :)
+          inferredSignatureCb =
+            if C.timing gopts || C.verbose gopts
+              then Just onInferredSignature
+              else Nothing
 
       env <- Acton.Env.mkEnv (searchPath paths) env0 parsed
       timeEnv <- getTime Monotonic
@@ -1706,7 +1727,7 @@ runFrontPasses gopts opts paths env0 parsed srcContent srcBytes sourceMeta resol
       timeKindsCheck <- getTime Monotonic
 
       -- Type-check and return both the typed AST and the interface NameInfo.
-      (nmod,tchecked,typeEnv,mrefs,tests) <- Acton.Types.reconstruct (Just onTypeProgress) env kchecked
+      (nmod,tchecked,typeEnv,mrefs,tests) <- Acton.Types.reconstruct (Just onTypeProgress) inferredSignatureCb env kchecked
       -- Module-level src hash uses raw bytes so any source edit forces re-parse.
       let moduleSrcBytesHash = SHA256.hash srcBytes
       -- Store roots so later builds can discover entry points without reparse.
@@ -1822,6 +1843,7 @@ runFrontPasses gopts opts paths env0 parsed srcContent srcBytes sourceMeta resol
                   typeStmtTimings <- reverse <$> readIORef typeStmtTimingsRef
 
                   timeFrontEnd <- getTime Monotonic
+                  inferredSigs <- reverse <$> readIORef inferredSigsRef
                   let frontTime = timeFrontEnd - timeStart
                       frontTimeMaybe = if not (quiet gopts opts)
                                          then Just frontTime
@@ -1849,6 +1871,7 @@ runFrontPasses gopts opts paths env0 parsed srcContent srcBytes sourceMeta resol
                                              , frNameHashes = publicNameHashes nameHashes
                                              , frFrontTime = frontTimeMaybe
                                              , frFrontTiming = frontTimingMaybe
+                                             , frInferredSigs = inferredSigs
                                              , frBackJob = backJob
                                              }
 
@@ -2204,6 +2227,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
               , frNameHashes = nameHashes
               , frFrontTime = Nothing
               , frFrontTiming = Nothing
+              , frInferredSigs = []
               , frBackJob = backJob
               }
           emptyFrontResult =
@@ -2214,6 +2238,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
               , frNameHashes = []
               , frFrontTime = Nothing
               , frFrontTiming = Nothing
+              , frInferredSigs = []
               , frBackJob = Nothing
               }
           cacheFrontResult fr = do

--- a/compiler/lib/src/Acton/NameInfo.hs
+++ b/compiler/lib/src/Acton/NameInfo.hs
@@ -11,9 +11,10 @@
 -- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 --
 
-{-# LANGUAGE FlexibleInstances, FlexibleContexts, DeriveGeneric #-}
+{-# LANGUAGE FlexibleInstances, FlexibleContexts, DeriveGeneric, DeriveAnyClass #-}
 module Acton.NameInfo where
 
+import Control.DeepSeq
 import qualified Data.Binary
 import GHC.Generics (Generic)
 import Data.Typeable
@@ -60,7 +61,7 @@ data NameInfo           = NVar      Type
                         | NMAlias   ModName
                         | NModule   TEnv (Maybe String)
                         | NReserved
-                        deriving (Eq,Show,Read,Generic)
+                        deriving (Eq,Show,Read,Generic,NFData)
 
 typeDecl (_,NDef{})     = False
 typeDecl _              = True

--- a/compiler/lib/src/Acton/TypeEnv.hs
+++ b/compiler/lib/src/Acton/TypeEnv.hs
@@ -247,14 +247,15 @@ initTypeState p                         = TypeState { nextint = 1, uniqprefix = 
 
 type TypeM a                            = ExceptT TypeError (State TypeState) a
 
-runTypeMState                           :: String -> TypeM a -> (a, TypeState)
+runTypeMState                           :: String -> TypeM a -> Either TypeError (a, TypeState)
 runTypeMState p m                       = case runState (runExceptT m) (initTypeState p) of
-                                            (Right x, st') -> (x, st')
-                                            (Left err, _)  -> error ("Unhandled TypeM exception: " ++ prstr loc ++ ": " ++ prstr str)
-                                              where (loc,str) : _ = typeError err
+                                            (Right x, st') -> Right (x, st')
+                                            (Left err, _)  -> Left err
 
 runTypeM                                :: TypeM a -> a
-runTypeM m                              = fst $ runTypeMState "" m
+runTypeM m                              = case runTypeMState "" m of
+                                            Right (x,_) -> x
+                                            Left err    -> Control.Exception.throw err
 
 currentState                            :: TypeM TypeState
 currentState                            = lift $ state $ \st -> (st, st)

--- a/compiler/lib/src/Acton/Types.hs
+++ b/compiler/lib/src/Acton/Types.hs
@@ -12,8 +12,12 @@
 --
 
 {-# LANGUAGE MultiParamTypeClasses, FlexibleInstances, FlexibleContexts #-}
-module Acton.Types(reconstruct, showTyFile, prettySigs, TypeError(..)) where
+module Acton.Types(reconstruct, showTyFile, prettySigs, TypeError(..), TypeErrors(..), TypeProgressCallback, TypeInferredCallback) where
 
+import Control.Concurrent.Async
+import Control.Concurrent.Chan
+import Control.Concurrent.QSem
+import Control.DeepSeq
 import Control.Monad
 import Data.Maybe (isJust)
 import Data.List (nub, intersect, sort)
@@ -36,37 +40,44 @@ import Acton.WitKnots
 import qualified InterfaceFiles
 import qualified Data.ByteString.Char8 as B
 import qualified Data.ByteString.Base16 as Base16
-import Data.List (intersperse, isPrefixOf, partition)
+import Data.List (foldl', intersperse, isPrefixOf, partition)
 import Data.Maybe (mapMaybe)
-import System.IO.Unsafe (unsafePerformIO)
+import GHC.Conc (getNumCapabilities)
 
 type TypeProgressCallback = Int -> Int -> Maybe String -> [String] -> Int -> IO ()
+type TypeInferredCallback = [String] -> String -> IO ()
 
-emitTypeProgress :: Maybe TypeProgressCallback -> Int -> Int -> Maybe String -> [String] -> Int -> TypeM ()
-emitTypeProgress Nothing _ _ _ _ _ = return ()
-emitTypeProgress (Just cb) total completed current names weight =
-  unsafePerformIO (cb total completed current names weight) `seq` return ()
+emitTypeProgressIO :: Maybe TypeProgressCallback -> Int -> Int -> Maybe String -> [String] -> Int -> IO ()
+emitTypeProgressIO Nothing _ _ _ _ _ = return ()
+emitTypeProgressIO (Just cb) total completed current names weight = cb total completed current names weight
+
+emitTypeInferredIO :: Maybe TypeInferredCallback -> Env -> TEnv -> IO ()
+emitTypeInferredIO Nothing _ _        = return ()
+emitTypeInferredIO (Just cb) env te   = cb (map nstr (dom te)) (render $ pretty (simp env [(n, stripDocsNI i) | (n,i) <- te]))
+
+data TypeErrors = TypeErrors [TypeError]
+                  deriving (Show)
+
+instance Control.Exception.Exception TypeErrors
 
 -- | Type-check a module and return its NameInfo, typed module, env, and discovered tests.
-reconstruct                             :: Maybe TypeProgressCallback -> Env0 -> Module -> IO (NameInfo, Module, Env0, [Acton.Syntax.ModName], [String])
-reconstruct progressCb env0 (Module m i mdoc ss)    = do --traceM ("#################### original env0 for " ++ prstr m ++ ":")
+reconstruct                             :: Maybe TypeProgressCallback -> Maybe TypeInferredCallback -> Env0 -> Module -> IO (NameInfo, Module, Env0, [Acton.Syntax.ModName], [String])
+reconstruct progressCb inferredCb env0 (Module m i mdoc ss)    = do --traceM ("#################### original env0 for " ++ prstr m ++ ":")
                                              --traceM (render (pretty env0))
-                                             let nmod = NModule iface mdoc
+                                             (te,ss1) <- infTop progressCb inferredCb env1 ss
+                                             let env2 = define te (setMod m env0)
+                                                 (teT,ssT,tests) =
+                                                   if hasTesting i
+                                                     then let (testSs, discovered) = testStmts env2 (modNameStr m) ss1
+                                                          in (te ++ testEnv, ss1 ++ testSs, discovered)
+                                                     else (te, ss1, [])
+                                                 iface = unalias env2 teT
+                                                 nmod = NModule iface mdoc
                                              --traceM ("#################### converted env0:")
                                              --traceM (render (pretty env0'))
                                              return (nmod, Module m i mdoc ssT, env0', mrefs, tests)
 
   where env1                            = reserve (assigned ss) (typeX env0)
-        (te,ss1)                        = runTypeM $ infTop progressCb env1 ss
-        env2                            = define te (setMod m env0)
-
-        (teT,ssT,tests)                 =
-          if hasTesting i
-            then let (testSs, discovered) = testStmts env2 (modNameStr m) ss1
-                 in (te ++ testEnv, ss1 ++ testSs, discovered)
-            else (te, ss1, [])
-        iface                           = unalias env2 teT
-
         mrefs                           = moduleRefs1 env0
         env0'                           = convEnvProtos env0
         hasTesting i                    = Import NoLoc [ModuleItem (ModName [name "testing"]) Nothing] `elem` i
@@ -80,9 +91,6 @@ reconstruct progressCb env0 (Module m i mdoc ss)    = do --traceM ("############
 
         -- Convert the module name (ModName) to a string, e.g. "foo.bar"
         modNameStr (ModName ns) = concat (intersperse "." (map nstr ns))
-        -- Inject __name__ variable
-        __name__assign = Assign NoLoc [PVar NoLoc (name "__name__") Nothing] (Strings NoLoc [modNameStr m])
-        ssT' = __name__assign : ssT
 
 
 -- | Print a .ty file header and interface; include name hashes when verbose.
@@ -153,45 +161,141 @@ addTyping env n s t c                   = c {info = addT n (simp env s) t (info 
 
 ------------------------------
 
-infTop                                  :: Maybe TypeProgressCallback -> Env -> Suite -> TypeM (TEnv,Suite)
-infTop progressCb env ss                = do --traceM ("\n## infEnv top")
-                                             let total = sum (map stmtProgressWeight ss)
-                                             (te,ss) <- infTopStmts progressCb env total 0 ss
-                                             when (total > 0) $
-                                               emitTypeProgress progressCb total total Nothing [] 0
-                                             checkSigs env te
-                                             return (te, ss)
+type TopProgressItem                    = ([String], Int)
 
-infTopStmts _ env _ _ []                = return ([], [])
-infTopStmts progressCb env total done (s : ss)
-                                         = do done' <- case stmtProgressLabel s of
-                                                        Just label -> do
-                                                          let names = stmtProgressNames s
-                                                              weight = stmtProgressWeight s
-                                                          emitTypeProgress progressCb total done (Just label) names weight
-                                                          return (done + weight)
-                                                        Nothing -> return done
-                                              let (te1, s1) = typeTopStmt env s
-                                              (te2, ss2) <- infTopStmts progressCb (define te1 env) total done' ss
-                                              return (te1++te2, s1++ss2)
+data TopProgressEvent                   = TopProgressStarted TopProgressItem
+                                        | TopProgressFinished TopProgressItem
+                                        | TopProgressStop
 
-typeTopStmt env s                       = fst $ runTypeMState (nstr $ uniqPrefix s) $ do
-                                          pushFX fxPure tNone
-                                          infTopStmt env s
+infTop                                  :: Maybe TypeProgressCallback -> Maybe TypeInferredCallback -> Env -> Suite -> IO (TEnv,Suite)
+infTop _ _ _ []                         = return ([], [])
+infTop progressCb inferredCb env ss     = do ncap <- getNumCapabilities
+                                             sem <- newQSem (max 1 (min ncap (length ss)))
+                                             progressQ <- newChan
+                                             progressA <- async $ topProgress progressCb total progressQ
+                                             let stopProgress = writeChan progressQ TopProgressStop >> wait progressA
+                                                 run = do
+                                                   (te,ss,errs) <- go sem progressQ env [] [] ss
+                                                   stopProgress
+                                                   if null errs
+                                                     then do runType "" (checkSigs env te)
+                                                             return (te, ss)
+                                                     else throwTopErrors errs
+                                             run `Control.Exception.finally` cancel progressA
+  where total                           = sum (map stmtProgressWeight ss)
 
--- | Display label for progress UI.
--- For recursive groups, abbreviate to a short "a, b, ... (+N)" form.
-stmtProgressLabel :: Stmt -> Maybe String
-stmtProgressLabel s
-  | null names = Nothing
-  | otherwise = Just (formatNames names)
-  where
-    names = stmtProgressNames s
-    formatNames [n] = n
-    formatNames [n1, n2] = n1 ++ ", " ++ n2
-    formatNames (n1 : n2 : rest) =
-      n1 ++ ", " ++ n2 ++ ", ... (+" ++ show (length rest) ++ ")"
-    formatNames [] = ""
+        go sem q env tes rs []          = collect tes rs
+        go sem q env tes rs (s:ss)      = do let item = topProgressItem s
+                                             writeChan q (TopProgressStarted item)
+                                             r <- scanOrCheck env s
+                                             case r of
+                                               Left err -> do
+                                                 writeChan q (TopProgressFinished item)
+                                                 collect tes (return (Left err) : rs)
+                                               Right (True,te1,s1,_) ->
+                                                 withAsync (Control.Exception.finally
+                                                   (Control.Exception.bracket_ (waitQSem sem) (signalQSem sem) (checkTotal env te1 s1))
+                                                   (writeChan q (TopProgressFinished item))) $ \a ->
+                                                     go sem q (define te1 env) (te1:tes) (wait a:rs) ss
+                                               Right (_,te1,_,ss1) -> do
+                                                 writeChan q (TopProgressFinished item)
+                                                 go sem q (define te1 env) (te1:tes) (return (Right ss1):rs) ss
+        collect tes rs                  = do xs <- sequence (reverse rs)
+                                             return (concat (reverse tes), [ s | Right ss1 <- xs, s <- ss1 ], [ e | Left e <- xs ])
+        scanOrCheck env s               = tryTop $ do
+                                             r <- runType (nstr $ uniqPrefix s) $ do
+                                               pushFX fxPure tNone
+                                               (total,te1,s1) <- scanTopStmt env s
+                                               if total
+                                                 then return (True,te1,s1,[])
+                                                 else do (te2,ss1) <- checkTopStmt env te1 s1
+                                                         return (False,te2,s1,ss1)
+                                             r <- forceTopResult r
+                                             case r of
+                                               (False,te,_,_) -> emitTypeInferredIO inferredCb env te
+                                               _ -> return ()
+                                             return r
+        checkTotal env te s             = tryTop $ do
+                                             (te1,ss1) <- runType (nstr $ uniqPrefix s) $ do
+                                               pushFX fxPure tNone
+                                               checkTopStmt env te s
+                                             forceSuite te1 ss1
+        runType p m                     = do r <- Control.Exception.evaluate (runTypeMState p m)
+                                             case r of
+                                               Left err -> Control.Exception.throwIO err
+                                               Right (x,_) -> return x
+        forceTopResult (True,te,s,ss)   = do te <- Control.Exception.evaluate (force te)
+                                             return (True,te,s,ss)
+        forceTopResult (_,te,s,ss)      = do (te,ss) <- forceChecked te ss
+                                             return (False,te,s,ss)
+        forceSuite te ss                = snd <$> forceChecked te ss
+        forceChecked te ss              = do te <- Control.Exception.evaluate (force te)
+                                             ss <- Control.Exception.evaluate (force ss)
+                                             return (te,ss)
+
+topProgress                             :: Maybe TypeProgressCallback -> Int -> Chan TopProgressEvent -> IO ()
+topProgress progressCb total q          = do when (total > 0) $
+                                               emit [] 0
+                                             loop [] 0
+  where loop active done                = do event <- readChan q
+                                             case event of
+                                               TopProgressStarted item -> do
+                                                 let active' = active ++ [item]
+                                                 emit active' done
+                                                 loop active' done
+                                               TopProgressFinished item -> do
+                                                 let active' = removeProgressItem item active
+                                                     done' = done + snd item
+                                                 emit active' done'
+                                                 loop active' done'
+                                               TopProgressStop ->
+                                                 emit [] done
+        emit active done                = emitTypeProgressIO progressCb total done (activeProgressLabel active) (concatMap fst active) 0
+
+topProgressItem                         :: Stmt -> TopProgressItem
+topProgressItem s                       = (stmtProgressNames s, stmtProgressWeight s)
+
+removeProgressItem                      :: TopProgressItem -> [TopProgressItem] -> [TopProgressItem]
+removeProgressItem item []              = []
+removeProgressItem item (x:xs)
+  | item == x                           = xs
+  | otherwise                           = x : removeProgressItem item xs
+
+activeProgressLabel                     :: [TopProgressItem] -> Maybe String
+activeProgressLabel []                  = Nothing
+activeProgressLabel active              = Just (formatNames (concatMap fst active))
+  where formatNames [n]                 = n
+        formatNames [n1,n2]             = n1 ++ ", " ++ n2
+        formatNames (n1:n2:rest)        = n1 ++ ", " ++ n2 ++ " (+" ++ show (length rest) ++ " others)"
+        formatNames []                  = ""
+
+tryTop                                  :: IO a -> IO (Either Control.Exception.SomeException a)
+tryTop m                                = do r <- Control.Exception.try m
+                                             case r of
+                                               Left err | isAsyncException err -> Control.Exception.throwIO err
+                                               _ -> return r
+
+isAsyncException                        :: Control.Exception.SomeException -> Bool
+isAsyncException err                    = isJust (Control.Exception.fromException err :: Maybe Control.Exception.SomeAsyncException)
+
+throwTopErrors                          :: [Control.Exception.SomeException] -> IO a
+throwTopErrors errs                     = case others of
+                                           err:_ -> Control.Exception.throwIO err
+                                           [] -> case typeErrs of
+                                                   [] -> error "Internal error: empty type error list"
+                                                   [err] -> Control.Exception.throwIO err
+                                                   _ -> Control.Exception.throwIO (TypeErrors typeErrs)
+  where (typeErrs, others)              = foldl' collect ([], []) errs
+        collect (ts, os) err            = case topTypeErrors err of
+                                            Just ts' -> (ts ++ ts', os)
+                                            Nothing -> (ts, os ++ [err])
+
+topTypeErrors                           :: Control.Exception.SomeException -> Maybe [TypeError]
+topTypeErrors err                       = case Control.Exception.fromException err of
+                                            Just (TypeErrors errs) -> Just errs
+                                            Nothing -> case Control.Exception.fromException err of
+                                                         Just typeErr -> Just [typeErr]
+                                                         Nothing -> Nothing
 
 -- | Progress weight for one top-level statement, based on bound names.
 -- This makes large recursive groups count proportionally.

--- a/compiler/lib/src/Acton/Types.hs
+++ b/compiler/lib/src/Acton/Types.hs
@@ -161,19 +161,39 @@ addTyping env n s t c                   = c {info = addT n (simp env s) t (info 
 
 ------------------------------
 
+-- | One source-level progress unit: the names in the top-level statement and
+-- its weight.  A recursive group can bind several names, so the weight is kept
+-- separate from the label.
 type TopProgressItem                    = ([String], Int)
 
+-- | Progress events are sent from the scanner thread and from background
+-- checker workers to the single progress reporter thread.
 data TopProgressEvent                   = TopProgressStarted TopProgressItem
                                         | TopProgressFinished TopProgressItem
                                         | TopProgressStop
 
+-- Concurrent type checker
 infTop                                  :: Maybe TypeProgressCallback -> Maybe TypeInferredCallback -> Env -> Suite -> IO (TEnv,Suite)
 infTop _ _ _ []                         = return ([], [])
-infTop progressCb inferredCb env ss     = do ncap <- getNumCapabilities
+infTop progressCb inferredCb env ss     = do -- The scanner itself is sequential, but total statements, i.e.
+                                             -- with a complete type signature can be independently type checked
+                                             -- in the background. Use RTS capabilities as this module's local
+                                             -- worker limit.
+                                             ncap <- getNumCapabilities
+                                             -- Counting semaphore to limit number of background workers
                                              sem <- newQSem (max 1 (min ncap (length ss)))
+                                             -- Progress is serialized through one channel so concurrent workers
+                                             -- do not call the UI callback directly.
                                              progressQ <- newChan
+                                             -- The progress reporter is independent from scanning/checking; it
+                                             -- consumes start/finish events until it receives TopProgressStop.
                                              progressA <- async $ topProgress progressCb total progressQ
+                                             -- Stop the reporter after all work has been collected, and wait so
+                                             -- the final progress update is emitted before infTop returns.
                                              let stopProgress = writeChan progressQ TopProgressStop >> wait progressA
+                                                 -- run is the real top-level flow: scan left-to-right, collect
+                                                 -- all completed worker results, then validate signatures once
+                                                 -- the whole top-level environment is known.
                                                  run = do
                                                    (te,ss,errs) <- go sem progressQ env [] [] ss
                                                    stopProgress
@@ -181,53 +201,109 @@ infTop progressCb inferredCb env ss     = do ncap <- getNumCapabilities
                                                      then do runType "" (checkSigs env te)
                                                              return (te, ss)
                                                      else throwTopErrors errs
+                                             -- If scan/check throws before stopProgress runs, make sure the
+                                             -- progress reporter does not stay blocked on readChan.
                                              run `Control.Exception.finally` cancel progressA
-  where total                           = sum (map stmtProgressWeight ss)
+  where -- Total source progress is known syntactically before any type checking.
+        total                           = sum (map stmtProgressWeight ss)
 
+        -- End of input: every statement has either produced an immediate
+        -- result or a worker wait action, so now wait for them and assemble the
+        -- final top-level environment and typed suite in source order.
         go sem q env tes rs []          = collect tes rs
+        -- Main scanner loop. This is deliberately sequential: every new scan
+        -- sees a type environment containing all previous top-level declarations.
         go sem q env tes rs (s:ss)      = do let item = topProgressItem s
+                                             -- Mark this statement active before scanning or checking it.
                                              writeChan q (TopProgressStarted item)
+                                             -- scanOrCheck always scans in this thread.  If the statement is not
+                                             -- total, scanOrCheck also runs checkTopStmt here and blocks progress.
                                              r <- scanOrCheck env s
                                              case r of
+                                               -- A scan error stops the source-order scan.
+                                               -- Existing worker results are still collected so their errors can
+                                               -- be reported together with this one.
                                                Left err -> do
                                                  writeChan q (TopProgressFinished item)
                                                  collect tes (return (Left err) : rs)
+                                               -- A total statement has a complete boundary after scanning.  Its
+                                               -- declarations can be put in env immediately, while full checking
+                                               -- continues in the background.
                                                Right (True,te1,s1,_) ->
+                                                 -- withAsync scopes the worker over the recursive go call.  Since
+                                                 -- go eventually calls collect before returning, wait a is consumed
+                                                 -- while the Async is still alive.
                                                  withAsync (Control.Exception.finally
+                                                   -- The semaphore limits only the actual checkTopStmt work, not
+                                                   -- the sequential scan of later statements.
                                                    (Control.Exception.bracket_ (waitQSem sem) (signalQSem sem) (checkTotal env te1 s1))
+                                                   -- Progress for a total statement finishes when its background
+                                                   -- checker finishes, not when scanning schedules it.
                                                    (writeChan q (TopProgressFinished item))) $ \a ->
+                                                     -- Continue scanning with the scanned declarations visible.
+                                                     -- Store te1 and wait a on reversed accumulators to preserve
+                                                     -- source order cheaply when collect reverses them.
                                                      go sem q (define te1 env) (te1:tes) (wait a:rs) ss
-                                               Right (_,te1,_,ss1) -> do
+                                               -- A non-total statement was already fully checked by scanOrCheck,
+                                               -- so becomes complete / total before we get here and the scanner may
+                                               -- continue.
+                                               Right (_,te2,_,ss1) -> do
                                                  writeChan q (TopProgressFinished item)
-                                                 go sem q (define te1 env) (te1:tes) (return (Right ss1):rs) ss
+                                                 go sem q (define te2 env) (te2:tes) (return (Right ss1):rs) ss
+        -- Wait for all statement results in source order, concatenate the
+        -- accumulated environments, keep typed statements whose checks
+        -- succeeded, and keep every error for aggregate reporting.
         collect tes rs                  = do xs <- sequence (reverse rs)
                                              return (concat (reverse tes), [ s | Right ss1 <- xs, s <- ss1 ], [ e | Left e <- xs ])
+        -- Scanner/checker front door for one statement.  Ordinary exceptions
+        -- become Left values so infTop can collect multiple errors; async
+        -- exceptions still escape through tryTop.
         scanOrCheck env s               = tryTop $ do
                                              r <- runType (nstr $ uniqPrefix s) $ do
                                                pushFX fxPure tNone
+                                               -- The scanner returns the syntactic totality bit, the scanned
+                                               -- top-level env, and the rewritten statement.
                                                (total,te1,s1) <- scanTopStmt env s
                                                if total
+                                                 -- Total means the signature boundary is complete, so the
+                                                 -- expensive check can be deferred to a worker.
                                                  then return (True,te1,s1,[])
+                                                 -- Non-total means inference/checking is needed now.  This blocks
+                                                 -- the scanner because later statements need this completed env.
                                                  else do (te2,ss1) <- checkTopStmt env te1 s1
                                                          return (False,te2,s1,ss1)
+                                             -- Force enough of the result here that delayed type errors are caught
+                                             -- inside tryTop instead of escaping later from collect.
                                              r <- forceTopResult r
                                              case r of
+                                               -- Only non-total statements produce inferred signatures useful for
+                                               -- the "make this total" callback/output.
                                                (False,te,_,_) -> emitTypeInferredIO inferredCb env te
                                                _ -> return ()
                                              return r
+        -- Background worker body for a total statement.  It receives exactly
+        -- the scanned env and scanned statement returned by scanTopStmt.
         checkTotal env te s             = tryTop $ do
                                              (te1,ss1) <- runType (nstr $ uniqPrefix s) $ do
                                                pushFX fxPure tNone
                                                checkTopStmt env te s
                                              forceSuite te1 ss1
+        -- Run a TypeM action and convert TypeM's Either error into the IO
+        -- exception path used by tryTop.
         runType p m                     = do r <- Control.Exception.evaluate (runTypeMState p m)
                                              case r of
                                                Left err -> Control.Exception.throwIO err
                                                Right (x,_) -> return x
+        -- For total statements, force the scanned type environment now; the
+        -- typed suite is produced later by checkTotal.
         forceTopResult (True,te,s,ss)   = do te <- Control.Exception.evaluate (force te)
                                              return (True,te,s,ss)
+        -- For non-total statements, both env and typed suite already exist and
+        -- must be forced before scanOrCheck reports success.
         forceTopResult (_,te,s,ss)      = do (te,ss) <- forceChecked te ss
                                              return (False,te,s,ss)
+        -- checkTotal returns only the typed statements, but still forces the
+        -- worker's type environment so any delayed failures surface in worker.
         forceSuite te ss                = snd <$> forceChecked te ss
         forceChecked te ss              = do te <- Control.Exception.evaluate (force te)
                                              ss <- Control.Exception.evaluate (force ss)

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -35,6 +35,7 @@ import qualified Control.Monad.Trans.State.Strict as St
 import Text.Megaparsec (runParser, errorBundlePretty, ShowErrorComponent(..))
 import qualified Data.Text as T
 import Data.List (isInfixOf, isPrefixOf, nub, sort)
+import Data.IORef
 import Data.Bits (shiftL, (.|.))
 import Error.Diagnose (printDiagnostic, prettyDiagnostic, WithUnicode(..), TabSize(..), defaultStyle, addReport, addFile)
 import Error.Diagnose.Report (Report(..))
@@ -919,11 +920,53 @@ main = do
         tchecked <- typecheckSource env0 "tlname_doc_ext" src
         tchecked `shouldSatisfy` const True
 
+      it "continues after a non-total top-level statement has been checked" $ do
+        let src = unlines
+              [ "value = 41"
+              , ""
+              , "def later() -> int:"
+              , "    return value + 1"
+              ]
+        tchecked <- typecheckSource env0 "top_non_total_then_total" src
+        tchecked `shouldSatisfy` const True
+
+      it "reports inferred signatures for non-total top-level statements" $ do
+        sigsRef <- liftIO $ newIORef []
+        let src = "value = 41\n"
+            moduleName = S.modName ["top_non_total_sig"]
+            actFile = "<top_non_total_sig>"
+            sysTypesPath = ".." </> ".." </> "dist" </> "base" </> "out" </> "types"
+            onInferred names sig = modifyIORef' sigsRef ((names, sig) :)
+        parsed <- liftIO $ P.parseModule moduleName actFile src
+        env <- liftIO $ Acton.Env.mkEnv [sysTypesPath] env0 parsed
+        kchecked <- liftIO $ Acton.Kinds.check env parsed
+        _ <- liftIO $ Acton.Types.reconstruct Nothing (Just onInferred) env kchecked
+        sigs <- liftIO $ reverse <$> readIORef sigsRef
+        sigs `shouldSatisfy` any (\(names, sig) -> names == ["value"] && "value : int" `isInfixOf` sig)
+
+      it "collects errors from independent total top-level statements" $ do
+        let src = unlines
+              [ "proc def first() -> int:"
+              , "    return \"one\""
+              , ""
+              , "value = 1"
+              , ""
+              , "proc def second() -> int:"
+              , "    return \"two\""
+              ]
+        result <- E.try (do
+          tchecked <- typecheckSource env0 "top_total_errors" src
+          E.evaluate (length (show tchecked))
+          return ()) :: IO (Either Acton.Types.TypeErrors ())
+        case result of
+          Left (Acton.Types.TypeErrors errs) -> length errs `shouldBe` 2
+          Right _ -> expectationFailure "Expected multiple type errors but type checking succeeded"
+
     describe "Import Semantics" $ do
       it "omits private names from the public interface" $ do
         (envA, parsedA) <- parseAct env0 "import_private_a"
         kcheckedA <- liftIO $ Acton.Kinds.check envA parsedA
-        (nmodA, _, _, _, _) <- liftIO $ Acton.Types.reconstruct Nothing envA kcheckedA
+        (nmodA, _, _, _, _) <- liftIO $ Acton.Types.reconstruct Nothing Nothing envA kcheckedA
         let I.NModule tenvA mdocA = nmodA
             env1 = Acton.Env.addMod (S.modname parsedA) tenvA mdocA env0
 
@@ -941,7 +984,7 @@ main = do
       it "blocks qualified access to private names" $ do
         (envA, parsedA) <- parseAct env0 "import_private_a"
         kcheckedA <- liftIO $ Acton.Kinds.check envA parsedA
-        (nmodA, _, _, _, _) <- liftIO $ Acton.Types.reconstruct Nothing envA kcheckedA
+        (nmodA, _, _, _, _) <- liftIO $ Acton.Types.reconstruct Nothing Nothing envA kcheckedA
         let I.NModule tenvA mdocA = nmodA
             publicTEnvA = Acton.Env.publicTEnv tenvA
             env1 = Acton.Env.addMod (S.modname parsedA) publicTEnvA mdocA env0
@@ -949,7 +992,7 @@ main = do
         (envB, parsedB) <- parseAct env1 "import_private_qualified"
         kcheckedB <- liftIO $ Acton.Kinds.check envB parsedB
         result <- liftIO $ (E.try (do
-          (_, tcheckedB, _, _, _) <- Acton.Types.reconstruct Nothing envB kcheckedB
+          (_, tcheckedB, _, _, _) <- Acton.Types.reconstruct Nothing Nothing envB kcheckedB
           _ <- E.evaluate (rnf tcheckedB)
           pure ()
           ) :: IO (Either CompilationError ()))
@@ -1717,7 +1760,7 @@ testDocGen env0 modulePaths = do
     let processModule (accEnv, accModules) modulePath = do
           (env, parsed) <- parseAct accEnv modulePath
           kchecked <- Acton.Kinds.check env parsed
-          (nmod, _, _, _, _) <- Acton.Types.reconstruct Nothing env kchecked
+          (nmod, _, _, _, _) <- Acton.Types.reconstruct Nothing Nothing env kchecked
           let I.NModule moduleTypeEnv moduleDoc = nmod
           let newAccEnv = Acton.Env.addMod (S.modname parsed) moduleTypeEnv moduleDoc accEnv
           return (newAccEnv, accModules ++ [((takeFileName modulePath), parsed, nmod)])
@@ -1765,7 +1808,7 @@ typecheckSource env0 modName src = do
   parsed <- liftIO $ P.parseModule moduleName actFile src
   env <- liftIO $ Acton.Env.mkEnv [sysTypesPath] env0 parsed
   kchecked <- liftIO $ Acton.Kinds.check env parsed
-  (_, tchecked, _, _, _) <- liftIO $ Acton.Types.reconstruct Nothing env kchecked
+  (_, tchecked, _, _, _) <- liftIO $ Acton.Types.reconstruct Nothing Nothing env kchecked
   return tchecked
 
 typedDefGeneratedNames env0 modName src defName = do
@@ -1827,7 +1870,7 @@ testTypes env0 modulePaths = do
     let processModule (accEnv, accModules) modulePath = do
           (env, parsed) <- parseAct accEnv modulePath
           kchecked <- Acton.Kinds.check env parsed
-          (nmod, tchecked, _, _, _) <- Acton.Types.reconstruct Nothing env kchecked
+          (nmod, tchecked, _, _, _) <- Acton.Types.reconstruct Nothing Nothing env kchecked
           let I.NModule tenv mdoc = nmod
           let newAccEnv = Acton.Env.addMod (S.modname parsed) tenv mdoc accEnv
           return (newAccEnv, accModules ++ [(takeFileName modulePath, kchecked, tchecked)])
@@ -1847,7 +1890,7 @@ testNorm env0 modulePaths = do
     let processModule (accEnv, accModules) modulePath = do
           (env, parsed) <- parseAct accEnv modulePath
           kchecked <- Acton.Kinds.check env parsed
-          (nmod, tchecked, env0Typed, _, _) <- Acton.Types.reconstruct Nothing env kchecked
+          (nmod, tchecked, env0Typed, _, _) <- Acton.Types.reconstruct Nothing Nothing env kchecked
           let I.NModule tenv mdoc = nmod
           (normalized, normEnv) <- Acton.Normalizer.normalize env0Typed tchecked
           let newAccEnv = Acton.Env.addMod (S.modname parsed) tenv mdoc accEnv
@@ -1868,7 +1911,7 @@ testDeact env0 modulePaths = do
     let processModule (accEnv, accModules) modulePath = do
           (env, parsed) <- parseAct accEnv modulePath
           kchecked <- Acton.Kinds.check env parsed
-          (nmod, tchecked, env0Typed, _, _) <- Acton.Types.reconstruct Nothing env kchecked
+          (nmod, tchecked, env0Typed, _, _) <- Acton.Types.reconstruct Nothing Nothing env kchecked
           let I.NModule tenv mdoc = nmod
           (normalized, normEnv) <- Acton.Normalizer.normalize env0Typed tchecked
           (deacted, deactEnv) <- Acton.Deactorizer.deactorize normEnv normalized
@@ -1890,7 +1933,7 @@ testCps env0 modulePaths = do
     let processModule (accEnv, accModules) modulePath = do
           (env, parsed) <- parseAct accEnv modulePath
           kchecked <- Acton.Kinds.check env parsed
-          (nmod, tchecked, env0Typed, _, _) <- Acton.Types.reconstruct Nothing env kchecked
+          (nmod, tchecked, env0Typed, _, _) <- Acton.Types.reconstruct Nothing Nothing env kchecked
           let I.NModule tenv mdoc = nmod
           (normalized, normEnv) <- Acton.Normalizer.normalize env0Typed tchecked
           (deacted, deactEnv) <- Acton.Deactorizer.deactorize normEnv normalized
@@ -1913,7 +1956,7 @@ testLL env0 modulePaths = do
     let processModule (accEnv, accModules) modulePath = do
           (env, parsed) <- parseAct accEnv modulePath
           kchecked <- Acton.Kinds.check env parsed
-          (nmod, tchecked, env0Typed, _, _) <- Acton.Types.reconstruct Nothing env kchecked
+          (nmod, tchecked, env0Typed, _, _) <- Acton.Types.reconstruct Nothing Nothing env kchecked
           let I.NModule tenv mdoc = nmod
           (normalized, normEnv) <- Acton.Normalizer.normalize env0Typed tchecked
           (deacted, deactEnv) <- Acton.Deactorizer.deactorize normEnv normalized
@@ -1937,7 +1980,7 @@ testBoxing env0 modulePaths = do
     let processModule (accEnv, accModules) modulePath = do
           (env, parsed) <- parseAct accEnv modulePath
           kchecked <- Acton.Kinds.check env parsed
-          (nmod, tchecked, env0Typed, _, _) <- Acton.Types.reconstruct Nothing env kchecked
+          (nmod, tchecked, env0Typed, _, _) <- Acton.Types.reconstruct Nothing Nothing env kchecked
           let I.NModule tenv mdoc = nmod
           (normalized, normEnv) <- Acton.Normalizer.normalize env0Typed tchecked
           (deacted, deactEnv) <- Acton.Deactorizer.deactorize normEnv normalized
@@ -1962,7 +2005,7 @@ testCodeGen env0 modulePaths = do
     let processModule (accEnv, accModules) modulePath = do
           (env, parsed) <- parseAct accEnv modulePath
           kchecked <- Acton.Kinds.check env parsed
-          (nmod, tchecked, env0Typed, _, _) <- Acton.Types.reconstruct Nothing env kchecked
+          (nmod, tchecked, env0Typed, _, _) <- Acton.Types.reconstruct Nothing Nothing env kchecked
           let I.NModule tenv mdoc = nmod
           (normalized, normEnv) <- Acton.Normalizer.normalize env0Typed tchecked
           (deacted, deactEnv) <- Acton.Deactorizer.deactorize normEnv normalized
@@ -1999,7 +2042,7 @@ testDocstrings env0 testname = do
   (env, parsed) <- parseAct env0 testname
 
   kchecked <- liftIO $ Acton.Kinds.check env parsed
-  (nmod, _, _, _, _) <- liftIO $ Acton.Types.reconstruct Nothing env kchecked
+  (nmod, _, _, _, _) <- liftIO $ Acton.Types.reconstruct Nothing Nothing env kchecked
   let I.NModule tenv mdoc = nmod
 
   -- Extract docstrings from the parsed AST
@@ -2230,7 +2273,7 @@ testTypeError env0 path = do
       result <- E.try $ do
         (env, parsed) <- parseAct env0 path
         kchecked <- Acton.Kinds.check env parsed
-        (nmod, tchecked, _, _, _) <- Acton.Types.reconstruct Nothing env kchecked
+        (nmod, tchecked, _, _, _) <- Acton.Types.reconstruct Nothing Nothing env kchecked
         -- Force evaluation to trigger any lazy exceptions
         E.evaluate $ length (show tchecked)
         return ()
@@ -2274,7 +2317,7 @@ testTypeSuccess env0 path = do
     result <- E.try $ do
       (env, parsed) <- parseAct env0 path
       kchecked <- Acton.Kinds.check env parsed
-      (nmod, tchecked, _, _, _) <- Acton.Types.reconstruct Nothing env kchecked
+      (nmod, tchecked, _, _, _) <- Acton.Types.reconstruct Nothing Nothing env kchecked
       -- Force evaluation to trigger any lazy exceptions
       E.evaluate $ length (show tchecked)
       return ()

--- a/compiler/lsp-server/package.yaml.in
+++ b/compiler/lsp-server/package.yaml.in
@@ -40,8 +40,7 @@ executables:
     ghc-options:
       - -threaded
       - -rtsopts
-      - -with-rtsopts=-N
-      - -with-rtsopts=-A64M
+      - '"-with-rtsopts=-N -A64M"'
     when:
       - condition: os(linux) && arch(aarch64)
         ghc-options:

--- a/test/compiler/concurrent_typecheck_heavy/.gitignore
+++ b/test/compiler/concurrent_typecheck_heavy/.gitignore
@@ -1,0 +1,3 @@
+.acton.lock
+build.zig*
+out

--- a/test/compiler/concurrent_typecheck_heavy/Build.act
+++ b/test/compiler/concurrent_typecheck_heavy/Build.act
@@ -1,0 +1,2 @@
+name = "concurrent_typecheck_heavy"
+fingerprint = 0xeea9c5c5365fa9d8

--- a/test/compiler/concurrent_typecheck_heavy/src/concurrent_typecheck_heavy.act
+++ b/test/compiler/concurrent_typecheck_heavy/src/concurrent_typecheck_heavy.act
@@ -1,0 +1,1601 @@
+# Heavy total top-level module used to benchmark concurrent type checking.
+
+pure def work_001(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 1
+    v1: int = v0 + x + y + z + 2
+    v2: int = v1 + x + y + z + 3
+    v3: int = v2 + x + y + z + 4
+    v4: int = v3 + x + y + z + 5
+    v5: int = v4 + x + y + z + 6
+    v6: int = v5 + x + y + z + 7
+    v7: int = v6 + x + y + z + 8
+    v8: int = v7 + x + y + z + 9
+    v9: int = v8 + x + y + z + 10
+    v10: int = v9 + x + y + z + 11
+    v11: int = v10 + x + y + z + 12
+    v12: int = v11 + x + y + z + 13
+    v13: int = v12 + x + y + z + 14
+    v14: int = v13 + x + y + z + 15
+    v15: int = v14 + x + y + z + 16
+    v16: int = v15 + x + y + z + 17
+    return v16
+
+pure def work_002(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 2
+    v1: int = v0 + x + y + z + 3
+    v2: int = v1 + x + y + z + 4
+    v3: int = v2 + x + y + z + 5
+    v4: int = v3 + x + y + z + 6
+    v5: int = v4 + x + y + z + 7
+    v6: int = v5 + x + y + z + 8
+    v7: int = v6 + x + y + z + 9
+    v8: int = v7 + x + y + z + 10
+    v9: int = v8 + x + y + z + 11
+    v10: int = v9 + x + y + z + 12
+    v11: int = v10 + x + y + z + 13
+    v12: int = v11 + x + y + z + 14
+    v13: int = v12 + x + y + z + 15
+    v14: int = v13 + x + y + z + 16
+    v15: int = v14 + x + y + z + 17
+    v16: int = v15 + x + y + z + 18
+    return v16
+
+pure def work_003(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 3
+    v1: int = v0 + x + y + z + 4
+    v2: int = v1 + x + y + z + 5
+    v3: int = v2 + x + y + z + 6
+    v4: int = v3 + x + y + z + 7
+    v5: int = v4 + x + y + z + 8
+    v6: int = v5 + x + y + z + 9
+    v7: int = v6 + x + y + z + 10
+    v8: int = v7 + x + y + z + 11
+    v9: int = v8 + x + y + z + 12
+    v10: int = v9 + x + y + z + 13
+    v11: int = v10 + x + y + z + 14
+    v12: int = v11 + x + y + z + 15
+    v13: int = v12 + x + y + z + 16
+    v14: int = v13 + x + y + z + 17
+    v15: int = v14 + x + y + z + 18
+    v16: int = v15 + x + y + z + 19
+    return v16
+
+pure def work_004(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 4
+    v1: int = v0 + x + y + z + 5
+    v2: int = v1 + x + y + z + 6
+    v3: int = v2 + x + y + z + 7
+    v4: int = v3 + x + y + z + 8
+    v5: int = v4 + x + y + z + 9
+    v6: int = v5 + x + y + z + 10
+    v7: int = v6 + x + y + z + 11
+    v8: int = v7 + x + y + z + 12
+    v9: int = v8 + x + y + z + 13
+    v10: int = v9 + x + y + z + 14
+    v11: int = v10 + x + y + z + 15
+    v12: int = v11 + x + y + z + 16
+    v13: int = v12 + x + y + z + 17
+    v14: int = v13 + x + y + z + 18
+    v15: int = v14 + x + y + z + 19
+    v16: int = v15 + x + y + z + 20
+    return v16
+
+pure def work_005(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 5
+    v1: int = v0 + x + y + z + 6
+    v2: int = v1 + x + y + z + 7
+    v3: int = v2 + x + y + z + 8
+    v4: int = v3 + x + y + z + 9
+    v5: int = v4 + x + y + z + 10
+    v6: int = v5 + x + y + z + 11
+    v7: int = v6 + x + y + z + 12
+    v8: int = v7 + x + y + z + 13
+    v9: int = v8 + x + y + z + 14
+    v10: int = v9 + x + y + z + 15
+    v11: int = v10 + x + y + z + 16
+    v12: int = v11 + x + y + z + 17
+    v13: int = v12 + x + y + z + 18
+    v14: int = v13 + x + y + z + 19
+    v15: int = v14 + x + y + z + 20
+    v16: int = v15 + x + y + z + 21
+    return v16
+
+pure def work_006(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 6
+    v1: int = v0 + x + y + z + 7
+    v2: int = v1 + x + y + z + 8
+    v3: int = v2 + x + y + z + 9
+    v4: int = v3 + x + y + z + 10
+    v5: int = v4 + x + y + z + 11
+    v6: int = v5 + x + y + z + 12
+    v7: int = v6 + x + y + z + 13
+    v8: int = v7 + x + y + z + 14
+    v9: int = v8 + x + y + z + 15
+    v10: int = v9 + x + y + z + 16
+    v11: int = v10 + x + y + z + 17
+    v12: int = v11 + x + y + z + 18
+    v13: int = v12 + x + y + z + 19
+    v14: int = v13 + x + y + z + 20
+    v15: int = v14 + x + y + z + 21
+    v16: int = v15 + x + y + z + 22
+    return v16
+
+pure def work_007(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 7
+    v1: int = v0 + x + y + z + 8
+    v2: int = v1 + x + y + z + 9
+    v3: int = v2 + x + y + z + 10
+    v4: int = v3 + x + y + z + 11
+    v5: int = v4 + x + y + z + 12
+    v6: int = v5 + x + y + z + 13
+    v7: int = v6 + x + y + z + 14
+    v8: int = v7 + x + y + z + 15
+    v9: int = v8 + x + y + z + 16
+    v10: int = v9 + x + y + z + 17
+    v11: int = v10 + x + y + z + 18
+    v12: int = v11 + x + y + z + 19
+    v13: int = v12 + x + y + z + 20
+    v14: int = v13 + x + y + z + 21
+    v15: int = v14 + x + y + z + 22
+    v16: int = v15 + x + y + z + 23
+    return v16
+
+pure def work_008(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 8
+    v1: int = v0 + x + y + z + 9
+    v2: int = v1 + x + y + z + 10
+    v3: int = v2 + x + y + z + 11
+    v4: int = v3 + x + y + z + 12
+    v5: int = v4 + x + y + z + 13
+    v6: int = v5 + x + y + z + 14
+    v7: int = v6 + x + y + z + 15
+    v8: int = v7 + x + y + z + 16
+    v9: int = v8 + x + y + z + 17
+    v10: int = v9 + x + y + z + 18
+    v11: int = v10 + x + y + z + 19
+    v12: int = v11 + x + y + z + 20
+    v13: int = v12 + x + y + z + 21
+    v14: int = v13 + x + y + z + 22
+    v15: int = v14 + x + y + z + 23
+    v16: int = v15 + x + y + z + 24
+    return v16
+
+pure def work_009(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 9
+    v1: int = v0 + x + y + z + 10
+    v2: int = v1 + x + y + z + 11
+    v3: int = v2 + x + y + z + 12
+    v4: int = v3 + x + y + z + 13
+    v5: int = v4 + x + y + z + 14
+    v6: int = v5 + x + y + z + 15
+    v7: int = v6 + x + y + z + 16
+    v8: int = v7 + x + y + z + 17
+    v9: int = v8 + x + y + z + 18
+    v10: int = v9 + x + y + z + 19
+    v11: int = v10 + x + y + z + 20
+    v12: int = v11 + x + y + z + 21
+    v13: int = v12 + x + y + z + 22
+    v14: int = v13 + x + y + z + 23
+    v15: int = v14 + x + y + z + 24
+    v16: int = v15 + x + y + z + 25
+    return v16
+
+pure def work_010(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 10
+    v1: int = v0 + x + y + z + 11
+    v2: int = v1 + x + y + z + 12
+    v3: int = v2 + x + y + z + 13
+    v4: int = v3 + x + y + z + 14
+    v5: int = v4 + x + y + z + 15
+    v6: int = v5 + x + y + z + 16
+    v7: int = v6 + x + y + z + 17
+    v8: int = v7 + x + y + z + 18
+    v9: int = v8 + x + y + z + 19
+    v10: int = v9 + x + y + z + 20
+    v11: int = v10 + x + y + z + 21
+    v12: int = v11 + x + y + z + 22
+    v13: int = v12 + x + y + z + 23
+    v14: int = v13 + x + y + z + 24
+    v15: int = v14 + x + y + z + 25
+    v16: int = v15 + x + y + z + 26
+    return v16
+
+pure def work_011(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 11
+    v1: int = v0 + x + y + z + 12
+    v2: int = v1 + x + y + z + 13
+    v3: int = v2 + x + y + z + 14
+    v4: int = v3 + x + y + z + 15
+    v5: int = v4 + x + y + z + 16
+    v6: int = v5 + x + y + z + 17
+    v7: int = v6 + x + y + z + 18
+    v8: int = v7 + x + y + z + 19
+    v9: int = v8 + x + y + z + 20
+    v10: int = v9 + x + y + z + 21
+    v11: int = v10 + x + y + z + 22
+    v12: int = v11 + x + y + z + 23
+    v13: int = v12 + x + y + z + 24
+    v14: int = v13 + x + y + z + 25
+    v15: int = v14 + x + y + z + 26
+    v16: int = v15 + x + y + z + 27
+    return v16
+
+pure def work_012(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 12
+    v1: int = v0 + x + y + z + 13
+    v2: int = v1 + x + y + z + 14
+    v3: int = v2 + x + y + z + 15
+    v4: int = v3 + x + y + z + 16
+    v5: int = v4 + x + y + z + 17
+    v6: int = v5 + x + y + z + 18
+    v7: int = v6 + x + y + z + 19
+    v8: int = v7 + x + y + z + 20
+    v9: int = v8 + x + y + z + 21
+    v10: int = v9 + x + y + z + 22
+    v11: int = v10 + x + y + z + 23
+    v12: int = v11 + x + y + z + 24
+    v13: int = v12 + x + y + z + 25
+    v14: int = v13 + x + y + z + 26
+    v15: int = v14 + x + y + z + 27
+    v16: int = v15 + x + y + z + 28
+    return v16
+
+pure def work_013(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 13
+    v1: int = v0 + x + y + z + 14
+    v2: int = v1 + x + y + z + 15
+    v3: int = v2 + x + y + z + 16
+    v4: int = v3 + x + y + z + 17
+    v5: int = v4 + x + y + z + 18
+    v6: int = v5 + x + y + z + 19
+    v7: int = v6 + x + y + z + 20
+    v8: int = v7 + x + y + z + 21
+    v9: int = v8 + x + y + z + 22
+    v10: int = v9 + x + y + z + 23
+    v11: int = v10 + x + y + z + 24
+    v12: int = v11 + x + y + z + 25
+    v13: int = v12 + x + y + z + 26
+    v14: int = v13 + x + y + z + 27
+    v15: int = v14 + x + y + z + 28
+    v16: int = v15 + x + y + z + 29
+    return v16
+
+pure def work_014(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 14
+    v1: int = v0 + x + y + z + 15
+    v2: int = v1 + x + y + z + 16
+    v3: int = v2 + x + y + z + 17
+    v4: int = v3 + x + y + z + 18
+    v5: int = v4 + x + y + z + 19
+    v6: int = v5 + x + y + z + 20
+    v7: int = v6 + x + y + z + 21
+    v8: int = v7 + x + y + z + 22
+    v9: int = v8 + x + y + z + 23
+    v10: int = v9 + x + y + z + 24
+    v11: int = v10 + x + y + z + 25
+    v12: int = v11 + x + y + z + 26
+    v13: int = v12 + x + y + z + 27
+    v14: int = v13 + x + y + z + 28
+    v15: int = v14 + x + y + z + 29
+    v16: int = v15 + x + y + z + 30
+    return v16
+
+pure def work_015(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 15
+    v1: int = v0 + x + y + z + 16
+    v2: int = v1 + x + y + z + 17
+    v3: int = v2 + x + y + z + 18
+    v4: int = v3 + x + y + z + 19
+    v5: int = v4 + x + y + z + 20
+    v6: int = v5 + x + y + z + 21
+    v7: int = v6 + x + y + z + 22
+    v8: int = v7 + x + y + z + 23
+    v9: int = v8 + x + y + z + 24
+    v10: int = v9 + x + y + z + 25
+    v11: int = v10 + x + y + z + 26
+    v12: int = v11 + x + y + z + 27
+    v13: int = v12 + x + y + z + 28
+    v14: int = v13 + x + y + z + 29
+    v15: int = v14 + x + y + z + 30
+    v16: int = v15 + x + y + z + 31
+    return v16
+
+pure def work_016(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 16
+    v1: int = v0 + x + y + z + 17
+    v2: int = v1 + x + y + z + 18
+    v3: int = v2 + x + y + z + 19
+    v4: int = v3 + x + y + z + 20
+    v5: int = v4 + x + y + z + 21
+    v6: int = v5 + x + y + z + 22
+    v7: int = v6 + x + y + z + 23
+    v8: int = v7 + x + y + z + 24
+    v9: int = v8 + x + y + z + 25
+    v10: int = v9 + x + y + z + 26
+    v11: int = v10 + x + y + z + 27
+    v12: int = v11 + x + y + z + 28
+    v13: int = v12 + x + y + z + 29
+    v14: int = v13 + x + y + z + 30
+    v15: int = v14 + x + y + z + 31
+    v16: int = v15 + x + y + z + 32
+    return v16
+
+pure def work_017(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 17
+    v1: int = v0 + x + y + z + 18
+    v2: int = v1 + x + y + z + 19
+    v3: int = v2 + x + y + z + 20
+    v4: int = v3 + x + y + z + 21
+    v5: int = v4 + x + y + z + 22
+    v6: int = v5 + x + y + z + 23
+    v7: int = v6 + x + y + z + 24
+    v8: int = v7 + x + y + z + 25
+    v9: int = v8 + x + y + z + 26
+    v10: int = v9 + x + y + z + 27
+    v11: int = v10 + x + y + z + 28
+    v12: int = v11 + x + y + z + 29
+    v13: int = v12 + x + y + z + 30
+    v14: int = v13 + x + y + z + 31
+    v15: int = v14 + x + y + z + 32
+    v16: int = v15 + x + y + z + 33
+    return v16
+
+pure def work_018(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 18
+    v1: int = v0 + x + y + z + 19
+    v2: int = v1 + x + y + z + 20
+    v3: int = v2 + x + y + z + 21
+    v4: int = v3 + x + y + z + 22
+    v5: int = v4 + x + y + z + 23
+    v6: int = v5 + x + y + z + 24
+    v7: int = v6 + x + y + z + 25
+    v8: int = v7 + x + y + z + 26
+    v9: int = v8 + x + y + z + 27
+    v10: int = v9 + x + y + z + 28
+    v11: int = v10 + x + y + z + 29
+    v12: int = v11 + x + y + z + 30
+    v13: int = v12 + x + y + z + 31
+    v14: int = v13 + x + y + z + 32
+    v15: int = v14 + x + y + z + 33
+    v16: int = v15 + x + y + z + 34
+    return v16
+
+pure def work_019(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 19
+    v1: int = v0 + x + y + z + 20
+    v2: int = v1 + x + y + z + 21
+    v3: int = v2 + x + y + z + 22
+    v4: int = v3 + x + y + z + 23
+    v5: int = v4 + x + y + z + 24
+    v6: int = v5 + x + y + z + 25
+    v7: int = v6 + x + y + z + 26
+    v8: int = v7 + x + y + z + 27
+    v9: int = v8 + x + y + z + 28
+    v10: int = v9 + x + y + z + 29
+    v11: int = v10 + x + y + z + 30
+    v12: int = v11 + x + y + z + 31
+    v13: int = v12 + x + y + z + 32
+    v14: int = v13 + x + y + z + 33
+    v15: int = v14 + x + y + z + 34
+    v16: int = v15 + x + y + z + 35
+    return v16
+
+pure def work_020(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 20
+    v1: int = v0 + x + y + z + 21
+    v2: int = v1 + x + y + z + 22
+    v3: int = v2 + x + y + z + 23
+    v4: int = v3 + x + y + z + 24
+    v5: int = v4 + x + y + z + 25
+    v6: int = v5 + x + y + z + 26
+    v7: int = v6 + x + y + z + 27
+    v8: int = v7 + x + y + z + 28
+    v9: int = v8 + x + y + z + 29
+    v10: int = v9 + x + y + z + 30
+    v11: int = v10 + x + y + z + 31
+    v12: int = v11 + x + y + z + 32
+    v13: int = v12 + x + y + z + 33
+    v14: int = v13 + x + y + z + 34
+    v15: int = v14 + x + y + z + 35
+    v16: int = v15 + x + y + z + 36
+    return v16
+
+pure def work_021(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 21
+    v1: int = v0 + x + y + z + 22
+    v2: int = v1 + x + y + z + 23
+    v3: int = v2 + x + y + z + 24
+    v4: int = v3 + x + y + z + 25
+    v5: int = v4 + x + y + z + 26
+    v6: int = v5 + x + y + z + 27
+    v7: int = v6 + x + y + z + 28
+    v8: int = v7 + x + y + z + 29
+    v9: int = v8 + x + y + z + 30
+    v10: int = v9 + x + y + z + 31
+    v11: int = v10 + x + y + z + 32
+    v12: int = v11 + x + y + z + 33
+    v13: int = v12 + x + y + z + 34
+    v14: int = v13 + x + y + z + 35
+    v15: int = v14 + x + y + z + 36
+    v16: int = v15 + x + y + z + 37
+    return v16
+
+pure def work_022(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 22
+    v1: int = v0 + x + y + z + 23
+    v2: int = v1 + x + y + z + 24
+    v3: int = v2 + x + y + z + 25
+    v4: int = v3 + x + y + z + 26
+    v5: int = v4 + x + y + z + 27
+    v6: int = v5 + x + y + z + 28
+    v7: int = v6 + x + y + z + 29
+    v8: int = v7 + x + y + z + 30
+    v9: int = v8 + x + y + z + 31
+    v10: int = v9 + x + y + z + 32
+    v11: int = v10 + x + y + z + 33
+    v12: int = v11 + x + y + z + 34
+    v13: int = v12 + x + y + z + 35
+    v14: int = v13 + x + y + z + 36
+    v15: int = v14 + x + y + z + 37
+    v16: int = v15 + x + y + z + 38
+    return v16
+
+pure def work_023(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 23
+    v1: int = v0 + x + y + z + 24
+    v2: int = v1 + x + y + z + 25
+    v3: int = v2 + x + y + z + 26
+    v4: int = v3 + x + y + z + 27
+    v5: int = v4 + x + y + z + 28
+    v6: int = v5 + x + y + z + 29
+    v7: int = v6 + x + y + z + 30
+    v8: int = v7 + x + y + z + 31
+    v9: int = v8 + x + y + z + 32
+    v10: int = v9 + x + y + z + 33
+    v11: int = v10 + x + y + z + 34
+    v12: int = v11 + x + y + z + 35
+    v13: int = v12 + x + y + z + 36
+    v14: int = v13 + x + y + z + 37
+    v15: int = v14 + x + y + z + 38
+    v16: int = v15 + x + y + z + 39
+    return v16
+
+pure def work_024(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 24
+    v1: int = v0 + x + y + z + 25
+    v2: int = v1 + x + y + z + 26
+    v3: int = v2 + x + y + z + 27
+    v4: int = v3 + x + y + z + 28
+    v5: int = v4 + x + y + z + 29
+    v6: int = v5 + x + y + z + 30
+    v7: int = v6 + x + y + z + 31
+    v8: int = v7 + x + y + z + 32
+    v9: int = v8 + x + y + z + 33
+    v10: int = v9 + x + y + z + 34
+    v11: int = v10 + x + y + z + 35
+    v12: int = v11 + x + y + z + 36
+    v13: int = v12 + x + y + z + 37
+    v14: int = v13 + x + y + z + 38
+    v15: int = v14 + x + y + z + 39
+    v16: int = v15 + x + y + z + 40
+    return v16
+
+pure def work_025(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 25
+    v1: int = v0 + x + y + z + 26
+    v2: int = v1 + x + y + z + 27
+    v3: int = v2 + x + y + z + 28
+    v4: int = v3 + x + y + z + 29
+    v5: int = v4 + x + y + z + 30
+    v6: int = v5 + x + y + z + 31
+    v7: int = v6 + x + y + z + 32
+    v8: int = v7 + x + y + z + 33
+    v9: int = v8 + x + y + z + 34
+    v10: int = v9 + x + y + z + 35
+    v11: int = v10 + x + y + z + 36
+    v12: int = v11 + x + y + z + 37
+    v13: int = v12 + x + y + z + 38
+    v14: int = v13 + x + y + z + 39
+    v15: int = v14 + x + y + z + 40
+    v16: int = v15 + x + y + z + 41
+    return v16
+
+pure def work_026(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 26
+    v1: int = v0 + x + y + z + 27
+    v2: int = v1 + x + y + z + 28
+    v3: int = v2 + x + y + z + 29
+    v4: int = v3 + x + y + z + 30
+    v5: int = v4 + x + y + z + 31
+    v6: int = v5 + x + y + z + 32
+    v7: int = v6 + x + y + z + 33
+    v8: int = v7 + x + y + z + 34
+    v9: int = v8 + x + y + z + 35
+    v10: int = v9 + x + y + z + 36
+    v11: int = v10 + x + y + z + 37
+    v12: int = v11 + x + y + z + 38
+    v13: int = v12 + x + y + z + 39
+    v14: int = v13 + x + y + z + 40
+    v15: int = v14 + x + y + z + 41
+    v16: int = v15 + x + y + z + 42
+    return v16
+
+pure def work_027(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 27
+    v1: int = v0 + x + y + z + 28
+    v2: int = v1 + x + y + z + 29
+    v3: int = v2 + x + y + z + 30
+    v4: int = v3 + x + y + z + 31
+    v5: int = v4 + x + y + z + 32
+    v6: int = v5 + x + y + z + 33
+    v7: int = v6 + x + y + z + 34
+    v8: int = v7 + x + y + z + 35
+    v9: int = v8 + x + y + z + 36
+    v10: int = v9 + x + y + z + 37
+    v11: int = v10 + x + y + z + 38
+    v12: int = v11 + x + y + z + 39
+    v13: int = v12 + x + y + z + 40
+    v14: int = v13 + x + y + z + 41
+    v15: int = v14 + x + y + z + 42
+    v16: int = v15 + x + y + z + 43
+    return v16
+
+pure def work_028(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 28
+    v1: int = v0 + x + y + z + 29
+    v2: int = v1 + x + y + z + 30
+    v3: int = v2 + x + y + z + 31
+    v4: int = v3 + x + y + z + 32
+    v5: int = v4 + x + y + z + 33
+    v6: int = v5 + x + y + z + 34
+    v7: int = v6 + x + y + z + 35
+    v8: int = v7 + x + y + z + 36
+    v9: int = v8 + x + y + z + 37
+    v10: int = v9 + x + y + z + 38
+    v11: int = v10 + x + y + z + 39
+    v12: int = v11 + x + y + z + 40
+    v13: int = v12 + x + y + z + 41
+    v14: int = v13 + x + y + z + 42
+    v15: int = v14 + x + y + z + 43
+    v16: int = v15 + x + y + z + 44
+    return v16
+
+pure def work_029(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 29
+    v1: int = v0 + x + y + z + 30
+    v2: int = v1 + x + y + z + 31
+    v3: int = v2 + x + y + z + 32
+    v4: int = v3 + x + y + z + 33
+    v5: int = v4 + x + y + z + 34
+    v6: int = v5 + x + y + z + 35
+    v7: int = v6 + x + y + z + 36
+    v8: int = v7 + x + y + z + 37
+    v9: int = v8 + x + y + z + 38
+    v10: int = v9 + x + y + z + 39
+    v11: int = v10 + x + y + z + 40
+    v12: int = v11 + x + y + z + 41
+    v13: int = v12 + x + y + z + 42
+    v14: int = v13 + x + y + z + 43
+    v15: int = v14 + x + y + z + 44
+    v16: int = v15 + x + y + z + 45
+    return v16
+
+pure def work_030(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 30
+    v1: int = v0 + x + y + z + 31
+    v2: int = v1 + x + y + z + 32
+    v3: int = v2 + x + y + z + 33
+    v4: int = v3 + x + y + z + 34
+    v5: int = v4 + x + y + z + 35
+    v6: int = v5 + x + y + z + 36
+    v7: int = v6 + x + y + z + 37
+    v8: int = v7 + x + y + z + 38
+    v9: int = v8 + x + y + z + 39
+    v10: int = v9 + x + y + z + 40
+    v11: int = v10 + x + y + z + 41
+    v12: int = v11 + x + y + z + 42
+    v13: int = v12 + x + y + z + 43
+    v14: int = v13 + x + y + z + 44
+    v15: int = v14 + x + y + z + 45
+    v16: int = v15 + x + y + z + 46
+    return v16
+
+pure def work_031(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 31
+    v1: int = v0 + x + y + z + 32
+    v2: int = v1 + x + y + z + 33
+    v3: int = v2 + x + y + z + 34
+    v4: int = v3 + x + y + z + 35
+    v5: int = v4 + x + y + z + 36
+    v6: int = v5 + x + y + z + 37
+    v7: int = v6 + x + y + z + 38
+    v8: int = v7 + x + y + z + 39
+    v9: int = v8 + x + y + z + 40
+    v10: int = v9 + x + y + z + 41
+    v11: int = v10 + x + y + z + 42
+    v12: int = v11 + x + y + z + 43
+    v13: int = v12 + x + y + z + 44
+    v14: int = v13 + x + y + z + 45
+    v15: int = v14 + x + y + z + 46
+    v16: int = v15 + x + y + z + 47
+    return v16
+
+pure def work_032(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 32
+    v1: int = v0 + x + y + z + 33
+    v2: int = v1 + x + y + z + 34
+    v3: int = v2 + x + y + z + 35
+    v4: int = v3 + x + y + z + 36
+    v5: int = v4 + x + y + z + 37
+    v6: int = v5 + x + y + z + 38
+    v7: int = v6 + x + y + z + 39
+    v8: int = v7 + x + y + z + 40
+    v9: int = v8 + x + y + z + 41
+    v10: int = v9 + x + y + z + 42
+    v11: int = v10 + x + y + z + 43
+    v12: int = v11 + x + y + z + 44
+    v13: int = v12 + x + y + z + 45
+    v14: int = v13 + x + y + z + 46
+    v15: int = v14 + x + y + z + 47
+    v16: int = v15 + x + y + z + 48
+    return v16
+
+pure def work_033(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 33
+    v1: int = v0 + x + y + z + 34
+    v2: int = v1 + x + y + z + 35
+    v3: int = v2 + x + y + z + 36
+    v4: int = v3 + x + y + z + 37
+    v5: int = v4 + x + y + z + 38
+    v6: int = v5 + x + y + z + 39
+    v7: int = v6 + x + y + z + 40
+    v8: int = v7 + x + y + z + 41
+    v9: int = v8 + x + y + z + 42
+    v10: int = v9 + x + y + z + 43
+    v11: int = v10 + x + y + z + 44
+    v12: int = v11 + x + y + z + 45
+    v13: int = v12 + x + y + z + 46
+    v14: int = v13 + x + y + z + 47
+    v15: int = v14 + x + y + z + 48
+    v16: int = v15 + x + y + z + 49
+    return v16
+
+pure def work_034(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 34
+    v1: int = v0 + x + y + z + 35
+    v2: int = v1 + x + y + z + 36
+    v3: int = v2 + x + y + z + 37
+    v4: int = v3 + x + y + z + 38
+    v5: int = v4 + x + y + z + 39
+    v6: int = v5 + x + y + z + 40
+    v7: int = v6 + x + y + z + 41
+    v8: int = v7 + x + y + z + 42
+    v9: int = v8 + x + y + z + 43
+    v10: int = v9 + x + y + z + 44
+    v11: int = v10 + x + y + z + 45
+    v12: int = v11 + x + y + z + 46
+    v13: int = v12 + x + y + z + 47
+    v14: int = v13 + x + y + z + 48
+    v15: int = v14 + x + y + z + 49
+    v16: int = v15 + x + y + z + 50
+    return v16
+
+pure def work_035(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 35
+    v1: int = v0 + x + y + z + 36
+    v2: int = v1 + x + y + z + 37
+    v3: int = v2 + x + y + z + 38
+    v4: int = v3 + x + y + z + 39
+    v5: int = v4 + x + y + z + 40
+    v6: int = v5 + x + y + z + 41
+    v7: int = v6 + x + y + z + 42
+    v8: int = v7 + x + y + z + 43
+    v9: int = v8 + x + y + z + 44
+    v10: int = v9 + x + y + z + 45
+    v11: int = v10 + x + y + z + 46
+    v12: int = v11 + x + y + z + 47
+    v13: int = v12 + x + y + z + 48
+    v14: int = v13 + x + y + z + 49
+    v15: int = v14 + x + y + z + 50
+    v16: int = v15 + x + y + z + 51
+    return v16
+
+pure def work_036(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 36
+    v1: int = v0 + x + y + z + 37
+    v2: int = v1 + x + y + z + 38
+    v3: int = v2 + x + y + z + 39
+    v4: int = v3 + x + y + z + 40
+    v5: int = v4 + x + y + z + 41
+    v6: int = v5 + x + y + z + 42
+    v7: int = v6 + x + y + z + 43
+    v8: int = v7 + x + y + z + 44
+    v9: int = v8 + x + y + z + 45
+    v10: int = v9 + x + y + z + 46
+    v11: int = v10 + x + y + z + 47
+    v12: int = v11 + x + y + z + 48
+    v13: int = v12 + x + y + z + 49
+    v14: int = v13 + x + y + z + 50
+    v15: int = v14 + x + y + z + 51
+    v16: int = v15 + x + y + z + 52
+    return v16
+
+pure def work_037(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 37
+    v1: int = v0 + x + y + z + 38
+    v2: int = v1 + x + y + z + 39
+    v3: int = v2 + x + y + z + 40
+    v4: int = v3 + x + y + z + 41
+    v5: int = v4 + x + y + z + 42
+    v6: int = v5 + x + y + z + 43
+    v7: int = v6 + x + y + z + 44
+    v8: int = v7 + x + y + z + 45
+    v9: int = v8 + x + y + z + 46
+    v10: int = v9 + x + y + z + 47
+    v11: int = v10 + x + y + z + 48
+    v12: int = v11 + x + y + z + 49
+    v13: int = v12 + x + y + z + 50
+    v14: int = v13 + x + y + z + 51
+    v15: int = v14 + x + y + z + 52
+    v16: int = v15 + x + y + z + 53
+    return v16
+
+pure def work_038(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 38
+    v1: int = v0 + x + y + z + 39
+    v2: int = v1 + x + y + z + 40
+    v3: int = v2 + x + y + z + 41
+    v4: int = v3 + x + y + z + 42
+    v5: int = v4 + x + y + z + 43
+    v6: int = v5 + x + y + z + 44
+    v7: int = v6 + x + y + z + 45
+    v8: int = v7 + x + y + z + 46
+    v9: int = v8 + x + y + z + 47
+    v10: int = v9 + x + y + z + 48
+    v11: int = v10 + x + y + z + 49
+    v12: int = v11 + x + y + z + 50
+    v13: int = v12 + x + y + z + 51
+    v14: int = v13 + x + y + z + 52
+    v15: int = v14 + x + y + z + 53
+    v16: int = v15 + x + y + z + 54
+    return v16
+
+pure def work_039(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 39
+    v1: int = v0 + x + y + z + 40
+    v2: int = v1 + x + y + z + 41
+    v3: int = v2 + x + y + z + 42
+    v4: int = v3 + x + y + z + 43
+    v5: int = v4 + x + y + z + 44
+    v6: int = v5 + x + y + z + 45
+    v7: int = v6 + x + y + z + 46
+    v8: int = v7 + x + y + z + 47
+    v9: int = v8 + x + y + z + 48
+    v10: int = v9 + x + y + z + 49
+    v11: int = v10 + x + y + z + 50
+    v12: int = v11 + x + y + z + 51
+    v13: int = v12 + x + y + z + 52
+    v14: int = v13 + x + y + z + 53
+    v15: int = v14 + x + y + z + 54
+    v16: int = v15 + x + y + z + 55
+    return v16
+
+pure def work_040(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 40
+    v1: int = v0 + x + y + z + 41
+    v2: int = v1 + x + y + z + 42
+    v3: int = v2 + x + y + z + 43
+    v4: int = v3 + x + y + z + 44
+    v5: int = v4 + x + y + z + 45
+    v6: int = v5 + x + y + z + 46
+    v7: int = v6 + x + y + z + 47
+    v8: int = v7 + x + y + z + 48
+    v9: int = v8 + x + y + z + 49
+    v10: int = v9 + x + y + z + 50
+    v11: int = v10 + x + y + z + 51
+    v12: int = v11 + x + y + z + 52
+    v13: int = v12 + x + y + z + 53
+    v14: int = v13 + x + y + z + 54
+    v15: int = v14 + x + y + z + 55
+    v16: int = v15 + x + y + z + 56
+    return v16
+
+pure def work_041(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 41
+    v1: int = v0 + x + y + z + 42
+    v2: int = v1 + x + y + z + 43
+    v3: int = v2 + x + y + z + 44
+    v4: int = v3 + x + y + z + 45
+    v5: int = v4 + x + y + z + 46
+    v6: int = v5 + x + y + z + 47
+    v7: int = v6 + x + y + z + 48
+    v8: int = v7 + x + y + z + 49
+    v9: int = v8 + x + y + z + 50
+    v10: int = v9 + x + y + z + 51
+    v11: int = v10 + x + y + z + 52
+    v12: int = v11 + x + y + z + 53
+    v13: int = v12 + x + y + z + 54
+    v14: int = v13 + x + y + z + 55
+    v15: int = v14 + x + y + z + 56
+    v16: int = v15 + x + y + z + 57
+    return v16
+
+pure def work_042(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 42
+    v1: int = v0 + x + y + z + 43
+    v2: int = v1 + x + y + z + 44
+    v3: int = v2 + x + y + z + 45
+    v4: int = v3 + x + y + z + 46
+    v5: int = v4 + x + y + z + 47
+    v6: int = v5 + x + y + z + 48
+    v7: int = v6 + x + y + z + 49
+    v8: int = v7 + x + y + z + 50
+    v9: int = v8 + x + y + z + 51
+    v10: int = v9 + x + y + z + 52
+    v11: int = v10 + x + y + z + 53
+    v12: int = v11 + x + y + z + 54
+    v13: int = v12 + x + y + z + 55
+    v14: int = v13 + x + y + z + 56
+    v15: int = v14 + x + y + z + 57
+    v16: int = v15 + x + y + z + 58
+    return v16
+
+pure def work_043(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 43
+    v1: int = v0 + x + y + z + 44
+    v2: int = v1 + x + y + z + 45
+    v3: int = v2 + x + y + z + 46
+    v4: int = v3 + x + y + z + 47
+    v5: int = v4 + x + y + z + 48
+    v6: int = v5 + x + y + z + 49
+    v7: int = v6 + x + y + z + 50
+    v8: int = v7 + x + y + z + 51
+    v9: int = v8 + x + y + z + 52
+    v10: int = v9 + x + y + z + 53
+    v11: int = v10 + x + y + z + 54
+    v12: int = v11 + x + y + z + 55
+    v13: int = v12 + x + y + z + 56
+    v14: int = v13 + x + y + z + 57
+    v15: int = v14 + x + y + z + 58
+    v16: int = v15 + x + y + z + 59
+    return v16
+
+pure def work_044(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 44
+    v1: int = v0 + x + y + z + 45
+    v2: int = v1 + x + y + z + 46
+    v3: int = v2 + x + y + z + 47
+    v4: int = v3 + x + y + z + 48
+    v5: int = v4 + x + y + z + 49
+    v6: int = v5 + x + y + z + 50
+    v7: int = v6 + x + y + z + 51
+    v8: int = v7 + x + y + z + 52
+    v9: int = v8 + x + y + z + 53
+    v10: int = v9 + x + y + z + 54
+    v11: int = v10 + x + y + z + 55
+    v12: int = v11 + x + y + z + 56
+    v13: int = v12 + x + y + z + 57
+    v14: int = v13 + x + y + z + 58
+    v15: int = v14 + x + y + z + 59
+    v16: int = v15 + x + y + z + 60
+    return v16
+
+pure def work_045(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 45
+    v1: int = v0 + x + y + z + 46
+    v2: int = v1 + x + y + z + 47
+    v3: int = v2 + x + y + z + 48
+    v4: int = v3 + x + y + z + 49
+    v5: int = v4 + x + y + z + 50
+    v6: int = v5 + x + y + z + 51
+    v7: int = v6 + x + y + z + 52
+    v8: int = v7 + x + y + z + 53
+    v9: int = v8 + x + y + z + 54
+    v10: int = v9 + x + y + z + 55
+    v11: int = v10 + x + y + z + 56
+    v12: int = v11 + x + y + z + 57
+    v13: int = v12 + x + y + z + 58
+    v14: int = v13 + x + y + z + 59
+    v15: int = v14 + x + y + z + 60
+    v16: int = v15 + x + y + z + 61
+    return v16
+
+pure def work_046(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 46
+    v1: int = v0 + x + y + z + 47
+    v2: int = v1 + x + y + z + 48
+    v3: int = v2 + x + y + z + 49
+    v4: int = v3 + x + y + z + 50
+    v5: int = v4 + x + y + z + 51
+    v6: int = v5 + x + y + z + 52
+    v7: int = v6 + x + y + z + 53
+    v8: int = v7 + x + y + z + 54
+    v9: int = v8 + x + y + z + 55
+    v10: int = v9 + x + y + z + 56
+    v11: int = v10 + x + y + z + 57
+    v12: int = v11 + x + y + z + 58
+    v13: int = v12 + x + y + z + 59
+    v14: int = v13 + x + y + z + 60
+    v15: int = v14 + x + y + z + 61
+    v16: int = v15 + x + y + z + 62
+    return v16
+
+pure def work_047(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 47
+    v1: int = v0 + x + y + z + 48
+    v2: int = v1 + x + y + z + 49
+    v3: int = v2 + x + y + z + 50
+    v4: int = v3 + x + y + z + 51
+    v5: int = v4 + x + y + z + 52
+    v6: int = v5 + x + y + z + 53
+    v7: int = v6 + x + y + z + 54
+    v8: int = v7 + x + y + z + 55
+    v9: int = v8 + x + y + z + 56
+    v10: int = v9 + x + y + z + 57
+    v11: int = v10 + x + y + z + 58
+    v12: int = v11 + x + y + z + 59
+    v13: int = v12 + x + y + z + 60
+    v14: int = v13 + x + y + z + 61
+    v15: int = v14 + x + y + z + 62
+    v16: int = v15 + x + y + z + 63
+    return v16
+
+pure def work_048(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 48
+    v1: int = v0 + x + y + z + 49
+    v2: int = v1 + x + y + z + 50
+    v3: int = v2 + x + y + z + 51
+    v4: int = v3 + x + y + z + 52
+    v5: int = v4 + x + y + z + 53
+    v6: int = v5 + x + y + z + 54
+    v7: int = v6 + x + y + z + 55
+    v8: int = v7 + x + y + z + 56
+    v9: int = v8 + x + y + z + 57
+    v10: int = v9 + x + y + z + 58
+    v11: int = v10 + x + y + z + 59
+    v12: int = v11 + x + y + z + 60
+    v13: int = v12 + x + y + z + 61
+    v14: int = v13 + x + y + z + 62
+    v15: int = v14 + x + y + z + 63
+    v16: int = v15 + x + y + z + 64
+    return v16
+
+pure def work_049(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 49
+    v1: int = v0 + x + y + z + 50
+    v2: int = v1 + x + y + z + 51
+    v3: int = v2 + x + y + z + 52
+    v4: int = v3 + x + y + z + 53
+    v5: int = v4 + x + y + z + 54
+    v6: int = v5 + x + y + z + 55
+    v7: int = v6 + x + y + z + 56
+    v8: int = v7 + x + y + z + 57
+    v9: int = v8 + x + y + z + 58
+    v10: int = v9 + x + y + z + 59
+    v11: int = v10 + x + y + z + 60
+    v12: int = v11 + x + y + z + 61
+    v13: int = v12 + x + y + z + 62
+    v14: int = v13 + x + y + z + 63
+    v15: int = v14 + x + y + z + 64
+    v16: int = v15 + x + y + z + 65
+    return v16
+
+pure def work_050(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 50
+    v1: int = v0 + x + y + z + 51
+    v2: int = v1 + x + y + z + 52
+    v3: int = v2 + x + y + z + 53
+    v4: int = v3 + x + y + z + 54
+    v5: int = v4 + x + y + z + 55
+    v6: int = v5 + x + y + z + 56
+    v7: int = v6 + x + y + z + 57
+    v8: int = v7 + x + y + z + 58
+    v9: int = v8 + x + y + z + 59
+    v10: int = v9 + x + y + z + 60
+    v11: int = v10 + x + y + z + 61
+    v12: int = v11 + x + y + z + 62
+    v13: int = v12 + x + y + z + 63
+    v14: int = v13 + x + y + z + 64
+    v15: int = v14 + x + y + z + 65
+    v16: int = v15 + x + y + z + 66
+    return v16
+
+pure def work_051(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 51
+    v1: int = v0 + x + y + z + 52
+    v2: int = v1 + x + y + z + 53
+    v3: int = v2 + x + y + z + 54
+    v4: int = v3 + x + y + z + 55
+    v5: int = v4 + x + y + z + 56
+    v6: int = v5 + x + y + z + 57
+    v7: int = v6 + x + y + z + 58
+    v8: int = v7 + x + y + z + 59
+    v9: int = v8 + x + y + z + 60
+    v10: int = v9 + x + y + z + 61
+    v11: int = v10 + x + y + z + 62
+    v12: int = v11 + x + y + z + 63
+    v13: int = v12 + x + y + z + 64
+    v14: int = v13 + x + y + z + 65
+    v15: int = v14 + x + y + z + 66
+    v16: int = v15 + x + y + z + 67
+    return v16
+
+pure def work_052(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 52
+    v1: int = v0 + x + y + z + 53
+    v2: int = v1 + x + y + z + 54
+    v3: int = v2 + x + y + z + 55
+    v4: int = v3 + x + y + z + 56
+    v5: int = v4 + x + y + z + 57
+    v6: int = v5 + x + y + z + 58
+    v7: int = v6 + x + y + z + 59
+    v8: int = v7 + x + y + z + 60
+    v9: int = v8 + x + y + z + 61
+    v10: int = v9 + x + y + z + 62
+    v11: int = v10 + x + y + z + 63
+    v12: int = v11 + x + y + z + 64
+    v13: int = v12 + x + y + z + 65
+    v14: int = v13 + x + y + z + 66
+    v15: int = v14 + x + y + z + 67
+    v16: int = v15 + x + y + z + 68
+    return v16
+
+pure def work_053(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 53
+    v1: int = v0 + x + y + z + 54
+    v2: int = v1 + x + y + z + 55
+    v3: int = v2 + x + y + z + 56
+    v4: int = v3 + x + y + z + 57
+    v5: int = v4 + x + y + z + 58
+    v6: int = v5 + x + y + z + 59
+    v7: int = v6 + x + y + z + 60
+    v8: int = v7 + x + y + z + 61
+    v9: int = v8 + x + y + z + 62
+    v10: int = v9 + x + y + z + 63
+    v11: int = v10 + x + y + z + 64
+    v12: int = v11 + x + y + z + 65
+    v13: int = v12 + x + y + z + 66
+    v14: int = v13 + x + y + z + 67
+    v15: int = v14 + x + y + z + 68
+    v16: int = v15 + x + y + z + 69
+    return v16
+
+pure def work_054(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 54
+    v1: int = v0 + x + y + z + 55
+    v2: int = v1 + x + y + z + 56
+    v3: int = v2 + x + y + z + 57
+    v4: int = v3 + x + y + z + 58
+    v5: int = v4 + x + y + z + 59
+    v6: int = v5 + x + y + z + 60
+    v7: int = v6 + x + y + z + 61
+    v8: int = v7 + x + y + z + 62
+    v9: int = v8 + x + y + z + 63
+    v10: int = v9 + x + y + z + 64
+    v11: int = v10 + x + y + z + 65
+    v12: int = v11 + x + y + z + 66
+    v13: int = v12 + x + y + z + 67
+    v14: int = v13 + x + y + z + 68
+    v15: int = v14 + x + y + z + 69
+    v16: int = v15 + x + y + z + 70
+    return v16
+
+pure def work_055(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 55
+    v1: int = v0 + x + y + z + 56
+    v2: int = v1 + x + y + z + 57
+    v3: int = v2 + x + y + z + 58
+    v4: int = v3 + x + y + z + 59
+    v5: int = v4 + x + y + z + 60
+    v6: int = v5 + x + y + z + 61
+    v7: int = v6 + x + y + z + 62
+    v8: int = v7 + x + y + z + 63
+    v9: int = v8 + x + y + z + 64
+    v10: int = v9 + x + y + z + 65
+    v11: int = v10 + x + y + z + 66
+    v12: int = v11 + x + y + z + 67
+    v13: int = v12 + x + y + z + 68
+    v14: int = v13 + x + y + z + 69
+    v15: int = v14 + x + y + z + 70
+    v16: int = v15 + x + y + z + 71
+    return v16
+
+pure def work_056(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 56
+    v1: int = v0 + x + y + z + 57
+    v2: int = v1 + x + y + z + 58
+    v3: int = v2 + x + y + z + 59
+    v4: int = v3 + x + y + z + 60
+    v5: int = v4 + x + y + z + 61
+    v6: int = v5 + x + y + z + 62
+    v7: int = v6 + x + y + z + 63
+    v8: int = v7 + x + y + z + 64
+    v9: int = v8 + x + y + z + 65
+    v10: int = v9 + x + y + z + 66
+    v11: int = v10 + x + y + z + 67
+    v12: int = v11 + x + y + z + 68
+    v13: int = v12 + x + y + z + 69
+    v14: int = v13 + x + y + z + 70
+    v15: int = v14 + x + y + z + 71
+    v16: int = v15 + x + y + z + 72
+    return v16
+
+pure def work_057(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 57
+    v1: int = v0 + x + y + z + 58
+    v2: int = v1 + x + y + z + 59
+    v3: int = v2 + x + y + z + 60
+    v4: int = v3 + x + y + z + 61
+    v5: int = v4 + x + y + z + 62
+    v6: int = v5 + x + y + z + 63
+    v7: int = v6 + x + y + z + 64
+    v8: int = v7 + x + y + z + 65
+    v9: int = v8 + x + y + z + 66
+    v10: int = v9 + x + y + z + 67
+    v11: int = v10 + x + y + z + 68
+    v12: int = v11 + x + y + z + 69
+    v13: int = v12 + x + y + z + 70
+    v14: int = v13 + x + y + z + 71
+    v15: int = v14 + x + y + z + 72
+    v16: int = v15 + x + y + z + 73
+    return v16
+
+pure def work_058(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 58
+    v1: int = v0 + x + y + z + 59
+    v2: int = v1 + x + y + z + 60
+    v3: int = v2 + x + y + z + 61
+    v4: int = v3 + x + y + z + 62
+    v5: int = v4 + x + y + z + 63
+    v6: int = v5 + x + y + z + 64
+    v7: int = v6 + x + y + z + 65
+    v8: int = v7 + x + y + z + 66
+    v9: int = v8 + x + y + z + 67
+    v10: int = v9 + x + y + z + 68
+    v11: int = v10 + x + y + z + 69
+    v12: int = v11 + x + y + z + 70
+    v13: int = v12 + x + y + z + 71
+    v14: int = v13 + x + y + z + 72
+    v15: int = v14 + x + y + z + 73
+    v16: int = v15 + x + y + z + 74
+    return v16
+
+pure def work_059(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 59
+    v1: int = v0 + x + y + z + 60
+    v2: int = v1 + x + y + z + 61
+    v3: int = v2 + x + y + z + 62
+    v4: int = v3 + x + y + z + 63
+    v5: int = v4 + x + y + z + 64
+    v6: int = v5 + x + y + z + 65
+    v7: int = v6 + x + y + z + 66
+    v8: int = v7 + x + y + z + 67
+    v9: int = v8 + x + y + z + 68
+    v10: int = v9 + x + y + z + 69
+    v11: int = v10 + x + y + z + 70
+    v12: int = v11 + x + y + z + 71
+    v13: int = v12 + x + y + z + 72
+    v14: int = v13 + x + y + z + 73
+    v15: int = v14 + x + y + z + 74
+    v16: int = v15 + x + y + z + 75
+    return v16
+
+pure def work_060(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 60
+    v1: int = v0 + x + y + z + 61
+    v2: int = v1 + x + y + z + 62
+    v3: int = v2 + x + y + z + 63
+    v4: int = v3 + x + y + z + 64
+    v5: int = v4 + x + y + z + 65
+    v6: int = v5 + x + y + z + 66
+    v7: int = v6 + x + y + z + 67
+    v8: int = v7 + x + y + z + 68
+    v9: int = v8 + x + y + z + 69
+    v10: int = v9 + x + y + z + 70
+    v11: int = v10 + x + y + z + 71
+    v12: int = v11 + x + y + z + 72
+    v13: int = v12 + x + y + z + 73
+    v14: int = v13 + x + y + z + 74
+    v15: int = v14 + x + y + z + 75
+    v16: int = v15 + x + y + z + 76
+    return v16
+
+pure def work_061(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 61
+    v1: int = v0 + x + y + z + 62
+    v2: int = v1 + x + y + z + 63
+    v3: int = v2 + x + y + z + 64
+    v4: int = v3 + x + y + z + 65
+    v5: int = v4 + x + y + z + 66
+    v6: int = v5 + x + y + z + 67
+    v7: int = v6 + x + y + z + 68
+    v8: int = v7 + x + y + z + 69
+    v9: int = v8 + x + y + z + 70
+    v10: int = v9 + x + y + z + 71
+    v11: int = v10 + x + y + z + 72
+    v12: int = v11 + x + y + z + 73
+    v13: int = v12 + x + y + z + 74
+    v14: int = v13 + x + y + z + 75
+    v15: int = v14 + x + y + z + 76
+    v16: int = v15 + x + y + z + 77
+    return v16
+
+pure def work_062(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 62
+    v1: int = v0 + x + y + z + 63
+    v2: int = v1 + x + y + z + 64
+    v3: int = v2 + x + y + z + 65
+    v4: int = v3 + x + y + z + 66
+    v5: int = v4 + x + y + z + 67
+    v6: int = v5 + x + y + z + 68
+    v7: int = v6 + x + y + z + 69
+    v8: int = v7 + x + y + z + 70
+    v9: int = v8 + x + y + z + 71
+    v10: int = v9 + x + y + z + 72
+    v11: int = v10 + x + y + z + 73
+    v12: int = v11 + x + y + z + 74
+    v13: int = v12 + x + y + z + 75
+    v14: int = v13 + x + y + z + 76
+    v15: int = v14 + x + y + z + 77
+    v16: int = v15 + x + y + z + 78
+    return v16
+
+pure def work_063(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 63
+    v1: int = v0 + x + y + z + 64
+    v2: int = v1 + x + y + z + 65
+    v3: int = v2 + x + y + z + 66
+    v4: int = v3 + x + y + z + 67
+    v5: int = v4 + x + y + z + 68
+    v6: int = v5 + x + y + z + 69
+    v7: int = v6 + x + y + z + 70
+    v8: int = v7 + x + y + z + 71
+    v9: int = v8 + x + y + z + 72
+    v10: int = v9 + x + y + z + 73
+    v11: int = v10 + x + y + z + 74
+    v12: int = v11 + x + y + z + 75
+    v13: int = v12 + x + y + z + 76
+    v14: int = v13 + x + y + z + 77
+    v15: int = v14 + x + y + z + 78
+    v16: int = v15 + x + y + z + 79
+    return v16
+
+pure def work_064(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 64
+    v1: int = v0 + x + y + z + 65
+    v2: int = v1 + x + y + z + 66
+    v3: int = v2 + x + y + z + 67
+    v4: int = v3 + x + y + z + 68
+    v5: int = v4 + x + y + z + 69
+    v6: int = v5 + x + y + z + 70
+    v7: int = v6 + x + y + z + 71
+    v8: int = v7 + x + y + z + 72
+    v9: int = v8 + x + y + z + 73
+    v10: int = v9 + x + y + z + 74
+    v11: int = v10 + x + y + z + 75
+    v12: int = v11 + x + y + z + 76
+    v13: int = v12 + x + y + z + 77
+    v14: int = v13 + x + y + z + 78
+    v15: int = v14 + x + y + z + 79
+    v16: int = v15 + x + y + z + 80
+    return v16
+
+pure def work_065(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 65
+    v1: int = v0 + x + y + z + 66
+    v2: int = v1 + x + y + z + 67
+    v3: int = v2 + x + y + z + 68
+    v4: int = v3 + x + y + z + 69
+    v5: int = v4 + x + y + z + 70
+    v6: int = v5 + x + y + z + 71
+    v7: int = v6 + x + y + z + 72
+    v8: int = v7 + x + y + z + 73
+    v9: int = v8 + x + y + z + 74
+    v10: int = v9 + x + y + z + 75
+    v11: int = v10 + x + y + z + 76
+    v12: int = v11 + x + y + z + 77
+    v13: int = v12 + x + y + z + 78
+    v14: int = v13 + x + y + z + 79
+    v15: int = v14 + x + y + z + 80
+    v16: int = v15 + x + y + z + 81
+    return v16
+
+pure def work_066(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 66
+    v1: int = v0 + x + y + z + 67
+    v2: int = v1 + x + y + z + 68
+    v3: int = v2 + x + y + z + 69
+    v4: int = v3 + x + y + z + 70
+    v5: int = v4 + x + y + z + 71
+    v6: int = v5 + x + y + z + 72
+    v7: int = v6 + x + y + z + 73
+    v8: int = v7 + x + y + z + 74
+    v9: int = v8 + x + y + z + 75
+    v10: int = v9 + x + y + z + 76
+    v11: int = v10 + x + y + z + 77
+    v12: int = v11 + x + y + z + 78
+    v13: int = v12 + x + y + z + 79
+    v14: int = v13 + x + y + z + 80
+    v15: int = v14 + x + y + z + 81
+    v16: int = v15 + x + y + z + 82
+    return v16
+
+pure def work_067(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 67
+    v1: int = v0 + x + y + z + 68
+    v2: int = v1 + x + y + z + 69
+    v3: int = v2 + x + y + z + 70
+    v4: int = v3 + x + y + z + 71
+    v5: int = v4 + x + y + z + 72
+    v6: int = v5 + x + y + z + 73
+    v7: int = v6 + x + y + z + 74
+    v8: int = v7 + x + y + z + 75
+    v9: int = v8 + x + y + z + 76
+    v10: int = v9 + x + y + z + 77
+    v11: int = v10 + x + y + z + 78
+    v12: int = v11 + x + y + z + 79
+    v13: int = v12 + x + y + z + 80
+    v14: int = v13 + x + y + z + 81
+    v15: int = v14 + x + y + z + 82
+    v16: int = v15 + x + y + z + 83
+    return v16
+
+pure def work_068(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 68
+    v1: int = v0 + x + y + z + 69
+    v2: int = v1 + x + y + z + 70
+    v3: int = v2 + x + y + z + 71
+    v4: int = v3 + x + y + z + 72
+    v5: int = v4 + x + y + z + 73
+    v6: int = v5 + x + y + z + 74
+    v7: int = v6 + x + y + z + 75
+    v8: int = v7 + x + y + z + 76
+    v9: int = v8 + x + y + z + 77
+    v10: int = v9 + x + y + z + 78
+    v11: int = v10 + x + y + z + 79
+    v12: int = v11 + x + y + z + 80
+    v13: int = v12 + x + y + z + 81
+    v14: int = v13 + x + y + z + 82
+    v15: int = v14 + x + y + z + 83
+    v16: int = v15 + x + y + z + 84
+    return v16
+
+pure def work_069(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 69
+    v1: int = v0 + x + y + z + 70
+    v2: int = v1 + x + y + z + 71
+    v3: int = v2 + x + y + z + 72
+    v4: int = v3 + x + y + z + 73
+    v5: int = v4 + x + y + z + 74
+    v6: int = v5 + x + y + z + 75
+    v7: int = v6 + x + y + z + 76
+    v8: int = v7 + x + y + z + 77
+    v9: int = v8 + x + y + z + 78
+    v10: int = v9 + x + y + z + 79
+    v11: int = v10 + x + y + z + 80
+    v12: int = v11 + x + y + z + 81
+    v13: int = v12 + x + y + z + 82
+    v14: int = v13 + x + y + z + 83
+    v15: int = v14 + x + y + z + 84
+    v16: int = v15 + x + y + z + 85
+    return v16
+
+pure def work_070(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 70
+    v1: int = v0 + x + y + z + 71
+    v2: int = v1 + x + y + z + 72
+    v3: int = v2 + x + y + z + 73
+    v4: int = v3 + x + y + z + 74
+    v5: int = v4 + x + y + z + 75
+    v6: int = v5 + x + y + z + 76
+    v7: int = v6 + x + y + z + 77
+    v8: int = v7 + x + y + z + 78
+    v9: int = v8 + x + y + z + 79
+    v10: int = v9 + x + y + z + 80
+    v11: int = v10 + x + y + z + 81
+    v12: int = v11 + x + y + z + 82
+    v13: int = v12 + x + y + z + 83
+    v14: int = v13 + x + y + z + 84
+    v15: int = v14 + x + y + z + 85
+    v16: int = v15 + x + y + z + 86
+    return v16
+
+pure def work_071(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 71
+    v1: int = v0 + x + y + z + 72
+    v2: int = v1 + x + y + z + 73
+    v3: int = v2 + x + y + z + 74
+    v4: int = v3 + x + y + z + 75
+    v5: int = v4 + x + y + z + 76
+    v6: int = v5 + x + y + z + 77
+    v7: int = v6 + x + y + z + 78
+    v8: int = v7 + x + y + z + 79
+    v9: int = v8 + x + y + z + 80
+    v10: int = v9 + x + y + z + 81
+    v11: int = v10 + x + y + z + 82
+    v12: int = v11 + x + y + z + 83
+    v13: int = v12 + x + y + z + 84
+    v14: int = v13 + x + y + z + 85
+    v15: int = v14 + x + y + z + 86
+    v16: int = v15 + x + y + z + 87
+    return v16
+
+pure def work_072(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 72
+    v1: int = v0 + x + y + z + 73
+    v2: int = v1 + x + y + z + 74
+    v3: int = v2 + x + y + z + 75
+    v4: int = v3 + x + y + z + 76
+    v5: int = v4 + x + y + z + 77
+    v6: int = v5 + x + y + z + 78
+    v7: int = v6 + x + y + z + 79
+    v8: int = v7 + x + y + z + 80
+    v9: int = v8 + x + y + z + 81
+    v10: int = v9 + x + y + z + 82
+    v11: int = v10 + x + y + z + 83
+    v12: int = v11 + x + y + z + 84
+    v13: int = v12 + x + y + z + 85
+    v14: int = v13 + x + y + z + 86
+    v15: int = v14 + x + y + z + 87
+    v16: int = v15 + x + y + z + 88
+    return v16
+
+pure def work_073(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 73
+    v1: int = v0 + x + y + z + 74
+    v2: int = v1 + x + y + z + 75
+    v3: int = v2 + x + y + z + 76
+    v4: int = v3 + x + y + z + 77
+    v5: int = v4 + x + y + z + 78
+    v6: int = v5 + x + y + z + 79
+    v7: int = v6 + x + y + z + 80
+    v8: int = v7 + x + y + z + 81
+    v9: int = v8 + x + y + z + 82
+    v10: int = v9 + x + y + z + 83
+    v11: int = v10 + x + y + z + 84
+    v12: int = v11 + x + y + z + 85
+    v13: int = v12 + x + y + z + 86
+    v14: int = v13 + x + y + z + 87
+    v15: int = v14 + x + y + z + 88
+    v16: int = v15 + x + y + z + 89
+    return v16
+
+pure def work_074(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 74
+    v1: int = v0 + x + y + z + 75
+    v2: int = v1 + x + y + z + 76
+    v3: int = v2 + x + y + z + 77
+    v4: int = v3 + x + y + z + 78
+    v5: int = v4 + x + y + z + 79
+    v6: int = v5 + x + y + z + 80
+    v7: int = v6 + x + y + z + 81
+    v8: int = v7 + x + y + z + 82
+    v9: int = v8 + x + y + z + 83
+    v10: int = v9 + x + y + z + 84
+    v11: int = v10 + x + y + z + 85
+    v12: int = v11 + x + y + z + 86
+    v13: int = v12 + x + y + z + 87
+    v14: int = v13 + x + y + z + 88
+    v15: int = v14 + x + y + z + 89
+    v16: int = v15 + x + y + z + 90
+    return v16
+
+pure def work_075(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 75
+    v1: int = v0 + x + y + z + 76
+    v2: int = v1 + x + y + z + 77
+    v3: int = v2 + x + y + z + 78
+    v4: int = v3 + x + y + z + 79
+    v5: int = v4 + x + y + z + 80
+    v6: int = v5 + x + y + z + 81
+    v7: int = v6 + x + y + z + 82
+    v8: int = v7 + x + y + z + 83
+    v9: int = v8 + x + y + z + 84
+    v10: int = v9 + x + y + z + 85
+    v11: int = v10 + x + y + z + 86
+    v12: int = v11 + x + y + z + 87
+    v13: int = v12 + x + y + z + 88
+    v14: int = v13 + x + y + z + 89
+    v15: int = v14 + x + y + z + 90
+    v16: int = v15 + x + y + z + 91
+    return v16
+
+pure def work_076(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 76
+    v1: int = v0 + x + y + z + 77
+    v2: int = v1 + x + y + z + 78
+    v3: int = v2 + x + y + z + 79
+    v4: int = v3 + x + y + z + 80
+    v5: int = v4 + x + y + z + 81
+    v6: int = v5 + x + y + z + 82
+    v7: int = v6 + x + y + z + 83
+    v8: int = v7 + x + y + z + 84
+    v9: int = v8 + x + y + z + 85
+    v10: int = v9 + x + y + z + 86
+    v11: int = v10 + x + y + z + 87
+    v12: int = v11 + x + y + z + 88
+    v13: int = v12 + x + y + z + 89
+    v14: int = v13 + x + y + z + 90
+    v15: int = v14 + x + y + z + 91
+    v16: int = v15 + x + y + z + 92
+    return v16
+
+pure def work_077(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 77
+    v1: int = v0 + x + y + z + 78
+    v2: int = v1 + x + y + z + 79
+    v3: int = v2 + x + y + z + 80
+    v4: int = v3 + x + y + z + 81
+    v5: int = v4 + x + y + z + 82
+    v6: int = v5 + x + y + z + 83
+    v7: int = v6 + x + y + z + 84
+    v8: int = v7 + x + y + z + 85
+    v9: int = v8 + x + y + z + 86
+    v10: int = v9 + x + y + z + 87
+    v11: int = v10 + x + y + z + 88
+    v12: int = v11 + x + y + z + 89
+    v13: int = v12 + x + y + z + 90
+    v14: int = v13 + x + y + z + 91
+    v15: int = v14 + x + y + z + 92
+    v16: int = v15 + x + y + z + 93
+    return v16
+
+pure def work_078(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 78
+    v1: int = v0 + x + y + z + 79
+    v2: int = v1 + x + y + z + 80
+    v3: int = v2 + x + y + z + 81
+    v4: int = v3 + x + y + z + 82
+    v5: int = v4 + x + y + z + 83
+    v6: int = v5 + x + y + z + 84
+    v7: int = v6 + x + y + z + 85
+    v8: int = v7 + x + y + z + 86
+    v9: int = v8 + x + y + z + 87
+    v10: int = v9 + x + y + z + 88
+    v11: int = v10 + x + y + z + 89
+    v12: int = v11 + x + y + z + 90
+    v13: int = v12 + x + y + z + 91
+    v14: int = v13 + x + y + z + 92
+    v15: int = v14 + x + y + z + 93
+    v16: int = v15 + x + y + z + 94
+    return v16
+
+pure def work_079(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 79
+    v1: int = v0 + x + y + z + 80
+    v2: int = v1 + x + y + z + 81
+    v3: int = v2 + x + y + z + 82
+    v4: int = v3 + x + y + z + 83
+    v5: int = v4 + x + y + z + 84
+    v6: int = v5 + x + y + z + 85
+    v7: int = v6 + x + y + z + 86
+    v8: int = v7 + x + y + z + 87
+    v9: int = v8 + x + y + z + 88
+    v10: int = v9 + x + y + z + 89
+    v11: int = v10 + x + y + z + 90
+    v12: int = v11 + x + y + z + 91
+    v13: int = v12 + x + y + z + 92
+    v14: int = v13 + x + y + z + 93
+    v15: int = v14 + x + y + z + 94
+    v16: int = v15 + x + y + z + 95
+    return v16
+
+pure def work_080(x: int, y: int, z: int) -> int:
+    v0: int = x + y + z + 80
+    v1: int = v0 + x + y + z + 81
+    v2: int = v1 + x + y + z + 82
+    v3: int = v2 + x + y + z + 83
+    v4: int = v3 + x + y + z + 84
+    v5: int = v4 + x + y + z + 85
+    v6: int = v5 + x + y + z + 86
+    v7: int = v6 + x + y + z + 87
+    v8: int = v7 + x + y + z + 88
+    v9: int = v8 + x + y + z + 89
+    v10: int = v9 + x + y + z + 90
+    v11: int = v10 + x + y + z + 91
+    v12: int = v11 + x + y + z + 92
+    v13: int = v12 + x + y + z + 93
+    v14: int = v13 + x + y + z + 94
+    v15: int = v14 + x + y + z + 95
+    v16: int = v15 + x + y + z + 96
+    return v16


### PR DESCRIPTION
Top-level type checking now scans statements in source order and schedules total statements for background checking. Non-total statements still run checkTopStmt immediately so later statements only see completed earlier definitions.

Worker concurrency is capped by the runtime capability count and scoped to the enclosing type-check run. Type errors from independent total statements are collected into multiple diagnostics.

Verbose and timing builds report inferred signatures for non-total top-level statements so users can add explicit signatures and make more code eligible for concurrent checking.

The commit also adds focused coverage for mixed total and non-total statements, restores the heavy concurrent type-check fixture, and fixes packaged RTS options so optimized binaries use threaded capabilities by default.

Fixes #2725 