### PR TITLE
Use Zig CC for GHC builds to control linking and target glibc 2.31

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,7 +106,7 @@ jobs:
         with:
           path: |
             ~/.stack
-          key: test-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.arch }}
+          key: test-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.arch }}-${{ hashFiles('compiler/stack.yaml', 'compiler/stack.yaml.lock', 'Makefile', 'compiler/tools/*.sh') }}
       - name: "Cache Acton"
         if: matrix.cache == true
         uses: actions/cache@v5
@@ -209,14 +209,14 @@ jobs:
         with:
           path: |
             ~/.stack
-          key: test-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.arch }}
+          key: test-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.arch }}-${{ hashFiles('compiler/stack.yaml', 'compiler/stack.yaml.lock', 'Makefile', 'compiler/tools/*.sh') }}
       - name: "chown our home dir to avoid stack complaining"
         run: chown -R root:root /github/home
       - name: "Install build prerequisites"
         run: |
           export DEBIAN_FRONTEND=noninteractive
           apt-get update
-          apt-get install -qy bzip2 curl g++ haskell-stack libtinfo-dev make procps zlib1g-dev
+          apt-get install -qy bzip2 curl g++ haskell-stack libgmp-dev libncurses-dev make procps zlib1g-dev
           apt-get install -qy gdb
       - name: "locale en_US.UTF-8"
         run: |
@@ -226,11 +226,28 @@ jobs:
           echo "locales locales/locales_to_be_generated multiselect en_US.UTF-8 UTF-8" | debconf-set-selections
           rm "/etc/locale.gen"
           dpkg-reconfigure --frontend noninteractive locales
-      - name: "Upgrade stack on old distributions"
-        if: ${{ matrix.os == 'ubuntu' && matrix.version == '22.04' }}
+      - name: "Install newer stack"
         run: |
-          stack upgrade
-          echo "PATH=~/.local/bin:$PATH" >> $GITHUB_ENV
+          STACK_VERSION=3.9.3
+          ARCH="$(uname -m)"
+          case "${ARCH}" in
+            x86_64) STACK_ARCH="x86_64" ;;
+            aarch64|arm64) STACK_ARCH="aarch64" ;;
+            *) echo "Unsupported arch: ${ARCH}" >&2; exit 1 ;;
+          esac
+          STACK_TAR="stack-${STACK_VERSION}-linux-${STACK_ARCH}.tar.gz"
+          STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK_VERSION}/${STACK_TAR}"
+          mkdir -p "${HOME}/.local/bin"
+          curl -fsSL "${STACK_URL}" -o /tmp/stack.tgz
+          tar -xzf /tmp/stack.tgz -C /tmp
+          install -m 0755 "/tmp/stack-${STACK_VERSION}-linux-${STACK_ARCH}/stack" "${HOME}/.local/bin/stack"
+          echo "${HOME}/.local/bin" >> "$GITHUB_PATH"
+          "${HOME}/.local/bin/stack" --version
+      - name: "Use container glibc target for source build"
+        run: |
+          GLIBC_VERSION="$(getconf GNU_LIBC_VERSION | awk '{print $2}')"
+          echo "ACTON_ZIG_GLIBC_VERSION=${GLIBC_VERSION}" >> "$GITHUB_ENV"
+          echo "Using Zig glibc target ${GLIBC_VERSION}"
       - name: "Build Acton"
         run: |
           make -j2 -C ${GITHUB_WORKSPACE} BUILD_RELEASE=${{ env.BUILD_RELEASE }} BUILD_TIME=${BUILD_TIME}
@@ -264,7 +281,7 @@ jobs:
         arch: [amd64, arm64]
     runs-on: ${{ matrix.arch == 'amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
     container:
-      image: ubuntu:22.04
+      image: debian:11
     env:
       LANG: en_US.UTF-8
       LC_ALL: en_US.UTF-8
@@ -285,7 +302,7 @@ jobs:
       - name: "Install build prerequisites"
         run: |
           apt-get update
-          apt-get install -qy bzip2 curl g++ haskell-stack libtinfo-dev make procps zlib1g-dev
+          apt-get install -qy bzip2 curl g++ haskell-stack libgmp-dev libncurses-dev make procps zlib1g-dev
           apt-get install -qy bash-completion build-essential debhelper devscripts
       - name: "Prepare stack directories"
         run: |
@@ -296,9 +313,8 @@ jobs:
         uses: actions/cache@v5
         with:
           path: |
-            ./debian/.debhelper/
             ${{ env.STACK_ROOT }}
-          key: build-debs-${{ matrix.arch }}
+          key: build-debs-${{ matrix.arch }}-${{ hashFiles('compiler/stack.yaml', 'compiler/stack.yaml.lock', 'Makefile', 'compiler/tools/*.sh', 'debian/control') }}
       - name: "locale en_US.UTF-8"
         run: |
           apt-get install -qy locales
@@ -328,6 +344,19 @@ jobs:
         run: |
           set -euo pipefail
           make -C "${GITHUB_WORKSPACE}" debs BUILD_RELEASE=${{ env.BUILD_RELEASE }} BUILD_TIME=${BUILD_TIME}
+      - name: "Show packaged Acton linkage"
+        shell: bash
+        run: |
+          set -euo pipefail
+          make -C "${GITHUB_WORKSPACE}" ldd
+          deb="$(ls "${GITHUB_WORKSPACE}"/../acton_*.deb | head -n1)"
+          dpkg-deb -I "$deb"
+          tmp="$(mktemp -d)"
+          dpkg-deb -x "$deb" "$tmp"
+          bins="$tmp/usr/lib/acton/bin/acton"
+          bins="$bins $tmp/usr/lib/acton/bin/lsp-server-acton"
+          bins="$bins $tmp/usr/lib/acton/bin/actondb"
+          make -C "${GITHUB_WORKSPACE}" ldd ACTON_LINKAGE_BINS="$bins"
       - name: "Compute variables"
         id: vars
         run: |

--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,35 @@ clean-compiler:
 		compiler/acton/package.yaml compiler/acton/acton.cabal \
 		compiler/lib/*.cabal compiler/acton/*.cabal compiler/lsp-server/*.cabal
 
+ACTON_LINKAGE_BINS ?= dist/bin/acton dist/bin/lsp-server-acton dist/bin/actondb
+ACTON_ALLOWED_NEEDED_RE ?= ^(libc\.so\.6|libm\.so\.6|libdl\.so\.2|libpthread\.so\.0|librt\.so\.1|libutil\.so\.1|ld-linux-x86-64\.so\.2|ld-linux-aarch64\.so\.1)$$
+.PHONY: ldd
+ldd: $(ACTON_LINKAGE_BINS)
+ifeq ($(OS),linux)
+	@for bin in $(ACTON_LINKAGE_BINS); do \
+		echo "== $$bin =="; \
+		ldd "$$bin"; \
+		if command -v readelf >/dev/null 2>&1; then \
+			unexpected_needed=$$(readelf -d "$$bin" | sed -n 's/.*Shared library: \[\(.*\)\].*/\1/p' | grep -Ev '$(ACTON_ALLOWED_NEEDED_RE)' || true); \
+			if [ -n "$$unexpected_needed" ]; then \
+				echo "unexpected dynamic libraries:" >&2; \
+				echo "$$unexpected_needed" >&2; \
+				exit 1; \
+			fi; \
+			max_glibc=$$(readelf --version-info "$$bin" | grep -o 'GLIBC_[0-9][.0-9]*' | sed 's/GLIBC_//' | sort -Vu | tail -n 1); \
+			if [ -n "$$max_glibc" ]; then \
+				echo "max GLIBC version required: $$max_glibc"; \
+				if [ "$$(printf '%s\n%s\n' "$$max_glibc" "$(ACTON_ZIG_GLIBC_VERSION)" | sort -V | tail -n 1)" != "$(ACTON_ZIG_GLIBC_VERSION)" ]; then \
+					echo "ERROR: $$bin requires GLIBC $$max_glibc, newer than target $(ACTON_ZIG_GLIBC_VERSION)" >&2; \
+					exit 1; \
+				fi; \
+			fi; \
+		fi; \
+	done
+else
+	@echo "ldd target is only meaningful on Linux"
+endif
+
 # /deps --------------------------------------------------
 DEPS += dist/deps/mbedtls
 DEPS += dist/deps/libargp

--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,14 @@ GIT_VERSION_TAG=$(shell git tag --points-at HEAD 2>/dev/null | grep "v[0-9]" | s
 
 ifdef HOME
 ZIG_LOCAL_CACHE_DIR ?= $(HOME)/.cache/acton/zig-local-cache
+ZIG_GLOBAL_CACHE_DIR ?= $(HOME)/.cache/acton/zig-global-cache
 else
 # TODO: Windows?
 ZIG_LOCAL_CACHE_DIR ?= $(TD)/zig-cache
+ZIG_GLOBAL_CACHE_DIR ?= $(TD)/zig-global-cache
 endif
 export ZIG_LOCAL_CACHE_DIR
+export ZIG_GLOBAL_CACHE_DIR
 
 ACTON=$(TD)/dist/bin/acton
 ACTONC=dist/bin/actonc
@@ -21,6 +24,11 @@ CC=$(ZIG) cc
 CXX=$(ZIG) c++
 export CC
 export CXX
+ACTON_STACK_CC=$(TD)/compiler/tools/zig-cc.sh
+ACTON_STACK_CXX=$(TD)/compiler/tools/zig-cxx.sh
+ACTON_STACK_NEEDS_ZIG=
+ACTON_ZIG_TARGET=
+STACK=unset CC && unset CXX && unset CFLAGS && unset CPPFLAGS && unset LDFLAGS && unset ACTON_REAL_LD && stack
 
 # Determine which xargs we have. BSD xargs does not have --no-run-if-empty,
 # rather, it is the default behavior so the argument is superfluous. We check if
@@ -72,13 +80,18 @@ endif
 # -- Linux ---------------------------------------------------------------------
 ifeq ($(shell uname -s),Linux)
 OS:=linux
+ACTON_ZIG_GLIBC_VERSION ?= 2.31
+export ACTON_ZIG_GLIBC_VERSION
+ACTON_STACK_NEEDS_ZIG=1
+STACK=CC="$(ACTON_STACK_CC)" CXX="$(ACTON_STACK_CXX)" CFLAGS= CPPFLAGS= LDFLAGS= ACTON_REAL_LD="$(ACTON_STACK_CC)" stack --with-gcc="$(ACTON_STACK_CC)"
 ifeq ($(shell uname -m),x86_64)
-ACTONC_TARGET := --target x86_64-linux-gnu.2.27
+ACTON_ZIG_TARGET := x86_64-linux-gnu.$(ACTON_ZIG_GLIBC_VERSION)
 else ifeq ($(shell uname -m),aarch64)
-ACTONC_TARGET := --target aarch64-linux-gnu.2.27
+ACTON_ZIG_TARGET := aarch64-linux-gnu.$(ACTON_ZIG_GLIBC_VERSION)
 else
 $(error "Unsupported architecture for Linux?" $(shell uname -m))
 endif
+ACTONC_TARGET := --target $(ACTON_ZIG_TARGET)
 endif # -- END: Linux ----------------------------------------------------------
 
 .PHONY: all
@@ -113,6 +126,11 @@ BUILTIN_HFILES=$(wildcard base/builtin/*.h)
 
 DIST_BINS=$(ACTONC) dist/bin/actondb dist/bin/runacton dist/bin/lsp-server-acton
 DIST_ZIG=dist/zig
+ifeq ($(ACTON_STACK_NEEDS_ZIG),1)
+ACTON_STACK_PREREQS=$(DIST_ZIG)
+else
+ACTON_STACK_PREREQS=
+endif
 
 .PHONY: test-backend
 test-backend: $(BACKEND_TESTS)
@@ -126,17 +144,16 @@ test-backend: $(BACKEND_TESTS)
 # /compiler ----------------------------------------------
 ACTONC_HS=$(wildcard compiler/lib/src/*.hs compiler/lib/src/*/*.hs compiler/acton/*.hs compiler/acton/*/*.hs)
 ACTONLSP_HS=$(wildcard compiler/lsp-server/*.hs)
-# NOTE: we're unsetting CC & CXX to avoid using zig cc & zig c++ for stack /
-# ghc, which doesn't seem to work properly
-dist/bin/acton: compiler/lib/package.yaml.in compiler/acton/package.yaml.in compiler/lsp-server/package.yaml.in compiler/stack.yaml $(ACTONC_HS) $(ACTONLSP_HS) version.mk dist/builder
+dist/bin/acton: compiler/lib/package.yaml.in compiler/acton/package.yaml.in compiler/lsp-server/package.yaml.in compiler/stack.yaml $(ACTONC_HS) $(ACTONLSP_HS) version.mk dist/builder $(ACTON_STACK_PREREQS)
 	mkdir -p dist/bin
 	rm -f dist/bin/actonc
 	cd compiler && sed 's,^version: BUILD_VERSION,version: "$(VERSION)",' < lib/package.yaml.in > lib/package.yaml
-	cd compiler && unset CC && unset CXX && unset CFLAGS && stack build acton lsp-server-acton $(ACTON_STACK_BUILD_OPTS) --ghc-options='-j4 $(ACTC_GHC_OPTS)' --dry-run 2>&1 | grep "Nothing to build" || \
+	cd compiler && $(STACK) build acton lsp-server-acton $(ACTON_STACK_BUILD_OPTS) --ghc-options='-j4 $(ACTC_GHC_OPTS)' --dry-run 2>&1 | grep "Nothing to build" || \
 		(sed 's,^version: BUILD_VERSION,version: "$(VERSION_INFO)",' < acton/package.yaml.in > acton/package.yaml \
 		&& sed 's,^version: BUILD_VERSION,version: "$(VERSION_INFO)",' < lsp-server/package.yaml.in > lsp-server/package.yaml \
-		&& stack build acton lsp-server-acton $(ACTON_STACK_BUILD_OPTS) --ghc-options='-j4 $(ACTC_GHC_OPTS)')
-	cd compiler && unset CC && unset CXX && unset CFLAGS && stack --local-bin-path=../dist/bin install acton lsp-server-acton $(ACTON_STACK_BUILD_OPTS) --ghc-options='-j4 $(ACTC_GHC_OPTS)'
+		&& unset CC && unset CXX && unset CFLAGS && unset CPPFLAGS && unset LDFLAGS && unset ACTON_REAL_LD && stack setup \
+		&& $(STACK) build acton lsp-server-acton $(ACTON_STACK_BUILD_OPTS) --ghc-options='-j4 $(ACTC_GHC_OPTS)')
+	cd compiler && $(STACK) --local-bin-path=../dist/bin install acton lsp-server-acton $(ACTON_STACK_BUILD_OPTS) --ghc-options='-j4 $(ACTC_GHC_OPTS)'
 	# Keep actonc as a symlink for compatibility
 	ln -sf acton dist/bin/actonc
 
@@ -422,7 +439,7 @@ dist/bin/actondb: export DEVELOPER_DIR := $(or $(DEVELOPER_DIR),/dev/null)
 endif
 dist/bin/actondb: $(DIST_ZIG) $(DEPS)
 	@mkdir -p $(dir $@)
-	cd dist/backend && "$(ZIG)" build -Donly_actondb --prefix "$(TD)/dist"
+	cd dist/backend && "$(ZIG)" build -Donly_actondb $(if $(ACTON_ZIG_TARGET),-Dtarget=$(ACTON_ZIG_TARGET)) --prefix "$(TD)/dist"
 
 dist/bin/runacton: bin/runacton
 	@mkdir -p $(dir $@)
@@ -517,7 +534,7 @@ debian/changelog: debian/changelog.in CHANGELOG.md
 
 .PHONY: debs
 debs: debian/changelog
-	debuild --preserve-envvar VERSION_INFO --preserve-envvar PATH --preserve-envvar STACK_ROOT --preserve-envvar ZIG_DOWNLOAD_BASE_URL -i -us -uc -nc -b
+	debuild --preserve-envvar VERSION_INFO --preserve-envvar PATH --preserve-envvar STACK_ROOT --preserve-envvar ZIG_DOWNLOAD_BASE_URL --preserve-envvar ACTON_ZIG_GLIBC_VERSION -i -us -uc -nc -b
 
 .PHONY: container-image image image-deb push-image
 container-image: all

--- a/compiler/acton/package.yaml.in
+++ b/compiler/acton/package.yaml.in
@@ -78,14 +78,11 @@ executables:
       - -with-rtsopts=-N
       - -with-rtsopts=-A64M
     when:
-    - condition: os(linux) && arch(aarch64)
+    - condition: os(linux)
       ghc-options:
         - -no-pie
         - -optl-no-pie
         - -pgml=../tools/ld-wrapper.sh
-    - condition: os(linux) && !arch(aarch64)
-      ld-options:
-        - -static
 
 tests:
   test_acton:

--- a/compiler/lsp-server/package.yaml.in
+++ b/compiler/lsp-server/package.yaml.in
@@ -43,11 +43,8 @@ executables:
       - -with-rtsopts=-N
       - -with-rtsopts=-A64M
     when:
-      - condition: os(linux) && arch(aarch64)
+      - condition: os(linux)
         ghc-options:
           - -no-pie
           - -optl-no-pie
           - -pgml=../tools/ld-wrapper.sh
-      - condition: os(linux) && !arch(aarch64)
-        ld-options:
-          - -static

--- a/compiler/tools/ld-wrapper.sh
+++ b/compiler/tools/ld-wrapper.sh
@@ -6,17 +6,35 @@ state="static"
 arch="$(uname -m 2>/dev/null || true)"
 allow_dynamic_glibc=false
 case "$arch" in
-  aarch64|arm64)
+  aarch64|arm64|x86_64|amd64)
     allow_dynamic_glibc=true
     ;;
 esac
 
 args=()
 args+=("-Wl,-Bstatic")
-gcc_lib="$(gcc -print-file-name=libgcc_s.so 2>/dev/null || true)"
-if [[ -n "$gcc_lib" && "$gcc_lib" != "libgcc_s.so" ]]; then
-  args+=("-L$(dirname "$gcc_lib")")
-fi
+
+gcc_lib_path() {
+  local lib="$1"
+  local lib_path
+  lib_path="$(gcc -print-file-name="$lib" 2>/dev/null || true)"
+  if [[ -n "$lib_path" && "$lib_path" != "$lib" ]]; then
+    echo "$lib_path"
+    return 0
+  fi
+  return 1
+}
+
+add_static_gcc_lib() {
+  local archive="$1"
+  local fallback="$2"
+  local archive_path
+  if archive_path="$(gcc_lib_path "$archive")"; then
+    args+=("$archive_path")
+  else
+    args+=("-l:$fallback")
+  fi
+}
 
 normalize_lib() {
   local lib="$1"
@@ -43,7 +61,7 @@ handle_lib() {
       args+=("-Wl,-Bstatic")
       state="static"
     fi
-    args+=("-l:libz.a")
+    add_static_gcc_lib libz.a libz.a
     return
   fi
   if [[ "$lib_key" == "gmp" ]]; then
@@ -51,7 +69,7 @@ handle_lib() {
       args+=("-Wl,-Bstatic")
       state="static"
     fi
-    args+=("-l:libgmp.a")
+    add_static_gcc_lib libgmp.a libgmp.a
     return
   fi
   if [[ "$lib_key" == "stdc++" ]]; then
@@ -59,12 +77,21 @@ handle_lib() {
       args+=("-Wl,-Bstatic")
       state="static"
     fi
-    args+=("-l:libstdc++.a")
+    add_static_gcc_lib libstdc++.a libstdc++.a
+    add_static_gcc_lib libgcc_eh.a libgcc_eh.a
+    return
+  fi
+  if [[ "$lib_key" == "tinfo" ]]; then
+    if [[ "$state" != "static" ]]; then
+      args+=("-Wl,-Bstatic")
+      state="static"
+    fi
+    add_static_gcc_lib libtinfo.a libtinfo.a
     return
   fi
   if [[ "$allow_dynamic_glibc" == true ]]; then
     case "$lib_key" in
-      c|m|dl|pthread|rt|util|gcc_s)
+      c|m|dl|pthread|rt|util)
         if [[ "$state" != "dynamic" ]]; then
           args+=("-Wl,-Bdynamic")
           state="dynamic"
@@ -73,6 +100,14 @@ handle_lib() {
         return
         ;;
     esac
+  fi
+  if [[ "$lib_key" == "gcc_s" ]]; then
+    if [[ "$state" != "static" ]]; then
+      args+=("-Wl,-Bstatic")
+      state="static"
+    fi
+    add_static_gcc_lib libgcc_eh.a libgcc_eh.a
+    return
   fi
   if [[ "$state" != "static" ]]; then
     args+=("-Wl,-Bstatic")

--- a/compiler/tools/zig-cc.sh
+++ b/compiler/tools/zig-cc.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+ZIG="${ROOT}/dist/zig/zig"
+
+run_zig_with_lock() {
+  if ! command -v flock >/dev/null 2>&1; then
+    echo "flock is required for Linux Zig compiler wrapper serialization" >&2
+    return 1
+  fi
+
+  local lock_root="${ZIG_GLOBAL_CACHE_DIR:-${TMPDIR:-/tmp}/acton-zig-global-cache}"
+  mkdir -p "$lock_root"
+  flock "$lock_root/acton-zig-cc.lock" "${ZIG}" "$@"
+}
+
+gcc_lib_path() {
+  local lib="$1"
+  local lib_path
+  lib_path="$(gcc -print-file-name="$lib" 2>/dev/null || true)"
+  if [[ -n "$lib_path" && "$lib_path" != "$lib" ]]; then
+    echo "$lib_path"
+    return 0
+  fi
+  return 1
+}
+
+add_system_include_dirs() {
+  local multiarch
+  args+=("-idirafter" "/usr/include")
+  multiarch="$(gcc -print-multiarch 2>/dev/null || true)"
+  if [[ -n "$multiarch" && -d "/usr/include/$multiarch" ]]; then
+    args+=("-idirafter" "/usr/include/$multiarch")
+  fi
+}
+
+add_arch_feature_args() {
+  case "${ZIG_ARCH}" in
+    x86_64)
+      args+=("-Xclang" "-target-feature" "-Xclang" "+evex512")
+      ;;
+  esac
+}
+
+rewrite_lib_arg() {
+  local arg="$1"
+  local lib_path
+  case "$arg" in
+    -lgmp|-l:libgmp.a)
+      if lib_path="$(gcc_lib_path libgmp.a)"; then
+        echo "$lib_path"
+      else
+        echo "$arg"
+      fi
+      ;;
+    -lz|-l:libz.a)
+      if lib_path="$(gcc_lib_path libz.a)"; then
+        echo "$lib_path"
+      else
+        echo "$arg"
+      fi
+      ;;
+    -lstdc++|-l:libstdc++.a)
+      if lib_path="$(gcc_lib_path libstdc++.a)"; then
+        echo "$lib_path"
+      else
+        echo "$arg"
+      fi
+      ;;
+    -ltinfo|-l:libtinfo.a)
+      if lib_path="$(gcc_lib_path libtinfo.a)"; then
+        echo "$lib_path"
+      else
+        echo "$arg"
+      fi
+      ;;
+    *)
+      echo "$arg"
+      ;;
+  esac
+}
+
+process_arg() {
+  local arg="$1"
+  case "$arg" in
+    @*)
+      local rsp="${arg#@}"
+      if [[ -f "$rsp" ]]; then
+        local line
+        while IFS= read -r line || [[ -n "$line" ]]; do
+          [[ -z "$line" ]] && continue
+          if [[ "$line" == \"*\" && "$line" == *\" ]]; then
+            line="${line:1:${#line}-2}"
+            line="${line//\\\\/\\}"
+            line="${line//\\\"/\"}"
+          fi
+          process_arg "$line"
+        done < "$rsp"
+      else
+        args+=("$(rewrite_lib_arg "$arg")")
+      fi
+      ;;
+    *)
+      args+=("$(rewrite_lib_arg "$arg")")
+      ;;
+  esac
+}
+
+case "$(uname -s)" in
+  Linux)
+    ARCH="$(uname -m)"
+    case "${ARCH}" in
+      x86_64) ZIG_ARCH=x86_64 ;;
+      aarch64|arm64) ZIG_ARCH=aarch64 ;;
+      *) echo "Unsupported architecture for Linux: ${ARCH}" >&2; exit 1 ;;
+    esac
+    GLIBC_VERSION="${ACTON_ZIG_GLIBC_VERSION:-2.31}"
+    args=()
+    add_system_include_dirs
+    add_arch_feature_args
+    for arg in "$@"; do
+      process_arg "$arg"
+    done
+    run_zig_with_lock cc -target "${ZIG_ARCH}-linux-gnu.${GLIBC_VERSION}" "${args[@]}"
+    ;;
+  *)
+    exec "${ZIG}" cc "$@"
+    ;;
+esac

--- a/compiler/tools/zig-cxx.sh
+++ b/compiler/tools/zig-cxx.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+ZIG="${ROOT}/dist/zig/zig"
+
+run_zig_with_lock() {
+  if ! command -v flock >/dev/null 2>&1; then
+    echo "flock is required for Linux Zig compiler wrapper serialization" >&2
+    return 1
+  fi
+
+  local lock_root="${ZIG_GLOBAL_CACHE_DIR:-${TMPDIR:-/tmp}/acton-zig-global-cache}"
+  mkdir -p "$lock_root"
+  flock "$lock_root/acton-zig-cc.lock" "${ZIG}" "$@"
+}
+
+gcc_lib_path() {
+  local lib="$1"
+  local lib_path
+  lib_path="$(gcc -print-file-name="$lib" 2>/dev/null || true)"
+  if [[ -n "$lib_path" && "$lib_path" != "$lib" ]]; then
+    echo "$lib_path"
+    return 0
+  fi
+  return 1
+}
+
+add_system_include_dirs() {
+  local multiarch
+  args+=("-idirafter" "/usr/include")
+  multiarch="$(gcc -print-multiarch 2>/dev/null || true)"
+  if [[ -n "$multiarch" && -d "/usr/include/$multiarch" ]]; then
+    args+=("-idirafter" "/usr/include/$multiarch")
+  fi
+}
+
+add_arch_feature_args() {
+  case "${ZIG_ARCH}" in
+    x86_64)
+      args+=("-Xclang" "-target-feature" "-Xclang" "+evex512")
+      ;;
+  esac
+}
+
+rewrite_lib_arg() {
+  local arg="$1"
+  local lib_path
+  case "$arg" in
+    -lgmp|-l:libgmp.a)
+      if lib_path="$(gcc_lib_path libgmp.a)"; then
+        echo "$lib_path"
+      else
+        echo "$arg"
+      fi
+      ;;
+    -lz|-l:libz.a)
+      if lib_path="$(gcc_lib_path libz.a)"; then
+        echo "$lib_path"
+      else
+        echo "$arg"
+      fi
+      ;;
+    -lstdc++|-l:libstdc++.a)
+      if lib_path="$(gcc_lib_path libstdc++.a)"; then
+        echo "$lib_path"
+      else
+        echo "$arg"
+      fi
+      ;;
+    -ltinfo|-l:libtinfo.a)
+      if lib_path="$(gcc_lib_path libtinfo.a)"; then
+        echo "$lib_path"
+      else
+        echo "$arg"
+      fi
+      ;;
+    *)
+      echo "$arg"
+      ;;
+  esac
+}
+
+process_arg() {
+  local arg="$1"
+  case "$arg" in
+    @*)
+      local rsp="${arg#@}"
+      if [[ -f "$rsp" ]]; then
+        local line
+        while IFS= read -r line || [[ -n "$line" ]]; do
+          [[ -z "$line" ]] && continue
+          if [[ "$line" == \"*\" && "$line" == *\" ]]; then
+            line="${line:1:${#line}-2}"
+            line="${line//\\\\/\\}"
+            line="${line//\\\"/\"}"
+          fi
+          process_arg "$line"
+        done < "$rsp"
+      else
+        args+=("$(rewrite_lib_arg "$arg")")
+      fi
+      ;;
+    *)
+      args+=("$(rewrite_lib_arg "$arg")")
+      ;;
+  esac
+}
+
+case "$(uname -s)" in
+  Linux)
+    ARCH="$(uname -m)"
+    case "${ARCH}" in
+      x86_64) ZIG_ARCH=x86_64 ;;
+      aarch64|arm64) ZIG_ARCH=aarch64 ;;
+      *) echo "Unsupported architecture for Linux: ${ARCH}" >&2; exit 1 ;;
+    esac
+    GLIBC_VERSION="${ACTON_ZIG_GLIBC_VERSION:-2.31}"
+    args=()
+    add_system_include_dirs
+    add_arch_feature_args
+    for arg in "$@"; do
+      process_arg "$arg"
+    done
+    run_zig_with_lock c++ -target "${ZIG_ARCH}-linux-gnu.${GLIBC_VERSION}" "${args[@]}"
+    ;;
+  *)
+    exec "${ZIG}" c++ "$@"
+    ;;
+esac

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,8 @@ Build-Depends:
  debhelper-compat (= 13),
  g++,
  haskell-stack,
- libtinfo-dev,
+ libgmp-dev,
+ libncurses-dev,
  make,
  zlib1g-dev
 Standards-Version: 4.6.0
@@ -18,6 +19,7 @@ Package: acton
 Architecture: any
 Depends:
  libc6 (>= 2.27),
+ ${shlibs:Depends},
  ${misc:Depends}
 Description: Acton Programming Language
  An awesome programming language.

--- a/debian/rules
+++ b/debian/rules
@@ -23,8 +23,7 @@ override_dh_auto_test:
 override_dh_strip:
 	@echo "Skipping strip"
 
-# dwz (on Debian 12, which we use for the build-debs CI job) does not support
-# DWARF v5 emitted by Zig 0.15
+# dwz in our CI package builder does not support DWARF v5 emitted by Zig 0.15.
 override_dh_dwz:
 	@echo "Skipping dwz"
 

--- a/docs/acton-dev-guide/src/getting_started/build.md
+++ b/docs/acton-dev-guide/src/getting_started/build.md
@@ -32,4 +32,6 @@ dist/bin/actonc path/to/file.act   # compatibility alias
 
 - `ZIG_LOCAL_CACHE_DIR` controls Zig's cache location (defaults to `~/.cache/acton/zig-local-cache` when `HOME` is set).
 - `BUILD_RELEASE=1 make` stamps release versions; default builds get a timestamped version suffix.
-- On Linux, the Makefile pins the default target to glibc 2.27 for compatibility.
+- On Linux, the Makefile uses Zig for the Stack/GHC C compiler path and pins the default glibc target to 2.31 for compatibility.
+- `ACTON_ZIG_GLIBC_VERSION` overrides the glibc version used for Stack/GHC linking on Linux.
+- Linux release builds should run in a builder with system static libraries no newer than the requested glibc target.


### PR DESCRIPTION
Acton’s Linux release binaries should not depend on static glibc linking or
on whatever glibc version happens to be present on the build host.

Use Zig CC as the underlying compiler for GHC to compile various libraries. With Zig we get a lot better control using cross-compilation to target a specific version of glibc. We use this to target glibc 2.31 and to link it dynamically, which is different compared to before when it has been static. GNU libc does not support static linking, so we have been doing the wrong thing and it has shown occasionally as we've seen segfaults. Dynamic linking GNU libc is the proper fix but that in turn has been difficult to do in a portable way, so it is the combination of zig and dynamic glibc with old versions of glibc that makes all of this work. We also use it for actondb. However, that is not enough, because the libraries that we want to link in statically, like libgmp, in turn depend on libc and thus the version of glibc on the build host. We would need to also build libgmp and others with zig cross-compilation in order to control this, so for now, the practical fix is that we run our release build jobs on old versions, i.e. debian 11.


Add CI checks for the generated binaries and Debian packages. The linkage
check rejects unexpected dynamic libraries and enforces that the maximum
required GLIBC symbol version does not exceed the configured target for acton,
lsp-server-acton, and actondb. Debian package jobs also exercise the generated
packages on older supported glibc distributions so runtime-floor regressions
are caught before release.