### PR TITLE
Update changelog for concurrent type checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Added
+- Add concurrent top-level type checking for total statements, allowing the
+  compiler to check independent top-level definitions in parallel while keeping
+  source-order semantics for non-total statements. [#2773]
+  - Verbose and timing builds now report inferred signatures for non-total
+    statements, making it easier to add explicit signatures and unlock more
+    concurrent checking.
+  - Type errors from independent total statements are collected into multiple
+    diagnostics instead of stopping at the first failing statement.
+
 ### Documentation
 - Document when and how to use the Acton container image, including
   copy-pastable Docker commands for checking the compiler version and building
@@ -3909,6 +3919,7 @@ then, this second incarnation has been in focus and 0.2.0 was its first version.
 [#2751]: https://github.com/actonlang/acton/pull/2751
 [#2761]: https://github.com/actonlang/acton/pull/2761
 [#2767]: https://github.com/actonlang/acton/pull/2767
+[#2773]: https://github.com/actonlang/acton/pull/2773
 
 
 [0.3.0]: https://github.com/actonlang/acton/releases/tag/v0.3.0


### PR DESCRIPTION
## Summary
- Inspect `v0.27.0..main`, including the already-covered container image documentation work from #2767/#2769 and the newly merged concurrent top-level type checking work from #2773.
- Add an `Unreleased` `Added` entry for #2773 covering concurrent top-level type checking, inferred-signature feedback for non-total statements, and multi-diagnostic type errors.
- Add the missing `[#2773]` changelog link definition.

## Skipped
- #2767 is already covered by the existing `Unreleased` documentation entry on `main`, so this PR keeps that entry unchanged.

## Validation
- `git diff --check origin/main..HEAD -- CHANGELOG.md`
- Dependency-free PR link reference check
- `git show --check --format=medium HEAD`

`utils/changelog-find-missing-link-defs.py` could not run locally because Python `requests` is unavailable.