### PR TITLE
Document no-threads compiler scope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+Acton compiler notes:
+
+- `acton build --no-threads` controls whether the produced Acton binary uses
+  threads in Acton RTS. It does not disable threads in the Acton compiler
+  process itself, so compilation still happens concurrently. This flag is only
+  to be used for compatibility with platforms that do no have thread support,
+  for example cross-compiling for Windows, we build without threads.


### PR DESCRIPTION
Clarify that acton build --no-threads affects generated binaries.

It does not disable threads in the Acton compiler process.