### PR TITLE
Build x86_64 Linux releases on Debian 11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -154,14 +154,14 @@ jobs:
         if: github.event_name != 'schedule'
         id: setmatrix_pr
         run: |
-          MATRIX_JSON='{\"include\":[{\"os\":\"debian\",\"version\":\"12\",\"arch\":\"x86_64\",\"cache\":true},{\"os\":\"ubuntu\",\"version\":\"24.04\",\"arch\":\"arm64v8\",\"cache\":true}]}'
+          MATRIX_JSON='{\"include\":[{\"os\":\"debian\",\"version\":\"11\",\"arch\":\"x86_64\",\"cache\":true},{\"os\":\"ubuntu\",\"version\":\"24.04\",\"arch\":\"arm64v8\",\"cache\":true}]}'
           echo "matrix=$MATRIX_JSON" >> $GITHUB_OUTPUT
 
       - name: "Set Matrix for nightly run"
         if: github.event_name == 'schedule'
         id: setmatrix_cron
         run: |
-          MATRIX_JSON='{\"include\":[{\"os\":\"debian\",\"version\":\"12\",\"arch\":\"x86_64\",\"cache\":true},{\"os\":\"ubuntu\",\"version\":\"22.04\",\"arch\":\"x86_64\",\"cache\":false},{\"os\":\"ubuntu\",\"version\":\"24.04\",\"arch\":\"x86_64\",\"cache\":false},{\"os\":\"ubuntu\",\"version\":\"24.04\",\"arch\":\"arm64v8\",\"cache\":true}]}'
+          MATRIX_JSON='{\"include\":[{\"os\":\"debian\",\"version\":\"11\",\"arch\":\"x86_64\",\"cache\":true},{\"os\":\"debian\",\"version\":\"12\",\"arch\":\"x86_64\",\"cache\":false},{\"os\":\"debian\",\"version\":\"13\",\"arch\":\"x86_64\",\"cache\":false},{\"os\":\"ubuntu\",\"version\":\"22.04\",\"arch\":\"x86_64\",\"cache\":false},{\"os\":\"ubuntu\",\"version\":\"24.04\",\"arch\":\"x86_64\",\"cache\":false},{\"os\":\"ubuntu\",\"version\":\"24.04\",\"arch\":\"arm64v8\",\"cache\":true}]}'
           echo "matrix=$MATRIX_JSON" >> $GITHUB_OUTPUT
 
       - name: "Set final matrix output"
@@ -755,10 +755,10 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: acton-macos-15-x86_64
-      - name: "Download artifacts for Linux x86_64, built on Debian:12"
+      - name: "Download artifacts for Linux x86_64, built on Debian:11"
         uses: actions/download-artifact@v8
         with:
-          name: acton-debian-12-x86_64
+          name: acton-debian-11-x86_64
       - name: "Download artifacts for Linux arm64, built on Ubuntu:24.04"
         uses: actions/download-artifact@v8
         with:
@@ -835,10 +835,10 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: acton-macos-15-x86_64
-      - name: "Download artifacts for Linux x86_64, built on Debian:12"
+      - name: "Download artifacts for Linux x86_64, built on Debian:11"
         uses: actions/download-artifact@v8
         with:
-          name: acton-debian-12-x86_64
+          name: acton-debian-11-x86_64
       - name: "Download artifacts for Linux arm64, built on Ubuntu:24.04"
         uses: actions/download-artifact@v8
         with:


### PR DESCRIPTION
Use Debian 11 for the x86_64 Linux release artifact while keeping scheduled coverage across Debian 11, 12, and 13.