### PR TITLE
Report parser progress percentages

### DIFF
--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -1249,7 +1249,7 @@ printDocs gopts opts = do
           ".act" -> do
             let modname = A.modName $ map (replace ".act" "") $ splitOn "/" $ fileBody
             paths <- findPaths filename defaultCompileOptions
-            parsedRes <- parseActFile Source.diskSourceProvider modname filename
+            parsedRes <- parseActFile Source.diskSourceProvider modname filename Nothing
             (_snap, parsed) <- case parsedRes of
               Left diags -> do
                 printDiagnostics gopts defaultCompileOptions diags
@@ -1451,6 +1451,13 @@ initCliCompileHooks :: ProgressUI
                     -> IO CliCompileHooks
 initCliCompileHooks progressUI progressState gopts sched gen plan = do
     let neededTasks = cpNeededTasks plan
+        rootProj = ccRootProj (cpContext plan)
+        optsPlan = ccOpts (cpContext plan)
+        isBuiltinTask t = tkMod (gtKey t) == A.modName ["__builtin__"]
+        parseNeeded t =
+          case gtTask t of
+            ParseTask{} -> not (isBuiltinTask t) && not (C.only_build optsPlan)
+            _ -> False
     sizeEntries <- forM neededTasks $ \t -> do
       let key = gtKey t
           path = srcFile (gtPaths t) (tkMod key)
@@ -1458,7 +1465,7 @@ initCliCompileHooks progressUI progressState gopts sched gen plan = do
       sz <- if exists then getFileSize path else return 0
       return (key, sz)
     progressRef <- newIORef (0 :: Double)
-    marksRef <- newIORef (M.empty :: M.Map TaskKey (Double, Bool))
+    marksRef <- newIORef (M.empty :: M.Map TaskKey (Double, Double, Bool))
     -- sizeMap is used for the progress bar indicator to determine how much a
     -- modules compilation should contribute to the overall progress. We use
     -- file size as a heuristic for this, but if all sizes are zero (e.g. due to
@@ -1480,12 +1487,23 @@ initCliCompileHooks progressUI progressState gopts sched gen plan = do
             then 1 / totalWeight
             else fromIntegral (M.findWithDefault 0 key sizeMap) / totalWeight
         compilePhaseTotal = 85.0
-        frontRatio = 0.7
+        parseRatio = 0.1
+        frontRatio = 0.6
         backRatio = 0.3
+        totalPhaseWeight =
+          sum
+            [ weightFor (gtKey t) * (frontRatio + backRatio + if parseNeeded t then parseRatio else 0)
+            | t <- neededTasks
+            ]
+        shareForPhase t ratio =
+          if totalPhaseWeight <= 0
+            then 0
+            else compilePhaseTotal * weightFor (gtKey t) * ratio / totalPhaseWeight
         shareMap =
           M.fromList
-            [ (gtKey t, (compilePhaseTotal * weightFor (gtKey t) * frontRatio
-                        , compilePhaseTotal * weightFor (gtKey t) * backRatio))
+            [ (gtKey t, (shareForPhase t (if parseNeeded t then parseRatio else 0)
+                        , shareForPhase t frontRatio
+                        , shareForPhase t backRatio))
             | t <- neededTasks
             ]
     let gate = whenCurrentGen sched gen
@@ -1499,8 +1517,6 @@ initCliCompileHooks progressUI progressState gopts sched gen plan = do
             else progressLogLine progressUI (render plainLogWidth)
         logDiagnostics optsT diags =
           gate (progressWithLog progressUI (printDiagnostics gopts optsT diags))
-        rootProj = ccRootProj (cpContext plan)
-        optsPlan = ccOpts (cpContext plan)
         termProgress = puTermProgress progressUI
         termEnabled = termProgressEnabled termProgress
         modLabel mn = modNameToString mn
@@ -1661,6 +1677,8 @@ initCliCompileHooks progressUI progressState gopts sched gen plan = do
           in fitBuildLineLayout width labelWidth statusWidth False modLbl statusRender
         parseActiveLine proj mn =
           renderProjectLine proj mn (staticStatusRenderer "Parsing" "Parse")
+        parseProgressLine proj mn p =
+          renderProjectLine proj mn (parseStatusRenderer p)
         frontInitialLine proj mn =
           renderProjectLine proj mn (staticStatusRenderer "Kinds check" "Kinds")
         backActiveLine proj mn =
@@ -1668,6 +1686,11 @@ initCliCompileHooks progressUI progressState gopts sched gen plan = do
         finalActiveLine width =
           fitBuildLineLayout width labelWidth statusWidth True "" (staticStatusRenderer "Final compilation" "Final")
         clamp01 x = max 0 (min 1 x)
+        parseProgressRatio p =
+          let total = ppTotal p
+          in if total <= 0
+               then 1
+               else clamp01 (fromIntegral (ppCompleted p) / fromIntegral total)
         progressRatio p =
           let total = fppTotal p
           in if total <= 0
@@ -1699,6 +1722,17 @@ initCliCompileHooks progressUI progressState gopts sched gen plan = do
               in case fppPass p of
                    FrontPassKinds -> staticStatusRenderer "Kinds check" "Kinds" budget
                    FrontPassTypes -> Just (fullTypeStatus (fppCurrent p))
+        parseStatusRenderer p budget
+          | budget < 10 = Nothing
+          | otherwise =
+              let pct = floor (100 * parseProgressRatio p :: Double)
+                  full = "Parsing " ++ show pct ++ "%"
+                  short = "Parse " ++ show pct ++ "%"
+              in if length full <= budget
+                   then Just full
+                   else if length short <= budget
+                          then Just short
+                          else Just (show pct ++ "%")
         frontProgressLine proj mn p =
           renderProjectLine proj mn (frontStatusRenderer p)
         finalKey = TaskKey rootProj (A.modName ["__final__"])
@@ -1708,24 +1742,34 @@ initCliCompileHooks progressUI progressState gopts sched gen plan = do
           when (termEnabled && delta > 0) $ do
             new <- atomicModifyIORef' progressRef (\x -> let x' = min compilePhaseTotal (x + delta) in (x', x'))
             setPercent (floor new)
-        shareFor key = M.findWithDefault (0, 0) key shareMap
-        creditFrontTo key frontFrac = gate $ do
-          let (frontShare, _) = shareFor key
+        shareFor key = M.findWithDefault (0, 0, 0) key shareMap
+        creditParseTo key parseFrac = gate $ do
+          let (parseShare, _, _) = shareFor key
           delta <- atomicModifyIORef' marksRef $ \m ->
-            let (frontDoneFrac, backDone) = M.findWithDefault (0, False) key m
+            let (parseDoneFrac, frontDoneFrac, backDone) = M.findWithDefault (0, 0, False) key m
+                parseDoneFrac' = max parseDoneFrac (clamp01 parseFrac)
+                deltaFrac = max 0 (parseDoneFrac' - parseDoneFrac)
+            in (M.insert key (parseDoneFrac', frontDoneFrac, backDone) m, parseShare * deltaFrac)
+          addProgress delta
+        creditFrontTo key frontFrac = gate $ do
+          let (_, frontShare, _) = shareFor key
+          delta <- atomicModifyIORef' marksRef $ \m ->
+            let (parseDoneFrac, frontDoneFrac, backDone) = M.findWithDefault (0, 0, False) key m
                 frontDoneFrac' = max frontDoneFrac (clamp01 frontFrac)
                 deltaFrac = max 0 (frontDoneFrac' - frontDoneFrac)
-            in (M.insert key (frontDoneFrac', backDone) m, frontShare * deltaFrac)
+            in (M.insert key (parseDoneFrac, frontDoneFrac', backDone) m, frontShare * deltaFrac)
           addProgress delta
+        creditParse key = creditParseTo key 1
+        creditParseProgress key p = creditParseTo key (parseProgressRatio p)
         creditFront key = creditFrontTo key 1
         creditFrontProgress key p = creditFrontTo key (frontPassFraction p)
         creditBack key = gate $ do
-          let (_, backShare) = shareFor key
+          let (_, _, backShare) = shareFor key
           delta <- atomicModifyIORef' marksRef $ \m ->
-            let (frontDoneFrac, backDone) = M.findWithDefault (0, False) key m
+            let (parseDoneFrac, frontDoneFrac, backDone) = M.findWithDefault (0, 0, False) key m
             in if backDone
                  then (m, 0)
-                 else (M.insert key (frontDoneFrac, True) m, backShare)
+                 else (M.insert key (parseDoneFrac, frontDoneFrac, True) m, backShare)
           addProgress delta
     setPercent 0
     let backJobKey job =
@@ -1757,9 +1801,17 @@ initCliCompileHooks progressUI progressState gopts sched gen plan = do
               let key = gtKey t
                   proj = tkProj key
                   mn = tkMod key
-              in gate (progressStartTask progressUI progressState key (parseActiveLine proj mn) Nothing)
+              in gate (progressStartTask progressUI progressState key (parseActiveLine proj mn) (Just 0))
+          , chOnParseProgress = \t p ->
+              let key = gtKey t
+                  proj = tkProj key
+                  mn = tkMod key
+              in do
+                gate (progressUpdateTask progressUI progressState key (parseProgressLine proj mn p) (Just (parseProgressRatio p)))
+                creditParseProgress key p
           , chOnParseDone = \t mtime -> do
               gate (progressDoneTask progressUI progressState (gtKey t))
+              creditParse (gtKey t)
               when (not (quiet gopts optsPlan)) $
                 forM_ mtime $ \tParse -> do
                   let proj = tkProj (gtKey t)

--- a/compiler/lib/src/Acton/BuildSpec.hs
+++ b/compiler/lib/src/Acton/BuildSpec.hs
@@ -352,7 +352,7 @@ findBodyOffsetsFromAST content varName (S.Module _ _ _ stmts) =
 parseModuleForSpec :: String -> Either String S.Module
 parseModuleForSpec content =
   let qn = S.ModName []  -- anonymous module
-  in case unsafePerformIO (E.try (AP.parseModule qn "Build.act" content) :: IO (Either E.SomeException S.Module)) of
+  in case unsafePerformIO (E.try (AP.parseModule qn "Build.act" content Nothing) :: IO (Either E.SomeException S.Module)) of
        Left e  -> Left (show e)
        Right m -> Right m
 

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -95,6 +95,7 @@ module Acton.Compile
   , BackTiming(..)
   , FrontPass(..)
   , FrontPassProgress(..)
+  , ParseProgress(..)
   , CompileCallbacks(..)
   , defaultCompileCallbacks
   , BackJobCallbacks(..)
@@ -314,6 +315,11 @@ data FrontPassProgress = FrontPassProgress
   , fppCurrent :: Maybe String
   } deriving (Eq, Show)
 
+data ParseProgress = ParseProgress
+  { ppCompleted :: Int
+  , ppTotal :: Int
+  } deriving (Eq, Show)
+
 data TypeStmtTiming = TypeStmtTiming
   { tstCompleted :: Int
   , tstTotal :: Int
@@ -348,6 +354,7 @@ data BackTiming = BackTiming
 data CompileCallbacks = CompileCallbacks
   { ccOnDiagnostics :: GlobalTask -> C.CompileOptions -> [Diagnostic String] -> IO ()
   , ccOnParseStart :: GlobalTask -> C.CompileOptions -> IO ()
+  , ccOnParseProgress :: GlobalTask -> C.CompileOptions -> ParseProgress -> IO ()
   , ccOnParseDone :: GlobalTask -> C.CompileOptions -> Maybe TimeSpec -> IO ()
   , ccOnFrontResult :: GlobalTask -> C.CompileOptions -> FrontResult -> IO ()
   , ccOnFrontStart :: GlobalTask -> C.CompileOptions -> IO ()
@@ -363,6 +370,7 @@ defaultCompileCallbacks :: CompileCallbacks
 defaultCompileCallbacks = CompileCallbacks
   { ccOnDiagnostics = \_ _ _ -> return ()
   , ccOnParseStart = \_ _ -> return ()
+  , ccOnParseProgress = \_ _ _ -> return ()
   , ccOnParseDone = \_ _ _ -> return ()
   , ccOnFrontResult = \_ _ _ -> return ()
   , ccOnFrontStart = \_ _ -> return ()
@@ -647,6 +655,7 @@ prepareCompilePlanFromContext sp gopts ctx srcFiles allowPrune mChangedPaths = d
 data CompileHooks = CompileHooks
   { chOnDiagnostics :: GlobalTask -> C.CompileOptions -> [Diagnostic String] -> IO ()
   , chOnParseStart :: GlobalTask -> IO ()
+  , chOnParseProgress :: GlobalTask -> ParseProgress -> IO ()
   , chOnParseDone :: GlobalTask -> Maybe TimeSpec -> IO ()
   , chOnFrontStart :: GlobalTask -> IO ()
   , chOnFrontDone :: GlobalTask -> IO ()
@@ -663,6 +672,7 @@ defaultCompileHooks =
   CompileHooks
     { chOnDiagnostics = \_ _ _ -> return ()
     , chOnParseStart = \_ -> return ()
+    , chOnParseProgress = \_ _ -> return ()
     , chOnParseDone = \_ _ -> return ()
     , chOnFrontStart = \_ -> return ()
     , chOnFrontDone = \_ -> return ()
@@ -694,6 +704,7 @@ runCompilePlan sp gopts plan sched gen hooks = do
       callbacks = defaultCompileCallbacks
         { ccOnDiagnostics = \t optsT diags -> chOnDiagnostics hooks t optsT diags
         , ccOnParseStart = \t _ -> chOnParseStart hooks t
+        , ccOnParseProgress = \t _ p -> chOnParseProgress hooks t p
         , ccOnParseDone = \t _ mtime -> chOnParseDone hooks t mtime
         , ccOnFrontResult = \t _ fr -> chOnFrontResult hooks t fr
         , ccOnFrontStart = \t _ -> chOnFrontStart hooks t
@@ -893,14 +904,17 @@ missingIfaceDiagnostics ownerMn src missingMn =
 
 -- | Parse a module from source text, returning diagnostics on failure.
 -- Wraps parser, context, and indentation errors into a uniform format.
-parseActSource :: A.ModName -> FilePath -> String -> IO (Either [Diagnostic String] A.Module)
-parseActSource mn actFile srcContent = do
-  (Right <$> Acton.Parser.parseModule mn actFile srcContent)
+parseActSource :: A.ModName -> FilePath -> String -> Maybe (ParseProgress -> IO ()) -> IO (Either [Diagnostic String] A.Module)
+parseActSource mn actFile srcContent mOnProgress = do
+  (Right <$> Acton.Parser.parseModule mn actFile srcContent (fmap wrapProgress mOnProgress))
     `catch` handleParseBundle
     `catch` handleCustomParse
     `catch` handleContextError
     `catch` handleIndentationError
   where
+    wrapProgress onProgress completed total =
+      onProgress (ParseProgress completed total)
+
     handleParseBundle :: ParseErrorBundle String CustomParseError -> IO (Either [Diagnostic String] A.Module)
     handleParseBundle bundle =
       return $ Left [Diag.parseDiagnosticFromBundle actFile srcContent bundle]
@@ -952,14 +966,20 @@ parseActSnapshot :: A.ModName -> FilePath -> Source.SourceSnapshot -> IO (Either
 parseActSnapshot mn actFile snap = do
   cwd <- getCurrentDirectory
   let displayFile = makeRelative cwd actFile
-  parseActSource mn displayFile (Source.ssText snap)
+  parseActSource mn displayFile (Source.ssText snap) Nothing
 
 -- | Read and parse a source file via SourceProvider (overlay-aware).
 -- Returns both the snapshot and the parsed AST for reuse by callers.
-parseActFile :: Source.SourceProvider -> A.ModName -> FilePath -> IO (Either [Diagnostic String] (Source.SourceSnapshot, A.Module))
-parseActFile sp mn actFile = do
+parseActFile :: Source.SourceProvider
+             -> A.ModName
+             -> FilePath
+             -> Maybe (ParseProgress -> IO ())
+             -> IO (Either [Diagnostic String] (Source.SourceSnapshot, A.Module))
+parseActFile sp mn actFile mOnProgress = do
   snap <- Source.readSource sp actFile
-  emod <- parseActSnapshot mn actFile snap
+  cwd <- getCurrentDirectory
+  let displayFile = makeRelative cwd actFile
+  emod <- parseActSource mn displayFile (Source.ssText snap) mOnProgress
   return $ fmap (\m -> (snap, m)) emod
 
 -- | Read stable source metadata used for quick .ty reuse checks.
@@ -1414,8 +1434,13 @@ readModuleDoc sp gopts opts paths actFile = do
 -- | Materialize a source-backed task into a fully parsed ActonTask.
 -- ParseTask reuses the snapshot captured during graph discovery; TyTask reparses
 -- from the current source file because the cached header was deemed stale.
-materializeTask :: Source.SourceProvider -> A.ModName -> FilePath -> CompileTask -> IO CompileTask
-materializeTask sp mn actFile task =
+materializeTask :: Source.SourceProvider
+                -> A.ModName
+                -> FilePath
+                -> Maybe (ParseProgress -> IO ())
+                -> CompileTask
+                -> IO CompileTask
+materializeTask sp mn actFile mOnProgress task =
   case task of
     ActonTask{} -> return task
     ParseErrorTask{} -> return task
@@ -1425,7 +1450,7 @@ materializeTask sp mn actFile task =
         Left diags -> return (ParseErrorTask mn diags)
         Right m -> return (ActonTask mn srcContent bytes mSourceMeta m)
     TyTask{} -> do
-      parsedRes <- parseActFile sp mn actFile
+      parsedRes <- parseActFile sp mn actFile mOnProgress
       case parsedRes of
         Left diags -> return (ParseErrorTask mn diags)
         Right (snap, m) -> do
@@ -1435,7 +1460,7 @@ materializeTask sp mn actFile task =
     parseStoredSource mn' file srcContent = do
       cwd <- getCurrentDirectory
       let displayFile = makeRelative cwd file
-      parseActSource mn' displayFile srcContent
+      parseActSource mn' displayFile srcContent mOnProgress
 
 
 -- | Recursively read imports for a set of tasks within the same project.
@@ -2163,8 +2188,8 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
         then return (Right ())
         else do
           t' <- case gtTask t of
-            TyTask{} | forceAlt -> materializeTask sp mn actFile (gtTask t)
-            ParseTask{} -> materializeTask sp mn actFile (gtTask t)
+            TyTask{} | forceAlt -> materializeTask sp mn actFile Nothing (gtTask t)
+            ParseTask{} -> materializeTask sp mn actFile Nothing (gtTask t)
             _ -> return (gtTask t)
           case t' of
             ParseErrorTask{ parseDiagnostics = diags } -> do
@@ -2549,7 +2574,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
                             ccOnInfo callbacks ("  Stale " ++ modNameToString mn ++ ": missing dep hashes in " ++ Data.List.intercalate ", " (pubMissingItems ++ implMissingItems))
                     t' <- case taskCurrent of
                             ActonTask{} -> return taskCurrent
-                            _ -> materializeTask sp mn actFile taskCurrent
+                            _ -> materializeTask sp mn actFile Nothing taskCurrent
                     case t' of
                       ParseErrorTask{ parseDiagnostics = diags } -> return (key, Left diags)
                       ActonTask{ src = srcContent, srcBytes = srcBytes, sourceMeta = mSourceMeta, atree = m } -> do
@@ -2595,7 +2620,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
                       case tyRes of
                         Left diags -> return (key, Left diags)
                         Right (_ms, nmod, tmod, sourceMeta, moduleSrcBytesHash, modulePubHash, _moduleImplHash, imps, nameHashes, roots, tests, mdoc) -> do
-                          parsedRes <- parseActFile sp mn actFile
+                          parsedRes <- parseActFile sp mn actFile Nothing
                           case parsedRes of
                             Left diags -> return (key, Left diags)
                             Right (snap, parsedMod) -> do
@@ -2697,11 +2722,12 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
       let optsT = optsFor key
           mn = name (gtTask t)
           actFile = srcFile (gtPaths t) mn
+          onProgress p = ccOnParseProgress callbacks t optsT p
       timeStart <- getTime Monotonic
       parsed <- if C.only_build optsT
                   then return (gtTask t)
                   else case gtTask t of
-                         ParseTask{} -> materializeTask sp mn actFile (gtTask t)
+                         ParseTask{} -> materializeTask sp mn actFile (Just onProgress) (gtTask t)
                          _ -> return (gtTask t)
       case parsed of
         ParseTask{} -> return (ParseStage key, Right (StageParsed parsed Nothing))

--- a/compiler/lib/src/Acton/Parser.hs
+++ b/compiler/lib/src/Acton/Parser.hs
@@ -21,6 +21,7 @@ module Acton.Parser
 import qualified Control.Monad.Trans.State.Strict as St
 import qualified Control.Exception
 import Control.Monad (void, when, join)
+import Data.IORef
 import Data.List (isPrefixOf)
 import Data.Maybe (fromMaybe)
 import Data.Void
@@ -114,13 +115,15 @@ makeReport ps src = errReport (map setSpan ps) src
 
 --- Main parsing and error message functions ------------------------------------------------------
 
-parseModule :: S.ModName -> String -> String -> IO S.Module
-parseModule qn fileName fileContent =
-    -- Add a newline at the end if there isn't one already to allow files ending without newline
-    let contentWithNewline = if null fileContent || last fileContent == '\n'
-                             then fileContent
-                             else fileContent ++ "\n"
-    in case runParser (St.evalStateT file_input initState) fileName contentWithNewline of
+parseModule :: S.ModName -> String -> String -> Maybe (Int -> Int -> IO ()) -> IO S.Module
+parseModule qn fileName fileContent mReportProgress = do
+    let contentWithNewline = addFinalNewline fileContent
+    st <- case mReportProgress of
+            Nothing -> return initState
+            Just reportProgress -> do
+              lastPercent <- newIORef 0
+              return initState { psProgress = Just (ParseProgressReporter (length contentWithNewline) lastPercent reportProgress) }
+    case runParser (St.evalStateT file_input st) fileName contentWithNewline of
         Left err -> Control.Exception.throw err
         Right (i,mdoc,s) -> return $ S.Module qn i mdoc s
 
@@ -129,12 +132,15 @@ parseModuleImports fileName fileContent = fst <$> parseModuleHeader fileName fil
 
 parseModuleHeader :: String -> String -> IO ([S.Import], Maybe String)
 parseModuleHeader fileName fileContent =
-    let contentWithNewline = if null fileContent || last fileContent == '\n'
-                             then fileContent
-                             else fileContent ++ "\n"
+    let contentWithNewline = addFinalNewline fileContent
     in case runParser (St.evalStateT import_input initState) fileName contentWithNewline of
         Left err -> Control.Exception.throw err
         Right res -> return res
+
+addFinalNewline :: String -> String
+addFinalNewline s
+    | null s || last s == '\n' = s
+    | otherwise = s ++ "\n"
 
 -- parseTest file = snd (unsafePerformIO (do cont <- readFile file; parseModule (S.modName ["test"]) file cont))
 
@@ -161,15 +167,52 @@ extractSrcSpan (Loc l r) src = sp
 
 -- Parser state -----------------------------------------------------------
 
-type ParserState = [CTX]  -- Parser contexts
+data ParserState = ParserState
+  { psContexts :: [CTX]
+  , psProgress :: Maybe ParseProgressReporter
+  }
+
+data ParseProgressReporter = ParseProgressReporter
+  { pprTotal :: Int
+  , pprLastPercent :: IORef Int
+  , pprReport :: Int -> Int -> IO ()
+  }
 
 type Parser = St.StateT ParserState (Parsec CustomParseError String)
 
-pushCtx ctx ctxs = ctx:ctxs
-popCtx ctxs      = tail ctxs
-getCtxs          = id
+pushCtx ctx st = st { psContexts = ctx : psContexts st }
+popCtx st      = st { psContexts = tail (psContexts st) }
+getCtxs        = psContexts
 
-initState        = []
+initState        = ParserState [] Nothing
+
+reportParseProgress :: Parser ()
+reportParseProgress = do
+    st <- St.get
+    case psProgress st of
+      Nothing -> return ()
+      Just p -> do
+        off <- getOffset
+        emitParseProgressUnsafe p off `seq` return ()
+
+-- The reporter is installed only when parseModule receives one and emits
+-- monotonic percent updates at successful statement/import boundaries.
+emitParseProgressUnsafe :: ParseProgressReporter -> Int -> ()
+emitParseProgressUnsafe p off = unsafePerformIO (emitParseProgress p off)
+{-# NOINLINE emitParseProgressUnsafe #-}
+
+emitParseProgress :: ParseProgressReporter -> Int -> IO ()
+emitParseProgress p off = do
+    let total = pprTotal p
+        completed = max 0 (min total off)
+        percent
+          | total <= 0 = 100
+          | otherwise = max 0 (min 100 ((completed * 100) `div` total))
+    prev <- readIORef (pprLastPercent p)
+    let shouldReport = percent > prev
+    when shouldReport $
+      writeIORef (pprLastPercent p) percent
+    when shouldReport (pprReport p completed total)
 
 -- Parser contexts ---------------------------------------------------------
 
@@ -1102,10 +1145,10 @@ import_input = sc2 *> do
     return (is, mbDocstring)
 
 imports :: Parser [S.Import]
-imports = many (L.nonIndented sc2 import_stmt <* eol <* sc2)
+imports = many (L.nonIndented sc2 import_stmt <* eol <* sc2 <* reportParseProgress)
 
 top_suite :: Parser S.Suite
-top_suite = concat <$> (many (L.nonIndented sc2 stmt <|> newline1))
+top_suite = concat <$> (many (L.nonIndented sc2 (stmt <* reportParseProgress) <|> (newline1 <* reportParseProgress)))
 
 validateModuleSuite :: S.Suite -> Parser ()
 validateModuleSuite stmts = do
@@ -1543,13 +1586,13 @@ data_stmt = addLoc $
 suiteWithDocstring :: CTX -> Pos -> Parser (S.Suite, Maybe String)
 suiteWithDocstring c p = do
     withCtx c colon
-    withCtx c (indentSuiteWithDocstring p <|> simple_stmt_with_docstring)
+    withCtx c (indentSuiteWithDocstring p <|> (simple_stmt_with_docstring <* reportParseProgress))
 
 suite :: CTX -> Pos -> Parser S.Suite
 suite c p = do
     o <- getOffset
     withCtx c colon
-    stmts <- withCtx c (indentSuite p <|> simple_stmt)
+    stmts <- withCtx c (indentSuite p <|> (simple_stmt <* reportParseProgress))
     return stmts
   where indentSuite p = do
           newline1
@@ -1570,7 +1613,7 @@ stmtAtIndentWithDocstring p1 = do
     case compare p1 p2 of
         LT -> do o <- getOffset
                  Control.Exception.throw $ IndentationError (Loc o o)
-        EQ -> stmtWithDocstring
+        EQ -> stmtWithDocstring <* reportParseProgress
         GT -> L.incorrectIndent GT p2 p1
 
 stmtAtIndent :: Pos -> Parser S.Suite
@@ -1579,7 +1622,7 @@ stmtAtIndent p1 = do
     case compare p1 p2 of
         LT -> do o <- getOffset
                  Control.Exception.throw $ IndentationError (Loc o o)
-        EQ -> stmt
+        EQ -> stmt <* reportParseProgress
         GT -> L.incorrectIndent GT p2 p1
 
 stmtWithDocstring :: Parser (S.Suite, Maybe String)

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -99,6 +99,17 @@ main = do
 
     describe "Pass 1: Parser" $ do
 
+      it "reports rough parse progress by source offset" $ do
+        progressRef <- newIORef []
+        _ <- P.parseModule (S.modName ["progress"]) "progress.act" "x = 1\n" (Just $ \completed total ->
+          modifyIORef' progressRef (++ [(completed, total)]))
+        progress <- readIORef progressRef
+        let completed = map fst progress
+            monotonic xs = and (zipWith (<=) xs (drop 1 xs))
+        progress `shouldSatisfy` (not . null)
+        completed `shouldSatisfy` monotonic
+        last progress `shouldBe` (6, 6)
+
       describe "Basic Syntax" $ do
         testParse env0 ["syntax1"]
 
@@ -937,7 +948,7 @@ main = do
             actFile = "<top_non_total_sig>"
             sysTypesPath = ".." </> ".." </> "dist" </> "base" </> "out" </> "types"
             onInferred names sig = modifyIORef' sigsRef ((names, sig) :)
-        parsed <- liftIO $ P.parseModule moduleName actFile src
+        parsed <- liftIO $ P.parseModule moduleName actFile src Nothing
         env <- liftIO $ Acton.Env.mkEnv [sysTypesPath] env0 parsed
         kchecked <- liftIO $ Acton.Kinds.check env parsed
         _ <- liftIO $ Acton.Types.reconstruct Nothing (Just onInferred) env kchecked
@@ -1797,7 +1808,7 @@ parseAct env0 modulePath = do
       sysTypesPath = ".." </> ".." </> "dist" </> "base" </> "out" </> "types"
 
   src <- liftIO $ readFile act_file
-  parsed <- liftIO $ P.parseModule moduleName act_file src
+  parsed <- liftIO $ P.parseModule moduleName act_file src Nothing
   env <- liftIO $ Acton.Env.mkEnv [sysTypesPath] env0 parsed
   return (env, parsed)
 
@@ -1805,7 +1816,7 @@ typecheckSource env0 modName src = do
   let moduleName = S.modName [modName]
       actFile = "<" ++ modName ++ ">"
       sysTypesPath = ".." </> ".." </> "dist" </> "base" </> "out" </> "types"
-  parsed <- liftIO $ P.parseModule moduleName actFile src
+  parsed <- liftIO $ P.parseModule moduleName actFile src Nothing
   env <- liftIO $ Acton.Env.mkEnv [sysTypesPath] env0 parsed
   kchecked <- liftIO $ Acton.Kinds.check env parsed
   (_, tchecked, _, _, _) <- liftIO $ Acton.Types.reconstruct Nothing Nothing env kchecked

--- a/compiler/tests/TestTransform.hs
+++ b/compiler/tests/TestTransform.hs
@@ -22,9 +22,9 @@ import Tests.CPretty
 import InterfaceFiles
 
 
-main                  = do (_,m) <- P.parseModule (ModName [name "__builtin__"]) "__builtin__.act"
+main                  = do src <- readFile "__builtin__.act"
+                           m <- P.parseModule (ModName [name "__builtin__"]) "__builtin__.act" src Nothing
                            let m1  = transform m
                            putStrLn (render(cprint m1))
-
 
 


### PR DESCRIPTION
The parser now reports rough percentage of progress. Good for very large files.

The reporter samples source offsets at successful boundaries and suppresses duplicate percentage updates with a parser-local IORef, avoiding per-token UI work.