### PR TITLE
Parse modules in parallel

### DIFF
--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -1249,7 +1249,7 @@ printDocs gopts opts = do
           ".act" -> do
             let modname = A.modName $ map (replace ".act" "") $ splitOn "/" $ fileBody
             paths <- findPaths filename defaultCompileOptions
-            parsedRes <- parseActFile Source.diskSourceProvider modname filename Nothing
+            parsedRes <- parseActFile defaultCompileOptions Source.diskSourceProvider modname filename Nothing
             (_snap, parsed) <- case parsedRes of
               Left diags -> do
                 printDiagnostics gopts defaultCompileOptions diags

--- a/compiler/acton/TestGolden.hs
+++ b/compiler/acton/TestGolden.hs
@@ -8,8 +8,7 @@ module TestGolden
 import           Data.Char (isDigit)
 import qualified Data.Text as T
 
--- | Replace trailing durations like "12.345 s" with a stable token
--- "0.000 s", preserving the original field width for alignment.
+-- | Replace trailing durations like "12.345 s" with a stable token.
 normalizeProgressTimingLine :: T.Text -> T.Text
 normalizeProgressTimingLine t =
   case T.stripSuffix " s" t of
@@ -24,7 +23,7 @@ normalizeProgressTimingLine t =
                && T.all isDigit intPart
                && T.all isDigit frac ->
                  let base = "0.000"
-                     padding = T.replicate (max 0 (T.length field - T.length base)) " "
+                     padding = if T.length field > T.length base then " " else ""
                  in pre' <> padding <> base <> " s"
            _ -> t
 

--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -443,6 +443,13 @@ parseFlagTests =
       assertParsedBuildOptimize ["build", "--release", "--optimize=releasesmall"] C.ReleaseSmall
       assertParsedBuildOptimize ["build", "--release=fast", "--optimize=debug"] C.Debug
       assertParsedBuildOptimize ["build", "--optimize=debug", "--release"] C.Debug
+  , testCase "build parser accepts --parse-serial" $ do
+      parsed <- parseArgs ["build", "--parse-serial"]
+      case parsed of
+        C.CmdOpt _ (C.Build buildOpts) ->
+          assertBool "serial parser flag should be set" (C.parse_serial (C.buildCompile buildOpts))
+        _ ->
+          assertFailure "expected build command"
   , testCase "build parser help includes --release alias" $ do
       helpText <- renderParserHelp ["build", "--help"]
       assertBool "help text should include --release" ("--release" `isInfixOf` helpText)

--- a/compiler/acton/test/syntaxerrors/err20.golden
+++ b/compiler/acton/test/syntaxerrors/err20.golden
@@ -1,12 +1,12 @@
 Building file test/syntaxerrors/err20.act using temporary scratch directory
-[error Parse error]: unexpected '@'
-                     expecting docstring, end of input, end of line, import statement, or statement
+[error Parse error]: unexpected "@<newline>def decorate"
+                     expecting statement
 
      +--> test/syntaxerrors/err20.act@2:1-2:2
      |
    2 | @
      : ^
-     : `- unexpected '@'
-     :    expecting docstring, end of input, end of line, import statement, or statement
+     : `- unexpected "@<newline>def decorate"
+     :    expecting statement
      :    
 -----+

--- a/compiler/lib/src/Acton/CommandLineParser.hs
+++ b/compiler/lib/src/Acton/CommandLineParser.hs
@@ -90,6 +90,7 @@ data CompileOptions   = CompileOptions {
                          skip_build  :: Bool,
                          watch       :: Bool,
                          no_threads  :: Bool,
+                         parse_serial :: Bool,
                          root        :: String,
                          tempdir     :: String,
                          syspath     :: String,
@@ -333,6 +334,7 @@ sigCompileOptions = mkSigCompileOptions
         , skip_build = True
         , watch = False
         , no_threads = False
+        , parse_serial = False
         , root = ""
         , tempdir = ""
         , syspath = syspath'
@@ -368,6 +370,7 @@ compileOptions = CompileOptions
         <*> switch (long "skip-build"   <> help "Skip final bulid of .c files")
         <*> switch (long "watch"        <> help "Rebuild on file changes")
         <*> switch (long "no-threads"   <> help "Don't use threads")
+        <*> switch (long "parse-serial" <> help "Use the serial whole-file parser")
         <*> strOption (long "root"      <> metavar "ROOTACTOR" <> value "" <> help "Set root actor")
         <*> strOption (long "tempdir"   <> metavar "TEMPDIR" <> value "" <> help "Set directory for build files")
         <*> strOption (long "syspath"   <> metavar "TARGETDIR" <> value "" <> help "Set syspath")

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -185,7 +185,7 @@ module Acton.Compile
 import Prelude hiding (readFile, writeFile)
 
 import qualified Acton.Parser
-import Acton.Parser (CustomParseError, CustomParseException, ContextError, IndentationError)
+import Acton.Parser (CustomParseError, CustomParseException, ChunkScanError(..), ContextError, IndentationError)
 import qualified Acton.Syntax as A
 import qualified Acton.NameInfo as I
 import Text.Megaparsec.Error (ParseErrorBundle)
@@ -747,6 +747,7 @@ defaultCompileOptions =
     , C.skip_build = False
     , C.watch = False
     , C.no_threads = False
+    , C.parse_serial = False
     , C.root = ""
     , C.tempdir = ""
     , C.syspath = ""
@@ -904,11 +905,15 @@ missingIfaceDiagnostics ownerMn src missingMn =
 
 -- | Parse a module from source text, returning diagnostics on failure.
 -- Wraps parser, context, and indentation errors into a uniform format.
-parseActSource :: A.ModName -> FilePath -> String -> Maybe (ParseProgress -> IO ()) -> IO (Either [Diagnostic String] A.Module)
-parseActSource mn actFile srcContent mOnProgress = do
-  (Right <$> Acton.Parser.parseModule mn actFile srcContent (fmap wrapProgress mOnProgress))
+parseActSource :: C.CompileOptions -> A.ModName -> FilePath -> String -> Maybe (ParseProgress -> IO ()) -> IO (Either [Diagnostic String] A.Module)
+parseActSource opts mn actFile srcContent mOnProgress = do
+  let parseModule
+        | C.parse_serial opts = Acton.Parser.parseModuleSerial
+        | otherwise             = Acton.Parser.parseModule
+  (Right <$> parseModule mn actFile srcContent (fmap wrapProgress mOnProgress))
     `catch` handleParseBundle
     `catch` handleCustomParse
+    `catch` handleChunkScanError
     `catch` handleContextError
     `catch` handleIndentationError
   where
@@ -922,6 +927,10 @@ parseActSource mn actFile srcContent mOnProgress = do
     handleCustomParse :: CustomParseException -> IO (Either [Diagnostic String] A.Module)
     handleCustomParse err =
       return $ Left [Diag.customParseExceptionToDiagnostic actFile srcContent err]
+
+    handleChunkScanError :: ChunkScanError -> IO (Either [Diagnostic String] A.Module)
+    handleChunkScanError (ChunkScanError loc msg) =
+      return $ Left (errsToDiagnostics "Parse error" actFile srcContent [(loc, msg)])
 
     handleContextError :: ContextError -> IO (Either [Diagnostic String] A.Module)
     handleContextError err =
@@ -962,24 +971,25 @@ parseActHeaderSnapshot mn actFile snap = do
 
 -- | Parse a SourceSnapshot with a display path relative to cwd.
 -- Keeps diagnostics stable regardless of absolute paths or overlays.
-parseActSnapshot :: A.ModName -> FilePath -> Source.SourceSnapshot -> IO (Either [Diagnostic String] A.Module)
-parseActSnapshot mn actFile snap = do
+parseActSnapshot :: C.CompileOptions -> A.ModName -> FilePath -> Source.SourceSnapshot -> IO (Either [Diagnostic String] A.Module)
+parseActSnapshot opts mn actFile snap = do
   cwd <- getCurrentDirectory
   let displayFile = makeRelative cwd actFile
-  parseActSource mn displayFile (Source.ssText snap) Nothing
+  parseActSource opts mn displayFile (Source.ssText snap) Nothing
 
 -- | Read and parse a source file via SourceProvider (overlay-aware).
 -- Returns both the snapshot and the parsed AST for reuse by callers.
-parseActFile :: Source.SourceProvider
+parseActFile :: C.CompileOptions
+             -> Source.SourceProvider
              -> A.ModName
              -> FilePath
              -> Maybe (ParseProgress -> IO ())
              -> IO (Either [Diagnostic String] (Source.SourceSnapshot, A.Module))
-parseActFile sp mn actFile mOnProgress = do
+parseActFile opts sp mn actFile mOnProgress = do
   snap <- Source.readSource sp actFile
   cwd <- getCurrentDirectory
   let displayFile = makeRelative cwd actFile
-  emod <- parseActSource mn displayFile (Source.ssText snap) mOnProgress
+  emod <- parseActSource opts mn displayFile (Source.ssText snap) mOnProgress
   return $ fmap (\m -> (snap, m)) emod
 
 -- | Read stable source metadata used for quick .ty reuse checks.
@@ -1435,13 +1445,14 @@ readModuleDoc sp gopts opts paths actFile = do
 -- | Materialize a source-backed task into a fully parsed ActonTask.
 -- ParseTask reuses the snapshot captured during graph discovery; TyTask reparses
 -- from the current source file because the cached header was deemed stale.
-materializeTask :: Source.SourceProvider
+materializeTask :: C.CompileOptions
+                -> Source.SourceProvider
                 -> A.ModName
                 -> FilePath
                 -> Maybe (ParseProgress -> IO ())
                 -> CompileTask
                 -> IO CompileTask
-materializeTask sp mn actFile mOnProgress task =
+materializeTask opts sp mn actFile mOnProgress task =
   case task of
     ActonTask{} -> return task
     ParseErrorTask{} -> return task
@@ -1451,7 +1462,7 @@ materializeTask sp mn actFile mOnProgress task =
         Left diags -> return (ParseErrorTask mn diags)
         Right m -> return (ActonTask mn srcContent bytes mSourceMeta m)
     TyTask{} -> do
-      parsedRes <- parseActFile sp mn actFile mOnProgress
+      parsedRes <- parseActFile opts sp mn actFile mOnProgress
       case parsedRes of
         Left diags -> return (ParseErrorTask mn diags)
         Right (snap, m) -> do
@@ -1461,7 +1472,7 @@ materializeTask sp mn actFile mOnProgress task =
     parseStoredSource mn' file srcContent = do
       cwd <- getCurrentDirectory
       let displayFile = makeRelative cwd file
-      parseActSource mn' displayFile srcContent mOnProgress
+      parseActSource opts mn' displayFile srcContent mOnProgress
 
 
 -- | Recursively read imports for a set of tasks within the same project.
@@ -2190,8 +2201,8 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
         then return (Right ())
         else do
           t' <- case gtTask t of
-            TyTask{} | forceAlt -> materializeTask sp mn actFile Nothing (gtTask t)
-            ParseTask{} -> materializeTask sp mn actFile Nothing (gtTask t)
+            TyTask{} | forceAlt -> materializeTask optsBuiltin sp mn actFile Nothing (gtTask t)
+            ParseTask{} -> materializeTask optsBuiltin sp mn actFile Nothing (gtTask t)
             _ -> return (gtTask t)
           case t' of
             ParseErrorTask{ parseDiagnostics = diags } -> do
@@ -2578,7 +2589,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
                             ccOnInfo callbacks ("  Stale " ++ modNameToString mn ++ ": missing dep hashes in " ++ Data.List.intercalate ", " (pubMissingItems ++ implMissingItems))
                     t' <- case taskCurrent of
                             ActonTask{} -> return taskCurrent
-                            _ -> materializeTask sp mn actFile Nothing taskCurrent
+                            _ -> materializeTask optsT sp mn actFile Nothing taskCurrent
                     case t' of
                       ParseErrorTask{ parseDiagnostics = diags } -> return (key, Left diags)
                       ActonTask{ src = srcContent, srcBytes = srcBytes, sourceMeta = mSourceMeta, atree = m } -> do
@@ -2624,7 +2635,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
                       case tyRes of
                         Left diags -> return (key, Left diags)
                         Right (_ms, nmod, tmod, sourceMeta, moduleSrcBytesHash, modulePubHash, _moduleImplHash, imps, nameHashes, roots, tests, mdoc) -> do
-                          parsedRes <- parseActFile sp mn actFile Nothing
+                          parsedRes <- parseActFile optsT sp mn actFile Nothing
                           case parsedRes of
                             Left diags -> return (key, Left diags)
                             Right (snap, parsedMod) -> do
@@ -2731,7 +2742,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
       parsed <- if C.only_build optsT
                   then return (gtTask t)
                   else case gtTask t of
-                         ParseTask{} -> materializeTask sp mn actFile (Just onProgress) (gtTask t)
+                         ParseTask{} -> materializeTask optsT sp mn actFile (Just onProgress) (gtTask t)
                          _ -> return (gtTask t)
       case parsed of
         ParseTask{} -> return (ParseStage key, Right (StageParsed parsed Nothing))

--- a/compiler/lib/src/Acton/Parser.hs
+++ b/compiler/lib/src/Acton/Parser.hs
@@ -20,7 +20,12 @@ module Acton.Parser
 
 import qualified Control.Monad.Trans.State.Strict as St
 import qualified Control.Exception
-import Control.Monad (void, when, join)
+import Control.Concurrent.Async (Async, async, cancel, wait)
+import Control.Concurrent.Chan
+import Control.Concurrent.MVar
+import Control.Concurrent.QSem
+import Control.Monad (replicateM, replicateM_, void, when, join)
+import Control.DeepSeq (rnf)
 import Data.IORef
 import Data.List (isPrefixOf)
 import Data.Maybe (fromMaybe)
@@ -28,10 +33,12 @@ import Data.Void
 import Data.Char
 import qualified Data.List.NonEmpty as N
 import qualified Data.Set as Set
+import GHC.Conc (getNumCapabilities)
 import Numeric
 import Text.Megaparsec
 import Text.Megaparsec.Char
 import Text.Megaparsec.Error
+import Text.Megaparsec.Pos (mkPos)
 --import Control.Monad.Combinators.Expr
 import Text_Megaparsec_Expr
 import qualified Text.Megaparsec.Char.Lexer as L
@@ -118,11 +125,22 @@ makeReport ps src = errReport (map setSpan ps) src
 parseModule :: S.ModName -> String -> String -> Maybe (Int -> Int -> IO ()) -> IO S.Module
 parseModule qn fileName fileContent mReportProgress = do
     let contentWithNewline = addFinalNewline fileContent
-    st <- case mReportProgress of
-            Nothing -> return initState
-            Just reportProgress -> do
-              lastPercent <- newIORef 0
-              return initState { psProgress = Just (ParseProgressReporter (length contentWithNewline) lastPercent reportProgress) }
+    (is, mdoc, bodyStart) <-
+      case runParser (St.evalStateT module_header_with_offset initState) fileName contentWithNewline of
+        Left err -> Control.Exception.throwIO err
+        Right h  -> return h
+    parsed <- parseTopLevelChunks fileName contentWithNewline bodyStart mReportProgress
+    let suite = regroupTopDecls (concat parsed)
+    case runParser (St.evalStateT (validateModuleSuite suite) initState) fileName contentWithNewline of
+      Left err -> Control.Exception.throwIO err
+      Right () -> do
+        reportFinalParseProgress contentWithNewline mReportProgress
+        return $ S.Module qn is mdoc suite
+
+parseModuleSerial :: S.ModName -> String -> String -> Maybe (Int -> Int -> IO ()) -> IO S.Module
+parseModuleSerial qn fileName fileContent mReportProgress = do
+    let contentWithNewline = addFinalNewline fileContent
+    st <- parserStateWithProgress contentWithNewline mReportProgress
     case runParser (St.evalStateT file_input st) fileName contentWithNewline of
         Left err -> Control.Exception.throw err
         Right (i,mdoc,s) -> return $ S.Module qn i mdoc s
@@ -185,6 +203,22 @@ popCtx st      = st { psContexts = tail (psContexts st) }
 getCtxs        = psContexts
 
 initState        = ParserState [] Nothing
+
+parserStateWithProgress :: String -> Maybe (Int -> Int -> IO ()) -> IO ParserState
+parserStateWithProgress contentWithNewline mReportProgress =
+    case mReportProgress of
+      Nothing -> return initState
+      Just reportProgress -> do
+        lastPercent <- newIORef 0
+        return initState { psProgress = Just (ParseProgressReporter (length contentWithNewline) lastPercent reportProgress) }
+
+reportFinalParseProgress :: String -> Maybe (Int -> Int -> IO ()) -> IO ()
+reportFinalParseProgress contentWithNewline mReportProgress =
+    case mReportProgress of
+      Nothing -> return ()
+      Just reportProgress ->
+        let total = length contentWithNewline
+        in reportProgress total total
 
 reportParseProgress :: Parser ()
 reportParseProgress = do
@@ -306,6 +340,10 @@ instance Control.Exception.Exception CustomParseException
 
 parseException :: SrcLoc -> CustomParseError -> a
 parseException loc customErr = Control.Exception.throw $ CustomParseException loc customErr
+
+data ChunkScanError = ChunkScanError SrcLoc String deriving (Show, Eq)
+
+instance Control.Exception.Exception ChunkScanError
 
 --- Whitespace consumers ----------------------------------------------------
 
@@ -1127,7 +1165,7 @@ module_docstring = do
     return (unescapeString (concat ss))
 
 file_input :: Parser ([S.Import], Maybe String, S.Suite)
-file_input = sc2 *>  do
+file_input = sc2 *> do
     -- Allow optional module docstring before imports
     mbDocstring <- optional (try (L.nonIndented sc2 module_docstring <* eol <* sc2))
     is <- imports
@@ -1139,10 +1177,16 @@ file_input = sc2 *>  do
 -- (((,) <$> imports <*> withCtx TOP top_suite) <* eof)
 
 import_input :: Parser ([S.Import], Maybe String)
-import_input = sc2 *> do
+import_input = do
+    (is, mbDocstring, _) <- module_header_with_offset
+    return (is, mbDocstring)
+
+module_header_with_offset :: Parser ([S.Import], Maybe String, Int)
+module_header_with_offset = sc2 *> do
     mbDocstring <- optional (try (L.nonIndented sc2 module_docstring <* eol <* sc2))
     is <- imports
-    return (is, mbDocstring)
+    off <- getOffset
+    return (is, mbDocstring, off)
 
 imports :: Parser [S.Import]
 imports = many (L.nonIndented sc2 import_stmt <* eol <* sc2 <* reportParseProgress)
@@ -1151,23 +1195,430 @@ top_suite :: Parser S.Suite
 top_suite = concat <$> (many (L.nonIndented sc2 (stmt <* reportParseProgress) <|> (newline1 <* reportParseProgress)))
 
 validateModuleSuite :: S.Suite -> Parser ()
-validateModuleSuite stmts = do
-  assigned <- concat <$> mapM validateModuleStmt stmts
-  case duplicates assigned of
-    n:_ -> parseException (loc n) (DuplicateTopLevelAssignment (S.rawstr n))
-    []  -> return ()
+validateModuleSuite = go Set.empty
+  where
+    go seen [] = return ()
+    go seen (stmt:stmts) =
+      case stmt of
+        S.Assign _ pats _ -> do
+          let names = Names.bound pats
+          if null names
+            then parseException (loc pats) InvalidTopLevelAssignmentPattern
+            else do
+              seen' <- addNames seen names
+              go seen' stmts
+        S.Signature{} -> go seen stmts
+        S.Decl{}      -> go seen stmts
+        _             -> parseException (S.sloc stmt) InvalidModuleStatement
 
-validateModuleStmt :: S.Stmt -> Parser [S.Name]
-validateModuleStmt stmt =
-  case stmt of
-    S.Assign _ pats _ ->
-      let names = Names.bound pats
-      in if null names
-         then parseException (loc pats) InvalidTopLevelAssignmentPattern
-         else return names
-    S.Signature{} -> return []
-    S.Decl{}      -> return []
-    _             -> parseException (S.sloc stmt) InvalidModuleStatement
+    addNames seen [] = return seen
+    addNames seen (n:ns)
+      | n `Set.member` seen = parseException (loc n) (DuplicateTopLevelAssignment (S.rawstr n))
+      | otherwise           = addNames (Set.insert n seen) ns
+
+data SourceSpan = SourceSpan !Int !Int deriving (Eq, Show)
+
+data TopLevelChunk = TopLevelChunk
+  { chunkSpan  :: !SourceSpan
+  , chunkInput :: String
+  , chunkLine  :: !Int
+  } deriving (Eq, Show)
+
+data ScanMode = ScanString
+  { scanQuote       :: Char
+  , scanTriple      :: Bool
+  , scanInterpolate :: Bool
+  , scanInterpDepth :: Int
+  } deriving (Eq, Show)
+
+data ChunkScanState = ChunkScanState
+  { scanActiveStart :: Maybe Int
+  , scanActiveInput :: Maybe String
+  , scanActiveLine  :: Maybe Int
+  , scanDepth       :: Int
+  , scanModes       :: [ScanMode]
+  , scanAtLineStart :: Bool
+  , scanLine        :: Int
+  , scanContinued   :: Bool
+  , scanBackslash   :: Bool
+  , scanPrev1       :: Maybe Char
+  , scanPrev2       :: Maybe Char
+  } deriving (Eq, Show)
+
+scanTopLevelChunks :: String -> Int -> (TopLevelChunk -> IO ()) -> IO (Either ChunkScanError ())
+scanTopLevelChunks src start emit
+  | start < 0 || start > length src = return (Left (ChunkScanError NoLoc "invalid module body offset"))
+  | otherwise = go start (drop start src) initScan
+  where
+    initScan = ChunkScanState
+      { scanActiveStart = Nothing
+      , scanActiveInput = Nothing
+      , scanActiveLine = Nothing
+      , scanDepth = 0
+      , scanModes = []
+      , scanAtLineStart = start == 0 || charBefore start == Just '\n'
+      , scanLine = startLine
+      , scanContinued = False
+      , scanBackslash = False
+      , scanPrev1 = charBefore start
+      , scanPrev2 = if start >= 2 then Just (src !! (start - 2)) else Nothing
+      }
+
+    charBefore 0 = Nothing
+    charBefore n = Just (src !! (n - 1))
+
+    startLine = 1 + length (filter (== '\n') (take start src))
+
+    go i [] st = do
+      emitOpenChunk i st
+      return (Right ())
+    go i xs@(c:_) st
+      | startsBoundary c st =
+          openChunk i xs st >>= scanCode i xs
+      | scanActiveStart st == Nothing
+        && null (scanModes st)
+        && scanDepth st == 0
+        && not (isTriviaStart c) =
+          return (Left (ChunkScanError (Loc i (i + 1)) "non-top-level text before first chunk"))
+      | otherwise =
+          scanStep i xs st
+
+    startsBoundary c st =
+      scanAtLineStart st &&
+      not (scanContinued st) &&
+      scanDepth st == 0 &&
+      null (scanModes st) &&
+      not (isTriviaStart c)
+
+    isTriviaStart c = c == '\n' || c == '\r' || c == ' ' || c == '\t' || c == '#'
+
+    openChunk i xs st = do
+      emitOpenChunk i st
+      return st
+        { scanActiveStart = Just i
+        , scanActiveInput = Just xs
+        , scanActiveLine = Just (scanLine st)
+        }
+
+    emitOpenChunk i st =
+      case scanActiveStart st of
+        Just s
+          | s < i ->
+              emit (TopLevelChunk (SourceSpan s i)
+                                    (fromMaybe [] (scanActiveInput st))
+                                    (fromMaybe (scanLine st) (scanActiveLine st)))
+        _ -> return ()
+
+    scanStep i xs st =
+      case scanModes st of
+        [] -> scanCode i xs st
+        _  -> scanString i xs st
+
+    scanCode i xs@(c:_) st
+      | c == '#' =
+          skipComment i xs st { scanBackslash = False }
+      | Just (mode, qlen) <- stringStartMode xs st =
+          let (_, rest, st') = consumeMany False qlen i xs st
+          in go (i + qlen) rest st' { scanModes = mode : scanModes st', scanBackslash = False }
+      | c `elem` "([{" =
+          let (_, rest, st') = consumeMany True 1 i xs st { scanDepth = scanDepth st + 1 }
+          in go (i + 1) rest st'
+      | c `elem` ")]}" =
+          let depth' = max 0 (scanDepth st - 1)
+              (_, rest, st') = consumeMany True 1 i xs st { scanDepth = depth' }
+          in go (i + 1) rest st'
+      | otherwise =
+          let (_, rest, st') = consumeMany True 1 i xs st
+          in go (i + 1) rest st'
+
+    scanString i [] st = go i [] st
+    scanString i xs@(c:_) st =
+      case scanModes st of
+        [] -> scanCode i xs st
+        mode:rest
+          | scanInterpDepth mode == 0 -> scanStringText i xs mode rest st
+          | otherwise                 -> scanInterpolation i xs mode rest st
+
+    scanStringText i xs@(c:_) mode rest st
+      | c == '\\' =
+          let n = case xs of
+                _:_:_ -> 2
+                _     -> 1
+              (_, xs', st') = consumeMany False n i xs st
+          in go (i + n) xs' st'
+      | scanInterpolate mode && startsWith "{{" xs =
+          let (_, xs', st') = consumeMany False 2 i xs st
+          in go (i + 2) xs' st'
+      | scanInterpolate mode && startsWith "}}" xs =
+          let (_, xs', st') = consumeMany False 2 i xs st
+          in go (i + 2) xs' st'
+      | scanInterpolate mode && c == '{' =
+          let mode' = mode { scanInterpDepth = 1 }
+              (_, xs', st') = consumeMany False 1 i xs st { scanModes = mode' : rest }
+          in go (i + 1) xs' st'
+      | Just n <- tripleInterpolatedQuoteText xs mode =
+          let (_, xs', st') = consumeMany False n i xs st
+          in go (i + n) xs' st'
+      | closesString xs mode =
+          let n = if scanTriple mode then 3 else 1
+              (_, xs', st') = consumeMany False n i xs st { scanModes = rest }
+          in go (i + n) xs' st'
+      | otherwise =
+          let (_, xs', st') = consumeMany False 1 i xs st
+          in go (i + 1) xs' st'
+
+    scanInterpolation i xs@(c:_) mode rest st
+      | c == '#' =
+          skipComment i xs st
+      | Just (nested, qlen) <- stringStartMode xs st =
+          let (_, xs', st') = consumeMany False qlen i xs st
+          in go (i + qlen) xs' st' { scanModes = nested : scanModes st' }
+      | c == '{' =
+          let mode' = mode { scanInterpDepth = scanInterpDepth mode + 1 }
+              (_, xs', st') = consumeMany False 1 i xs st { scanModes = mode' : rest }
+          in go (i + 1) xs' st'
+      | c == '}' =
+          let depth' = scanInterpDepth mode - 1
+              modes' = if depth' == 0 then mode { scanInterpDepth = 0 } : rest
+                                      else mode { scanInterpDepth = depth' } : rest
+              (_, xs', st') = consumeMany False 1 i xs st { scanModes = modes' }
+          in go (i + 1) xs' st'
+      | otherwise =
+          let (_, xs', st') = consumeMany False 1 i xs st
+          in go (i + 1) xs' st'
+
+    stringStartMode xs@(q:_) st
+      | q == '"' || q == '\'' =
+          let triple = startsWith [q, q, q] xs
+              raw = scanPrev1 st == Just 'r' ||
+                    (scanPrev2 st == Just 'r' && scanPrev1 st == Just 'b')
+              bytes = scanPrev1 st == Just 'b' ||
+                      (scanPrev2 st == Just 'r' && scanPrev1 st == Just 'b')
+              interpolate = not raw && not bytes
+              qlen = if triple then 3 else 1
+          in Just (ScanString q triple interpolate 0, qlen)
+      | otherwise = Nothing
+    stringStartMode [] _ = Nothing
+
+    closesString xs mode
+      | scanTriple mode = startsWith (replicate 3 (scanQuote mode)) xs
+      | otherwise = case xs of
+          c:_ -> c == scanQuote mode
+          []  -> False
+
+    tripleInterpolatedQuoteText xs mode
+      | scanTriple mode && scanInterpolate mode =
+          case quoteRunLength (scanQuote mode) xs of
+            4 -> Just 1
+            5 -> Just 2
+            _ -> Nothing
+      | otherwise = Nothing
+
+    quoteRunLength q = length . takeWhile (== q)
+
+    startsWith prefix xs = prefix `isPrefixOf` xs
+
+    skipComment i [] st = go i [] st
+    skipComment i xs@(c:_) st
+      | c == '\n' =
+          let (_, xs', st') = consumeMany False 1 i xs st
+          in go (i + 1) xs' st'
+      | otherwise =
+          let (_, xs', st') = consumeMany False 1 i xs st
+          in skipComment (i + 1) xs' st'
+
+    consumeMany _ 0 i xs st = (i, xs, st)
+    consumeMany track n i (c:cs) st =
+      let st' = advance track c st
+      in consumeMany track (n - 1) (i + 1) cs st'
+    consumeMany _ _ i [] st = (i, [], st)
+
+    advance track c st =
+      let stPrev = st { scanPrev2 = scanPrev1 st, scanPrev1 = Just c }
+      in if c == '\n'
+           then stPrev
+             { scanAtLineStart = True
+             , scanLine = scanLine st + 1
+             , scanContinued = scanBackslash st
+             , scanBackslash = False
+             }
+           else stPrev
+             { scanAtLineStart = False
+             , scanContinued = False
+             , scanBackslash =
+                 if track && c /= ' ' && c /= '\t' && c /= '\r'
+                   then c == '\\'
+                   else scanBackslash st
+             }
+
+parseTopLevelChunk :: String -> String -> TopLevelChunk -> IO (Either Control.Exception.SomeException [S.Stmt])
+parseTopLevelChunk fileName fileContent chunk = do
+  parsed <- tryNonAsync $
+    Control.Exception.evaluate $
+      runParser (St.evalStateT (top_chunk_input fileName chunk) initState) fileName fileContent
+  case parsed of
+    Left err -> return (Left err)
+    Right (Left bundle) -> return (Left (Control.Exception.toException bundle))
+    Right (Right stmts) -> do
+      forced <- tryNonAsync (Control.Exception.evaluate (rnf stmts))
+      case forced of
+        Left err -> return (Left err)
+        Right () -> return (Right stmts)
+  where
+    tryNonAsync action = do
+      result <- Control.Exception.try action
+      case result of
+        Left err ->
+          case Control.Exception.fromException err :: Maybe Control.Exception.SomeAsyncException of
+            Just _  -> Control.Exception.throwIO err
+            Nothing -> return (Left err)
+        Right ok -> return (Right ok)
+
+data ChunkProgressEvent = ChunkProgressDone Int | ChunkProgressStop
+
+data ChunkProgress = ChunkProgress (Chan ChunkProgressEvent) (Async ())
+
+parseTopLevelChunks :: String -> String -> Int -> Maybe (Int -> Int -> IO ()) -> IO [[S.Stmt]]
+parseTopLevelChunks fileName fileContent bodyStart mReportProgress = do
+  ncap <- getNumCapabilities
+  let nworkers = max 1 ncap
+  withChunkProgress mReportProgress (length fileContent) bodyStart $ \progress -> do
+    let window = max 1 (10 * nworkers)
+    slots <- newQSem window
+    workQ <- newChan
+    resultsRef <- newIORef []
+    workers <- replicateM nworkers (async (worker slots workQ progress))
+    let stopWorkers = replicateM_ nworkers (writeChan workQ Nothing) >> mapM_ wait workers
+        run = do
+          scanResult <- scanTopLevelChunks fileContent bodyStart $ \chunk -> do
+            waitQSem slots
+            result <- newEmptyMVar
+            modifyIORef' resultsRef (result :)
+            writeChan workQ (Just (chunk, result))
+          case scanResult of
+            Left err -> Control.Exception.throwIO err
+            Right () -> do
+              stopWorkers
+              finishChunkProgress progress
+              results <- mapM readMVar . reverse =<< readIORef resultsRef
+              collectParsedChunks results
+    run `Control.Exception.finally` mapM_ cancel workers
+  where
+    worker slots workQ progress = do
+      job <- readChan workQ
+      case job of
+        Nothing -> return ()
+        Just (chunk, result) -> do
+          Control.Exception.finally
+            (runWorker chunk result progress)
+            (signalQSem slots)
+          worker slots workQ progress
+
+    runWorker chunk result progress = Control.Exception.mask $ \restore -> do
+      parsed <- Control.Exception.try (restore (parseTopLevelChunk fileName fileContent chunk))
+      case parsed of
+        Left err -> do
+          putMVar result (Left err)
+          case Control.Exception.fromException err :: Maybe Control.Exception.SomeAsyncException of
+            Just _  -> Control.Exception.throwIO err
+            Nothing -> return ()
+        Right chunkResult -> do
+          putMVar result chunkResult
+          reportChunkDone progress chunk
+
+collectParsedChunks :: [Either Control.Exception.SomeException [S.Stmt]] -> IO [[S.Stmt]]
+collectParsedChunks results =
+  case [ err | Left err <- results ] of
+    err:_ -> Control.Exception.throwIO err
+    []    -> return [ stmts | Right stmts <- results ]
+
+withChunkProgress :: Maybe (Int -> Int -> IO ()) -> Int -> Int -> (Maybe ChunkProgress -> IO a) -> IO a
+withChunkProgress mReportProgress total done0 action = do
+  progress <- startChunkProgress mReportProgress total done0
+  action progress `Control.Exception.finally` cancelChunkProgress progress
+
+startChunkProgress :: Maybe (Int -> Int -> IO ()) -> Int -> Int -> IO (Maybe ChunkProgress)
+startChunkProgress Nothing _ _ = return Nothing
+startChunkProgress (Just reportProgress) total done0 = do
+  progressQ <- newChan
+  progressA <- async $ do
+    lastPercent <- emit done0 0
+    loop done0 lastPercent progressQ
+  return (Just (ChunkProgress progressQ progressA))
+  where
+    loop done lastPercent progressQ = do
+      event <- readChan progressQ
+      case event of
+        ChunkProgressDone n -> do
+          let done' = min total (done + n)
+          lastPercent' <- emit done' lastPercent
+          loop done' lastPercent' progressQ
+        ChunkProgressStop -> return ()
+
+    emit done lastPercent = do
+      let completed
+            | total <= 1 = 0
+            | otherwise  = max 0 (min (total - 1) done)
+          percent
+            | total <= 0 = 100
+            | otherwise  = max 0 (min 99 ((completed * 100) `div` total))
+      if percent > lastPercent
+        then reportProgress completed total >> return percent
+        else return lastPercent
+
+finishChunkProgress :: Maybe ChunkProgress -> IO ()
+finishChunkProgress Nothing = return ()
+finishChunkProgress (Just (ChunkProgress progressQ progressA)) =
+  writeChan progressQ ChunkProgressStop >> wait progressA
+
+cancelChunkProgress :: Maybe ChunkProgress -> IO ()
+cancelChunkProgress Nothing = return ()
+cancelChunkProgress (Just (ChunkProgress _ progressA)) = cancel progressA
+
+reportChunkDone :: Maybe ChunkProgress -> TopLevelChunk -> IO ()
+reportChunkDone Nothing _ = return ()
+reportChunkDone (Just (ChunkProgress progressQ _)) chunk =
+  writeChan progressQ (ChunkProgressDone (topLevelChunkLength chunk))
+
+topLevelChunkLength :: TopLevelChunk -> Int
+topLevelChunkLength chunk =
+  let SourceSpan start end = chunkSpan chunk
+  in end - start
+
+top_chunk_input :: String -> TopLevelChunk -> Parser [S.Stmt]
+top_chunk_input fileName chunk = do
+  state <- getParserState
+  let SourceSpan start end = chunkSpan chunk
+      input = chunkInput chunk
+      startPosState = (statePosState state)
+        { pstateSourcePos = SourcePos fileName (mkPos (chunkLine chunk)) (mkPos 1)
+        , pstateInput = input
+        , pstateOffset = start
+        , pstateLinePrefix = ""
+        }
+  let chunkState = state
+        { stateInput = input
+        , stateOffset = start
+        , statePosState = startPosState
+        }
+  setParserState chunkState
+  ss <- withCtx TOP (L.nonIndented sc2 top_chunk_stmt)
+  sc2
+  off <- getOffset
+  if off == end
+    then return ss
+    else fail ("chunk parser stopped at offset " ++ show off ++ ", expected " ++ show end)
+
+regroupTopDecls :: S.Suite -> S.Suite
+regroupTopDecls = go []
+  where
+    go [] [] = []
+    go ds [] = flush ds
+    go ds (S.Decl _ ds' : rest) = go (ds ++ ds') rest
+    go ds (stmt : rest) = flush ds ++ stmt : go [] rest
+
+    flush [] = []
+    flush ds = [ S.Decl (loc group) group | group <- Names.splitDeclGroup ds ]
 
 -- Row parsers ----------------------------------------------------------------------
 
@@ -1291,6 +1742,14 @@ target = try $ do
 
 stmt, simple_stmt :: Parser [S.Stmt]
 stmt = ((:[]) <$> compound_stmt)  <|> try ((:[]) <$> (signature <* newline1)) <|> decl_group <|> simple_stmt <?> "statement"
+
+top_chunk_stmt :: Parser [S.Stmt]
+top_chunk_stmt =
+       ((:[]) <$> compound_stmt)
+  <|> try ((:[]) <$> (signature <* newline1))
+  <|> ((\d -> [S.Decl (loc d) [d]]) <$> decl)
+  <|> simple_stmt
+  <?> "statement"
 
 simple_stmt = (small_stmt `sepEndBy1` semicolon) <* newline1 <?> "simple statement"
 

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -32,17 +32,19 @@ import qualified Pretty
 import Test.Syd
 import Test.Syd.Def.Golden (goldenTextFile)
 import qualified Control.Monad.Trans.State.Strict as St
-import Text.Megaparsec (runParser, errorBundlePretty, ShowErrorComponent(..))
+import Text.Megaparsec (ParseErrorBundle, PosState(..), bundleErrors, bundlePosState, errorOffset, reachOffset, runParser, errorBundlePretty, ShowErrorComponent(..))
+import Text.Megaparsec.Pos (sourceLine, unPos)
 import qualified Data.Text as T
 import Data.List (isInfixOf, isPrefixOf, nub, sort)
+import qualified Data.List.NonEmpty as NE
 import Data.IORef
 import Data.Bits (shiftL, (.|.))
 import Error.Diagnose (printDiagnostic, prettyDiagnostic, WithUnicode(..), TabSize(..), defaultStyle, addReport, addFile)
 import Error.Diagnose.Report (Report(..))
 import Prettyprinter (unAnnotate, layoutPretty, defaultLayoutOptions)
 import Prettyprinter.Render.Text (renderStrict)
-import System.FilePath ((</>), joinPath, takeFileName, takeBaseName, takeDirectory, splitDirectories)
-import System.Directory (createDirectoryIfMissing, getCurrentDirectory, setCurrentDirectory)
+import System.FilePath ((</>), joinPath, takeFileName, takeBaseName, takeDirectory, splitDirectories, takeExtension)
+import System.Directory (createDirectoryIfMissing, getCurrentDirectory, setCurrentDirectory, listDirectory, doesDirectoryExist)
 import System.IO.Temp (withSystemTempDirectory)
 import Control.Monad (forM_, when, foldM)
 import qualified Control.Exception as E
@@ -192,6 +194,90 @@ main = do
           it "rejects top-level wildcard-only destructuring assignment" $ do
             err <- expectModuleParseFailure "[_, _] = [1, 2]\n"
             err `shouldContain` "Module top-level assignments must bind at least one name"
+
+        describe "Chunked module parser" $ do
+          it "matches the serial parser for mixed top-level forms" $ do
+            expectChunkedParseMatchesSerial $ unlines
+              [ "\"\"\"module docs\"\"\""
+              , "import math"
+              , "answer: int"
+              , "answer = ("
+              , "    40 +"
+              , "    2"
+              , ")"
+              , "class Box:"
+              , "    def get(self):"
+              , "        return answer"
+              , "actor Worker(env):"
+              , "    def run(self):"
+              , "        env.exit(0)"
+              ]
+
+          it "does not split on column-zero text inside strings" $ do
+            expectChunkedParseMatchesSerial $ unlines
+              [ "text = \"\"\""
+              , "def not_a_chunk():"
+              , "    pass"
+              , "\"\"\""
+              , "formatted = \"value {str('class also_not_a_chunk:')}\""
+              , "def real():"
+              , "    return text"
+              ]
+
+          it "matches triple-string quote run handling" $ do
+            expectChunkedParseMatchesSerial $ unlines
+              [ "quote_tail = \"\"\"foo\"\"\"\""
+              , "two_quote_tail = \"\"\"foo\"\"\"\"\""
+              , "formatted = \"\"\"value {str(\"class not_a_chunk:\")}\"\"\"\""
+              , "def real():"
+              , "    return formatted"
+              ]
+
+          it "preserves adjacent declaration grouping" $ do
+            expectChunkedParseMatchesSerial $ unlines
+              [ "def even(n):"
+              , "    if n == 0:"
+              , "        return True"
+              , "    return odd(n - 1)"
+              , "def odd(n):"
+              , "    if n == 0:"
+              , "        return False"
+              , "    return even(n - 1)"
+              , "value = even(2)"
+              ]
+
+          it "reports later chunk parse errors at original source lines" $ do
+            let input = unlines
+                  [ "ok = 1"
+                  , "def broken():"
+                  , "    if True"
+                  , "        pass"
+                  ]
+                moduleName = S.modName ["chunked"]
+            result <- E.try (P.parseModule moduleName "chunked.act" input Nothing)
+            case result of
+              Left (bundle :: ParseErrorBundle String P.CustomParseError) ->
+                parseBundleErrorLine bundle `shouldBe` 3
+              Right _ ->
+                expectationFailure "Expected chunked parser to reject malformed input"
+
+          it "returns diagnostics for chunk scanner failures" $ do
+            let input = "    pass\n"
+                moduleName = S.modName ["chunked"]
+            result <- Compile.parseActSource Compile.defaultCompileOptions moduleName "chunked.act" input Nothing
+            case result of
+              Left [diagnostic] ->
+                renderDiagnosticText diagnostic `shouldContain` "non-top-level text before first chunk"
+              Left diagnostics ->
+                expectationFailure ("Expected one diagnostic, got " ++ show (length diagnostics))
+              Right _ ->
+                expectationFailure "Expected scanner failure diagnostic"
+
+          it "matches the serial parser for existing fixtures" $ do
+            actFiles <- actFilesUnder ("test" </> "src")
+            forM_ actFiles $ \actFile -> do
+              input <- readFile actFile
+              expectChunkedParseMatchesSerialFile actFile input
 
       describe "Numeric literals" $ do
         it "parses INT64_MIN as a single literal" $ do
@@ -1569,6 +1655,41 @@ parseModuleTest input =
     handleCustomParseException :: P.CustomParseException -> IO (Either String String)
     handleCustomParseException (P.CustomParseException loc err) =
       return $ Left $ formatCustomParseError "test.act" inputWithNewline loc err
+
+expectChunkedParseMatchesSerial :: String -> Expectation
+expectChunkedParseMatchesSerial input = do
+  let actFile = "chunked.act"
+  expectChunkedParseMatchesSerialFile actFile input
+
+expectChunkedParseMatchesSerialFile :: FilePath -> String -> Expectation
+expectChunkedParseMatchesSerialFile actFile input = do
+  let moduleName = S.modName ["chunked"]
+  serial <- P.parseModuleSerial moduleName actFile input Nothing
+  chunked <- P.parseModule moduleName actFile input Nothing
+  when (chunked /= serial) $
+    expectationFailure ("Chunked parser AST differs from serial parser for " ++ actFile)
+
+parseBundleErrorLine :: ParseErrorBundle String P.CustomParseError -> Int
+parseBundleErrorLine bundle =
+  let firstError = NE.head (bundleErrors bundle)
+      (_, posState) = reachOffset (errorOffset firstError) (bundlePosState bundle)
+  in unPos (sourceLine (pstateSourcePos posState))
+
+renderDiagnosticText diagnostic =
+  let doc = prettyDiagnostic WithUnicode (TabSize 4) diagnostic
+      layout = layoutPretty defaultLayoutOptions (unAnnotate doc)
+  in T.unpack $ renderStrict layout
+
+actFilesUnder :: FilePath -> IO [FilePath]
+actFilesUnder root = do
+  entries <- sort <$> listDirectory root
+  fmap concat $ mapM (\entry -> do
+    let path = root </> entry
+    isDir <- doesDirectoryExist path
+    if isDir
+      then actFilesUnder path
+      else return [path | takeExtension path == ".act"]
+    ) entries
 
 expectModuleParseSuccess :: String -> IO ()
 expectModuleParseSuccess input =


### PR DESCRIPTION
Parsing now uses a worker pool for top-level statement chunks. We parse the module header once, start workers, scan the body cheaply for top-level chunks, and enqueue chunks as soon as they are found. Workers run the normal statement parser on each chunk, and results are collected in source order.

`--parse-serial` keeps the old whole-file parser available for fallback and benchmarking.

Keeping the old module-suite validation semantics exposed an existing quadratic duplicate top-level assignment check. This now uses a `Set`, which removes the long post-worker tail that previously left parse progress stuck at 99% on large generated files.

Performance on `test/compiler/concurrent_typecheck_class_heavy` generated with `./generate_heavy.py --trees 3000`:

```text
30000 classes, 60000 top-level statements

default chunked:  Parse done   8.190 s
--parse-serial:   Parse done  48.129 s
```

Verification:

```text
stack build libacton
stack test libacton
make dist/bin/acton
```