### PR TITLE
Index active Env names

### DIFF
--- a/compiler/lib/bench/KindsBench.hs
+++ b/compiler/lib/bench/KindsBench.hs
@@ -57,6 +57,7 @@ main = do
         printStatsMaybe "parse_stats" s0 s1
 
         env <- Env.mkEnv [typesPath] env0 parsed
+        E.evaluate (forceHTEnv (Env.hnames env))
         E.evaluate (forceHTEnv (Env.hmodules env))
         t2 <- getCurrentTime
         s2 <- getStats statsEnabled

--- a/compiler/lib/bench/KindsBench.hs
+++ b/compiler/lib/bench/KindsBench.hs
@@ -1,0 +1,73 @@
+import qualified Acton.Env as Env
+import qualified Acton.Kinds as Kinds
+import qualified Acton.NameInfo as NameInfo
+import qualified Acton.Parser as Parser
+import qualified Acton.Syntax as Syntax
+
+import Control.DeepSeq (rnf)
+import qualified Control.Exception as E
+import qualified Data.HashMap.Strict as HashMap
+import Data.Time.Clock (diffUTCTime, getCurrentTime)
+import GHC.Stats
+import System.Environment (getArgs)
+import System.FilePath (takeBaseName)
+
+-- Usage:
+--   stack build libacton:exe:kinds-bench
+--   stack exec kinds-bench -- ../dist/base/out/types path/to/file.act +RTS -T -RTS
+--
+-- This uses Parser.parseModule, the normal parallel parser entrypoint. The RTS
+-- flag is optional. With -T, the driver also prints per-phase allocation and
+-- GC deltas.
+
+elapsed label t0 t1 = putStrLn $ label ++ " " ++ show (diffUTCTime t1 t0)
+
+printStats label before after =
+    putStrLn $ label ++ " alloc " ++ show alloc ++ " gc_elapsed " ++ show gcElapsed ++ " gcs " ++ show collections
+  where alloc = allocated_bytes after - allocated_bytes before
+        gcElapsed = gc_elapsed_ns after - gc_elapsed_ns before
+        collections = gcs after - gcs before
+
+getStats enabled =
+    if enabled then Just <$> getRTSStats else return Nothing
+
+printStatsMaybe label (Just before) (Just after) = printStats label before after
+printStatsMaybe _ _ _                            = return ()
+
+forceHTEnv = HashMap.foldl' forceHNameInfo () where
+    forceHNameInfo () (NameInfo.HNModule _ te _) = forceHTEnv te
+    forceHNameInfo () hni                        = hni `seq` ()
+
+main = do
+    args <- getArgs
+    case args of
+      [typesPath, sourcePath] -> do
+        statsEnabled <- getRTSStatsEnabled
+        src <- readFile sourcePath
+        env0 <- Env.initEnv typesPath False
+        let modName = Syntax.modName [takeBaseName sourcePath]
+
+        s0 <- getStats statsEnabled
+        t0 <- getCurrentTime
+        parsed <- Parser.parseModule modName sourcePath src Nothing
+        E.evaluate (rnf parsed)
+        t1 <- getCurrentTime
+        s1 <- getStats statsEnabled
+        elapsed "parse" t0 t1
+        printStatsMaybe "parse_stats" s0 s1
+
+        env <- Env.mkEnv [typesPath] env0 parsed
+        E.evaluate (forceHTEnv (Env.hmodules env))
+        t2 <- getCurrentTime
+        s2 <- getStats statsEnabled
+        elapsed "env" t1 t2
+        printStatsMaybe "env_stats" s1 s2
+
+        kchecked <- Kinds.check env parsed
+        E.evaluate (rnf kchecked)
+        t3 <- getCurrentTime
+        s3 <- getStats statsEnabled
+        elapsed "kinds" t2 t3
+        printStatsMaybe "kinds_stats" s2 s3
+      _ ->
+        error "usage: kinds-bench TYPES_PATH SOURCE.act"

--- a/compiler/lib/package.yaml.in
+++ b/compiler/lib/package.yaml.in
@@ -103,3 +103,14 @@ tests:
       - -threaded
       - -rtsopts
       - -with-rtsopts=-N
+
+executables:
+  kinds-bench:
+    main: KindsBench.hs
+    source-dirs: bench
+    dependencies:
+      - libacton
+    ghc-options:
+      - -threaded
+      - -rtsopts
+      - '"-with-rtsopts=-N -A64M"'

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -50,6 +50,7 @@ mkEnv spath env m           = getImps spath env (imps m)
 
 data EnvF x                 = EnvF {
                                 names      :: TEnv,
+                                hnames     :: HTEnv,
                                 imports    :: [ModName],
                                 improots   :: [Name],
                                 modules    :: TEnv,
@@ -64,7 +65,7 @@ type Env0                   = EnvF ()
 
 
 setX                        :: EnvF y -> x -> EnvF x
-setX env x                  = EnvF { names = names env, imports = imports env, improots = improots env,
+setX env x                  = EnvF { names = names env, hnames = hnames env, imports = imports env, improots = improots env,
                                      modules = modules env, hmodules = hmodules env, thismod = thismod env,
                                      context = context env, qlevel = qlevel env, envX = x }
 
@@ -151,8 +152,8 @@ instance (Unalias a) => Unalias (Maybe a) where
 instance Unalias ModName where
     unalias env m@(ModName ns)
       | inBuiltin env               = m
-      | otherwise                   = case lookup (head ns) (names env) of
-                                        Just (NMAlias m') -> m'
+      | otherwise                   = case lookupName (head ns) env of
+                                        Just (HNMAlias m') -> m'
                                         Nothing | m `elem` (mPrim:mBuiltin:imports env)  -> m
                                         _ -> noModule m
 instance Unalias QName where
@@ -165,8 +166,8 @@ instance Unalias QName where
       where m'                      = unalias env m
     unalias env (NoQ n)
       | inBuiltin env               = GName mBuiltin n
-      | otherwise                   = case lookup n (names env) of
-                                        Just (NAlias qn) -> setLoc (loc n) qn
+      | otherwise                   = case lookupName n env of
+                                        Just (HNAlias qn) -> setLoc (loc n) qn
                                         _ -> case thismod env of Just m -> GName m n; _ -> NoQ n
     unalias env (GName m n)
 --      | inBuiltin env, m==mBuiltin  = NoQ n
@@ -235,6 +236,7 @@ publicTEnv                 = filter (isPublicName . fst)
 
 initEnv                    :: FilePath -> Bool -> IO Env0
 initEnv path True          = return $ EnvF{ names = [(nPrim,NMAlias mPrim)],
+                                            hnames = hnamesFrom [(nPrim,NMAlias mPrim)],
                                             imports = [],
                                             improots = [],
                                             modules = [(nPrim,NModule [] primEnv Nothing)],
@@ -247,6 +249,7 @@ initEnv path False         = do (_,nmod,_,_,_,_,_,_,_,_,_,_) <- InterfaceFiles.r
                                 let NModule _ envBuiltin builtinDocstring = nmod
                                     envBuiltinPublic = publicTEnv envBuiltin
                                     env0 = EnvF{ names = [(nPrim,NMAlias mPrim), (nBuiltin,NMAlias mBuiltin)],
+                                                 hnames = hnamesFrom [(nPrim,NMAlias mPrim), (nBuiltin,NMAlias mBuiltin)],
                                                  imports = [],
                                                  improots = [],
                                                  modules = [(nPrim,NModule [] primEnv Nothing), (nBuiltin,NModule [] envBuiltin builtinDocstring)],
@@ -261,17 +264,32 @@ initEnv path False         = do (_,nmod,_,_,_,_,_,_,_,_,_,_) <- InterfaceFiles.r
 withModulesFrom             :: EnvF x -> EnvF x -> EnvF x
 env `withModulesFrom` env'  = env{modules = modules env'}
 
+hnamesFrom                  :: TEnv -> HTEnv
+hnamesFrom te               = extendHNames te M.empty
+
+extendHNames                :: TEnv -> HTEnv -> HTEnv
+extendHNames te hte         = foldr add hte te
+  where add (n,i) hte       = M.insert n (convNameInfo2HNameInfo i) hte
+
+setNames                    :: TEnv -> EnvF x -> EnvF x
+setNames te env             = env{ names = te, hnames = hnamesFrom te }
+
+lookupName                  :: Name -> EnvF x -> Maybe HNameInfo
+lookupName n env            = M.lookup n (hnames env)
+
 reserve                     :: [Name] -> EnvF x -> EnvF x
 reserve xs env
   | not $ null badSelf      = selfParamError (loc $ head badSelf)
-  | otherwise               = env{ names = [ (x, NReserved) | x <- nub xs ] ++ names env }
+  | otherwise               = env{ names = te ++ names env, hnames = extendHNames te (hnames env) }
   where badSelf             = if inAct env then xs `intersect` [selfKW] else []
+        te                  = [ (x, NReserved) | x <- nub xs ]
 
 define                      :: TEnv -> EnvF x -> EnvF x
 define te env
   | not $ null badSelf      = selfParamError (loc $ head badSelf)
-  | otherwise               = env{ names = reverse te ++ names env }
+  | otherwise               = env{ names = te' ++ names env, hnames = extendHNames te' (hnames env) }
   where badSelf             = if inAct env then dom te `intersect` [selfKW] else []
+        te'                 = reverse te
 
 
 addImport                   :: ModName -> EnvF x -> EnvF x
@@ -286,8 +304,9 @@ getImports env              = reverse (imports env)
 
 defineTVars                 :: QBinds -> EnvF x -> EnvF x
 defineTVars q env           = foldr f env (unalias env q)
-  where f (QBind tv us) env = env{ names = (tvname tv, NTVar (tvkind tv) c ps) : names env, qlevel = qlevel env + 1 }
+  where f (QBind tv us) env = env{ names = ni : names env, hnames = extendHNames [ni] (hnames env), qlevel = qlevel env + 1 }
           where (c,ps)      = case us of u:us' | not $ isProto env (tcname u) -> (u,us'); _ -> (cValue,us)
+                ni          = (tvname tv, NTVar (tvkind tv) c ps)
 
 selfSubst n q               = vsubst [(tvSelf, tCon tc)]
   where tc                  = TC n (map tVar $ qbound q)
@@ -346,9 +365,9 @@ tryQName (QName m n) env    = case findHMod m env of
                                     Just i -> Just i
                                     _ -> noItem m n
                                 _ -> noModule m
-tryQName (NoQ n) env        = case lookup n (names env) of
-                                Just (NAlias qn) -> tryQName qn env
-                                Just ni -> Just (convNameInfo2HNameInfo ni)
+tryQName (NoQ n) env        = case lookupName n env of
+                                Just (HNAlias qn) -> tryQName qn env
+                                Just ni -> Just ni
                                 Nothing -> Nothing
 tryQName (GName m n) env
   | Just m == thismod env   = tryQName (NoQ n) env
@@ -374,15 +393,15 @@ findDefLoc n env            = findSL (names env)
 
 findName n env              = findQName (NoQ n) env
 
-lookupVar n env             = case lookup n (names env) of
-                                Just (NVar t) -> Just t
+lookupVar n env             = case lookupName n env of
+                                Just (HNVar t) -> Just t
                                 _ -> Nothing
 
 findHMod                    :: ModName -> EnvF x -> Maybe HTEnv  -- m is modname part of a QName, so we must check for aliasing
 findHMod m env | inBuiltin env, m==mBuiltin
-                            = Just (convTEnv2HTEnv (names env))
-findHMod m@(ModName ns) env = case lookup (head ns) (names env) of
-                                Just (NMAlias (ModName m')) -> lookupHMod (ModName $ m'++tail ns) env
+                            = Just (hnames env)
+findHMod m@(ModName ns) env = case lookupName (head ns) env of
+                                Just (HNMAlias (ModName m')) -> lookupHMod (ModName $ m'++tail ns) env
                                 Nothing | m `elem` (mPrim:mBuiltin:imports env) -> lookupHMod m env
                                 _ -> Nothing
 
@@ -391,7 +410,7 @@ lookupHMod m env                = case lookupHModule m env of Just (imps, te, do
 
 
 lookupHModule m env
- | inBuiltin env, m==mBuiltin   = Just ([], convTEnv2HTEnv (names env), Nothing)
+ | inBuiltin env, m==mBuiltin   = Just ([], hnames env, Nothing)
 lookupHModule (ModName ns) env  = f ns (hmodules env)
   where f (n:ns) te             = case M.lookup n te of
                                     Just (HNModule imps te' doc) -> g ns imps te' doc
@@ -421,13 +440,13 @@ isMod env ns@(n:_)          = maybe False (const True) (findHMod (ModName ns) en
   where rooted              = n `elem` improots env || isMAlias n env
 
 isMAlias                    :: Name -> EnvF x -> Bool
-isMAlias n env              = case lookup n (names env) of
-                                Just NMAlias{} -> True
+isMAlias n env              = case lookupName n env of
+                                Just HNMAlias{} -> True
                                 _ -> False
 
 isAlias                     :: Name -> EnvF x -> Bool
-isAlias n env               = case lookup n (names env) of
-                                Just NAlias{} -> True
+isAlias n env               = case lookupName n env of
+                                Just HNAlias{} -> True
                                 _ -> False
 
 kindOf env (TVar _ tv)      = tvkind tv
@@ -454,8 +473,8 @@ tconKind n env              = case findQName n env of
   where kind k []           = k
         kind k q            = KFun [ tvkind v | QBind v _ <- q ] k
 
-actorSelf env               = case lookup selfKW (names env) of
-                                Just (NVar (TCon _ tc)) | isActor env (tcname tc) -> True
+actorSelf env               = case lookupName selfKW env of
+                                Just (HNVar (TCon _ tc)) | isActor env (tcname tc) -> True
                                 _ -> False
 
 actorMethod env n0          = walk [] (names env)

--- a/compiler/lib/src/Acton/Kinds.hs
+++ b/compiler/lib/src/Acton/Kinds.hs
@@ -15,6 +15,7 @@
 module Acton.Kinds(check) where
 
 import qualified Control.Exception
+import Control.DeepSeq (force)
 import qualified Data.Map.Strict as Map
 import Data.Map.Strict (Map)
 import Control.Monad.State.Strict
@@ -30,9 +31,10 @@ import Acton.Env
 
 
 check                               :: Env0 -> Module -> IO Module
-check env0 (Module m imps mdoc ss)  = do return (Module m imps mdoc ss1)
+check env0 (Module m imps mdoc ss)  = do Control.Exception.evaluate $ force checked
   where env                         = kindEnv env0
         ss1                         = runKindM (kchkTop env ss)
+        checked                     = Module m imps mdoc ss1
 
 
 data KindState                      = KindState {

--- a/compiler/lib/src/Acton/TypeEnv.hs
+++ b/compiler/lib/src/Acton/TypeEnv.hs
@@ -207,7 +207,7 @@ limitQuant                      :: TUni -> Env -> Env
 limitQuant (UV _ l _) env
   | n <= 0                      = env
   | otherwise                   = modX env1 $ \x -> x{ witnesses = dropw n (witnesses x) }
-  where env1                    = env{ names = dropv n (names env), qlevel = qlevel env - n }
+  where env1                    = setNames (dropv n (names env)) env{ qlevel = qlevel env - n }
         n                       = qlevel env - l
         dropv 0 te              = te
         dropv n ((v,i):te)
@@ -797,7 +797,7 @@ instance USubst Witness where
 instance USubst Env where
     usubst env                  = do ne <- usubst (names env)
                                      ex <- usubst (envX env)
-                                     return env{ names = ne, envX = ex }
+                                     return $ setNames ne env{ envX = ex }
 
 instance UFree Env where
     ufree env                   = ufree (names env) ++ ufree (envX env)


### PR DESCRIPTION
Env.names keeps the active name list used by the compiler. In many situations,
the order of names matters, so names is kept as an ordered list.

Many compiler paths repeatedly ask whether a name is in that list and what it
means. Since lookup scans the list from the front, the lookup costs grow with
the size of the list. That cost is present for every module and becomes
especially noticeable for large modules.

We now add hnames, a hash map from each name to its HNameInfo, to make lookups
fast. names is still kept as the ordered source of truth from which hnames is
produced. define, reserve, defineTVars, limitQuant, and Env substitution now
maintain the hnames index next to names, while order-sensitive traversals
continue to read names directly.

Route the central unqualified lookup paths through hnames so Kinds and Types
avoid repeated list scans without changing TEnv layout or attribute/MRO
ordering. On the heavy class benchmark at 1000 trees, the standalone Kinds
phase dropped from 83.96 s to 1.56 s. On a smaller 100 trees (I didn't want to
wait for type checking on 1000 trees) type checking dropped from over 300
seconds to around 100seconds. On a 200 trees module, type checking went from
over 2000 seconds to around 300 seconds. The difference increases with size,
showing the change from superlinear to being closer to linear (there are likely
many other parts that are not linear contributing time), yet we can still see
how the type checking time is still not linear (more than double; from 100s to
300s) for a twice as large module (100 -> 200 trees)


A new benchmark programming is added to benchmark the Kinds pass. It is rather 
useful as it forces the kinds check result and we can look at that independently
 from type checking. Kinds checking is simpler, so the name lookup make up a 
larger fraction of the total time, making it more extreme than the types pass.
 I think this benchmark can be useful going forward as well.

We now force the kinds checking result in the normal compiler pipeline as well.