### PR TITLE
Add optional OCI output artifacts

### DIFF
--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -160,6 +160,7 @@ main = do
           C.CmdOpt gopts (C.PkgUpgrade opts) -> PkgCommands.pkgUpgradeCommand gopts opts
           C.CmdOpt gopts C.PkgUpdate         -> PkgCommands.pkgUpdateCommand gopts
           C.CmdOpt gopts (C.PkgSearch opts)  -> PkgCommands.pkgSearchCommand gopts opts
+          C.CmdOpt gopts (C.Artifact opts)   -> artifactCommand gopts opts
           C.CmdOpt gopts (C.BuildSpecCmd o)   -> buildSpecCommand o
           C.CmdOpt gopts (C.Cloud opts)       -> undefined
           C.CmdOpt gopts (C.Doc opts)         -> printDocs gopts opts
@@ -509,6 +510,24 @@ withProjectLockForGen gopts sched gen projDir action =
     whenCurrentGen sched gen $
       withProjectLockNotice gopts projDir $
         whenCurrentGen sched gen action
+
+artifactCommand :: C.GlobalOptions -> C.ArtifactCommand -> IO ()
+artifactCommand gopts cmd =
+    case cmd of
+      C.ArtifactHash _ ->
+        PkgCommands.artifactCommand gopts cmd
+      _ -> do
+        let opts = defaultCompileOptions { C.skip_build = True }
+            sp = Source.diskSourceProvider
+        paths <- loadProjectPaths opts
+        let projDir = projPath paths
+        withProjectLockNotice gopts projDir $ do
+          unless (C.quiet gopts) $
+            putStrLn ("Building project in " ++ projDir)
+          srcFiles <- projectSourceFiles paths
+          compileFiles sp gopts opts srcFiles True
+          generateProjectDocIndex sp gopts opts paths srcFiles
+          PkgCommands.artifactCommand gopts cmd
 
 requireProjectLayout :: Paths -> IO ()
 requireProjectLayout paths = do
@@ -946,7 +965,7 @@ runWatchFile gopts absFile sched runOnce = do
 fetchCommand :: C.GlobalOptions -> IO ()
 fetchCommand gopts = do
     paths <- loadProjectPaths defaultCompileOptions
-    res <- try (fetchDependencies gopts paths []) :: IO (Either ProjectError ())
+    res <- try (fetchDependencies gopts paths [] []) :: IO (Either ProjectError ())
     case res of
       Left (ProjectError msg) -> printErrorAndExit msg
       Right () ->
@@ -972,7 +991,7 @@ sigCommand gopts sigOpts = do
     rootProj <- normalizePathSafe (projPath paths)
     sysAbs <- normalizePathSafe (sysPath paths)
     withProjectLockNotice queryGopts rootProj $ do
-      fetchDependencies queryGopts paths depOverrides
+      fetchDependencies queryGopts paths depOverrides (C.artifact_repos opts)
       projMap <- discoverProjects queryGopts sysAbs rootProj depOverrides
       target <- resolveSigTarget opts paths rootProj projMap (C.sigTarget sigOpts)
       tyFile <- case target of

--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -517,7 +517,9 @@ artifactCommand gopts cmd =
       C.ArtifactHash _ ->
         PkgCommands.artifactCommand gopts cmd
       _ -> do
-        let opts = defaultCompileOptions { C.skip_build = True }
+        -- Artifacts ship interfaces (.tydb) only; code generation is deferred
+        -- to the consuming build, so the back passes are skipped here.
+        let opts = defaultCompileOptions { C.skip_build = True, C.skip_backpass = True }
             sp = Source.diskSourceProvider
         paths <- loadProjectPaths opts
         let projDir = projPath paths
@@ -1033,7 +1035,7 @@ compileSigTarget gopts queryGopts opts paths rootProj sysAbs depOverrides target
           , ccOnInfo = \msg -> when (C.verbose gopts) $ putStrLn msg
           , ccOnBackJob = \_ -> return ()
           }
-    compileRes <- compileTasks sp queryGopts opts' (ccPathsRoot cctx') (ccRootProj cctx') (cpNeededTasks plan) (cpDbpBlocked plan) callbacks
+    compileRes <- compileTasks sp queryGopts opts' (ccPathsRoot cctx') (ccRootProj cctx') (cpNeededTasks plan) (cpDbpBlocked plan) (cpPrebuiltRoots plan) callbacks
     case compileRes of
       Left err -> printErrorAndExit (compileFailureMessage err)
       Right (_, hadErrors) -> when hadErrors System.Exit.exitFailure
@@ -2091,7 +2093,7 @@ runCliPostCompile cliHooks gopts plan env = do
           cchFinalStart cliHooks
           action `onException` cchFinalDone cliHooks False
           cchFinalDone cliHooks True
-    if C.skip_build opts'
+    if C.skip_build opts' || C.skip_backpass opts'
       then
         logLine "  Skipping final build step"
       else

--- a/compiler/acton/PkgCommands.hs
+++ b/compiler/acton/PkgCommands.hs
@@ -369,6 +369,7 @@ packActonArtifactTo sourceHash outputArg = do
       Artifact.writeManifest tmp (Artifact.expectedManifest sourceHash)
       runProcessChecked Nothing "tar"
         [ "-czf", output0
+        , "--exclude=*.c", "--exclude=*.h"
         , "-C", tmp, Artifact.artifactManifestFile
         , "-C", cwd, "Build.act", "out/types"
         ]

--- a/compiler/acton/PkgCommands.hs
+++ b/compiler/acton/PkgCommands.hs
@@ -7,6 +7,7 @@ module PkgCommands
   , pkgUpgradeCommand
   , pkgUpdateCommand
   , pkgSearchCommand
+  , artifactCommand
   , zigPkgAddCommand
   , zigPkgRemoveCommand
   , PackageEntry(..)
@@ -24,6 +25,7 @@ import Prelude hiding (readFile, writeFile)
 
 import Acton.ArchiveDownload (downloadArchive)
 import Acton.HttpFetch (httpGetBytes, isHttpUrl, newProxyManager)
+import qualified Acton.Artifact as Artifact
 import qualified Acton.BuildSpec as BuildSpec
 import qualified Acton.CommandLineParser as C
 import Acton.Compile (loadBuildSpec, throwProjectError)
@@ -32,7 +34,7 @@ import Control.Exception (IOException, SomeException, try, displayException, eva
 import Control.Monad (filterM, forM, forM_, unless, when)
 import Data.Char (isHexDigit, isSpace)
 import Data.Foldable (toList)
-import Data.List (dropWhileEnd, isPrefixOf, isSuffixOf, sortOn)
+import Data.List (dropWhileEnd, isPrefixOf, isSuffixOf, sort, sortOn)
 import Data.List.Split (splitOn)
 import Data.Maybe (isJust)
 import qualified Data.Map as M
@@ -43,7 +45,7 @@ import qualified Data.Aeson.Key as AesonKey
 import qualified Data.Aeson.KeyMap as AesonKM
 import qualified Data.Text as T
 import Network.HTTP.Client (Manager)
-import System.Directory (Permissions, canonicalizePath, copyFile, createDirectoryIfMissing, doesDirectoryExist, doesFileExist, doesPathExist, getCurrentDirectory, getHomeDirectory, getPermissions, listDirectory, removeFile, setPermissions)
+import System.Directory (Permissions, canonicalizePath, copyFile, copyFileWithMetadata, createDirectoryIfMissing, doesDirectoryExist, doesFileExist, doesPathExist, getCurrentDirectory, getHomeDirectory, getPermissions, listDirectory, makeAbsolute, pathIsSymbolicLink, removeFile, setPermissions)
 import System.Environment (getExecutablePath, lookupEnv)
 import System.Exit (ExitCode(..))
 import System.FilePath ((</>), takeDirectory)
@@ -320,6 +322,159 @@ pkgSearchCommand _ opts = do
     if null matched
       then putStrLn "No packages matched your search."
       else forM_ (sortOn pkgName matched) printPkg
+
+artifactCommand :: C.GlobalOptions -> C.ArtifactCommand -> IO ()
+artifactCommand gopts cmd =
+    case cmd of
+      C.ArtifactPack opts ->
+        packActonArtifact gopts (C.artifactPackOutput opts)
+      C.ArtifactPush opts ->
+        pushActonArtifact gopts opts
+      C.ArtifactHash opts ->
+        printActonArtifactHash (C.artifactHashSourcePath opts)
+
+packActonArtifact :: C.GlobalOptions -> String -> IO ()
+packActonArtifact gopts outputArg = do
+    sourceHash <- computeArtifactSourceHash "."
+    output <- packActonArtifactTo sourceHash outputArg
+    unless (C.quiet gopts) $
+      putStrLn ("Wrote Acton artifact " ++ output)
+
+pushActonArtifact :: C.GlobalOptions -> C.ArtifactPushOptions -> IO ()
+pushActonArtifact gopts opts = do
+    sourceHash <- computeArtifactSourceHash "."
+    ref0 <- resolveArtifactRef sourceHash
+                               (C.artifactPushRepoUrl opts)
+                               (C.artifactPushArtifactRepo opts)
+    ref <- absolutizeLocalArtifactRef ref0
+    withSystemTempDirectory "acton-artifact-push" $ \tmp -> do
+      let archive = tmp </> Artifact.artifactArchiveFile
+      _ <- packActonArtifactTo sourceHash archive
+      runProcessChecked (Just tmp) "oras"
+        (["push"]
+         ++ Artifact.ociRefOrasOptions ref
+         ++ [ "--artifact-type", Artifact.artifactType
+            , Artifact.ociRefOrasTarget ref
+            , Artifact.artifactArchiveFile ++ ":" ++ Artifact.artifactMediaType
+            ])
+      unless (C.quiet gopts) $
+        putStrLn ("Pushed Acton artifact " ++ ref)
+
+packActonArtifactTo :: String -> String -> IO FilePath
+packActonArtifactTo sourceHash outputArg = do
+    cwd <- getCurrentDirectory
+    let output0 = if null outputArg then "out" </> Artifact.artifactArchiveFile else outputArg
+    createDirectoryIfMissing True (takeDirectory output0)
+    withSystemTempDirectory "acton-artifact-pack" $ \tmp -> do
+      Artifact.writeManifest tmp (Artifact.expectedManifest sourceHash)
+      runProcessChecked Nothing "tar"
+        [ "-czf", output0
+        , "-C", tmp, Artifact.artifactManifestFile
+        , "-C", cwd, "Build.act", "out/types"
+        ]
+    return output0
+
+printActonArtifactHash :: String -> IO ()
+printActonArtifactHash source = do
+    h <- computeArtifactSourceHash source
+    putStrLn h
+
+computeArtifactSourceHash :: FilePath -> IO String
+computeArtifactSourceHash source = do
+    isDir <- doesDirectoryExist source
+    unless isDir $
+      throwProjectError ("ERROR: Artifact source hash expects a package directory: " ++ source)
+    zigExe <- getZigExe
+    withSystemTempDirectory "acton-artifact-source" $ \tmp -> do
+      let staged = tmp </> "source"
+      -- TODO(source-hash): Avoid staging a copied package tree here.
+      --
+      -- This copy is intentionally simple and conservative, but source hashing is
+      -- foundational identity machinery and should eventually be computed directly
+      -- from the package directory. The desired implementation is an Acton-owned
+      -- package hash walker that follows Zig's package hashing semantics exactly
+      -- rather than invoking `zig fetch` on a temporary copy.
+      --
+      -- Requirements for that replacement:
+      --
+      -- * Keep the source boundary independent of git or any other VCS.
+      -- * Preserve the current Acton package selection rules: include only the
+      --   canonical package inputs Acton knows about, currently Build.act and
+      --   src/.
+      -- * Match Zig's path normalization, directory ordering, file metadata/mode
+      --   treatment, digest algorithm, and final package-hash text encoding.
+      -- * Keep symlink behavior explicit. Today symlinks are rejected rather than
+      --   guessed; any future support must match Zig and have test coverage.
+      -- * Add stable fixture tests that compare Acton's in-place implementation
+      --   with `zig fetch` for representative package trees before switching over.
+      --
+      -- Until then, copying to a clean temp directory keeps generated build output
+      -- out of the hash while delegating the actual hash algorithm to Zig.
+      copyCanonicalSource source staged
+      requireRightWith "ERROR: Failed to compute source hash: " =<< zigFetchHash zigExe staged
+
+copyCanonicalSource :: FilePath -> FilePath -> IO ()
+copyCanonicalSource src dst = do
+    copyRequiredSourceInput src dst "Build.act"
+    copyRequiredSourceInput src dst "src"
+
+copyRequiredSourceInput :: FilePath -> FilePath -> FilePath -> IO ()
+copyRequiredSourceInput src dst name = do
+    let srcEntry = src </> name
+        dstEntry = dst </> name
+    exists <- doesPathExist srcEntry
+    unless exists $
+      throwProjectError ("ERROR: Artifact source hash missing package input: " ++ srcEntry)
+    copyCanonicalSourceInput srcEntry dstEntry
+
+copyCanonicalSourceInput :: FilePath -> FilePath -> IO ()
+copyCanonicalSourceInput src dst = do
+    isSymlink <- pathIsSymbolicLink src
+    when isSymlink $
+      throwProjectError ("ERROR: Artifact source hash does not support symbolic links: " ++ src)
+    isDir <- doesDirectoryExist src
+    if isDir
+      then do
+        createDirectoryIfMissing True dst
+        entries <- sort <$> listDirectory src
+        forM_ entries $ \entry ->
+          copyCanonicalSourceInput (src </> entry) (dst </> entry)
+      else do
+        createDirectoryIfMissing True (takeDirectory dst)
+        copyFileWithMetadata src dst
+
+absolutizeLocalArtifactRef :: String -> IO String
+absolutizeLocalArtifactRef ref
+  | Artifact.ociRefIsLocal ref =
+      case splitLocalOciTarget (Artifact.ociRefOrasTarget ref) of
+        Just (path, tag) -> do
+          path' <- makeAbsolute path
+          return ("oci-layout://" ++ path' ++ ":" ++ tag)
+        Nothing -> return ref
+  | otherwise = return ref
+
+splitLocalOciTarget :: String -> Maybe (FilePath, String)
+splitLocalOciTarget target =
+    case break (== ':') (reverse target) of
+      (revTag, ':' : revPath)
+        | not (null revTag) && not (null revPath) ->
+            Just (reverse revPath, reverse revTag)
+      _ -> Nothing
+
+resolveArtifactRef :: String -> String -> String -> IO String
+resolveArtifactRef sourceHash repoUrl artifactRepo
+  | not (null artifactRepo) =
+      case Artifact.ociRefForRepository artifactRepo sourceHash of
+        Just ref -> return ref
+        Nothing ->
+          throwProjectError ("ERROR: Invalid OCI artifact repository " ++ artifactRepo)
+  | not (null repoUrl) =
+      case Artifact.deriveOciRef repoUrl sourceHash of
+        Just ref -> return ref
+        Nothing ->
+          throwProjectError ("ERROR: Could not derive OCI artifact ref from " ++ repoUrl)
+  | otherwise =
+      throwProjectError "ERROR: Specify --artifact-repo or --repo-url for artifact push"
 
 zigPkgAddCommand :: C.GlobalOptions -> C.ZigPkgAddOptions -> IO ()
 zigPkgAddCommand _ opts = do

--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -1682,6 +1682,30 @@ actonProjTests =
             assertBool "path error should point users to artifact repos"
               ("Use --artifact-repo to search output artifacts" `isInfixOf` pathErr)
 
+  -- Producing an artifact ships .tydb only, so the back passes must not run;
+  -- code generation is deferred to the build that consumes the artifact.
+  , testCase "artifact pack skips back passes" $ do
+        withSystemTempDirectory "acton-artifact-pack-nocodegen" $ \proj -> do
+            let srcDir = proj </> "src"
+            createDirectoryIfMissing True srcDir
+            writeFile (proj </> "Build.act") $ unlines
+              [ "name = \"artifact_pack_nocodegen\""
+              , "fingerprint = 0xd51ea8e2a1b2c3d4"
+              ]
+            writeFile (srcDir </> "lib.act") $ unlines
+              [ "def greeting() -> str:"
+              , "    return \"hello\""
+              ]
+            actonExe <- canonicalizePath "../../dist/bin/acton"
+            (returnCode, _cmdOut, cmdErr) <- readCreateProcessWithExitCode (proc actonExe ["artifact", "pack"]){ cwd = Just proj } ""
+            assertEqual ("artifact pack should succeed: " ++ cmdErr) ExitSuccess returnCode
+            archiveExists <- doesFileExist (proj </> "out" </> "acton-out.tar.gz")
+            assertBool "artifact archive should be written" archiveExists
+            tydbExists <- doesDirectoryExist (proj </> "out" </> "types" </> "artifact_pack_nocodegen" </> "lib.tydb")
+            assertBool "artifact pack should write .tydb" tydbExists
+            cExists <- doesFileExist (proj </> "out" </> "types" </> "artifact_pack_nocodegen" </> "lib.c")
+            assertBool "artifact pack should not generate C code" (not cExists)
+
   -- Verify pruning keeps binaries for modules that still have roots across build / test runs.
   , testCase "executable pruning" $ do
         let proj = "test/project/prune_executables"

--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -1005,6 +1005,31 @@ parseFlagTests =
           assertBool "no-dbp option should be set" (C.no_dbp (C.buildCompile buildOpts))
         _ ->
           assertFailure "expected build command"
+  , testCase "build parser accepts artifact repositories" $ do
+      parsed <- parseArgs ["build", "--artifact-repo", "local-registry.local-domain.com/acton-out"]
+      case parsed of
+        C.CmdOpt _ (C.Build buildOpts) ->
+          assertEqual "artifact repos"
+            ["local-registry.local-domain.com/acton-out"]
+            (C.artifact_repos (C.buildCompile buildOpts))
+        _ ->
+          assertFailure "expected build command"
+  , testCase "artifact parser accepts top-level push command" $ do
+    parsed <- parseArgs ["artifact", "push", "--artifact-repo", "registry.local/acton-out"]
+    case parsed of
+      C.CmdOpt _ (C.Artifact (C.ArtifactPush opts)) -> do
+        assertEqual "artifact repo" "registry.local/acton-out" (C.artifactPushArtifactRepo opts)
+      _ ->
+        assertFailure "expected artifact push command"
+  , testCase "artifact parser rejects raw push refs" $ do
+      assertParseFails ["artifact", "push", "--ref", "registry.local/acton-out:anything"]
+  , testCase "artifact subcommands accept global options" $ do
+      parsed <- parseArgs ["artifact", "pack", "--verbose"]
+      case parsed of
+        C.CmdOpt gopts (C.Artifact (C.ArtifactPack _)) ->
+          assertBool "verbose should be set" (C.verbose gopts)
+        _ ->
+          assertFailure "expected artifact pack command"
   , testCase "build parser help includes --release alias" $ do
       helpText <- renderParserHelp ["build", "--help"]
       assertBool "help text should include --release" ("--release" `isInfixOf` helpText)
@@ -1270,6 +1295,13 @@ parseFlagTests =
         OA.Failure failure -> do
           let (msg, _) = OA.renderFailure failure "acton"
           assertFailure ("parser failed for " ++ unwords args ++ ":\n" ++ msg)
+        OA.CompletionInvoked _ ->
+          assertFailure ("parser requested shell completion for " ++ unwords args)
+
+    assertParseFails args =
+      case OA.execParserPure OA.defaultPrefs parserInfo args of
+        OA.Failure _ -> return ()
+        OA.Success _ -> assertFailure ("parser unexpectedly accepted " ++ unwords args)
         OA.CompletionInvoked _ ->
           assertFailure ("parser requested shell completion for " ++ unwords args)
 
@@ -1597,31 +1629,58 @@ actonProjTests =
           assertBool "root build.zig should bind the colliding zig dep separately"
             ("const dep_shared_2 = b.dependency(\"acton_zig_shared_2\"" `isInfixOf` rootBuildZig)
   , testCase "dep override path must be an Acton project root" $ do
-        withSystemTempDirectory "acton-invalid-dep-override" $ \proj -> do
-          let srcDir = proj </> "src"
-              buildAct = proj </> "Build.act"
-              mainAct = srcDir </> "main.act"
-          createDirectoryIfMissing True srcDir
-          createDirectoryIfMissing True (proj </> "deps")
-          writeFile buildAct $ unlines
-            [ "name = \"invalid_dep_override\""
-            , "fingerprint = 0xb33bef4512345678"
-            , ""
-            , "dependencies = {"
-            , "  \"dep_a\": (path=\"deps/dep_a_missing\")"
-            , "}"
-            ]
-          writeFile mainAct $ unlines
-            [ "actor main(env):"
-            , "    print(\"hello\")"
-            , "    env.exit(0)"
-            ]
-          actonExe <- canonicalizePath "../../dist/bin/acton"
-          (returnCode, _cmdOut, cmdErr) <- readCreateProcessWithExitCode (proc actonExe ["build", "--dep", "dep_a=deps"]){ cwd = Just proj } ""
-          assertEqual "acton should fail for invalid --dep path" (ExitFailure 1) returnCode
-          assertBool "error should mention bad dependency path" ("Dependency dep_a path is not an Acton project root" `isInfixOf` cmdErr)
-          assertBool "error should mention required project files" ("Build.act" `isInfixOf` cmdErr)
-          assertBool "error should mention src requirement" ("src/" `isInfixOf` cmdErr)
+        withSystemTempDirectory "acton-invalid-dep-override" $ \proj ->
+          withSystemTempDirectory "acton-artifact-dep" $ \artifactDep -> do
+            let srcDir = proj </> "src"
+                buildAct = proj </> "Build.act"
+                mainAct = srcDir </> "main.act"
+                invalidDepDir = proj </> "not_a_project_root"
+            createDirectoryIfMissing True srcDir
+            createDirectoryIfMissing True invalidDepDir
+            createDirectoryIfMissing True (artifactDep </> "out" </> "types")
+            writeFile buildAct $ unlines
+              [ "name = \"invalid_dep_override\""
+              , "fingerprint = 0xb33bef4512345678"
+              , ""
+              , "dependencies = {"
+              , "  \"dep_a\": (path=\"deps/dep_a_missing\")"
+              , "}"
+              ]
+            writeFile mainAct $ unlines
+              [ "actor main(env):"
+              , "    print(\"hello\")"
+              , "    env.exit(0)"
+              ]
+            writeFile (artifactDep </> "Build.act") $ unlines
+              [ "name = \"artifact_dep\""
+              , "fingerprint = 0xa44bef4512345678"
+              , "dependencies = {}"
+              , "zig_dependencies = {}"
+              ]
+            writeFile (artifactDep </> "acton-artifact.json") "{}"
+            actonExe <- canonicalizePath "../../dist/bin/acton"
+            (returnCode, _cmdOut, cmdErr) <- readCreateProcessWithExitCode (proc actonExe ["build", "--dep", "dep_a=not_a_project_root"]){ cwd = Just proj } ""
+            assertEqual "acton should fail for invalid --dep path" (ExitFailure 1) returnCode
+            assertBool "error should mention bad dependency path" ("Dependency dep_a path is not an Acton project root" `isInfixOf` cmdErr)
+            assertBool "error should mention required project files" ("Build.act" `isInfixOf` cmdErr)
+            assertBool "error should mention src requirement" ("src/" `isInfixOf` cmdErr)
+            (artifactReturnCode, _artifactOut, artifactErr) <- readCreateProcessWithExitCode
+              (proc actonExe ["build", "--dep", "dep_a=" ++ artifactDep]){ cwd = Just proj } ""
+            assertEqual "acton should reject artifact roots as --dep paths" (ExitFailure 1) artifactReturnCode
+            assertBool "artifact root should still be rejected as a local source dep"
+              ("Dependency dep_a path is not an Acton project root" `isInfixOf` artifactErr)
+            writeFile buildAct $ unlines
+              [ "name = \"invalid_dep_override\""
+              , "fingerprint = 0xb33bef4512345678"
+              , ""
+              , "dependencies = {"
+              , "  \"dep_a\": (path=" ++ show artifactDep ++ ")"
+              , "}"
+              ]
+            (pathReturnCode, _pathOut, pathErr) <- readCreateProcessWithExitCode (proc actonExe ["build"]){ cwd = Just proj } ""
+            assertEqual "acton should reject artifact roots as Build.act paths" (ExitFailure 1) pathReturnCode
+            assertBool "path error should point users to artifact repos"
+              ("Use --artifact-repo to search output artifacts" `isInfixOf` pathErr)
 
   -- Verify pruning keeps binaries for modules that still have roots across build / test runs.
   , testCase "executable pruning" $ do
@@ -1833,6 +1892,40 @@ pkgCliTests =
         case PkgCommands.decodePackageIndex (LBS.pack body) of
           Left _ -> return ()
           Right _ -> assertFailure "package index entry without kinds should fail"
+  , testCase "artifact hash only includes package inputs" $ do
+        withSystemTempDirectory "acton-artifact-hash-inputs" $ \tmp -> do
+          acton <- canonicalizePath "../../dist/bin/acton"
+          let clean = tmp </> "clean"
+              noisy = tmp </> "noisy"
+              writePkg dir body = do
+                createDirectoryIfMissing True (dir </> "src")
+                writeFile (dir </> "Build.act") $ unlines
+                  [ "name = \"hash_pkg\""
+                  , "fingerprint = 0xa33bef4512345678"
+                  , "dependencies = {}"
+                  , "zig_dependencies = {}"
+                  ]
+                writeFile (dir </> "src" </> "main.act") body
+              hashPath dir = do
+                (code, out, err) <- readCreateProcessWithExitCode
+                  (proc acton ["artifact", "hash", dir]) ""
+                assertEqual ("acton artifact hash should succeed\n" ++ err) ExitSuccess code
+                return (dropWhileEnd isSpace (dropWhile isSpace out))
+          writePkg clean "actor main(env):\n    env.exit(0)\n"
+          writePkg noisy "actor main(env):\n    env.exit(0)\n"
+          createDirectoryIfMissing True (noisy </> "out" </> "types")
+          createDirectoryIfMissing True (noisy </> ".build")
+          writeFile (noisy </> "README.md") "not a package input\n"
+          writeFile (noisy </> "out" </> "types" </> "ignored.ty") "ignored\n"
+          writeFile (noisy </> ".build" </> "ignored") "ignored\n"
+          writeFile (noisy </> "build.zig") "ignored\n"
+          writeFile (noisy </> "build.zig.zon") "ignored\n"
+          cleanHash <- hashPath clean
+          noisyHash <- hashPath noisy
+          assertEqual "non-package files should not affect artifact source hash" cleanHash noisyHash
+          writeFile (noisy </> "src" </> "main.act") "actor main(env):\n    print(\"changed\")\n    env.exit(0)\n"
+          changedHash <- hashPath noisy
+          assertBool "source files should affect artifact source hash" (cleanHash /= changedHash)
   ]
 
 -- Creates testgroup from .act files found in specified directory

--- a/compiler/lib/package.yaml.in
+++ b/compiler/lib/package.yaml.in
@@ -65,6 +65,7 @@ library:
   exposed-modules:
     - Acton.ArchiveDownload
     - Acton.Analytics
+    - Acton.Artifact
     - Acton.Boxing
     - Acton.BuildSpec
     - Acton.Builtin

--- a/compiler/lib/src/Acton/Artifact.hs
+++ b/compiler/lib/src/Acton/Artifact.hs
@@ -1,0 +1,255 @@
+-- Copyright (C) 2019-2021 Data Ductus AB
+--
+-- Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+--
+-- 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+--
+-- 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+--
+-- 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+--
+-- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
+
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Acton.Artifact
+  ( ActonOutManifest(..)
+  , artifactFormatVersion
+  , artifactManifestFile
+  , artifactArchiveFile
+  , artifactRepositoryName
+  , artifactMediaType
+  , artifactType
+  , currentTargetTuple
+  , currentInterfaceVersion
+  , currentInterfaceVersionText
+  , expectedManifest
+  , validateManifest
+  , encodeManifest
+  , decodeManifest
+  , writeManifest
+  , readManifest
+  , ociTagForSourceHash
+  , ociRefForRepository
+  , deriveOciRef
+  , ociRefWithoutScheme
+  , ociRefIsLocal
+  , ociRefOrasOptions
+  , ociRefOrasTarget
+  ) where
+
+import GHC.Generics (Generic)
+import Control.Exception (SomeException, displayException, try)
+import Data.Aeson (FromJSON(..), ToJSON(..), (.:), (.=))
+import qualified Data.Aeson as Ae
+import qualified Data.ByteString.Lazy as BL
+import Data.Char (isAlphaNum)
+import Data.List (intercalate, isPrefixOf, isSuffixOf)
+import qualified Acton.Syntax as A
+import System.FilePath ((</>))
+
+data ActonOutManifest = ActonOutManifest
+  { manifestArtifactFormat   :: Int
+  , manifestSourceHash       :: String
+  , manifestInterfaceVersion :: [Int]
+  , manifestTargetTuple      :: String
+  , manifestContents         :: [String]
+  } deriving (Eq, Show, Generic)
+
+instance FromJSON ActonOutManifest where
+  parseJSON = Ae.withObject "ActonOutManifest" $ \o ->
+    ActonOutManifest <$> o .: "artifact_format"
+                     <*> o .: "source_hash"
+                     <*> o .: "interface_version"
+                     <*> o .: "target_tuple"
+                     <*> o .: "contents"
+
+instance ToJSON ActonOutManifest where
+  toJSON m = Ae.object
+    [ "artifact_format"   .= manifestArtifactFormat m
+    , "source_hash"       .= manifestSourceHash m
+    , "interface_version" .= manifestInterfaceVersion m
+    , "target_tuple"      .= manifestTargetTuple m
+    , "contents"          .= manifestContents m
+    ]
+
+artifactFormatVersion :: Int
+artifactFormatVersion = 1
+
+artifactManifestFile :: FilePath
+artifactManifestFile = "acton-artifact.json"
+
+artifactArchiveFile :: FilePath
+artifactArchiveFile = "acton-out.tar.gz"
+
+artifactRepositoryName :: String
+artifactRepositoryName = "acton-out"
+
+artifactMediaType :: String
+artifactMediaType = "application/vnd.acton.out.v1+tar+gzip"
+
+artifactType :: String
+artifactType = "application/vnd.acton.out.v1"
+
+currentTargetTuple :: String
+currentTargetTuple = ""
+
+currentInterfaceVersion :: [Int]
+currentInterfaceVersion = A.version
+
+currentInterfaceVersionText :: String
+currentInterfaceVersionText = intercalate "." (map show currentInterfaceVersion)
+
+expectedManifest :: String -> ActonOutManifest
+expectedManifest sourceHash =
+  ActonOutManifest
+    { manifestArtifactFormat = artifactFormatVersion
+    , manifestSourceHash = sourceHash
+    , manifestInterfaceVersion = currentInterfaceVersion
+    , manifestTargetTuple = currentTargetTuple
+    , manifestContents = [artifactManifestFile, "Build.act", "out/types"]
+    }
+
+validateManifest :: String -> ActonOutManifest -> Either String ()
+validateManifest sourceHash manifest
+  | manifestArtifactFormat manifest /= artifactFormatVersion =
+      Left ("unsupported artifact format "
+            ++ show (manifestArtifactFormat manifest)
+            ++ ", expected "
+            ++ show artifactFormatVersion)
+  | manifestSourceHash manifest /= sourceHash =
+      Left ("artifact source hash "
+            ++ manifestSourceHash manifest
+            ++ " does not match dependency source hash "
+            ++ sourceHash)
+  | manifestInterfaceVersion manifest /= currentInterfaceVersion =
+      Left ("artifact interface version "
+            ++ show (manifestInterfaceVersion manifest)
+            ++ " does not match compiler interface version "
+            ++ show currentInterfaceVersion)
+  | manifestTargetTuple manifest /= currentTargetTuple =
+      Left ("artifact target tuple "
+            ++ show (manifestTargetTuple manifest)
+            ++ " does not match expected "
+            ++ show currentTargetTuple)
+  | otherwise = Right ()
+
+encodeManifest :: ActonOutManifest -> BL.ByteString
+encodeManifest = Ae.encode
+
+decodeManifest :: BL.ByteString -> Either String ActonOutManifest
+decodeManifest = Ae.eitherDecode'
+
+writeManifest :: FilePath -> ActonOutManifest -> IO ()
+writeManifest dir manifest =
+  BL.writeFile (dir </> artifactManifestFile) (encodeManifest manifest)
+
+readManifest :: FilePath -> IO (Either String ActonOutManifest)
+readManifest dir = do
+  bytes <- try (BL.readFile (dir </> artifactManifestFile)) :: IO (Either SomeException BL.ByteString)
+  case bytes of
+    Left ex -> return (Left (displayException ex))
+    Right bs -> return (decodeManifest bs)
+
+ociTagForSourceHash :: String -> Maybe String
+ociTagForSourceHash sourceHash =
+  let tag = sourceHash ++ "-iface" ++ currentInterfaceVersionText
+  in if validOciTag tag then Just tag else Nothing
+
+deriveOciRef :: String -> String -> Maybe String
+deriveOciRef repoUrl sourceHash =
+  case parseRepoPath repoUrl of
+    Just ("github.com", [owner, repo]) ->
+      ociRefForRepository ("ghcr.io/" ++ owner ++ "/" ++ repo ++ "/" ++ artifactRepositoryName) sourceHash
+    Just ("gitlab.com", parts@(_:_)) ->
+      ociRefForRepository ("registry.gitlab.com/" ++ intercalate "/" parts ++ "/" ++ artifactRepositoryName) sourceHash
+    _ -> Nothing
+
+ociRefForRepository :: String -> String -> Maybe String
+ociRefForRepository repo sourceHash = do
+  tag <- ociTagForSourceHash sourceHash
+  case localOciLayoutPath repo of
+    Just path ->
+      let path' = dropTrailingSlash path
+      in if null path'
+           then Nothing
+           else Just ("oci-layout://" ++ path' ++ ":" ++ tag)
+    Nothing ->
+      let repo' = dropTrailingSlash (ociRefWithoutScheme repo)
+      in if null repo' || taggedRepository repo'
+           then Nothing
+           else Just ("oci://" ++ repo' ++ ":" ++ tag)
+
+ociRefWithoutScheme :: String -> String
+ociRefWithoutScheme ref
+  | "oci-layout://" `isPrefixOf` ref = drop (length ("oci-layout://" :: String)) ref
+  | "oci://" `isPrefixOf` ref = drop (length ("oci://" :: String)) ref
+  | otherwise = ref
+
+ociRefIsLocal :: String -> Bool
+ociRefIsLocal ref = "oci-layout://" `isPrefixOf` ref
+
+ociRefOrasOptions :: String -> [String]
+ociRefOrasOptions ref
+  | ociRefIsLocal ref = ["--oci-layout"]
+  | otherwise = []
+
+ociRefOrasTarget :: String -> String
+ociRefOrasTarget = ociRefWithoutScheme
+
+localOciLayoutPath :: String -> Maybe FilePath
+localOciLayoutPath repo
+  | "oci-layout://" `isPrefixOf` repo =
+      Just (drop (length ("oci-layout://" :: String)) repo)
+  | "/" `isPrefixOf` repo = Just repo
+  | "./" `isPrefixOf` repo = Just repo
+  | "../" `isPrefixOf` repo = Just repo
+  | otherwise = Nothing
+
+taggedRepository :: String -> Bool
+taggedRepository ref =
+  let lastPart = reverse (takeWhile (/= '/') (reverse ref))
+  in ':' `elem` lastPart
+
+validOciTag :: String -> Bool
+validOciTag [] = False
+validOciTag tag =
+  length tag <= 128 && validFirst (head tag) && all validRest tag
+  where
+    validFirst c = isAlphaNum c || c == '_'
+    validRest c = isAlphaNum c || c == '_' || c == '.' || c == '-'
+
+parseRepoPath :: String -> Maybe (String, [String])
+parseRepoPath raw =
+  let noScheme = dropPrefix "https://" (dropPrefix "http://" raw)
+      noFragment = takeWhile (/= '#') noScheme
+      (host, rest0) = break (== '/') noFragment
+      rest = dropWhile (== '/') rest0
+      parts = pathParts (dropGitSuffix (dropTrailingSlash rest))
+  in case host of
+       "github.com" | length parts >= 2 -> Just (host, take 2 parts)
+       "gitlab.com" | length parts >= 2 -> Just (host, parts)
+       _ -> Nothing
+
+dropPrefix :: String -> String -> String
+dropPrefix prefix s
+  | prefix `isPrefixOf` s = drop (length prefix) s
+  | otherwise = s
+
+dropGitSuffix :: String -> String
+dropGitSuffix s
+  | ".git" `isSuffixOf` s = take (length s - 4) s
+  | otherwise = s
+
+dropTrailingSlash :: String -> String
+dropTrailingSlash s
+  | "/" `isSuffixOf` s = dropTrailingSlash (take (length s - 1) s)
+  | otherwise = s
+
+pathParts :: String -> [String]
+pathParts "" = []
+pathParts s =
+  let (x, rest) = break (== '/') s
+      rest' = dropWhile (== '/') rest
+  in if null x then pathParts rest' else x : pathParts rest'

--- a/compiler/lib/src/Acton/CommandLineParser.hs
+++ b/compiler/lib/src/Acton/CommandLineParser.hs
@@ -53,6 +53,7 @@ data Command        = New NewOptions
                     | PkgUpgrade PkgUpgradeOptions
                     | PkgUpdate
                     | PkgSearch PkgSearchOptions
+                    | Artifact ArtifactCommand
                     | BuildSpecCmd BuildSpecCommand
                     | Cloud CloudOptions
                     | Doc DocOptions
@@ -100,7 +101,8 @@ data CompileOptions   = CompileOptions {
                          cpu         :: String,
                          test        :: Bool,
                          searchpath  :: [String],
-                         dep_overrides :: [(String,String)]
+                         dep_overrides :: [(String,String)],
+                         artifact_repos :: [String]
                      } deriving Show
 
 data BuildOptions = BuildOptions
@@ -194,6 +196,25 @@ data PkgSearchOptions = PkgSearchOptions
     { pkgSearchTerms :: [String]
     } deriving Show
 
+data ArtifactCommand
+    = ArtifactPack ArtifactPackOptions
+    | ArtifactPush ArtifactPushOptions
+    | ArtifactHash ArtifactHashOptions
+    deriving Show
+
+data ArtifactPackOptions = ArtifactPackOptions
+    { artifactPackOutput     :: String
+    } deriving Show
+
+data ArtifactPushOptions = ArtifactPushOptions
+    { artifactPushRepoUrl      :: String
+    , artifactPushArtifactRepo :: String
+    } deriving Show
+
+data ArtifactHashOptions = ArtifactHashOptions
+    { artifactHashSourcePath :: String
+    } deriving Show
+
 data ZigPkgAddOptions = ZigPkgAddOptions
     { zigPkgAddUrl       :: String
     , zigPkgAddName      :: String
@@ -218,6 +239,7 @@ cmdLineParser       = hsubparser
                         <> command "repl"    (info (CmdOpt <$> globalOptions <*> (Repl <$> compileOptions)) (progDesc "Run an interactive Acton shell"))
                         <> command "fetch"   (info (CmdOpt <$> globalOptions <*> pure Fetch) (progDesc "Fetch project dependencies (offline prep)"))
                         <> command "pkg"     (info (CmdOpt <$> globalOptions <*> pkgSubcommands) (progDesc "Library package/dependency commands"))
+                        <> command "artifact" (info artifactSubcommands (progDesc "Build or publish Acton output artifacts"))
                         <> command "zig-pkg" (info (CmdOpt <$> globalOptions <*> zigPkgSubcommands) (progDesc "Zig package dependency commands"))
                         <> command "spec"    (info (CmdOpt <$> globalOptions <*> (BuildSpecCmd <$> buildSpecCommand)) (progDesc "Inspect or update build specification"))
                         <> command "cloud"   (info (CmdOpt <$> globalOptions <*> (Cloud <$> cloudOptions)) (progDesc "Run an Acton project in the cloud"))
@@ -347,6 +369,7 @@ sigCompileOptions = mkSigCompileOptions
         , test = False
         , searchpath = search
         , dep_overrides = depOverrides
+        , artifact_repos = []
         }
 
 compileOptions = CompileOptions
@@ -387,6 +410,7 @@ compileOptions = CompileOptions
                (long "dep"
                 <> metavar "NAME=PATH"
                 <> help "Override dependency NAME with local PATH"))
+        <*> many (strOption (long "artifact-repo" <> metavar "OCI_REPO" <> help "Search OCI repository for Acton output artifacts"))
 
 pkgSubcommands :: Parser Command
 pkgSubcommands = hsubparser
@@ -428,6 +452,31 @@ pkgUpgradeOptions =
 pkgSearchOptions :: Parser PkgSearchOptions
 pkgSearchOptions =
     PkgSearchOptions <$> many (argument str (metavar "TERM" <> help "Search term (regex, ANDed)"))
+
+-- Global options are parsed by each leaf command, not at the "artifact"
+-- level: a nested hsubparser hands all remaining arguments to the leaf
+-- parser, so this is what lets "acton artifact pack --verbose" parse.
+artifactSubcommands :: Parser CmdLineOptions
+artifactSubcommands = hsubparser
+  (  command "pack" (artifactInfo (ArtifactPack <$> artifactPackOptions) "Pack out/types as an Acton artifact")
+  <> command "push" (artifactInfo (ArtifactPush <$> artifactPushOptions) "Pack and push an Acton artifact to OCI")
+  <> command "hash" (artifactInfo (ArtifactHash <$> artifactHashOptions) "Compute the Acton package source hash for a local path")
+  )
+  where
+    artifactInfo p desc = info (CmdOpt <$> globalOptions <*> (Artifact <$> p)) (progDesc desc)
+
+artifactPackOptions :: Parser ArtifactPackOptions
+artifactPackOptions = ArtifactPackOptions
+    <$> strOption (long "output" <> metavar "FILE" <> value "" <> help "Output archive (defaults to out/acton-out.tar.gz)")
+
+artifactPushOptions :: Parser ArtifactPushOptions
+artifactPushOptions = ArtifactPushOptions
+    <$> strOption (long "repo-url" <> metavar "URL" <> value "" <> help "Repository URL used to derive the OCI ref")
+    <*> strOption (long "artifact-repo" <> metavar "OCI_REPO" <> value "" <> help "OCI repository to push to")
+
+artifactHashOptions :: Parser ArtifactHashOptions
+artifactHashOptions =
+    ArtifactHashOptions <$> argument str (metavar "PATH" <> value "." <> help "Source package path")
 
 zigPkgSubcommands :: Parser Command
 zigPkgSubcommands = hsubparser

--- a/compiler/lib/src/Acton/CommandLineParser.hs
+++ b/compiler/lib/src/Acton/CommandLineParser.hs
@@ -91,6 +91,7 @@ data CompileOptions   = CompileOptions {
                          optimize    :: OptimizeMode,
                          only_build  :: Bool,
                          skip_build  :: Bool,
+                         skip_backpass :: Bool,
                          watch       :: Bool,
                          no_threads  :: Bool,
                          parse_serial :: Bool,
@@ -358,6 +359,7 @@ sigCompileOptions = mkSigCompileOptions
         , optimize = Debug
         , only_build = False
         , skip_build = True
+        , skip_backpass = False
         , watch = False
         , no_threads = False
         , parse_serial = False
@@ -396,6 +398,7 @@ compileOptions = CompileOptions
         <*> optimizeOption
         <*> switch (long "only-build"   <> help "Only perform final build of .c files, do not compile .act files")
         <*> switch (long "skip-build"   <> help "Skip final bulid of .c files")
+        <*> switch (long "skip-backpass" <> help "Skip back passes (no C code generation), only type check and write interfaces")
         <*> switch (long "watch"        <> help "Rebuild on file changes")
         <*> switch (long "no-threads"   <> help "Don't use threads")
         <*> switch (long "parse-serial" <> help "Use the serial whole-file parser")

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -227,6 +227,7 @@ import qualified Acton.Boxing
 import qualified Acton.CodeGen
 import Acton.Builtin (mBuiltin)
 import Acton.Prim (mPrim)
+import qualified Acton.Artifact as Artifact
 import qualified Acton.BuildSpec as BuildSpec
 import qualified Acton.DocPrinter as DocP
 import qualified Acton.Fingerprint as Fingerprint
@@ -677,7 +678,7 @@ prepareCompilePlan sp gopts sched opts srcFiles allowPrune mChangedPaths = do
   ctx <- prepareCompileContext opts srcFiles
   specChanged <- checkBuildSpecChange sched (ccBuildStamp ctx)
   when specChanged $
-    fetchDependencies gopts (ccPathsRoot ctx) (ccDepOverrides ctx)
+    fetchDependencies gopts (ccPathsRoot ctx) (ccDepOverrides ctx) (C.artifact_repos opts)
   let mChanged = if specChanged then Nothing else mChangedPaths
   prepareCompilePlanFromContext sp gopts ctx srcFiles allowPrune mChanged
 
@@ -721,6 +722,7 @@ prepareCompilePlanFromContext sp gopts ctx srcFiles allowPrune mChangedPaths = d
             , projSysTypes = joinPath [sysAbs, "base", "out", "types"]
             , projBuildSpec = scratchBuildSpec rootProj
             , projDeps = []
+            , projPrebuilt = False
             }
       return (M.singleton rootProj ctx')
     else discoverProjects gopts sysAbs rootProj depOverrides
@@ -900,6 +902,7 @@ defaultCompileOptions =
     , C.test = False
     , C.searchpath = []
     , C.dep_overrides = []
+    , C.artifact_repos = []
     }
 
 -- | Debug helper for pass dumps.
@@ -1613,7 +1616,9 @@ buildGlobalTasks sp gopts opts projMap mSeeds = do
             Just actFile -> do
               let ctx = projMap M.! tkProj k
               paths <- pathsForModule opts projMap ctx (tkMod k)
-              task  <- readModuleTask sp gopts opts paths actFile
+              task  <- if projPrebuilt ctx
+                          then readPrebuiltModuleTask paths actFile
+                          else readModuleTask sp gopts opts paths actFile
               let order = M.findWithDefault [tkProj k] (tkProj k) orderCache
                   deps = M.findWithDefault Data.Set.empty (tkProj k) allDeps
                   imps = restoredImportsOf paths task
@@ -2066,6 +2071,30 @@ readModuleTask sp gopts opts paths actFile = do
       ParseTask mn srcContent bytes mSourceMeta imps
     HeadError{ mhName = mn, mhDiagnostics = diags } ->
       ParseErrorTask mn diags
+
+readPrebuiltModuleTask :: Paths -> FilePath -> IO CompileTask
+readPrebuiltModuleTask paths tyFile = do
+  let mn = modName paths
+  hdrE <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readHeader tyFile
+  case hdrE of
+    Left ex ->
+      throwProjectError ("Invalid prebuilt Acton interface " ++ tyFile ++ ": " ++ displayException ex)
+    Right (_sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash, imps, depModules, nameHashes, roots, tests, mdoc) ->
+      let nmodStub = I.NModule [] [] mdoc
+          tmodStub = A.Module mn [] mdoc []
+      in return TyTask { name      = mn
+                       , tyHash     = moduleSrcBytesHash
+                       , tyPubHash  = modulePubHash
+                       , tyImplHash = moduleImplHash
+                       , tyImports  = imps
+                       , tyDepModules = depModules
+                       , tyNameHashes = nameHashes
+                       , tyNameCount = length nameHashes
+                       , tyRoots   = roots
+                       , tyTests   = tests
+                       , tyDoc     = mdoc
+                       , iface     = nmodStub
+                       , typed     = tmodStub }
 
 readModuleDoc :: Source.SourceProvider
               -> C.GlobalOptions
@@ -4361,7 +4390,8 @@ data ProjCtx = ProjCtx {
                      projSysPath :: FilePath,
                      projSysTypes:: FilePath,
                      projBuildSpec :: BuildSpec.BuildSpec,
-                     projDeps     :: [(String, FilePath)]          -- resolved dependency roots (abs paths)
+                     projDeps     :: [(String, FilePath)],         -- resolved dependency roots (abs paths)
+                     projPrebuilt :: Bool
                    } deriving (Show)
 
 systemTypePaths :: FilePath -> FilePath -> [FilePath]
@@ -4431,7 +4461,8 @@ discoverProjects gopts sysAbs rootProj depOverrides = do
           let outDir   = joinPath [dirAbs, "out"]
               typesDir = joinPath [outDir, "types"]
               srcDir'  = joinPath [dirAbs, "src"]
-              ctx = ProjCtx { projRoot = dirAbs
+          prebuilt <- isActonArtifactOnlyRoot dirAbs
+          let ctx = ProjCtx { projRoot = dirAbs
                             , projOutDir = outDir
                             , projTypesDir = typesDir
                             , projSrcDir = srcDir'
@@ -4439,6 +4470,7 @@ discoverProjects gopts sysAbs rootProj depOverrides = do
                             , projSysTypes = joinPath [sysAbs, "base", "out", "types"]
                             , projBuildSpec = spec
                             , projDeps = [ (n, p) | (n, p, _) <- reverse deps ]
+                            , projPrebuilt = prebuilt
                             }
               acc' = M.insert dirAbs ctx acc
               seen' = Data.Set.insert dirAbs seen
@@ -4458,6 +4490,7 @@ discoverProjects gopts sysAbs rootProj depOverrides = do
                     ++ " overridden by root pin")
       depBase <- resolveDepBase base depName chosenDep
       depAbs  <- normalizePathSafe depBase
+      validateDependencyPath depName chosenDep depAbs
       (depPath, fpMap', depSpec) <- canonicalizeDep depAbs fpMap
       return ((depName, depPath, depSpec) : accDeps, fpMap')
 
@@ -4525,6 +4558,19 @@ isActonProjectRoot path = do
         hasBuildAct <- doesFileExist (path </> "Build.act")
         hasSrcDir <- doesDirectoryExist (path </> "src")
         return (hasBuildAct && hasSrcDir)
+
+isActonArtifactRoot :: FilePath -> IO Bool
+isActonArtifactRoot path = do
+    hasManifest <- doesFileExist (path </> Artifact.artifactManifestFile)
+    hasBuildAct <- doesFileExist (path </> "Build.act")
+    hasTypesDir <- doesDirectoryExist (path </> "out" </> "types")
+    return (hasManifest && hasBuildAct && hasTypesDir)
+
+isActonArtifactOnlyRoot :: FilePath -> IO Bool
+isActonArtifactOnlyRoot path = do
+    isArtifact <- isActonArtifactRoot path
+    hasSrcDir <- doesDirectoryExist (path </> "src")
+    return (isArtifact && not hasSrcDir)
 
 findProjectDir :: FilePath -> IO (Maybe FilePath)
 findProjectDir path = do
@@ -4650,23 +4696,42 @@ moduleNameFromFile srcBase proj actFile = do
 -- Used to seed the project module index for graph construction.
 enumerateProjectModules :: ProjCtx -> IO [(FilePath, A.ModName)]
 enumerateProjectModules ctx = do
-    exists <- doesDirectoryExist (projSrcDir ctx)
+    if projPrebuilt ctx
+      then enumeratePrebuiltModules ctx
+      else do
+        exists <- doesDirectoryExist (projSrcDir ctx)
+        if not exists
+          then return []
+          else do
+            files <- getFilesRecursive (projSrcDir ctx)
+            let actFiles = filter (\f -> takeExtension f == ".act") files
+                proj = BuildSpec.specName $ projBuildSpec ctx
+                rootName = head . splitDirectories . makeRelative (projSrcDir ctx) . dropExtension
+                depNames = map fst $ projDeps ctx
+                depOverlaps = filter ((`elem` depNames) . rootName) actFiles
+            when (not $ null depOverlaps) $
+                throwProjectError ("Source files in project " ++ projRoot ctx ++ " overlap with declared dependencies:\n" ++
+                                   concat ["    " ++ makeRelative (projRoot ctx) f ++ "\n" | f <- depOverlaps])
+            forM actFiles $ \f -> do
+              mn <- moduleNameFromFile (projSrcDir ctx) proj f
+              return (f, mn)
+
+enumeratePrebuiltModules :: ProjCtx -> IO [(FilePath, A.ModName)]
+enumeratePrebuiltModules ctx = do
+    exists <- doesDirectoryExist (projTypesDir ctx)
     if not exists
       then return []
       else do
-        files <- getFilesRecursive (projSrcDir ctx)
-        let actFiles = filter (\f -> takeExtension f == ".act") files
-            proj = BuildSpec.specName $ projBuildSpec ctx
-            rootName = head . splitDirectories . makeRelative (projSrcDir ctx) . dropExtension
-            depNames = map fst $ projDeps ctx
-            depOverlaps = filter ((`elem` depNames) . rootName) actFiles
-
-        when (not $ null depOverlaps) $
-            throwProjectError ("Source files in project " ++ projRoot ctx ++ " overlap with declared dependencies:\n" ++
-                               concat ["    " ++ makeRelative (projRoot ctx) f ++ "\n" | f <- depOverlaps])
-
-        forM actFiles $ \f -> do
-          mn <- moduleNameFromFile (projSrcDir ctx) proj f
+        tyFiles <- InterfaceFiles.listInterfaceDirsRecursive (projTypesDir ctx)
+        base <- normalizePathSafe (projTypesDir ctx)
+        forM tyFiles $ \f -> do
+          file <- normalizePathSafe f
+          -- Interface paths under out/types already encode the full, project-
+          -- prefixed module name (see interfacePath), so derive it directly
+          -- rather than via moduleNameFromFile, which would prepend the project
+          -- name a second time.
+          let rel = dropExtension (makeRelative base file)
+              mn = A.modName (splitDirectories rel)
           return (f, mn)
 
 -- | Remove stale generated module artifacts when source modules disappear.
@@ -4674,22 +4739,23 @@ enumerateProjectModules ctx = do
 -- cached headers cannot mask deleted .act modules.
 pruneMissingModuleOutputs :: ProjCtx -> IO ()
 pruneMissingModuleOutputs ctx = do
-    let srcRoot = projSrcDir ctx
-        typesRoot = projTypesDir ctx
-    typesExists <- doesDirectoryExist typesRoot
-    when typesExists $ do
-      srcExists <- doesDirectoryExist srcRoot
-      srcMods <- if srcExists
-                   then do
-                     srcFiles <- getFilesRecursive srcRoot
-                     let actFiles = filter (\f -> takeExtension f == ".act") srcFiles
-                         modBases = map (normalise . dropExtension . makeRelative srcRoot) actFiles
-                     return (Data.Set.fromList modBases)
-                   else return Data.Set.empty
-      outFiles <- getFilesRecursive typesRoot
-      mapM_ (pruneFile srcMods typesRoot) outFiles
-      tyDbs <- InterfaceFiles.listInterfaceDirsRecursive typesRoot
-      mapM_ (pruneTyDb srcMods typesRoot) tyDbs
+    unless (projPrebuilt ctx) $ do
+      let srcRoot = projSrcDir ctx
+          typesRoot = projTypesDir ctx
+      typesExists <- doesDirectoryExist typesRoot
+      when typesExists $ do
+        srcExists <- doesDirectoryExist srcRoot
+        srcMods <- if srcExists
+                     then do
+                       srcFiles <- getFilesRecursive srcRoot
+                       let actFiles = filter (\f -> takeExtension f == ".act") srcFiles
+                           modBases = map (normalise . dropExtension . makeRelative srcRoot) actFiles
+                       return (Data.Set.fromList modBases)
+                     else return Data.Set.empty
+        outFiles <- getFilesRecursive typesRoot
+        mapM_ (pruneFile srcMods typesRoot) outFiles
+        tyDbs <- InterfaceFiles.listInterfaceDirsRecursive typesRoot
+        mapM_ (pruneTyDb srcMods typesRoot) tyDbs
   where
     isRootStub rel ext =
       ext == ".c" &&
@@ -4735,14 +4801,15 @@ pruneMissingChangedModuleOutputs ctxs changedPaths = do
         mapM_ (pruneForCtx actPath) ctxs
   where
     pruneForCtx actPath ctx = do
-      srcRoot <- normalizePathSafe (projSrcDir ctx)
-      let srcRoot' = addTrailingPathSeparator (normalise srcRoot)
-          actPath' = normalise actPath
-      when (Data.List.isPrefixOf srcRoot' actPath') $ do
-        let modBase = normalise (dropExtension (makeRelative srcRoot actPath'))
-            outBase = projTypesDir ctx </> modBase
-        removePathForcibly (outBase ++ InterfaceFiles.interfaceExt) `catch` ignoreNotExists
-        mapM_ (\ext -> removeFile (outBase ++ ext) `catch` ignoreNotExists) [".c", ".h"]
+      unless (projPrebuilt ctx) $ do
+        srcRoot <- normalizePathSafe (projSrcDir ctx)
+        let srcRoot' = addTrailingPathSeparator (normalise srcRoot)
+            actPath' = normalise actPath
+        when (Data.List.isPrefixOf srcRoot' actPath') $ do
+          let modBase = normalise (dropExtension (makeRelative srcRoot actPath'))
+              outBase = projTypesDir ctx </> modBase
+          removePathForcibly (outBase ++ InterfaceFiles.interfaceExt) `catch` ignoreNotExists
+          mapM_ (\ext -> removeFile (outBase ++ ext) `catch` ignoreNotExists) [".c", ".h"]
 
     ignoreNotExists :: IOException -> IO ()
     ignoreNotExists _ = return ()
@@ -4955,12 +5022,18 @@ applyDepOverrides base overrides spec = do
         Just dep -> do
           let absP0 = if isAbsolutePath depPath then depPath else joinPath [base, depPath]
           absP <- normalizePathSafe absP0
-          validateDepOverridePath depName absP
+          validateLocalDepPath depName absP
           let dep' = dep { BuildSpec.path = Just absP }
           return (M.insert depName dep' depsMap)
 
-validateDepOverridePath :: String -> FilePath -> IO ()
-validateDepOverridePath depName depPath = do
+validateDependencyPath :: String -> BuildSpec.PkgDep -> FilePath -> IO ()
+validateDependencyPath depName dep depPath =
+    case BuildSpec.path dep of
+      Just p | not (null p) -> rejectArtifactDepPath depName depPath
+      _ -> return ()
+
+validateLocalDepPath :: String -> FilePath -> IO ()
+validateLocalDepPath depName depPath = do
     exists <- doesDirectoryExist depPath
     unless exists $
       throwProjectError ("Dependency " ++ depName ++ " path does not exist: " ++ depPath ++ "\n"
@@ -4972,8 +5045,15 @@ validateDepOverridePath depName depPath = do
                          ++ "Hint: Local dependency paths must point to an Acton project root\n"
                          ++ "(directory with src/ and Build.act).")
 
-fetchDependencies :: C.GlobalOptions -> Paths -> [(String, FilePath)] -> IO ()
-fetchDependencies gopts paths depOverrides = do
+rejectArtifactDepPath :: String -> FilePath -> IO ()
+rejectArtifactDepPath depName depPath = do
+    isArtifactRoot <- isActonArtifactOnlyRoot depPath
+    when isArtifactRoot $
+      throwProjectError ("Dependency " ++ depName ++ " path points to an Acton output artifact: " ++ depPath ++ "\n"
+                         ++ "Hint: Use --artifact-repo to search output artifacts; local dependency paths are not artifact roots.")
+
+fetchDependencies :: C.GlobalOptions -> Paths -> [(String, FilePath)] -> [String] -> IO ()
+fetchDependencies gopts paths depOverrides artifactRepos = do
     if isTmp paths
       then return ()
       else do
@@ -5007,7 +5087,7 @@ fetchDependencies gopts paths depOverrides = do
           selectedDeps <- forM (M.toList (BuildSpec.dependencies spec)) $
             selectDependency rootPins projAbs
           let pkgFetches = catMaybes
-                [ mkPkgFetch cacheDir zigExe globalCache name dep | (name, dep) <- selectedDeps ]
+                [ mkPkgFetch cacheDir zigExe globalCache depsCache name dep | (name, dep) <- selectedDeps ]
               zigFetches = catMaybes
                 [ mkZigFetch cacheDir zigExe globalCache name dep
                 | (name, dep) <- M.toList (BuildSpec.zig_dependencies spec)
@@ -5064,16 +5144,17 @@ fetchDependencies gopts paths depOverrides = do
                                     ++ "(directory with src/ and Build.act).")
                _ -> return seen
         else do
+          validateDependencyPath depName dep depAbs
           depSpec0 <- loadBuildSpec depAbs
           depSpec <- applyDepOverrides depAbs depOverrides depSpec0
           walkProject rootPins cacheDir zigExe globalCache depsCache zigSeen seen depAbs depSpec
 
-    mkPkgFetch cacheDir zigExe globalCache name dep =
+    mkPkgFetch cacheDir zigExe globalCache depsCache name dep =
       case BuildSpec.path dep of
         Just p | not (null p) -> Nothing
         _ -> case (BuildSpec.url dep, BuildSpec.hash dep) of
                (Just u, Just h) ->
-                 Just (fetchOne "pkg" name u (Just h) cacheDir zigExe globalCache)
+                 Just (fetchPkg name dep u h cacheDir zigExe globalCache depsCache)
                (Just _, Nothing) ->
                  Just (return (Left ("Dependency " ++ name ++ " is missing hash")))
                _ -> Nothing
@@ -5160,6 +5241,209 @@ fetchDependencies gopts paths depOverrides = do
     -- Atomically record a key; returns True the first time it is seen.
     claimVisited ref key = atomicModifyIORef' ref $ \s ->
       if Data.Set.member key s then (s, False) else (Data.Set.insert key s, True)
+
+    fetchPkg name dep url h cacheDir zigExe globalCache depsCache = do
+      let dst = joinPath [depsCache, name ++ "-" ++ h]
+      present <- doesDirectoryExist dst
+      if present
+        then do
+          cachedArtifact <- validateCachedArtifactDir name h dst
+          case cachedArtifact of
+            Left err -> return (Left err)
+            Right True -> useCachedArtifact name h dst
+            Right False -> do
+              stillPresent <- doesDirectoryExist dst
+              if stillPresent
+                then useCachedPkg name h dst
+                else fetchPkgFresh name dep url h cacheDir zigExe globalCache depsCache dst
+        else fetchPkgFresh name dep url h cacheDir zigExe globalCache depsCache dst
+
+    useCachedArtifact name h _dst = do
+      unless (C.quiet gopts) $
+        putStrLn ("Using cached Acton artifact for dependency " ++ name ++ " (" ++ h ++ ")")
+      return (Right h)
+
+    useCachedPkg name h _dst = do
+      unless (C.quiet gopts) $
+        putStrLn ("Using cached pkg dependency " ++ name ++ " (" ++ h ++ ")")
+      return (Right h)
+
+    fetchPkgFresh name dep url h cacheDir zigExe globalCache depsCache dst = do
+      sourcePresent <- doesDirectoryExist (cacheDir h)
+      if sourcePresent
+        then fetchOne "pkg" name url (Just h) cacheDir zigExe globalCache
+        else do
+          artifact <- fetchPkgArtifact name dep h dst depsCache
+          case artifact of
+            Left err -> return (Left err)
+            Right True -> return (Right h)
+            Right False -> fetchOne "pkg" name url (Just h) cacheDir zigExe globalCache
+
+    validateCachedArtifactDir name h dst = do
+      artifactRoot <- isActonArtifactOnlyRoot dst
+      if not artifactRoot
+        then return (Right False)
+        else do
+          valid <- validateArtifactDir name h dst
+          case valid of
+            Right () -> return (Right True)
+            Left err -> do
+              when (C.verbose gopts) $
+                putStrLn ("Ignoring cached Acton artifact for " ++ name ++ ": " ++ err)
+              rm <- try (removePathForcibly dst) :: IO (Either IOException ())
+              case rm of
+                Right _ -> return (Right False)
+                Left ex -> return (Left ("Failed to remove stale Acton artifact " ++ dst ++ ": " ++ displayException ex))
+
+    fetchPkgArtifact name dep h dst depsCache = do
+      refs <- artifactRefs dep h
+      case refs of
+        Left err -> return (Left err)
+        Right allRefs -> tryArtifactRefs name h dst depsCache (localArtifactRefs allRefs ++ remoteArtifactRefs allRefs)
+
+    localArtifactRefs refs = filter Artifact.ociRefIsLocal refs
+
+    remoteArtifactRefs refs = filter (not . Artifact.ociRefIsLocal) refs
+
+    artifactRefs dep h =
+      let (repoErrors, repoRefs) = partitionEithers [ artifactRepoRef repo h | repo <- artifactRepos ]
+      in case repoErrors of
+           err:_ -> return (Left err)
+           [] -> return (Right (repoRefs ++ derivedArtifactRefs dep h))
+      where
+        artifactRepoRef repo h =
+          case Artifact.ociRefForRepository repo h of
+            Just ref -> Right ref
+            Nothing  -> Left ("Invalid Acton artifact repository " ++ repo)
+
+        derivedArtifactRefs dep h =
+          catMaybes [ BuildSpec.repo_url dep >>= \repoUrl -> Artifact.deriveOciRef repoUrl h ]
+
+    tryArtifactRefs name h dst depsCache refs =
+      case refs of
+        [] -> return (Right False)
+        ref:rest -> do
+          unless (C.quiet gopts) $
+            putStrLn ("Trying Acton artifact " ++ name ++ " from " ++ ref)
+          tmpRoot <- getTemporaryDirectory
+          nonce <- randomRIO (0, maxBound :: Int)
+          let tmpDir = joinPath [tmpRoot, "acton-oci-" ++ show nonce]
+              pullDir = joinPath [tmpDir, "pull"]
+              stageDir = joinPath [tmpDir, "stage"]
+              refArg = Artifact.ociRefOrasTarget ref
+              pullArgs = ["pull"] ++ Artifact.ociRefOrasOptions ref ++ [refArg, "--output", pullDir]
+          createDirectoryIfMissing True pullDir
+          pullRes <- runProcessCapture "oras" pullArgs Nothing
+          case pullRes of
+            Left _ -> cleanupTmp tmpDir >> tryArtifactRefs name h dst depsCache rest
+            Right (ExitFailure _, _, _) -> cleanupTmp tmpDir >> tryArtifactRefs name h dst depsCache rest
+            Right (ExitSuccess, _, _) -> do
+              let archive = pullDir </> Artifact.artifactArchiveFile
+              archiveExists <- doesFileExist archive
+              if not archiveExists
+                then do
+                  skipArtifact name h dst depsCache ref tmpDir rest ("did not contain " ++ Artifact.artifactArchiveFile)
+                else do
+                  createDirectoryIfMissing True stageDir
+                  extracted <- extractArtifactArchive ref archive stageDir
+                  case extracted of
+                    Left err -> skipArtifact name h dst depsCache ref tmpDir rest err
+                    Right () -> do
+                      valid <- validateArtifactDir name h stageDir
+                      case valid of
+                        Left err -> skipArtifact name h dst depsCache ref tmpDir rest err
+                        Right () -> do
+                          createDirectoryIfMissing True depsCache
+                          dstExists <- doesDirectoryExist dst
+                          materialized <- if dstExists
+                                            then try (removePathForcibly dst >> renameDirectory stageDir dst) :: IO (Either IOException ())
+                                            else try (renameDirectory stageDir dst) :: IO (Either IOException ())
+                          case materialized of
+                            Right _ -> do
+                              cleanupTmp tmpDir
+                              unless (C.quiet gopts) $
+                                putStrLn ("Using Acton artifact for dependency " ++ name ++ " (" ++ h ++ ")")
+                              return (Right True)
+                            Left ex -> do
+                              cleanupTmp tmpDir
+                              return (Left ("Failed to materialize Acton artifact " ++ ref ++ ": " ++ displayException ex))
+
+    skipArtifact name h dst depsCache ref tmpDir rest reason = do
+      when (C.verbose gopts) $
+        putStrLn ("Ignoring Acton artifact " ++ ref ++ ": " ++ reason)
+      cleanupTmp tmpDir
+      tryArtifactRefs name h dst depsCache rest
+
+    validateArtifactDir name h dir = do
+      manifestE <- Artifact.readManifest dir
+      case manifestE of
+        Left err -> return (Left ("Invalid Acton artifact manifest for " ++ name ++ ": " ++ err))
+        Right manifest ->
+          case Artifact.validateManifest h manifest of
+            Left err -> return (Left ("Invalid Acton artifact manifest for " ++ name ++ ": " ++ err))
+            Right () -> do
+              hasBuildAct <- doesFileExist (dir </> "Build.act")
+              hasTypesDir <- doesDirectoryExist (dir </> "out" </> "types")
+              if hasBuildAct && hasTypesDir
+                then return (Right ())
+                else return (Left ("Acton artifact for " ++ name ++ " must contain Build.act and out/types"))
+
+    extractArtifactArchive ref archive stageDir = do
+      safe <- validateArtifactArchiveEntries archive
+      case safe of
+        Left err ->
+          return (Left ("Unsafe Acton artifact " ++ ref ++ ": " ++ err))
+        Right () -> do
+          extractRes <- runProcessCapture "tar" ["-xzf", archive, "-C", stageDir] Nothing
+          case extractRes of
+            Left ex ->
+              return (Left ("Failed to extract Acton artifact " ++ ref ++ ": " ++ displayException ex))
+            Right (ExitFailure _, _, err) ->
+              return (Left ("Failed to extract Acton artifact " ++ ref ++ ":\n" ++ err))
+            Right (ExitSuccess, _, _) -> return (Right ())
+
+    validateArtifactArchiveEntries archive = do
+      namesRes <- runProcessCapture "tar" ["-tzf", archive] Nothing
+      case namesRes of
+        Left ex -> return (Left ("failed to list archive entries: " ++ displayException ex))
+        Right (ExitFailure _, _, err) -> return (Left ("failed to list archive entries:\n" ++ err))
+        Right (ExitSuccess, out, _) -> do
+          let entries = filter (not . null) (lines out)
+              badPaths = filter (not . safeArtifactPath) entries
+          if not (null badPaths)
+            then return (Left ("invalid archive path " ++ head badPaths))
+            else do
+              typesRes <- runProcessCapture "tar" ["-tvzf", archive] Nothing
+              case typesRes of
+                Left ex -> return (Left ("failed to inspect archive entries: " ++ displayException ex))
+                Right (ExitFailure _, _, err) -> return (Left ("failed to inspect archive entries:\n" ++ err))
+                Right (ExitSuccess, typeOut, _) -> do
+                  let badTypes = filter (not . safeArtifactTypeLine) (filter (not . null) (lines typeOut))
+                  if null badTypes
+                    then return (Right ())
+                    else return (Left ("unsupported archive entry type " ++ take 1 (head badTypes)))
+
+    safeArtifactPath p =
+      not (isAbsolute p) &&
+      ".." `notElem` splitDirectories p &&
+      (p == Artifact.artifactManifestFile ||
+       p == "Build.act" ||
+       p == "out" ||
+       p == "out/types" ||
+       "out/types/" `isPrefixOf` p)
+
+    safeArtifactTypeLine [] = True
+    safeArtifactTypeLine (c:_) = c == '-' || c == 'd'
+
+    runProcessCapture exe args mcwd = do
+      let cmd = (proc exe args){ cwd = mcwd }
+      try (readCreateProcessWithExitCode cmd "") :: IO (Either SomeException (ExitCode, String, String))
+
+    cleanupTmp dir =
+      removePathForcibly dir `catch` ignoreCleanup
+
+    ignoreCleanup :: IOException -> IO ()
+    ignoreCleanup _ = return ()
 
     fetchOne kind name url mh cacheDir zigExe globalCache = do
       case mh of
@@ -5330,6 +5614,7 @@ collectDepTypePaths projDir overrides = do
                                     ++ "(directory with src/ and Build.act).")
                _ -> return (seen, fpMap, acc)
         else do
+          validateDependencyPath depName dep depAbs
           (depPath, fpMap') <- canonicalizeDep depAbs fpMap
           let typesDir = joinPath [depPath, "out", "types"]
           if Data.Set.member depPath seen

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -5279,6 +5279,14 @@ fetchDependencies gopts paths depOverrides artifactRepos = do
     claimVisited ref key = atomicModifyIORef' ref $ \s ->
       if Data.Set.member key s then (s, False) else (Data.Set.insert key s, True)
 
+    -- Passing --artifact-repo opts in to artifact consumption: a valid output
+    -- artifact is then preferred over already-cached source. Without it cached
+    -- source always wins, so ordinary builds never retry artifact pulls for
+    -- deps they already have. The opt-in matters on any host that has run
+    -- 'acton artifact hash/push': producing seeds the caches with the
+    -- producer's own source, which would otherwise shadow the artifact forever.
+    preferArtifacts = not (null artifactRepos)
+
     fetchPkg name dep url h cacheDir zigExe globalCache depsCache = do
       let dst = joinPath [depsCache, name ++ "-" ++ h]
       present <- doesDirectoryExist dst
@@ -5291,9 +5299,21 @@ fetchDependencies gopts paths depOverrides artifactRepos = do
             Right False -> do
               stillPresent <- doesDirectoryExist dst
               if stillPresent
-                then useCachedPkg name h dst
+                then usePkgOrPreferredArtifact name dep h dst depsCache
                 else fetchPkgFresh name dep url h cacheDir zigExe globalCache depsCache dst
         else fetchPkgFresh name dep url h cacheDir zigExe globalCache depsCache dst
+
+    -- dst holds a cached source checkout. With artifact consumption enabled,
+    -- try to replace it with the matching output artifact (tryArtifactRefs
+    -- swaps dst in place); on a miss keep building from the cached source.
+    usePkgOrPreferredArtifact name dep h dst depsCache
+      | not preferArtifacts = useCachedPkg name h dst
+      | otherwise = do
+          artifact <- fetchPkgArtifact name dep h dst depsCache
+          case artifact of
+            Left err -> return (Left err)
+            Right True -> return (Right h)
+            Right False -> useCachedPkg name h dst
 
     useCachedArtifact name h _dst = do
       unless (C.quiet gopts) $
@@ -5306,8 +5326,8 @@ fetchDependencies gopts paths depOverrides artifactRepos = do
       return (Right h)
 
     fetchPkgFresh name dep url h cacheDir zigExe globalCache depsCache dst = do
-      sourcePresent <- doesDirectoryExist (cacheDir h)
-      if sourcePresent
+      sourcePresent <- cacheEntryExists cacheDir h
+      if sourcePresent && not preferArtifacts
         then fetchOne "pkg" name url (Just h) cacheDir zigExe globalCache
         else do
           artifact <- fetchPkgArtifact name dep h dst depsCache

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -688,6 +688,7 @@ data CompilePlan = CompilePlan
   , cpGlobalTasks :: [GlobalTask]
   , cpNeededTasks :: [GlobalTask]
   , cpDbpBlocked :: Data.Set.Set TaskKey
+  , cpPrebuiltRoots :: Data.Set.Set FilePath
   , cpRootTasks :: [CompileTask]
   , cpRootPins :: M.Map String BuildSpec.PkgDep
   , cpIncremental :: Bool
@@ -742,12 +743,14 @@ prepareCompilePlanFromContext sp gopts ctx srcFiles allowPrune mChangedPaths = d
   let neededTasks = expandBuildLibraryTasks projMap globalTasks neededTasks0
       rootTasks = [ gtTask t | t <- neededTasks0, tkProj (gtKey t) == rootProj ]
       rootPins = maybe M.empty (BuildSpec.dependencies . projBuildSpec) (M.lookup rootProj projMap)
+      prebuiltRoots = Data.Set.fromList [ projRoot pctx | pctx <- M.elems projMap, projPrebuilt pctx ]
   return CompilePlan
     { cpContext = ctx
     , cpProjMap = projMap
     , cpGlobalTasks = globalTasks
     , cpNeededTasks = neededTasks
     , cpDbpBlocked = dbpBlocked
+    , cpPrebuiltRoots = prebuiltRoots
     , cpRootTasks = rootTasks
     , cpRootPins = rootPins
     , cpIncremental = incremental
@@ -839,7 +842,7 @@ runCompilePlan sp gopts plan sched gen hooks0 = withAnalytics $ \ana -> do
         , ccOnBackSkipped = chOnBackSkipped hooks
         , ccOnInfo = chOnInfo hooks
         }
-  compileTasks sp gopts opts' pathsRoot rootProj (cpNeededTasks plan) (cpDbpBlocked plan) callbacks
+  compileTasks sp gopts opts' pathsRoot rootProj (cpNeededTasks plan) (cpDbpBlocked plan) (cpPrebuiltRoots plan) callbacks
 
 -- | Tap the generic progress hooks to feed the analytics sampler. Each pass
 -- already reports through these callbacks, so a single wrapper covers parse,
@@ -891,6 +894,7 @@ defaultCompileOptions =
     , C.optimize = C.Debug
     , C.only_build = False
     , C.skip_build = False
+    , C.skip_backpass = False
     , C.watch = False
     , C.no_threads = False
     , C.parse_serial = False
@@ -2702,19 +2706,27 @@ runFrontPasses gopts opts dbpBlocked paths env0 parsed srcContent srcBytes sourc
                                  , ftTypeStmtTimings = typeStmtTimings
                                  }
                           else Nothing
-                      deferredBackJob = dbpDeferredBackJob dbpBlocked (A.hasNotImpl (A.mbody tchecked)) opts paths mn moduleImplHash (length nameHashes)
-                      backJob =
-                        case deferredBackJob of
-                          Just _ -> Nothing
-                          Nothing ->
-                            Just BackJob { bjPaths = paths
-                                         , bjOpts = opts
-                                         , bjInput = BackInput { biTypeEnv = typeEnv
-                                                              , biTypedMod = tchecked
-                                                              , biSrc = srcContent
-                                                              , biImplHash = moduleImplHash
-                                                              }
-                                         }
+                      -- With skip_backpass no back job is created at all, eager or
+                      -- deferred: the .tydb committed by the front pass is the
+                      -- complete output, and code generation is left to a later
+                      -- build that consumes it.
+                      deferredBackJob
+                        | C.skip_backpass opts = Nothing
+                        | otherwise = dbpDeferredBackJob dbpBlocked (A.hasNotImpl (A.mbody tchecked)) opts paths mn moduleImplHash (length nameHashes)
+                      backJob
+                        | C.skip_backpass opts = Nothing
+                        | otherwise =
+                            case deferredBackJob of
+                              Just _ -> Nothing
+                              Nothing ->
+                                Just BackJob { bjPaths = paths
+                                             , bjOpts = opts
+                                             , bjInput = BackInput { biTypeEnv = typeEnv
+                                                                  , biTypedMod = tchecked
+                                                                  , biSrc = srcContent
+                                                                  , biImplHash = moduleImplHash
+                                                                  }
+                                             }
                   do
                     let outputKey = TaskKey (projPath paths) mn
                     -- The .tydb commit is synchronous with front completion:
@@ -2767,14 +2779,24 @@ data DbpNameSelection = DbpNameSelection
   , dnsNameHashes :: [InterfaceFiles.NameHashInfo]
   }
 
+-- | Source text to embed in a module's back-pass input. It feeds only the
+-- #line directives in generated C (byte offset -> source line). A prebuilt
+-- artifact-only dependency ships no source, and its regenerated C carries no
+-- #line directives, so the empty string is exactly right -- and it avoids
+-- reading a source file that does not exist.
+backSrcText :: Source.SourceProvider -> Bool -> FilePath -> IO String
+backSrcText _ True _         = return ""
+backSrcText sp False actFile = Source.ssText <$> Source.readSource sp actFile
+
 prepareDeferredBackJob :: Source.SourceProvider
                        -> C.GlobalOptions
                        -> CompileCallbacks
                        -> Acton.Env.Env0
                        -> InterestMap
+                       -> Bool
                        -> DeferredBackJob
                        -> IO (Maybe BackJob)
-prepareDeferredBackJob sp gopts callbacks envAcc interestMap dbj = do
+prepareDeferredBackJob sp gopts callbacks envAcc interestMap prebuilt dbj = do
   let paths = dbjPaths dbj
       mn = dbjMod dbj
       tyFile = tyDbPath paths mn
@@ -2799,7 +2821,7 @@ prepareDeferredBackJob sp gopts callbacks envAcc interestMap dbj = do
       selection <- case selectedTmod of
         Just tmod -> return $ selectDbpModule totalNames nameSelection tmod
         Nothing -> error ("Internal error: missing statement rows in " ++ tyFile)
-      snap <- Source.readSource sp actFile
+      srcText <- backSrcText sp prebuilt actFile
       env1 <- Acton.Env.mkEnv (searchPath paths) envAcc (dbsModule selection)
       logDbpSelection gopts callbacks mn dbj totalNames (Data.Set.size interested) (Data.Set.size rootSeeds) (dbsSelectedCount selection) (dbsFallbackReason selection) "generated code out of date"
       return $ Just BackJob
@@ -2808,7 +2830,7 @@ prepareDeferredBackJob sp gopts callbacks envAcc interestMap dbj = do
         , bjInput = BackInput
             { biTypeEnv = Converter.convEnvProtos env1
             , biTypedMod = dbsModule selection
-            , biSrc = Source.ssText snap
+            , biSrc = srcText
             , biImplHash = codegenHash
             }
         }
@@ -3056,7 +3078,10 @@ runBackPassesWithProgress gopts opts paths backInput shouldWrite onProgress = do
 
       ((_,h,c), tCodeGen) <- timedBackPass BackPassCodeGen $ do
         let hexHash = B.unpack $ Base16.encode (biImplHash backInput)
-            emitLines = not (C.dbg_no_lines opts)
+            -- With no source text (a prebuilt artifact-only dep) there are no
+            -- byte offsets to map, so skip #line directives rather than point
+            -- them at source that was never shipped.
+            emitLines = not (C.dbg_no_lines opts) && not (null (biSrc backInput))
         Acton.CodeGen.generate liftEnv relSrcBase (biSrc backInput) emitLines boxed hexHash
 
       let finishBack = finish tNormalize tDeactorize tCPS tLLift tBoxing tCodeGen
@@ -3147,9 +3172,10 @@ compileTasks :: Source.SourceProvider
              -> FilePath                  -- root project path
              -> [GlobalTask]
              -> Data.Set.Set TaskKey
+             -> Data.Set.Set FilePath     -- prebuilt (artifact-only) project roots
              -> CompileCallbacks
              -> IO (Either CompileFailure (Acton.Env.Env0, Bool))
-compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
+compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked prebuiltRoots callbacks = do
     runningRef <- newIORef []
     frontOutputRef <- newIORef []
     let cancelRunning = do
@@ -3208,6 +3234,9 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
     -- Basic maps/sets ----------------------------------------------------
     taskMap = M.fromList [ (gtKey t, t) | t <- tasks ]
     isDbpBlocked k = Data.Set.member k dbpBlocked
+    -- Artifact-only dependency: no local source, so back passes regenerate its
+    -- C from the .tydb alone (see backSrcText).
+    isPrebuilt k = Data.Set.member (tkProj k) prebuiltRoots
     isBuiltinKey k = tkMod k == A.modName ["__builtin__"]
     builtinOrder = [ t | t <- tasks, isBuiltinKey (gtKey t) ]
     nonBuiltinTasks = [ t | t <- tasks, not (isBuiltinKey (gtKey t)) ]
@@ -3310,7 +3339,8 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
               deferredBacks
       prepared <- (try $
         forM (M.elems ready) $ \(dbj, _waitSet) -> do
-          mJob <- prepareDeferredBackJob sp gopts callbacks envAcc interestMap dbj
+          let prebuilt = isPrebuilt (TaskKey (projPath (dbjPaths dbj)) (dbjMod dbj))
+          mJob <- prepareDeferredBackJob sp gopts callbacks envAcc interestMap prebuilt dbj
           case mJob of
             Nothing -> ccOnBackSkipped callbacks (TaskKey (projPath (dbjPaths dbj)) (dbjMod dbj))
             Just _ -> return ()
@@ -3871,7 +3901,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                     TyTask{ tyImplHash = implHash } -> Just implHash
                     _ -> Nothing
               cachedDeferredBackJob <- case taskCurrent of
-                    TyTask{ tyImplHash = implHash, tyNameCount = nameCount } -> do
+                    TyTask{ tyImplHash = implHash, tyNameCount = nameCount } | not (C.skip_backpass optsT) -> do
                       hasNotImpl <- InterfaceFiles.readStmtHasNotImpl tyFile
                       return (dbpDeferredBackJob (isDbpBlocked key) hasNotImpl optsT paths mn implHash nameCount)
                     _ -> return Nothing
@@ -3879,7 +3909,9 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                     case cachedDeferredBackJob of
                       Just _ -> True
                       Nothing -> False
-              let canCheckCodegen = not needFront && not needByImpl && not (altOutput optsT) && not isCachedDbp
+              -- With skip_backpass generated code is never (re)built, so its
+              -- staleness must not force any work.
+              let canCheckCodegen = not needFront && not needByImpl && not (altOutput optsT) && not isCachedDbp && not (C.skip_backpass optsT)
               mCodegenStatus <- case mModuleImplHash of
                 Just implHash | canCheckCodegen -> Just <$> codegenStatus paths mn implHash
                 _ -> return Nothing
@@ -4036,9 +4068,14 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                                                                                  FrontOutputTydbCopy
                                                                                  (copyTydbInterface optsT paths mn)
                                               else return []
-                                          deferredBackJob0 = dbpDeferredBackJob (isDbpBlocked key) moduleHasNotImpl optsT paths mn moduleImplHash (length updatedNameHashes)
-                                      case deferredBackJob0 of
-                                        Just _ -> do
+                                          -- Under skip_backpass the refreshed rows are the whole
+                                          -- point; no back job follows, deferred or eager.
+                                          skipBack = C.skip_backpass optsT
+                                          deferredBackJob0
+                                            | skipBack = Nothing
+                                            | otherwise = dbpDeferredBackJob (isDbpBlocked key) moduleHasNotImpl optsT paths mn moduleImplHash (length updatedNameHashes)
+                                      if skipBack || isJust deferredBackJob0
+                                        then do
                                           ifaceRes <- readIfaceFromTy paths mn "" (Just storedPubHash)
                                           case ifaceRes of
                                             Left diags -> return (key, Left diags)
@@ -4055,12 +4092,12 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                                                         , frModuleInfo = mModuleInfo
                                                         }
                                                   cacheFrontResult fr
-                                        Nothing -> do
+                                        else do
                                           tyRes <- readTyFile
                                           case tyRes of
                                             Left diags -> return (key, Left diags)
                                             Right (_ms, nmod, tmod, _sourceMeta, _moduleSrcBytesHash, modulePubHash, _moduleImplHash, _imps, _depModules, _nameHashes, _roots, _tests, mdoc) -> do
-                                              snap <- Source.readSource sp actFile
+                                              srcText <- backSrcText sp (isPrebuilt key) actFile
                                               envRes <- (try :: IO Acton.Env.Env0 -> IO (Either SomeException Acton.Env.Env0)) $
                                                 Acton.Env.mkEnv (searchPath paths) envSnap tmod
                                               case envRes of
@@ -4076,7 +4113,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                                                       rememberFrontOutputJobList frontOutputRef outputJobs
                                                       let I.NModule imps ifaceFull _mdoc = nmod
                                                           ifaceTE = publicIfaceTE ifaceFull
-                                                          backJob = Just (mkBackJob env1 tmod (Source.ssText snap) moduleImplHash)
+                                                          backJob = Just (mkBackJob env1 tmod srcText moduleImplHash)
                                                           fr = (mkFrontResult imps ifaceTE mdoc modulePubHash moduleImplHash (publicNameHashes updatedNameHashes) updatedNameHashes backJob Nothing)
                                                             { frOutputJobs = outputJobs }
                                                       cacheFrontResult fr
@@ -4091,7 +4128,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                     case tyRes of
                       Left diags -> return (key, Left diags)
                       Right (_ms, nmod, tmod, _sourceMeta, _moduleSrcBytesHash, modulePubHash, moduleImplHashStored, _imps, _depModules, nameHashes, _roots, _tests, mdoc) -> do
-                        snap <- Source.readSource sp actFile
+                        srcText <- backSrcText sp (isPrebuilt key) actFile
                         env1 <- Acton.Env.mkEnv (searchPath paths) envSnap tmod
                         interestDeps <- cachedInterestDeps
                         let I.NModule imps ifaceFull _mdoc = nmod
@@ -4100,7 +4137,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                             backJob =
                               case deferredBackJob of
                                 Just _ -> Nothing
-                                Nothing -> Just (mkBackJob env1 tmod (Source.ssText snap) moduleImplHashStored)
+                                Nothing -> Just (mkBackJob env1 tmod srcText moduleImplHashStored)
                             fr = (mkFrontResult imps ifaceTE mdoc modulePubHash moduleImplHashStored (publicNameHashes nameHashes) nameHashes backJob deferredBackJob)
                                    { frInterestDeps = interestDeps }
                         cacheFrontResult fr

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -27,7 +27,9 @@ import qualified Acton.Diagnostics as Diag
 import qualified Acton.Compile as Compile
 import qualified Acton.Zon as Zon
 import qualified Acton.CommandLineParser as C
+import qualified Acton.Artifact as Artifact
 import qualified Acton.Fingerprint as Fingerprint
+import qualified Acton.SourceProvider as Source
 import qualified Acton.Completion as Completion
 import qualified Acton.Hashing as Hashing
 import qualified InterfaceFiles
@@ -64,6 +66,7 @@ import qualified Acton.BuildSpec as BuildSpec
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.Aeson as Ae
+import qualified Data.Map as M
 import qualified System.IO.Unsafe
 
 
@@ -922,6 +925,81 @@ main = do
           (putMVar releaseOldCleanup ())
         _ <- wait nextCompile
         timeout 1000000 (takeMVar newStarted) `shouldReturn` Just ()
+
+    describe "Artifacts" $ do
+      it "derives default OCI refs from GitHub repo URLs" $ do
+        Artifact.deriveOciRef "https://github.com/actonlang/acton-yang" "1220abcdef"
+          `shouldBe` Just ("oci://ghcr.io/actonlang/acton-yang/acton-out:1220abcdef-iface" ++ Artifact.currentInterfaceVersionText)
+
+      it "derives OCI refs from explicit artifact repositories" $ do
+        Artifact.ociRefForRepository "local-registry.local-domain.com/acton-out" "1220abcdef"
+          `shouldBe` Just ("oci://local-registry.local-domain.com/acton-out:1220abcdef-iface" ++ Artifact.currentInterfaceVersionText)
+
+      it "derives OCI layout refs from local artifact repositories" $ do
+        let ref = "oci-layout:///tmp/acton-out:1220abcdef-iface" ++ Artifact.currentInterfaceVersionText
+        Artifact.ociRefForRepository "/tmp/acton-out" "1220abcdef" `shouldBe` Just ref
+        Artifact.ociRefIsLocal ref `shouldBe` True
+        Artifact.ociRefOrasOptions ref `shouldBe` ["--oci-layout"]
+        Artifact.ociRefOrasTarget ref `shouldBe` "/tmp/acton-out:1220abcdef-iface" ++ Artifact.currentInterfaceVersionText
+
+      it "validates manifests against source hash and interface version" $ do
+        let manifest = Artifact.expectedManifest "1220abcdef"
+        Artifact.validateManifest "1220abcdef" manifest `shouldBe` Right ()
+        Artifact.validateManifest "other" manifest
+          `shouldBe` Left "artifact source hash 1220abcdef does not match dependency source hash other"
+
+      it "enumerates prebuilt artifact modules from .ty files" $ do
+        withSystemTempDirectory "acton-artifact-root" $ \dir -> do
+          let mn = S.modName ["prebuilt", "mod"]
+              tyFile = (dir </> "out" </> "types" </> "prebuilt" </> "mod") ++ InterfaceFiles.interfaceExt
+              spec = BuildSpec.BuildSpec "prebuilt" Nothing "0x1234abcd5678ef00" M.empty M.empty M.empty
+              ctx = Compile.ProjCtx
+                    { Compile.projRoot = dir
+                    , Compile.projOutDir = dir </> "out"
+                    , Compile.projTypesDir = dir </> "out" </> "types"
+                    , Compile.projSrcDir = dir </> "src"
+                    , Compile.projSysPath = dir
+                    , Compile.projSysTypes = dir </> "sys-types"
+                    , Compile.projBuildSpec = spec
+                    , Compile.projDeps = []
+                    , Compile.projPrebuilt = True
+                    }
+              gopts = C.GlobalOptions C.Never True True False False False False 0
+          createDirectoryIfMissing True (takeDirectory tyFile)
+          InterfaceFiles.writeFile tyFile B8.empty B8.empty B8.empty Nothing [] [] [] [] [] Nothing
+            (I.NModule [] [] Nothing)
+            (S.Module mn [] Nothing [])
+          Artifact.writeManifest dir (Artifact.expectedManifest "1220abcdef")
+          mods <- Compile.enumerateProjectModules ctx
+          mods `shouldBe` [(tyFile, mn)]
+          (tasks, _) <- Compile.buildGlobalTasks Source.diskSourceProvider gopts Compile.defaultCompileOptions (M.singleton dir ctx) Nothing
+          map (Compile.name . Compile.gtTask) tasks `shouldBe` [mn]
+
+      it "keeps source projects in source mode even with artifact files present" $ do
+        withSystemTempDirectory "acton-source-with-artifact-files" $ \dir -> do
+          let name = "source_with_artifact_files"
+              fp = Fingerprint.formatFingerprint
+                (Fingerprint.updateFingerprintPrefix
+                  (Fingerprint.fingerprintPrefixForName name) 1)
+              src = dir </> "src" </> "foo.act"
+              gopts = C.GlobalOptions C.Never True True False False False False 0
+          createDirectoryIfMissing True (takeDirectory src)
+          createDirectoryIfMissing True (dir </> "out" </> "types")
+          writeFile (dir </> "Build.act") $ unlines
+            [ "name = " ++ show name
+            , "fingerprint = " ++ fp
+            , "dependencies = {}"
+            , "zig_dependencies = {}"
+            ]
+          writeFile src "def marker() -> int:\n    return 1\n"
+          Artifact.writeManifest dir (Artifact.expectedManifest "1220abcdef")
+          projMap <- Compile.discoverProjects gopts dir dir []
+          case M.elems projMap of
+            [ctx] -> do
+              Compile.projPrebuilt ctx `shouldBe` False
+              mods <- Compile.enumerateProjectModules ctx
+              map snd mods `shouldBe` [S.modName ["source_with_artifact_files", "foo"]]
+            _ -> expectationFailure "expected one discovered project"
 
     describe "Environment" $ do
       it "treats mismatched .tydb headers for loaded modules as stale" $ do

--- a/compiler/lsp-server/Main.hs
+++ b/compiler/lsp-server/Main.hs
@@ -398,6 +398,11 @@ compilePlanFromCache ctx changedPath cache = do
         , Compile.cpGlobalTasks = globalTasks
         , Compile.cpNeededTasks = neededTasks
         , Compile.cpDbpBlocked = dbpBlocked
+        , Compile.cpPrebuiltRoots = Data.Set.fromList
+            [ Compile.projRoot pctx
+            | pctx <- M.elems (cachedProjectMap cache)
+            , Compile.projPrebuilt pctx
+            ]
         , Compile.cpRootTasks = rootTasks
         , Compile.cpRootPins = cachedRootPins cache
         , Compile.cpIncremental = True

--- a/docs/acton-guide/src/SUMMARY.md
+++ b/docs/acton-guide/src/SUMMARY.md
@@ -100,6 +100,7 @@
   - [Override Dependency](pkg/override_dependency.md)
   - [Remove Dependency](pkg/remove_dependency.md)
   - [Fetch Deps (Airplane mode)](pkg/fetch_dependencies.md)
+  - [Output Artifacts & Cache](output_artifacts.md)
   - [Zig / C / C++ dependencies](zig_dependencies.md)
 - [Security and Trust](security/intro.md)
 - [Working with Zig / C / C++](working_with_zig.md)

--- a/docs/acton-guide/src/output_artifacts.md
+++ b/docs/acton-guide/src/output_artifacts.md
@@ -6,6 +6,11 @@ use a prebuilt output artifact instead of rebuilding the dependency from
 source. If no matching artifact is available, Acton falls back to fetching and
 building the source locally.
 
+An output artifact contains the package's compiled type interfaces, not
+generated code. Producing an artifact only runs the compiler front end (parse
+and type check); code generation is deferred to the consuming build, which
+generates code from the artifact for the parts it uses.
+
 Acton uses OCI repositories for artifact distribution. OCI is the image and
 artifact format used by container registries. Acton takes advantage of that
 registry infrastructure, which is widely available across hosting providers,
@@ -118,16 +123,18 @@ acton artifact push --artifact-repo ghcr.io/OWNER/REPO/acton-out
 acton artifact push --artifact-repo /tmp/acton-out
 ```
 
-`acton artifact push` builds the current package before packaging and pushing
-it. `acton artifact pack` does the same build-and-pack step but only writes the
-artifact locally:
+`acton artifact push` type checks the current package before packaging and
+pushing it. No code is generated in this step; the artifact ships the compiled
+type interfaces and the consuming build performs code generation. `acton
+artifact pack` does the same check-and-pack step but only writes the artifact
+locally:
 
 ```bash
 acton artifact pack
 ```
 
 The artifact is packaged from the local checkout. Acton computes the source
-content hash from the package source after the build step, and the artifact tag
+content hash from the package source after the check step, and the artifact tag
 is derived from that hash. Consumers need matching source content to use the
 artifact.
 

--- a/docs/acton-guide/src/output_artifacts.md
+++ b/docs/acton-guide/src/output_artifacts.md
@@ -77,9 +77,15 @@ Once an artifact has been pulled into the dependency cache, later plain
 
 Acton checks the local dependency cache before contacting any registry. If a
 matching artifact is available locally, Acton checks that it matches the
-requested source content hash, interface version, and target before using it. If
-only a source cache entry exists, Acton uses that entry without probing remote
-artifact repositories.
+requested source content hash, interface version, and target before using it.
+
+Passing `--artifact-repo` opts the build into artifact consumption: a valid
+artifact is preferred even when a cached source entry already exists, and the
+cached source is used only when no artifact can be found. This matters on a
+machine that has published the artifact itself, since producing seeds the
+caches with the package source, which would otherwise always win over the
+artifact. Without `--artifact-repo`, a cached source entry is used as is,
+without probing remote artifact repositories.
 
 For local testing or offline workflows, `--artifact-repo` can also point to an
 OCI image layout directory:

--- a/docs/acton-guide/src/output_artifacts.md
+++ b/docs/acton-guide/src/output_artifacts.md
@@ -1,0 +1,157 @@
+# Output Artifacts
+
+Acton treats source as the canonical form of a package. Dependencies are
+identified by the content hash of their source. For large packages, Acton can
+use a prebuilt output artifact instead of rebuilding the dependency from
+source. If no matching artifact is available, Acton falls back to fetching and
+building the source locally.
+
+Acton uses OCI repositories for artifact distribution. OCI is the image and
+artifact format used by container registries. Acton takes advantage of that
+registry infrastructure, which is widely available across hosting providers,
+CI systems, and private deployments.
+
+OCI is the transport and storage convention, not the source of artifact
+identity. Artifacts are identified by the content hash of the source, the Acton
+interface version, and the current target tuple. The source content hash
+remains the stable identity; OCI tags are only the lookup convention.
+
+## Install oras
+
+Acton uses the `oras` command-line tool to pull and publish OCI artifacts.
+Install `oras` and make sure it is on your `PATH` before using output
+artifacts.
+
+A build can still fall back to source when `oras` is not installed. An artifact
+that is already available in the local dependency cache can also be used without
+contacting any registry. Publishing artifacts requires `oras`.
+
+## Using artifacts
+
+At build time, Acton knows the artifact identity it is looking for: the
+dependency source content hash, interface version, and target tuple. It searches
+OCI repositories for an artifact with that identity.
+
+Those repositories can be published in two common places. Package authors can
+publish artifacts near their source repository, and Acton can derive those
+locations for some repository URLs. A team can also run its own artifact
+repository as a shared cache, populated from packages that may only publish
+source.
+
+To search a shared artifact repository, pass it during the build:
+
+```bash
+acton build --artifact-repo local-registry.local-domain.com/acton-out
+```
+
+The artifact repository is the full OCI image name without the tag. The path
+can include whatever namespace, group, or organization layout your registry
+uses. Acton appends a tag derived from the dependency source content hash and
+interface version:
+
+```text
+<source-hash>-iface<interface-version>
+```
+
+For example, Acton may expand the artifact repository above to:
+
+```text
+oci://local-registry.local-domain.com/acton-out:N-V-__8AAJqWJQA7T6BgHCyrFsXB4bMcBA4_qmIOxqVaL8Vm-iface0.18
+```
+
+You can search more than one artifact repository by repeating the option:
+
+```bash
+acton build \
+  --artifact-repo local-registry.local-domain.com/acton-out \
+  --artifact-repo backup-registry.local-domain.com/platform/cache/acton-out
+```
+
+Once an artifact has been pulled into the dependency cache, later plain
+`acton build` runs reuse it without repeating `--artifact-repo`.
+
+Acton checks the local dependency cache before contacting any registry. If a
+matching artifact is available locally, Acton checks that it matches the
+requested source content hash, interface version, and target before using it. If
+only a source cache entry exists, Acton uses that entry without probing remote
+artifact repositories.
+
+For local testing or offline workflows, `--artifact-repo` can also point to an
+OCI image layout directory:
+
+```bash
+acton build --artifact-repo /tmp/acton-out
+```
+
+Local OCI layouts are queried before remote repositories and do not require a
+registry service.
+
+For dependency repository URLs on GitHub or GitLab, Acton can derive a
+producer-side OCI repository to try automatically:
+
+- GitHub `https://github.com/OWNER/REPO` maps to
+  `oci://ghcr.io/OWNER/REPO/acton-out:<source-hash>-iface<interface-version>`.
+- GitLab `https://gitlab.com/GROUP/PROJECT` maps to
+  `oci://registry.gitlab.com/GROUP/PROJECT/acton-out:<source-hash>-iface<interface-version>`.
+
+If the artifact is missing or incompatible, Acton falls back to the source
+package.
+
+An artifact also carries enough package metadata for the build planner to know
+the project name, fingerprint, and transitive dependency graph.
+
+## Publishing artifacts
+
+To publish an artifact from a package checkout:
+
+```bash
+acton artifact push --repo-url https://github.com/OWNER/REPO
+```
+
+This command derives the conventional OCI reference from the repository URL and
+uses `oras` to push the artifact. To publish to another registry or local OCI
+layout, provide the artifact repository without a tag:
+
+```bash
+acton artifact push --artifact-repo local-registry.local-domain.com/acton-out
+acton artifact push --artifact-repo ghcr.io/OWNER/REPO/acton-out
+acton artifact push --artifact-repo /tmp/acton-out
+```
+
+`acton artifact push` builds the current package before packaging and pushing
+it. `acton artifact pack` does the same build-and-pack step but only writes the
+artifact locally:
+
+```bash
+acton artifact pack
+```
+
+The artifact is packaged from the local checkout. Acton computes the source
+content hash from the package source after the build step, and the artifact tag
+is derived from that hash. Consumers need matching source content to use the
+artifact.
+
+To print the hash without building or publishing:
+
+```bash
+acton artifact hash
+```
+
+## Validation and trust
+
+The source content hash is the artifact identity. The OCI lookup key is derived
+from that identity and Acton's compatibility metadata, so a matching lookup is
+expected to return the artifact for that source content.
+
+Acton still records the same identity inside the artifact and checks it before
+use. This is a sanity check against stale uploads, manual registry mistakes, and
+incompatible compiler outputs. It is not a separate binary signing scheme.
+
+Remote artifact pulls use the registry transport, normally HTTPS with TLS. When
+Acton derives an artifact repository from a dependency `repo_url`, the registry
+namespace follows the source repository owner. For example, a GitHub dependency
+maps to `ghcr.io/OWNER/REPO/acton-out`, and a GitLab dependency maps to
+`registry.gitlab.com/GROUP/PROJECT/acton-out`.
+
+For custom `--artifact-repo` values, Acton cannot derive that ownership
+relationship. Trust in those repositories has to be established out of band.

--- a/docs/acton-guide/src/package_management.md
+++ b/docs/acton-guide/src/package_management.md
@@ -11,17 +11,16 @@ same compilation result can be reproduced on another machine.
 
 The guiding principle behind Acton's package management is to strive for
 determinism, robustness, and safety. Dependencies are resolved at design time by
-the package developer and written into `Build.act` as archive URLs plus content
-hashes. Later builds fetch those recorded archives and verify the hashes; they
-do not pick newer compatible versions or rely on a name to mean the same thing
-forever.
+the package developer and written into `Build.act` as source URLs plus content
+hashes. Later builds fetch those recorded source packages and verify the hashes;
+they do not pick newer compatible versions or rely on a name to mean the same
+thing forever.
 
 Acton's public package index is a discovery index. Packages are hosted
-by their owners, and dependencies are recorded as URLs from which a
-specific package archive can be downloaded. This is typically a tar.gz
-or zip archive from GitHub, GitLab, or a similar source hosting site.
-The index helps find packages; `Build.act` records the exact archive and
-hash used by a project.
+by their owners, and dependencies are recorded as URLs from which specific
+package source can be downloaded. This is often provided by GitHub, GitLab, or a
+similar source hosting site. The index helps find packages; `Build.act` records
+the exact source URL and hash used by a project.
 
 The public index is decentralized in the sense that package authors opt
 in from their own GitHub repositories. The index collects repositories
@@ -45,6 +44,11 @@ dependency project. Other files in that dependency are imported below
 the same prefix, such as `import foo.parser` for `src/parser.act`.
 Currently, the dependency name must match the dependency project's
 `name` field.
+
+Large packages can optionally provide prebuilt Acton output artifacts for faster
+dependency builds. Source remains canonical; artifacts are a cache and
+distribution mechanism for compiler outputs. See
+[Output Artifacts](output_artifacts.md) for details.
 
 ## Project lineage fingerprint
 


### PR DESCRIPTION
Support optional Acton output artifacts fetched from OCI repositories during dependency resolution. Artifacts are keyed by source content hash, interface version, and target tuple.

Use valid local cache entries before registry lookups and fall back to source when no matching artifact is available.

Add artifact pack, push, and hash commands, local OCI layout support, tests, and guide documentation.