### PR TITLE
Limit Env scans to live names

### DIFF
--- a/compiler/lib/bench/TypesBench.hs
+++ b/compiler/lib/bench/TypesBench.hs
@@ -3,6 +3,7 @@ import qualified Acton.Kinds as Kinds
 import qualified Acton.NameInfo as NameInfo
 import qualified Acton.Parser as Parser
 import qualified Acton.Syntax as Syntax
+import qualified Acton.Types as Types
 
 import Control.DeepSeq (rnf)
 import qualified Control.Exception as E
@@ -14,8 +15,8 @@ import System.FilePath (takeBaseName)
 import System.IO (BufferMode(LineBuffering), hSetBuffering, stdout)
 
 -- Usage:
---   stack build libacton:exe:kinds-bench
---   stack exec kinds-bench -- ../dist/base/out/types path/to/file.act +RTS -T -RTS
+--   stack build libacton:exe:types-bench
+--   stack exec types-bench -- ../dist/base/out/types path/to/file.act +RTS -T -RTS
 --
 -- This uses Parser.parseModule, the normal parallel parser entrypoint. The RTS
 -- flag is optional. With -T, the driver also prints per-phase allocation and
@@ -72,5 +73,16 @@ main = do
         s3 <- getStats statsEnabled
         elapsed "kinds" t2 t3
         printStatsMaybe "kinds_stats" s2 s3
+
+        (nmod, tchecked, typeEnv, tests) <- Types.reconstruct Nothing Nothing env kchecked
+        E.evaluate (rnf nmod)
+        E.evaluate (rnf tchecked)
+        E.evaluate (forceHTEnv (Env.hnames typeEnv))
+        E.evaluate (forceHTEnv (Env.hmodules typeEnv))
+        E.evaluate (length tests)
+        t4 <- getCurrentTime
+        s4 <- getStats statsEnabled
+        elapsed "types" t3 t4
+        printStatsMaybe "types_stats" s3 s4
       _ ->
-        error "usage: kinds-bench TYPES_PATH SOURCE.act"
+        error "usage: types-bench TYPES_PATH SOURCE.act"

--- a/compiler/lib/package.yaml.in
+++ b/compiler/lib/package.yaml.in
@@ -108,6 +108,17 @@ executables:
   kinds-bench:
     main: KindsBench.hs
     source-dirs: bench
+    other-modules: []
+    dependencies:
+      - libacton
+    ghc-options:
+      - -threaded
+      - -rtsopts
+      - '"-with-rtsopts=-N -A64M"'
+  types-bench:
+    main: TypesBench.hs
+    source-dirs: bench
+    other-modules: []
     dependencies:
       - libacton
     ghc-options:

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -231,6 +231,7 @@ import Data.List (find, foldl', intercalate, intersperse, isPrefixOf, isSuffixOf
 import qualified Data.List
 import Data.IORef
 import Data.Maybe (catMaybes, isJust, listToMaybe, mapMaybe)
+import qualified Data.HashMap.Strict as HM
 import qualified Data.Map as M
 import Data.Ord (Down(..))
 import qualified Data.Set
@@ -1075,6 +1076,19 @@ data StageKey = ParseStage TaskKey | FrontStage TaskKey deriving (Eq, Ord, Show)
 
 data StageSuccess = StageParsed CompileTask (Maybe TimeSpec) | StageFronted FrontResult
 
+forceHTEnv :: I.HTEnv -> ()
+forceHTEnv hte                  = HM.foldl' forceHNameInfo () hte
+  where forceHNameInfo () (I.HNModule _ te _) = forceHTEnv te
+        forceHNameInfo () hni  = hni `seq` ()
+
+forceTypeResult :: I.NameInfo -> A.Module -> Acton.Env.EnvF x -> [String] -> IO ()
+forceTypeResult nmod tchecked typeEnv tests = do
+  evaluate (rnf nmod)
+  evaluate (rnf tchecked)
+  evaluate (forceHTEnv (Acton.Env.hnames typeEnv))
+  evaluate (forceHTEnv (Acton.Env.hmodules typeEnv))
+  evaluate (rnf tests)
+
 data GlobalTask = GlobalTask
   { gtKey             :: TaskKey
   , gtPaths           :: Paths
@@ -1765,6 +1779,7 @@ runFrontPasses gopts opts paths env0 parsed srcContent srcBytes sourceMeta resol
 
       -- Type-check and return both the typed AST and the interface NameInfo.
       (nmod,tchecked,typeEnv,tests) <- Acton.Types.reconstruct (Just onTypeProgress) inferredSignatureCb env kchecked
+      forceTypeResult nmod tchecked typeEnv tests
       -- Module-level src hash uses raw bytes so any source edit forces re-parse.
       let moduleSrcBytesHash = SHA256.hash srcBytes
       -- Store roots so later builds can discover entry points without reparse.

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -51,6 +51,7 @@ mkEnv spath env m           = getImps spath env (imps m)
 data EnvF x                 = EnvF {
                                 names      :: TEnv,
                                 hnames     :: HTEnv,
+                                substPLen  :: Int,
                                 imports    :: [ModName],
                                 improots   :: [Name],
                                 modules    :: TEnv,
@@ -65,7 +66,7 @@ type Env0                   = EnvF ()
 
 
 setX                        :: EnvF y -> x -> EnvF x
-setX env x                  = EnvF { names = names env, hnames = hnames env, imports = imports env, improots = improots env,
+setX env x                  = EnvF { names = names env, hnames = hnames env, substPLen = substPLen env, imports = imports env, improots = improots env,
                                      modules = modules env, hmodules = hmodules env, thismod = thismod env,
                                      context = context env, qlevel = qlevel env, envX = x }
 
@@ -237,6 +238,7 @@ publicTEnv                 = filter (isPublicName . fst)
 initEnv                    :: FilePath -> Bool -> IO Env0
 initEnv path True          = return $ EnvF{ names = [(nPrim,NMAlias mPrim)],
                                             hnames = hnamesFrom [(nPrim,NMAlias mPrim)],
+                                            substPLen = 0,
                                             imports = [],
                                             improots = [],
                                             modules = [(nPrim,NModule [] primEnv Nothing)],
@@ -250,6 +252,7 @@ initEnv path False         = do (_,nmod,_,_,_,_,_,_,_,_,_,_) <- InterfaceFiles.r
                                     envBuiltinPublic = publicTEnv envBuiltin
                                     env0 = EnvF{ names = [(nPrim,NMAlias mPrim), (nBuiltin,NMAlias mBuiltin)],
                                                  hnames = hnamesFrom [(nPrim,NMAlias mPrim), (nBuiltin,NMAlias mBuiltin)],
+                                                 substPLen = 0,
                                                  imports = [],
                                                  improots = [],
                                                  modules = [(nPrim,NModule [] primEnv Nothing), (nBuiltin,NModule [] envBuiltin builtinDocstring)],
@@ -271,8 +274,19 @@ extendHNames                :: TEnv -> HTEnv -> HTEnv
 extendHNames te hte         = foldr add hte te
   where add (n,i) hte       = M.insert n (convNameInfo2HNameInfo i) hte
 
+substPLenOf                 :: TEnv -> Int
+substPLenOf te
+  | null (ufree te)          = 0
+  | otherwise                = length te
+
+extendSubstPLen             :: TEnv -> EnvF x -> Int
+extendSubstPLen te env
+  | substPLen env == 0,
+    null (ufree te)          = 0
+  | otherwise                = length te + substPLen env
+
 setNames                    :: TEnv -> EnvF x -> EnvF x
-setNames te env             = env{ names = te, hnames = hnamesFrom te }
+setNames te env             = env{ names = te, hnames = hnamesFrom te, substPLen = substPLenOf te }
 
 lookupName                  :: Name -> EnvF x -> Maybe HNameInfo
 lookupName n env            = M.lookup n (hnames env)
@@ -280,14 +294,14 @@ lookupName n env            = M.lookup n (hnames env)
 reserve                     :: [Name] -> EnvF x -> EnvF x
 reserve xs env
   | not $ null badSelf      = selfParamError (loc $ head badSelf)
-  | otherwise               = env{ names = te ++ names env, hnames = extendHNames te (hnames env) }
+  | otherwise               = env{ names = te ++ names env, hnames = extendHNames te (hnames env), substPLen = extendSubstPLen te env }
   where badSelf             = if inAct env then xs `intersect` [selfKW] else []
         te                  = [ (x, NReserved) | x <- nub xs ]
 
 define                      :: TEnv -> EnvF x -> EnvF x
 define te env
   | not $ null badSelf      = selfParamError (loc $ head badSelf)
-  | otherwise               = env{ names = te' ++ names env, hnames = extendHNames te' (hnames env) }
+  | otherwise               = env{ names = te' ++ names env, hnames = extendHNames te' (hnames env), substPLen = extendSubstPLen te' env }
   where badSelf             = if inAct env then dom te `intersect` [selfKW] else []
         te'                 = reverse te
 
@@ -304,7 +318,7 @@ getImports env              = reverse (imports env)
 
 defineTVars                 :: QBinds -> EnvF x -> EnvF x
 defineTVars q env           = foldr f env (unalias env q)
-  where f (QBind tv us) env = env{ names = ni : names env, hnames = extendHNames [ni] (hnames env), qlevel = qlevel env + 1 }
+  where f (QBind tv us) env = env{ names = ni : names env, hnames = extendHNames [ni] (hnames env), substPLen = extendSubstPLen [ni] env, qlevel = qlevel env + 1 }
           where (c,ps)      = case us of u:us' | not $ isProto env (tcname u) -> (u,us'); _ -> (cValue,us)
                 ni          = (tvname tv, NTVar (tvkind tv) c ps)
 

--- a/compiler/lib/src/Acton/TypeEnv.hs
+++ b/compiler/lib/src/Acton/TypeEnv.hs
@@ -231,8 +231,11 @@ isForced env                    = forced $ envX env
 
 
 instance Polarity Env where
-    polvars env                 = polvars pte `polcat` invvars ite
-      where (pte, ite)          = span ((`elem` pvs) . fst) (names env)
+    polvars env
+      | substPLen env == 0      = polnil
+      | otherwise               = polvars pte `polcat` invvars ite
+      where (pre,_)             = splitAt (substPLen env) (names env)
+            (pte, ite)          = span ((`elem` pvs) . fst) pre
             pvs                 = posnames $ envX env
 
 
@@ -795,9 +798,13 @@ instance USubst Witness where
 
 
 instance USubst Env where
-    usubst env                  = do ne <- usubst (names env)
+    usubst env                  = do pre' <- usubst pre
                                      ex <- usubst (envX env)
-                                     return $ setNames ne env{ envX = ex }
+                                     return env{ names = pre' ++ suf,
+                                                 hnames = extendHNames pre' (hnames env),
+                                                 substPLen = substPLenOf pre',
+                                                 envX = ex }
+      where (pre,suf)           = splitAt (substPLen env) (names env)
 
 instance UFree Env where
     ufree env                   = ufree (names env) ++ ufree (envX env)


### PR DESCRIPTION
Type checking repeatedly substitutes Env and asks Env for polarity while
improving constraints. Env.names uses list semantics and also contains
previously defined names, so scanning the whole list in these paths makes
all modules pay for accumulated environment size. That cost is particularly
visible as modules get larger.

Track how many leading names may still contain unification variables.
define, reserve, defineTVars, and setNames update that live-prefix length
when they change names. Env substitution and Env polarity then inspect only
that prefix; the closed suffix remains shared and contributes no unification
variables.

On the heavy-class type benchmark, the 100-tree type phase dropped from
about 90.9 s before this Env-scan work to 15.7 s. A 300-tree run with this
patch still takes about 155 s, so this removes one expensive Env scan but
certainly does not make the full type pass scale linearly yet.