### PR TITLE
Split active Env names from closed names

### DIFF
--- a/compiler/lib/src/Acton/Completion.hs
+++ b/compiler/lib/src/Acton/Completion.hs
@@ -610,8 +610,8 @@ shallowModuleItem :: [FilePath] -> Env.Env0 -> S.ModuleItem -> IO Env.Env0
 shallowModuleItem searchPath env (S.ModuleItem m as) =
   shallowModule searchPath env m $ \te env' ->
     case as of
-        Nothing -> Env.addImport m env'
-        Just n -> Env.define [(n, I.NMAlias m)] env'
+      Nothing -> Env.addImport m env'
+      Just n -> Env.defineClosed [(n, I.NMAlias m)] env'
 
 shallowModule
   :: [FilePath]
@@ -791,10 +791,7 @@ lookupQNameInfo :: Env.Env0 -> S.QName -> Maybe I.NameInfo
 lookupQNameInfo env qn =
   case qn of
     S.NoQ n ->
-      case lookup n (Env.names env) of
-        Just (I.NAlias qn') -> lookupQNameInfo env qn'
-        Just info -> Just info
-        Nothing -> Nothing
+      lookupNoQ n
     S.QName m n ->
       lookupModuleItem env (Env.findHMod m env) n
     S.GName m n
@@ -802,6 +799,11 @@ lookupQNameInfo env qn =
           lookupQNameInfo env (S.NoQ n)
       | otherwise ->
           lookupModuleItem env (Env.lookupHMod m env) n
+  where
+    lookupNoQ n              = resolve =<< Env.lookupName n env
+
+    resolve (I.HNAlias qn')  = lookupQNameInfo env qn'
+    resolve info             = Just (I.convHNameInfo2NameInfo info)
 
 lookupModuleItem :: Env.Env0 -> Maybe I.HTEnv -> S.Name -> Maybe I.NameInfo
 lookupModuleItem env mtenv n = do

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -49,8 +49,10 @@ mkEnv spath env m           = getImps spath env (imps m)
 -- Full environment -------------------------------------------------------------------------------
 
 data EnvF x                 = EnvF {
-                                names      :: TEnv,
+                                activeNames:: TEnv,
+                                closedNames:: TEnv,
                                 hnames     :: HTEnv,
+                                closedHNames:: HTEnv,
                                 imports    :: [ModName],
                                 improots   :: [Name],
                                 modules    :: TEnv,
@@ -63,9 +65,14 @@ data EnvF x                 = EnvF {
 
 type Env0                   = EnvF ()
 
+-- activeNames may contain live unification variables; closedNames must not.
+-- hnames is the full active-over-closed lookup index, while closedHNames is
+-- the reusable closed-only part.
 
 setX                        :: EnvF y -> x -> EnvF x
-setX env x                  = EnvF { names = names env, hnames = hnames env, imports = imports env, improots = improots env,
+setX env x                  = EnvF { activeNames = activeNames env, closedNames = closedNames env,
+                                     hnames = hnames env, closedHNames = closedHNames env,
+                                     imports = imports env, improots = improots env,
                                      modules = modules env, hmodules = hmodules env, thismod = thismod env,
                                      context = context env, qlevel = qlevel env, envX = x }
 
@@ -124,8 +131,10 @@ mapModules f env            = env1 { hmodules = convTEnv2HTEnv (modules env1) }
 instance (Pretty x) => Pretty (EnvF x) where
     pretty env                  = text "--- modules:"  $+$
                                   vcat (map pretty (modules env)) $+$
-                                  text "--- names" <+> pretty (thismod env) <+> parens (text (show (qlevel env))) <> colon $+$
-                                  vcat (map pretty (names env)) $+$
+                                  text "--- active names" <+> pretty (thismod env) <+> parens (text (show (qlevel env))) <> colon $+$
+                                  vcat (map pretty (activeNames env)) $+$
+                                  text "--- closed names" <+> pretty (thismod env) <> colon $+$
+                                  vcat (map pretty (closedNames env)) $+$
                                   text "--- imports" <+> pretty (thismod env) <> colon $+$
                                   vcat (map pretty (imports env)) $+$
                                   pretty (envX env) $+$
@@ -235,12 +244,14 @@ publicTEnv                 :: TEnv -> TEnv
 publicTEnv                 = filter (isPublicName . fst)
 
 initEnv                    :: FilePath -> Bool -> IO Env0
-initEnv path True          = return $ EnvF{ names = [(nPrim,NMAlias mPrim)],
+initEnv path True          = return $ EnvF{ activeNames = [],
+                                            closedNames = [(nPrim,NMAlias mPrim)],
                                             hnames = hnamesFrom [(nPrim,NMAlias mPrim)],
+                                            closedHNames = hnamesFrom [(nPrim,NMAlias mPrim)],
                                             imports = [],
                                             improots = [],
                                             modules = [(nPrim,NModule [] primEnv Nothing)],
-                                            hmodules = M.empty, 
+                                            hmodules = M.empty,
                                             thismod = Nothing,
                                             context = [],
                                             qlevel = 0,
@@ -248,8 +259,11 @@ initEnv path True          = return $ EnvF{ names = [(nPrim,NMAlias mPrim)],
 initEnv path False         = do (_,nmod,_,_,_,_,_,_,_,_,_,_) <- InterfaceFiles.readFile (joinPath [path,"__builtin__.ty"])
                                 let NModule _ envBuiltin builtinDocstring = nmod
                                     envBuiltinPublic = publicTEnv envBuiltin
-                                    env0 = EnvF{ names = [(nPrim,NMAlias mPrim), (nBuiltin,NMAlias mBuiltin)],
-                                                 hnames = hnamesFrom [(nPrim,NMAlias mPrim), (nBuiltin,NMAlias mBuiltin)],
+                                    initialNames = [(nPrim,NMAlias mPrim), (nBuiltin,NMAlias mBuiltin)]
+                                    env0 = EnvF{ activeNames = [],
+                                                 closedNames = initialNames,
+                                                 hnames = hnamesFrom initialNames,
+                                                 closedHNames = hnamesFrom initialNames,
                                                  imports = [],
                                                  improots = [],
                                                  modules = [(nPrim,NModule [] primEnv Nothing), (nBuiltin,NModule [] envBuiltin builtinDocstring)],
@@ -271,8 +285,15 @@ extendHNames                :: TEnv -> HTEnv -> HTEnv
 extendHNames te hte         = foldr add hte te
   where add (n,i) hte       = M.insert n (convNameInfo2HNameInfo i) hte
 
-setNames                    :: TEnv -> EnvF x -> EnvF x
-setNames te env             = env{ names = te, hnames = hnamesFrom te }
+setActiveNames              :: TEnv -> EnvF x -> EnvF x
+setActiveNames te env       = env{ activeNames = te, hnames = extendHNames te (closedHNames env) }
+
+addActiveNames              :: TEnv -> EnvF x -> EnvF x
+addActiveNames te env       = env{ activeNames = te ++ activeNames env, hnames = extendHNames te (hnames env) }
+
+addClosedNames              :: TEnv -> EnvF x -> EnvF x
+addClosedNames te env       = env{ closedNames = te ++ closedNames env, hnames = extendHNames (activeNames env) hte, closedHNames = hte }
+  where hte                 = extendHNames te (closedHNames env)
 
 lookupName                  :: Name -> EnvF x -> Maybe HNameInfo
 lookupName n env            = M.lookup n (hnames env)
@@ -280,14 +301,28 @@ lookupName n env            = M.lookup n (hnames env)
 reserve                     :: [Name] -> EnvF x -> EnvF x
 reserve xs env
   | not $ null badSelf      = selfParamError (loc $ head badSelf)
-  | otherwise               = env{ names = te ++ names env, hnames = extendHNames te (hnames env) }
+  | otherwise               = addActiveNames te env
+  where badSelf             = if inAct env then xs `intersect` [selfKW] else []
+        te                  = [ (x, NReserved) | x <- nub xs ]
+
+reserveClosed               :: [Name] -> EnvF x -> EnvF x
+reserveClosed xs env
+  | not $ null badSelf      = selfParamError (loc $ head badSelf)
+  | otherwise               = addClosedNames te env
   where badSelf             = if inAct env then xs `intersect` [selfKW] else []
         te                  = [ (x, NReserved) | x <- nub xs ]
 
 define                      :: TEnv -> EnvF x -> EnvF x
 define te env
   | not $ null badSelf      = selfParamError (loc $ head badSelf)
-  | otherwise               = env{ names = te' ++ names env, hnames = extendHNames te' (hnames env) }
+  | otherwise               = addActiveNames te' env
+  where badSelf             = if inAct env then dom te `intersect` [selfKW] else []
+        te'                 = reverse te
+
+defineClosed                :: TEnv -> EnvF x -> EnvF x
+defineClosed te env
+  | not $ null badSelf      = selfParamError (loc $ head badSelf)
+  | otherwise               = addClosedNames te' env
   where badSelf             = if inAct env then dom te `intersect` [selfKW] else []
         te'                 = reverse te
 
@@ -304,7 +339,7 @@ getImports env              = reverse (imports env)
 
 defineTVars                 :: QBinds -> EnvF x -> EnvF x
 defineTVars q env           = foldr f env (unalias env q)
-  where f (QBind tv us) env = env{ names = ni : names env, hnames = extendHNames [ni] (hnames env), qlevel = qlevel env + 1 }
+  where f (QBind tv us) env = addActiveNames [ni] (env{ qlevel = qlevel env + 1 })
           where (c,ps)      = case us of u:us' | not $ isProto env (tcname u) -> (u,us'); _ -> (cValue,us)
                 ni          = (tvname tv, NTVar (tvkind tv) c ps)
 
@@ -336,19 +371,20 @@ inBuiltin                   :: EnvF x -> Bool
 inBuiltin env               = length (modules env) == 1     -- mPrim only
 
 stateScope                  :: EnvF x -> [Name]
-stateScope env              = [ z | (z, NSVar _) <- names env ]
+stateScope env              = scopes (activeNames env) ++ scopes (closedNames env)
+  where scopes te           = [ z | (z, NSVar _) <- te ]
 
 quantScope0                 :: EnvF x -> QBinds
-quantScope0 env             = [ QBind (TV k n) (if c==cValue then ps else (c:ps)) | (n, NTVar k c ps) <- names env ]
+quantScope0 env             = [ QBind (TV k n) (if c==cValue then ps else (c:ps)) | (n, NTVar k c ps) <- activeNames env ]
 
 quantScope                  :: EnvF x -> QBinds
 quantScope env              = [ q | q@(QBind tv _) <- quantScope0 env, tv /= tvSelf ]
 
 tvarDescendants             :: EnvF x -> [TCon] -> [TVar]
-tvarDescendants env cs      = [ TV k n | (n, NTVar k c _) <- names env, c `elem` cs ]
+tvarDescendants env cs      = [ TV k n | (n, NTVar k c _) <- activeNames env, c `elem` cs ]
 
 selfScopeSubst              :: EnvF x -> Substitution
-selfScopeSubst env          = [ (TV k n, tCon c) | (n, NTVar k c ps) <- names env, n == nSelf ]
+selfScopeSubst env          = [ (TV k n, tCon c) | (n, NTVar k c ps) <- activeNames env, n == nSelf ]
 
 
 -- Name queries -------------------------------------------------------------------------------------------------------------------
@@ -379,17 +415,19 @@ tryQName (GName m n) env
                                     Nothing -> noItem m n -- error ("## Failed lookup of " ++ prstr n ++ " in module " ++ prstr m)
                                 Nothing -> noModule m -- error ("## Failed lookup of module " ++ prstr m)
 
-findSigLoc n env            = findSL (names env)
-    where findSL ((n',t):ps)
+findSigLoc n env            = findSL (activeNames env) (closedNames env)
+    where findSL ((n',t):ps) rest
              | NSig{} <- t, n==n' = Just (loc n')
-             | otherwise          = findSL ps
-          findSL []               = Nothing
+             | otherwise          = findSL ps rest
+          findSL [] []            = Nothing
+          findSL [] rest          = findSL rest []
 
-findDefLoc n env            = findSL (names env)
-    where findSL ((n',t):ps)
+findDefLoc n env            = findSL (activeNames env) (closedNames env)
+    where findSL ((n',t):ps) rest
              | NDef{} <- t, n==n' = Just (loc n')
-             | otherwise          = findSL ps
-          findSL []               = Nothing
+             | otherwise          = findSL ps rest
+          findSL [] []            = Nothing
+          findSL [] rest          = findSL rest []
 
 findName n env              = findQName (NoQ n) env
 
@@ -424,7 +462,7 @@ lookupMod                       :: ModName -> EnvF x -> Maybe TEnv
 lookupMod m env                 = case lookupModule m env of Just (imps, te, doc) -> Just te; _ -> Nothing
 
 lookupModule m env
-  | inBuiltin env, m==mBuiltin  = Just ([], names env, Nothing)
+  | inBuiltin env, m==mBuiltin  = Just ([], activeNames env ++ closedNames env, Nothing)
 lookupModule (ModName ns) env   = f ns (modules env)
   where f (n:ns) te             = case lookup n te of
                                     Just (NModule imps te' doc) -> g ns imps te' doc
@@ -477,13 +515,15 @@ actorSelf env               = case lookupName selfKW env of
                                 Just (HNVar (TCon _ tc)) | isActor env (tcname tc) -> True
                                 _ -> False
 
-actorMethod env n0          = walk [] (names env)
+actorMethod env n0          = walk [] (activeNames env) (closedNames env)
   where
-    walk ns ((n,NDef{}):te) = walk (n:ns) te
-    walk ns ((n,NVar (TCon _ tc)):te)
+    walk ns ((n,NDef{}):te) rest
+                            = walk (n:ns) te rest
+    walk ns ((n,NVar (TCon _ tc)):te) rest
       | n == selfKW         = isActor env (tcname tc) && n0 `elem` ns
-    walk ns (_ : te)        = walk ns te
-    walk ns []              = False
+    walk ns (_ : te) rest   = walk ns te rest
+    walk ns [] []           = False
+    walk ns [] rest         = walk ns rest []
 
 isDef                       :: EnvF x -> QName -> Bool
 isDef env n                 = case tryQName n env of
@@ -653,10 +693,11 @@ transitiveImports env       = mBuiltin : reverse (foldl trav [] (getImports env)
 allTypes                    :: (NameInfo -> Bool) -> EnvF x -> [TCon]
 allTypes select env         = concatMap impcons mods ++ localcons
   where mods                = transitiveImports env
-        localnames          = reverse (names env)
+        local te
+          | inBuiltin env   = [ TC (GName mBuiltin n) (wildargs i) | (n,i) <- te, select i ]
+          | otherwise       = [ TC (NoQ n) (wildargs i) | (n,i) <- te, select i ]
         localcons
-          | inBuiltin env   = [ TC (GName mBuiltin n) (wildargs i) | (n,i) <- localnames, select i ]
-          | otherwise       = [ TC (NoQ n) (wildargs i) | (n,i) <- localnames, select i ]
+                            = local (reverse (closedNames env)) ++ local (reverse (activeNames env))
         impcons m           = [ TC (GName m n) (wildargs i) | (n,i) <- te, select i ]
           where Just te     = lookupMod m env
 
@@ -679,7 +720,16 @@ allConAttr                  :: EnvF x -> Name -> [TCon]
 allConAttr env n            = [ tc | tc <- allCons env, n `elem` allAttrs' env tc ]
 
 allConAttrUFree             :: EnvF x -> Name -> [TUni]
-allConAttrUFree env n       = concat [ ufree $ fst $ findAttr' env tc n | tc <- allConAttr env n ]
+allConAttrUFree env n       = concat [ ufree $ fst $ findAttr' env tc n | tc <- activeConAttr env n ]
+
+activeConAttr               :: EnvF x -> Name -> [TCon]
+activeConAttr env n         = [ tc | (x,i) <- activeNames env, isCon i, let tc = TC (localQName x) (wildargs i), n `elem` allAttrs' env tc ]
+  where isCon NClass{}      = True
+        isCon NAct{}        = True
+        isCon _             = False
+        localQName x
+          | inBuiltin env   = GName mBuiltin x
+          | otherwise       = NoQ x
 
 allPConAttr                 :: EnvF x -> Name -> [PCon]
 allPConAttr env n           = [ p | p <- allProtos env, n `elem` allAttrs' env p ]
@@ -1022,7 +1072,7 @@ impModule spath env (Import _ ms)
   where imp env []              = return env
         imp env (ModuleItem m as : is)
                                 = do (env1,te) <- doImp spath env m
-                                     let env2 = maybe (addImpRoot m) (\n->define [(n, NMAlias m)]) as env1
+                                     let env2 = maybe (addImpRoot m) (\n->defineClosed [(n, NMAlias m)]) as env1
                                      imp env2 is
 impModule spath env (FromImport _ (ModRef (0,Just m)) items)
                                 = do (env1,te) <- doImp spath env m
@@ -1093,7 +1143,7 @@ doImp spath env m            = do (env', te, _) <- doImpSeen S.empty env m
       subImpSeen seen' env' ms
 
 importSome                  :: [ImportItem] -> ModName -> TEnv -> EnvF x -> EnvF x
-importSome items m te env   = define (map pick items) env
+importSome items m te env   = defineClosed (map pick items) env
   where
     te1                     = impNames m te
     pick (ImportItem n mbn) = case lookup n te1 of
@@ -1101,7 +1151,7 @@ importSome items m te env   = define (map pick items) env
                                     Nothing -> noItem m n
 
 importAll                   :: ModName -> TEnv -> EnvF x -> EnvF x
-importAll m te env          = define (impNames m te) env
+importAll m te env          = defineClosed (impNames m te) env
 
 impNames                    :: ModName -> TEnv -> TEnv
 impNames m te               = mapMaybe imp (publicTEnv te)
@@ -1288,6 +1338,10 @@ instance Simp QName where
       | inBuiltin env               = NoQ n                                                     -- Restore builtins
       | Just m == thismod env       = NoQ n                                                     -- Restore locals
     simp env n
-      | not $ null aliases          = NoQ $ head aliases                                        -- Restore aliases
+      | Just n1 <- findAlias (activeNames env) = NoQ n1                                      -- Restore aliases
+      | Just n1 <- findAlias (closedNames env) = NoQ n1                                      -- Restore aliases
       | otherwise                   = n
-      where aliases                 = [ n1 | (n1, NAlias n2) <- names env, n2 == n ]
+      where findAlias ((n1, NAlias n2):te)
+              | n2 == n             = Just n1
+            findAlias (_:te)        = findAlias te
+            findAlias []            = Nothing

--- a/compiler/lib/src/Acton/Kinds.hs
+++ b/compiler/lib/src/Acton/Kinds.hs
@@ -75,7 +75,8 @@ type KindEnv                        = EnvF ()
 
 kindEnv env0                        = env0
 
-tvars env                           = [ TV k n | (n, NTVar k _ _) <- names env ]
+tvars env                           = tvs (activeNames env) ++ tvs (closedNames env)
+  where tvs te                      = [ TV k n | (n, NTVar k _ _) <- te ]
 
 extcons ke env                      = define ke env
 
@@ -778,4 +779,3 @@ instance KSubst Assoc where
 
 instance KSubst Sliz where
     ksubst g (Sliz l e1 e2 e3)      = Sliz l <$> ksubst g e1 <*> ksubst g e2 <*> ksubst g e3
-

--- a/compiler/lib/src/Acton/NameInfo.hs
+++ b/compiler/lib/src/Acton/NameInfo.hs
@@ -37,7 +37,7 @@ import Acton.Printer
     -   NClass, NProto, NExt and NAct represent class, protocol, extension and actor declarations. They each contain a TEnv of visible local attributes.
     -   Signatures must appear before the defs/assignments they describe, and every TEnv respects the order of the syntactic constructs binding each name.
     -   The attribute TEnvs of NClass, NProto, NExt and NAct are searched left-to-right, thus favoring (explicit) NSigs over (inferred) NDefs/NVars.
-    -   The global inference TEnv (names env) is searched right-to-left, thereby prioritizing NDefs/NVars over NSigs, as well as any inner bindings in scope.
+    -   The global inference environment is searched from active names to closed names, thereby prioritizing NDefs/NVars over NSigs, as well as any inner bindings in scope.
     -   The NameInfo assumption on a (recursive) Def is always an NDef, initialized to the corresponding NSig if present, or a fresh unquantified variable.
     -   The inferred schema for each def is checked to be no less general than the corresponding NDef assumption.
     -   Unquantified NDefs are generalized at the close of the outermost recursive declaration in scope.

--- a/compiler/lib/src/Acton/TypeEnv.hs
+++ b/compiler/lib/src/Acton/TypeEnv.hs
@@ -156,6 +156,10 @@ tydefine                        :: TEnv -> Env -> Env
 tydefine te env                 = modX (define te env) (setupCons f te . setupWits NoQ te)
   where f                       = if inBuiltin env then GName mBuiltin else NoQ
 
+tydefineClosed                  :: TEnv -> Env -> Env
+tydefineClosed te env           = modX (defineClosed te env) (setupCons f te . setupWits NoQ te)
+  where f                       = if inBuiltin env then GName mBuiltin else NoQ
+
 setupCons                       :: (Name -> QName) -> TEnv -> TypeX -> TypeX
 setupCons f te x                = foldl' (addconinfo f) x te
  
@@ -179,7 +183,7 @@ tydefineVars                    :: QBinds -> Env -> Env
 tydefineVars q env              = modX env1 (\x -> foldl' addvarinfo x tvs)
   where env1                    = modX env0 (\x -> foldl' addWit x wits)
         env0                    = defineTVars q env
-        tvs                     = [ (TV k v, c, us) | (v, NTVar k c us) <- take (length q) (names env0), let tv = TV k v ]
+        tvs                     = [ (TV k v, c, us) | (v, NTVar k c us) <- take (length q) (activeNames env0), let tv = TV k v ]
         wits                    = [ WInst [] (tVar tv) p (NoQ $ tvarWit tv u) wchain | (tv, _, us) <- tvs, u <- us, (wchain,p) <- findAncestry env u ]
 
 tydefineInst                    :: TCon -> [WTCon] -> Name -> Env -> Env
@@ -207,7 +211,7 @@ limitQuant                      :: TUni -> Env -> Env
 limitQuant (UV _ l _) env
   | n <= 0                      = env
   | otherwise                   = modX env1 $ \x -> x{ witnesses = dropw n (witnesses x) }
-  where env1                    = setNames (dropv n (names env)) env{ qlevel = qlevel env - n }
+  where env1                    = setActiveNames (dropv n (activeNames env)) env{ qlevel = qlevel env - n }
         n                       = qlevel env - l
         dropv 0 te              = te
         dropv n ((v,i):te)
@@ -232,7 +236,7 @@ isForced env                    = forced $ envX env
 
 instance Polarity Env where
     polvars env                 = polvars pte `polcat` invvars ite
-      where (pte, ite)          = span ((`elem` pvs) . fst) (names env)
+      where (pte, ite)          = span ((`elem` pvs) . fst) (activeNames env)
             pvs                 = posnames $ envX env
 
 
@@ -267,7 +271,7 @@ instance Pretty Constraint where
 prettyQuant env
   | qlevel env > 0                  = brackets (commaSep pretty q) <+> text "=>"
   | otherwise                       = empty
-  where q                           = [ QBind (TV k tv) (if c == cValue then ps else c:ps) | (tv, NTVar k c ps) <- names env ]
+  where q                           = [ QBind (TV k tv) (if c == cValue then ps else c:ps) | (tv, NTVar k c ps) <- activeNames env ]
 
 instance VFree Constraint where
     vfree (Cast info env t1 t2)     = vfree t1 ++ vfree t2
@@ -795,12 +799,12 @@ instance USubst Witness where
 
 
 instance USubst Env where
-    usubst env                  = do ne <- usubst (names env)
+    usubst env                  = do ne <- usubst (activeNames env)
                                      ex <- usubst (envX env)
-                                     return $ setNames ne env{ envX = ex }
+                                     return $ setActiveNames ne env{ envX = ex }
 
 instance UFree Env where
-    ufree env                   = ufree (names env) ++ ufree (envX env)
+    ufree env                   = ufree (activeNames env) ++ ufree (envX env)
 
 
 -- Well-formed tycon applications -------------------------------------------------------------------------------------------------

--- a/compiler/lib/src/Acton/Types.hs
+++ b/compiler/lib/src/Acton/Types.hs
@@ -68,7 +68,7 @@ reconstruct                             :: Maybe TypeProgressCallback -> Maybe T
 reconstruct progressCb inferredCb env0 (Module m i mdoc ss)    = do --traceM ("#################### original env0 for " ++ prstr m ++ ":")
                                              --traceM (render (pretty env0))
                                              (te,ss1) <- infTop progressCb inferredCb env1 ss
-                                             let env2 = define te (setMod m env0)
+                                             let env2 = defineClosed te (setMod m env0)
                                                  (teT,ssT,tests) =
                                                    if hasTesting i
                                                      then let (testSs, discovered) = testStmts env2 (modNameStr m) ss1
@@ -80,7 +80,7 @@ reconstruct progressCb inferredCb env0 (Module m i mdoc ss)    = do --traceM ("#
                                              --traceM (render (pretty env0'))
                                              return (nmod, Module m i mdoc ssT, env0', tests)
 
-  where env1                            = reserve (assigned ss) (initTypeEnv env0)
+  where env1                            = reserveClosed (assigned ss) (initTypeEnv env0)
         env0'                           = convEnvProtos env0
         hasTesting i                    = Import NoLoc [ModuleItem (ModName [name "testing"]) Nothing] `elem` i
         rmTests (Assign _ [PVar _ n _] _ : ss)
@@ -147,7 +147,7 @@ showTyFile env0 m fname verbose = do
 
 prettySigs env m imps te        = render $ vcat [ text "import" <+> pretty m | m <- imps ] $++$
                                            vpretty (simp env1 te)
-  where env1                    = define te $ setMod m env
+  where env1                    = defineClosed te $ setMod m env
 
 nodup x
   | not $ null vs               = err2 vs "Duplicate names:"
@@ -261,12 +261,12 @@ infTop progressCb inferredCb env ss     = do -- The scanner itself is sequential
                                                  -- Continue scanning with the scanned declarations visible.
                                                  -- Store te1 and result wait on reversed accumulators to preserve
                                                  -- source order cheaply when collect reverses them.
-                                                 go slots workQ q (tydefine te1 env) (te1:tes) (readMVar result:rs) ss
+                                                 go slots workQ q (tydefineClosed te1 env) (te1:tes) (readMVar result:rs) ss
                                                -- A non-total statement was already fully checked by scanOrCheck,
                                                -- so becomes complete / total before we get here and the scanner may
                                                -- continue.
                                                Right (_,te2,_,ss1) ->
-                                                 go slots workQ q (tydefine te2 env) (te2:tes) (return (Right ss1):rs) ss
+                                                 go slots workQ q (tydefineClosed te2 env) (te2:tes) (return (Right ss1):rs) ss
         -- Wait for all statement results in source order, concatenate the
         -- accumulated environments, keep typed statements whose checks
         -- succeeded, and keep every error for aggregate reporting.
@@ -1162,9 +1162,13 @@ checkClassAttributesInitialized className classLoc env ancestors b
                                           in [ n | (n, NSig _ Property _) <- te ]
 
         -- Helper to look up class location in environment
-        getClassLoc env qname           = case [ className | (className, NClass{}) <- names env, className == noq qname ] of
-                                            (Name classLoc _:_) -> classLoc
-                                            _                   -> NoLoc
+        getClassLoc env qname           = case findClass (activeNames env) of
+                                            Just l  -> l
+                                            Nothing -> maybe NoLoc id (findClass (closedNames env))
+          where findClass ((n, NClass{}):te)
+                  | n == noq qname      = Just (loc n)
+                findClass (_:te)        = findClass te
+                findClass []            = Nothing
 
         -- Find which parent class (if any) defines the given attribute
         findAttributeParent attrName    = case [ n | Signature _ ns _ _ <- b, n <- ns, n == attrName ] of

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -1068,14 +1068,12 @@ main = do
             env1 = Acton.Env.addMod (S.modname parsedA) impsA tenvA mdocA env0
 
         (envB, _) <- parseAct env1 "import_private"
-        let namesB = Acton.Env.names envB
-
-        case lookup (S.name "__foo") namesB of
+        case Acton.Env.lookupName (S.name "__foo") envB of
           Nothing -> pure ()
           Just _ -> expectationFailure "from import * should skip __foo"
 
-        case lookup (S.name "public_value") namesB of
-          Just (I.NAlias _) -> pure ()
+        case Acton.Env.lookupName (S.name "public_value") envB of
+          Just (I.HNAlias _) -> pure ()
           _ -> expectationFailure "from import * should include public_value"
 
       it "blocks qualified access to private names" $ do


### PR DESCRIPTION
Type checking repeatedly substitutes and scans the environment while solving constraints. Env bindings have two different lifetimes: active local names can contain live unification variables, while imported names and finalized top-level names should be closed. Treating both groups as one list makes each substitution, free-variable scan, polarity check, and quantifier pass scale with all visible names, i.e. poorly.

Store activeNames and closedNames as the ordered sources of truth instead of maintaining a separate combined names list. hnames remains the full hash lookup cache for exact name lookup, while closedHNames lets active changes rebuild hnames without rehashing the closed part. Ordered scan sites now say which side they need: active then closed for normal scope order, or reverse closed then reverse active where the previous code used reverse scope order.

define and reserve keep adding ordinary local names to the active side, while imports, finalized module interfaces, and completed top-level scanner entries use the closed side. Env substitution, free-variable scans, polarity checks, quantifier limiting, and quantifier display now only visit active names, which keeps closed module-scale bindings out of the hot type-checking paths.

On 100 trees, type checking goes from 83s -> 1.63s