### PR TITLE
Deduplicate reserved names with a hash index

### DIFF
--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -303,14 +303,20 @@ reserve xs env
   | not $ null badSelf      = selfParamError (loc $ head badSelf)
   | otherwise               = addActiveNames te env
   where badSelf             = if inAct env then xs `intersect` [selfKW] else []
-        te                  = [ (x, NReserved) | x <- nub xs ]
+        te                  = [ (x, NReserved) | x <- uniqueNames xs ]
 
 reserveClosed               :: [Name] -> EnvF x -> EnvF x
 reserveClosed xs env
   | not $ null badSelf      = selfParamError (loc $ head badSelf)
   | otherwise               = addClosedNames te env
   where badSelf             = if inAct env then xs `intersect` [selfKW] else []
-        te                  = [ (x, NReserved) | x <- nub xs ]
+        te                  = [ (x, NReserved) | x <- uniqueNames xs ]
+
+uniqueNames                 :: [Name] -> [Name]
+uniqueNames ns              = reverse $ snd $ foldl' add (M.empty, []) ns
+  where add (seen, out) n
+          | M.member n seen = (seen, out)
+          | otherwise       = (M.insert n () seen, n:out)
 
 define                      :: TEnv -> EnvF x -> EnvF x
 define te env


### PR DESCRIPTION
Every module reserves assigned names before type checking starts, so definitions can refer to names that appear elsewhere in the module. That reservation path must preserve first-occurrence order, but it does not need the quadratic behavior of nub.

Use the existing Name hash instance to keep the same order while tracking seen names in a hash map. Apply this to reserve and reserveClosed, since module-level reservation now goes through the closed side of Env after the active/closed split.

This keeps the reserved TEnv and hnames behavior the same while avoiding a large CPU cost before the concurrent top-level type checker can make useful progress.