### PR TITLE
Index term substitutions in Transform

### DIFF
--- a/compiler/lib/src/Acton/Transform.hs
+++ b/compiler/lib/src/Acton/Transform.hs
@@ -14,6 +14,8 @@
 {-# LANGUAGE MultiParamTypeClasses, FlexibleInstances, FlexibleContexts #-}
 module Acton.Transform where
 
+import qualified Data.HashMap.Strict as M
+
 import Utils
 import Acton.Syntax
 import Acton.Names
@@ -35,24 +37,28 @@ termsubst s x                           = trans (finalize $ extsubst s env0) x
 class Transform a where
     trans                               :: TransEnv -> a -> a
 
+type TSubst                             = M.HashMap Name (Maybe Expr)
+
 data TransEnv                           = TransEnv {
                                             eqns     :: Equations,                  -- Top-level constraint solutions
-                                            trsubst  :: [(Name,Maybe Expr)],        -- Inlineable assignments in scope
+                                            trsubst  :: TSubst,                     -- Inlineable assignments and scope blockers
                                             witscope :: [(Name,Type,Expr)],         -- Preserved witness bindings in scope, for the purpose of duplicate removals
                                             final    :: Bool
                                           }
 
-env0                                    = TransEnv{ eqns = [], trsubst = [], witscope = [], final = False }
+env0                                    = TransEnv{ eqns = [], trsubst = M.empty, witscope = [], final = False }
 
-blockscope ns env                       = env{ trsubst = (ns `zip` repeat Nothing) ++ trsubst env }
+blockscope ns env                       = env{ trsubst = foldr (`M.insert` Nothing) (trsubst env) ns }
 
-extsubst ns env                         = env{ trsubst = [ (n,Just e) | (n,e) <- ns ] ++ trsubst env }
+extsubst ns env                         = env{ trsubst = foldr (\(n,e) -> M.insert n (Just e)) (trsubst env) ns }
 
-limsubst ns env                         = env{ trsubst = trsubst env `exclude` ns }
+limsubst ns env                         = env{ trsubst = foldr M.delete (trsubst env) ns }
 
-trfind n env                            = case lookup n (trsubst env) of
+trfind n env                            = case M.lookup n (trsubst env) of
                                             Just (Just e) -> Just e
                                             _ -> Nothing
+
+trfinds ns env                          = [ e | n <- ns, Just e <- [trfind n env] ]
 
 
 extscope n t e env                      = env{ witscope = (n,t,e) : witscope env }
@@ -182,7 +188,7 @@ instance Transform Expr where
       where fvs                         = free e
             bvs                         = bound p ++ bound k
             env1                        = limsubst bvs env
-            clash                       = bvs `intersect` free (rng $ restrict (trsubst env1) fvs)
+            clash                       = bvs `intersect` free (trfinds fvs env1)
             s                           = clash `zip` (yNames \\ (fvs++bvs))
             e1                          = Lambda l (prename s p) (krename s k) (erename s e) fx
     trans env (Yield l e)               = Yield l (trans env e)


### PR DESCRIPTION
Transform keeps inlineable term substitutions in TransEnv. During type
checking, reconstructed expressions are repeatedly transformed with that
substitution environment. The environment had list semantics and was
implemented as a list, so each lambda traversal used list deletion, list
filtering, and linear lookup over the active substitutions.

This made ordinary term substitution work scale with the size of the
current substitution environment. It is especially visible in larger
modules because the same name comparisons are repeated many times while
walking method bodies.

Store term substitutions in a HashMap keyed by Name. blockscope inserts
Nothing to preserve local shadowing, extsubst inserts Just values,
limsubst deletes names, and trfind becomes a direct map lookup.

The lambda capture check now looks up only the free variables it needs
instead of filtering the whole substitution environment. That preserves
the old observable behavior because the check only needs the free names
from matching substitution right-hand sides, not the original list
order.

On the 3000-tree heavy-class types-bench, Types now takes 30.98 s,
35.06 s, and 33.63 s in isolated samples, compared with 53.03 s and
54.66 s on the preceding commit in the same session. Type allocation
dropped from about 1.02 TB to about 811 GB.