### PR TITLE
Split and index type witnesses

### DIFF
--- a/compiler/lib/src/Acton/TypeEnv.hs
+++ b/compiler/lib/src/Acton/TypeEnv.hs
@@ -46,7 +46,8 @@ import Acton.Env
 
 
 data TypeX                      = TypeX {
-                                    witnesses   :: [Witness],
+                                    activeWits  :: [Witness],
+                                    closedWits  :: [Witness],
                                     posnames    :: [Name],
                                     indecl      :: Bool,
                                     forced      :: Bool,
@@ -68,7 +69,8 @@ type Env                        = EnvF TypeX
 initTypeEnv                     :: Env0 -> Env
 initTypeEnv env0                = setX env0 $ foldl' importInfo x0 imps
   where x0                      = TypeX {
-                                    witnesses   = primWits,
+                                    activeWits  = [],
+                                    closedWits  = primWits,
                                     posnames    = [],
                                     indecl      = False,
                                     forced      = False,
@@ -77,7 +79,7 @@ initTypeEnv env0                = setX env0 $ foldl' importInfo x0 imps
                                     typrotos    = IntSet.empty,
                                     tyactors    = IntSet.empty
                                   }
-        importInfo x (m,te)     = setupCons f te $ setupWits f te x
+        importInfo x (m,te)     = setupCons f te $ setupWits addClosedWit f te x
           where f               = GName m
         imps | inBuiltin env0   = []
              | otherwise        = [ (m, fromJust $ lookupMod m env0) | m <- mBuiltin : transitiveImports env0 ]
@@ -120,11 +122,14 @@ prinfo x (n, tid)               = pretty (noq n) <+> text "=" <+> pretty tid <> 
   where info                    = tyinfos x IntMap.! tid
 
 instance USubst TypeX where
-    usubst x                    = do we <- usubst (witnesses x)
-                                     return x{ witnesses = we }
+    usubst x                    = do we <- usubst (activeWits x)
+                                     return x{ activeWits = we }
 
 instance UFree TypeX where
-    ufree x                     = ufree (witnesses x)
+    ufree x                     = ufree (activeWits x)
+
+witnesses                       :: TypeX -> [Witness]
+witnesses x                     = activeWits x ++ closedWits x
 
 
 nextid x                        = 1 + fst (IntMap.findMax $ tyinfos x)
@@ -153,18 +158,18 @@ addconinfo f x (n,i)
 
 
 tydefine                        :: TEnv -> Env -> Env
-tydefine te env                 = modX (define te env) (setupCons f te . setupWits NoQ te)
+tydefine te env                 = modX (define te env) (setupCons f te . setupWits addActiveWit NoQ te)
   where f                       = if inBuiltin env then GName mBuiltin else NoQ
 
 tydefineClosed                  :: TEnv -> Env -> Env
-tydefineClosed te env           = modX (defineClosed te env) (setupCons f te . setupWits NoQ te)
+tydefineClosed te env           = modX (defineClosed te env) (setupCons f te . setupWits addClosedWit NoQ te)
   where f                       = if inBuiltin env then GName mBuiltin else NoQ
 
 setupCons                       :: (Name -> QName) -> TEnv -> TypeX -> TypeX
 setupCons f te x                = foldl' (addconinfo f) x te
  
-setupWits                       :: (Name -> QName) -> TEnv -> TypeX -> TypeX
-setupWits f te x                = foldl' addWit x wits
+setupWits                       :: (TypeX -> Witness -> TypeX) -> (Name -> QName) -> TEnv -> TypeX -> TypeX
+setupWits add f te x            = foldl' add x wits
   where wits                    = [ WClass q (tCon c) p (f n) ws (length opts) | (n, NExt q c ps te' opts _) <- te, (ws,p) <- ps ]
 
 addvarinfo x (tv, c, _)         = x{ tyids = Map.insert (NoQ $ tvname tv) tid (tyids x), tyinfos = IntMap.insert tid info tyinfos' }
@@ -181,36 +186,45 @@ addvarinfo x (tv, c, _)         = x{ tyids = Map.insert (NoQ $ tvname tv) tid (t
 
 tydefineVars                    :: QBinds -> Env -> Env
 tydefineVars q env              = modX env1 (\x -> foldl' addvarinfo x tvs)
-  where env1                    = modX env0 (\x -> foldl' addWit x wits)
+  where env1                    = modX env0 (\x -> foldl' addActiveWit x wits)
         env0                    = defineTVars q env
         tvs                     = [ (TV k v, c, us) | (v, NTVar k c us) <- take (length q) (activeNames env0), let tv = TV k v ]
         wits                    = [ WInst [] (tVar tv) p (NoQ $ tvarWit tv u) wchain | (tv, _, us) <- tvs, u <- us, (wchain,p) <- findAncestry env u ]
 
 tydefineInst                    :: TCon -> [WTCon] -> Name -> Env -> Env
-tydefineInst c ps w env         = modX env (\x -> foldl' addWit x wits)
+tydefineInst c ps w env         = modX env (\x -> foldl' addActiveWit x wits)
   where wits                    = [ WInst [] (tCon c) p (NoQ w) ws | (ws,p) <- ps ]
 
-addWit                          :: TypeX -> Witness -> TypeX
-addWit x wit
-  | null same                   = x{ witnesses = wit : witnesses x }
+addActiveWit                    :: TypeX -> Witness -> TypeX
+addActiveWit x wit
+  | null same                   = x{ activeWits = wit : activeWits x }
   | otherwise                   = x
   where same                    = [ w | w <- witsByPNameX x (tcname $ proto wit), wtype w == wtype wit ]
 
-witsByPNameX x pn               = [ w | w <- witnesses x, tcname (proto w) == pn ]
+addClosedWit                    :: TypeX -> Witness -> TypeX
+addClosedWit x wit
+  | null same                   = x{ closedWits = wit : closedWits x }
+  | otherwise                   = x
+  where same                    = [ w | w <- witsByPNameX x (tcname $ proto wit), wtype w == wtype wit ]
+
+witsByPNameX x pn               = [ w | w <- activeWits x, tcname (proto w) == pn ] ++
+                                  [ w | w <- closedWits x, tcname (proto w) == pn ]
 
 witsByPName                     :: Env -> QName -> [Witness]
 witsByPName env pn              = witsByPNameX (envX env) pn
 
 witsByTName                     :: Env -> QName -> [Witness]
-witsByTName env tn              = [ w | w <- witnesses (envX env), eqname (wtype w) ]
+witsByTName env tn              = [ w | w <- activeWits x, eqname (wtype w) ] ++
+                                  [ w | w <- closedWits x, eqname (wtype w) ]
   where eqname (TCon _ c)       = tcname c == tn
         eqname (TVar _ v)       = NoQ (tvname v) == tn
         eqname _                = False
+        x                       = envX env
 
 limitQuant                      :: TUni -> Env -> Env
 limitQuant (UV _ l _) env
   | n <= 0                      = env
-  | otherwise                   = modX env1 $ \x -> x{ witnesses = dropw (witnesses x) }
+  | otherwise                   = modX env1 $ \x -> x{ activeWits = dropw (activeWits x) }
   where env1                    = setActiveNames (dropv n (activeNames env)) env{ qlevel = qlevel env - n }
         n                       = qlevel env - l
         vs                      = takev n (activeNames env)

--- a/compiler/lib/src/Acton/TypeEnv.hs
+++ b/compiler/lib/src/Acton/TypeEnv.hs
@@ -48,6 +48,8 @@ import Acton.Env
 data TypeX                      = TypeX {
                                     activeWits  :: [Witness],
                                     closedWits  :: [Witness],
+                                    activeWitMap :: WitMap,
+                                    closedWitMap :: WitMap,
                                     posnames    :: [Name],
                                     indecl      :: Bool,
                                     forced      :: Bool,
@@ -65,12 +67,15 @@ data TyInfo                     = TyInfo {
                                   }
 
 type Env                        = EnvF TypeX
+type WitMap                     = Map QName [Witness]
 
 initTypeEnv                     :: Env0 -> Env
 initTypeEnv env0                = setX env0 $ foldl' importInfo x0 imps
   where x0                      = TypeX {
                                     activeWits  = [],
                                     closedWits  = primWits,
+                                    activeWitMap = Map.empty,
+                                    closedWitMap = witMap primWits,
                                     posnames    = [],
                                     indecl      = False,
                                     forced      = False,
@@ -123,13 +128,16 @@ prinfo x (n, tid)               = pretty (noq n) <+> text "=" <+> pretty tid <> 
 
 instance USubst TypeX where
     usubst x                    = do we <- usubst (activeWits x)
-                                     return x{ activeWits = we }
+                                     return x{ activeWits = we, activeWitMap = witMap we }
 
 instance UFree TypeX where
     ufree x                     = ufree (activeWits x)
 
 witnesses                       :: TypeX -> [Witness]
 witnesses x                     = activeWits x ++ closedWits x
+
+witMap                          :: [Witness] -> WitMap
+witMap                          = foldr addWit Map.empty
 
 
 nextid x                        = 1 + fst (IntMap.findMax $ tyinfos x)
@@ -197,18 +205,23 @@ tydefineInst c ps w env         = modX env (\x -> foldl' addActiveWit x wits)
 
 addActiveWit                    :: TypeX -> Witness -> TypeX
 addActiveWit x wit
-  | null same                   = x{ activeWits = wit : activeWits x }
+  | null same                   = x{ activeWits = wit : activeWits x,
+                                     activeWitMap = addWit wit (activeWitMap x) }
   | otherwise                   = x
   where same                    = [ w | w <- witsByPNameX x (tcname $ proto wit), wtype w == wtype wit ]
 
 addClosedWit                    :: TypeX -> Witness -> TypeX
 addClosedWit x wit
-  | null same                   = x{ closedWits = wit : closedWits x }
+  | null same                   = x{ closedWits = wit : closedWits x,
+                                     closedWitMap = addWit wit (closedWitMap x) }
   | otherwise                   = x
   where same                    = [ w | w <- witsByPNameX x (tcname $ proto wit), wtype w == wtype wit ]
 
-witsByPNameX x pn               = [ w | w <- activeWits x, tcname (proto w) == pn ] ++
-                                  [ w | w <- closedWits x, tcname (proto w) == pn ]
+addWit                          :: Witness -> WitMap -> WitMap
+addWit w                        = Map.insertWith (++) (tcname $ proto w) [w]
+
+witsByPNameX x pn               = Map.findWithDefault [] pn (activeWitMap x) ++
+                                  Map.findWithDefault [] pn (closedWitMap x)
 
 witsByPName                     :: Env -> QName -> [Witness]
 witsByPName env pn              = witsByPNameX (envX env) pn
@@ -224,7 +237,8 @@ witsByTName env tn              = [ w | w <- activeWits x, eqname (wtype w) ] ++
 limitQuant                      :: TUni -> Env -> Env
 limitQuant (UV _ l _) env
   | n <= 0                      = env
-  | otherwise                   = modX env1 $ \x -> x{ activeWits = dropw (activeWits x) }
+  | otherwise                   = modX env1 $ \x -> let we = dropw (activeWits x)
+                                                    in x{ activeWits = we, activeWitMap = witMap we }
   where env1                    = setActiveNames (dropv n (activeNames env)) env{ qlevel = qlevel env - n }
         n                       = qlevel env - l
         vs                      = takev n (activeNames env)


### PR DESCRIPTION
`TypeX` now separates active witnesses from closed witnesses. Builtins, imports, and closed top-level declarations populate the closed side, while local quantifier and instance witnesses remain active. `USubst` and `UFree` only inspect active witnesses, matching the invariant used for closed names: closed environment data should not contain live unification variables from the current module.

Second, witness lookup by protocol name now uses active and closed maps keyed by protocol name. The ordered witness lists remain in place, and `witsByPName` still returns active witnesses before closed witnesses.

Types checking on the 3000 trees heavy class test is down from ~35s to ~26 seconds.