### PR TITLE
Fix list.index on empty list

### DIFF
--- a/base/builtin/list.c
+++ b/base/builtin/list.c
@@ -207,10 +207,11 @@ B_int B_listD_index(B_list self, B_Eq W_EqD_B, $WORD val, B_int start, B_int sto
     if (strt > self->length)
         $RAISE((B_BaseException)$NEW(B_ValueError, to$str("start position must not exceed list length")));
     int stp = self->length;
-    if (stop)
+    if (stop) {
         stp = fromB_int(stop);
-    if (stp <= strt)
-        $RAISE((B_BaseException)$NEW(B_ValueError, to$str("stop position must be higher than start position")));
+        if (stp <= strt)
+            $RAISE((B_BaseException)$NEW(B_ValueError, to$str("stop position must be higher than start position")));
+    }
     if (stp > self->length)
         stp = self->length;
     for (int i=strt; i < stp; i++) {

--- a/test/builtins_auto/list.act
+++ b/test/builtins_auto/list.act
@@ -19,6 +19,13 @@ def test_list_index():
     except KeyError:
         pass
 
+def test_list_index_empty():
+    l = []
+    try:
+        l.index(1)
+    except KeyError as e:
+        pass
+
 def test_list_index_errs():
     l = [1, 2, 3]
     try:
@@ -43,6 +50,7 @@ def test_list_index_errs():
 actor main(env):
     try:
         test_list_index()
+        test_list_index_empty()
         test_list_index_errs()
     except Exception as e:
         print("Unexpected exception", e)


### PR DESCRIPTION
Skip the stop<=start validation for empty list when stop is not explicitly provided.