### PR TITLE
Report active back pass progress

### DIFF
--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -1632,7 +1632,8 @@ initCliCompileHooks progressUI progressState gopts sched gen plan = do
           ++ ", llift " ++ fmtTimePrecise (btLLift bt)
           ++ ", boxing " ++ fmtTimePrecise (btBoxing bt)
           ++ ", codegen " ++ fmtTimePrecise (btCodeGen bt)
-          ++ maybe "" (\t -> ", write " ++ fmtTimePrecise t) (btWriteCode bt)
+          ++ ", render " ++ fmtTimePrecise (btRender bt)
+          ++ maybe "" (\t -> ", write " ++ fmtTimePrecise t) (btWrite bt)
         parseDoneRenderer =
           staticStatusRenderer parseDoneStatus "Parsed"
         frontDoneRenderer =
@@ -1683,6 +1684,8 @@ initCliCompileHooks progressUI progressState gopts sched gen plan = do
           renderProjectLine proj mn (staticStatusRenderer "Kinds check" "Kinds")
         backActiveLine proj mn =
           renderProjectLine proj mn (staticStatusRenderer "Back passes" "Back")
+        backProgressLine proj mn p =
+          renderProjectLine proj mn (backPassStatusRenderer p)
         finalActiveLine width =
           fitBuildLineLayout width labelWidth statusWidth True "" (staticStatusRenderer "Final compilation" "Final")
         clamp01 x = max 0 (min 1 x)
@@ -1722,6 +1725,12 @@ initCliCompileHooks progressUI progressState gopts sched gen plan = do
               in case fppPass p of
                    FrontPassKinds -> staticStatusRenderer "Kinds check" "Kinds" budget
                    FrontPassTypes -> Just (fullTypeStatus (fppCurrent p))
+        backPassStatusRenderer (BackPassSkipped pass _ _) =
+          let passName = backPassName pass
+          in staticStatusRenderer ("Back " ++ passName ++ " skipped") (passName ++ " skipped")
+        backPassStatusRenderer p =
+          let passName = backPassName (backProgressPass p)
+          in staticStatusRenderer ("Back " ++ passName) passName
         parseStatusRenderer p budget
           | budget < 10 = Nothing
           | otherwise =
@@ -1735,6 +1744,22 @@ initCliCompileHooks progressUI progressState gopts sched gen plan = do
                           else Just (show pct ++ "%")
         frontProgressLine proj mn p =
           renderProjectLine proj mn (frontStatusRenderer p)
+        backProgressPass (BackPassStarted pass _ _) = pass
+        backProgressPass (BackPassFinished pass _ _ _) = pass
+        backProgressPass (BackPassSkipped pass _ _) = pass
+        backProgressCompleted (BackPassStarted _ completed _) = completed
+        backProgressCompleted (BackPassFinished _ completed _ _) = completed
+        backProgressCompleted (BackPassSkipped _ completed _) = completed
+        backProgressTotal (BackPassStarted _ _ total) = total
+        backProgressTotal (BackPassFinished _ _ total _) = total
+        backProgressTotal (BackPassSkipped _ _ total) = total
+        backProgressRatio p =
+          let total = backProgressTotal p
+          in if total <= 0
+               then 1
+               else clamp01 (fromIntegral (backProgressCompleted p) / fromIntegral total)
+        backPassDoneLine proj mn pass =
+          "Back " ++ backPassName pass ++ " done: " ++ projectModuleLabel proj mn
         finalKey = TaskKey rootProj (A.modName ["__final__"])
         withTerm action = when termEnabled $ gate (withProgressLock progressUI action)
         setPercent pct = withTerm (termProgressPercent termProgress pct)
@@ -1779,6 +1804,18 @@ initCliCompileHooks progressUI progressState gopts sched gen plan = do
               mn = A.modname (biTypedMod (bjInput job))
           in do
             gate (progressStartTask progressUI progressState (backJobKey job) (backActiveLine proj mn) (Just 0))
+        onBackProgress job p = do
+          let proj = projPath (bjPaths job)
+              mn = A.modname (biTypedMod (bjInput job))
+          gate (progressUpdateTask progressUI progressState (backJobKey job)
+                  (backProgressLine proj mn p) (Just (backProgressRatio p)))
+          when (not (quiet gopts optsPlan) && (C.timing gopts || C.verbose gopts)) $
+            case p of
+              BackPassFinished pass _ _ elapsed ->
+                logRendered (\cols ->
+                  detailTimedLine cols detailStmtIndentWide detailStmtIndentNarrow
+                    (backPassDoneLine proj mn pass) elapsed)
+              _ -> return ()
         onBackDone job result = do
           gate (progressDoneTask progressUI progressState (backJobKey job))
           creditBack (backJobKey job)
@@ -1853,6 +1890,7 @@ initCliCompileHooks progressUI progressState gopts sched gen plan = do
               creditFront (gtKey t)
           , chOnBackQueued = \_ _ -> return ()
           , chOnBackStart = onBackStart
+          , chOnBackProgress = onBackProgress
           , chOnBackDone = onBackDone
           , chOnInfo = logLine
           }

--- a/compiler/acton/test/rebuild/golden/file_02-initial-build.golden
+++ b/compiler/acton/test/rebuild/golden/file_02-initial-build.golden
@@ -13,7 +13,31 @@ Resolving dependencies (fetching if missing)...
    c  Parse done                                                            0.000 s
   Stale c: source changed
    c  Type check done                                                       0.000 s
+     Back normalize done: a                                                 0.000 s
+     Back deactorize done: a                                                0.000 s
+     Back cps done: a                                                       0.000 s
+     Back llift done: a                                                     0.000 s
+     Back boxing done: a                                                    0.000 s
+     Back codegen done: a                                                   0.000 s
+     Back render done: a                                                    0.000 s
+     Back write done: a                                                     0.000 s
    a  Compilation done                                                      0.000 s
+     Back normalize done: b                                                 0.000 s
+     Back deactorize done: b                                                0.000 s
+     Back cps done: b                                                       0.000 s
+     Back llift done: b                                                     0.000 s
+     Back boxing done: b                                                    0.000 s
+     Back codegen done: b                                                   0.000 s
+     Back render done: b                                                    0.000 s
+     Back write done: b                                                     0.000 s
    b  Compilation done                                                      0.000 s
+     Back normalize done: c                                                 0.000 s
+     Back deactorize done: c                                                0.000 s
+     Back cps done: c                                                       0.000 s
+     Back llift done: c                                                     0.000 s
+     Back boxing done: c                                                    0.000 s
+     Back codegen done: c                                                   0.000 s
+     Back render done: c                                                    0.000 s
+     Back write done: c                                                     0.000 s
    c  Compilation done                                                      0.000 s
       Final compilation done                                                0.000 s

--- a/compiler/acton/test/rebuild/golden/file_06-change-a-impl.golden
+++ b/compiler/acton/test/rebuild/golden/file_06-change-a-impl.golden
@@ -8,7 +8,31 @@ Resolving dependencies (fetching if missing)...
        aaa : int
   Stale b: impl changes in a.aaa HASH1 → HASH2 (used by baa)
   Stale c: impl changes in b.baa HASH1 → HASH2 (used by main)
+     Back normalize done: a                                                 0.000 s
+     Back deactorize done: a                                                0.000 s
+     Back cps done: a                                                       0.000 s
+     Back llift done: a                                                     0.000 s
+     Back boxing done: a                                                    0.000 s
+     Back codegen done: a                                                   0.000 s
+     Back render done: a                                                    0.000 s
+     Back write done: a                                                     0.000 s
    a  Compilation done                                                      0.000 s
+     Back normalize done: b                                                 0.000 s
+     Back deactorize done: b                                                0.000 s
+     Back cps done: b                                                       0.000 s
+     Back llift done: b                                                     0.000 s
+     Back boxing done: b                                                    0.000 s
+     Back codegen done: b                                                   0.000 s
+     Back render done: b                                                    0.000 s
+     Back write done: b                                                     0.000 s
    b  Compilation done                                                      0.000 s
+     Back normalize done: c                                                 0.000 s
+     Back deactorize done: c                                                0.000 s
+     Back cps done: c                                                       0.000 s
+     Back llift done: c                                                     0.000 s
+     Back boxing done: c                                                    0.000 s
+     Back codegen done: c                                                   0.000 s
+     Back render done: c                                                    0.000 s
+     Back write done: c                                                     0.000 s
    c  Compilation done                                                      0.000 s
       Final compilation done                                                0.000 s

--- a/compiler/acton/test/rebuild/golden/file_08-change-b-impl.golden
+++ b/compiler/acton/test/rebuild/golden/file_08-change-b-impl.golden
@@ -12,6 +12,22 @@ Resolving dependencies (fetching if missing)...
            G_init : () -> None
            get : () -> int
   Stale c: impl changes in b.baa HASH1 → HASH2 (used by main)
+     Back normalize done: b                                                 0.000 s
+     Back deactorize done: b                                                0.000 s
+     Back cps done: b                                                       0.000 s
+     Back llift done: b                                                     0.000 s
+     Back boxing done: b                                                    0.000 s
+     Back codegen done: b                                                   0.000 s
+     Back render done: b                                                    0.000 s
+     Back write done: b                                                     0.000 s
    b  Compilation done                                                      0.000 s
+     Back normalize done: c                                                 0.000 s
+     Back deactorize done: c                                                0.000 s
+     Back cps done: c                                                       0.000 s
+     Back llift done: c                                                     0.000 s
+     Back boxing done: c                                                    0.000 s
+     Back codegen done: c                                                   0.000 s
+     Back render done: c                                                    0.000 s
+     Back write done: c                                                     0.000 s
    c  Compilation done                                                      0.000 s
       Final compilation done                                                0.000 s

--- a/compiler/acton/test/rebuild/golden/project_02-initial-build.golden
+++ b/compiler/acton/test/rebuild/golden/project_02-initial-build.golden
@@ -16,7 +16,31 @@ Resolving dependencies (fetching if missing)...
    c  Parse done                                                            0.000 s
   Stale c: source changed
    c  Type check done                                                       0.000 s
+     Back normalize done: a                                                 0.000 s
+     Back deactorize done: a                                                0.000 s
+     Back cps done: a                                                       0.000 s
+     Back llift done: a                                                     0.000 s
+     Back boxing done: a                                                    0.000 s
+     Back codegen done: a                                                   0.000 s
+     Back render done: a                                                    0.000 s
+     Back write done: a                                                     0.000 s
    a  Compilation done                                                      0.000 s
+     Back normalize done: b                                                 0.000 s
+     Back deactorize done: b                                                0.000 s
+     Back cps done: b                                                       0.000 s
+     Back llift done: b                                                     0.000 s
+     Back boxing done: b                                                    0.000 s
+     Back codegen done: b                                                   0.000 s
+     Back render done: b                                                    0.000 s
+     Back write done: b                                                     0.000 s
    b  Compilation done                                                      0.000 s
+     Back normalize done: c                                                 0.000 s
+     Back deactorize done: c                                                0.000 s
+     Back cps done: c                                                       0.000 s
+     Back llift done: c                                                     0.000 s
+     Back boxing done: c                                                    0.000 s
+     Back codegen done: c                                                   0.000 s
+     Back render done: c                                                    0.000 s
+     Back write done: c                                                     0.000 s
    c  Compilation done                                                      0.000 s
       Final compilation done                                                0.000 s

--- a/compiler/acton/test/rebuild/golden/project_06-change-a-impl.golden
+++ b/compiler/acton/test/rebuild/golden/project_06-change-a-impl.golden
@@ -7,7 +7,31 @@ Resolving dependencies (fetching if missing)...
        aaa : int
   Stale b: impl changes in a.aaa HASH1 → HASH2 (used by baa)
   Stale c: impl changes in b.baa HASH1 → HASH2 (used by main)
+     Back normalize done: a                                                 0.000 s
+     Back deactorize done: a                                                0.000 s
+     Back cps done: a                                                       0.000 s
+     Back llift done: a                                                     0.000 s
+     Back boxing done: a                                                    0.000 s
+     Back codegen done: a                                                   0.000 s
+     Back render done: a                                                    0.000 s
+     Back write done: a                                                     0.000 s
    a  Compilation done                                                      0.000 s
+     Back normalize done: b                                                 0.000 s
+     Back deactorize done: b                                                0.000 s
+     Back cps done: b                                                       0.000 s
+     Back llift done: b                                                     0.000 s
+     Back boxing done: b                                                    0.000 s
+     Back codegen done: b                                                   0.000 s
+     Back render done: b                                                    0.000 s
+     Back write done: b                                                     0.000 s
    b  Compilation done                                                      0.000 s
+     Back normalize done: c                                                 0.000 s
+     Back deactorize done: c                                                0.000 s
+     Back cps done: c                                                       0.000 s
+     Back llift done: c                                                     0.000 s
+     Back boxing done: c                                                    0.000 s
+     Back codegen done: c                                                   0.000 s
+     Back render done: c                                                    0.000 s
+     Back write done: c                                                     0.000 s
    c  Compilation done                                                      0.000 s
       Final compilation done                                                0.000 s

--- a/compiler/acton/test/rebuild/golden/project_08-change-b-impl.golden
+++ b/compiler/acton/test/rebuild/golden/project_08-change-b-impl.golden
@@ -11,6 +11,22 @@ Resolving dependencies (fetching if missing)...
            G_init : () -> None
            get : () -> int
   Stale c: impl changes in b.baa HASH1 → HASH2 (used by main)
+     Back normalize done: b                                                 0.000 s
+     Back deactorize done: b                                                0.000 s
+     Back cps done: b                                                       0.000 s
+     Back llift done: b                                                     0.000 s
+     Back boxing done: b                                                    0.000 s
+     Back codegen done: b                                                   0.000 s
+     Back render done: b                                                    0.000 s
+     Back write done: b                                                     0.000 s
    b  Compilation done                                                      0.000 s
+     Back normalize done: c                                                 0.000 s
+     Back deactorize done: c                                                0.000 s
+     Back cps done: c                                                       0.000 s
+     Back llift done: c                                                     0.000 s
+     Back boxing done: c                                                    0.000 s
+     Back codegen done: c                                                   0.000 s
+     Back render done: c                                                    0.000 s
+     Back write done: c                                                     0.000 s
    c  Compilation done                                                      0.000 s
       Final compilation done                                                0.000 s

--- a/compiler/acton/test/rebuild/golden/project_10-change-a-iface.golden
+++ b/compiler/acton/test/rebuild/golden/project_10-change-a-iface.golden
@@ -17,7 +17,31 @@ Resolving dependencies (fetching if missing)...
   Stale c: pub changes in b.baa HASH1 → HASH2 (used by main)
   Hash deltas c: ~main{impl HASH1 -> HASH2}
    c  Type check done                                                       0.000 s
+     Back normalize done: a                                                 0.000 s
+     Back deactorize done: a                                                0.000 s
+     Back cps done: a                                                       0.000 s
+     Back llift done: a                                                     0.000 s
+     Back boxing done: a                                                    0.000 s
+     Back codegen done: a                                                   0.000 s
+     Back render done: a                                                    0.000 s
+     Back write done: a                                                     0.000 s
    a  Compilation done                                                      0.000 s
+     Back normalize done: b                                                 0.000 s
+     Back deactorize done: b                                                0.000 s
+     Back cps done: b                                                       0.000 s
+     Back llift done: b                                                     0.000 s
+     Back boxing done: b                                                    0.000 s
+     Back codegen done: b                                                   0.000 s
+     Back render done: b                                                    0.000 s
+     Back write done: b                                                     0.000 s
    b  Compilation done                                                      0.000 s
+     Back normalize done: c                                                 0.000 s
+     Back deactorize done: c                                                0.000 s
+     Back cps done: c                                                       0.000 s
+     Back llift done: c                                                     0.000 s
+     Back boxing done: c                                                    0.000 s
+     Back codegen done: c                                                   0.000 s
+     Back render done: c                                                    0.000 s
+     Back write done: c                                                     0.000 s
    c  Compilation done                                                      0.000 s
       Final compilation done                                                0.000 s

--- a/compiler/acton/test/rebuild/golden/project_11-change-b-doc.golden
+++ b/compiler/acton/test/rebuild/golden/project_11-change-b-doc.golden
@@ -11,5 +11,13 @@ Resolving dependencies (fetching if missing)...
            G_init : () -> None
            get : () -> int
   Fresh c: using cached .ty
+     Back normalize done: b                                                 0.000 s
+     Back deactorize done: b                                                0.000 s
+     Back cps done: b                                                       0.000 s
+     Back llift done: b                                                     0.000 s
+     Back boxing done: b                                                    0.000 s
+     Back codegen done: b                                                   0.000 s
+     Back render done: b                                                    0.000 s
+     Back write done: b                                                     0.000 s
    b  Compilation done                                                      0.000 s
       Final compilation done                                                0.000 s

--- a/compiler/acton/test/rebuild/golden/project_12-codegen-stale.golden
+++ b/compiler/acton/test/rebuild/golden/project_12-codegen-stale.golden
@@ -2,5 +2,13 @@ Resolving dependencies (fetching if missing)...
   Fresh a: using cached .ty
   Stale b: generated code out of date {impl c missing -> HASH2, h missing -> HASH2}
   Fresh c: using cached .ty
+     Back normalize done: b                                                 0.000 s
+     Back deactorize done: b                                                0.000 s
+     Back cps done: b                                                       0.000 s
+     Back llift done: b                                                     0.000 s
+     Back boxing done: b                                                    0.000 s
+     Back codegen done: b                                                   0.000 s
+     Back render done: b                                                    0.000 s
+     Back write done: b                                                     0.000 s
    b  Compilation done                                                      0.000 s
       Final compilation done                                                0.000 s

--- a/compiler/acton/test_incremental.hs
+++ b/compiler/acton/test_incremental.hs
@@ -14,9 +14,9 @@ import           Data.Bits (shiftL, (.|.))
 import           Data.Word (Word64)
 import qualified Acton.Fingerprint as Fingerprint
 import qualified Crypto.Hash.SHA256 as SHA256
-import           Data.List (find, partition, sort)
+import           Data.List (elemIndex, find, partition, sort, sortOn)
 import qualified Data.Map.Strict as M
-import           Data.Maybe (isJust)
+import           Data.Maybe (fromMaybe, isJust)
 import           System.Directory
 import           System.Exit
 import           System.FilePath
@@ -185,16 +185,28 @@ sanitize = LBS.fromStrict
     reorderBackLines ls =
       let (backLines, otherLines) = partition isBackLine ls
           (pre, post) = break isFinalLine otherLines
-      in pre ++ sort backLines ++ post
+      in pre ++ sortOn backLineKey backLines ++ post
       where
         isBackLine t =
           T.isPrefixOf "   Finished compilation of" t ||
-          (T.isInfixOf "Compilation done" t && not (isFinalLine t))
+          (T.isInfixOf "Compilation done" t && not (isFinalLine t)) ||
+          isBackPassLine t
         isFinalLine t =
           T.isPrefixOf "   Finished final compilation" t ||
           T.isPrefixOf "   Finished final compilation step" t ||
           T.isInfixOf "Final compilation done" t ||
           T.isPrefixOf "  Skipping final build step" t
+        isBackPassLine t =
+          case T.words t of
+            ("Back":_:"done:":_:_) -> True
+            _ -> False
+        backLineKey t =
+          case T.words t of
+            ("Back":pass:"done:":mn:_) -> (mn, passIndex pass, t)
+            (mn:"Compilation":"done":_) -> (mn, 100 :: Int, t)
+            _ -> (t, 101, t)
+        passIndex pass = fromMaybe 99 (pass `elemIndex` backPassOrder)
+        backPassOrder = ["normalize", "deactorize", "cps", "llift", "boxing", "codegen", "render", "write"]
 
 -- | Atomically write UTF-8 text to a file.
 writeFileUtf8 :: FilePath -> T.Text -> IO ()

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -93,6 +93,9 @@ module Acton.Compile
   , TypeStmtTiming(..)
   , InferredSignature(..)
   , BackTiming(..)
+  , BackPass(..)
+  , BackPassProgress(..)
+  , backPassName
   , FrontPass(..)
   , FrontPassProgress(..)
   , ParseProgress(..)
@@ -304,6 +307,33 @@ data BackJobResult
   | BackJobFailed BackPassFailure
   deriving (Eq, Show)
 
+data BackPass
+  = BackPassNormalize
+  | BackPassDeactorize
+  | BackPassCPS
+  | BackPassLLift
+  | BackPassBoxing
+  | BackPassCodeGen
+  | BackPassRender
+  | BackPassWrite
+  deriving (Eq, Show)
+
+backPassName :: BackPass -> String
+backPassName BackPassNormalize  = "normalize"
+backPassName BackPassDeactorize = "deactorize"
+backPassName BackPassCPS        = "cps"
+backPassName BackPassLLift      = "llift"
+backPassName BackPassBoxing     = "boxing"
+backPassName BackPassCodeGen    = "codegen"
+backPassName BackPassRender     = "render"
+backPassName BackPassWrite      = "write"
+
+data BackPassProgress
+  = BackPassStarted BackPass Int Int
+  | BackPassFinished BackPass Int Int TimeSpec
+  | BackPassSkipped BackPass Int Int
+  deriving (Eq, Show)
+
 data FrontPass
   = FrontPassKinds
   | FrontPassTypes
@@ -348,7 +378,8 @@ data BackTiming = BackTiming
   , btLLift :: TimeSpec
   , btBoxing :: TimeSpec
   , btCodeGen :: TimeSpec
-  , btWriteCode :: Maybe TimeSpec
+  , btRender :: TimeSpec
+  , btWrite :: Maybe TimeSpec
   } deriving (Eq, Show)
 
 
@@ -383,6 +414,7 @@ defaultCompileCallbacks = CompileCallbacks
 
 data BackJobCallbacks = BackJobCallbacks
   { bjcOnStart :: BackJob -> IO ()
+  , bjcOnProgress :: BackJob -> BackPassProgress -> IO ()
   , bjcOnDone :: BackJob -> BackJobResult -> IO ()
   }
 
@@ -391,6 +423,7 @@ defaultBackJobCallbacks :: BackJobCallbacks
 defaultBackJobCallbacks =
   BackJobCallbacks
     { bjcOnStart = \_ -> return ()
+    , bjcOnProgress = \_ _ -> return ()
     , bjcOnDone = \_ _ -> return ()
     }
 
@@ -477,7 +510,10 @@ newBackQueue genRef gopts maxPar = do
                       currentWrite <- readIORef genRef
                       return (currentWrite == gen)
                 bjcOnStart callbacks job
-                res <- (try $ runBackPasses gopts (bjOpts job) (bjPaths job) (bjInput job) shouldWrite)
+                res <- (try $
+                          runBackPassesWithProgress
+                            gopts (bjOpts job) (bjPaths job) (bjInput job)
+                            shouldWrite (bjcOnProgress callbacks job))
                         :: IO (Either SomeException (Maybe TimeSpec, Maybe BackTiming))
                 currentDone <- readIORef genRef
                 when (currentDone == gen) $
@@ -664,6 +700,7 @@ data CompileHooks = CompileHooks
   , chOnFrontResult :: GlobalTask -> FrontResult -> IO ()
   , chOnBackQueued :: TaskKey -> Bool -> IO ()
   , chOnBackStart :: BackJob -> IO ()
+  , chOnBackProgress :: BackJob -> BackPassProgress -> IO ()
   , chOnBackDone :: BackJob -> BackJobResult -> IO ()
   , chOnInfo :: String -> IO ()
   }
@@ -681,6 +718,7 @@ defaultCompileHooks =
     , chOnFrontResult = \_ _ -> return ()
     , chOnBackQueued = \_ _ -> return ()
     , chOnBackStart = \_ -> return ()
+    , chOnBackProgress = \_ _ -> return ()
     , chOnBackDone = \_ _ -> return ()
     , chOnInfo = \_ -> return ()
     }
@@ -700,6 +738,7 @@ runCompilePlan sp gopts plan sched gen hooks = do
       backQueue = csBackQueue sched
       backCallbacks = BackJobCallbacks
         { bjcOnStart = chOnBackStart hooks
+        , bjcOnProgress = chOnBackProgress hooks
         , bjcOnDone = chOnBackDone hooks
         }
       callbacks = defaultCompileCallbacks
@@ -1933,51 +1972,63 @@ runFrontPasses gopts opts paths env0 parsed srcContent srcBytes sourceMeta resol
 -- Executes normalization through codegen, writes .c/.h output as needed, and
 -- returns the back-pass elapsed time for logging.
 runBackPasses :: C.GlobalOptions -> C.CompileOptions -> Paths -> BackInput -> IO Bool -> IO (Maybe TimeSpec, Maybe BackTiming)
-runBackPasses gopts opts paths backInput shouldWrite = do
+runBackPasses gopts opts paths backInput shouldWrite =
+      runBackPassesWithProgress gopts opts paths backInput shouldWrite (\_ -> return ())
+
+runBackPassesWithProgress :: C.GlobalOptions
+                          -> C.CompileOptions
+                          -> Paths
+                          -> BackInput
+                          -> IO Bool
+                          -> (BackPassProgress -> IO ())
+                          -> IO (Maybe TimeSpec, Maybe BackTiming)
+runBackPassesWithProgress gopts opts paths backInput shouldWrite onProgress = do
       let mn = A.modname (biTypedMod backInput)
           outbase = outBase paths mn
           relSrcBase = makeRelative (projPath paths) (srcBase paths mn)
+          writesOutput = not (altOutput opts)
+          backPasses =
+            [ BackPassNormalize
+            , BackPassDeactorize
+            , BackPassCPS
+            , BackPassLLift
+            , BackPassBoxing
+            , BackPassCodeGen
+            , BackPassRender
+            ] ++ [BackPassWrite | writesOutput]
+          backPassTotal = length backPasses
+          backPassIndex pass =
+            case Data.List.elemIndex pass backPasses of
+              Just ix -> ix
+              Nothing -> backPassTotal
+          emitStarted pass =
+            onProgress (BackPassStarted pass (backPassIndex pass) backPassTotal)
+          emitFinished pass t0 t1 =
+            onProgress (BackPassFinished pass (backPassIndex pass + 1) backPassTotal (t1 - t0))
+          emitSkipped pass =
+            onProgress (BackPassSkipped pass (backPassIndex pass + 1) backPassTotal)
       timeStart <- getTime Monotonic
-      writeTimingRef <- newIORef Nothing
-
-      (normalized, normEnv) <- Acton.Normalizer.normalize (biTypeEnv backInput) (biTypedMod backInput)
-      iff (C.norm opts && mn == (modName paths)) $ dump mn "norm" (Pretty.print normalized)
-      timeNormalized <- getTime Monotonic
-
-      (deacted,deactEnv) <- Acton.Deactorizer.deactorize normEnv normalized
-      iff (C.deact opts && mn == (modName paths)) $ dump mn "deact" (Pretty.print deacted)
-      timeDeactorizer <- getTime Monotonic
-
-      (cpstyled,cpsEnv) <- Acton.CPS.convert deactEnv deacted
-      iff (C.cps opts && mn == (modName paths)) $ dump mn "cps" (Pretty.print cpstyled)
-      timeCPS <- getTime Monotonic
-
-      (lifted,liftEnv) <- Acton.LambdaLifter.liftModule cpsEnv cpstyled
-      iff (C.llift opts && mn == (modName paths)) $ dump mn "llift" (Pretty.print lifted)
-      timeLLift <- getTime Monotonic
-
-      boxed <- Acton.Boxing.doBoxing liftEnv lifted
-      iff (C.box opts && mn == (modName paths)) $ dump mn "box" (Pretty.print boxed)
-      timeBoxing <- getTime Monotonic
-
-      let hexHash = B.unpack $ Base16.encode (biImplHash backInput)
-          emitLines = not (C.dbg_no_lines opts)
-      (n,h,c) <- Acton.CodeGen.generate liftEnv relSrcBase (biSrc backInput) emitLines boxed hexHash
-      timeCodeGen <- getTime Monotonic
-      let finish = do
+      let timedBackPass pass action = do
+            emitStarted pass
+            passStart <- getTime Monotonic
+            result <- action
+            passEnd <- getTime Monotonic
+            emitFinished pass passStart passEnd
+            return (result, passEnd - passStart)
+          finish tNormalize tDeactorize tCPS tLLift tBoxing tCodeGen tRender mWriteTime = do
             timeEnd <- getTime Monotonic
             let backTime = timeEnd - timeStart
-            mWriteTime <- readIORef writeTimingRef
             let backTimingMaybe =
                   if C.timing gopts
                     then Just BackTiming
-                           { btNormalize = timeNormalized - timeStart
-                           , btDeactorize = timeDeactorizer - timeNormalized
-                           , btCPS = timeCPS - timeDeactorizer
-                           , btLLift = timeLLift - timeCPS
-                           , btBoxing = timeBoxing - timeLLift
-                           , btCodeGen = timeCodeGen - timeBoxing
-                           , btWriteCode = mWriteTime
+                           { btNormalize = tNormalize
+                           , btDeactorize = tDeactorize
+                           , btCPS = tCPS
+                           , btLLift = tLLift
+                           , btBoxing = tBoxing
+                           , btCodeGen = tCodeGen
+                           , btRender = tRender
+                           , btWrite = mWriteTime
                            }
                     else Nothing
             if not (quiet gopts opts)
@@ -1985,35 +2036,71 @@ runBackPasses gopts opts paths backInput shouldWrite = do
               else return (Nothing, backTimingMaybe)
           forceOut s = evaluate (rnf s)
 
+      ((normalized, normEnv), tNormalize) <- timedBackPass BackPassNormalize $ do
+        res@(normalized', _) <- Acton.Normalizer.normalize (biTypeEnv backInput) (biTypedMod backInput)
+        iff (C.norm opts && mn == (modName paths)) $ dump mn "norm" (Pretty.print normalized')
+        return res
+
+      ((deacted,deactEnv), tDeactorize) <- timedBackPass BackPassDeactorize $ do
+        res@(deacted', _) <- Acton.Deactorizer.deactorize normEnv normalized
+        iff (C.deact opts && mn == (modName paths)) $ dump mn "deact" (Pretty.print deacted')
+        return res
+
+      ((cpstyled,cpsEnv), tCPS) <- timedBackPass BackPassCPS $ do
+        res@(cpstyled', _) <- Acton.CPS.convert deactEnv deacted
+        iff (C.cps opts && mn == (modName paths)) $ dump mn "cps" (Pretty.print cpstyled')
+        return res
+
+      ((lifted,liftEnv), tLLift) <- timedBackPass BackPassLLift $ do
+        res@(lifted', _) <- Acton.LambdaLifter.liftModule cpsEnv cpstyled
+        iff (C.llift opts && mn == (modName paths)) $ dump mn "llift" (Pretty.print lifted')
+        return res
+
+      (boxed, tBoxing) <- timedBackPass BackPassBoxing $ do
+        res <- Acton.Boxing.doBoxing liftEnv lifted
+        iff (C.box opts && mn == (modName paths)) $ dump mn "box" (Pretty.print res)
+        return res
+
+      ((_,h,c), tCodeGen) <- timedBackPass BackPassCodeGen $ do
+        let hexHash = B.unpack $ Base16.encode (biImplHash backInput)
+            emitLines = not (C.dbg_no_lines opts)
+        Acton.CodeGen.generate liftEnv relSrcBase (biSrc backInput) emitLines boxed hexHash
+
+      let finishBack = finish tNormalize tDeactorize tCPS tLLift tBoxing tCodeGen
       if C.hgen opts
         then do
-          forceOut h
+          (_, tRender) <- timedBackPass BackPassRender (forceOut h)
           putStrLn h
-          finish
+          finishBack tRender Nothing
         else if C.cgen opts
           then do
-            forceOut c
+            (_, tRender) <- timedBackPass BackPassRender (forceOut c)
             putStrLn c
-            finish
+            finishBack tRender Nothing
           else do
-            forceOut h
-            forceOut c
-            iff (not (altOutput opts)) (do
-                ok <- shouldWrite
-                when ok $ do
-                  let cFile = outbase ++ ".c"
-                      hFile = outbase ++ ".h"
-
-                  writeFile hFile h
-                  writeFile cFile c
-                  let tyFileName = modNameToString(modName paths) ++ ".ty"
-                  iff (C.ty opts) $
-                       copyFileWithMetadata (joinPath [projTypes paths, tyFileName]) (joinPath [srcDir paths, tyFileName])
-
-                  timeCodeWrite <- getTime Monotonic
-                  writeIORef writeTimingRef (Just (timeCodeWrite - timeCodeGen))
-                                     )
-            finish
+            (_, tRender) <- timedBackPass BackPassRender (forceOut h >> forceOut c)
+            mWriteTime <-
+              if not writesOutput
+                then return Nothing
+                else do
+                  ok <- shouldWrite
+                  if not ok
+                    then do
+                      emitSkipped BackPassWrite
+                      return Nothing
+                    else do
+                      (_, tWrite) <- timedBackPass BackPassWrite $ do
+                        let cFile = outbase ++ ".c"
+                            hFile = outbase ++ ".h"
+                        writeFile hFile h
+                        writeFile cFile c
+                        let tyFileName = modNameToString(modName paths) ++ ".ty"
+                        iff (C.ty opts) $
+                             copyFileWithMetadata
+                               (joinPath [projTypes paths, tyFileName])
+                               (joinPath [srcDir paths, tyFileName])
+                      return (Just tWrite)
+            finishBack tRender mWriteTime
 
 
 -- | Compile a set of GlobalTasks using a parallel, dependency-aware scheduler.

--- a/compiler/lsp-server/Main.hs
+++ b/compiler/lsp-server/Main.hs
@@ -536,6 +536,12 @@ backProgressMessage job result =
       Compile.BackJobOk{} -> "Generated " ++ backJobLabel job
       Compile.BackJobFailed{} -> "Codegen failed for " ++ backJobLabel job
 
+backPassProgressMessage :: Compile.BackJob -> Compile.BackPassProgress -> Maybe T.Text
+backPassProgressMessage job (Compile.BackPassStarted pass _ _) =
+  Just $
+    T.pack ("Generating " ++ backJobLabel job ++ " (" ++ Compile.backPassName pass ++ ")")
+backPassProgressMessage _ _ = Nothing
+
 warnBackgroundCompilerLocked :: FilePath -> LspM () ()
 warnBackgroundCompilerLocked projRoot = do
   first <- liftIO $ atomicModifyIORef' backgroundCompilerWarnedRef $ \m ->
@@ -678,6 +684,8 @@ runCompilePlanWithHooks gen rootProj path sp gopts opts progress = do
             progressForQueued (T.pack ("Checked " ++ moduleLabel t))
         , Compile.chOnBackStart = \job ->
             progressForQueued (T.pack ("Generating " ++ backJobLabel job))
+        , Compile.chOnBackProgress = \job p ->
+            forM_ (backPassProgressMessage job p) progressForQueued
         , Compile.chOnBackDone = \job result ->
             progressForQueued (backProgressMessage job result)
         , Compile.chOnInfo = \_ -> return ()


### PR DESCRIPTION
Back-pass work used to appear as one opaque per-module task until the whole back job finished. Add explicit back-pass progress events for normalize, deactorize, CPS, lambda lifting, boxing, codegen, render, and write so CLI and LSP users can see which pass is currently running.

Use the same events to print per-pass elapsed times under --timing or --verbose. Keep the existing final Back timing summary, but split the old write bucket into render and write so lazy generated C/H rendering is not reported as filesystem IO.