### PR TITLE
Add compiler benchmark and avoid redundant CodeGen type rendering

### DIFF
--- a/compiler/lib/bench/CompilerBench.hs
+++ b/compiler/lib/bench/CompilerBench.hs
@@ -1,0 +1,243 @@
+import qualified Acton.CommandLineParser as C
+import qualified Acton.Compile as Compile
+import qualified Acton.Env as Env
+import qualified Acton.Kinds as Kinds
+import qualified Acton.NameInfo as NameInfo
+import qualified Acton.Parser as Parser
+import qualified Acton.Syntax as Syntax
+import qualified Acton.Types as Types
+
+import Control.DeepSeq (rnf)
+import qualified Control.Exception as E
+import Control.Monad (forM_)
+import qualified Data.ByteString.Char8 as B
+import qualified Data.HashMap.Strict as HashMap
+import qualified Data.Map as Map
+import Data.Time.Clock (diffUTCTime, getCurrentTime)
+import GHC.Stats
+import System.Clock (TimeSpec, toNanoSecs)
+import System.Environment (getArgs)
+import System.FilePath (takeDirectory)
+import System.IO (BufferMode(LineBuffering), hSetBuffering, stdout)
+import qualified InterfaceFiles
+
+-- Usage:
+--   stack build libacton:exe:compiler-bench
+--   stack exec compiler-bench -- --parse TYPES_PATH SOURCE.act +RTS -T -RTS
+--   stack exec compiler-bench -- --kinds TYPES_PATH SOURCE.act +RTS -T -RTS
+--   stack exec compiler-bench -- --types TYPES_PATH SOURCE.act +RTS -T -RTS
+--   stack exec compiler-bench -- --front TYPES_PATH SOURCE.act +RTS -T -RTS
+--   stack exec compiler-bench -- --front-docs TYPES_PATH SOURCE.act +RTS -T -RTS
+--   stack exec compiler-bench -- --pipeline TYPES_PATH SOURCE.act +RTS -T -RTS
+--
+-- The direct modes stop after the named pass. --front runs the normal compiler
+-- front pass without docs, --front-docs includes project front-pass work such
+-- as docs, and --pipeline runs front plus back passes.
+
+data DirectMode = ParseOnly | KindsOnly | TypesOnly
+
+elapsed label t0 t1 = putStrLn $ label ++ " " ++ show (diffUTCTime t1 t0)
+
+printStats label before after =
+    putStrLn $ label ++ " alloc " ++ show alloc
+                    ++ " copied " ++ show copied
+                    ++ " max_live " ++ show (max_live_bytes after)
+                    ++ " max_mem " ++ show (max_mem_in_use_bytes after)
+                    ++ " gc_elapsed " ++ show gcElapsed
+                    ++ " gcs " ++ show collections
+  where alloc = allocated_bytes after - allocated_bytes before
+        copied = copied_bytes after - copied_bytes before
+        gcElapsed = gc_elapsed_ns after - gc_elapsed_ns before
+        collections = gcs after - gcs before
+
+getStats enabled =
+    if enabled then Just <$> getRTSStats else return Nothing
+
+printStatsMaybe label (Just before) (Just after) = printStats label before after
+printStatsMaybe _ _ _                            = return ()
+
+forceHTEnv = HashMap.foldl' forceHNameInfo () where
+    forceHNameInfo () (NameInfo.HNModule _ te _) = forceHTEnv te
+    forceHNameInfo () hni                        = hni `seq` ()
+
+fmtTime :: TimeSpec -> String
+fmtTime t = show seconds ++ "s"
+  where seconds = (fromIntegral (toNanoSecs t) / 1000000000.0 :: Double)
+
+printFrontTiming :: Compile.FrontTiming -> IO ()
+printFrontTiming ft =
+    putStrLn $ "front_timing env " ++ fmtTime (Compile.ftEnv ft)
+            ++ " kinds " ++ fmtTime (Compile.ftKinds ft)
+            ++ " types " ++ fmtTime (Compile.ftTypes ft)
+
+printBackTiming :: Compile.BackTiming -> IO ()
+printBackTiming bt =
+    putStrLn $ "back_timing normalize " ++ fmtTime (Compile.btNormalize bt)
+            ++ " deactorize " ++ fmtTime (Compile.btDeactorize bt)
+            ++ " cps " ++ fmtTime (Compile.btCPS bt)
+            ++ " llift " ++ fmtTime (Compile.btLLift bt)
+            ++ " boxing " ++ fmtTime (Compile.btBoxing bt)
+            ++ " codegen " ++ fmtTime (Compile.btCodeGen bt)
+            ++ " render " ++ fmtTime (Compile.btRender bt)
+            ++ maybe "" (\t -> " write " ++ fmtTime t) (Compile.btWrite bt)
+
+sysRootFromTypesPath :: FilePath -> FilePath
+sysRootFromTypesPath = takeDirectory . takeDirectory . takeDirectory
+
+benchGopts :: C.GlobalOptions
+benchGopts = C.GlobalOptions
+    { C.color = C.Never
+    , C.quiet = False
+    , C.noProgress = True
+    , C.timing = True
+    , C.tty = False
+    , C.verbose = False
+    , C.verboseZig = False
+    , C.jobs = 0
+    }
+
+benchOpts :: FilePath -> Bool -> C.CompileOptions
+benchOpts typesPath skipBuild =
+    Compile.defaultCompileOptions
+      { C.ignore_compiler_version = True
+      , C.skip_build = skipBuild
+      , C.syspath = sysRootFromTypesPath typesPath
+      }
+
+nameHashMapFromHeader :: [InterfaceFiles.NameHashInfo] -> Map.Map Syntax.Name InterfaceFiles.NameHashInfo
+nameHashMapFromHeader infos =
+    Map.fromList [ (InterfaceFiles.nhName info, info) | info <- infos ]
+
+resolveNameHashMap :: Compile.Paths -> Syntax.ModName -> IO (Maybe (Map.Map Syntax.Name InterfaceFiles.NameHashInfo))
+resolveNameHashMap paths mn = do
+    mty <- Env.findTyFile (Compile.searchPath paths) mn
+    case mty of
+      Nothing -> return Nothing
+      Just ty -> do
+        mh <- InterfaceFiles.readHeaderMaybe ty
+        return $ case mh of
+          Just (_, _, _, _, _, nameHashes, _, _, _) -> Just (nameHashMapFromHeader nameHashes)
+          Nothing -> Nothing
+
+runDirect :: DirectMode -> FilePath -> FilePath -> IO ()
+runDirect mode typesPath sourcePath = do
+    statsEnabled <- getRTSStatsEnabled
+    src <- readFile sourcePath
+    let opts = benchOpts typesPath True
+    paths <- Compile.findPaths sourcePath opts
+    env0 <- Env.initEnv typesPath False
+    let modName = Compile.modName paths
+
+    s0 <- getStats statsEnabled
+    t0 <- getCurrentTime
+    parsed <- Parser.parseModule modName sourcePath src Nothing
+    E.evaluate (rnf parsed)
+    t1 <- getCurrentTime
+    s1 <- getStats statsEnabled
+    elapsed "parse" t0 t1
+    printStatsMaybe "parse_stats" s0 s1
+
+    case mode of
+      ParseOnly -> return ()
+      _ -> do
+        env <- Env.mkEnv [typesPath] env0 parsed
+        E.evaluate (forceHTEnv (Env.hnames env))
+        E.evaluate (forceHTEnv (Env.hmodules env))
+        t2 <- getCurrentTime
+        s2 <- getStats statsEnabled
+        elapsed "env" t1 t2
+        printStatsMaybe "env_stats" s1 s2
+
+        kchecked <- Kinds.check env parsed
+        E.evaluate (rnf kchecked)
+        t3 <- getCurrentTime
+        s3 <- getStats statsEnabled
+        elapsed "kinds" t2 t3
+        printStatsMaybe "kinds_stats" s2 s3
+
+        case mode of
+          KindsOnly -> return ()
+          _ -> do
+            (nmod, tchecked, typeEnv, tests) <- Types.reconstruct Nothing Nothing env kchecked
+            E.evaluate (rnf nmod)
+            E.evaluate (rnf tchecked)
+            E.evaluate (forceHTEnv (Env.hnames typeEnv))
+            E.evaluate (forceHTEnv (Env.hmodules typeEnv))
+            E.evaluate (length tests)
+            t4 <- getCurrentTime
+            s4 <- getStats statsEnabled
+            elapsed "types" t3 t4
+            printStatsMaybe "types_stats" s3 s4
+
+runCompilerFront :: Bool -> Bool -> FilePath -> FilePath -> IO ()
+runCompilerFront buildFront runBack typesPath sourcePath = do
+    statsEnabled <- getRTSStatsEnabled
+    src <- readFile sourcePath
+    srcBytes <- B.readFile sourcePath
+    let opts = benchOpts typesPath (not buildFront)
+    paths <- Compile.findPaths sourcePath opts
+    env0 <- Env.initEnv typesPath False
+    let modName = Compile.modName paths
+
+    s0 <- getStats statsEnabled
+    t0 <- getCurrentTime
+    parsed <- Parser.parseModule modName sourcePath src Nothing
+    E.evaluate (rnf parsed)
+    t1 <- getCurrentTime
+    s1 <- getStats statsEnabled
+    elapsed "parse" t0 t1
+    printStatsMaybe "parse_stats" s0 s1
+
+    res <- Compile.runFrontPasses
+      benchGopts
+      opts
+      paths
+      env0
+      parsed
+      src
+      srcBytes
+      Nothing
+      (Compile.getPubHashCached paths)
+      (resolveNameHashMap paths)
+      (\_ -> return ())
+    fr <- case res of
+            Left diags -> error ("front pass failed with " ++ show (length diags) ++ " diagnostics")
+            Right fr -> return fr
+    E.evaluate (length (Compile.frIfaceTE fr) + length (Compile.frImps fr) + length (Compile.frNameHashes fr))
+    t2 <- getCurrentTime
+    s2 <- getStats statsEnabled
+    elapsed "front" t1 t2
+    printStatsMaybe "front_stats" s1 s2
+    forM_ (Compile.frFrontTiming fr) printFrontTiming
+
+    case (runBack, Compile.frBackJob fr) of
+      (True, Just job) -> do
+        s3 <- getStats statsEnabled
+        t3 <- getCurrentTime
+        (_mtime, mtiming) <- Compile.runBackPasses benchGopts (Compile.bjOpts job) (Compile.bjPaths job) (Compile.bjInput job) (return True)
+        t4 <- getCurrentTime
+        s4 <- getStats statsEnabled
+        elapsed "back" t3 t4
+        printStatsMaybe "back_stats" s3 s4
+        forM_ mtiming printBackTiming
+      (True, Nothing) -> error "front pass did not return a back job"
+      (False, _) -> return ()
+
+main = do
+    hSetBuffering stdout LineBuffering
+    args <- getArgs
+    case args of
+      ["--parse", typesPath, sourcePath] ->
+        runDirect ParseOnly typesPath sourcePath
+      ["--kinds", typesPath, sourcePath] ->
+        runDirect KindsOnly typesPath sourcePath
+      ["--types", typesPath, sourcePath] ->
+        runDirect TypesOnly typesPath sourcePath
+      ["--front", typesPath, sourcePath] ->
+        runCompilerFront False False typesPath sourcePath
+      ["--front-docs", typesPath, sourcePath] ->
+        runCompilerFront True False typesPath sourcePath
+      ["--pipeline", typesPath, sourcePath] ->
+        runCompilerFront True True typesPath sourcePath
+      _ ->
+        error "usage: compiler-bench (--parse|--kinds|--types|--front|--front-docs|--pipeline) TYPES_PATH SOURCE.act"

--- a/compiler/lib/package.yaml.in
+++ b/compiler/lib/package.yaml.in
@@ -105,6 +105,16 @@ tests:
       - -with-rtsopts=-N
 
 executables:
+  compiler-bench:
+    main: CompilerBench.hs
+    source-dirs: bench
+    other-modules: []
+    dependencies:
+      - libacton
+    ghc-options:
+      - -threaded
+      - -rtsopts
+      - '"-with-rtsopts=-N -A64M"'
   kinds-bench:
     main: KindsBench.hs
     source-dirs: bench

--- a/compiler/lib/src/Acton/CodeGen.hs
+++ b/compiler/lib/src/Acton/CodeGen.hs
@@ -810,6 +810,7 @@ targetType env e                    = typeOf env e                  -- Must be a
 dotCast env ent ts (Var _ x) n
   | GName m _ <- x, m == mPrim      = id
 dotCast env ent ts e n
+  | t == t1                         = id
   | gen_t == gen env t1             = id
   | otherwise                       = parens . (parens gen_t <>)
   where t0                          = typeOf env e


### PR DESCRIPTION
Adds `compiler-bench`, a single benchmark driver for the compiler pass pipeline. It has explicit modes for:

- `--parse`
- `--kinds`
- `--types`
- `--front`
- `--front-docs`
- `--pipeline`

The existing `kinds-bench` and `types-bench` executables are left unchanged.

This also adds a small CodeGen shortcut: when the substituted attribute type is already equal to the schema type, skip rendering both C types just to compare their generated text.

Benchmark command:

```sh
stack --stack-yaml compiler/stack.yaml exec compiler-bench -- --pipeline dist/base/out/types test/compiler/concurrent_typecheck_class_heavy/src/concurrent_typecheck_class_heavy.act +RTS -T -RTS
```

Baseline `dfa2a0d51`:

```text
back 151.509806s
back_stats alloc 375909913064 copied 90217269504 max_live 12682724888 max_mem 37701550080 gc_elapsed 33190629000 gcs 429
back_timing normalize 0.0s deactorize 3.498941s cps 0.0s llift 37.071329s boxing 1.0e-6s codegen 0.0s render 106.575599s write 4.363918s
```

With CodeGen change `df294d233`:

```text
back 149.21808s
back_stats alloc 371523804920 copied 91507697392 max_live 13959974712 max_mem 38736494592 gc_elapsed 32594293000 gcs 424
back_timing normalize 0.0s deactorize 3.505019s cps 0.0s llift 36.910349s boxing 0.0s codegen 0.0s render 104.231845s write 4.570854s
```

The front pass fluctuated between runs, so the relevant signal for the CodeGen change is the back/render path and back allocation.

Checks run:

```sh
stack --stack-yaml compiler/stack.yaml build libacton:exe:compiler-bench libacton:exe:kinds-bench libacton:exe:types-bench
stack --stack-yaml compiler/stack.yaml exec compiler-bench -- --types dist/base/out/types test/compiler/hello/src/hello.act +RTS -T -RTS
stack --stack-yaml compiler/stack.yaml exec compiler-bench -- --pipeline dist/base/out/types test/compiler/hello/src/hello.act +RTS -T -RTS
```