### PR TITLE
Avoid CPS effect type instantiation

### DIFF
--- a/compiler/lib/src/Acton/CPS.hs
+++ b/compiler/lib/src/Acton/CPS.hs
@@ -278,7 +278,7 @@ kRef k ns x t                           = eLambda' [(x,t)] $ eCall (eVar k) (map
 
 fxCall env test (Call _ Async{} p k)    = False
 fxCall env test (Call _ e p k)          = test fx
-  where TFun _ fx _ _ _                 = typeOf env e
+  where TFun _ fx _ _ _                 = sctype $ fst $ schemaOf env e
 fxCall env test e                       = False
 
 contCall env e                          = fxCall env contFX e


### PR DESCRIPTION
## Summary

- Read CPS call effects through `schemaOf` instead of forcing the full callee type with `typeOf`.
- Dropped the typed-local initializer `QuickType` skip after review. That path can lose argument coercions because `genExp`/`qType` also rewrites call arguments with `qMatch`.

## Performance

Measured on the 61 MB `concurrent_typecheck_class_heavy` fixture with `out` cleared before each run:

```text
compiler-bench --pipeline dist/base/out/types test/compiler/concurrent_typecheck_class_heavy/src/concurrent_typecheck_class_heavy.act +RTS -T -A64M -RTS
```

The earlier combined numbers included the dropped QuickType commit and no longer apply. This is the current one-commit branch result compared with the previous baseline run from the compiler-bench head now merged to `main`.

```text
Baseline:
parse 10.655304s
front 347.252679s
front_timing env 0.0s kinds 5.467403s types 341.778869s
back 153.737079s
back_stats alloc 371524555088 copied 90198456432 max_live 12653155120 max_mem 37528535040 gc_elapsed 35213930000 gcs 424
back_timing normalize 0.0s deactorize 3.600145s cps 1.0e-6s llift 37.588621s boxing 0.0s codegen 1.0e-6s render 107.705677s write 4.842622s

CPS-only branch:
parse 10.01912s
front 342.031121s
front_timing env 1.0e-6s kinds 5.433949s types 336.579875s
back 168.719363s
back_stats alloc 369063478000 copied 90455088080 max_live 13566249416 max_mem 36836474880 gc_elapsed 41838148000 gcs 422
back_timing normalize 0.0s deactorize 3.987647s cps 1.0e-6s llift 40.53988s boxing 0.0s codegen 1.0e-6s render 119.530711s write 4.661106s
```

This run does not show a wall-time improvement for the remaining CPS-only change. Back allocation is slightly lower, but back wall time is worse in this sample.

## Check

```text
stack --stack-yaml compiler/stack.yaml build libacton:exe:compiler-bench
```