### PR TITLE
Split std into bundled project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -458,7 +458,7 @@ test-rts:
 test-rts-db:
 	$(MAKE) -C test
 
-test-stdlib: dist/bin/acton
+test-stdlib: dist/bin/acton dist/std
 	cd compiler && stack test acton --ta '-p "stdlib"'
 	$(MAKE) -C test tls-test-server
 	cd test/stdlib_tests && "$(ACTON)" test
@@ -467,14 +467,17 @@ online-tests: dist/bin/actonc
 	cd compiler && stack test acton:test_acton_online
 
 
-.PHONY: clean clean-all clean-base
-clean: clean-distribution clean-base
+.PHONY: clean clean-all clean-base clean-std
+clean: clean-distribution clean-base clean-std
 
 clean-all: clean clean-compiler
 	rm -rf $(ZIG_LOCAL_CACHE_DIR)
 
 clean-base:
 	rm -rf base/out
+
+clean-std:
+	rm -rf std/out
 
 # == DIST ==
 #
@@ -488,8 +491,16 @@ dist/backend%: backend/%
 .PHONY: dist/base
 dist/base: base base/.build base/__root.zig base/acton.zig base/build.zig base/build.zig.zon base/acton.zig dist/bin/actonc $(DEPS) dist/backend/Build.act
 	mkdir -p "$@" "$@/.build" "$@/out"
+	rm -rf "$@/src" "$@/out/types/std"
 	cp -a base/__root.zig base/Build.act base/acton.zig base/build.zig base/build.zig.zon base/builtin base/rts base/src dist/base/
 	cd dist/base && ../bin/actonc build --skip-build && rm -rf .build
+
+.PHONY: dist/std
+dist/std: std std/Build.act std/build.zig std/build.zig.zon dist/base dist/bin/actonc $(DEPS)
+	mkdir -p "$@" "$@/.build" "$@/out"
+	rm -rf "$@/src" "$@/out/types"
+	cp -a std/Build.act std/build.zig std/build.zig.zon std/src dist/std/
+	cd dist/std && ../bin/actonc build --skip-build && rm -rf .build
 
 # This does a little hack, first copying and then moving the file in place. This
 # is to avoid an error if the executable is currently running. cp tries to open
@@ -551,7 +562,7 @@ deps-download/$(ZIG_TARBALL):
 	$(CURL) -o $@ "$(ZIG_DOWNLOAD_URL)"
 
 .PHONY: distribution1 distribution clean-distribution
-distribution1: dist/base $(DIST_BACKEND_FILES) dist/builder $(DIST_BINS) $(DIST_ZIG)
+distribution1: dist/base dist/std $(DIST_BACKEND_FILES) dist/builder $(DIST_BINS) $(DIST_ZIG)
 	$(MAKE) $(DEPS)
 
 distribution: distribution1 dist/lldb/acton.py

--- a/base/__root.zig
+++ b/base/__root.zig
@@ -45,6 +45,14 @@ export fn base64Q_decode(data: *acton.bytes) callconv(.c) *acton.bytes {
     return res;
 }
 
+export fn stdQ_base64Q_encode(data: *acton.bytes) callconv(.c) *acton.bytes {
+    return base64Q_encode(data);
+}
+
+export fn stdQ_base64Q_decode(data: *acton.bytes) callconv(.c) *acton.bytes {
+    return base64Q_decode(data);
+}
+
 export fn zig_crypto_hash_md5_init() callconv(.c) *std.crypto.hash.Md5 {
     const alloc = gc.allocator();
     const hasher_ptr = alloc.create(std.crypto.hash.Md5) catch {

--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -2387,11 +2387,21 @@ genBuildZigFiles spec rootPins depOverrides paths depModuleOpts depPathOverrides
                      ]
         applyPins deps = M.mapWithKey (\n d -> M.findWithDefault d n rootPins) deps
         mergedSpec0 = normalizedSpec { BuildSpec.dependencies = applyPins (BuildSpec.dependencies normalizedSpec) `M.union` transPkgs }
-        mergedSpec = applyPkgDepPathOverrides projAbs depPathOverrides mergedSpec0
+        mergedSpec1 = applyPkgDepPathOverrides projAbs depPathOverrides mergedSpec0
+        mergedSpec = addImplicitStdDependency absSys mergedSpec1
         resolvedZigs = resolveZigDepRefs (M.keys (BuildSpec.dependencies mergedSpec)) (directZigs ++ transZigs)
         zonWithFp = replace "{{fingerprint}}" fp . replace "{{name}}" zonName
     writeFile buildZigPath (genBuildZig buildZigTemplate mergedSpec resolvedZigs depModuleOpts)
     writeFileAtomic buildZonPath (genBuildZigZon buildZonTemplate relSys depsRootAbs projAbs fp zonName mergedSpec resolvedZigs)
+
+addImplicitStdDependency :: FilePath -> BuildSpec.BuildSpec -> BuildSpec.BuildSpec
+addImplicitStdDependency sys spec
+  | BuildSpec.specName spec == "std" = spec
+  | M.member "std" deps = spec
+  | otherwise = spec { BuildSpec.dependencies = M.insert "std" stdDep deps }
+  where
+    deps = BuildSpec.dependencies spec
+    stdDep = BuildSpec.PkgDep Nothing Nothing (Just (joinPath [sys, "std"])) Nothing Nothing
 
 applyPkgDepPathOverrides :: FilePath -> M.Map String FilePath -> BuildSpec.BuildSpec -> BuildSpec.BuildSpec
 applyPkgDepPathOverrides projRoot depPathOverrides spec =
@@ -2518,6 +2528,8 @@ genBuildZig template spec zigDeps depModuleOpts =
       in unlines [ "    const actdep_" ++ name ++ " = b.dependency(\"" ++ name ++ "\", .{"
                  , "        .target = target,"
                  , "        .optimize = optimize,"
+                 , "        .no_threads = no_threads,"
+                 , "        .db = db,"
                  , "        .acton_modules = " ++ show selectedCsv ++ ","
                  , "        .acton_root_stubs = \"\","
                  , "    });"

--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -808,6 +808,35 @@ actonProjTests =
         testBuild "" ExitSuccess False "test/project/simple"
         testBuild "" ExitSuccess False "test/project/simple"
 
+  , testCase "project imports std.json" $ do
+        withSystemTempDirectory "acton-std-json-import" $ \tmp -> do
+          actonExe <- canonicalizePath "../../dist/bin/acton"
+          let proj = tmp </> "std_json_import"
+              mkFp name = Fingerprint.formatFingerprint
+                (Fingerprint.updateFingerprintPrefix
+                  (Fingerprint.fingerprintPrefixForName name) 1)
+          createDirectoryIfMissing True (proj </> "src")
+          writeFile (proj </> "Build.act") $ unlines
+            [ "name = \"std_json_import\""
+            , "fingerprint = " ++ mkFp "std_json_import"
+            ]
+          writeFile (proj </> "src" </> "main.act") $ unlines
+            [ "import std.json as json"
+            , ""
+            , "actor main(env):"
+            , "    print(json.encode({\"answer\": 42}))"
+            , "    env.exit(0)"
+            ]
+          (returnCode, cmdOut, cmdErr) <- readCreateProcessWithExitCode
+            (proc actonExe ["build", "--always-build", "--color", "never"]) { cwd = Just proj } ""
+          assertEqual ("project importing std.json should build\nstdout:\n" ++ cmdOut ++ "\nstderr:\n" ++ cmdErr)
+            ExitSuccess returnCode
+          (runCode, runOut, runErr) <- readCreateProcessWithExitCode
+            (proc (proj </> "out/bin/main") []) ""
+          assertEqual ("project importing std.json should run\nstdout:\n" ++ runOut ++ "\nstderr:\n" ++ runErr)
+            ExitSuccess runCode
+          assertEqual "std.json output" "{\"answer\":42}\n" runOut
+
   , testCase "with missing src/ dir" $ do
         testBuild "" (ExitFailure 1) False "test/project/missing_src"
 

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -2436,14 +2436,15 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
 
           checkMissingImports imps = do
             userSearchAbs <- mapM normalizePathSafe (C.searchpath optsT)
-            sysTypesAbs <- normalizePathSafe (sysTypes paths)
+            systemTypesAbs <- mapM normalizePathSafe (systemTypePaths (sysPath paths) (sysTypes paths))
             searchAbs <- mapM normalizePathSafe (searchPath paths)
             let userSearchSet = Data.Set.fromList (map normalise userSearchAbs)
+                systemTypeSet = Data.Set.fromList (map normalise systemTypesAbs)
                 managedTypeDirs =
                   [ p
                   | p <- searchAbs
                   , let pNorm = normalise p
-                  , pNorm /= normalise sysTypesAbs
+                  , Data.Set.notMember pNorm systemTypeSet
                   , Data.Set.notMember pNorm userSearchSet
                   ]
                 isUnder dir path =
@@ -3056,6 +3057,10 @@ data ProjCtx = ProjCtx {
                      projDeps     :: [(String, FilePath)]          -- resolved dependency roots (abs paths)
                    } deriving (Show)
 
+systemTypePaths :: FilePath -> FilePath -> [FilePath]
+systemTypePaths sys types =
+    [joinPath [sys, "std", "out", "types"], types]
+
 type FingerprintMap = M.Map String FilePath
 
 scratchBuildSpec :: FilePath -> BuildSpec.BuildSpec
@@ -3290,7 +3295,7 @@ findPaths actFile opts  = do execDir <- takeDirectory <$> getExecutablePath
                              -- join the search paths from command line options with the ones found in the deps directory
                              depOverrides <- normalizeDepOverrides projPath (C.dep_overrides opts)
                              depTypePaths <- if isTmp then return [] else collectDepTypePaths projPath depOverrides
-                             let sPaths = [projTypes] ++ depTypePaths ++ (C.searchpath opts) ++ [sysTypes]
+                             let sPaths = [projTypes] ++ depTypePaths ++ (C.searchpath opts) ++ systemTypePaths sysPath sysTypes
                              createDirectoryIfMissing True binDir
                              createDirectoryIfMissing True projOut
                              createDirectoryIfMissing True projTypes
@@ -3402,7 +3407,7 @@ pruneMissingChangedModuleOutputs ctxs changedPaths = do
 searchPathForProject :: C.CompileOptions -> M.Map FilePath ProjCtx -> ProjCtx -> [FilePath]
 searchPathForProject opts projMap ctx =
     let deps = depTypePathsFromMap projMap (projRoot ctx)
-    in [projTypesDir ctx] ++ deps ++ (C.searchpath opts) ++ [projSysTypes ctx]
+    in [projTypesDir ctx] ++ deps ++ (C.searchpath opts) ++ systemTypePaths (projSysPath ctx) (projSysTypes ctx)
 
 -- | Construct a Paths record for a module within a project context.
 -- Creates output directories and ensures the types directory exists.

--- a/std/Build.act
+++ b/std/Build.act
@@ -1,0 +1,17 @@
+name = "std"
+fingerprint = 0xa87a16a800000001
+
+zig_dependencies = {
+    "libpcre2": (
+        path="../deps/pcre2/"
+    ),
+    "libsnappy": (
+        path="../deps/libsnappy_c/"
+    ),
+    "libxml2": (
+        path="../deps/libxml2/"
+    ),
+    "libyyjson": (
+        path="../deps/libyyjson/"
+    )
+}

--- a/std/build.zig
+++ b/std/build.zig
@@ -1,0 +1,214 @@
+// Acton Standard Library Builder
+// Builds the generated C code for the std project.
+
+const std = @import("std");
+const print = @import("std").debug.print;
+const ArrayList = std.ArrayList;
+
+pub const FilePath = struct {
+    filename: []const u8,
+    full_path: []const u8,
+    dir: []const u8,
+    file_path: []const u8,
+};
+
+fn joinPath(allocator: std.mem.Allocator, base: []const u8, relative: []const u8) []const u8 {
+    const path = allocator.alloc(u8, base.len + relative.len + 1) catch @panic("OOM");
+    _ = std.fmt.bufPrint(path, "{s}/{s}", .{base, relative}) catch @panic("Error joining paths");
+    return path;
+}
+
+pub fn build(b: *std.Build) void {
+    const io = b.graph.io;
+    const buildroot_path = b.build_root.join(b.allocator, &.{}) catch unreachable;
+    const optimize = b.standardOptimizeOption(.{});
+    const target = b.standardTargetOptions(.{});
+    const db = b.option(bool, "db", "") orelse false;
+    const no_threads = b.option(bool, "no_threads", "") orelse false;
+
+    print("Acton Standard Library Builder\nBuilding in {s}\n", .{buildroot_path});
+
+    const actonbase_dep = b.dependency("base", .{
+        .target = target,
+        .optimize = optimize,
+        .no_threads = no_threads,
+        .db = db,
+    });
+
+    const dep_libpcre2 = b.dependency("libpcre2", .{
+        .target = target,
+        .optimize = optimize,
+        .linkage = .static,
+    });
+
+    const dep_libsnappy_c = b.dependency("libsnappy", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const dep_libxml2 = b.dependency("libxml2", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const dep_libyyjson = b.dependency("libyyjson", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    var iter_dir = b.build_root.handle.openDir(
+        io,
+        "out/types/",
+        .{
+            .iterate = true
+        },
+    ) catch |err| {
+        std.log.err("Error opening iterable dir: {}", .{err});
+        std.process.exit(1);
+    };
+
+    var c_files = ArrayList([]const u8).empty;
+    defer c_files.deinit(b.allocator);
+    var walker = iter_dir.walk(b.allocator) catch |err| {
+        std.log.err("Error walking dir: {}", .{err});
+        std.process.exit(1);
+    };
+    defer walker.deinit();
+
+    while (true) {
+        const next_result = walker.next(io) catch |err| {
+            std.log.err("Error getting next: {}", .{err});
+            std.process.exit(1);
+        };
+        if (next_result) |entry| {
+            if (entry.kind == .file and std.mem.endsWith(u8, entry.basename, ".c")) {
+                if (std.mem.endsWith(u8, entry.basename, ".root.c")) continue;
+                if (std.mem.endsWith(u8, entry.basename, ".test_root.c")) continue;
+
+                const file_path = std.fs.path.join(b.allocator, &.{ "out/types", entry.path }) catch |err| {
+                    std.log.err("Error allocating C source path: {}", .{err});
+                    std.process.exit(1);
+                };
+                c_files.append(b.allocator, file_path) catch |err| {
+                    std.log.err("Error appending C source path: {}", .{err});
+                    std.process.exit(1);
+                };
+            }
+        } else {
+            break;
+        }
+    }
+
+    if (c_files.items.len == 0) {
+        const dummy_rel = "out/types/acton_empty.c";
+        b.build_root.handle.createDirPath(io, "out/types") catch |err| {
+            std.log.err("Error creating out/types directory: {}", .{err});
+            std.process.exit(1);
+        };
+        const dummy_file = b.build_root.handle.createFile(io, dummy_rel, .{}) catch |err| {
+            std.log.err("Error creating dummy C file: {}", .{err});
+            std.process.exit(1);
+        };
+        var write_buffer: [64]u8 = undefined;
+        var dummy_writer = dummy_file.writer(io, &write_buffer);
+        dummy_writer.interface.writeAll("int acton_empty(void) { return 0; }\n") catch |err| switch (err) {
+            error.WriteFailed => {
+                std.log.err("Error writing dummy C file: {}", .{dummy_writer.err.?});
+                std.process.exit(1);
+            },
+        };
+        dummy_writer.flush() catch |err| {
+            std.log.err("Error flushing dummy C file: {}", .{err});
+            std.process.exit(1);
+        };
+        dummy_file.close(io);
+        c_files.append(b.allocator, dummy_rel) catch |err| {
+            std.log.err("Error appending dummy C file path: {}", .{err});
+            std.process.exit(1);
+        };
+    }
+
+    var flags = std.ArrayList([]const u8).empty;
+    defer flags.deinit(b.allocator);
+
+    var file_prefix_map = std.ArrayList(u8).empty;
+    defer file_prefix_map.deinit(b.allocator);
+    const file_prefix_path_path = std.fs.path.dirname(buildroot_path) orelse buildroot_path;
+    file_prefix_map.appendSlice(b.allocator, "-ffile-prefix-map=") catch unreachable;
+    file_prefix_map.appendSlice(b.allocator, file_prefix_path_path) catch unreachable;
+    file_prefix_map.appendSlice(b.allocator, "/=") catch unreachable;
+    flags.append(b.allocator, file_prefix_map.items) catch unreachable;
+
+    if (optimize == .Debug) {
+        print("Debug build\n", .{});
+        flags.appendSlice(b.allocator, &.{
+            "-DDEV",
+        }) catch |err| {
+            std.log.err("Error appending flags: {}", .{err});
+            std.process.exit(1);
+        };
+    }
+
+    if (db)
+        flags.appendSlice(b.allocator, &.{"-DACTON_DB",}) catch unreachable;
+
+    if (no_threads) {
+        print("No threads\n", .{});
+    } else {
+        print("Threads enabled\n", .{});
+        flags.appendSlice(b.allocator, &.{
+            "-DACTON_THREADS",
+        }) catch |err| {
+            std.log.err("Error appending flags: {}", .{err});
+            std.process.exit(1);
+        };
+    }
+
+    flags.appendSlice(b.allocator, &.{
+        "-fno-sanitize=signed-integer-overflow",
+    }) catch unreachable;
+
+    const libActonProject = b.addLibrary(.{
+        .name = "ActonProject",
+        .linkage = .static,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+
+    for (c_files.items) |entry| {
+        libActonProject.root_module.addCSourceFile(.{ .file = b.path(entry), .flags = flags.items });
+    }
+
+    libActonProject.root_module.addIncludePath(b.path("."));
+    libActonProject.root_module.addIncludePath(b.path("../base"));
+
+    libActonProject.root_module.linkLibrary(actonbase_dep.artifact("Acton"));
+    libActonProject.root_module.linkLibrary(dep_libpcre2.artifact("pcre2-8"));
+    libActonProject.root_module.linkLibrary(dep_libsnappy_c.artifact("snappy-c"));
+    libActonProject.root_module.linkLibrary(dep_libxml2.artifact("xml2"));
+    libActonProject.root_module.linkLibrary(dep_libyyjson.artifact("yyjson"));
+
+    libActonProject.installHeadersDirectory(b.path("out/types"), "out/types", .{});
+
+    var hiter_dir = b.build_root.handle.openDir(io, "out/types/", .{ .iterate = true }) catch unreachable;
+    var hwalker = hiter_dir.walk(b.allocator) catch unreachable;
+    defer hwalker.deinit();
+
+    while (true) {
+        const next_result = hwalker.next(io) catch unreachable;
+        if (next_result) |entry| {
+            if (entry.kind == .file and std.mem.endsWith(u8, entry.basename, ".h")) {
+                const file_path = std.fs.path.join(b.allocator, &.{ "out/types", entry.path }) catch unreachable;
+                libActonProject.installHeader(b.path(file_path), file_path);
+            }
+        } else {
+            break;
+        }
+    }
+
+    libActonProject.root_module.link_libc = true;
+    libActonProject.root_module.link_libcpp = true;
+    b.installArtifact(libActonProject);
+}

--- a/std/build.zig.zon
+++ b/std/build.zig.zon
@@ -1,0 +1,24 @@
+.{
+    .name = .actonstd,
+    .version = "0.0.0",
+    .fingerprint = 0xc42ec9f500000001,
+    .minimum_zig_version = "0.16.0",
+    .dependencies = .{
+        .base = .{
+            .path = "../base/",
+        },
+        .libpcre2 = .{
+            .path = "../deps/pcre2/",
+        },
+        .libsnappy = .{
+            .path = "../deps/libsnappy_c/",
+        },
+        .libxml2 = .{
+            .path = "../deps/libxml2/",
+        },
+        .libyyjson = .{
+            .path = "../deps/libyyjson/",
+        },
+    },
+    .paths = .{""},
+}

--- a/std/src/std/argparse.act
+++ b/std/src/std/argparse.act
@@ -1,0 +1,633 @@
+"""Command line argument parsing
+
+The argparse module provides command-line argument parsing for Acton applications.
+It supports options (flags), positional arguments, sub-commands, and automatic
+help generation.
+
+## Basic Usage
+
+```acton
+import argparse
+
+actor main(env):
+    def _parse_args():
+        p = argparse.Parser()
+        p.add_option("lines", "int", default=10, help="Number of lines", short="n")
+        p.add_bool("follow", "Follow file changes", short="f")
+        p.add_arg("file", "File to tail")
+        return p.parse(env.argv)
+
+    try:
+        args = _parse_args()
+
+        num_lines = args.get_int("lines")
+        follow = args.get_bool("follow")
+        filename = args.get_str("file")
+
+        print("Tailing", num_lines, "lines from", filename)
+        if follow:
+            print("Following file changes...")
+
+    except argparse.PrintUsage as exc:
+        print(exc.error_message)
+        env.exit(0)
+    except argparse.ArgumentError as exc:
+        print(exc.error_message, err=True)
+        env.exit(1)
+```
+
+The typical idiom is to define a `_parse_args()` function that sets up the parser
+and returns the parsed arguments, then wrap the main logic in a try/except block
+to handle help requests and argument errors gracefully.
+
+## Positional arguments
+
+Positional arguments must appear in a specific order and as plain values, i.e.
+no leading `-` or `--`:
+
+```acton
+p.add_arg("file", "File to tail")                    # required
+p.add_arg("backup", "Backup file", required=False)   # optional
+p.add_arg("files", "Files to tail", nargs="+")       # one or more
+
+# Usage: tail log.txt
+# Usage: tail log.txt backup.log
+# Usage: tail app.log error.log debug.log
+```
+
+## Boolean flags
+
+Boolean flags are options that do not take a value. If present, they are `True`,
+otherwise they are `False`:
+
+```acton
+p.add_bool("follow", "Follow file changes", short="f")
+p.add_bool("quiet", "Suppress headers", short="q")
+
+args = p.parse(["tail", "-f", "-q", "app.log"])
+follow = args.get_bool("follow")   # True
+quiet = args.get_bool("quiet")     # True
+
+# Usage: tail -f app.log
+# Usage: tail --follow --quiet app.log
+# Usage: tail -fq app.log  (grouped)
+```
+
+
+## Options with values
+
+Options can take values of different types:
+
+```acton
+# Integer option
+p.add_option("lines", "int", default=10, help="Number of lines", short="n")
+num_lines = args.get_int("lines")
+
+# String option
+p.add_option("format", "str", default="plain", help="Output format")
+fmt = args.get_str("format")
+
+# String list option
+p.add_option("exclude", "strlist", nargs="+", help="Patterns to exclude")
+patterns = args.get_strlist("exclude")
+
+# Usage: tail -n 20 --format json --exclude "ERROR" "DEBUG" app.log
+```
+
+## Short options
+
+Short options are single character aliases prefixed with a single dash:
+
+```acton
+p.add_option("lines", "int", default=10, help="Number of lines", short="n")
+p.add_bool("follow", "Follow file changes", short="f")
+
+# These are equivalent:
+# --lines 20 --follow
+# -n 20 -f
+# -n20 -f      (inline value)
+# -fn 20       (grouped boolean + option)
+```
+
+### Grouping rules
+- Boolean flags can be grouped: `-fq` = `-f -q`
+- Options with values: `-n 20` or `-n20` (inline)
+- Short options must be alphanumeric (a-z, A-Z, 0-9)
+- Each short option must be unique
+
+## Sub-commands
+
+Sub-commands enable hierarchical CLIs like `git add` or `docker run`:
+
+```acton
+def cmd_head(args):
+    lines = args.get_int("lines")
+    print("Head mode:", lines, "lines")
+
+def cmd_tail(args):
+    lines = args.get_int("lines")
+    follow = args.get_bool("follow")
+    print("Tail mode:", lines, "lines, follow:", follow)
+
+p = argparse.Parser()
+p.add_bool("verbose", "Verbose output", short="v")
+
+head_cmd = p.add_cmd("head", "Show first lines", cmd_head)
+head_cmd.add_option("lines", "int", default=10, short="n")
+
+tail_cmd = p.add_cmd("tail", "Show last lines", cmd_tail)
+tail_cmd.add_option("lines", "int", default=10, short="n")
+tail_cmd.add_bool("follow", "Follow changes", short="f")
+
+# Usage: viewer -v tail -n 20 -f app.log
+```
+
+## Command handlers and execution
+
+After parsing, execute the command handler if one was specified:
+
+```acton
+args = parser.parse(env.argv)
+cmd = args.cmd
+if cmd is not None:
+    cmd(args)  # Execute the command function
+else:
+    # No sub-command, default behavior
+    filename = args.get_str("file")
+    print("Processing", filename, "with default settings")
+```
+
+## Help generation
+
+Help is automatically generated and displayed with `--help`:
+
+```
+Usage: tail [-n LINES] [-f] FILE
+
+Positional arguments:
+  FILE               File to tail
+
+Options:
+  -n, --lines LINES  Number of lines
+  -f, --follow       Follow file changes
+  --help             show this help message
+```
+
+## Error handling
+
+The parser raises specific exceptions for different error conditions:
+
+- `ArgumentError`: Invalid arguments, missing values, unknown options
+- `PrintUsage`: Help requested (catch and print, then exit)
+
+Always wrap parsing in try/except to handle these gracefully.
+"""
+
+# TODO: mutually exclusive argument groups
+# TODO: argument metavar
+# TODO: required options (oxymoronic)?
+# TODO: bash completion
+#
+
+# Parsing Algorithm: Three-Phase Approach
+#
+# Phase 1 - Option Recognition and Collection:
+# Parser processes argv sequentially, identifying known long options (--option) and
+# short options (-x). For grouped short options (-abc), recognized options are processed
+# immediately while unknown options are reconstructed and added to 'rest'. Sub-commands
+# are detected and registered but parsing continues. All unrecognized arguments go to 'rest'.
+#
+# Phase 2 - Sub-command Processing (recursive):
+# If a sub-command was identified, its parser receives the 'rest' arguments and repeats
+# Phase 1 with its own option definitions. This happens recursively for nested sub-commands,
+# with each level processing its known options and passing unknowns down the chain.
+#
+# Phase 3 - Positional Argument Matching:
+# After all option processing, remaining arguments are matched to positional argument
+# definitions. Inner-most parsers (deepest sub-commands) process positional arguments
+# first, enabling optional positional arguments at higher levels while still consuming
+# required positional arguments in sub-commands.
+#
+# Grouped Short Options (-abc):
+# Recognized options are processed immediately, unknown options are reconstructed as
+# separate arguments for 'rest' (e.g., -a known, -bc unknown -> -bc goes to rest).
+# This enables mixed groups where some options belong to the main parser and others
+# to sub-command parsers.
+
+class ArgumentError(Exception):
+    pass
+
+class PrintUsage(ArgumentError):
+    pass
+
+
+class Args(object):
+    cmd_parser: ?Parser
+    options: dict[str, (type: str, value: value)]
+    cmd: ?proc(Args) -> None
+
+    def __init__(self):
+        self.cmd_parser = None
+        self.options = {}
+        self.cmd = None
+
+    def get_bool(self, name: str) -> bool:
+        try:
+            opt = self.options[name]
+            if opt.type != "bool":
+                raise ValueError(f"Option {name} is not a bool")
+            val = opt.value
+            if isinstance(val, bool):
+                return val
+            raise ValueError(f"Option value {str(val)} is not a bool")
+        except KeyError:
+            raise ArgumentError(f"Option '{name}' not found")
+
+    def get_int(self, name: str) -> int:
+        try:
+            opt = self.options[name]
+            if opt.type != "int":
+                raise ValueError(f"Option '{name}' is not a int")
+            val = opt.value
+            if isinstance(val, int):
+                return val
+            raise ValueError(f"Option value '{str(val)}' is not a int")
+        except KeyError:
+            raise ArgumentError(f"Option '{name}' not found")
+
+    def get_str(self, name: str) -> str:
+        try:
+            opt = self.options[name]
+            if opt.type != "str":
+                raise ValueError(f"Option '{name}' is not a str")
+            val = opt.value
+            if isinstance(val, str):
+                return val
+            raise ValueError(f"Option value '{str(val)}' is not a str")
+        except KeyError:
+            raise ArgumentError(f"Option '{name}' not found")
+
+    def get_strlist(self, name: str) -> list[str]:
+        try:
+            opt = self.options[name]
+            if opt.type != "strlist":
+                raise ValueError(f"Option '{name}' is not a list[str]")
+            val = opt.value
+            if isinstance(val, list):
+                return val
+            raise ValueError(f"Option value '{str(val)}' is not a list[str]")
+        except KeyError:
+            raise ArgumentError(f"Option '{name}' not found")
+
+
+class Parser(object):
+    cmd: str
+    opts: dict[str, (name: str, type: str, nargs: str, default: ?value, help: str, short: ?str)]
+    short_opts: dict[str, str]  # short -> long name mapping
+    args: list[(name: str, help: str, required: bool, nargs: str, left: int)]
+    cmds: dict[str, (help: str, parser: Parser, fn: proc(Args) -> None)]
+    prog: str
+
+    def __init__(self, cmd=""):
+        self.cmd = cmd
+        self.opts = {}
+        self.short_opts = {}
+        self.args = []
+        self.cmds = {}
+        self.prog = ""
+
+    def add_bool(self, name: str, help: str, short: ?str=None):
+        if short is not None:
+            if len(short) != 1:
+                raise ArgumentError("Short option must be exactly one character")
+            if not short.isalnum():
+                raise ArgumentError("Short option must be alphanumeric")
+            if short in self.short_opts:
+                raise ArgumentError(f"Short option '{short}' already exists")
+            self.short_opts[short] = name
+
+        self.opts[name] = (name=name, type="bool", nargs="?", default=False, help=help, short=short)
+
+    def add_option(self, name: str, type: str, nargs: str="?", default: ?value=None, help="", short: ?str=None):
+        if name in self.opts:
+            raise ArgumentError(f"Option '{name}' already exists")
+        if type not in {"int", "str", "strlist"}:
+            raise ArgumentError(f"Invalid option type '{type}'")
+
+        if short is not None:
+            if len(short) != 1:
+                raise ArgumentError("Short option must be exactly one character")
+            if not short.isalnum():
+                raise ArgumentError("Short option must be alphanumeric")
+            if short in self.short_opts:
+                raise ArgumentError(f"Short option '{short}' already exists")
+            self.short_opts[short] = name
+
+        self.opts[name] = (name=name, type=type, nargs=nargs, default=default, help=help, short=short)
+
+    def add_arg(self, name: str, help: str="", required: bool=True, nargs: str="?"):
+        if nargs == "+" or nargs == "*":
+            for arg in self.args:
+                if arg.nargs == "+" or arg.nargs == "*":
+                    raise ArgumentError("Only one positional argument with multiple values allowed")
+        self.args.append((name=name, help=help, required=required, nargs=nargs, left=1))
+
+    def add_cmd(self, name: str, help: str="", fn: proc(Args) -> None):
+        p = Parser(name)
+        self.cmds[name] = (help=help, parser=p, fn=fn)
+        return p
+
+    def print_usage(self):
+        print(self.get_usage())
+
+    def get_usage(self):
+        usage_text = ""
+        short_opts = ""
+        for name in sorted(self.opts.keys()):
+            opt = self.opts[name]
+            short_opt = opt.short
+            if opt.type == "bool":
+                if short_opt is not None:
+                    short_opts += f" [-{short_opt}]"
+                else:
+                    short_opts += f" [--{name}]"
+            else:
+                if short_opt is not None:
+                    short_opts += f" [-{short_opt} {name.upper()}]"
+                else:
+                    short_opts += f" [--{name} {name.upper()}]"
+        for arg in self.args:
+            n = arg.name
+            if n is not None:
+                if arg.nargs == "?":
+                    if arg.required:
+                        short_opts += f" {n.upper()}"
+                    else:
+                        short_opts += f" [{n.upper()}]"
+                elif arg.nargs == "+":
+                    short_opts += f" {n.upper()} [{n.upper()} ...]"
+        if len(self.cmds) > 0:
+            short_opts += " COMMAND"
+        usage_text += f"Usage: {self.prog}{short_opts}\n"
+
+        if len(self.cmds) > 0:
+            usage_text += "\nCommands:\n"
+            for name in sorted(self.cmds.keys()):
+                usage_text += f"  {name:<14} {self.cmds[name].help}\n"
+        if len(self.args) > 0:
+            usage_text += "\nPositional arguments:\n"
+            for arg in self.args:
+                n = arg.name
+                if n is not None:
+                    usage_text += f"  {n.upper():<14} {arg.help}\n"
+        if len(self.opts) > 0:
+            usage_text += "\nOptions:\n"
+            for name in sorted(self.opts.keys()):
+                opt = self.opts[name]
+                opt_help = f"--{name}"
+                short_opt = opt.short
+                if short_opt is not None:
+                    opt_help = f"-{short_opt}, {opt_help}"
+                if opt.type != "bool":
+                    opt_help += f" {name.upper()}"
+                usage_text += f"  {opt_help:<14} {opt.help}\n"
+        return usage_text
+
+    def parse(self, argv: list[str]) -> Args:
+        return self._parse(argv)
+
+    def _parse(self, argin: list[str], res_args: ?Args=None) -> Args:
+        injected_help = False
+        if "help" not in self.opts:
+            injected_help = True
+            self.add_bool("help", "show this help message")
+
+        if res_args is None: # top level call
+            self.prog = argin[0]
+            args_to_parse = argin[1:]
+        else: # recursively called
+            args_to_parse = argin
+        args, rest = self._parse_and_consume(args_to_parse, res_args, prog=self.prog)
+        cmd_parser = args.cmd_parser
+
+        if injected_help and args.get_bool("help"):
+            if cmd_parser is not None:
+                raise PrintUsage(cmd_parser.get_usage())
+            raise PrintUsage(self.get_usage())
+
+        for arg in self.args:
+            if arg.required and arg.name not in args.options:
+                raise ArgumentError(f"Missing positional argument: {arg.name}")
+
+        return args
+
+    def _parse_and_consume(self, argv: list[str], res_args: ?Args, prog="") -> (Args, list[str]):
+        self.prog = prog
+        #print(self, "_parse_and_consume, argv:", argv, "res_args:", res_args)
+        rest: list[str] = []
+        cmd_parser = None
+        if res_args is not None:
+            res = res_args
+        else:
+            res = Args()
+        # Insert default values
+        for akey, aspec in self.opts.items():
+            defval = aspec.default
+            if defval is not None:
+                res.options[akey] = ("type"=aspec.type, "value"=defval)
+        for arg in self.args:
+            if not arg.required:
+                if arg.nargs == "+":
+                    res.options[arg.name] = ("type"="strlist", "value"=[])
+
+        skip = 0
+        for i in range(len(argv)):
+            p = i + skip
+            if p >= len(argv):
+                break
+            arg = argv[p]
+            start = 0
+            end = len(arg)
+            if arg == '--':
+                rest.extend(argv[p+1:])
+                break
+            elif arg.startswith('--'):
+                start = 2
+                val_in_arg = False
+                if arg.find('=') != -1:
+                    val_in_arg = True
+                    end = arg.find('=')
+                akey = arg[start:end]
+
+                if akey in self.opts:
+                    aspec = self.opts[akey]
+                    val = False
+                    if aspec.type != "bool": # all other types take a value
+                        if val_in_arg:
+                            val = arg[end+1:]
+                        else:
+                            try:
+                                val = argv[p+1]
+                            except IndexError:
+                                raise ArgumentError(f"Missing value to option {arg}")
+                            skip += 1
+
+                    if aspec.type == "bool":
+                        res.options[akey] = ("type"="bool", "value"=True)
+                    elif aspec.type == "int":
+                        try:
+                            res.options[akey] = ("type"="int", "value"=int(val))
+                        except ValueError:
+                            raise ArgumentError(f"Option {akey} requires an integer value")
+                    elif aspec.type == "str":
+                        res.options[akey] = ("type"="str", "value"=val)
+                    elif aspec.type == "strlist":
+                        newval = []
+                        if akey in res.options:
+                            curlist = res.options[akey].value
+                            if isinstance(curlist, list):
+                                newval = curlist
+                        newval.append(val)
+                        res.options[akey] = ("type"="strlist", "value"=newval)
+                else:
+                    #raise ArgumentError(f"Unknown option {arg}")
+                    rest.append(arg)
+            elif arg.startswith('-') and len(arg) > 1:
+                # Handle short options (-x or -xyz for grouped bools only)
+                short_chars = arg[1:]  # Remove leading dash
+
+                # Check if this is a single non-bool option with inline value
+                if len(short_chars) > 1:
+                    first_char = short_chars[0]
+                    if first_char in self.short_opts:
+                        first_spec = self.opts[self.short_opts[first_char]]
+                        if first_spec.type != "bool":
+                            # Single non-bool option with inline value: -ofile.txt
+                            akey = self.short_opts[first_char]
+                            val = short_chars[1:]  # Rest is the value
+
+                            if first_spec.type == "int":
+                                try:
+                                    res.options[akey] = ("type"="int", "value"=int(val))
+                                except ValueError:
+                                    raise ArgumentError(f"Option -{first_char} requires an integer value")
+                            elif first_spec.type == "str":
+                                res.options[akey] = ("type"="str", "value"=val)
+                            elif first_spec.type == "strlist":
+                                newval = []
+                                if akey in res.options:
+                                    curlist = res.options[akey].value
+                                    if isinstance(curlist, list):
+                                        newval = curlist
+                                newval.append(val)
+                                res.options[akey] = ("type"="strlist", "value"=newval)
+                            continue  # Skip to next argument
+
+                # Process as grouped boolean options or single option
+                unknown_chars = []
+                processed_any = False
+
+                for j in range(len(short_chars)):
+                    short_char = short_chars[j]
+
+                    if short_char in self.short_opts:
+                        akey = self.short_opts[short_char]
+                        aspec = self.opts[akey]
+
+                        if aspec.type == "bool":
+                            res.options[akey] = ("type"="bool", "value"=True)
+                            processed_any = True
+                        else:
+                            # Non-bool short option in group context
+                            if j != len(short_chars) - 1:
+                                raise ArgumentError(f"Non-boolean option -{short_char} cannot be grouped (must be last or use separate argument)")
+
+                            # Single non-bool option, value comes from next arg
+                            val = ""
+                            try:
+                                val = argv[p+1]
+                                skip += 1
+                            except IndexError:
+                                raise ArgumentError(f"Missing value to option -{short_char}")
+
+                            if aspec.type == "int":
+                                try:
+                                    res.options[akey] = ("type"="int", "value"=int(val))
+                                except ValueError:
+                                    raise ArgumentError(f"Option -{short_char} requires an integer value")
+                            elif aspec.type == "str":
+                                res.options[akey] = ("type"="str", "value"=val)
+                            elif aspec.type == "strlist":
+                                newval = []
+                                if akey in res.options:
+                                    curlist = res.options[akey].value
+                                    if isinstance(curlist, list):
+                                        newval = curlist
+                                newval.append(val)
+                                res.options[akey] = ("type"="strlist", "value"=newval)
+                            processed_any = True
+                            break  # Exit loop after processing value
+                    else:
+                        # Unknown short option, collect for later
+                        unknown_chars.append(short_char)
+
+                # If we have unknown chars, add them to rest as separate arguments
+                if len(unknown_chars) > 0:
+                    if len(unknown_chars) == 1:
+                        rest.append("-" + unknown_chars[0])
+                    else:
+                        rest.append("-" + "".join(unknown_chars))
+
+                # If no known options were processed and we have unknowns,
+                # it means the entire arg was unknown
+                if not processed_any and len(unknown_chars) > 0:
+                    # We already added the reconstructed unknown args above
+                    pass
+            else:
+                if arg in self.cmds:
+                    # We found a sub-command, store which one but continue
+                    # parsing the rest of the options. Make sure not to set
+                    # pass rest of args to subparser for command
+                    if cmd_parser is None:
+                        cmd = self.cmds[arg]
+                        res.cmd = cmd.fn
+                        res.cmd_parser = cmd.parser
+                        cmd_parser = cmd.parser
+                    else:
+                        rest.append(arg)
+
+                else:
+                    rest.append(arg)
+
+        # Run sub-command parser
+        if cmd_parser is not None:
+            #print(self, ": cmd found, invoking cmd parser with", rest)
+            res, posargs = cmd_parser._parse_and_consume(rest, res, prog=self.prog + " " + cmd_parser.cmd)
+            #print(self, ": cmd parser done, res:", res, "posargs:", posargs, "res.cmd:", res.cmd)
+        else:
+            posargs = rest
+        rest = []
+
+        #print(self, "Do second loop for optional posargs on rest:", posargs)
+        for i in range(len(posargs)):
+            arg = posargs[i]
+            if len(self.args) == 0:
+                rest.append(arg)
+            else:
+                posarg = self.args[0]
+                if posarg.nargs == "?":
+                    res.options[posarg.name] = ("type"="str", "value"=arg)
+                    self.args.pop(0)
+                elif posarg.nargs == "+":
+                    newval = []
+                    if posarg.name in res.options:
+                        curlist = res.options[posarg.name].value
+                        if isinstance(curlist, list):
+                            newval = curlist
+                    newval.append(arg)
+                    res.options[posarg.name] = ("type"="strlist", "value"=newval)
+                    remaining_posargs = len(self.args) - 1
+                    if len(posargs)-(i+1) == remaining_posargs:
+                        self.args.pop(0)
+
+        return res, rest

--- a/std/src/std/base64.act
+++ b/std/src/std/base64.act
@@ -1,0 +1,5 @@
+def encode(data: bytes) -> bytes:
+    NotImplemented
+
+def decode(data: bytes) -> bytes:
+    NotImplemented

--- a/std/src/std/base64.ext.c
+++ b/std/src/std/base64.ext.c
@@ -1,0 +1,1 @@
+void stdQ_base64Q___ext_init__() {}

--- a/std/src/std/crypto/hash/md5.act
+++ b/std/src/std/crypto/hash/md5.act
@@ -1,0 +1,27 @@
+class Hasher(object):
+    _hasher: u64
+    def __init__(self):
+        """Initialize a new MD5 hashing context
+        """
+        self._hasher = 0
+        self._init()
+
+    def _init(self):
+        """C function to reach out to Zig code"""
+        NotImplemented
+
+    def update(self, data: bytes) -> None:
+        """Update the hasher state with the given chunk of data"""
+        NotImplemented
+
+    def finalize(self) -> bytes:
+        """Finalize the hash and return the 16-byte MD5 digest as bytes
+        After final() is called, this instance should not be used again.
+        """
+        NotImplemented
+
+def hash(data: bytes) -> bytes:
+    """Compute and return the MD5 digest of the given data"""
+    m = Hasher()
+    m.update(data)
+    return m.finalize()

--- a/std/src/std/crypto/hash/md5.ext.c
+++ b/std/src/std/crypto/hash/md5.ext.c
@@ -1,0 +1,19 @@
+void stdQ_cryptoQ_hashQ_md5Q___ext_init__() {}
+
+void *zig_crypto_hash_md5_init();
+void *zig_crypto_hash_md5_update(void *hasher, B_bytes data);
+void *zig_crypto_hash_md5_finalize(void *hasher, B_bytes output);
+
+B_NoneType stdQ_cryptoQ_hashQ_md5Q_HasherD__init (stdQ_cryptoQ_hashQ_md5Q_Hasher self) {
+    self->_hasher = zig_crypto_hash_md5_init();
+    return B_None;
+}
+B_NoneType stdQ_cryptoQ_hashQ_md5Q_HasherD_update (stdQ_cryptoQ_hashQ_md5Q_Hasher self, B_bytes data) {
+    zig_crypto_hash_md5_update(self->_hasher, data);
+    return B_None;
+}
+B_bytes stdQ_cryptoQ_hashQ_md5Q_HasherD_finalize (stdQ_cryptoQ_hashQ_md5Q_Hasher self) {
+    B_bytes output = to$bytes("1234567890abcdef");
+    zig_crypto_hash_md5_finalize(self->_hasher, output);
+    return output;
+}

--- a/std/src/std/diff.act
+++ b/std/src/std/diff.act
@@ -1,0 +1,471 @@
+import std.term as term
+
+# Implementation of Myers-inspired diff algorithm, which is efficient and produces
+# good results for typical text file differences.
+# This algorithm uses a divide-and-conquer approach with features from Myers and
+# Patience diff algorithms to identify changes between two sequences.
+# The algorithm focuses on finding common sequences and anchors to produce
+# minimal, readable diffs.
+# Myers algorithm is documented at: http://blog.robertelder.org/diff-algorithm/
+
+def myers_diff(e: list[str], f: list[str], i: int = 0, j: int = 0) -> list[Op]:
+    """
+    Myers-inspired diff algorithm implementation - finds the minimal edit script between two sequences.
+
+    This algorithm combines elements of Myers diff and Patience diff to efficiently find
+    differences between sequences. It uses a divide-and-conquer approach that:
+    1. Quickly identifies common prefixes and suffixes
+    2. Finds matching sections in the middle ("middle snake")
+    3. Uses unique lines as anchors to align content
+    4. Handles special cases efficiently (empty sequences, single elements)
+
+    The implementation creates Keep/Insert/Delete operations directly, compatible with the
+    unified diff format.
+
+    Args:
+        e: First sequence (old)
+        f: Second sequence (new)
+        i: Starting position in first sequence (used in recursion)
+        j: Starting position in second sequence (used in recursion)
+
+    Returns:
+        List of diff operations (Keep, Insert, Delete) representing the minimal edit script
+    """
+    # Handle edge cases first
+    if len(e) == 0:
+        # All lines in f were inserted
+        result = []
+        for n in range(0, len(f)):
+            result.append(Insert(f[n], j + n))
+        return result
+
+    if len(f) == 0:
+        # All lines in e were deleted
+        result = []
+        for n in range(0, len(e)):
+            result.append(Delete(e[n], i + n))
+        return result
+
+    # Find the longest common prefix
+    prefix_len = 0
+    while prefix_len < len(e) and prefix_len < len(f) and e[prefix_len] == f[prefix_len]:
+        prefix_len += 1
+
+    # Generate Keep operations for the common prefix
+    prefix_ops = []
+    for n in range(0, prefix_len):
+        prefix_ops.append(Keep(e[n], i + n, j + n))
+
+    # Find the longest common suffix
+    suffix_len = 0
+    while suffix_len < len(e) - prefix_len and suffix_len < len(f) - prefix_len and e[len(e) - 1 - suffix_len] == f[len(f) - 1 - suffix_len]:
+        suffix_len += 1
+
+    # Generate Keep operations for the common suffix
+    suffix_ops = []
+    for n in range(0, suffix_len):
+        old_idx = len(e) - suffix_len + n
+        new_idx = len(f) - suffix_len + n
+        suffix_ops.append(Keep(e[old_idx], i + old_idx, j + new_idx))
+
+    # If we have a common prefix or suffix, recursively diff the middle part
+    if prefix_len > 0 or suffix_len > 0:
+        middle_ops = myers_diff(
+            e[prefix_len:len(e)-suffix_len],
+            f[prefix_len:len(f)-suffix_len],
+            i + prefix_len,
+            j + prefix_len
+        )
+        return prefix_ops + middle_ops + suffix_ops
+
+    # If e is just one element and f has multiple elements, delete e and insert all of f
+    if len(e) == 1 and len(f) > 1:
+        result = [Delete(e[0], i)]
+        for n in range(0, len(f)):
+            result.append(Insert(f[n], j + n))
+        return result
+
+    # If f is just one element and e has multiple elements, delete all of e and insert f
+    if len(f) == 1 and len(e) > 1:
+        result = []
+        for n in range(0, len(e)):
+            result.append(Delete(e[n], i + n))
+        result.append(Insert(f[0], j))
+        return result
+
+    # If both have just one element, compare them
+    if len(e) == 1 and len(f) == 1:
+        if e[0] == f[0]:
+            return [Keep(e[0], i, j)]
+        else:
+            return [Delete(e[0], i), Insert(f[0], j)]
+
+    # Divide and conquer: find the middle snake
+    middle = len(e) // 2
+
+    # Find best matching line in f for the middle of e
+    best_match_pos = -1
+    best_match_len = -1
+
+    for pos in range(0, len(f)):
+        match_len = 0
+        while middle + match_len < len(e) and pos + match_len < len(f) and e[middle + match_len] == f[pos + match_len]:
+            match_len += 1
+
+        if match_len > best_match_len:
+            best_match_len = match_len
+            best_match_pos = pos
+
+    if best_match_len > 0:
+        # Generate Keep operations for the matching segment
+        match_ops = []
+        for n in range(0, best_match_len):
+            match_ops.append(Keep(e[middle + n], i + middle + n, j + best_match_pos + n))
+
+        # Recursively diff the segments before and after the match
+        before_ops = myers_diff(e[0:middle], f[0:best_match_pos], i, j)
+        after_ops = myers_diff(
+            e[middle+best_match_len:],
+            f[best_match_pos+best_match_len:],
+            i + middle + best_match_len,
+            j + best_match_pos + best_match_len
+        )
+
+        return before_ops + match_ops + after_ops
+
+    # No good match in the middle, use Patience diff approach
+    # Try to identify unique lines and align around them
+    unique_lines_e = {}
+    for idx, line in enumerate(e):
+        if line not in unique_lines_e:
+            unique_lines_e[line] = []
+        unique_lines_e[line].append(idx)
+
+    unique_lines_f = {}
+    for idx, line in enumerate(f):
+        if line not in unique_lines_f:
+            unique_lines_f[line] = []
+        unique_lines_f[line].append(idx)
+
+    # Find lines that appear exactly once in both sequences
+    anchors: list[(int, int)] = []
+
+    for line, e_indices in unique_lines_e.items():
+        if len(e_indices) == 1 and line in unique_lines_f and len(unique_lines_f[line]) == 1:
+            e_idx = e_indices[0]
+            f_idx = unique_lines_f[line][0]
+            anchors.append((e_idx, f_idx))
+
+    # Sort anchors by position in e
+    # We'll do a simple bubble sort that uses a temporary variable for the swap
+    sorted_anchors = list(anchors)  # Make a copy
+    for i in range(len(sorted_anchors)):
+        for j in range(len(sorted_anchors) - i - 1):
+            if sorted_anchors[j].0 > sorted_anchors[j+1].0:
+                # Swap using a temporary variable
+                temp = sorted_anchors[j]
+                sorted_anchors[j] = sorted_anchors[j+1]
+                sorted_anchors[j+1] = temp
+
+    # Extract sorted indices
+    sorted_e_indices = []
+    sorted_f_indices = []
+    for anchor in sorted_anchors:
+        sorted_e_indices.append(anchor.0)
+        sorted_f_indices.append(anchor.1)
+
+    if len(sorted_e_indices) > 0:
+        # We found unique matching lines, use them as anchors
+        result = []
+
+        # Initialize with starting positions
+        last_e = 0
+        last_f = 0
+
+        for idx in range(len(sorted_e_indices)):
+            e_idx = sorted_e_indices[idx]
+            f_idx = sorted_f_indices[idx]
+
+            # Recursively diff the segment before this anchor
+            if e_idx > last_e or f_idx > last_f:
+                before_ops = myers_diff(e[last_e:e_idx], f[last_f:f_idx], i + last_e, j + last_f)
+                result.extend(before_ops)
+
+            # Add the anchor line as a Keep operation
+            result.append(Keep(e[e_idx], i + e_idx, j + f_idx))
+
+            # Update last positions
+            last_e = e_idx + 1
+            last_f = f_idx + 1
+
+        # Process the last segment after the last anchor
+        if last_e < len(e) or last_f < len(f):
+            after_ops = myers_diff(e[last_e:], f[last_f:], i + last_e, j + last_f)
+            result.extend(after_ops)
+
+        return result
+
+    # Fall back to simple edit script if no anchors found
+    result = []
+    for n in range(0, len(e)):
+        result.append(Delete(e[n], i + n))
+    for n in range(0, len(f)):
+        result.append(Insert(f[n], j + n))
+    return result
+
+# Base operation class
+class Op:
+    def __init__(self):
+        pass
+
+    def format_with_color(self) -> str:
+        return ""
+
+class Gap(Op):
+    def __init__(self):
+        pass
+
+    def __str__(self) -> str:
+        return "..."
+
+    def format_with_color(self) -> str:
+        return term.grey20 + "..." + term.normal
+
+# Keep operation class (for context lines)
+class Keep(Op):
+    content: str
+    index_old: int
+    index_new: int
+
+    def __init__(self, content: str, index_old: int, index_new: int):
+        self.content = content
+        self.index_old = index_old
+        self.index_new = index_new
+
+    def __str__(self) -> str:
+        return f" {self.content}"
+
+    def format_with_color(self) -> str:
+        return term.grey20 + str(self) + term.normal
+
+# Delete operation class
+class Delete(Op):
+    content: str
+    index_old: int
+
+    def __init__(self, content: str, index_old: int):
+        self.content = content
+        self.index_old = index_old
+
+    def __str__(self) -> str:
+        return f"-{self.content}"
+
+    def format_with_color(self) -> str:
+        return term.red + str(self) + term.normal
+
+# Insert operation class
+class Insert(Op):
+    content: str
+    index_new: int
+
+    def __init__(self, content: str, index_new: int):
+        self.content = content
+        self.index_new = index_new
+
+    def __str__(self) -> str:
+        return f"+{self.content}"
+
+    def format_with_color(self) -> str:
+        return term.green + str(self) + term.normal
+
+def filter_operations_with_context(operations: list[Op], context_lines: int) -> list[Op]:
+    """
+    Filter operations to only include changes and their surrounding context.
+
+    Args:
+        operations: List of diff operations
+        context_lines: Number of unchanged lines to include around each change
+
+    Returns:
+        Filtered list of operations with only changes and their context
+    """
+    if context_lines < 0:
+        # Show all context
+        return operations
+
+    # Find the indices of operations with changes (deletes and inserts)
+    change_indices = []
+    for i in range(len(operations)):
+        if isinstance(operations[i], Delete) or isinstance(operations[i], Insert):
+            change_indices.append(i)
+
+    # If no changes, return empty list
+    if len(change_indices) == 0:
+        return []
+
+    # Determine which lines should be included
+    include_line = [False] * len(operations)
+
+    # Mark lines within context_lines of any change
+    for i in range(len(operations)):
+        for change_idx in change_indices:
+            if abs(i - change_idx) <= context_lines:
+                include_line[i] = True
+                break
+
+    # Create filtered list
+    filtered_ops = []
+
+    # Add operations with Gap markers for gaps
+    in_chunk = False
+    for i in range(len(operations)):
+        if include_line[i]:
+            # If starting a new chunk after a gap, add a marker line
+            if not in_chunk and i > 0 and len(filtered_ops) > 0:
+                filtered_ops.append(Gap())
+
+            filtered_ops.append(operations[i])
+            in_chunk = True
+        else:
+            in_chunk = False
+
+    return filtered_ops
+
+def generate_chunk_header(chunk_ops: list[Op]) -> str:
+    """
+    Generate a unified diff chunk header showing line numbers.
+
+    Format: @@ -<old_start>,<old_count> +<new_start>,<new_count> @@
+
+    Args:
+        chunk_ops: List of operations for this chunk
+
+    Returns:
+        Chunk header string in unified diff format
+    """
+    # Find line numbers for old and new files
+    old_start = -1
+    old_count = 0
+    new_start = -1
+    new_count = 0
+
+    for op in chunk_ops:
+        if isinstance(op, Gap):
+            continue
+
+        if isinstance(op, Keep):
+            # Line exists in both files
+            if old_start == -1:
+                old_start = op.index_old
+            if new_start == -1:
+                new_start = op.index_new
+            old_count += 1
+            new_count += 1
+        elif isinstance(op, Delete):
+            # Line only exists in old file
+            if old_start == -1:
+                old_start = op.index_old
+            old_count += 1
+        elif isinstance(op, Insert):
+            # Line only exists in new file
+            if new_start == -1:
+                new_start = op.index_new
+            new_count += 1
+
+    # Default to 1 if no valid index found (shouldn't happen)
+    if old_start == -1:
+        old_start = 0
+    if new_start == -1:
+        new_start = 0
+
+    # Line numbers in display are 1-based
+    return f"@@ -{old_start+1},{old_count} +{new_start+1},{new_count} @@"
+
+def find_chunks(operations: list[Op]) -> list[list[Op]]:
+    """
+    Split operations into chunks, using Gap operations as dividers.
+
+    Args:
+        operations: List of diff operations, potentially including Gap markers
+
+    Returns:
+        List of operation chunks, where each chunk is a list of operations
+    """
+    chunks = []
+    current_chunk = []
+
+    for op in operations:
+        if isinstance(op, Gap):
+            # End the current chunk if it has operations
+            if len(current_chunk) > 0:
+                chunks.append(current_chunk)
+                current_chunk = []
+        else:
+            # Add to the current chunk
+            current_chunk.append(op)
+
+    # Add the last chunk if it exists
+    if len(current_chunk) > 0:
+        chunks.append(current_chunk)
+
+    return chunks
+
+def diff(old_text: str, new_text: str, color=False, context_lines=3) -> str:
+    """ Generate a unified diff between two text strings
+
+    Uses the Myers diff algorithm.
+
+    Args:
+        old_text: Original text content
+        new_text: New text content
+        color: Whether to add terminal color codes to the output (default False)
+        context_lines: Number of unchanged lines to show around each change
+                       (default 3 lines), use -1 for showing all lines
+
+    Returns:
+        Empty string if texts are identical, otherwise returns a unified diff.
+        If context_lines is specified, only shows that many unchanged lines around changes.
+    """
+    if old_text == new_text:
+        return ""
+
+    old_lines = old_text.splitlines(True)
+    new_lines = new_text.splitlines(True)
+
+    # Handle case where last line doesn't have newline
+    if len(old_lines) > 0 and old_text[-1] != '\n':
+        old_lines[-1] = old_lines[-1] + '\n'
+    if len(new_lines) > 0 and new_text[-1] != '\n':
+        new_lines[-1] = new_lines[-1] + '\n'
+
+    operations = myers_diff(old_lines, new_lines)
+
+    if context_lines >= 0:
+        operations = filter_operations_with_context(operations, context_lines)
+
+    if len(operations) == 0:
+        return ""
+
+    result = []
+
+    # Skip headers only when context_lines=-1 (showing full file)
+    # We're going to simplify our approach here
+    skip_headers = context_lines < 0
+
+    for chunk in find_chunks(operations):
+        if not skip_headers:
+            # Generate and add chunk header
+            header = generate_chunk_header(chunk)
+            if color:
+                result.append(term.grey20 + header + "\n" + term.normal)
+            else:
+                result.append(header + "\n")
+
+        # Add the operations for this chunk
+        for op in chunk:
+            if color:
+                result.append(op.format_with_color())
+            else:
+                result.append(str(op))
+
+    return "".join(result).rstrip()

--- a/std/src/std/hash/wyhash.act
+++ b/std/src/std/hash/wyhash.act
@@ -1,0 +1,24 @@
+class Hasher(object):
+    _hasher: u64
+    def __init__(self, seed: u64 = 0):
+        """Initialize a new MD5 hashing context
+        """
+        self._hasher = 0  # type: u64
+        self._init(seed)
+
+    def _init(self, seed: u64) -> None:
+        """C function to reach out to Zig code"""
+        NotImplemented
+
+    def update(self, data: bytes) -> None:
+        """Update the hasher state with the given chunk of data"""
+        NotImplemented
+
+    def finalize(self) -> u64:
+        """Finalize and return the hash
+        """
+        NotImplemented
+
+def hash(seed: u64, data: bytes) -> u64:
+    """Compute and return the Wyash digest of the given data"""
+    NotImplemented

--- a/std/src/std/hash/wyhash.ext.c
+++ b/std/src/std/hash/wyhash.ext.c
@@ -1,0 +1,27 @@
+void stdQ_hashQ_wyhashQ___ext_init__() {}
+
+void *zig_hash_wyhash_init(uint64_t seed);
+void zig_hash_wyhash_update(void *hasher, B_bytes data);
+uint64_t zig_hash_wyhash_final(void *hasher);
+uint64_t zig_hash_wyhash_hash(uint64_t seed, B_bytes data);
+
+B_NoneType stdQ_hashQ_wyhashQ_HasherD__init (stdQ_hashQ_wyhashQ_Hasher self, B_u64 seed) {
+    self->_hasher = zig_hash_wyhash_init(fromB_u64(seed));
+    return B_None;
+}
+
+B_NoneType stdQ_hashQ_wyhashQ_HasherD_update (stdQ_hashQ_wyhashQ_Hasher self, B_bytes data) {
+    zig_hash_wyhash_update(self->_hasher, data);
+    return B_None;
+}
+
+B_u64 stdQ_hashQ_wyhashQ_HasherD_finalize (stdQ_hashQ_wyhashQ_Hasher self) {
+    uint64_t h = zig_hash_wyhash_final(self->_hasher);
+    B_u64 result = toB_u64(h);
+    return result;
+}
+
+uint64_t stdQ_hashQ_wyhashQ_U_1hash (uint64_t seed, B_bytes data) {
+    uint64_t result = zig_hash_wyhash_hash(seed, data);
+    return result;
+}

--- a/std/src/std/http.act
+++ b/std/src/std/http.act
@@ -1,0 +1,709 @@
+import acton.rts
+import std.json as json
+import logging
+import net
+import time
+
+responses : dict[int,bytes] = {
+    100: b"Continue",
+    101: b"Switching Protocols",
+    102: b"Processing",
+    103: b"Early Hints",
+    200: b"OK",
+    201: b"Created",
+    202: b"Accepted",
+    203: b"Non-Authoritative Information",
+    204: b"No Content",
+    205: b"Reset Content",
+    206: b"Partial Content",
+    207: b"Multi-Status",
+    208: b"Already Reported",
+    226: b"IM Used",
+    300: b"Multiple Choices",
+    301: b"Moved Permanently",
+    302: b"Found",
+    303: b"See Other",
+    304: b"Not Modified",
+    305: b"Use Proxy",
+    306: b"(Unused)",
+    307: b"Temporary Redirect",
+    308: b"Permanent Redirect",
+    400: b"Bad Request",
+    401: b"Unauthorized",
+    402: b"Payment Required",
+    403: b"Forbidden",
+    404: b"Not Found",
+    405: b"Method Not Allowed",
+    406: b"Not Acceptable",
+    407: b"Proxy Authentication Required",
+    408: b"Request Timeout",
+    409: b"Conflict",
+    410: b"Gone",
+    411: b"Length Required",
+    412: b"Precondition Failed",
+    413: b"Content Too Large",
+    414: b"URI Too Long",
+    415: b"Unsupported Media Type",
+    416: b"Range Not Satisfiable",
+    417: b"Expectation Failed",
+    418: b"(Unused)",
+    421: b"Misdirected Request",
+    422: b"Unprocessable Content",
+    423: b"Locked",
+    424: b"Failed Dependency",
+    425: b"Too Early",
+    426: b"Upgrade Required",
+    428: b"Precondition Required",
+    429: b"Too Many Requests",
+    431: b"Request Header Fields Too Large",
+    451: b"Unavailable For Legal Reasons",
+    500: b"Internal Server Error",
+    501: b"Not Implemented",
+    502: b"Bad Gateway",
+    503: b"Service Unavailable",
+    504: b"Gateway Timeout",
+    505: b"HTTP Version Not Supported",
+    506: b"Variant Also Negotiates",
+    507: b"Insufficient Storage",
+    508: b"Loop Detected",
+    510: b"Not Extended (OBSOLETED)",
+    511: b"Network Authentication Required"
+}
+
+
+def build_request(host: str, method: bytes, path: bytes, version: bytes, headers: dict[str, str], body: bytes) -> bytes:
+    r = [ method + b" " + path + b" HTTP/" + version ]
+    lheaders: dict[str, str] = {}
+    for k in headers:
+        lheaders[k.lower()] = k
+
+    if "host" not in lheaders:
+        headers["Host"] = host
+    if "user-agent" not in lheaders:
+        headers["User-Agent"] = "Acton HTTP Client"
+    if "accept" not in lheaders:
+        headers["Accept"] = "*/*"
+#    if "accept-encoding" not in lheaders:
+#        headers["Accept-Encoding"] = "gzip, deflate"
+    if "connection" not in lheaders:
+        headers["Connection"] = "keep-alive"
+    if "content-length" not in lheaders:
+        headers["Content-Length"] = str(len(body))
+
+    for k, v in headers.items():
+        r.append(k.encode() + b": " + v.encode())
+
+    r.append(b"\r\n")
+    res = b"\r\n".join(r)
+    if len(body) > 0:
+        res += body
+    return res
+
+
+def build_response(version: bytes, status: int, headers: dict[str, str], body: str):
+    b = body.encode()
+    # TODO: Add Connection?
+    status_line: bytes = b"HTTP/" + version + b" " + str(status).encode()
+    if status in responses:
+        status_line += b" " + responses[status]
+
+    r = [ status_line ]
+    header_keys = [k.lower() for k in headers.keys()]
+    if "server" not in header_keys:
+        headers["Server"] = "Acton HTTP Server"
+    if "content-type" not in header_keys:
+        headers["Content-Type"] = "text/html; charset=utf-8"
+    if "date" not in header_keys:
+        headers["Date"] = time.now().str_rfc1123()
+
+    for k, v in headers.items():
+        if k.lower() == "content-length":
+            # Disregard content-length, we'll compute it from body length
+            continue
+        r.append(k.encode() + b": " + v.encode())
+
+    r.append(b"Content-Length: " + str(len(b)).encode())
+    r.append(b"\r\n")
+    res = b"\r\n".join(r)
+    if len(b) > 0:
+       res += b
+
+    return res
+
+
+class Message(object):
+    def __init__(self, start_line: bytes, headers: dict[str, str], body: bytes):
+        self.start_line = start_line
+        self.headers = headers
+        self.body = body
+
+
+class Request(object):
+    @property
+    method: str
+    @property
+    path: str
+    @property
+    version: bytes
+    @property
+    headers: dict[str, str]
+    @property
+    body: bytes
+
+    def __init__(self, method: str, path: str, version: bytes, headers: dict[str, str], body: bytes):
+        self.method = method
+        self.path = path
+        self.version = version
+        self.headers = headers
+        self.body = body
+
+    def __str__(self):
+        return f"<http.Request {self.method} {self.path} {str(self.version)} {self.headers.__str__()} {str(self.body)}>"
+
+extension Request(Eq):
+    def __eq__(self, other):
+        return self.method == other.method and self.path == other.path and self.version == other.version and self.headers == other.headers and self.body == other.body
+
+
+class Response(object):
+    @property
+    version: bytes
+    @property
+    status: int
+    @property
+    headers: dict[str, str]
+    @property
+    body: bytes
+
+    def __init__(self, version: bytes, status: int, headers: dict[str, str], body: bytes) -> None:
+        self.version = version
+        self.status = status
+        self.headers = headers
+        self.body = body
+
+    def __str__(self) -> str:
+        return f"<http.Response {self.status}>"
+
+    def decode_json(self):
+        return json.decode(self.body.decode())
+
+extension Response(Eq):
+    def __eq__(self, other):
+        return self.version == other.version and self.status == other.status and self.headers == other.headers and self.body == other.body
+
+
+def parse_message(i: bytes, log: logging.Logger) -> (?Message, bytes):
+    rs = i.split(b"\r\n\r\n", 1)
+    if len(rs) == 1:
+        return None, i
+    else:
+        header_lines = rs[0].split(b"\r\n", None)
+        start_line = header_lines[0].rstrip(b"\r\n")
+
+        headers : dict[str, str] = {}
+        for hline in header_lines[1:]:
+            hv = hline.split(b":", 1)
+            if len(hv) == 1:
+                # TODO: silently ignore or explicitly throw error or something?
+                pass
+            else:
+                try:
+                    hname = hv[0].decode().strip(" ").lower()
+                    headers[hname] = hv[1].decode().strip(" ")
+                except ValueError:
+                    log.debug("Invalid header")
+                    return None, i
+
+        # TODO: why do we have to init body & rest here? seems we segfault otherwise...
+        body = b""
+        rest = b""
+        if "content-length" in headers:
+            clen = int(headers["content-length"].strip(" "))
+            log.trace(f"Got content-length in headers, expecting {clen} bytes", None)
+            if len(rs[1]) >= clen:
+                body = rs[1][:clen]
+                rest = rs[1][clen:]
+                log.trace("Enough data to reach content-length!", None)
+                msg = Message(start_line, headers, body)
+                return msg, rest
+            else:
+                log.trace("Not enough data to reach content-length", None)
+                return None, i
+        elif "transfer-encoding" in headers:
+            tenc = set(headers["transfer-encoding"].strip(" ").split(",", None))
+            if "chunked" in tenc:
+                log.trace("Got chunked transfer-encoding", None)
+                reached_end = False
+                rest = rs[1]
+                log.trace(f"Rest: {str(rest)}", None)
+                body = b""
+                while not reached_end:
+                    maybe_chunk = rest.split(b"\r\n", 1)
+                    if len(maybe_chunk) == 1:
+                        log.trace("No chunk header found", None)
+                        return None, i
+                    elif len(maybe_chunk) == 2:
+                        chunk_header = maybe_chunk[0].strip(b"\r\n")
+                        if chunk_header == b"":
+                            log.trace("Empty chunk header", None)
+                            return None, i
+                        try:
+                            chunk_header_str = chunk_header.decode()
+                        except ValueError:
+                            log.debug("Invalid chunk header")
+                            return None, i
+                        else:
+                            rest = maybe_chunk[1]
+                            log.trace(f"Chunk header: {chunk_header[:20]}", None)
+                            try:
+                                clen = int(chunk_header_str, 16)
+                                log.trace(f"Chunk length: {clen}", None)
+                            except ValueError:
+                                log.trace("Chunk header not a length", None)
+                            else:
+                                if len(rest) >= clen:
+                                    gap = rest[clen-10:clen+10]
+                                    chunk = rest[:clen]
+                                    log.trace(f"Read chunk: {str(chunk)}", None)
+                                    rest = rest[clen:]
+                                    if len(rest) < 2 and rest[0:2] != b"\r\n":
+                                        log.trace("Could not find chunk end marker", None)
+                                        return None, i
+                                    rest = rest[2:]
+                                    #log.trace("Enough data to reach end of chunk", None)
+                                    chunk_preview = str(chunk[-5:])
+                                    rest_preview = str(rest[:5])
+                                    log.trace(f"Enough data to reach end of chunk, chunk gap: {chunk_preview}|{rest_preview}", None)
+                                    body += chunk
+                                    if clen == 0:
+                                        reached_end = True
+                                        msg = Message(start_line, headers, body)
+                                        log.trace("Reached end of chunked message", None)
+                                        return msg, rest
+                                else:
+                                    log.trace("Not enough data to reach end of chunk", None)
+                                    return None, i
+
+                    else:
+                        # TODO: InternalError?
+                        raise ValueError("Unreachable")
+        else:
+            body = b""
+            rest = rs[1]
+            msg = Message(start_line, headers, body)
+            return msg, rest
+        return None, i
+
+
+def parse_request(i: bytes, log: logging.Logger) -> (?Request, bytes):
+    msg, rest = parse_message(i, log)
+    if msg is not None:
+        slparts = msg.start_line.split(b" ", None)
+        if len(slparts) != 3:
+            # HTTP request must have exactly 3 parts: METHOD PATH HTTP/VERSION
+            return None, b""
+        try:
+            method = slparts[0].decode()
+            path = slparts[1].decode()
+        except ValueError:
+            log.debug("Invalid method/path")
+            return None, b""
+        else:
+            verparts = slparts[2].split(b"/", 1)
+            if len(verparts) != 2:
+                # invalid request
+                # TODO: actually HTTP 0.9 might only have 2 parts, but we don't support that
+                return None, b""
+            version = verparts[1]
+            if version != b"1.1" and version != b"1.0":
+                return None, b""
+            req = Request(method, path, version, msg.headers, msg.body)
+            return req, rest
+    return None, i
+
+def parse_response(i: bytes, log: logging.Logger) -> (?Response, bytes):
+    msg, rest = parse_message(i, log)
+    if msg is not None:
+        slparts = msg.start_line.split(b" ", None)
+        if len(slparts) < 2:
+            # HTTP response must have at least 2 parts: HTTP/VERSION STATUS_CODE [REASON_PHRASE]
+            return None, b""
+        verparts = slparts[0].split(b"/", 1)
+        if len(verparts) != 2:
+            # invalid request
+            # TODO: actually HTTP 0.9 might only have 2 parts, but we don't support that
+            return None, b""
+        version = verparts[1]
+        if version != b"1.1" and version != b"1.0":
+            log.trace("Invalid HTTP version", None)
+            return None, b""
+
+        try:
+            status = int(slparts[1].decode())
+        except ValueError:
+            log.debug("Invalid status")
+            return None, b""
+        else:
+            resp = Response(version, status, msg.headers, msg.body)
+            return resp, b""
+    return None, i
+
+
+actor Server(conn: net.TCPListenConnection, on_accept: action(Server) -> None, log_handler: ?logging.Handler):
+    """Server serves a single client connection"""
+    _log = logging.Logger(log_handler)
+    var on_request_cb: ?action(Server, Request, action(int, dict[str, str], str) -> None) -> None = None
+    var on_error_cb: ?action(Server, str) -> None = None
+    var version: ?bytes = None
+    var buf = b""
+    var close_connection: bool = True
+    var query_count: u64 = 0
+    var response_count: u64 = 0
+    var outstanding_requests: dict[u64, Response] = {}
+
+    def cb_install(new_on_request: action(Server, Request, action(int, dict[str, str], str) -> None) -> None, new_on_error: action(Server, str) -> None):
+        on_request_cb = new_on_request
+        on_error_cb = new_on_error
+        if buf != b"":
+            req, buf = parse_request(buf, _log)
+
+    def on_conn_receive(conn_obj, data: bytes) -> None:
+        # TODO: do we really need a buf?
+        if on_request_cb is None:
+            buf += data
+            return None
+        else:
+            if buf != b"":
+                data = buf + data
+
+        req, buf = parse_request(data, _log)
+        if req is not None:
+            if version is None:
+                version = req.version
+            elif version is not None and version != req.version:
+                _log.debug("Version mismatch", None)
+                conn.close()
+
+            if version is not None and version == b"1.0":
+                if "connection" in req.headers:
+                    if req.headers["connection"] == "close":
+                        _log.debug("HTTP 1.0 with connection: close, closing connection...", None)
+                        close_connection = True
+                    else:
+                        _log.debug("HTTP 1.0 with connection header, not closing connection...", None)
+                        _log.trace("connection header", {"connection": req.headers["connection"]})
+                else:
+                    close_connection = True
+            elif version is not None and version == b"1.1":
+                if "connection" in req.headers and req.headers["connection"] == "close":
+                    _log.debug("HTTP 1.1, closing connection...", None)
+                    close_connection = True
+                else:
+                    close_connection = False
+
+            query_count += 1
+            def respond(status_code: int, headers: dict[str, str], body: str):
+                _log.trace("Going to respond with query id", {"query_count": query_count})
+                if query_count == response_count + 1:
+                    # In order, send response immediately
+                    _log.trace("Sending response immediately", None)
+                    send_response(status_code, headers, body)
+                    response_count += 1
+                else:
+                    # Buffer up response
+                    _log.trace("Buffering response", None)
+                    # TODO: actually implement buffering?
+                    #outstanding_requests[query_count] = Response("GABBA", version, status_code, headers, body.encode())
+
+            if on_request_cb is not None:
+                response = on_request_cb(self, req, respond)
+                if response is not None:
+                    _log.trace("Sending response immediately", None)
+                else:
+                    _log.trace("Async response", None)
+            else:
+                _log.notice("No on_request callback set", None)
+
+    def on_conn_error(conn, error):
+        # TODO: the conn should really be in here, but type error!?
+        _log.trace(f"There was an error: {str(error)} from: {str("")}", None)
+
+    def close():
+        conn.close()
+
+    def send_response(status_code: int, headers: dict[str, str], data: str):
+        if version is not None:
+            res = build_response(version, status_code, headers, data)
+            conn.write(res)
+
+        if close_connection:
+            conn.close()
+
+
+actor TLSServer(conn: net.TLSListenConnection, on_accept: action(TLSServer) -> None, log_handler: ?logging.Handler):
+    """Server serves a single TLS client connection"""
+    _log = logging.Logger(log_handler)
+    var on_request_cb: ?action(TLSServer, Request, action(int, dict[str, str], str) -> None) -> None = None
+    var on_error_cb: ?action(TLSServer, str) -> None = None
+    var version: ?bytes = None
+    var buf = b""
+    var close_connection: bool = True
+    var query_count: u64 = 0
+    var response_count: u64 = 0
+    var outstanding_requests: dict[u64, Response] = {}
+
+    def cb_install(new_on_request: action(TLSServer, Request, action(int, dict[str, str], str) -> None) -> None, new_on_error: action(TLSServer, str) -> None):
+        on_request_cb = new_on_request
+        on_error_cb = new_on_error
+        if buf != b"":
+            req, buf = parse_request(buf, _log)
+
+    def on_conn_receive(conn_obj, data: bytes) -> None:
+        # TODO: do we really need a buf?
+        if on_request_cb is None:
+            buf += data
+            return None
+        else:
+            if buf != b"":
+                data = buf + data
+
+        req, buf = parse_request(data, _log)
+        if req is not None:
+            if version is None:
+                version = req.version
+            elif version is not None and version != req.version:
+                _log.debug("Version mismatch", None)
+                conn.close()
+
+            if version is not None and version == b"1.0":
+                if "connection" in req.headers:
+                    if req.headers["connection"] == "close":
+                        _log.debug("HTTP 1.0 with connection: close, closing connection...", None)
+                        close_connection = True
+                    else:
+                        _log.debug("HTTP 1.0 with connection header, not closing connection...", None)
+                        _log.trace("connection header", {"connection": req.headers["connection"]})
+                else:
+                    close_connection = True
+            elif version is not None and version == b"1.1":
+                if "connection" in req.headers and req.headers["connection"] == "close":
+                    _log.debug("HTTP 1.1, closing connection...", None)
+                    close_connection = True
+                else:
+                    close_connection = False
+
+            query_count += 1
+            def respond(status_code: int, headers: dict[str, str], body: str):
+                _log.trace("Going to respond with query id", {"query_count": query_count})
+                if query_count == response_count + 1:
+                    # In order, send response immediately
+                    _log.trace("Sending response immediately", None)
+                    send_response(status_code, headers, body)
+                    response_count += 1
+                else:
+                    # Buffer up response
+                    _log.trace("Buffering response", None)
+                    # TODO: actually implement buffering?
+                    #outstanding_requests[query_count] = Response("GABBA", version, status_code, headers, body.encode())
+
+            if on_request_cb is not None:
+                response = on_request_cb(self, req, respond)
+                if response is not None:
+                    _log.trace("Sending response immediately", None)
+                else:
+                    _log.trace("Async response", None)
+            else:
+                _log.notice("No on_request callback set", None)
+
+    def on_conn_error(conn, error):
+        # TODO: the conn should really be in here, but type error!?
+        _log.trace(f"There was an error: {str(error)} from: {str("")}", None)
+
+    def close():
+        conn.close()
+
+    def send_response(status_code: int, headers: dict[str, str], data: str):
+        if version is not None:
+            res = build_response(version, status_code, headers, data)
+            conn.write(res)
+
+        if close_connection:
+            conn.close()
+
+
+# TODO: change port to u16, when u16 has a sub-type relationship to int
+# TODO: the on_listen_error default should be some action that just automatically retries with a backoff
+# TODO: add restart method to restart the listener
+actor Listener(cap: net.TCPListenCap, address: str, port: int, on_accept: action(Server) -> None, on_listen_error: ?action(net.TCPListener, str) -> None = None, log_handler: ?logging.Handler = None):
+    """HTTP Server Listener"""
+    _log = logging.Logger(log_handler)
+    var bufs = []
+
+    def on_conn_listen(listener, error):
+        if error is not None:
+            _log.notice("There was an error with the listener socket", {"error": error})
+            if on_listen_error is not None:
+                on_listen_error(listener, error)
+
+    def on_listener_accept(conn):
+        s = Server(conn, on_accept, log_handler)
+        await async on_accept(s)
+        await async conn.cb_install(s.on_conn_receive, s.on_conn_error, None)
+
+    var _listener = net.TCPListener(cap, address, port, on_conn_listen, on_listener_accept)
+
+
+# TODO: change port to u16, when u16 has a sub-type relationship to int
+# TODO: the on_listen_error default should be some action that just automatically retries with a backoff
+# TODO: add restart method to restart the listener
+actor TLSListener(cap: net.TCPListenCap, address: str, port: int, cert_pem: bytes, key_pem: bytes, on_accept: action(TLSServer) -> None, on_listen_error: ?action(net.TLSListener, str) -> None = None, log_handler: ?logging.Handler = None):
+    """HTTPS Server Listener"""
+    _log = logging.Logger(log_handler)
+    var bufs = []
+
+    def on_conn_listen(listener, error):
+        if error is not None:
+            _log.notice("There was an error with the listener socket", {"error": error})
+            if on_listen_error is not None:
+                on_listen_error(listener, error)
+
+    def on_listener_accept(conn):
+        s = TLSServer(conn, on_accept, log_handler)
+        await async on_accept(s)
+        await async conn.cb_install(s.on_conn_receive, s.on_conn_error, None)
+
+    var _listener = net.TLSListener(cap, address, port, cert_pem, key_pem, on_conn_listen, on_listener_accept)
+
+
+# TODO: change port to u16, when u16 has a sub-type relationship to int
+actor Client(cap: net.TCPConnectCap, address: str, on_connect: action(Client) -> None, on_error: action(Client, str) -> None, scheme: str="https", port: ?int=None, tls_verify: bool=True, log_handler: ?logging.Handler):
+    """HTTP(S) Client
+
+    scheme is either 'http' or 'https', the default is 'https'
+    port is optional, if not provided, it will be inferred from the scheme where http=80 and https=443
+    """
+    _log = logging.Logger(log_handler)
+    var _on_response: list[(bytes, action(Client, Response) -> None)] = []
+    var version: ?bytes = None
+    var buf = b""
+    var close_connection: bool = True
+    var tcp_conn: ?net.TCPConnection = None
+    var tls_conn: ?net.TLSConnection = None
+
+    def _connect():
+        if scheme == "http":
+            _log.verbose("Using http scheme and port 80", None)
+            tcp_port = port if port is not None else 80
+            tcp_conn = net.TCPConnection(cap, address, tcp_port, _on_tcp_connect, _on_tcp_receive, _on_tcp_error, None, connect_timeout=10.0)
+        elif scheme == "https":
+            _log.verbose("Using https scheme and port 443", None)
+            tls_port = port if port is not None else 443
+            tls_conn = net.TLSConnection(cap, address, tls_port, _on_tls_connect, _on_tls_receive, _on_tls_error, None, tls_verify)
+        else:
+            raise ValueError(f"Only http and https schemes are supported. Unsupported scheme: {scheme}")
+
+    def _on_conn_connect():
+        # If there are outstanding requests, it probably means we were
+        for r in _on_response:
+            _conn_write(r.0)
+        await async on_connect(self)
+
+    def _on_tcp_connect(conn: net.TCPConnection) -> None:
+        _on_conn_connect()
+
+    def _on_tls_connect(conn: net.TLSConnection) -> None:
+        _on_conn_connect()
+
+    def _on_tcp_receive(conn: net.TCPConnection, data: bytes) -> None:
+        _on_con_receive(data)
+
+    def _on_tls_receive(conn: net.TLSConnection, data: bytes) -> None:
+        _on_con_receive(data)
+
+    def _on_con_receive(data: bytes) -> None:
+        buf += data
+        _log.debug("Received data", {"bytes": len(data)})
+        #_log.trace("Received data", {"data": data})
+
+        while True:
+            r, buf = parse_response(buf, _log)
+            if r is not None:
+                if "connection" in r.headers and r.headers["connection"] == "close":
+                    close_connection = True
+                    _conn_close()
+                    _log.debug("Closing TCP connection due to header: Connection: close", None)
+                    _connect()
+                if len(_on_response) == 0:
+                    _log.notice("Data received with no on_response callback set", None)
+                    break
+                outreq = _on_response[0]
+                del _on_response[0]
+                cb = outreq.1
+
+                await async cb(self, r)
+            else:
+                break
+
+    def _on_tcp_error(conn: net.TCPConnection, error: str) -> None:
+        _on_con_error(error)
+
+    def _on_tls_error(conn: net.TLSConnection, error: str) -> None:
+        _on_con_error(error)
+
+    def _on_con_error(error: str) -> None:
+        on_error(self, error)
+
+    def _conn_close() -> None:
+        if tcp_conn is not None:
+            def _noop(c):
+                pass
+            tcp_conn.close(_noop)
+        elif tls_conn is not None:
+            def _noop(c):
+                pass
+            tls_conn.close(_noop)
+
+    def _conn_write(data: bytes) -> None:
+        _log.trace("Sending data", {"data": data})
+        if tcp_conn is not None:
+            tcp_conn.write(data)
+        elif tls_conn is not None:
+            tls_conn.write(data)
+
+    def close():
+        _conn_close()
+
+    # HTTP methods
+    def get(path: str, on_response: action(Client, Response) -> None, headers: dict[str, str] = {}):
+        req = build_request(address, b"GET", path.encode(), b"1.1", headers, b"")
+        _log.debug("Sending request", {"method": "GET", "path": path})
+        _on_response.append((req, on_response))
+        _conn_write(req)
+
+    def head(path: str, on_response: action(Client, Response) -> None, headers: dict[str, str] = {}):
+        req = build_request(address, b"HEAD", path.encode(), b"1.1", headers, b"")
+        _log.debug("Sending request", {"method": "HEAD", "path": path})
+        _on_response.append((req, on_response))
+        _conn_write(req)
+
+    def post(path: str, body: bytes, on_response: action(Client, Response) -> None, headers: dict[str, str] = {}):
+        if "Content-Type" not in headers:
+            headers["Content-Type"] = "application/x-www-form-urlencoded"
+        req = build_request(address, b"POST", path.encode(), b"1.1", headers, body)
+        _log.debug("Sending request", {"method": "POST", "path": path})
+        _on_response.append((req, on_response))
+        _conn_write(req)
+
+    def put(path: str, body: bytes, on_response: action(Client, Response) -> None, headers: dict[str, str] = {}):
+        req = build_request(address, b"PUT", path.encode(), b"1.1", headers, body)
+        _log.debug("Sending request", {"method": "PUT", "path": path})
+        _on_response.append((req, on_response))
+        _conn_write(req)
+
+    def delete(path: str, on_response: action(Client, Response) -> None, headers: dict[str, str] = {}):
+        req = build_request(address, b"DELETE", path.encode(), b"1.1", headers, b"")
+        _log.debug("Sending request", {"method": "DELETE", "path": path})
+        _on_response.append((req, on_response))
+        _conn_write(req)
+
+    _connect()

--- a/std/src/std/json.act
+++ b/std/src/std/json.act
@@ -1,0 +1,44 @@
+actor Json():
+    """JSON actor for distributed async processing
+
+    This actor can be used to process JSON data in a asynchronous distributed
+    fashion. The `encode` and `decode` methods are identical to the free
+    `encode` and `decode` functions in this module but by being wrapped in an
+    actor, they can be:
+    - called asynchronously
+    - the Json actor can be run by a different worker
+    Thus, by using one or multiple Json actors, the work of encoding or decoding
+    JSON can be distributed across multiple actors / workers / CPUs.
+    """
+    action def decode(data: str) -> dict[str, ?value]:
+        return decode(data)
+
+    action def decode_list(data: str) -> list[?value]:
+        return decode_list(data)
+
+    action def encode(data: dict[str, ?value]) -> str:
+        return encode(data)
+
+    action def encode_list(data: list[?value], pretty=False) -> str:
+        return encode_list(data, pretty)
+
+
+def decode(data: str) -> dict[str, ?value]:
+    """Decode a JSON string into a dictionary of values
+    """
+    NotImplemented
+
+def decode_list(data: str) -> list[?value]:
+    """Decode a JSON string (containing an array) into a list of values
+    """
+    NotImplemented
+
+def encode(data: dict[str, ?value], pretty=False) -> str:
+    """Encode a dictionary into a JSON string
+    """
+    NotImplemented
+
+def encode_list(data: list[?value], pretty=False) -> str:
+    """Encode a list into a JSON array string
+    """
+    NotImplemented

--- a/std/src/std/json.ext.c
+++ b/std/src/std/json.ext.c
@@ -1,0 +1,356 @@
+
+#include "rts/io.h"
+#include "rts/log.h"
+#include "yyjson.h"
+
+static void *my_malloc(void *ctx, size_t size) {
+    return acton_malloc(size);
+}
+
+static void *my_realloc(void *ctx, void *ptr, size_t size) {
+    return acton_realloc(ptr, size);
+}
+
+static void my_free(void *ctx, void *ptr) {
+    acton_free(ptr);
+}
+
+
+yyjson_alc stdQ_jsonQ_acton_alc;
+
+void stdQ_jsonQ___ext_init__() {
+    stdQ_jsonQ_acton_alc.malloc = my_malloc;
+    stdQ_jsonQ_acton_alc.realloc = my_realloc;
+    stdQ_jsonQ_acton_alc.free = my_free;
+}
+
+void stdQ_jsonQ_encode_list_into(yyjson_mut_doc *doc, yyjson_mut_val *node, B_list data);
+void stdQ_jsonQ_encode_dict(yyjson_mut_doc *doc, yyjson_mut_val *node, B_dict data) {
+    B_IteratorD_dict_items iter = $NEW(B_IteratorD_dict_items, data);
+    B_tuple item;
+
+    for (int i=0; i < data->numelements; i++) {
+        item = (B_tuple)iter->$class->__next__(iter);
+        char *key = (char *)fromB_str((B_str)item->components[0]);
+        B_value v = item->components[1];
+        if (v) {
+            switch (v->$class->$class_id) {
+                case INT_ID:;
+                    yyjson_mut_obj_add_int(doc, node, key, fromB_int((B_int)v));
+                    break;
+                case FLOAT_ID:;
+                    yyjson_mut_obj_add_real(doc, node, key, fromB_float((B_float)v));
+                    break;
+                case BOOL_ID:;
+                    yyjson_mut_obj_add_bool(doc, node, key, fromB_bool((B_bool)v));
+                    break;
+                case STR_ID:;
+                    yyjson_mut_obj_add_str(doc, node, key,  (char *)fromB_str((B_str)v));
+                    break;
+                case LIST_ID:;
+                    yyjson_mut_val *l = yyjson_mut_arr(doc);
+                    yyjson_mut_obj_add_val(doc, node, key, l);
+                    stdQ_jsonQ_encode_list_into(doc, l, (B_list)v);
+                    break;
+                case DICT_ID:;
+                    yyjson_mut_val *d = yyjson_mut_obj(doc);
+                    yyjson_mut_obj_add_val(doc, node, key, d);
+                    stdQ_jsonQ_encode_dict(doc, d, (B_dict)v);
+                    break;
+                case I8_ID:;
+                    yyjson_mut_obj_add_int(doc, node, key, ((B_i8)v)->val);
+                    break;
+                case I16_ID:;
+                    yyjson_mut_obj_add_int(doc, node, key, ((B_i16)v)->val);
+                    break;
+                case I32_ID:;
+                    yyjson_mut_obj_add_int(doc, node, key, ((B_i32)v)->val);
+                    break;
+                case I64_ID:;
+                    yyjson_mut_obj_add_int(doc, node, key, ((B_int)v)->val);
+                    break;
+                case U1_ID:;
+                    yyjson_mut_obj_add_uint(doc, node, key, ((B_u1)v)->val);
+                    break;
+                case U8_ID:;
+                    yyjson_mut_obj_add_uint(doc, node, key, ((B_u8)v)->val);
+                    break;
+                case U16_ID:;
+                    yyjson_mut_obj_add_uint(doc, node, key, ((B_u16)v)->val);
+                    break;
+                case U32_ID:;
+                    yyjson_mut_obj_add_uint(doc, node, key, ((B_u32)v)->val);
+                    break;
+                case U64_ID:;
+                    yyjson_mut_obj_add_uint(doc, node, key, ((B_u64)v)->val);
+                    break;
+                default:;
+                    // TODO: hmm, at least handle all builtin types? and that's it,
+                    // maybe? like we really shouldn't accept user-defined types
+                    // here, just throw an exception? or when we have unions, just
+                    // accept union of the types we support
+                    $RAISE(((B_BaseException)B_ValueErrorG_new($FORMAT("stdQ_jsonQ_encode_dict: for key %s unknown type: %s", key, v->$class->$GCINFO))));
+            }
+        } else {
+            yyjson_mut_obj_add_null(doc, node, key);
+        }
+    }
+}
+
+void stdQ_jsonQ_encode_list_into(yyjson_mut_doc *doc, yyjson_mut_val *node, B_list data) {
+    for (int i = 0; i < data->length; i++) {
+        B_value v = data->data[i];
+        if (v) {
+            switch (v->$class->$class_id) {
+                case INT_ID:;
+                    yyjson_mut_arr_add_int(doc, node, fromB_int((B_int)v));
+                    break;
+                case FLOAT_ID:;
+                    yyjson_mut_arr_add_real(doc, node, fromB_float((B_float)v));
+                    break;
+                case BOOL_ID:;
+                    yyjson_mut_arr_add_bool(doc, node, fromB_bool((B_bool)v));
+                    break;
+                case STR_ID:;
+                    yyjson_mut_arr_add_str(doc, node,  (char *)fromB_str((B_str)v));
+                    break;
+                case LIST_ID:;
+                    yyjson_mut_val *l = yyjson_mut_arr_add_arr(doc, node);
+                    if (l) {
+                        stdQ_jsonQ_encode_list_into(doc, l, (B_list)v);
+                    } else {
+                        // TODO: raise exception
+                    }
+                    break;
+                case DICT_ID:;
+                    yyjson_mut_val *d = yyjson_mut_arr_add_obj(doc, node);
+                    if (d) {
+                        stdQ_jsonQ_encode_dict(doc, d, (B_dict)v);
+                    } else {
+                        // TODO: raise exception
+                    }
+                    break;
+                case I8_ID:;
+                    yyjson_mut_arr_add_int(doc, node, ((B_i8)v)->val);
+                    break;
+                case I16_ID:;
+                    yyjson_mut_arr_add_int(doc, node, ((B_i16)v)->val);
+                    break;
+                case I32_ID:;
+                    yyjson_mut_arr_add_int(doc, node, ((B_i32)v)->val);
+                    break;
+                case I64_ID:;
+                    yyjson_mut_arr_add_int(doc, node, ((B_int)v)->val);
+                    break;
+                case U1_ID:;
+                    yyjson_mut_arr_add_uint(doc, node, ((B_u1)v)->val);
+                    break;
+                case U8_ID:;
+                    yyjson_mut_arr_add_uint(doc, node, ((B_u8)v)->val);
+                    break;
+                case U16_ID:;
+                    yyjson_mut_arr_add_uint(doc, node, ((B_u16)v)->val);
+                    break;
+                case U32_ID:;
+                    yyjson_mut_arr_add_uint(doc, node, ((B_u32)v)->val);
+                    break;
+                case U64_ID:;
+                    yyjson_mut_arr_add_uint(doc, node, ((B_u64)v)->val);
+                    break;
+                default:;
+                    // TODO: hmm, at least handle all builtin types? and that's it,
+                    // maybe? like we really shouldn't accept user-defined types
+                    // here, just throw an exception? or when we have unions, just
+                    // accept union of the types we support
+                    $RAISE(((B_BaseException)B_ValueErrorG_new($FORMAT("stdQ_jsonQ_encode_list: unknown type: %s", v->$class->$GCINFO))));
+            }
+        } else {
+            yyjson_mut_arr_add_null(doc, node);
+        }
+    }
+}
+
+B_list stdQ_jsonQ_decode_arr(yyjson_val *);
+
+B_dict stdQ_jsonQ_decode_obj(yyjson_val *obj) {
+
+    B_Hashable wit = (B_Hashable)B_HashableD_strG_witness;
+    B_dict res = $NEW(B_dict, wit, NULL, NULL);
+    yyjson_obj_iter iter;
+    yyjson_obj_iter_init(obj, &iter);
+    yyjson_val *key, *val;
+    while ((key = yyjson_obj_iter_next(&iter))) {
+        val = yyjson_obj_iter_get_val(key);
+
+        switch (yyjson_get_type(val)) {
+            case YYJSON_TYPE_NONE:;
+                break;
+            case YYJSON_TYPE_NULL:;
+                B_dictD_setitem(res, wit, to$str(yyjson_get_str(key)), B_None);
+                break;
+            case YYJSON_TYPE_BOOL:;
+                B_dictD_setitem(res, wit, to$str(yyjson_get_str(key)), toB_bool(yyjson_get_bool(val)));
+                break;
+            case YYJSON_TYPE_NUM:;
+                switch (yyjson_get_subtype(val)) {
+                    case YYJSON_SUBTYPE_UINT:;
+                        B_dictD_setitem(res, wit, to$str(yyjson_get_str(key)), toB_int(yyjson_get_int(val)));
+                        break;
+                    case YYJSON_SUBTYPE_SINT:;
+                        B_dictD_setitem(res, wit, to$str(yyjson_get_str(key)), toB_int(yyjson_get_int(val)));
+                        break;
+                    case YYJSON_SUBTYPE_REAL:;
+                        B_dictD_setitem(res, wit, to$str(yyjson_get_str(key)), to$float(yyjson_get_real(val)));
+                        break;
+                }
+                break;
+            case YYJSON_TYPE_STR:;
+                B_dictD_setitem(res, wit, to$str(yyjson_get_str(key)), to$str(yyjson_get_str(val)));
+                break;
+            case YYJSON_TYPE_ARR:;
+                B_list l = stdQ_jsonQ_decode_arr(val);
+                B_dictD_setitem(res, wit, to$str(yyjson_get_str(key)), l);
+                break;
+            case YYJSON_TYPE_OBJ:;
+                B_dict d = stdQ_jsonQ_decode_obj(val);
+                B_dictD_setitem(res, wit, to$str(yyjson_get_str(key)), d);
+                break;
+            default:;
+                // unreachable
+                $RAISE(((B_BaseException)B_ValueErrorG_new($FORMAT("stdQ_jsonQ_encode_list: unknown type: %d", yyjson_get_type(val)))));
+        }
+    }
+    return res;
+}
+
+B_list stdQ_jsonQ_decode_arr(yyjson_val *arr) {
+    B_SequenceD_list wit = B_SequenceD_listG_witness;
+    B_list res = B_listG_new(NULL, NULL);
+    yyjson_val *val;
+    yyjson_arr_iter iter;
+    yyjson_arr_iter_init(arr, &iter);
+    while ((val = yyjson_arr_iter_next(&iter))) {
+        switch (yyjson_get_type(val)) {
+            case YYJSON_TYPE_NONE:
+                break;
+            case YYJSON_TYPE_NULL:;
+                wit->$class->append(wit, res, B_None);
+                break;
+            case YYJSON_TYPE_BOOL:;
+                wit->$class->append(wit, res, toB_bool(yyjson_get_bool(val)));
+                break;
+            case YYJSON_TYPE_NUM:;
+                switch (yyjson_get_subtype(val)) {
+                    case YYJSON_SUBTYPE_UINT:;
+                        wit->$class->append(wit, res, toB_int(yyjson_get_int(val)));
+                        break;
+                    case YYJSON_SUBTYPE_SINT:;
+                        wit->$class->append(wit, res, toB_int(yyjson_get_int(val)));
+                        break;
+                    case YYJSON_SUBTYPE_REAL:;
+                        wit->$class->append(wit, res, to$float(yyjson_get_real(val)));
+                        break;
+                }
+                break;
+            case YYJSON_TYPE_STR:;
+                wit->$class->append(wit, res, to$str(yyjson_get_str(val)));
+                break;
+            case YYJSON_TYPE_ARR:;
+                B_list l = stdQ_jsonQ_decode_arr(val);
+                wit->$class->append(wit, res, l);
+                break;
+            case YYJSON_TYPE_OBJ:;
+                B_dict d = stdQ_jsonQ_decode_obj(val);
+                wit->$class->append(wit, res, d);
+                break;
+            default:;
+                // TODO: just handle all types?
+                $RAISE(((B_BaseException)B_ValueErrorG_new($FORMAT("stdQ_jsonQ_decode_arr: unknown type: %d", yyjson_get_type(val)))));
+        }
+    }
+    return res;
+}
+
+B_dict stdQ_jsonQ_decode (B_str data) {
+    // Read JSON and get root
+    yyjson_read_err err;
+    yyjson_doc *doc = yyjson_read_opts(fromB_str(data), strlen(fromB_str(data)), 0, &stdQ_jsonQ_acton_alc, &err);
+    yyjson_val *root = yyjson_doc_get_root(doc);
+
+    B_dict res = $NEW(B_dict,(B_Hashable)B_HashableD_strG_witness,NULL,NULL);
+    // Iterate over the root object
+    if (doc) {
+        yyjson_val *obj = yyjson_doc_get_root(doc);
+        res = stdQ_jsonQ_decode_obj(obj);
+    } else {
+        char errmsg[1024];
+        snprintf(errmsg, sizeof(errmsg), "JSON parsing error: %s (%u) at position %ld", err.msg, err.code, err.pos);
+        $RAISE((B_BaseException)$NEW(B_ValueError, to$str(errmsg)));
+    }
+
+    yyjson_doc_free(doc);
+    return res;
+}
+
+B_list stdQ_jsonQ_decode_list (B_str data) {
+    // Read JSON and get root
+    yyjson_read_err err;
+    yyjson_doc *doc = yyjson_read_opts(fromB_str(data), strlen(fromB_str(data)), 0, &stdQ_jsonQ_acton_alc, &err);
+    if (!doc) {
+        char errmsg[1024];
+        snprintf(errmsg, sizeof(errmsg), "JSON parsing error: %s (%u) at position %ld", err.msg, err.code, err.pos);
+        $RAISE((B_BaseException)$NEW(B_ValueError, to$str(errmsg)));
+    }
+
+    yyjson_val *root = yyjson_doc_get_root(doc);
+    if (yyjson_get_type(root) != YYJSON_TYPE_ARR) {
+        yyjson_doc_free(doc);
+        $RAISE(((B_BaseException)B_ValueErrorG_new(to$str("JSON root is not an array"))));
+    }
+
+    B_list res = stdQ_jsonQ_decode_arr(root);
+    yyjson_doc_free(doc);
+    return res;
+}
+
+B_str stdQ_jsonQ_encode (B_dict data, B_bool pretty) {
+    if (pretty == NULL)
+        pretty = B_False;
+
+    // Create JSON document
+    yyjson_mut_doc *doc = yyjson_mut_doc_new(&stdQ_jsonQ_acton_alc);
+    yyjson_mut_val *root = yyjson_mut_obj(doc);
+    yyjson_mut_doc_set_root(doc, root);
+
+    stdQ_jsonQ_encode_dict(doc, root, data);
+
+    yyjson_write_err err;
+    int flags = 0;
+    if (pretty == B_True)
+        flags += YYJSON_WRITE_PRETTY;
+
+    char *json = yyjson_mut_write_opts(doc, flags, &stdQ_jsonQ_acton_alc, NULL, &err);
+    //yyjson_doc_free(doc);
+    return to$str(json);
+}
+
+B_str stdQ_jsonQ_encode_list (B_list data, B_bool pretty) {
+    if (pretty == NULL)
+        pretty = B_False;
+
+    // Create JSON document
+    yyjson_mut_doc *doc = yyjson_mut_doc_new(&stdQ_jsonQ_acton_alc);
+    yyjson_mut_val *root = yyjson_mut_arr(doc);
+    yyjson_mut_doc_set_root(doc, root);
+
+    stdQ_jsonQ_encode_list_into(doc, root, data);
+
+    yyjson_write_err err;
+    int flags = 0;
+    if (pretty == B_True)
+        flags += YYJSON_WRITE_PRETTY;
+
+    char *json = yyjson_mut_write_opts(doc, flags, &stdQ_jsonQ_acton_alc, NULL, &err);
+    //yyjson_doc_free(doc);
+    return to$str(json);
+}

--- a/std/src/std/math.act
+++ b/std/src/std/math.act
@@ -1,0 +1,80 @@
+# Copyright (C) 2019-2021 Data Ductus AB
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+pi = 3.141592653589793
+
+protocol RealFuns:
+    @staticmethod
+    sqrt       : (Self) -> Self
+    @staticmethod
+    exp        : (Self) -> Self
+    @staticmethod
+    log        : (Self) -> Self
+    @staticmethod
+    sin        : (Self) -> Self
+    @staticmethod
+    cos        : (Self) -> Self
+    @staticmethod
+    tan        : (Self) -> Self
+    @staticmethod
+    asin       : (Self) -> Self
+    @staticmethod
+    acos       : (Self) -> Self
+    @staticmethod
+    atan       : (Self) -> Self
+    @staticmethod
+    sinh       : (Self) -> Self
+    @staticmethod
+    cosh       : (Self) -> Self
+    @staticmethod
+    tanh       : (Self) -> Self
+    @staticmethod
+    asinh       : (Self) -> Self
+    @staticmethod
+    acosh       : (Self) -> Self
+    @staticmethod
+    atanh       : (Self) -> Self
+
+extension float (RealFuns):
+    NotImplemented
+
+def sqrt(x: float):
+   return RealFuns.sqrt(x)
+def exp(x: float):
+   return RealFuns.exp(x)
+def log(x: float):
+   return RealFuns.log(x)
+def sin(x: float):
+   return RealFuns.sin(x)
+def cos(x: float):
+   return RealFuns.cos(x)
+def tan(x: float):
+   return RealFuns.tan(x)
+def asin(x: float):
+   return RealFuns.asin(x)
+def acos(x: float):
+   return RealFuns.acos(x)
+def atan(x: float):
+   return RealFuns.atan(x)
+def sinh(x: float):
+   return RealFuns.sinh(x)
+def cosh(x: float):
+   return RealFuns.cosh(x)
+def tanh(x: float):
+   return RealFuns.tanh(x)
+def asinh(x: float):
+   return RealFuns.asinh(x)
+def acosh(x: float):
+   return RealFuns.acosh(x)
+def atanh(x: float):
+   return RealFuns.atanh(x)

--- a/std/src/std/math.ext.c
+++ b/std/src/std/math.ext.c
@@ -1,0 +1,49 @@
+B_float stdQ_mathQ_RealFunsD_floatD_sqrt(stdQ_mathQ_RealFunsD_float wit, B_float x) {
+  return to$float(sqrt(x->val));
+}
+B_float stdQ_mathQ_RealFunsD_floatD_exp(stdQ_mathQ_RealFunsD_float wit, B_float x) {
+  return to$float(exp(x->val));
+}
+B_float stdQ_mathQ_RealFunsD_floatD_log(stdQ_mathQ_RealFunsD_float wit, B_float x) {
+  return to$float(log(x->val));
+}
+B_float stdQ_mathQ_RealFunsD_floatD_sin(stdQ_mathQ_RealFunsD_float wit, B_float x) {
+  return to$float(sin(x->val));
+}
+B_float stdQ_mathQ_RealFunsD_floatD_cos(stdQ_mathQ_RealFunsD_float wit, B_float x) {
+  return to$float(cos(x->val));
+}
+B_float stdQ_mathQ_RealFunsD_floatD_tan(stdQ_mathQ_RealFunsD_float wit, B_float x) {
+  return to$float(tan(x->val));
+}
+B_float stdQ_mathQ_RealFunsD_floatD_asin(stdQ_mathQ_RealFunsD_float wit, B_float x) {
+  return to$float(asin(x->val));
+}
+B_float stdQ_mathQ_RealFunsD_floatD_acos(stdQ_mathQ_RealFunsD_float wit, B_float x) {
+  return to$float(acos(x->val));
+}
+B_float stdQ_mathQ_RealFunsD_floatD_atan(stdQ_mathQ_RealFunsD_float wit, B_float x) {
+  return to$float(atan(x->val));
+}
+B_float stdQ_mathQ_RealFunsD_floatD_sinh(stdQ_mathQ_RealFunsD_float wit, B_float x) {
+  return to$float(sinh(x->val));
+}
+B_float stdQ_mathQ_RealFunsD_floatD_cosh(stdQ_mathQ_RealFunsD_float wit, B_float x) {
+  return to$float(cosh(x->val));
+}
+B_float stdQ_mathQ_RealFunsD_floatD_tanh(stdQ_mathQ_RealFunsD_float wit, B_float x) {
+  return to$float(tanh(x->val));
+}
+B_float stdQ_mathQ_RealFunsD_floatD_asinh(stdQ_mathQ_RealFunsD_float wit, B_float x) {
+  return to$float(asinh(x->val));
+}
+B_float stdQ_mathQ_RealFunsD_floatD_acosh(stdQ_mathQ_RealFunsD_float wit, B_float x) {
+  return to$float(acosh(x->val));
+}
+B_float stdQ_mathQ_RealFunsD_floatD_atanh(stdQ_mathQ_RealFunsD_float wit, B_float x) {
+  return to$float(atanh(x->val));
+}
+
+void stdQ_mathQ___ext_init__() {
+    //NOP
+};

--- a/std/src/std/qcheck.act
+++ b/std/src/std/qcheck.act
@@ -1,0 +1,108 @@
+from std.random import *
+
+def qcheck_int_1(name: str, prop: (int) -> bool, verbose = False)->int:
+    print("Testing",name)
+    i: int = 1
+    while i <= 100:
+        m = i*i
+        a = randint(-m,m)
+        if not prop(a):
+            print("   ",name,"failed after",i,"tests:\n",a,"\n")
+            return 1
+        else:
+            if verbose:
+                print("   Argument =",a,"; passed")
+        i += 1
+    print("   OK,",name,"passed 100 tests\n")
+    return 0
+
+def qcheck_int_2(name: str, prop: (int, int) -> bool, verbose = False)->int:
+    print("Testing",name)
+    i: int = 1
+    while i <= 100:
+        m = i*i
+        a = randint(-m,m)
+        b = randint(-m,m)
+        if not prop(a,b):
+            print("   ",name,"failed after",i,"tests:\n",a,"\n",b)
+            return 1
+        else:
+            if verbose:
+                print("   Argument 1 =",a," argument 2 =",b,"; passed")
+        i += 1
+    print("   OK,",name,"passed 100 tests\n")
+    return 0
+
+def qcheck_bigint_1(name: str, prop: (bigint) -> bool, verbose = False)->int:
+    print("Testing",name)
+    i= 1
+    while i <= 100:
+        m = 2+i//2
+        a = rand_bigint(m)
+        if not prop(a):
+            print("   ",name,"failed after",i,"tests:\n",a)
+            return 1
+        else:
+            if verbose:
+                print("   Argument =",a,"; passed")
+        i += 1
+    print("   OK,",name,"passed 100 tests\n")
+    return 0
+
+def qcheck_bigint_2(name: str, prop: (bigint, bigint) -> bool, verbose = False)->int:
+    print("Testing",name)
+    i= 1
+    while i <= 100:
+        a = rand_bigint(randint(2,i+2))
+        b = rand_bigint(randint(2,i+2))
+        if not prop(a,b):
+            print("   ",name,"failed after",i,"tests:\n",a,"\n",b)
+            return 1
+        else:
+            if verbose:
+                print("   Argument 1 =",a," argument 2 =",b,"; passed")
+        i += 1
+    print("   OK,",name,"passed 100 tests\n")
+    return 0
+
+def qcheck_bigint_int(name: str, prop: (bigint, int) -> bool, verbose = False)->int:
+    print("Testing",name)
+    i= 1
+    while i <= 100:
+        a = rand_bigint(randint(2,i+2))
+        b = randint(-i*i,i*i)
+        if not prop(a,b):
+            print("   ",name,"failed after",i,"tests:\n",a,"\n",b)
+            return 1
+        else:
+            if verbose:
+                print("   Argument 1 =",a," argument 2 =",b,"; passed")
+        i += 1
+    print("   OK,",name,"passed 100 tests\n")
+    return 0
+
+
+def qcheck_0(name: str, prop: () -> bool)->int:
+    print("Testing",name)
+    if prop ():
+        print("   OK,",name,"passed\n")
+        return 0
+    else:
+        print("   ",name,"failed")
+        return 1
+
+def qcheck_list_2(name: str, prop: (list[int], list[int]) -> bool, verbose = False)->int:
+    print("Testing",name)
+    i = 1
+    while i <= 100:
+        a = rand_list(i)
+        b = rand_list(i)
+        if not prop(a,b):
+            print("   *************",name,"FAILED AFTER",i,"TESTS:*************\n",a,"\n",b)
+            return 1
+        else:
+            if verbose:
+                print("   Argument 1 =",a," argument 2 =",b,"; passed")
+        i += 1
+    print("   OK,",name,"passed 100 tests\n")
+    return 0

--- a/std/src/std/random.act
+++ b/std/src/std/random.act
@@ -1,0 +1,75 @@
+# TODO: randint should not be pure!!! but what should it be?
+def randint(min: int, max: int) -> int:
+    NotImplemented
+
+def randstr(length: int) -> str:
+    char_set = list("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
+    res = ""
+    for i in range(length):
+        res += choice(char_set)
+    return res
+
+def choice[T](sequence: Sequence[T]) -> T:
+    """
+    Return a random element from the non-empty sequence.
+
+    :param sequence: List or sequence to choose from.
+    :return: A random element from the sequence.
+    """
+    if len(sequence) == 0:
+        raise ValueError('Cannot choose from an empty sequence')
+
+    index = randint(0, len(sequence))
+    return sequence[index]
+
+
+def sample[T](population: list[T], k: int) -> list[T]:
+    """
+    Chooses k unique random elements from a population sequence.
+
+    :param population: List from which to sample.
+    :param k: Number of unique elements to pick.
+    :return: A new list containing elements from the population while maintaining the original sequence order.
+    """
+    if not (0 <= k and k <= len(population)):
+        raise ValueError("Sample larger than population or is negative")
+
+    result = []
+    indices = list(range(len(population)))
+    for _ in range(k):
+        idx_to_pop = choice(indices)
+        idx = 0
+        for i in range(len(indices)):
+            if indices[i] == idx_to_pop:
+                idx = i
+                break
+        indices.pop(idx)
+        result.append(population[idx_to_pop])
+    return result
+
+
+def rand_bigint(size):
+    """
+    Returns a randomly chosen integer (positive, zero or negative)
+
+    :param size: Maximal number of decimal digits (must be positive)
+    """
+    if (size <= 0):
+        raise ValueError('decimal length of int must be positive')
+    digits = [choice(["","-"])]
+    for i in range(size):
+        digits.append(choice(["0","1","2","3","4","5","6","7","8","9"]))
+    return bigint("".join(digits))
+
+def rand_list(size)->list[int]:
+    """
+    Returns a randomly chosen list of integers.
+
+    :param size: Maximal number of elements and maximal size of list elements (must be positive)
+    """
+    if (size <= 0):
+        raise ValueError('decimal length of int must be positive')
+    res = []
+    for i in range(randint(0,size)):
+        res.append(randint(-size, size))
+    return res

--- a/std/src/std/random.ext.c
+++ b/std/src/std/random.ext.c
@@ -1,0 +1,44 @@
+#include <stdlib.h>
+
+void stdQ_randomQ___ext_init__() {
+    // seed the random number generator with nanoseconds since the epoch and our
+    // PID
+    uv_timespec64_t ts;
+    uv_clock_gettime(UV_CLOCK_MONOTONIC, &ts);
+    srand(ts.tv_nsec ^ pid);
+}
+
+// NOTE: the standard srand / rand functions are not thread safe, but what does
+// that really mean in this context? While we could use thread safe functions
+// for deterministic random numbers (based on the seed), we won't guarantee
+// deterministic scheduling of actors on our RTS threads and so there still
+// would not be a guarantee for thread safe random numbers. Also, having to call
+// srand to seed reflects the C implementation, which we're not keen on doing -
+// rather we want it Pythonic - you should be able to get a random number with a
+// single call to random.randint(1, 3). So instead we just seed on startup with
+// the time, which is prolly good enough for now. In a future, we could cook up
+// something better.
+
+long stdQ_randomQ_randlong (long min, long max) {
+    // ensure we have a valid range where min is smaller than max
+    if (min > max) {
+        $RAISE(((B_BaseException)B_ValueErrorG_new(to$str("min value must be smaller than max"))));
+    }
+    // upper end of the range we want when "based to 0"
+    long range = max - min;
+    // chop off all values that would cause skew, leaving only things within the
+    // range that maps up to a multiple of the specified range
+    long end = RAND_MAX / range;
+    // new end
+    end *= range;
+    // run rand() until we get a value below end
+    long r;
+    // spin getting new values until we find one in range
+    while ((r = rand()) >= end);
+    // normalize back to the requested range
+    return min + r%range;
+}
+
+int64_t stdQ_randomQ_U_randint(int64_t min, int64_t max) {
+    return stdQ_randomQ_randlong(min,max);
+}

--- a/std/src/std/re.act
+++ b/std/src/std/re.act
@@ -1,0 +1,123 @@
+
+#class Pattern():
+#    pass
+#
+#class Or(Pattern):
+#    def __init__(self, p: list[Pattern]):
+#        self.p = p
+#
+#    def __str__(self):
+#        res = "("
+#        l = len(self.p)
+#        for i in range(l):
+#            res += str(self.p[i])
+#            if i < l-1:
+#                res += "|"
+#        res += ")"
+#        return res
+#
+#class Text(Pattern):
+#    """Literal text
+#    """
+#    def __init__(self, t: str):
+#        self.text = t
+#        # TODO: complete patterns for escaping re patterns
+#        self.re_text = t.replace(".", r"\.", None).replace("?", r"\?", None)
+#
+#    def __str__(self):
+#        return self.re_text
+
+
+class Match:
+    def __init__(self, pattern: str, string: str, start_pos: int, end_pos: int, group: list[?str], named_group: dict[str, ?str]) -> None:
+        self.pattern = pattern
+        self.string = string
+        self.start_pos = start_pos
+        self.end_pos = end_pos
+        self.group = group
+        self.named = named_group
+
+# TODO: add _compile function to compile a pattern to a regex, and use it in
+# _match function to avoid recompiling the pattern each time
+
+def _match(pattern: str, string: str, start_pos: int) -> ?Match:
+    NotImplemented
+
+def match(pattern: str, string: str, start_pos: int=0) -> ?Match:
+    """Scan through string looking for a match to the pattern, returning
+    a match object, or None if no match was found. start_pos sets the
+    index to begin scanning at.
+    """
+    return _match(pattern, string, start_pos)
+
+def matches(pattern: str, string: str) -> list[Match]:
+    """Find all non-overlapping matches in string
+    """
+    # TODO: implement as a generator instead
+    res = []
+    pos = 0
+    str_len = len(string)
+    while True:
+        if pos >= str_len:
+            break
+        m = _match(pattern, string, pos)
+        if m is None:
+            break
+        if m is not None:
+            res.append(m)
+            if m.end_pos == pos:
+                # Zero-width match: move forward one character if possible
+                if pos < str_len:
+                    pos += 1
+                else:
+                    # At the very end, just break
+                    break
+            else:
+                pos = m.end_pos
+    return res
+
+def split(pattern: str, subject: str, max_split: int=0) -> list[str]:
+    if pattern == "":
+        raise ValueError("empty pattern")
+
+    result = []
+    splits_done = 0
+    pos = 0
+    str_len = len(subject)
+
+    while True:
+        if max_split != 0 and splits_done >= max_split:
+            # Reached maximum number of splits
+            break
+
+        m = _match(pattern, subject, pos)
+        if m is not None:
+            # Append substring before match (normal match)
+            if m.end_pos > pos:
+                result.append(subject[pos:m.start_pos])
+                if len(m.group) > 1:
+                    for g in m.group[1:]:
+                        result.append(g if g is not None else "")
+                pos = m.end_pos
+                splits_done += 1
+            else:
+                # Zero-width match
+                if pos == 0:
+                    # At the start: append empty substring to indicate a split at the start
+                    result.append(subject[pos:m.start_pos])
+                else:
+                    # Not at the start: do not append empty substring
+                    # If there are capturing groups, append them (if any)
+                    if len(m.group) > 1:
+                        for g in m.group[1:]:
+                            result.append(g if g is not None else "")
+
+                # After handling zero-width match, break to avoid infinite loops
+                break
+        else:
+            # No match found
+            break
+
+    # Append remainder
+    result.append(subject[pos:])
+    return result

--- a/std/src/std/re.ext.c
+++ b/std/src/std/re.ext.c
@@ -1,0 +1,156 @@
+#define PCRE2_CODE_UNIT_WIDTH 8
+
+#include <pcre2.h>
+
+static void *pcre2_malloc(size_t size, void *data) {
+    (void)data;
+    return acton_malloc(size);
+}
+
+static void pcre2_free(void *ptr, void *data) {}
+
+pcre2_compile_context *stdQ_reQ_compile_context;
+pcre2_general_context *stdQ_reQ_general_context;
+
+void stdQ_reQ___ext_init__() {
+    stdQ_reQ_general_context = pcre2_general_context_create(pcre2_malloc, pcre2_free, NULL);
+    if (stdQ_reQ_general_context == NULL) {
+        // Handle error
+        assert(0);
+    }
+    stdQ_reQ_compile_context = pcre2_compile_context_create(stdQ_reQ_general_context);
+}
+
+
+// TODO: use u64 instead of int for arg_start_pos
+stdQ_reQ_Match stdQ_reQ_U__match (B_str arg_pattern, B_str arg_text, int64_t arg_start_pos) {
+    B_Hashable hwit = (B_Hashable)B_HashableD_strG_witness;
+    B_SequenceD_list swit = B_SequenceD_listG_witness;
+    B_list groups = B_listG_new(NULL, NULL);
+    B_dict named_groups = $NEW(B_dict, hwit, NULL, NULL);
+
+    PCRE2_SPTR pattern = (PCRE2_SPTR)fromB_str(arg_pattern);
+    PCRE2_SPTR text = (PCRE2_SPTR)fromB_str(arg_text);
+    size_t text_length = strlen((char *)text);
+    // TODO: use u64 instead of int to eradicate possibility of < 0
+
+    // Validate start_pos
+    long start_offset = arg_start_pos;
+    if (start_offset < 0) {
+        $RAISE(((B_BaseException)B_ValueErrorG_new(to_str_noc("PCRE2 matching failed: negative start_pos"))));
+    }
+    if ((size_t)start_offset > text_length) {
+        $RAISE(((B_BaseException)B_ValueErrorG_new(to_str_noc("start position is greater than string length"))));
+    }
+
+    int errornumber;
+    PCRE2_SIZE erroroffset;
+    pcre2_code *re = pcre2_compile(
+        pattern,
+        PCRE2_ZERO_TERMINATED,
+        PCRE2_UTF,
+        &errornumber,
+        &erroroffset,
+        stdQ_reQ_compile_context
+    );
+
+    if (re == NULL) {
+        PCRE2_UCHAR buffer[256];
+        pcre2_get_error_message(errornumber, buffer, sizeof(buffer));
+        char errmsg[1024] = "regex compilation failed at offset ";
+        snprintf(errmsg + strlen(errmsg), sizeof(errmsg) - strlen(errmsg), "%d: %s", (int)erroroffset, buffer);
+        $RAISE(((B_BaseException)B_ValueErrorG_new(to$str(errmsg))));
+    }
+
+    pcre2_match_data *match_data = pcre2_match_data_create_from_pattern(re, NULL);
+    int rc = pcre2_match(
+        re,
+        text,
+        text_length,
+        (PCRE2_SIZE)start_offset,
+        0,
+        match_data,
+        NULL
+    );
+
+    if (rc < 0) {
+        pcre2_match_data_free(match_data);
+        pcre2_code_free(re);
+
+        if (rc == PCRE2_ERROR_NOMATCH) {
+            return B_None;
+        } else {
+            // Some other error
+            char errmsg[256];
+            snprintf(errmsg, sizeof(errmsg), "PCRE2 matching error: %d", rc);
+            $RAISE(((B_BaseException)B_RuntimeErrorG_new(to$str(errmsg))));
+        }
+    }
+
+    PCRE2_SIZE *ovector = pcre2_get_ovector_pointer(match_data);
+    if (rc == 0) {
+        pcre2_match_data_free(match_data);
+        pcre2_code_free(re);
+        $RAISE(((B_BaseException)B_RuntimeErrorG_new(to_str_noc("ovector was not big enough for all captured substrings"))));
+    }
+
+    // Extract all unnamed groups
+    // group 0 is the entire match, group 1... are subgroups
+    for (int i = 0; i < rc; i++) {
+        PCRE2_SIZE ss_start = ovector[2*i];
+        PCRE2_SIZE ss_end = ovector[2*i+1];
+        if (ss_start == PCRE2_UNSET || ss_end == PCRE2_UNSET) {
+            swit->$class->append(swit, groups, B_None);
+        } else {
+            size_t substring_length = ss_end - ss_start;
+            char *substring = acton_malloc_atomic(substring_length + 1);
+            memcpy(substring, text + ss_start, substring_length);
+            substring[substring_length] = '\0';
+            swit->$class->append(swit, groups, to_str_noc(substring));
+        }
+    }
+
+    // Named groups
+    int namecount;
+    pcre2_pattern_info(re, PCRE2_INFO_NAMECOUNT, &namecount);
+
+    if (namecount > 0) {
+        PCRE2_SPTR name_table;
+        int name_entry_size;
+        pcre2_pattern_info(re, PCRE2_INFO_NAMETABLE, &name_table);
+        pcre2_pattern_info(re, PCRE2_INFO_NAMEENTRYSIZE, &name_entry_size);
+
+        PCRE2_SPTR tabptr = name_table;
+        for (int i = 0; i < namecount; i++) {
+            int n = (tabptr[0] << 8) | tabptr[1]; // group number for this name
+            // The name itself starts at tabptr+2 and has length (name_entry_size-2)
+            int namelen = name_entry_size - 2;
+            char *group_name = acton_malloc_atomic(namelen + 1);
+            memcpy(group_name, tabptr+2, namelen);
+            group_name[namelen] = '\0';
+
+            PCRE2_SIZE ss_start = ovector[2*n];
+            PCRE2_SIZE ss_end = ovector[2*n+1];
+            if (ss_start == PCRE2_UNSET || ss_end == PCRE2_UNSET) {
+                B_dictD_setitem(named_groups, hwit, to_str_noc(group_name), B_None);
+            } else {
+                size_t substring_length = ss_end - ss_start;
+                char *substring = acton_malloc_atomic(substring_length + 1);
+                memcpy(substring, text + ss_start, substring_length);
+                substring[substring_length] = '\0';
+                B_dictD_setitem(named_groups, hwit, to_str_noc(group_name), to_str_noc(substring));
+            }
+
+            tabptr += name_entry_size;
+        }
+    }
+
+    // Entire match offsets
+    PCRE2_SIZE match_start = ovector[0];
+    PCRE2_SIZE match_end = ovector[1];
+
+    pcre2_match_data_free(match_data);
+    pcre2_code_free(re);
+
+    return stdQ_reQ_MatchG_new(arg_pattern, arg_text, toB_int(match_start), toB_int(match_end), groups, named_groups);
+}

--- a/std/src/std/snappy.act
+++ b/std/src/std/snappy.act
@@ -1,0 +1,9 @@
+def compress(data: bytes) -> bytes:
+    """Compress data using Snappy
+    """
+    NotImplemented
+
+def decompress(data: bytes) -> bytes:
+    """Decompress Snappy data
+    """
+    NotImplemented

--- a/std/src/std/snappy.ext.c
+++ b/std/src/std/snappy.ext.c
@@ -1,0 +1,66 @@
+
+#include "rts/io.h"
+#include "rts/log.h"
+#include <snappy-c.h>
+
+void stdQ_snappyQ___ext_init__() {
+    // NOP
+}
+
+B_bytes stdQ_snappyQ_compress (B_bytes data) {
+    char *input;
+    char *compressed;
+    size_t input_len;
+    size_t compressed_len;
+    snappy_status status;
+    B_bytes ret;
+
+    input = (char*)fromB_bytes(data);
+    input_len = (size_t)data->nbytes;
+
+    compressed_len = snappy_max_compressed_length(input_len);
+    compressed = acton_malloc(compressed_len);
+    status = snappy_compress(input, input_len, compressed, &compressed_len);
+
+    if (SNAPPY_OK == status) {
+        ret = to$bytesD_len(compressed, (int)compressed_len);
+    }
+    else {
+        char *errmsg = SNAPPY_INVALID_INPUT == status ? "Invalid input" : "Buffer too small";
+        $RAISE((B_BaseException)$NEW(B_ValueError, to$str(errmsg)));
+    }
+
+    return ret;
+}
+
+B_bytes stdQ_snappyQ_decompress (B_bytes data) {
+    char *input;
+    char *uncompressed;
+    size_t input_len;
+    size_t uncompressed_len;
+    snappy_status status;
+    B_bytes ret;
+
+    input = (char*)fromB_bytes(data);
+    input_len = (size_t)data->nbytes;
+
+    status = snappy_uncompressed_length(input, input_len, &uncompressed_len);
+
+    if (SNAPPY_OK != status) {
+	char *errmsg = (SNAPPY_INVALID_INPUT == status) ? "Invalid input" : "Buffer too small";
+        $RAISE((B_BaseException)$NEW(B_ValueError, to$str(errmsg)));
+    }
+
+    uncompressed = acton_malloc(uncompressed_len);
+    snappy_uncompress(input, input_len, uncompressed, &uncompressed_len);
+
+    if (SNAPPY_OK == status) {
+	ret = to$bytesD_len(uncompressed, (int)uncompressed_len);
+    }
+    else {
+	char *errmsg = SNAPPY_INVALID_INPUT == status ? "Invalid input" : "Buffer too small";
+        $RAISE((B_BaseException)$NEW(B_ValueError, to$str(errmsg)));
+    }
+
+    return ret;
+}

--- a/std/src/std/term.act
+++ b/std/src/std/term.act
@@ -1,0 +1,96 @@
+
+
+normal = "\x1b[0m"
+
+bold = "\x1b[1m"
+underline = "\x1b[4m"
+blink = "\x1b[5m"
+reverse = "\x1b[7m"
+
+# colors
+red = "\x1b[31m"
+green = "\x1b[32m"
+yellow = "\x1b[33m"
+blue = "\x1b[34m"
+magenta = "\x1b[35m"
+cyan = "\x1b[36m"
+white = "\x1b[37m"
+
+grey1 = "\x1b[38;5;232m"
+grey2 = "\x1b[38;5;233m"
+grey3 = "\x1b[38;5;234m"
+grey4 = "\x1b[38;5;235m"
+grey5 = "\x1b[38;5;236m"
+grey6 = "\x1b[38;5;237m"
+grey7 = "\x1b[38;5;238m"
+grey8 = "\x1b[38;5;239m"
+grey9 = "\x1b[38;5;240m"
+grey10 = "\x1b[38;5;241m"
+grey11 = "\x1b[38;5;242m"
+grey12 = "\x1b[38;5;243m"
+grey13 = "\x1b[38;5;244m"
+grey14 = "\x1b[38;5;245m"
+grey15 = "\x1b[38;5;246m"
+grey16 = "\x1b[38;5;247m"
+grey17 = "\x1b[38;5;248m"
+grey18 = "\x1b[38;5;249m"
+grey19 = "\x1b[38;5;250m"
+grey20 = "\x1b[38;5;251m"
+grey21 = "\x1b[38;5;252m"
+grey22 = "\x1b[38;5;253m"
+grey23 = "\x1b[38;5;254m"
+grey24 = "\x1b[38;5;255m"
+
+# background colors
+bg_red = "\x1b[41m"
+bg_green = "\x1b[42m"
+bg_yellow = "\x1b[43m"
+bg_blue = "\x1b[44m"
+bg_magenta = "\x1b[45m"
+bg_cyan = "\x1b[46m"
+bg_white = "\x1b[47m"
+
+clear = "\x1b[0J"
+top = "\x1b[H"
+
+def up(n=1):
+    """Move cursor up n lines.
+    """
+    if n < 0:
+        raise ValueError("n must be >= 0")
+    res = ""
+    for i in range(n):
+        res += "\x1b[A"
+    return res
+
+def down(n=1):
+    """Move cursor down n lines.
+    """
+    if n < 0:
+        raise ValueError("n must be >= 0")
+    res = ""
+    for i in range(n):
+        res += "\x1b[B"
+    return res
+
+def right(n=1):
+    """Move cursor right n columns.
+    """
+    if n < 0:
+        raise ValueError("n must be >= 0")
+    res = ""
+    for i in range(n):
+        res += "\x1b[C"
+    return res
+
+def left(n=1):
+    """Move cursor left n columns.
+    """
+    if n < 0:
+        raise ValueError("n must be >= 0")
+    res = ""
+    for i in range(n):
+        res += "\x1b[D"
+    return res
+
+clearline = "\x1b[0G\x1b[2K"

--- a/std/src/std/uri.act
+++ b/std/src/std/uri.act
@@ -1,0 +1,265 @@
+
+_UNRESERVED = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~"
+_HEX_DIGITS = "0123456789ABCDEF"
+
+
+def quote(text: str, safe: str="/") -> str:
+    """Percent-encode a string for use in a URI.
+
+    Unreserved characters defined by RFC 3986 are preserved. Characters in
+    the safe set are also preserved when they are ASCII bytes.
+    """
+    allowed = set(_UNRESERVED + safe)
+    encoded = text.encode()
+    parts: list[str] = []
+
+    for i in range(len(encoded)):
+        byte = encoded[i]
+        if byte < 128 and chr(byte) in allowed:
+            parts.append(chr(byte))
+        else:
+            parts.append(_quote_byte(byte))
+
+    return "".join(parts)
+
+
+def unquote(text: str) -> str:
+    """Decode percent-escaped bytes in a URI string as UTF-8."""
+    result = bytearray(b"")
+    i = 0
+
+    while i < len(text):
+        if text[i] != "%":
+            _append_bytes(result, text[i].encode())
+            i += 1
+            continue
+
+        if i + 2 >= len(text):
+            raise ValueError("Incomplete percent escape: {text[i:]}")
+
+        escape = text[i:i+3]
+        hi = _hex_value(text[i+1])
+        lo = _hex_value(text[i+2])
+        result.append(hi * 16 + lo)
+        i += 3
+
+    try:
+        return result.decode()
+    except ValueError:
+        raise ValueError("Invalid UTF-8 in percent-escaped text")
+
+
+def _append_bytes(result: bytearray, data: bytes) -> None:
+    for i in range(len(data)):
+        result.append(data[i])
+
+
+def _quote_byte(byte: int) -> str:
+    return "%" + _HEX_DIGITS[byte // 16] + _HEX_DIGITS[byte % 16]
+
+
+def _hex_value(char: str) -> int:
+    idx = _HEX_DIGITS.find(char.upper())
+    if idx == -1:
+        raise ValueError("Invalid percent escape: %%{char}")
+    return idx
+
+
+class URI(object):
+    """A class representing a Uniform Resource Identifier (URI).
+
+    Implements parsing according to RFC 1630.
+
+    Attributes:
+        scheme (str): The URI scheme (e.g. 'http', 'https', 'file')
+        authority (str | None): The authority component (e.g. 'example.com:8080')
+        host (str | None): The hostname part of the authority
+        port (int | None): The port number if specified
+        path (str | None): The path component
+        query (str | None): The query string if present
+        fragment (str | None): The fragment identifier if present
+    """
+    scheme: ?str
+    authority: ?str
+    host: ?str
+    port: ?int
+    path: ?str
+    query: ?str
+    fragment: ?str
+
+    def __init__(self, uri_string: str):
+        """Parse a URI string into its components.
+
+        Args:
+            uri_string: The URI string to parse
+
+        Raises:
+            ValueError: If the URI string is invalid
+        """
+        # Parse scheme
+        scheme, remainder = parse_schema(uri_string)
+        self.scheme = scheme
+
+        # Parse authority
+        authority, host, port, remainder = parse_authority(remainder)
+        self.authority = authority
+        self.host = host
+        self.port = port
+
+        # Parse path
+        path, remainder = parse_path(remainder)
+        self.path = path
+
+        # Parse query
+        query, remainder = parse_query(remainder)
+        self.query = query
+
+        # Parse fragment
+        self.fragment = parse_fragment(remainder)
+
+    def __str__(self) -> str:
+        """Return the canonical string representation of the URI."""
+        scheme_sep = "://" if self.scheme is not None else ""
+        query_sep = "?" if self.query is not None else ""
+        frag_sep = "#" if self.fragment is not None else ""
+        return (e_str(self.scheme) +
+                scheme_sep +
+                e_str(self.authority) +
+                e_str(self.path) +
+                query_sep +
+                e_str(self.query) +
+                frag_sep +
+                e_str(self.fragment))
+
+    def __repr__(self) -> str:
+        """Return a detailed string representation for debugging."""
+        return f"URI(scheme='{self.scheme}', authority='{self.authority}', host='{self.host}', port={self.port}, path='{self.path}', query='{self.query}', fragment='{self.fragment}')"
+
+
+def e_str[T](s: ?T) -> str:
+    return str(s) if s is not None else ""
+
+def opt_str[T](s: ?T) -> str:
+    return str(s) if s is not None else "None"
+
+def is_valid_scheme(scheme: str) -> bool:
+    """
+    Validate if a scheme string follows RFC 3986 rules:
+    1. Must begin with a letter
+    2. Can contain letters, digits, plus (+), period (.), or hyphen (-)
+    3. Case-insensitive
+
+    Args:
+        scheme: The scheme string to validate
+
+    Returns:
+        bool: True if scheme is valid, False otherwise
+    """
+    if not scheme or not scheme[0].isalpha():
+        return False
+
+    # Check each character is valid
+    valid_chars = set('abcdefghijklmnopqrstuvwxyz'
+                     'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+                     '0123456789'
+                     '+.-')
+
+    return all(map(lambda c: c in valid_chars, scheme))
+
+
+def parse_schema(uri: str) -> (?str, str):
+    if ":" not in uri:
+        return None, uri
+    split_result = uri.split(":", 1)
+    if len(split_result) == 1:
+        return None, split_result[0]
+    elif len(split_result) == 2:
+        scheme = split_result[0]
+        remainder = split_result[1]
+        if not remainder.startswith("//"):
+            raise ValueError("Invalid separator after scheme")
+        if not is_valid_scheme(scheme):
+            raise ValueError("Invalid scheme")
+        return scheme, remainder[2:]
+    raise ValueError("Invalid URI, unable to parse scheme")
+
+
+def parse_authority(uri: str) -> (?str, ?str, ?int, str):
+    """Parse authority component, returning authority, host, port, and remainder."""
+    if uri == "":
+        return None, None, None, ""
+
+    # Find end of authority component
+    slash_idx = uri.find("/")
+    question_idx = uri.find("?")
+    hash_idx = uri.find("#")
+
+    # Find the first occurring delimiter
+    end_idx = -1
+    if slash_idx != -1:
+        end_idx = slash_idx
+    if question_idx != -1 and (end_idx == -1 or question_idx < end_idx):
+        end_idx = question_idx
+    if hash_idx != -1 and (end_idx == -1 or hash_idx < end_idx):
+        end_idx = hash_idx
+
+    # Extract authority and remainder
+    if end_idx == -1:
+        authority = uri
+        remainder = ""
+    else:
+        authority = uri[:end_idx]
+        remainder = uri[end_idx:]
+
+    if not authority:
+        return None, None, None, remainder
+
+    # Parse host and port
+    if ":" in authority:
+        host_part = authority.split(":", 1)
+        try:
+            port = int(host_part[1])
+            if port < 0 or port > 65535:
+                raise ValueError(f"Port must be between 0 and 65535: {host_part[1]}")
+            return authority, host_part[0], port, remainder
+        except ValueError:
+            raise ValueError(f"Invalid port: {host_part[1]}")
+    else:
+        return authority, authority, None, remainder
+
+def parse_path(uri: str) -> (?str, str):
+    """Parse path component, returning path and remainder."""
+    if not uri:
+        return None, ""
+
+    if uri[0] != "/":
+        uri = "/" + uri
+
+    question_idx = uri.find("?")
+    hash_idx = uri.find("#")
+
+    if question_idx != -1 and (hash_idx == -1 or question_idx < hash_idx):
+        return uri[:question_idx], uri[question_idx:]
+    elif hash_idx != -1:
+        return uri[:hash_idx], uri[hash_idx:]
+    else:
+        return uri, ""
+
+def parse_query(uri: str) -> (?str, str):
+    """Parse query component, returning query and remainder."""
+    if not uri or uri[0] != "?":
+        return None, uri
+
+    hash_idx = uri.find("#")
+    if hash_idx != -1:
+        query = uri[1:hash_idx]
+        return "" if not query else query, uri[hash_idx:]
+    else:
+        query = uri[1:]
+        return "" if not query else query, ""
+
+def parse_fragment(uri: str) -> ?str:
+    """Parse fragment component."""
+    if not uri or uri[0] != "#":
+        return None
+    return "" if len(uri) == 1 else uri[1:]

--- a/std/src/std/xml.act
+++ b/std/src/std/xml.act
@@ -1,0 +1,73 @@
+class Node():
+    """
+A node is an abstract syntax tree for XML.
+
+It is similar to Python's xml.etree.ElementTree.Element.
+A node always represent an XML tagged element; so also the children are elements.
+Text is represented in the attributes text and tail: in node n,
+ - n.text is the string before n's first child;
+ - n.tail is the string before n's next sibling.
+So, to get the text at top level of node n, one must concatenate
+n.text and c.tail for all children of n.
+"""
+    def __init__(self, tag: str, nsdefs: list[(?str,str)]=[], prefix: ?str=None,
+                 attributes: list[(str, str)]=[], children: list[Node]=[], text: ?str=None, tail: ?str=None):
+        self.tag = tag
+        self.nsdefs = nsdefs
+        self.prefix = prefix
+        self.attributes = attributes
+        self.children = children
+        self.text = text
+        self.tail = tail
+
+    def encode(self, pretty=False) -> str:
+        NotImplemented
+
+class XmlParseError(ValueError):
+    """Exception raised for XML parsing errors
+
+    Attributes:
+        line: The line number where the error occurred (if available)
+        column: The column number where the error occurred (if available)
+    """
+    line: ?int
+    column: ?int
+
+    def __init__(self, msg: ?str, line: ?int=None, column: ?int=None):
+        self.error_message = msg if msg is not None else ""
+        self.line = line
+        self.column = column
+
+    def __str__(self):
+        context = ""
+        if self.line is not None:
+            context += ":{self.line}"
+        if self.column is not None:
+            context += ":{self.column}"
+        return "{self._name()}{context}: {self.error_message}"
+
+    def __repr__(self):
+        return "{self._name()}({repr(self.error_message)}, {repr(self.line)}, {repr(self.column)})"
+
+def decode(data : str) -> Node:
+    NotImplemented
+
+def encode(node: Node, pretty=False) -> str:
+    return node.encode(pretty)
+
+def toplevel_text(node):
+     """Returns the toplevel text in node, as if all subelements were replaced by sep"""
+     sep = ' '
+     chunks = []
+     txt = node.text
+     if txt is not None:
+         chunks.append(txt)
+     for c in node.children:
+         tl = c.tail
+         if tl is not None:
+             chunks.append(tl)
+     return sep.join(chunks)
+
+def encode_nodes(nodes: list[Node], pretty=False) -> str:
+    sep = "\n" if pretty else ""
+    return sep.join([node.encode(pretty) for node in nodes])

--- a/std/src/std/xml.ext.c
+++ b/std/src/std/xml.ext.c
@@ -1,0 +1,440 @@
+#define LIBXML_STATIC
+#include <libxml/xmlmemory.h>
+#include <libxml/parser.h>
+
+// TODO: The macro below is from builtin/str.c. We should not duplicate it...
+#define NEW_UNFILLED_STR(nm, nchrs, nbtes)      \
+    assert(nbtes >= nchrs);                     \
+    nm = acton_malloc(sizeof(struct B_str));           \
+    (nm)->$class = &B_strG_methods;               \
+    (nm)->nchars = nchrs;                       \
+    (nm)->nbytes = nbtes;                       \
+    (nm)->str = acton_malloc_atomic((nm)->nbytes + 1);       \
+    (nm)->str[(nm)->nbytes] = 0
+
+// Helper function to count extra bytes needed for XML escaping
+// Returns the number of extra bytes needed to replace the special character
+// with encoded entity (not total bytes)
+//
+static int count_xml_escape_extra(B_str str, int escape_quotes) {
+    int extra = 0;
+    // Note: It's safe to iterate byte-by-byte even for UTF-8 strings because we
+    // only check for ASCII characters (&, <, "). The codepoints for ASCII
+    // characters are backwards compatible (0x00-0x7F -> 00000000-01111111).
+    // Continuation bytes (2nd, ...) in multi-byte UTF-8 characters always have
+    // the same pattern 10xxxxxx (0x80-0xBF) so no UTF-8 continuation byte can
+    // be mistaken for an ASCII character.
+    for (int i = 0; i < str->nbytes; i++) {
+        switch (str->str[i]) {
+            case '&': extra += 4; break;  // &amp; = 5 bytes instead of 1
+            case '<': extra += 3; break;  // &lt; = 4 bytes instead of 1
+            case '"':
+                if (escape_quotes) extra += 5;  // &quot; = 6 bytes instead of 1
+                break;
+        }
+    }
+    return extra;
+}
+
+// Helper function to copy string with XML escaping
+// Returns pointer to position after copied data
+static unsigned char* copy_with_xml_escape(unsigned char *dst, B_str src, int escape_quotes) {
+    for (int i = 0; i < src->nbytes; i++) {
+        // Note: It's safe to iterate byte-for-byte here because we're only
+        // inserting ASCII and copying (maybe UTF-8 multi-byte) characters as
+        // individual bytes, iterating over the total byte length of B_str
+        switch (src->str[i]) {
+            case '&':
+                memcpy(dst, "&amp;", 5);
+                dst += 5;
+                break;
+            case '<':
+                memcpy(dst, "&lt;", 4);
+                dst += 4;
+                break;
+            case '"':
+                if (escape_quotes) {
+                    memcpy(dst, "&quot;", 6);
+                    dst += 6;
+                } else {
+                    *dst++ = src->str[i];
+                }
+                break;
+            default:
+                *dst++ = src->str[i];
+                break;
+        }
+    }
+    return dst;
+}
+
+// Helper function to collect text from consecutive TEXT and CDATA nodes
+// Returns the combined string and updates the node pointer to the first non-text node
+// Note: cur_ptr is passed by reference (pointer to pointer) so we can update the caller's pointer
+//       to skip past all consumed text/CDATA nodes
+static B_str collect_text_cdata_nodes(xmlNodePtr *cur_ptr) {
+    xmlNodePtr cur = *cur_ptr;
+    if (!cur || (cur->type != XML_TEXT_NODE && cur->type != XML_CDATA_SECTION_NODE)) {
+        return NULL;
+    }
+
+    // Count total length of combined text and CDATA nodes
+    size_t text_len = 0;
+    xmlNodePtr text_start = cur;
+    while (cur && (cur->type == XML_TEXT_NODE || cur->type == XML_CDATA_SECTION_NODE)) {
+        if (cur->content) text_len += strlen((char *)cur->content);
+        cur = cur->next;
+    }
+
+    // Create combined string
+    if (text_len > 0) {
+        char *combined = acton_malloc_atomic(text_len + 1);
+        char *p = combined;
+        xmlNodePtr t = text_start;
+        while (t != cur) {
+            if (t->content) {
+                size_t len = strlen((char *)t->content);
+                memcpy(p, t->content, len);
+                p += len;
+            }
+            t = t->next;
+        }
+        *p = '\0';
+        B_str result = to_str_noc(combined);
+        *cur_ptr = cur;
+        return result;
+    }
+
+    *cur_ptr = cur;
+    return NULL;
+}
+
+stdQ_xmlQ_Node stdQ_xmlQ_NodePtr2Node(xmlNodePtr node) {
+    B_SequenceD_list wit = B_SequenceD_listG_witness;
+    if (node->type == XML_COMMENT_NODE) {
+        return NULL;
+    }
+    if (node->type != XML_ELEMENT_NODE) {
+        char *errmsg = NULL;
+        RAISE(stdQ_xmlQ_XmlParseError, $FORMAT("Unexpected nodetype %d, content is %s", node->type, node->content), NULL, NULL);
+    }
+
+    B_list nsdefs = B_listG_new(NULL, NULL);
+    xmlNsPtr nsDef = node->nsDef;
+    while (nsDef) {
+        B_str prefix = NULL;
+        if (nsDef->prefix) prefix = to$str((char *)nsDef->prefix);
+        B_str href = to$str((char *)nsDef->href);
+        wit->$class->append(wit,nsdefs, $NEWTUPLE(2, prefix, href));
+        nsDef=nsDef->next;
+    }
+
+    B_str prefix = NULL;
+    if (node->ns && node->ns->prefix)
+        prefix = to$str((char *)node->ns->prefix);
+
+    B_list attributes = B_listG_new(NULL, NULL);
+    xmlAttrPtr attr = node->properties;
+    while (attr) {
+        B_str attr_name;
+        // libxml2 handles namespace prefixes in two ways:
+        // 1. Defined namespaces: attr->ns is set, attr->name has local name only
+        //    e.g., xmlns:ns="http://foo" ns:op="x" -> attr->ns->prefix="ns", attr->name="op"
+        // 2. Undefined namespaces: attr->ns is NULL, attr->name contains the full prefixed name
+        //    e.g., ns:op="x" (no xmlns:ns) -> attr->ns=NULL, attr->name="ns:op"
+        if (attr->ns && attr->ns->prefix) {
+            // Reconstruct prefixed name for defined namespace
+            attr_name = $FORMAT("%s:%s", attr->ns->prefix, attr->name);
+        } else {
+            // Use name as-is (either unprefixed or undefined prefix already in name)
+            attr_name = to$str((char *)attr->name);
+        }
+        wit->$class->append(wit,attributes, $NEWTUPLE(2, attr_name, to$str((char *)xmlGetProp(node, attr->name))));
+        attr = attr->next;
+    }
+
+    B_list children = B_listG_new(NULL, NULL);
+    xmlNodePtr cur = node->xmlChildrenNode;
+
+    // Collect initial text/CDATA nodes
+    B_str text = collect_text_cdata_nodes(&cur);
+
+    while (cur != NULL) {
+        stdQ_xmlQ_Node child = stdQ_xmlQ_NodePtr2Node(cur);
+        if (child)
+            wit->$class->append(wit,children, child);
+        cur = cur->next;
+    }
+
+    // Collect tail text/CDATA nodes after we have exhausted the child nodes
+    cur = node->next;
+    B_str tail = collect_text_cdata_nodes(&cur);
+    // Update the tree structure to skip consumed tail text/CDATA nodes.
+    // This prevents the parent from seeing these text nodes again during its
+    // child iteration, since tail text of an element is part of the parent's
+    // child list in the XML tree.
+    node->next = cur;
+    return (stdQ_xmlQ_Node)$NEW(stdQ_xmlQ_Node, to$str((char *)node->name), nsdefs, prefix, attributes, children, text, tail);
+}
+
+stdQ_xmlQ_Node stdQ_xmlQ_decode(B_str data) {
+    // With XML_PARSE_NOERROR we suppress printing error and warning reports to stderr
+    xmlDocPtr doc = xmlReadMemory((char *)data->str, data->nbytes, NULL, NULL, XML_PARSE_NOERROR);
+    if (!doc) {
+        xmlErrorPtr err = xmlGetLastError();
+        B_str errmsg;
+        B_int line = NULL;
+        B_int column = NULL;
+
+        if (err && err->message) {
+            if (err->line > 0) {
+                line = toB_int(err->line);
+            }
+            if (err->int2 > 0) {  // int2 contains the column in libxml2
+                column = toB_int(err->int2);
+            }
+
+            // Strip trailing whitespace from error message if needed
+            int orig_len = strlen(err->message);
+            int len = orig_len;
+            while (len > 0 && isspace((unsigned char)err->message[len-1])) {
+                len--;
+            }
+
+            if (len < orig_len) {
+                // Only copy if we actually stripped something
+                char msg_clean[len + 1];
+                strncpy(msg_clean, err->message, len);
+                msg_clean[len] = '\0';
+                errmsg = to$str(msg_clean);
+            } else {
+                // Use original message as-is
+                errmsg = to$str(err->message);
+            }
+        } else {
+            errmsg = to$str("XML parse error");
+        }
+        RAISE(stdQ_xmlQ_XmlParseError, errmsg, line, column);
+    }
+    xmlNodePtr root = xmlDocGetRootElement(doc);
+    stdQ_xmlQ_Node t = stdQ_xmlQ_NodePtr2Node(root);
+    xmlFreeDoc(doc);
+    return t;
+}
+
+
+static B_str stdQ_xmlQ_encode_nsdefs(B_list nsdefs);
+static B_str stdQ_xmlQ_encode_attrs(B_list attrs);
+
+
+B_str stdQ_xmlQ_node2str(stdQ_xmlQ_Node node, bool pretty, int depth) {
+    B_str nsdefs = stdQ_xmlQ_encode_nsdefs(node->nsdefs);
+    B_str attrs = stdQ_xmlQ_encode_attrs(node->attributes);
+
+    // Is this an empty element (no text, no children), then use self-closing tag
+    bool is_empty = !node->text && node->children->length == 0;
+
+
+    // Encode the child nodes to a single string (pretty-printed)
+    bool has_children = node->children->length > 0;
+    B_str nul = to$str("");
+    B_str children_str;
+
+    if (has_children) {
+        B_list children = B_listD_new(node->children->length);
+        children->length = node->children->length;
+        for (int i = 0; i < node->children->length; i++) {
+            stdQ_xmlQ_Node ch = (stdQ_xmlQ_Node)node->children->data[i];
+            children->data[i] = stdQ_xmlQ_node2str(ch, pretty, depth + 1);
+        }
+
+        if (pretty) {
+            // Join with newlines
+            B_str separator = to$str("\n");
+            children_str = separator->$class->join(separator, B_SequenceD_listG_witness->W_Collection, children);
+        } else {
+            // Join with empty string
+            children_str = nul->$class->join(nul, B_SequenceD_listG_witness->W_Collection, children);
+        }
+    } else {
+      children_str = nul;
+    }
+
+    // Calculate extra bytes needed for escaping text and tail
+    int text_extra = node->text ? count_xml_escape_extra(node->text, 0) : 0;
+    int tail_extra = node->tail ? count_xml_escape_extra(node->tail, 0) : 0;
+
+    int indent_size = pretty ? depth * 2 : 0;
+
+    // Calculate total size
+    int res_bytes = indent_size +
+                    (is_empty ? 1 : 2) * (node->tag->nbytes + (node->prefix ? node->prefix->nbytes + 1 : 0)) +
+                    nsdefs->nbytes + attrs->nbytes +
+                    (is_empty ? 0 : (node->text ? node->text->nbytes + text_extra : 0)) +
+                    (is_empty ? 0 : (has_children && pretty ? 1 : 0)) + // newline before children
+                    (is_empty ? 0 : children_str->nbytes) +
+                    (is_empty ? 0 : (has_children && pretty ? 1 + indent_size : 0)) + // newline + indent before closing
+                    (node->tail ? node->tail->nbytes + tail_extra : 0) +
+                    (is_empty ? 3 : 5); // self-closing tag - 3 bytes (< / >); open+close tag - 5 bytes (< > < / >)
+
+    int res_chars = indent_size +
+                    (is_empty ? 1 : 2) * (node->tag->nchars + (node->prefix ? node->prefix->nchars + 1 : 0)) +
+                    nsdefs->nchars + attrs->nchars +
+                    (is_empty ? 0 : (node->text ? node->text->nchars + text_extra : 0)) +
+                    (is_empty ? 0 : (has_children && pretty ? 1 : 0)) +
+                    (is_empty ? 0 : children_str->nchars) +
+                    (is_empty ? 0 : (has_children && pretty ? 1 + indent_size : 0)) +
+                    (node->tail ? node->tail->nchars + tail_extra : 0) +
+                    (is_empty ? 3 : 5);
+
+    // Build the result string
+    B_str res;
+    NEW_UNFILLED_STR(res, res_chars, res_bytes);
+    unsigned char *p = res->str;
+
+    // Write initial indentation
+    for (int i = 0; i < indent_size; i++) {
+        *p++ = ' ';
+    }
+
+    // Write opening tag
+    *p++ = '<';
+    if (node->prefix) {
+        memcpy(p, node->prefix->str, node->prefix->nbytes);
+        p += node->prefix->nbytes;
+        *p++ = ':';
+    }
+    memcpy(p, node->tag->str, node->tag->nbytes);
+    p += node->tag->nbytes;
+    memcpy(p, nsdefs->str, nsdefs->nbytes);
+    p += nsdefs->nbytes;
+    memcpy(p, attrs->str, attrs->nbytes);
+    p += attrs->nbytes;
+
+    // Write self-closing tag or children followed by explicit close tag
+    if (is_empty) {
+        *p++ = '/';
+        *p++ = '>';
+    } else {
+        *p++ = '>';
+
+        // Write text content
+        if (node->text) {
+            p = copy_with_xml_escape(p, node->text, 0);
+        }
+
+        if (has_children) {
+            // Write newline after opening tag, write children
+            if (pretty) {
+                *p++ = '\n';
+            }
+            memcpy(p, children_str->str, children_str->nbytes);
+            p += children_str->nbytes;
+
+            // Write newline and indent before closing tag if needed
+            if (pretty) {
+                *p++ = '\n';
+                for (int i = 0; i < indent_size; i++) {
+                    *p++ = ' ';
+                }
+            }
+        }
+
+        // Write closing tag
+        *p++ = '<';
+        *p++ = '/';
+        if (node->prefix) {
+            memcpy(p, node->prefix->str, node->prefix->nbytes);
+            p += node->prefix->nbytes;
+            *p++ = ':';
+        }
+        memcpy(p, node->tag->str, node->tag->nbytes);
+        p += node->tag->nbytes;
+        *p++ = '>';
+    }
+
+    // Write tail
+    if (node->tail) {
+        p = copy_with_xml_escape(p, node->tail, 0);
+    }
+
+    return res;
+}
+
+static B_str stdQ_xmlQ_encode_nsdefs(B_list nsdefs) {
+    int res_bytes = 0;
+    int res_chars = 0;
+    for (int i=0; i<nsdefs->length;i++) {
+        B_tuple nsdef = nsdefs->data[i];
+        B_str prefix = (B_str)nsdef->components[0];
+        B_str href = (B_str)nsdef->components[1];
+
+        // Count extra bytes needed for escaping href
+        int href_extra = count_xml_escape_extra(href, 1);
+
+        res_bytes += (prefix ? prefix->nbytes+1 : 0) + href->nbytes + href_extra + 9; // 9 = len(" xmlns" + "=" + '"' + '"')
+        res_chars += (prefix ? prefix->nchars+1 : 0) + href->nchars + href_extra + 9;
+    }
+    B_str res;
+    NEW_UNFILLED_STR(res, res_chars, res_bytes);
+    unsigned char *p = res->str;
+    for (int i=0; i<nsdefs->length; i++) {
+        B_tuple nsdef = nsdefs->data[i];
+        *p++ = ' ';
+        B_str prefix = (B_str)nsdef->components[0];
+        B_str href = (B_str)nsdef->components[1];
+        char * xmlns = "xmlns";
+        memcpy(p, xmlns, 5); p += 5;
+        if (prefix) {
+            *p++ = ':';
+            memcpy(p, prefix->str, prefix->nbytes); p += prefix->nbytes;
+        }
+        *p++ = '=';
+        *p++ = '"';
+        p = copy_with_xml_escape(p, href, 1);
+        *p++ = '"';
+    }
+    return res;
+}
+
+
+static B_str stdQ_xmlQ_encode_attrs(B_list attrs) {
+    int res_bytes = 0;
+    int res_chars = 0;
+    for (int i=0; i < attrs->length; i++) {
+        B_tuple attr = attrs->data[i];
+        B_str key = (B_str)attr->components[0];
+        B_str value = (B_str)attr->components[1];
+
+        // Count extra bytes needed for escaping
+        int extra_bytes = count_xml_escape_extra(value, 1);
+
+        res_bytes += key->nbytes + value->nbytes + extra_bytes + 4; // 4 = len(" " + "=" + "'" + "'")
+        res_chars += key->nchars + value->nchars + extra_bytes + 4;
+    }
+    B_str res;
+    NEW_UNFILLED_STR(res, res_chars, res_bytes);
+
+    unsigned char *p = res->str;
+    for (int i=0; i < attrs->length; i++) {
+        B_tuple attr = attrs->data[i];
+        B_str key = (B_str)attr->components[0];
+        B_str value = (B_str)attr->components[1];
+        *p++ = ' ';
+        memcpy(p, key->str, key->nbytes); p += key->nbytes;
+        *p++ = '=';
+        *p++ = '"';
+        p = copy_with_xml_escape(p, value, 1);
+        *p++ = '"';
+    }
+    return res;
+}
+
+B_str stdQ_xmlQ_NodeD_encode(stdQ_xmlQ_Node self, B_bool pretty) {
+    // Use the internal function with depth 0 for the root node
+    return stdQ_xmlQ_node2str(self, pretty ? pretty->val != 0 : false, 0);
+}
+
+void stdQ_xmlQ___ext_init__() {
+    // NOP
+}

--- a/test/stdlib_tests/src/test_std_namespace.act
+++ b/test/stdlib_tests/src/test_std_namespace.act
@@ -1,0 +1,60 @@
+import testing
+
+import std.argparse as argparse
+import std.base64 as base64
+import std.crypto.hash.md5 as md5
+import std.diff as diff
+import std.hash.wyhash as wyhash
+import std.http as http
+import std.json as json
+import std.math as math
+import std.qcheck as qcheck
+import std.random as random
+import std.re as re
+import std.snappy as snappy
+import std.term as term
+import std.xml as xml
+
+from std.uri import URI, quote, unquote
+
+
+def _test_std_namespace_data_modules():
+    testing.assertEqual(base64.decode(base64.encode(b"hello")), b"hello")
+    testing.assertEqual(json.encode({"answer": 42}), r"""{"answer":42}""")
+    testing.assertEqual(xml.encode(xml.Node("a", text="hello")), "<a>hello</a>")
+    testing.assertEqual(snappy.decompress(snappy.compress(b"hello hello hello")), b"hello hello hello")
+    testing.assertEqual(md5.hash(b"abc"), b"\x90\x01\x50\x98\x3c\xd2\x4f\xb0\xd6\x96\x3f\x7d\x28\xe1\x7f\x72")
+    testing.assertEqual(wyhash.hash(2, b"abc"), 0x32dd92e4b2915153)
+
+
+def _test_std_namespace_pure_helpers():
+    testing.assertEqual(diff.diff("same", "same"), "")
+    testing.assertEqual(math.sqrt(9.0), 3.0)
+    testing.assertEqual(quote("hello world"), "hello%20world")
+    testing.assertEqual(unquote("hello%20world"), "hello world")
+    testing.assertEqual(URI("https://example.com/path").host, "example.com")
+    testing.assertEqual(term.red + "x" + term.normal, "\x1b[31mx\x1b[0m")
+
+
+def _test_std_namespace_parsers_and_random():
+    parser = argparse.Parser()
+    parser.add_option("count", "int", default=1, short="c")
+    args = parser.parse(["./app", "-c", "4"])
+    testing.assertEqual(args.get_int("count"), 4)
+
+    m = re.match("foo([0-9]+)", "foo123")
+    testing.assertNotNone(m, "std.re.match returned None")
+
+    n = random.randint(1, 4)
+    testing.assertTrue(1 <= n and n < 4, "std.random.randint outside expected range")
+
+    def prop_true():
+        return True
+
+    prop_ok = qcheck.qcheck_0("std qcheck smoke", prop_true)
+    testing.assertEqual(prop_ok, 0)
+
+
+def _test_std_namespace_protocol_module():
+    response = http.build_response(b"1.1", 200, {}, "ok")
+    testing.assertEqual(response[:15], b"HTTP/1.1 200 OK")


### PR DESCRIPTION
Move the std modules into a dedicated Acton project under std/src and publish it as dist/std as part of the Acton distribution. Base remains the builtin/runtime package, while std becomes a separate library project bundled with the distribution.

Generated project builds now add an implicit std dependency unless the project declares one. Compiler type lookup also includes dist/std/out/types alongside the base type interfaces, and generated package dependency calls propagate db and no_threads so std and base are configured consistently across targets.