### PR TITLE
Replace .ty binary file format with LMDB

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -165,6 +165,8 @@ jobs:
         id: build_acton
         run: |
           make -j2 -C ${{ github.workspace }} BUILD_RELEASE=${{ env.BUILD_RELEASE }} BUILD_TIME=${BUILD_TIME}
+      - name: "Show Acton linkage"
+        run: make -C ${{ github.workspace }} ldd
       - name: "Build a release"
         id: build_release
         run: make -C ${{ github.workspace }} release BUILD_TIME=${BUILD_TIME}

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 **/.build/
 **/*.swp
 **/*.ty
+**/*.tydb/
 
 backend/actondb
 backend/failure_detector/db_messages_test
@@ -95,5 +96,7 @@ test/**/snapshots/output/**
 snapshots/output/**
 
 # tests organized as acton projects; ignore all but source
-test/*/*/out/**
+test/**/out/**
+test/**/.acton.lock
 compiler/acton/test/project/*/out
+compiler/acton/test/root/test

--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,9 @@ export ACTON_BDEPS_DIR
 # this archive's full path; dropping any future lib's .a into bdeps/out/lib (e.g.
 # liblmdb.a) makes it link statically the same way, with no per-lib wiring.
 BDEPS += bdeps/out/lib/libz.a
+# liblmdb backs the compiler's .tydb interface cache; GHC links it into acton on
+# every platform, so -- unlike gmp/tinfo below -- it is an unconditional bdep.
+BDEPS += bdeps/out/lib/liblmdb.a
 ifeq ($(OS),linux)
 # gmp and tinfo are only pulled in by GHC on Linux (macOS GHC uses the native
 # bignum backend and the SDK's libncurses), so they are Linux-only bdeps.
@@ -218,8 +221,19 @@ ifeq ($(OS),linux)
 			fi; \
 		fi; \
 	done
+else ifeq ($(OS),macos)
+	@for bin in $(ACTON_LINKAGE_BINS); do \
+		echo "== $$bin =="; \
+		otool -L "$$bin"; \
+		dynamic_lmdb=$$(otool -L "$$bin" | awk 'NR > 1 {print $$1}' | grep -E '(^|/|@rpath/|@loader_path/|@executable_path/)liblmdb' || true); \
+		if [ -n "$$dynamic_lmdb" ]; then \
+			echo "unexpected dynamic LMDB dependency (liblmdb must be linked statically):" >&2; \
+			echo "$$dynamic_lmdb" >&2; \
+			exit 1; \
+		fi; \
+	done
 else
-	@echo "ldd target is only meaningful on Linux"
+	@echo "ldd target is only meaningful on Linux and macOS"
 endif
 
 # /deps --------------------------------------------------
@@ -309,6 +323,12 @@ bdeps/out/lib/libgmp.a: bdeps/gmp/build.zig bdeps/gmp/build.zig.zon $(DIST_ZIG)
 bdeps/out/lib/libtinfo.a: bdeps/ncurses/build.zig bdeps/ncurses/build.zig.zon \
 		bdeps/ncurses/gencaps.c bdeps/ncurses/tinfo.c $(DIST_ZIG)
 	cd bdeps/ncurses && "$(ZIG)" build -Doptimize=ReleaseFast --prefix "$(TD)/bdeps/out" \
+		$(if $(ACTON_ZIG_TARGET),-Dtarget=$(ACTON_ZIG_TARGET))
+	$(call bdeps_align_macho,$(abspath $@))
+
+# /bdeps/lmdb (compiler .tydb interface cache) -----------
+bdeps/out/lib/liblmdb.a: bdeps/lmdb/build.zig bdeps/lmdb/build.zig.zon $(DIST_ZIG)
+	cd bdeps/lmdb && "$(ZIG)" build -Doptimize=ReleaseFast --prefix "$(TD)/bdeps/out" \
 		$(if $(ACTON_ZIG_TARGET),-Dtarget=$(ACTON_ZIG_TARGET))
 	$(call bdeps_align_macho,$(abspath $@))
 
@@ -488,6 +508,10 @@ dist/deps/libyyjson: deps/libyyjson $(DIST_ZIG)
 # top level targets
 .PHONY: test test-builtins test-compiler test-db test-examples test-lang test-regressions test-rts test-stdlib online-tests
 .PHONY: test-compiler-accept test-lib-accept test-acton-goldens-accept test-goldens-accept
+# These run stack against libacton/acton, which link liblmdb, so the bdeps
+# archives must exist first. (test, test-stdlib, test-incremental, online-tests
+# already pull it in transitively via dist/bin/acton[c].)
+test-builtins test-compiler test-lib-accept test-acton-goldens-accept test-cross-compile test-syntaxerrors test-syntaxerrors-accept test-typeerrors test-typeerrors-accept test-db test-examples test-lang test-regressions test-rts: $(BDEPS)
 test: dist/bin/acton
 	cd compiler && stack test libacton acton:test_acton acton:incremental
 	$(MAKE) test-stdlib

--- a/bdeps/lmdb/build.zig
+++ b/bdeps/lmdb/build.zig
@@ -1,0 +1,38 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const optimize = b.standardOptimizeOption(.{});
+    var target = b.standardTargetOptions(.{});
+
+    // On a native macOS build zig defaults the deployment target to the build
+    // host's SDK version. That tags the archive with whatever the build machine
+    // happens to run and makes ld64 warn "object built for newer macOS version"
+    // when GHC later links acton against an older minos. Pin a conservative floor
+    // so the archive is reproducible across hosts and links cleanly. An explicit
+    // -Dtarget=...-macos.<ver> still wins.
+    if (target.result.os.tag == .macos and target.query.os_version_min == null) {
+        var query = target.query;
+        query.os_version_min = .{ .semver = .{ .major = 11, .minor = 0, .patch = 0 } };
+        target = b.resolveTargetQuery(query);
+    }
+
+    const source = b.dependency("source", .{});
+
+    const lib = b.addLibrary(.{
+        .name = "lmdb",
+        .linkage = .static,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+
+    lib.root_module.link_libc = true;
+    lib.root_module.addIncludePath(source.path("libraries/liblmdb"));
+    const c_flags = [_][]const u8{"-DMDB_MAXKEYSIZE=512"};
+    lib.root_module.addCSourceFile(.{ .file = source.path("libraries/liblmdb/mdb.c"), .flags = &c_flags });
+    lib.root_module.addCSourceFile(.{ .file = source.path("libraries/liblmdb/midl.c"), .flags = &c_flags });
+    lib.installHeader(source.path("libraries/liblmdb/lmdb.h"), "lmdb.h");
+
+    b.installArtifact(lib);
+}

--- a/bdeps/lmdb/build.zig.zon
+++ b/bdeps/lmdb/build.zig.zon
@@ -1,0 +1,16 @@
+.{
+    .name = .lmdb,
+    .version = "0.0.0",
+    .fingerprint = 0xb2966103f9989484,
+    .minimum_zig_version = "0.16.0",
+    .dependencies = .{
+        .source = .{
+            .url = "https://github.com/LMDB/lmdb/archive/LMDB_0.9.31.tar.gz",
+            .hash = "N-V-__8AAHEsCACb_b9D1HnCysDKIhKFOrITbxYh9JRh9ix5",
+        },
+    },
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+    },
+}

--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -150,7 +150,7 @@ runFile :: C.GlobalOptions -> C.CompileOptions -> FilePath -> IO ()
 runFile gopts opts fname =
     case takeExtension fname of
       ".act" -> buildFile gopts (applyGlobalOpts gopts opts) fname
-      ".ty" -> printDocs gopts (C.DocOptions fname (Just C.AsciiFormat) Nothing)
+      ".tydb" -> printDocs gopts (C.DocOptions fname (Just C.AsciiFormat) Nothing)
       _ -> printErrorAndExit ("Unknown filetype: " ++ fname)
 
 -- Ensure enough capabilities: honor --jobs if set, otherwise at least 2 or #procs.
@@ -692,8 +692,8 @@ changedModulesFromPaths paths files = do
 
 readModuleImports :: Paths -> A.ModName -> IO [A.ModName]
 readModuleImports paths mn = do
-    let tyFile = outBase paths mn ++ ".ty"
-    exists <- doesFileExist tyFile
+    let tyFile = tyDbPath paths mn
+    exists <- InterfaceFiles.interfaceExists tyFile
     if not exists
       then return []
       else do
@@ -1006,7 +1006,7 @@ compileSigTarget gopts queryGopts opts paths rootProj sysAbs depOverrides target
                        Just ctx -> ctx
                        Nothing  -> targetCtx
     targetPaths <- pathsForModule opts' (cpProjMap plan) targetCtx' mn
-    return (outBase targetPaths mn ++ ".ty")
+    return (tyDbPath targetPaths mn)
 
 resolveSigTarget :: C.CompileOptions -> Paths -> FilePath -> M.Map FilePath ProjCtx -> String -> IO SigTarget
 resolveSigTarget opts paths rootProj projMap rawTarget = do
@@ -1090,7 +1090,7 @@ findSigTyFile = Acton.Env.findTyFile
 
 printSigInterface :: Paths -> A.ModName -> Maybe A.Name -> FilePath -> IO ()
 printSigInterface paths mn mName tyFile = do
-    exists <- doesFileExist tyFile
+    exists <- InterfaceFiles.interfaceExists tyFile
     unless exists $
       printErrorAndExit ("Type interface not found for " ++ modNameToString mn)
     tyRes <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readFile tyFile
@@ -1242,7 +1242,7 @@ printDocs gopts opts = do
         let (fileBody,fileExt) = splitExtension $ takeFileName filename
 
         case fileExt of
-          ".ty" -> do
+          ".tydb" -> do
             paths <- findPaths filename defaultCompileOptions
             env0 <- Acton.Env.initEnv (sysTypes paths) False
             Acton.Types.showTyFile env0 (modName paths) filename (C.verbose gopts)
@@ -1983,7 +1983,7 @@ runCliPostCompile cliHooks gopts plan env = do
             unless (altOutput opts') $
               runFinal (compileBins gopts opts' pathsRoot env rootSpec rootTasks preBinTasks allowPrune' rootModuleEntries rootBuildLibraries rootDepModuleOpts rootDepPathOverrides (Just (cchProgressUI cliHooks)))
 -- Generate documentation index for a project build by reading module names and
--- docstrings from cached .ty headers or source headers.
+-- docstrings from cached .tydb headers or source headers.
 generateProjectDocIndex :: Source.SourceProvider -> C.GlobalOptions -> C.CompileOptions -> Paths -> [String] -> IO ()
 generateProjectDocIndex sp gopts opts paths srcFiles = do
     unless (C.skip_build opts || C.only_build opts || isTmp paths) $ do
@@ -2102,22 +2102,26 @@ removeOrphanFiles paths tasks roots = do
     forM_ absOutFiles $ \absFile -> do
         let isC  = takeExtension absFile == ".c"
             isH  = takeExtension absFile == ".h"
-            isTy = takeExtension absFile == ".ty"
             bext = takeExtension (takeBaseName absFile)
             isRootStub = isC && (bext == ".root" || bext == ".test_root")
             base = dropExtension absFile
             modBase = if isRootStub then dropExtension base else base
         if isRootStub
           then when (not (absFile `elem` roots) || not (modBase `elem` allowedBases)) (removeIfExists absFile)
-          else when (isC || isH || isTy) $ do
+          else when (isC || isH) $ do
                  unless (base `elem` allowedBases) (removeIfExists absFile)
+    tyDbs <- InterfaceFiles.listInterfaceDirsRecursive dir
+    forM_ tyDbs $ \tyDb -> do
+      let base = dropExtension tyDb
+      unless (base `elem` allowedBases) (removeDirIfExists tyDb)
   where
     removeIfExists f = removeFile f `catch` handleNotExists
+    removeDirIfExists f = removePathForcibly f `catch` handleNotExists
     handleNotExists :: IOException -> IO ()
     handleNotExists _ = return ()
 
 -- | Determine which root stub files should be preserved for the current build.
--- We read the freshly written .ty headers (post-compile) for each task to keep
+-- We read the freshly written .tydb headers (post-compile) for each task to keep
 -- whichever roots are still declared. This lets us drop stale root stubs when
 -- a module loses its root actor while still retaining stubs that belong to
 -- other build modes (e.g. keeping .root.c when running `acton test`).
@@ -2126,7 +2130,7 @@ expectedRootStubs paths tasks = do
     roots <- forM tasks $ \t -> do
         let mn     = name t
             outbase = outBase paths mn
-            tyPath = outbase ++ ".ty"
+            tyPath = tyDbPath paths mn
         hdrE <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readHeader tyPath
         case hdrE of
           Right (_sourceMeta, _, _, _implH, _imps, _nameHashes, rs, _tests, _) -> return (map (mkStub outbase) rs)
@@ -2161,8 +2165,8 @@ Build Pipeline Overview
 
 We want the compiler to be fast. The primary principle by which to achieve this
 is to avoid doing unnecessary work. Practically, this happens by caching
-information in .ty files and only selectively reading what we need. We do not
-eagerly load whole .ty files but rather read the header fields: moduleSrcBytesHash,
+information in .tydb files and only selectively reading what we need. We do not
+eagerly load whole .tydb files but rather read the header fields: moduleSrcBytesHash,
 modulePubHash, moduleImplHash, imports, per-name hashes (src/pub/impl + deps),
 roots, tests, and docstrings. This lets us quickly decide which passes to rerun and
 reuse work from previous compilations.
@@ -2182,30 +2186,30 @@ Terminology
 - ParseTask: a source-backed module whose imports are known but whose full AST
   has not been materialized yet
 - ActonTask: a fully parsed source module ready for front passes
-- TyTask: a module loaded from the cached .ty file on disk. Note how there are
+- TyTask: a module loaded from the cached .tydb file on disk. Note how there are
   two variants, a stubbed TyTask where only header fields are loaded and the
   full TyTask where all module content is available.
 
 High-level Steps
 1) Discover and read tasks using header-first strategy (readModuleTask)
-   - For each module, try to use its .ty header to avoid parsing:
-     - If .ty is missing/unreadable → read source and parse only the import
+   - For each module, try to use its .tydb header to avoid parsing:
+     - If .tydb is missing/unreadable → read source and parse only the import
        header (ParseTask).
      - If the compiler compatibility guard says the cache is stale
        → read source and parse the import header now (ParseTask).
-     - If source metadata in the .ty header still matches the current .act and
-       the source mtime is strictly older than the .ty mtime
-       → trust .ty header imports and create a TyTask stub (no heavy decode)
+     - If source metadata in the .tydb header still matches the current .act and
+       the source mtime is strictly older than the .tydb mtime
+       → trust .tydb header imports and create a TyTask stub (no heavy decode)
        for graph building.
-     - If metadata differs, or source/.ty mtimes are equal, verify by content
+     - If metadata differs, or source/.tydb mtimes are equal, verify by content
        hash:
        – If stored moduleSrcBytesHash == current bytes hash → header is still
          valid (TyTask) and refresh cached source metadata.
        – Else → read source and parse the import header now (ParseTask)
-     - Equal source/.ty mtimes are treated as ambiguous because coarse-mtime
+     - Equal source/.tydb mtimes are treated as ambiguous because coarse-mtime
        filesystems can assign the same visible timestamp to a changed source
-       and the cached .ty written from an earlier version of that source.
-   - This ensures that .ty is up to date with the .act source and lets us
+       and the cached .tydb written from an earlier version of that source.
+   - This ensures that .tydb is up to date with the .act source and lets us
      read module imports/roots/docstring from the header, which is much faster
      than parsing the full .act file.
 
@@ -2213,8 +2217,8 @@ High-level Steps
    - For project builds, we enumerate all modules under src/ upfront, so chasing
      is typically a no-op.
    - For single-file builds (or partial sets), we chase imports from the seeded
-     tasks to ensure all project-local dependencies are included. We prefer .ty
-     headers to avoid parsing; we parse only when a .ty is missing/unreadable.
+     tasks to ensure all project-local dependencies are included. We prefer .tydb
+     headers to avoid parsing; we parse only when a .tydb is missing/unreadable.
 
 3) Compile and build
    - compileTasks builds a stage graph and prefers front work over parse work:
@@ -2224,9 +2228,9 @@ High-level Steps
    - Front-stage rebuild decisions are then made per module:
      - Source changed (ParseTask/ActonTask) → run front passes
      - Otherwise, compare each used pub dependency hash from the dependent’s
-       .ty header with the provider’s current pub hash. If any differ → front.
+       .tydb header with the provider’s current pub hash. If any differ → front.
      - Otherwise, compare each used impl dependency hash from the dependent’s
-       .ty header with the provider’s current impl hash. If any differ → refresh
+       .tydb header with the provider’s current impl hash. If any differ → refresh
        impl hashes and run back passes.
      - Otherwise, if generated .c/.h hashes do not match moduleImplHash → run
        back passes.
@@ -2270,7 +2274,7 @@ writeRootC env gopts opts paths tasks binTask = do
     if C.only_build opts && existing
       then return (Just binTask)
       else do
-        -- Read the up-to-date roots from the on-disk .ty header (post-compile)
+        -- Read the up-to-date roots from the on-disk .tydb header (post-compile)
         -- Avoid using preloaded TyTask roots, which may be stale if the module
         -- was rebuilt during this run.
         tyPath <- Acton.Env.findTyFile (searchPath paths) m

--- a/compiler/acton/TestRunner.hs
+++ b/compiler/acton/TestRunner.hs
@@ -92,7 +92,7 @@ moduleHeaderLine modName
   | null modName = "Tests"
   | otherwise = "Tests - module " ++ modName ++ ":"
 
--- | List test modules by reading discovered tests from .ty headers.
+-- | List test modules by reading discovered tests from .tydb headers.
 listTestModules :: C.CompileOptions -> Paths -> IO [String]
 listTestModules _opts paths = do
     srcFiles <- listActFilesRecursive (srcDir paths)
@@ -544,16 +544,16 @@ compileTestNameRegexes patterns =
 regexMatches :: TDFA.Regex -> String -> Bool
 regexMatches re text = isJust (TDFA.matchOnceText re text)
 
--- | Read the discovered tests for a module from its .ty header.
+-- | Read the discovered tests for a module from its .tydb header.
 listModuleTests :: C.CompileOptions -> Paths -> String -> IO [String]
 listModuleTests _opts paths modName =
     readModuleTests paths (modNameFromString modName)
 
--- | Read tests from a module's .ty header, returning [] on any error.
+-- | Read tests from a module's .tydb header, returning [] on any error.
 readModuleTests :: Paths -> A.ModName -> IO [String]
 readModuleTests paths mn = do
-    let tyFile = outBase paths mn ++ ".ty"
-    exists <- doesFileExist tyFile
+    let tyFile = tyDbPath paths mn
+    exists <- InterfaceFiles.interfaceExists tyFile
     if not exists
       then return []
       else do

--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -1204,7 +1204,7 @@ actonProjTests =
             barContent = "actor main(env):\n    print(\"bar\")\n    env.exit(0)\n"
             barC    = proj </> "out/types/bar.c"
             barH    = proj </> "out/types/bar.h"
-            barTy   = proj </> "out/types/bar.ty"
+            barTy   = proj </> "out/types/bar.tydb"
         createDirectoryIfMissing True srcDir
         writeFile fooAct fooContent
         writeFile barAct barContent
@@ -1216,7 +1216,24 @@ actonProjTests =
         -- since we don't have full visibility, so bar should remain
         (returnCode, _, _) <- readCreateProcessWithExitCode (proc acton ["--skip-build", "--always-build", "src/foo.act"]){ cwd = Just proj } ""
         assertEqual "acton single-file build should succeed" ExitSuccess returnCode
-        mapM_ (\p -> doesFileExist p >>= assertBool (p ++ " should exist")) [barC, barH, barTy]
+        mapM_ (\p -> doesFileExist p >>= assertBool (p ++ " should exist")) [barC, barH]
+        doesDirectoryExist barTy >>= assertBool (barTy ++ " should exist")
+
+  , testCase "--ty copies nested module interface next to source" $ do
+        withSystemTempDirectory "acton-ty-nested" $ \proj -> do
+          let srcDir = proj </> "src" </> "pkg"
+              nestedAct = srcDir </> "nested.act"
+              nestedTy = srcDir </> "nested.tydb"
+              flatTy = proj </> "src" </> "pkg.nested.tydb"
+          createDirectoryIfMissing True srcDir
+          writeFile (proj </> "Build.act") "name = \"ty_nested\"\nfingerprint = 0x36cff6d86d8575b6\n"
+          writeFile nestedAct "actor main(env):\n    env.exit(0)\n"
+          acton <- canonicalizePath "../../dist/bin/acton"
+          (returnCode, cmdOut, cmdErr) <-
+            readCreateProcessWithExitCode (proc acton ["--skip-build", "--always-build", "--ty", "src/pkg/nested.act"]){ cwd = Just proj } ""
+          assertEqual ("acton --ty should succeed\nSTDOUT:\n" ++ cmdOut ++ "\nSTDERR:\n" ++ cmdErr) ExitSuccess returnCode
+          doesDirectoryExist nestedTy >>= assertBool (nestedTy ++ " should exist")
+          doesDirectoryExist flatTy >>= assertBool (flatTy ++ " should not exist") . not
 
   -- Full rebuild should prune roots / bins when the source module is removed.
   , testCase "full build prunes stale roots and bins" $ do

--- a/compiler/acton/test/rebuild/golden/file_03-up-to-date.golden
+++ b/compiler/acton/test/rebuild/golden/file_03-up-to-date.golden
@@ -1,6 +1,6 @@
 Building file src/c.act in project .
 Resolving dependencies (fetching if missing)...
-  Fresh a: using cached .ty
-  Fresh b: using cached .ty
-  Fresh c: using cached .ty
+  Fresh a: using cached .tydb
+  Fresh b: using cached .tydb
+  Fresh c: using cached .tydb
       Final compilation done                                                0.000 s

--- a/compiler/acton/test/rebuild/golden/file_04-touch-no-rebuild.golden
+++ b/compiler/acton/test/rebuild/golden/file_04-touch-no-rebuild.golden
@@ -1,6 +1,6 @@
 Building file src/c.act in project .
 Resolving dependencies (fetching if missing)...
-  Fresh a: using cached .ty
-  Fresh b: using cached .ty
-  Fresh c: using cached .ty
+  Fresh a: using cached .tydb
+  Fresh b: using cached .tydb
+  Fresh c: using cached .tydb
       Final compilation done                                                0.000 s

--- a/compiler/acton/test/rebuild/golden/file_08-change-b-impl.golden
+++ b/compiler/acton/test/rebuild/golden/file_08-change-b-impl.golden
@@ -1,6 +1,6 @@
 Building file src/c.act in project .
 Resolving dependencies (fetching if missing)...
-  Fresh a: using cached .ty
+  Fresh a: using cached .tydb
    b  Parse done                                                            0.000 s
   Stale b: source changed
   Hash deltas b: +DocInfo, ~baa{src HASH1 -> HASH2, impl HASH1 -> HASH2}

--- a/compiler/acton/test/rebuild/golden/project_03-up-to-date.golden
+++ b/compiler/acton/test/rebuild/golden/project_03-up-to-date.golden
@@ -1,5 +1,5 @@
 Resolving dependencies (fetching if missing)...
-  Fresh a: using cached .ty
-  Fresh b: using cached .ty
-  Fresh c: using cached .ty
+  Fresh a: using cached .tydb
+  Fresh b: using cached .tydb
+  Fresh c: using cached .tydb
       Final compilation done                                                0.000 s

--- a/compiler/acton/test/rebuild/golden/project_04-touch-no-rebuild.golden
+++ b/compiler/acton/test/rebuild/golden/project_04-touch-no-rebuild.golden
@@ -1,5 +1,5 @@
 Resolving dependencies (fetching if missing)...
-  Fresh a: using cached .ty
-  Fresh b: using cached .ty
-  Fresh c: using cached .ty
+  Fresh a: using cached .tydb
+  Fresh b: using cached .tydb
+  Fresh c: using cached .tydb
       Final compilation done                                                0.000 s

--- a/compiler/acton/test/rebuild/golden/project_08-change-b-impl.golden
+++ b/compiler/acton/test/rebuild/golden/project_08-change-b-impl.golden
@@ -1,5 +1,5 @@
 Resolving dependencies (fetching if missing)...
-  Fresh a: using cached .ty
+  Fresh a: using cached .tydb
    b  Parse done                                                            0.000 s
   Stale b: source changed
   Hash deltas b: ~baa{src HASH1 -> HASH2, impl HASH1 -> HASH2}

--- a/compiler/acton/test/rebuild/golden/project_11-change-b-doc.golden
+++ b/compiler/acton/test/rebuild/golden/project_11-change-b-doc.golden
@@ -1,5 +1,5 @@
 Resolving dependencies (fetching if missing)...
-  Fresh a: using cached .ty
+  Fresh a: using cached .tydb
    b  Parse done                                                            0.000 s
   Stale b: source changed
   Hash deltas b: ~DocInfo{src HASH1 -> HASH2, impl HASH1 -> HASH2}
@@ -10,7 +10,7 @@ Resolving dependencies (fetching if missing)...
        class DocInfo (value):
            G_init : () -> None
            get : () -> int
-  Fresh c: using cached .ty
+  Fresh c: using cached .tydb
      Back normalize done: b                                                 0.000 s
      Back deactorize done: b                                                0.000 s
      Back cps done: b                                                       0.000 s

--- a/compiler/acton/test/rebuild/golden/project_12-codegen-stale.golden
+++ b/compiler/acton/test/rebuild/golden/project_12-codegen-stale.golden
@@ -1,7 +1,7 @@
 Resolving dependencies (fetching if missing)...
-  Fresh a: using cached .ty
+  Fresh a: using cached .tydb
   Stale b: generated code out of date {impl c missing -> HASH2, h missing -> HASH2}
-  Fresh c: using cached .ty
+  Fresh c: using cached .tydb
      Back normalize done: b                                                 0.000 s
      Back deactorize done: b                                                0.000 s
      Back cps done: b                                                       0.000 s

--- a/compiler/acton/test_incremental.hs
+++ b/compiler/acton/test_incremental.hs
@@ -3,7 +3,6 @@
 module Main (main) where
 
 import           Control.Monad (unless, when)
-import qualified Data.Binary as Binary
 import qualified Data.ByteString.Lazy.Char8 as LBS
 import qualified Data.ByteString as B
 import qualified Data.Text as T
@@ -334,6 +333,11 @@ removeDirIfExists p = do
   exists <- doesDirectoryExist p
   when exists $ removeDirectoryRecursive p
 
+artifactExists :: FilePath -> IO Bool
+artifactExists p
+  | takeExtension p == ".tydb" = doesDirectoryExist p
+  | otherwise = doesFileExist p
+
 -- | Reset a project directory including deps and build outputs.
 ensureCleanProjectAt :: FilePath -> IO ()
 ensureCleanProjectAt proj = do
@@ -452,13 +456,13 @@ buildProject = do
     ExitSuccess -> pure ()
     ExitFailure c -> assertFailure ("acton build failed: " ++ show c ++ "\n" ++ T.unpack out)
 
--- | Read name hashes from a .ty file.
+-- | Read name hashes from a .tydb file.
 readTyNameHashes :: FilePath -> IO [InterfaceFiles.NameHashInfo]
 readTyNameHashes tyPath = do
   (_, _, _, _, _, _, _, _, nameHashes, _, _, _) <- InterfaceFiles.readFile tyPath
   pure nameHashes
 
--- | Read pub/impl dependency names for a binding in a .ty file.
+-- | Read pub/impl dependency names for a binding in a .tydb file.
 readTyDeps :: FilePath -> String -> IO ([String], [String])
 readTyDeps tyPath nameLabel = do
   nameHashes <- readTyNameHashes tyPath
@@ -472,7 +476,7 @@ readTyDeps tyPath nameLabel = do
           implDeps = sort (map (prstr . fst) (InterfaceFiles.nhImplDeps nh))
       pure (pubDeps, implDeps)
 
--- | Rewrite source hash and name-hash section of a .ty file.
+-- | Rewrite source hash and name-hash section of a .tydb file.
 rewriteTySrcHashAndNameHashes :: FilePath -> B.ByteString -> ([InterfaceFiles.NameHashInfo] -> [InterfaceFiles.NameHashInfo]) -> IO ()
 rewriteTySrcHashAndNameHashes tyPath srcHash' f = do
   (_mods, nmod, tmod, sourceMeta, _srcHash, pubHash, implHash, imps, nameHashes, roots, tests, mdoc) <- InterfaceFiles.readFile tyPath
@@ -486,8 +490,7 @@ rewriteTySourceMeta tyPath sourceMeta' = do
 rewriteTyVersion :: FilePath -> [Int] -> IO ()
 rewriteTyVersion tyPath version' = do
   (_mods, nmod, tmod, sourceMeta, srcHash, pubHash, implHash, imps, nameHashes, roots, tests, mdoc) <- InterfaceFiles.readFile tyPath
-  LBS.writeFile tyPath $
-    Binary.encode ((version', sourceMeta, srcHash, pubHash, implHash), imps, nameHashes, roots, tests, mdoc, nmod, tmod)
+  InterfaceFiles.writeFileWithVersion version' tyPath srcHash pubHash implHash sourceMeta imps nameHashes roots tests mdoc nmod tmod
 
 readTySourceMeta :: FilePath -> IO (Maybe InterfaceFiles.SourceFileMeta)
 readTySourceMeta tyPath = do
@@ -1164,11 +1167,11 @@ p25_whitespace_change = testCase "25-whitespace-only change does not propagate" 
   assertBool "did not expect c.act to type check" (not (typechecked out modC))
 
 p26_corrupt_ty_header :: TestTree
-p26_corrupt_ty_header = testCase "26-corrupt .ty header forces re-parse" $ do
+p26_corrupt_ty_header = testCase "26-corrupt .tydb header forces re-parse" $ do
   let proj = casesProjDir
       src = casesSrcDir
       modA = modLabel proj "a"
-      tyA = proj </> "out" </> "types" </> "a.ty"
+      tyA = proj </> "out" </> "types" </> "a.tydb"
   ensureCasesProject
   writeFileUtf8 (src </> "a.act") "aaa = 1\n"
   writeFileUtf8 (src </> "c.act") $ T.unlines
@@ -1179,16 +1182,18 @@ p26_corrupt_ty_header = testCase "26-corrupt .ty header forces re-parse" $ do
     , "    env.exit(0)"
     ]
   _ <- buildOutIn proj
-  writeFileUtf8 tyA "garbage\n"
+  removePathForcibly tyA
+  createDirectoryIfMissing True tyA
+  writeFileUtf8 (tyA </> "data.mdb") "garbage\n"
   out <- buildOutIn proj
-  assertBool "expected a.act to type check after corrupt .ty" (typechecked out modA)
+  assertBool "expected a.act to type check after corrupt .tydb" (typechecked out modA)
 
 p26_ty_version_mismatch :: TestTree
-p26_ty_version_mismatch = testCase "26b-.ty version mismatch forces re-parse" $ do
+p26_ty_version_mismatch = testCase "26b-.tydb version mismatch forces re-parse" $ do
   let proj = casesProjDir
       src = casesSrcDir
       modA = modLabel proj "a"
-      tyA = proj </> "out" </> "types" </> "a.ty"
+      tyA = proj </> "out" </> "types" </> "a.tydb"
   ensureCasesProject
   writeFileUtf8 (src </> "a.act") "aaa = 1\n"
   writeFileUtf8 (src </> "c.act") $ T.unlines
@@ -1201,9 +1206,9 @@ p26_ty_version_mismatch = testCase "26b-.ty version mismatch forces re-parse" $ 
   _ <- buildOutIn proj
   rewriteTyVersion tyA (map (+ 1) A.version)
   out <- buildOutIn proj
-  assertBool "expected a.act to type check after .ty version mismatch" (typechecked out modA)
-  assertBool "did not expect raw .ty version mismatch" $
-    not (".ty version mismatch" `T.isInfixOf` out)
+  assertBool "expected a.act to type check after .tydb version mismatch" (typechecked out modA)
+  assertBool "did not expect raw .tydb version mismatch" $
+    not (".tydb version mismatch" `T.isInfixOf` out)
 
 p27_overlay_source_provider :: TestTree
 p27_overlay_source_provider = testCase "27-overlay snapshots drive readModuleTask" $ do
@@ -1270,8 +1275,8 @@ p28_protocol_extension_deps :: TestTree
 p28_protocol_extension_deps = testCase "28-protocol/extension deps are recorded by name" $ do
   let proj = casesProjDir
       src = casesSrcDir
-      tyA = proj </> "out" </> "types" </> "a.ty"
-      tyB = proj </> "out" </> "types" </> "b.ty"
+      tyA = proj </> "out" </> "types" </> "a.tydb"
+      tyB = proj </> "out" </> "types" </> "b.tydb"
   ensureCasesProject
   writeFileUtf8 (src </> "a.act") $ T.unlines
     [ "protocol FooProto:"
@@ -1515,8 +1520,8 @@ p33_comprehensive_hashes = testCase "33-comprehensive hash propagation" $ do
       modA = modLabel proj "a"
       modB = modLabel proj "b"
       modC = modLabel proj "c"
-      tyA = proj </> "out" </> "types" </> "a.ty"
-      tyB = proj </> "out" </> "types" </> "b.ty"
+      tyA = proj </> "out" </> "types" </> "a.tydb"
+      tyB = proj </> "out" </> "types" </> "b.tydb"
   ensureCasesProjectWithDeps [("libfoo", "deps/libfoo")]
   depDir <- ensureDepProject proj "libfoo"
   let depSrc = depDir </> "src" </> "libfoo.act"
@@ -1612,7 +1617,7 @@ p33_comprehensive_hashes = testCase "33-comprehensive hash propagation" $ do
     , "    env.exit(0)"
     ]
   _ <- buildOutIn proj
-  let tyDep = depDir </> "out" </> "types" </> "libfoo.ty"
+  let tyDep = depDir </> "out" </> "types" </> "libfoo.tydb"
   depNameHashes <- readTyNameHashes tyDep
   let depNames = sort (map (prstr . InterfaceFiles.nhName) depNameHashes)
   assertBool "expected derived proto name" ("ExtraProtoD_MegaProto" `elem` depNames)
@@ -1676,9 +1681,9 @@ p34_removed_import_module = testCase "34-removed imported module fails before Zi
   res@(ec, out) <- runActonIn proj ["build", "--color", "never", "--verbose"]
   assertExitFailure "build after deleting imported module" 1 res
   mapM_ (\ext -> do
-    exists <- doesFileExist (outA ++ ext)
+    exists <- artifactExists (outA ++ ext)
     assertBool ("did not expect stale generated " ++ outA ++ ext) (not exists))
-    [".ty", ".c", ".h"]
+    [".tydb", ".c", ".h"]
   assertBool "expected missing import diagnostic"
     (T.isInfixOf "Type interface file not found or unreadable for a" out)
   assertBool "did not expect Zig build to run" (not (T.isInfixOf "zigCmd:" out))
@@ -1781,7 +1786,7 @@ p37_impl_refresh_missing_dep_hashes_reruns_front =
     ensureCasesProjectWithDeps [("libfoo", "deps/libfoo")]
     depDir <- ensureDepProject proj "libfoo"
     let depSrc = depDir </> "src" </> "libfoo.act"
-        tyMain = proj </> "out" </> "types" </> "main.ty"
+        tyMain = proj </> "out" </> "types" </> "main.tydb"
     writeFileUtf8 depSrc $ T.unlines
       [ "def foo() -> int:"
       , "    return 1"
@@ -1923,7 +1928,7 @@ p41_stale_header_missing_import_reparses_source =
         src = casesSrcDir
         actA = src </> "a.act"
         actB = src </> "b.act"
-        tyB = proj </> "out" </> "types" </> "b.ty"
+        tyB = proj </> "out" </> "types" </> "b.tydb"
         outA = proj </> "out" </> "types" </> "a"
         modB = modLabel proj "b"
     ensureCasesProject
@@ -1946,15 +1951,15 @@ p41_stale_header_missing_import_reparses_source =
       [ "def bar() -> int:"
       , "    return 7"
       ]
-    tyTime <- getModificationTime tyB
+    tyTime <- InterfaceFiles.interfaceModifiedTime tyB
     setModificationTime actB (addUTCTime (-10) tyTime)
     removeFile actA
     res@(_ec, out) <- runActonIn proj ["build", "--color", "never", "--verbose"]
     assertExitSuccess "build after stale header import removal" res
     mapM_ (\ext -> do
-      exists <- doesFileExist (outA ++ ext)
+      exists <- artifactExists (outA ++ ext)
       assertBool ("did not expect stale generated " ++ outA ++ ext) (not exists))
-      [".ty", ".c", ".h"]
+      [".tydb", ".c", ".h"]
     assertBool "expected b.act to type check after stale header reparse"
       (typechecked out modB)
     assertBool ("did not expect stale import diagnostic\n" ++ T.unpack out)
@@ -1966,7 +1971,7 @@ p42_metadata_drift_refreshes_header =
     let proj = casesProjDir
         src = casesSrcDir
         actA = src </> "a.act"
-        tyA = proj </> "out" </> "types" </> "a.ty"
+        tyA = proj </> "out" </> "types" </> "a.tydb"
         modA = modLabel proj "a"
     ensureCasesProject
     writeFileUtf8 actA "aaa = 1\n"
@@ -1986,7 +1991,7 @@ p42_metadata_drift_refreshes_header =
     currentMeta <- sourceFileMetaForPath actA
     assertBool "did not expect a.act to type check after metadata-only drift"
       (not (typechecked out modA))
-    assertBool "expected .ty header to carry source metadata"
+    assertBool "expected .tydb header to carry source metadata"
       (isJust metaAfter)
     assertBool "expected metadata drift to update cached source metadata"
       (metaBefore /= metaAfter)
@@ -1999,7 +2004,8 @@ p43_equal_act_ty_mtime_hashes_source =
         src = casesSrcDir
         actA = src </> "a.act"
         actB = src </> "b.act"
-        tyB = proj </> "out" </> "types" </> "b.ty"
+        tyB = proj </> "out" </> "types" </> "b.tydb"
+        tyBData = tyB </> "data.mdb"
         outA = proj </> "out" </> "types" </> "a"
         modB = modLabel proj "b"
     ensureCasesProject
@@ -2023,21 +2029,21 @@ p43_equal_act_ty_mtime_hashes_source =
       , "    return 7"
       ]
     rewriteTySourceMeta tyB Nothing
-    tyStatus <- getFileStatus tyB
+    tyStatus <- getFileStatus tyBData
     let tyMTimeNs = floor (toRational (modificationTimeHiRes tyStatus) * 1000000000)
     setFileMTimeNs actB tyMTimeNs
     currentMeta <- sourceFileMetaForPath actB
     rewriteTySourceMeta tyB (Just currentMeta)
-    setFileMTimeNs tyB tyMTimeNs
+    setFileMTimeNs tyBData tyMTimeNs
     metaAfter <- readTySourceMeta tyB
     metaAfter @?= Just currentMeta
     removeFile actA
     res@(_ec, out) <- runActonIn proj ["build", "--color", "never", "--verbose"]
     assertExitSuccess "build after equal act/ty mtime stale header" res
     mapM_ (\ext -> do
-      exists <- doesFileExist (outA ++ ext)
+      exists <- artifactExists (outA ++ ext)
       assertBool ("did not expect stale generated " ++ outA ++ ext) (not exists))
-      [".ty", ".c", ".h"]
+      [".tydb", ".c", ".h"]
     assertBool "expected b.act to type check after equal-mtime hash check"
       (typechecked out modB)
     assertBool ("did not expect stale import diagnostic\n" ++ T.unpack out)

--- a/compiler/lib/package.yaml.in
+++ b/compiler/lib/package.yaml.in
@@ -37,6 +37,7 @@ dependencies:
   - http-client
   - http-client-tls
   - http-types
+  - lmdb
   - megaparsec
   - mtl
   - optparse-applicative

--- a/compiler/lib/src/Acton/CommandLineParser.hs
+++ b/compiler/lib/src/Acton/CommandLineParser.hs
@@ -300,7 +300,7 @@ sigOptions = SigOptions
 sigCompileOptions :: Parser CompileOptions
 sigCompileOptions = mkSigCompileOptions
         <$> switch (long "always-build" <> help "Recompute signatures instead of reusing fresh cached interfaces")
-        <*> switch (long "ignore-compiler-version" <> help "Ignore acton version when checking .ty freshness")
+        <*> switch (long "ignore-compiler-version" <> help "Ignore acton version when checking .tydb freshness")
         <*> strOption (long "syspath"   <> metavar "TARGETDIR" <> value "" <> help "Set syspath")
         <*> many (strOption (long "searchpath" <> metavar "DIR" <> help "Add search path"))
         <*> many (option depOverrideReader
@@ -347,7 +347,7 @@ sigCompileOptions = mkSigCompileOptions
 
 compileOptions = CompileOptions
         <$> switch (long "always-build" <> help "Show the result of parsing")
-        <*> switch (long "ignore-compiler-version" <> help "Ignore acton version when checking .ty freshness")
+        <*> switch (long "ignore-compiler-version" <> help "Ignore acton version when checking .tydb freshness")
         <*> switch (long "db"           <> help "Enable DB backend")
         <*> switch (long "parse"        <> help "Show the result of parsing")
         <*> switch (long "parse-ast"    <> help "Show the raw AST (Haskell Show)")
@@ -362,7 +362,7 @@ compileOptions = CompileOptions
         <*> switch (long "hgen"         <> help "Show the generated .h header")
         <*> switch (long "cgen"         <> help "Show the generated .c code")
         <*> switch (long "ccmd"         <> help "Show CC / LD commands")
-        <*> switch (long "ty"           <> help "Write .ty file to src file directory")
+        <*> switch (long "ty"           <> help "Write .tydb directory to src file directory")
         <*> switch (long "cpedantic"    <> help "Pedantic C compilation with -Werror")
         <*> switch (long "dbg-no-lines" <> help "Disable emission of C #line directives (for debugging codegen)")
         <*> optimizeOption
@@ -447,7 +447,7 @@ cloudOptions = CloudOptions
         <*> switch (long "stop"         <> help "Help stop!")
 
 docOptions = DocOptions
-    <$> (argument str (metavar "FILE" <> help "Input file (.act or .ty) - optional in projects" <> completer (bashCompleter "file -X '!*.act' -X '!*.ty' -o plusdirs")) <|> pure "")
+    <$> (argument str (metavar "FILE" <> help "Input file (.act or .tydb) - optional in projects" <> completer (bashCompleter "file -X '!*.act' -X '!*.tydb' -o plusdirs")) <|> pure "")
     <*> formatFlags
     <*> optional (strOption (long "output" <> short 'o' <> metavar "FILE" <> help "Output file (default: stdout)"))
   where

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -4,7 +4,7 @@ Overview
 
 This module implements the shared Acton compilation pipeline that both the
 acton CLI and the LSP server drive. It builds a dependency graph across
-projects, runs the front passes (parse, kinds, types) to produce .ty interface
+projects, runs the front passes (parse, kinds, types) to produce .tydb interface
 files and diagnostics, and then emits the back passes (normalizer through
 codegen) as separate jobs.
 
@@ -14,7 +14,7 @@ about a modified module, cancel running tasks and restart compilation of that
 module from that point. This is used by watch mode and LSP where updates to
 files or in-editor buffers trigger recompilation. Dependencies are considered so
 that updates to a module only cause the affected part of the subgraph, i.e. the
-modified module and downstream dependencies to be recompiled. Cached .ty headers
+modified module and downstream dependencies to be recompiled. Cached .tydb headers
 are reused when public module interfaces are unchanged. Per-name pub/impl hashes
 stored in the header drive front-pass vs back-pass decisions, and moduleImplHash
 is embedded in generated .c/.h to detect stale codegen. Inter-module
@@ -60,7 +60,7 @@ Call flow:
 
 State and orchestration:
   - Acton.Compile holds only small in-process caches (tyPathCache, pubHashCache,
-    and nameHashCache) to speed up .ty lookups; all orchestration state is
+    and nameHashCache) to speed up .tydb lookups; all orchestration state is
     owned by the caller.
   - Callers allocate and hold a CompileScheduler from this module. The
     scheduler encapsulates mutable state (generation id, cancelable async
@@ -167,6 +167,7 @@ module Acton.Compile
   , filterActFile
   , srcFile
   , outBase
+  , tyDbPath
   , srcBase
   , getModPath
   , modNameToFilename
@@ -248,7 +249,7 @@ import Network.HTTP.Types.Header (hContentDisposition, hContentType)
 import Network.HTTP.Types.Status (statusCode)
 import System.Clock
 import System.Directory
-import System.Directory.Recursive
+import System.Directory.Recursive (getFilesRecursive)
 import System.Environment (getExecutablePath, lookupEnv)
 import System.FileLock (FileLock, SharedExclusive(Exclusive), tryLockFile, unlockFile, withFileLock)
 import System.FilePath ((</>))
@@ -810,12 +811,12 @@ dump mn h txt =
             ++ '\n' : replicate (38 + length h + length (modNameToString mn)) '=' ++ "\n")
 
 -- | Compute the subdirectory for a module within a types root.
--- Used when creating directories before writing .ty files.
+-- Used when creating directories before writing .tydb files.
 getModPath :: FilePath -> A.ModName -> FilePath
 getModPath path mn =
   joinPath [path, joinPath $ init $ A.modPath mn]
 
--- Global caches (process‑wide) to reduce repeated .ty lookups during parallel builds
+-- Global caches (process‑wide) to reduce repeated .tydb lookups during parallel builds
 --
 -- We deliberately create top‑level MVars via unsafePerformIO and mark them
 -- NOINLINE so their initializer runs exactly once. Without NOINLINE, GHC could
@@ -824,11 +825,11 @@ getModPath path mn =
 --
 -- Thread‑safety: all access goes through modifyMVar/modifyMVar_ so read/modify/
 -- write is atomic. These caches are best‑effort for performance; correctness
--- does not depend on them. On a miss we fall back to reading .ty headers from
+-- does not depend on them. On a miss we fall back to reading .tydb headers from
 -- disk. After a successful compile we update pubHashCache so dependents in
 -- this process see the new public hash.
 --
--- tyPathCache    :: ModName -> absolute .ty path (resolved from searchPath)
+-- tyPathCache    :: ModName -> absolute .tydb path (resolved from searchPath)
 -- pubHashCache :: ModName -> current public hash (from header or compile)
 -- nameHashCache  :: ModName -> per-name hash info (from header or compile)
 {-# NOINLINE tyPathCache #-}
@@ -843,7 +844,7 @@ pubHashCache = unsafePerformIO (newMVar M.empty)
 nameHashCache :: MVar (M.Map A.ModName (M.Map A.Name InterfaceFiles.NameHashInfo))
 nameHashCache = unsafePerformIO (newMVar M.empty)
 
--- | Resolve the on-disk .ty path for a module, using a process-wide cache.
+-- | Resolve the on-disk .tydb path for a module, using a process-wide cache.
 -- Avoids repeated filesystem walks when many modules share dependencies.
 getTyFileCached :: [FilePath] -> A.ModName -> IO (Maybe FilePath)
 getTyFileCached spaths mn = modifyMVar tyPathCache $ \m -> do
@@ -862,13 +863,13 @@ getTyFileCached spaths mn = modifyMVar tyPathCache $ \m -> do
   case M.lookup mn m of
     Just p -> do
       pNorm <- normalizePathSafe p
-      exists <- doesFileExist pNorm
+      exists <- InterfaceFiles.interfaceExists pNorm
       if exists && inSearchPath pNorm
         then return (m, Just pNorm)
         else refresh m
     Nothing -> refresh m
 
--- | Read a module's public hash using the cache and .ty header.
+-- | Read a module's public hash using the cache and .tydb header.
 -- This drives dependency invalidation when an imported interface changes.
 getPubHashCached :: Paths -> A.ModName -> IO (Maybe B.ByteString)
 getPubHashCached paths mn = modifyMVar pubHashCache $ \m -> do
@@ -899,7 +900,7 @@ publicIfaceTE = filter (Names.isPublicName . fst)
 publicNameHashes :: [InterfaceFiles.NameHashInfo] -> [InterfaceFiles.NameHashInfo]
 publicNameHashes = filter (Names.isPublicName . InterfaceFiles.nhName)
 
--- | Read a module's per-name hash map using the cache and .ty header.
+-- | Read a module's per-name hash map using the cache and .tydb header.
 getNameHashMapCached :: Paths -> A.ModName -> IO (Maybe (M.Map A.Name InterfaceFiles.NameHashInfo))
 getNameHashMapCached paths mn = modifyMVar nameHashCache $ \m -> do
   case M.lookup mn m of
@@ -939,7 +940,7 @@ errsToDiagnostics :: String -> FilePath -> String -> [(SrcLoc, String)] -> [Diag
 errsToDiagnostics errKind filename src errs =
     [ Diag.actErrToDiagnostic errKind filename src loc msg | (loc, msg) <- errs ]
 
--- | Emit diagnostics when a dependency .ty file is missing or unreadable.
+-- | Emit diagnostics when a dependency .tydb file is missing or unreadable.
 -- Anchors the error to the owning module's filename for consistent reporting.
 missingIfaceDiagnostics :: A.ModName -> String -> A.ModName -> [Diagnostic String]
 missingIfaceDiagnostics ownerMn src missingMn =
@@ -1035,7 +1036,7 @@ parseActFile opts sp mn actFile mOnProgress = do
   emod <- parseActSource opts mn displayFile (Source.ssText snap) mOnProgress
   return $ fmap (\m -> (snap, m)) emod
 
--- | Read stable source metadata used for quick .ty reuse checks.
+-- | Read stable source metadata used for quick .tydb reuse checks.
 -- Device/inode act as file identity on POSIX so metadata drift from copies or
 -- restores falls back to content hashing instead of blindly trusting mtimes.
 readSourceFileMeta :: FilePath -> IO InterfaceFiles.SourceFileMeta
@@ -1374,7 +1375,7 @@ data ModuleHead
       }
 
 -- | Read the cheap module header used by discovery and doc indexing.
--- Reuse a valid .ty header when possible; otherwise read the source snapshot
+-- Reuse a valid .tydb header when possible; otherwise read the source snapshot
 -- and parse only the module docstring plus imports.
 readModuleHeader :: Source.SourceProvider
                  -> C.GlobalOptions
@@ -1384,19 +1385,18 @@ readModuleHeader :: Source.SourceProvider
                  -> IO ModuleHead
 readModuleHeader sp gopts opts paths actFile = do
     let mn      = modName paths
-        tyFile  = outBase paths mn ++ ".ty"
-    tyExists <- doesFileExist tyFile
+        tyFile  = tyDbPath paths mn
+    tyExists <- InterfaceFiles.interfaceExists tyFile
     if not tyExists
       then readSourceHead mn
       else do
-        -- .ty exists: read the cached header and validate it against compiler
+        -- .tydb exists: read the cached header and validate it against compiler
         -- compatibility plus source metadata/content as needed.
         hdrE <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readHeader tyFile
         case hdrE of
           Left _ -> readSourceHead mn
           Right (cachedSourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash, imps, nameHashes, roots, tests, mdoc) -> do
-            tyStatus <- getFileStatus tyFile
-            let tyMTimeNs = fileStatusMTimeNs tyStatus
+            tyMTimeNs <- InterfaceFiles.interfaceModifiedTimeNs tyFile
             newCompiler <- compilerNewerThan tyMTimeNs
             mOverlay <- Source.spReadOverlay sp actFile
             case mOverlay of
@@ -1468,7 +1468,7 @@ readModuleHeader sp gopts opts paths actFile = do
                 Right exeStatus -> return (fileStatusMTimeNs exeStatus > tyMTimeNs)
 
     refreshCachedSourceMeta currentSourceMeta = do
-      let tyFilePath = outBase paths (modName paths) ++ ".ty"
+      let tyFilePath = tyDbPath paths (modName paths)
       tyRes <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readFile tyFilePath
       case tyRes of
         Left _ -> return ()
@@ -1481,7 +1481,7 @@ readModuleHeader sp gopts opts paths actFile = do
           same = curHash == moduleSrcBytesHash
       when (C.verbose gopts && Source.ssIsOverlay snap) $ do
         actTime <- Source.spGetModTime sp actFile
-        tyTime <- getModificationTime (outBase paths mn ++ ".ty")
+        tyTime <- InterfaceFiles.interfaceModifiedTime (tyDbPath paths mn)
         let len = B.length (Source.ssBytes snap)
         putStrLn ("[debug] readModuleHeader " ++ modNameToString mn
                   ++ " act=" ++ show actTime
@@ -1498,7 +1498,7 @@ readModuleHeader sp gopts opts paths actFile = do
         else sourceHeadFromSnapshot mn snap
 
 -- | Prepare a task for dependency graph construction.
--- The full source parse is deferred for modules whose .ty header cannot be
+-- The full source parse is deferred for modules whose .tydb header cannot be
 -- reused, but discovery still gets accurate imports from the source header.
 readModuleTask :: Source.SourceProvider -> C.GlobalOptions -> C.CompileOptions -> Paths -> String -> IO CompileTask
 readModuleTask sp gopts opts paths actFile = do
@@ -1584,7 +1584,7 @@ materializeTask opts sp mn actFile mOnProgress task =
 
 
 -- | Recursively read imports for a set of tasks within the same project.
--- Any missing module is added by parsing or reading its .ty header via
+-- Any missing module is added by parsing or reading its .tydb header via
 -- readModuleTask, yielding a self-contained task list.
 readImports :: Source.SourceProvider -> C.GlobalOptions -> C.CompileOptions -> Paths -> [CompileTask] -> IO [CompileTask]
 readImports sp gopts opts paths tasks = do
@@ -1623,7 +1623,7 @@ readImports sp gopts opts paths tasks = do
 quiet :: C.GlobalOptions -> C.CompileOptions -> Bool
 quiet gopts opts = C.quiet gopts || altOutput opts
 
--- | Read an interface from a .ty file and return its NameInfo and public hash.
+-- | Read an interface from a .tydb file and return its NameInfo and public hash.
 -- This is used when a module is deemed fresh and we want to avoid reparsing.
 readIfaceFromTy :: Paths -> A.ModName -> String -> Maybe B.ByteString -> IO (Either [Diagnostic String] ([A.ModName], [(A.Name, I.NameInfo)], Maybe String, B.ByteString))
 readIfaceFromTy paths mn src mHash = do
@@ -1707,7 +1707,7 @@ formatCodegenDelta status =
 
 -- | Run the front passes for a single module.
 -- Builds the environment, runs kinds/types, computes per-name src/pub/impl
--- hashes plus module pub/impl hashes, and writes the .ty header. Returns the
+-- hashes plus module pub/impl hashes, and writes the .tydb header. Returns the
 -- front result plus a BackJob for later passes when compilation is needed.
 runFrontPasses :: C.GlobalOptions
                -> C.CompileOptions
@@ -1880,7 +1880,7 @@ runFrontPasses gopts opts paths env0 parsed srcContent srcBytes sourceMeta resol
       let I.NModule imps fullIface mdoc = nmod
           publicIface = publicIfaceTE fullIface
       let roots = [ n | (n,i) <- fullIface, rootEligible i ]
-      -- Import hashes are recorded in the .ty header so dep changes can be detected.
+      -- Import hashes are recorded in the .tydb header so dep changes can be detected.
       impsRes <- resolveImportHashes imps
       case impsRes of
         Left diags -> return (Left diags)
@@ -1928,7 +1928,7 @@ runFrontPasses gopts opts paths env0 parsed srcContent srcBytes sourceMeta resol
               (pubSigLocalDeps, pubSigExtDeps) = Hashing.splitDeps mn hashEnv nameKeys pubSigDepsRaw
               (_, pubExtDeps) = Hashing.splitDeps mn hashEnv nameKeys pubDepsRaw
               (implLocalDeps, implExtDeps) = Hashing.splitDeps mn hashEnv nameKeys implDepsRaw
-              -- Load .ty maps for any external modules referenced by deps.
+              -- Load .tydb maps for any external modules referenced by deps.
               extMods = Data.Set.toList (Hashing.externalModules pubExtDeps `Data.Set.union` Hashing.externalModules implExtDeps)
           extMapsRes <- resolveNameHashMaps extMods
           case extMapsRes of
@@ -1943,7 +1943,7 @@ runFrontPasses gopts opts paths env0 parsed srcContent srcBytes sourceMeta resol
                 (_, Left diags, _) -> return (Left diags)
                 (_, _, Left diags) -> return (Left diags)
                 (Right pubSigExtHashes, Right pubExtHashes, Right implExtHashes) -> do
-                  -- Build per-name hash records (src/pub/impl + deps) for .ty.
+                  -- Build per-name hash records (src/pub/impl + deps) for .tydb.
                   let nameHashes =
                         Hashing.buildNameHashes
                           nameKeys
@@ -1959,8 +1959,8 @@ runFrontPasses gopts opts paths env0 parsed srcContent srcBytes sourceMeta resol
                   -- Module-level hashes summarize the per-name hashes.
                   let modulePubHash = Hashing.modulePubHashFromIface nmod nameHashes
                       moduleImplHash = Hashing.moduleImplHashFromNameHashes nameHashes
-                  -- Write .ty now so later builds can reuse this front-pass work.
-                  InterfaceFiles.writeFile (outbase ++ ".ty") moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta impsWithHash nameHashes roots tests mdoc nmod tchecked
+                  -- Write .tydb now so later builds can reuse this front-pass work.
+                  InterfaceFiles.writeFile (tyDbPath paths mn) moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta impsWithHash nameHashes roots tests mdoc nmod tchecked
 
                   iff (C.types opts && isRoot) $ dump mn "types" (Pretty.print tchecked)
                   iff (C.sigs opts && isRoot) $ dump mn "sigs" (Acton.Types.prettySigs env mn imps fullIface)
@@ -2149,11 +2149,10 @@ runBackPassesWithProgress gopts opts paths backInput shouldWrite onProgress = do
                             hFile = outbase ++ ".h"
                         writeFile hFile h
                         writeFile cFile c
-                        let tyFileName = modNameToString(modName paths) ++ ".ty"
-                        iff (C.ty opts) $
-                             copyFileWithMetadata
-                               (joinPath [projTypes paths, tyFileName])
-                               (joinPath [srcDir paths, tyFileName])
+                        let tySrc = tyDbPath paths (modName paths)
+                            tyDst = srcBase paths (modName paths) ++ InterfaceFiles.interfaceExt
+                        iff (C.ty opts) $ do
+                             InterfaceFiles.copyInterface tySrc tyDst
                       return (Just tWrite)
             finishBack tRender mWriteTime
 
@@ -2181,14 +2180,14 @@ runBackPassesWithProgress gopts opts paths backInput shouldWrite onProgress = do
 --
 --   1) Construct a dependency graph over non-builtin tasks and topologically order it.
 --   2) Compile __builtin__ first if present.
---   3) Walk modules in topo order, deciding per module whether to compile or reuse cached .ty,
+--   3) Walk modules in topo order, deciding per module whether to compile or reuse cached .tydb,
 --      and update the shared environment.
 --   4) Track per-name pub/impl hashes and only redo the work that changed:
 --      pub changes trigger front passes; impl changes trigger back passes (with
 --      an impl-hash refresh); codegen hash mismatches trigger back passes only.
 --
 -- Key ideas (ActonTask vs TyTask caching):
---   - TyTask is lightweight, read from the .ty header: moduleSrcBytesHash, modulePubHash,
+--   - TyTask is lightweight, read from the .tydb header: moduleSrcBytesHash, modulePubHash,
 --     moduleImplHash, imports annotated with the pub hash used, per-name hashes (src/pub/impl
 --     + deps), roots, tests, and docstring. It avoids decoding heavy sections.
 --   - ParseTask carries source text plus discovered imports; full parsing is
@@ -2196,7 +2195,7 @@ runBackPassesWithProgress gopts opts paths backInput shouldWrite onProgress = do
 --   - ActonTask carries parsed source and must be compiled.
 --   - pubMap :: Map TaskKey ByteString and nameMap :: Map TaskKey (Map Name NameHashInfo) are
 --     maintained during the run. TyTask compares recorded dependency hashes against current
---     provider hashes (in-graph via pubMap/nameMap, otherwise via cached .ty headers). Pub deltas
+--     provider hashes (in-graph via pubMap/nameMap, otherwise via cached .tydb headers). Pub deltas
 --     trigger front passes; impl deltas trigger back passes with an impl-hash refresh.
 --   - When a TyTask is stale for public reasons (or altOutput on the root), we convert it to an
 --     ActonTask by parsing the .act file and run front passes; when it is fresh we reuse the
@@ -2412,7 +2411,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
           optsT = optsFor key
           providers = gtImportProviders t
           actFile = srcFile paths mn
-          tyFile = outBase paths mn ++ ".ty"
+          tyFile = tyDbPath paths mn
           short8 bs   = take 8 (B.unpack $ Base16.encode bs)
           mkFrontResult imps ifaceTE mdoc pubHash nameHashes backJob =
             FrontResult
@@ -2621,7 +2620,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
               return (fmap (\vals -> (n, vals)) resolvedQns)) (M.toList deps)
             return (fmap M.fromList resolved)
 
-          -- For stale checks on cached .ty tasks we treat missing names/hashes
+          -- For stale checks on cached .tydb tasks we treat missing names/hashes
           -- as "stale cache" signals and force front passes, instead of failing
           -- early with internal hash diagnostics.
           resolveQNameHashForStaleCheck getHash qn =
@@ -2674,7 +2673,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
                 Left _ ->
                   return (key, Right emptyFrontResult)
         _ -> do
-          -- For cached .ty tasks, compare recorded dep hashes against current deps.
+          -- For cached .tydb tasks, compare recorded dep hashes against current deps.
           -- This is the up-to-date check that decides if we can skip work. If
           -- any implDeps have changed we need to rerun out back passes and if
           -- any pubDeps have changed we need to rerun front passes (and back
@@ -2856,7 +2855,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
                         cacheFrontResult fr
                   runReuse = do
                     when (C.verbose gopts) $
-                      ccOnInfo callbacks ("  Fresh " ++ modNameToString mn ++ ": using cached .ty")
+                      ccOnInfo callbacks ("  Fresh " ++ modNameToString mn ++ ": using cached .tydb")
                     ifaceRes <- case taskCurrent of
                                   TyTask{ tyPubHash = h } -> readIfaceFromTy paths mn "" (Just h)
                                   _ -> readIfaceFromTy paths mn "" Nothing
@@ -3239,9 +3238,12 @@ srcFile                 :: Paths -> A.ModName -> FilePath
 srcFile paths mn        = joinPath (srcDir paths : A.modPath mn) ++ ".act"
 
 -- | Compute the output base path (without extension) for a module.
--- Used to locate .ty/.c/.h output under the project's types directory.
+-- Used to locate .tydb/.c/.h output under the project's types directory.
 outBase                 :: Paths -> A.ModName -> FilePath
 outBase paths mn        = joinPath (projTypes paths : A.modPath mn)
+
+tyDbPath                :: Paths -> A.ModName -> FilePath
+tyDbPath paths mn       = outBase paths mn ++ InterfaceFiles.interfaceExt
 
 -- | Compute the module path without extension under the project's src dir.
 -- Used to derive the .act path or related per-module files.
@@ -3395,7 +3397,7 @@ enumerateProjectModules ctx = do
           return (f, mn)
 
 -- | Remove stale generated module artifacts when source modules disappear.
--- Prunes orphan .ty/.c/.h outputs under out/types before task planning so
+-- Prunes orphan .tydb/.c/.h outputs under out/types before task planning so
 -- cached headers cannot mask deleted .act modules.
 pruneMissingModuleOutputs :: ProjCtx -> IO ()
 pruneMissingModuleOutputs ctx = do
@@ -3413,6 +3415,8 @@ pruneMissingModuleOutputs ctx = do
                    else return Data.Set.empty
       outFiles <- getFilesRecursive typesRoot
       mapM_ (pruneFile srcMods typesRoot) outFiles
+      tyDbs <- InterfaceFiles.listInterfaceDirsRecursive typesRoot
+      mapM_ (pruneTyDb srcMods typesRoot) tyDbs
   where
     isRootStub rel ext =
       ext == ".c" &&
@@ -3425,11 +3429,17 @@ pruneMissingModuleOutputs ctx = do
 
     pruneFile srcMods typesRoot absFile = do
       let ext = takeExtension absFile
-      when (ext == ".ty" || ext == ".c" || ext == ".h") $ do
+      when (ext == ".c" || ext == ".h") $ do
         let rel = normalise (makeRelative typesRoot absFile)
             base = normalise (moduleBase rel ext)
         unless (Data.Set.member base srcMods) $
           removeFile absFile `catch` ignoreNotExists
+
+    pruneTyDb srcMods typesRoot absDir = do
+      let rel = normalise (makeRelative typesRoot absDir)
+          base = normalise (dropExtension rel)
+      unless (Data.Set.member base srcMods) $
+        removePathForcibly absDir `catch` ignoreNotExists
 
     ignoreNotExists :: IOException -> IO ()
     ignoreNotExists _ = return ()
@@ -3451,7 +3461,8 @@ pruneMissingChangedModuleOutputs ctxs changedPaths = do
       when (Data.List.isPrefixOf srcRoot' actPath') $ do
         let modBase = normalise (dropExtension (makeRelative srcRoot actPath'))
             outBase = projTypesDir ctx </> modBase
-        mapM_ (\ext -> removeFile (outBase ++ ext) `catch` ignoreNotExists) [".ty", ".c", ".h"]
+        removePathForcibly (outBase ++ InterfaceFiles.interfaceExt) `catch` ignoreNotExists
+        mapM_ (\ext -> removeFile (outBase ++ ext) `catch` ignoreNotExists) [".c", ".h"]
 
     ignoreNotExists :: IOException -> IO ()
     ignoreNotExists _ = return ()
@@ -4147,7 +4158,7 @@ nameToString (A.Name _ s) = s
 
 
 -- | Check whether a NameInfo represents a root-eligible actor.
--- Used to decide which roots to include in .ty headers and root generation.
+-- Used to decide which roots to include in .tydb headers and root generation.
 rootEligible :: I.NameInfo -> Bool
 rootEligible (I.NAct [] p k _ _) = case (p,k) of
                                       (A.TNil{}, A.TRow _ _ _ t A.TNil{}) ->

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -20,7 +20,7 @@ import GHC.Generics (Generic)
 import Data.Typeable
 import Data.Char
 import System.FilePath.Posix (joinPath,takeDirectory)
-import System.Directory (doesFileExist)
+import System.Directory (doesDirectoryExist, doesFileExist)
 import System.Environment (getExecutablePath)
 import Control.Monad
 import Control.Monad.Except
@@ -256,7 +256,7 @@ initEnv path True          = return $ EnvF{ activeNames = [],
                                             context = [],
                                             qlevel = 0,
                                             envX = () }
-initEnv path False         = do (_,nmod,_,_,_,_,_,_,_,_,_,_) <- InterfaceFiles.readFile (joinPath [path,"__builtin__.ty"])
+initEnv path False         = do (_,nmod,_,_,_,_,_,_,_,_,_,_) <- InterfaceFiles.readFile (InterfaceFiles.interfacePath path (modName ["__builtin__"]))
                                 let NModule _ envBuiltin builtinDocstring = nmod
                                     envBuiltinPublic = publicTEnv envBuiltin
                                     initialNames = [(nPrim,NMAlias mPrim), (nBuiltin,NMAlias mBuiltin)]
@@ -1123,14 +1123,14 @@ findTyFile spaths mn = go spaths
   where
     go []     = return Nothing
     go (p:ps) = do
-      let fullPath = joinPath (p : modPath mn) ++ ".ty"
-      exists <- doesFileExist fullPath
+      let fullPath = InterfaceFiles.interfacePath p mn
+      exists <- InterfaceFiles.interfaceExists fullPath
       --traceM ("findTyFile: " ++ fullPath ++ " " ++ show exists)
       if exists
         then return (Just fullPath)
         else go ps
 
--- | Import a module, loading its .ty and extending the environment.
+-- | Import a module, loading its .tydb and extending the environment.
 doImp                        :: [FilePath] -> EnvF x -> ModName -> IO (EnvF x, TEnv)
 doImp spath env m            = do (env', te, _) <- doImpSeen S.empty env m
                                   return (addImport m env', te)

--- a/compiler/lib/src/Acton/NameInfo.hs
+++ b/compiler/lib/src/Acton/NameInfo.hs
@@ -143,7 +143,7 @@ stripDocsNI ni = case ni of
 
 -- | Strip source locations from NameInfo (and nested syntax fragments).
 -- This keeps public interface hashes independent from whitespace-only source
--- edits while preserving locations in the cached .ty payload itself.
+-- edits while preserving locations in the cached .tydb payload itself.
 stripLocsNI :: NameInfo -> NameInfo
 stripLocsNI ni = case ni of
   NVar t             -> NVar (stripLocsType t)

--- a/compiler/lib/src/Acton/Syntax.hs
+++ b/compiler/lib/src/Acton/Syntax.hs
@@ -25,7 +25,7 @@ import Control.DeepSeq
 import Prelude hiding((<>))
 
 version :: [Int]
-version = [0,17]
+version = [0,20]
 
 data Module     = Module        { modname::ModName, imps::[Import], mdoc::Maybe String, mbody::Suite } deriving (Eq,Show,Generic,NFData)
 

--- a/compiler/lib/src/Acton/Types.hs
+++ b/compiler/lib/src/Acton/Types.hs
@@ -95,7 +95,7 @@ reconstruct progressCb inferredCb env0 (Module m i mdoc ss)    = do --traceM ("#
         modNameStr (ModName ns) = concat (intersperse "." (map nstr ns))
 
 
--- | Print a .ty file header and interface; include name hashes when verbose.
+-- | Print a .tydb header and interface; include name hashes when verbose.
 showTyFile env0 m fname verbose = do
                                      (_,nmod,_,sourceMeta,srcH,pubH,implH,imps,nameHashes,roots,tests,mdocH) <- InterfaceFiles.readFile fname
                                      putStrLn ("\n############### Header ###############")

--- a/compiler/lib/src/InterfaceFiles.hs
+++ b/compiler/lib/src/InterfaceFiles.hs
@@ -11,51 +11,108 @@
 -- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 --
 
-{-# LANGUAGE DeriveGeneric #-}
--- Acton Interface (.ty) Files
+{-# LANGUAGE DeriveGeneric, ScopedTypeVariables #-}
+-- Acton Interface (.tydb) Files
 --
 -- Purpose
 -- - Cache compiled module information so later builds can avoid unnecessary
 --   work by reading a small header instead of decoding large structures.
--- - If a .ty cannot be decoded or the version mismatches, the caller must
+-- - If a .tydb cannot be decoded or the version mismatches, the caller must
 --   treat the module as out-of-date and recompile from source.
 --
--- On-disk layout (Binary, in this exact order)
---   1) version            :: [Int]                         -- Acton.Syntax.version
---   2) sourceMeta         :: Maybe SourceFileMeta          -- cached source stat metadata
---   3) moduleSrcBytesHash :: ByteString                    -- SHA-256 of raw source bytes
---   4) modulePubHash      :: ByteString                    -- SHA-256 of public NameInfo (doc-free)
---                                                       -- augmented with imports' pub hashes
---   5) moduleImplHash     :: ByteString                    -- SHA-256 of per-name impl hashes
---   6) imports            :: [(A.ModName, ByteString)]     -- imported module and pub hash used
---   7) nameHashes         :: [NameHashInfo]                -- per-name src/pub/impl hashes + deps
---   8) roots              :: [A.Name]                      -- root actors (e.g., main or test_main)
---   9) tests              :: [String]                      -- discovered test names
---  10) docstring          :: Maybe String                  -- module docstring
---  11) nameInfo           :: I.NameInfo                    -- type/name environment
---  12) typedModule        :: A.Module                      -- typed module
+-- On-disk layout
+-- A .tydb is an LMDB directory environment (containing data.mdb and lock.mdb)
+-- holding a single unnamed database. Each field below is one key; values are
+-- encoded with Data.Binary. Where the old .ty format wrote one blob in a fixed
+-- order, here every field is an independently addressable key.
 --
--- Rationale for ordering
--- - Put cache validity fields first so callers can validate and reuse a cache
---   entry without decoding the large NameInfo and typed Module sections.
--- - Follow with the remaining module hashes used for dependency checks.
--- - Follow with small variable fields (imports, roots, docstring).
--- - Put heavy sections last (NameInfo, typed Module) to preserve laziness.
+--   Module-level keys (one each):
+--     "version"        :: [Int]                       -- Acton.Syntax.version
+--     "meta"           :: ( Maybe SourceFileMeta      -- cached source stat metadata
+--                         , ByteString                -- moduleSrcBytesHash: SHA-256 of raw source
+--                         , ByteString                -- modulePubHash: SHA-256 of public NameInfo
+--                                                     --   (doc-free) + imports' pub hashes
+--                         , ByteString )              -- moduleImplHash: SHA-256 of per-name impl hashes
+--     "imports"        :: [(A.ModName, ByteString)]   -- imported module and pub hash used
+--     "roots"          :: [A.Name]                    -- root actors (e.g. main or test_main)
+--     "tests"          :: [String]                    -- discovered test names
+--     "doc"            :: Maybe String                -- module docstring
+--     "name-count"     :: Int                         -- number of NameInfo entries (see name-order)
+--     "stmt-count"     :: Int                         -- number of typed top-level statements
+--     "module-header"  :: (A.ModName, Imports, Maybe String)
+--                                                     -- typed module name, imports, docstring
+--
+--   Per-name keys (NameInfo / TEnv, one set per name):
+--     "name-order/<NNN>"   :: ByteString              -- name-key suffix, in TEnv order (NNN = padIndex)
+--     "name-info/<suffix>" :: (A.Name, I.NameInfo)    -- the name and its type/name environment entry
+--     "name-hash/<suffix>" :: NameHashInfo            -- per-name src/pub/impl hashes + deps
+--
+--   Per-statement keys (typed Module body):
+--     "stmt/<NNN>"     :: A.Stmt                      -- one typed top-level statement (NNN = padIndex)
+--
+-- <suffix> encodes the semantic name: "p/<text>" for plain safe names (used as
+-- the key verbatim) or "h/<sha256hex>" for long or unsafe names. See nameKeySuffix.
+--
+-- Rationale for the keyed layout
+-- - Keep the small validity/header fields (version, meta, imports, roots, tests,
+--   doc, name-hashes) as their own keys so callers can validate and reuse a cache
+--   entry, or do freshness/dependency checks, without decoding the large NameInfo
+--   and typed Module sections (readHeader vs readFile).
+-- - Store NameInfo and the typed module body as explicitly-ordered entries
+--   (name-order/... and stmt/...) rather than relying on LMDB cursor order, so a
+--   full read reconstructs the exact original ordering -- and so later work can
+--   move from full reconstruction to selective per-name lookup without changing
+--   the outer cache boundary.
 
-module InterfaceFiles where
+module InterfaceFiles
+  ( NameHashInfo(..)
+  , SourceFileMeta(..)
+  , TyFile
+  , TyHeader
+  , interfaceExt
+  , interfacePath
+  , interfaceExists
+  , interfaceModifiedTime
+  , interfaceModifiedTimeNs
+  , copyInterface
+  , listInterfaceDirsRecursive
+  , keyNameInfo
+  , keyNameHash
+  , readFile
+  , readHeader
+  , readFileMaybe
+  , readHeaderMaybe
+  , writeFile
+  , writeFileWithVersion
+  ) where
 
 import Prelude hiding (readFile, writeFile)
 import Data.Binary
 import qualified Control.Exception as E
-import qualified Data.Binary.Get as BinaryGet
+import Control.Concurrent (runInBoundThread)
+import Control.Concurrent.MVar (MVar, modifyMVar, newMVar, withMVar)
+import Control.Monad (forM, forM_, unless, when)
+import qualified Crypto.Hash.SHA256 as SHA256
+import qualified Data.ByteString.Base16 as Base16
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as B
+import qualified Data.List
+import qualified Data.Map.Strict as Map
 import qualified Data.ByteString.Lazy as BL
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import Data.Time.Clock (UTCTime)
+import qualified Database.LMDB.Raw as LMDB
 import qualified Acton.Syntax as A
 import qualified Acton.NameInfo as I
+import Foreign.Ptr (castPtr)
+import Foreign.Storable (peek)
 import GHC.Generics (Generic)
-import System.Directory (renameFile)
-import System.IO (IOMode(ReadMode), hClose, hFileSize, openBinaryFile)
-import System.Posix.Process (getProcessID)
+import System.Directory (canonicalizePath, createDirectoryIfMissing, doesDirectoryExist, doesFileExist, getFileSize, getModificationTime, listDirectory, removeFile, removePathForcibly)
+import System.FilePath ((</>), takeExtension)
+import System.IO.Error (isDoesNotExistError)
+import System.IO.Unsafe (unsafePerformIO)
+import System.Posix.Files (fileAccess, getFileStatus, modificationTimeHiRes, setFileMode)
 
 data NameHashInfo = NameHashInfo
   { nhName     :: A.Name
@@ -105,89 +162,434 @@ type TyHeader =
   , Maybe String
   )
 
+type TyMeta =
+  ( Maybe SourceFileMeta
+  , BS.ByteString
+  , BS.ByteString
+  , BS.ByteString
+  )
+
 -- Note: tests are stored in the header to support listing without compiling
 --       or executing test binaries.
 
-readTyBytes :: FilePath -> IO BL.ByteString
-readTyBytes f = do
-    h <- openBinaryFile f ReadMode
-    size <- hFileSize h
-    bs <- BS.hGet h (fromIntegral size)
-    hClose h
-    return (BL.fromStrict bs)
+interfaceExt :: String
+interfaceExt = ".tydb"
+
+interfacePath :: FilePath -> A.ModName -> FilePath
+interfacePath root mn = foldl (</>) root (A.modPath mn) ++ interfaceExt
+
+dataFilePath :: FilePath -> FilePath
+dataFilePath path = path </> "data.mdb"
+
+lockFilePath :: FilePath -> FilePath
+lockFilePath path = path </> "lock.mdb"
+
+-- The raw LMDB binding can race when several threads open environments at once.
+lmdbOpenLock :: MVar ()
+{-# NOINLINE lmdbOpenLock #-}
+lmdbOpenLock = unsafePerformIO (newMVar ())
+
+-- LMDB does not support opening the same environment twice in one process, so
+-- keep one in-process lock per .tydb path while an environment handle is open.
+interfaceLocks :: MVar (Map.Map FilePath (MVar ()))
+{-# NOINLINE interfaceLocks #-}
+interfaceLocks = unsafePerformIO (newMVar Map.empty)
+
+interfaceExists :: FilePath -> IO Bool
+interfaceExists = doesDirectoryExist
+
+interfaceModifiedTime :: FilePath -> IO UTCTime
+interfaceModifiedTime path = getModificationTime (dataFilePath path)
+
+interfaceModifiedTimeNs :: FilePath -> IO Integer
+interfaceModifiedTimeNs path = do
+    st <- getFileStatus (dataFilePath path)
+    return (floor (toRational (modificationTimeHiRes st) * 1000000000))
+
+copyInterface :: FilePath -> FilePath -> IO ()
+copyInterface src dst = do
+    removePathForcibly dst `E.catch` ignoreMissing
+    createDirectoryIfMissing True dst
+    mapSize <- readMapSize src
+    runInLmdbThread $
+      withEnv src True mapSize $ \env ->
+        LMDB.mdb_env_copy env dst
+    setReadableInterfacePermissions dst
+  where
+    ignoreMissing :: E.IOException -> IO ()
+    ignoreMissing _ = return ()
+
+listInterfaceDirsRecursive :: FilePath -> IO [FilePath]
+listInterfaceDirsRecursive root = do
+    entries <- listDirectory root
+    fmap concat $ forM entries $ \entry -> do
+      let path = root </> entry
+      isDir <- doesDirectoryExist path
+      if not isDir
+        then return []
+        else if takeExtension path == interfaceExt
+               then return [path]
+               else listInterfaceDirsRecursive path
 
 versionMismatch :: [Int] -> IO a
 versionMismatch vs =
-    ioError (userError (".ty version mismatch: file has " ++ show vs ++ ", expected " ++ show A.version))
+    ioError (userError (".tydb version mismatch: file has " ++ show vs ++ ", expected " ++ show A.version))
 
-readTyVersion :: BL.ByteString -> IO BL.ByteString
-readTyVersion bsLazy =
-    case BinaryGet.runGetOrFail (get :: BinaryGet.Get [Int]) bsLazy of
-      Left _ -> ioError (userError "Failed to decode .ty version")
-      Right (rest, _, vs)
-        | vs == A.version -> return rest
-        | otherwise -> versionMismatch vs
+decodeStrict :: Binary a => String -> BS.ByteString -> IO a
+decodeStrict label bs =
+    case decodeOrFail (BL.fromStrict bs) of
+      Left (_, _, err) -> ioError (userError ("Failed to decode .tydb " ++ label ++ ": " ++ err))
+      Right (_, _, v) -> return v
 
-decodeTyPrefix :: BL.ByteString -> IO (Maybe SourceFileMeta, BS.ByteString, BS.ByteString, BS.ByteString, BL.ByteString)
-decodeTyPrefix bsLazy =
-    case BinaryGet.runGetOrFail getPrefix bsLazy of
-      Left _ -> ioError (userError "Failed to decode .ty prefix")
-      Right (rest, _, (sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash)) ->
-        return (sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash, rest)
+encodeStrict :: Binary a => a -> BS.ByteString
+encodeStrict = BL.toStrict . encode
+
+key :: String -> BS.ByteString
+key = B.pack
+
+keyVersion, keyMeta, keyImports, keyRoots, keyTests, keyDoc, keyNameCount, keyStmtCount, keyModuleHeader :: BS.ByteString
+keyVersion      = key "version"
+keyMeta         = key "meta"
+keyImports      = key "imports"
+keyRoots        = key "roots"
+keyTests        = key "tests"
+keyDoc          = key "doc"
+keyNameCount    = key "name-count"
+keyStmtCount    = key "stmt-count"
+keyModuleHeader = key "module-header"
+
+padIndex :: Int -> String
+padIndex i =
+    let s = show i
+    in replicate (12 - length s) '0' ++ s
+
+plainNameKeyLimit :: Int
+plainNameKeyLimit = 400
+
+nameKeySuffix :: A.Name -> BS.ByteString
+nameKeySuffix n =
+    let raw = TE.encodeUtf8 (T.pack (A.rawstr n))
+    in if plainNameKey raw
+         then B.concat [key "p/", raw]
+         else B.concat [key "h/", Base16.encode (SHA256.hash raw)]
   where
-    getPrefix = do
-      sourceMeta <- get :: BinaryGet.Get (Maybe SourceFileMeta)
-      moduleSrcBytesHash <- get :: BinaryGet.Get BS.ByteString
-      modulePubHash <- get :: BinaryGet.Get BS.ByteString
-      moduleImplHash <- get :: BinaryGet.Get BS.ByteString
-      return (sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash)
+    plainNameKey raw =
+        BS.length raw <= plainNameKeyLimit && BS.all safe raw
+    safe w =
+        w > 32 && w < 127 && w /= 47
+
+keyNameInfo :: A.Name -> BS.ByteString
+keyNameInfo n = B.concat [key "name-info/", nameKeySuffix n]
+
+keyNameInfoSuffix :: BS.ByteString -> BS.ByteString
+keyNameInfoSuffix suffix = B.concat [key "name-info/", suffix]
+
+keyNameOrder :: Int -> BS.ByteString
+keyNameOrder i = B.pack ("name-order/" ++ padIndex i)
+
+keyNameHashPrefix :: BS.ByteString
+keyNameHashPrefix = key "name-hash/"
+
+keyNameHash :: A.Name -> BS.ByteString
+keyNameHash n = B.concat [keyNameHashPrefix, nameKeySuffix n]
+
+keyStmt :: Int -> BS.ByteString
+keyStmt i = B.pack ("stmt/" ++ padIndex i)
+
+withVal :: BS.ByteString -> (LMDB.MDB_val -> IO a) -> IO a
+withVal bs f =
+    BS.useAsCStringLen bs $ \(ptr, len) ->
+      f (LMDB.MDB_val (fromIntegral len) (castPtr ptr))
+
+copyVal :: LMDB.MDB_val -> IO BS.ByteString
+copyVal (LMDB.MDB_val len ptr) =
+    BS.packCStringLen (castPtr ptr, fromIntegral len)
+
+withEnv :: FilePath -> Bool -> Int -> (LMDB.MDB_env -> IO a) -> IO a
+withEnv path readOnly mapSize action =
+    withInterfaceLock path $
+      E.bracket open LMDB.mdb_env_close action
+  where
+    open = withMVar lmdbOpenLock $ \_ -> do
+      env <- LMDB.mdb_env_create
+      (do LMDB.mdb_env_set_mapsize env mapSize
+          openEnv env
+          return env)
+        `E.onException` LMDB.mdb_env_close env
+    openEnv env
+      | readOnly  = do
+          flags <- readOnlyOpenFlags path
+          LMDB.mdb_env_open env path flags
+      | otherwise = LMDB.mdb_env_open env path []
+
+withInterfaceLock :: FilePath -> IO a -> IO a
+withInterfaceLock path action = do
+    cpath <- canonicalizePath path
+    lock <- modifyMVar interfaceLocks $ \locks ->
+      case Map.lookup cpath locks of
+        Just lock -> return (locks, lock)
+        Nothing -> do
+          lock <- newMVar ()
+          return (Map.insert cpath lock locks, lock)
+    withMVar lock $ \_ -> action
+
+withReadTxn :: FilePath -> (LMDB.MDB_txn -> LMDB.MDB_dbi -> IO a) -> IO a
+withReadTxn path action = do
+    mapSize <- readMapSize path
+    runInLmdbThread $
+      withEnv path True mapSize $ \env ->
+        E.bracket (LMDB.mdb_txn_begin env Nothing True) LMDB.mdb_txn_abort $ \txn -> do
+          dbi <- LMDB.mdb_dbi_open txn Nothing []
+          action txn dbi
+
+withWriteTxn :: FilePath -> Int -> (LMDB.MDB_txn -> LMDB.MDB_dbi -> IO a) -> IO a
+withWriteTxn path mapSize action =
+    runInLmdbThread $
+      withEnv path False mapSize $ \env -> do
+        txn <- LMDB.mdb_txn_begin env Nothing False
+        r <- (LMDB.mdb_dbi_open txn Nothing [] >>= action txn) `E.onException` LMDB.mdb_txn_abort txn
+        LMDB.mdb_txn_commit txn
+        return r
+
+-- The raw LMDB binding requires transaction setup from a bound thread; this
+-- applies to reads too because of its Haskell-side lock guard.
+runInLmdbThread :: IO a -> IO a
+runInLmdbThread = runInBoundThread
+
+readMapSize :: FilePath -> IO Int
+readMapSize path = do
+    exists <- doesFileExist (dataFilePath path)
+    if exists
+      then max minMapSize . fromIntegral <$> getFileSize (dataFilePath path)
+      else return minMapSize
+
+minMapSize :: Int
+minMapSize = 1024 * 1024
+
+entryMapSize :: [(BS.ByteString, BS.ByteString)] -> IO Int
+entryMapSize entries = do
+    let payload = sum [ BS.length k + BS.length v | (k, v) <- entries ]
+        wanted = max minMapSize (payload * 4 + minMapSize)
+    return (nextPowerOfTwo wanted)
+
+nextPowerOfTwo :: Int -> Int
+nextPowerOfTwo n = go minMapSize
+  where
+    go x | x >= n = x
+         | otherwise = go (x * 2)
+
+getValue :: Binary a => String -> LMDB.MDB_txn -> LMDB.MDB_dbi -> BS.ByteString -> IO a
+getValue label txn dbi k = do
+    mv <- withVal k (LMDB.mdb_get txn dbi)
+    case mv of
+      Nothing -> ioError (userError ("Missing .tydb key: " ++ label))
+      Just v -> copyVal v >>= decodeStrict label
+
+getValuesWithPrefix :: LMDB.MDB_txn -> LMDB.MDB_dbi -> BS.ByteString -> IO [BS.ByteString]
+getValuesWithPrefix txn dbi prefix =
+    E.bracket (LMDB.mdb_cursor_open txn dbi) LMDB.mdb_cursor_close $ \cursor ->
+      withVal prefix $ \start ->
+        withVal BS.empty $ \empty ->
+          LMDB.withKVPtrs start empty $ \kp vp -> do
+            found <- LMDB.mdb_cursor_get LMDB.MDB_SET_RANGE cursor kp vp
+            go cursor kp vp found
+  where
+    go _ _ _ False = return []
+    go cursor kp vp True = do
+      k <- peek kp >>= copyVal
+      if not (prefix `BS.isPrefixOf` k)
+        then return []
+        else do
+          v <- peek vp >>= copyVal
+          found <- LMDB.mdb_cursor_get LMDB.MDB_NEXT cursor kp vp
+          (v :) <$> go cursor kp vp found
+
+putValue :: LMDB.MDB_txn -> LMDB.MDB_dbi -> BS.ByteString -> BS.ByteString -> IO ()
+putValue txn dbi k v =
+    withVal k $ \kv ->
+      withVal v $ \vv -> do
+        _ <- LMDB.mdb_put (LMDB.compileWriteFlags []) txn dbi kv vv
+        return ()
+
+isMapFull :: E.SomeException -> Bool
+isMapFull err =
+    case E.fromException err of
+      Just LMDB.LMDB_Error{ LMDB.e_code = Right LMDB.MDB_MAP_FULL } -> True
+      _ -> False
+
+readOnlyOpenFlags :: FilePath -> IO [LMDB.MDB_EnvFlag]
+readOnlyOpenFlags path = do
+    useLock <- canUseLockFile path
+    noLock <- canReadWithoutLock path
+    -- Installed interface caches may be root-owned/read-only. Only use
+    -- MDB_NOLOCK when this user also cannot update the data file or directory,
+    -- so project-local writable caches still fail instead of bypassing LMDB's
+    -- cross-process locking.
+    return $ if useLock || not noLock
+               then [LMDB.MDB_RDONLY]
+               else [LMDB.MDB_RDONLY, LMDB.MDB_NOLOCK]
+
+canUseLockFile :: FilePath -> IO Bool
+canUseLockFile path = do
+    let lockPath = lockFilePath path
+    exists <- doesFileExist lockPath
+    if exists
+      then fileAccess lockPath False True False
+      else fileAccess path False True True
+
+canReadWithoutLock :: FilePath -> IO Bool
+canReadWithoutLock path = do
+    let dataPath = dataFilePath path
+    exists <- doesFileExist dataPath
+    if not exists
+      then return False
+      else do
+        dataWritable <- fileAccess dataPath False True False
+        dirWritable <- fileAccess path False True True
+        return (not dataWritable && not dirWritable)
+
+isCorruptEnv :: E.SomeException -> Bool
+isCorruptEnv err =
+    case E.fromException err of
+      Just LMDB.LMDB_Error{ LMDB.e_code = Right code } ->
+        code `elem` [ LMDB.MDB_PAGE_NOTFOUND
+                    , LMDB.MDB_CORRUPTED
+                    , LMDB.MDB_PANIC
+                    , LMDB.MDB_VERSION_MISMATCH
+                    , LMDB.MDB_INVALID
+                    ]
+      _ -> False
+
+writeEntries :: FilePath -> [(BS.ByteString, BS.ByteString)] -> IO ()
+writeEntries path entries = do
+    fileExists <- doesFileExist path
+    when fileExists (removeFile path)
+    createDirectoryIfMissing True path
+    entrySize <- entryMapSize entries
+    existingSize <- readMapSize path
+    go False (max entrySize existingSize)
+  where
+    go replaced size = do
+      res <- E.try $ withWriteTxn path size $ \txn dbi -> do
+        LMDB.mdb_clear txn dbi
+        forM_ entries $ \(k, v) -> putValue txn dbi k v
+      case res of
+        Right () -> return ()
+        Left err | isMapFull err -> go replaced (size * 2)
+        Left err | isCorruptEnv err && not replaced -> do
+          removePathForcibly path
+          createDirectoryIfMissing True path
+          go True size
+        Left (err :: E.SomeException) -> E.throwIO err
+
+setReadableInterfacePermissions :: FilePath -> IO ()
+setReadableInterfacePermissions path = do
+    setFileMode path 0o755
+    setFileMode (dataFilePath path) 0o644
+    optional (setFileMode (lockFilePath path) 0o644)
+  where
+    optional :: IO () -> IO ()
+    optional action =
+        action `E.catch` \err ->
+          if isDoesNotExistError err
+            then return ()
+            else E.throwIO (err :: E.IOException)
+
+validateVersion :: LMDB.MDB_txn -> LMDB.MDB_dbi -> IO ()
+validateVersion txn dbi = do
+    vs <- getValue "version" txn dbi keyVersion
+    unless (vs == A.version) (versionMismatch vs)
+
+readMeta :: LMDB.MDB_txn -> LMDB.MDB_dbi -> IO TyMeta
+readMeta txn dbi = do
+    validateVersion txn dbi
+    getValue "meta" txn dbi keyMeta
+
+readNameEntries :: LMDB.MDB_txn -> LMDB.MDB_dbi -> IO ([(A.Name, I.NameInfo)], [NameHashInfo])
+readNameEntries txn dbi = do
+    te <- readNameInfoEntries txn dbi
+    nameHashes <- readNameHashEntries txn dbi
+    return (te, nameHashes)
+
+readNameInfoEntries :: LMDB.MDB_txn -> LMDB.MDB_dbi -> IO [(A.Name, I.NameInfo)]
+readNameInfoEntries txn dbi = do
+    nameCount <- getValue "name-count" txn dbi keyNameCount
+    forM [0 .. nameCount - 1] $ \i -> do
+      suffix <- getValue ("name-order " ++ show i) txn dbi (keyNameOrder i)
+      getValue ("name-info " ++ show i) txn dbi (keyNameInfoSuffix suffix)
+
+readNameHashEntries :: LMDB.MDB_txn -> LMDB.MDB_dbi -> IO [NameHashInfo]
+readNameHashEntries txn dbi = do
+    vals <- getValuesWithPrefix txn dbi keyNameHashPrefix
+    infos <- forM (zip [0..] vals) $ \(i, v) ->
+      decodeStrict ("name-hash " ++ show (i :: Int)) v
+    return (Data.List.sortOn (A.nstr . nhName) infos)
+
+readStmtEntries :: LMDB.MDB_txn -> LMDB.MDB_dbi -> IO [A.Stmt]
+readStmtEntries txn dbi = do
+    count <- getValue "stmt-count" txn dbi keyStmtCount
+    forM [0 .. count - 1] $ \i ->
+      getValue ("stmt " ++ show i) txn dbi (keyStmt i)
+
+interfaceEntries :: [Int] -> BS.ByteString -> BS.ByteString -> BS.ByteString -> Maybe SourceFileMeta -> [(A.ModName, BS.ByteString)] -> [NameHashInfo] -> [A.Name] -> [String] -> Maybe String -> I.NameInfo -> A.Module -> [(BS.ByteString, BS.ByteString)]
+interfaceEntries version moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta imps nameHashes roots tests mdoc nmod tchecked =
+    [ (keyVersion, encodeStrict version)
+    , (keyMeta, encodeStrict (sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash))
+    , (keyImports, encodeStrict imps)
+    , (keyRoots, encodeStrict roots)
+    , (keyTests, encodeStrict tests)
+    , (keyDoc, encodeStrict mdoc)
+    , (keyNameCount, encodeStrict (length te))
+    , (keyStmtCount, encodeStrict (length body))
+    , (keyModuleHeader, encodeStrict (tmn, timps, tdoc))
+    ]
+    ++ concat [ [ (keyNameOrder i, encodeStrict suffix)
+                , (keyNameInfoSuffix suffix, encodeStrict (n, info))
+                ]
+              | (i, (n, info)) <- zip [0..] te
+              , let suffix = nameKeySuffix n
+              ]
+    ++ [ (keyNameHash (nhName nh), encodeStrict nh) | nh <- nameHashes ]
+    ++ [ (keyStmt i, encodeStrict stmt) | (i, stmt) <- zip [0..] body ]
+  where
+    I.NModule _ te _ = nmod
+    A.Module tmn timps tdoc body = tchecked
 
 writeFile :: FilePath -> BS.ByteString -> BS.ByteString -> BS.ByteString -> Maybe SourceFileMeta -> [(A.ModName, BS.ByteString)] -> [NameHashInfo] -> [A.Name] -> [String] -> Maybe String -> I.NameInfo -> A.Module -> IO ()
-writeFile f moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta imps nameHashes roots tests mdoc nmod tchecked = do
-    pid <- getProcessID
-    let tmpFile = f ++ "." ++ show pid
-    BL.writeFile tmpFile (encode ((A.version, sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash), imps, nameHashes, roots, tests, mdoc, nmod, tchecked))
-    renameFile tmpFile f
+writeFile = writeFileWithVersion A.version
+
+writeFileWithVersion :: [Int] -> FilePath -> BS.ByteString -> BS.ByteString -> BS.ByteString -> Maybe SourceFileMeta -> [(A.ModName, BS.ByteString)] -> [NameHashInfo] -> [A.Name] -> [String] -> Maybe String -> I.NameInfo -> A.Module -> IO ()
+writeFileWithVersion version f moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta imps nameHashes roots tests mdoc nmod tchecked =
+    writeEntries f (interfaceEntries version moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta imps nameHashes roots tests mdoc nmod tchecked)
 
 readFile :: FilePath -> IO TyFile
-readFile f = do
-    bsLazy <- readTyBytes f
-    body0 <- readTyVersion bsLazy
-    (sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash, body1) <- decodeTyPrefix body0
-    let getBody = do
-          imps <- get :: BinaryGet.Get [(A.ModName, BS.ByteString)]
-          nameHashes <- get :: BinaryGet.Get [NameHashInfo]
-          roots <- get :: BinaryGet.Get [A.Name]
-          tests <- get :: BinaryGet.Get [String]
-          mdoc <- get :: BinaryGet.Get (Maybe String)
-          nmod <- get :: BinaryGet.Get I.NameInfo
-          tmod <- get :: BinaryGet.Get A.Module
-          return (imps, nameHashes, roots, tests, mdoc, nmod, tmod)
-    case BinaryGet.runGetOrFail getBody body1 of
-      Left _ -> ioError (userError "Failed to decode .ty file")
-      Right (_, _, (imps, nameHashes, roots, tests, mdoc, nmod, tmod)) ->
-        return (map fst imps, nmod, tmod, sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash, imps, nameHashes, roots, tests, mdoc)
+readFile f =
+    withReadTxn f $ \txn dbi -> do
+      (sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash) <- readMeta txn dbi
+      imps <- getValue "imports" txn dbi keyImports
+      roots <- getValue "roots" txn dbi keyRoots
+      tests <- getValue "tests" txn dbi keyTests
+      mdoc <- getValue "doc" txn dbi keyDoc
+      (te, nameHashes) <- readNameEntries txn dbi
+      (tmn, timps, tdoc) <- getValue "module-header" txn dbi keyModuleHeader
+      stmts <- readStmtEntries txn dbi
+      let nmod = I.NModule (map fst imps) te mdoc
+          tmod = A.Module tmn timps tdoc stmts
+      return (map fst imps, nmod, tmod, sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash, imps, nameHashes, roots, tests, mdoc)
 
--- Read only the cached header fields from .ty: source metadata, module hashes,
--- imports, name hashes, roots, tests, and docstring.
--- This avoids decoding the large NameInfo and typed Module sections and is
--- much faster than readFile for freshness checks and dependency discovery.
+-- Read only cached header fields from .tydb. This avoids decoding the large
+-- NameInfo and typed Module statement sections and is much faster than readFile
+-- for freshness checks and dependency discovery.
 readHeader :: FilePath -> IO TyHeader
-readHeader f = do
-    bsLazy <- readTyBytes f
-    body0 <- readTyVersion bsLazy
-    (sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash, body1) <- decodeTyPrefix body0
-    let getHdr = do
-          imps  <- get :: BinaryGet.Get [(A.ModName, BS.ByteString)]
-          nameHashes <- get :: BinaryGet.Get [NameHashInfo]
-          roots <- get :: BinaryGet.Get [A.Name]
-          tests <- get :: BinaryGet.Get [String]
-          doc   <- get :: BinaryGet.Get (Maybe String)
-          return (imps, nameHashes, roots, tests, doc)
-    case BinaryGet.runGetOrFail getHdr body1 of
-      Left _ -> ioError (userError "Failed to decode .ty header")
-      Right (_, _, (imps, nameHashes, roots, tests, doc)) ->
-        return (sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash, imps, nameHashes, roots, tests, doc)
+readHeader f =
+    withReadTxn f $ \txn dbi -> do
+      (sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash) <- readMeta txn dbi
+      imps <- getValue "imports" txn dbi keyImports
+      roots <- getValue "roots" txn dbi keyRoots
+      tests <- getValue "tests" txn dbi keyTests
+      doc <- getValue "doc" txn dbi keyDoc
+      nameHashes <- readNameHashEntries txn dbi
+      return (sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash, imps, nameHashes, roots, tests, doc)
 
 -- Interface files are caches for most callers. If a file is missing,
 -- unreadable, corrupt, or from a different compiler interface version, the
@@ -201,5 +603,14 @@ readHeaderMaybe = readTyMaybe readHeader
 readTyMaybe :: (FilePath -> IO a) -> FilePath -> IO (Maybe a)
 readTyMaybe readTy f = (Just <$> readTy f) `E.catch` tyCacheMiss
 
-tyCacheMiss :: E.IOException -> IO (Maybe a)
-tyCacheMiss _ = return Nothing
+tyCacheMiss :: E.SomeException -> IO (Maybe a)
+tyCacheMiss err
+  | Just (_ :: E.SomeAsyncException) <- E.fromException err = E.throwIO err
+  | isTyCacheMiss err = return Nothing
+  | otherwise = E.throwIO err
+
+isTyCacheMiss :: E.SomeException -> Bool
+isTyCacheMiss err
+  | Just (_ :: E.IOException) <- E.fromException err = True
+  | Just (_ :: LMDB.LMDB_Error) <- E.fromException err = True
+  | otherwise = False

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -2,8 +2,8 @@
 
 module Main (main) where
 
+import Control.Concurrent.Async (mapConcurrently_)
 import Data.Char (toLower, isAlphaNum)
-
 
 import qualified Acton.Parser as P
 import qualified Acton.Syntax as S
@@ -44,14 +44,14 @@ import Error.Diagnose.Report (Report(..))
 import Prettyprinter (unAnnotate, layoutPretty, defaultLayoutOptions)
 import Prettyprinter.Render.Text (renderStrict)
 import System.FilePath ((</>), joinPath, takeFileName, takeBaseName, takeDirectory, splitDirectories, takeExtension)
-import System.Directory (createDirectoryIfMissing, getCurrentDirectory, setCurrentDirectory, listDirectory, doesDirectoryExist)
+import System.Directory (createDirectoryIfMissing, getCurrentDirectory, setCurrentDirectory, listDirectory, doesDirectoryExist, doesFileExist)
+import System.Posix.Files (setFileMode)
 import System.IO.Temp (withSystemTempDirectory)
 import Control.Monad (forM_, when, foldM)
 import qualified Control.Exception as E
 import Control.DeepSeq (rnf)
 import Utils (SrcLoc(..), loc, prstr)
 import qualified Acton.BuildSpec as BuildSpec
-import qualified Data.Binary as Binary
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.Aeson as Ae
@@ -66,11 +66,150 @@ main = do
   env0 <- Acton.Env.initEnv sysTypesPath False
 
   sydTest $ do
+    describe "InterfaceFiles" $ do
+      it "round-trips payloads and preserves ordered name entries" $ do
+        withSystemTempDirectory "acton-iface" $ \dir -> do
+          let mn = S.modName ["iface"]
+              tyPath = dir </> "iface.tydb"
+              firstName = S.name "first"
+              secondName = S.name "second"
+              firstishName = S.name "firstish"
+              sourcePlainName = S.name "foo_bar"
+              derivedName = S.Derived (S.name "encode") (S.name "witness")
+              longName = S.name (replicate 401 'x')
+              iface =
+                [ (firstName, I.NVar S.tWild)
+                , (secondName, I.NDef (S.tSchema [] S.tWild) S.NoDec Nothing)
+                , (sourcePlainName, I.NVar S.tWild)
+                , (derivedName, I.NVar S.tWild)
+                , (longName, I.NVar S.tWild)
+                ]
+              nameHashes =
+                [ InterfaceFiles.NameHashInfo derivedName "src4" "pub4" "impl4" [] []
+                , InterfaceFiles.NameHashInfo firstName "src1" "pub1" "impl1" [] []
+                , InterfaceFiles.NameHashInfo sourcePlainName "src3" "pub3" "impl3" [] []
+                , InterfaceFiles.NameHashInfo secondName "src2" "pub2" "impl2" [] []
+                , InterfaceFiles.NameHashInfo longName "src5" "pub5" "impl5" [] []
+                ]
+              roots = [secondName, firstName]
+              tests = ["test_second", "test_first"]
+              nmod = I.NModule [] iface (Just "module docs")
+              tmod = S.Module mn [] (Just "typed docs") []
+          InterfaceFiles.writeFile tyPath "src" "pub" "impl" Nothing [] nameHashes roots tests (Just "module docs") nmod tmod
+          InterfaceFiles.keyNameInfo firstName `shouldBe` "name-info/p/first"
+          InterfaceFiles.keyNameInfo firstName `shouldNotBe` InterfaceFiles.keyNameInfo firstishName
+          InterfaceFiles.keyNameHash secondName `shouldBe` "name-hash/p/second"
+          InterfaceFiles.keyNameInfo sourcePlainName `shouldBe` "name-info/p/foo_bar"
+          InterfaceFiles.keyNameInfo derivedName `shouldBe` "name-info/p/encodeD_witness"
+          InterfaceFiles.keyNameInfo longName `shouldSatisfy` B8.isPrefixOf "name-info/h/"
+          (_mods, I.NModule _ te mdoc, tmod', sourceMeta, srcHash, pubHash, implHash, imps, nameHashes', roots', tests', doc') <-
+            InterfaceFiles.readFile tyPath
+          te `shouldBe` iface
+          mdoc `shouldBe` Just "module docs"
+          tmod' `shouldBe` tmod
+          sourceMeta `shouldBe` Nothing
+          (srcHash, pubHash, implHash) `shouldBe` ("src", "pub", "impl")
+          imps `shouldBe` []
+          nameHashes' `shouldBe` nameHashes
+          roots' `shouldBe` roots
+          tests' `shouldBe` tests
+          doc' `shouldBe` Just "module docs"
+
+          (sourceMetaH, srcHashH, pubHashH, implHashH, impsH, nameHashesH, rootsH, testsH, docH) <-
+            InterfaceFiles.readHeader tyPath
+          sourceMetaH `shouldBe` Nothing
+          (srcHashH, pubHashH, implHashH) `shouldBe` ("src", "pub", "impl")
+          impsH `shouldBe` []
+          nameHashesH `shouldBe` nameHashes
+          rootsH `shouldBe` roots
+          testsH `shouldBe` tests
+          docH `shouldBe` Just "module docs"
+
+      it "supports concurrent read-only access to one interface" $ do
+        withSystemTempDirectory "acton-iface-concurrent" $ \dir -> do
+          let mn = S.modName ["iface"]
+              tyPath = dir </> "iface.tydb"
+              firstName = S.name "first"
+              iface = [(firstName, I.NVar S.tWild)]
+              nameHashes = [InterfaceFiles.NameHashInfo firstName "src1" "pub1" "impl1" [] []]
+              nmod = I.NModule [] iface Nothing
+              tmod = S.Module mn [] Nothing []
+          InterfaceFiles.writeFile tyPath "src" "pub" "impl" Nothing [] nameHashes [] [] Nothing nmod tmod
+          mapConcurrently_
+            (\_ -> do
+                (_sourceMetaH, srcHashH, pubHashH, implHashH, _impsH, nameHashesH, _rootsH, _testsH, _docH) <-
+                  InterfaceFiles.readHeader tyPath
+                (srcHashH, pubHashH, implHashH) `shouldBe` ("src", "pub", "impl")
+                nameHashesH `shouldBe` nameHashes)
+            [1..64 :: Int]
+
+      it "copies interface data without carrying LMDB lock state" $ do
+        withSystemTempDirectory "acton-iface-copy" $ \dir -> do
+          let mn = S.modName ["iface"]
+              srcPath = dir </> "iface.tydb"
+              dstPath = dir </> "iface-copy.tydb"
+              firstName = S.name "first"
+              iface = [(firstName, I.NVar S.tWild)]
+              nameHashes = [InterfaceFiles.NameHashInfo firstName "src1" "pub1" "impl1" [] []]
+              nmod = I.NModule [] iface Nothing
+              tmod = S.Module mn [] Nothing []
+          InterfaceFiles.writeFile srcPath "src" "pub" "impl" Nothing [] nameHashes [] [] Nothing nmod tmod
+          InterfaceFiles.copyInterface srcPath dstPath
+          doesFileExist (dstPath </> "data.mdb") `shouldReturn` True
+          doesFileExist (dstPath </> "lock.mdb") `shouldReturn` False
+          (_sourceMetaH, srcHashH, pubHashH, implHashH, _impsH, nameHashesH, _rootsH, _testsH, _docH) <-
+            InterfaceFiles.readHeader dstPath
+          (srcHashH, pubHashH, implHashH) `shouldBe` ("src", "pub", "impl")
+          nameHashesH `shouldBe` nameHashes
+
+      it "reads interfaces from read-only installed directories" $ do
+        withSystemTempDirectory "acton-iface-readonly" $ \dir -> do
+          let mn = S.modName ["iface"]
+              tyPath = dir </> "iface.tydb"
+              dataPath = tyPath </> "data.mdb"
+              lockPath = tyPath </> "lock.mdb"
+              firstName = S.name "first"
+              iface = [(firstName, I.NVar S.tWild)]
+              nameHashes = [InterfaceFiles.NameHashInfo firstName "src1" "pub1" "impl1" [] []]
+              nmod = I.NModule [] iface Nothing
+              tmod = S.Module mn [] Nothing []
+          InterfaceFiles.writeFile tyPath "src" "pub" "impl" Nothing [] nameHashes [] [] Nothing nmod tmod
+          let restore = do
+                setFileMode tyPath 0o755
+                setFileMode dataPath 0o644
+                setFileMode lockPath 0o644
+          (do setFileMode tyPath 0o555
+              setFileMode dataPath 0o444
+              setFileMode lockPath 0o444
+              (_sourceMetaH, srcHashH, pubHashH, implHashH, _impsH, nameHashesH, _rootsH, _testsH, _docH) <-
+                InterfaceFiles.readHeader tyPath
+              (srcHashH, pubHashH, implHashH) `shouldBe` ("src", "pub", "impl")
+              nameHashesH `shouldBe` nameHashes)
+            `E.finally` restore
+
+      it "treats corrupt .tydb directories as cache misses" $ do
+        withSystemTempDirectory "acton-iface-corrupt" $ \dir -> do
+          let tyPath = dir </> "corrupt.tydb"
+          createDirectoryIfMissing True tyPath
+          B8.writeFile (tyPath </> "data.mdb") "garbage"
+          InterfaceFiles.readHeaderMaybe tyPath `shouldReturn` Nothing
+          InterfaceFiles.readFileMaybe tyPath `shouldReturn` Nothing
+
+      it "treats version mismatches as cache misses" $ do
+        withSystemTempDirectory "acton-iface-version" $ \dir -> do
+          let mn = S.modName ["iface_version"]
+              tyPath = dir </> "iface_version.tydb"
+              nmod = I.NModule [] [] Nothing
+              tmod = S.Module mn [] Nothing []
+          InterfaceFiles.writeFileWithVersion (map (+ 1) S.version) tyPath "" "" "" Nothing [] [] [] [] Nothing nmod tmod
+          InterfaceFiles.readHeaderMaybe tyPath `shouldReturn` Nothing
+          InterfaceFiles.readFileMaybe tyPath `shouldReturn` Nothing
+
     describe "Environment" $ do
-      it "treats mismatched .ty headers for loaded modules as stale" $ do
+      it "treats mismatched .tydb headers for loaded modules as stale" $ do
         withSystemTempDirectory "acton-env" $ \dir -> do
           let directMod = S.modName ["direct"]
-              directTy = dir </> "direct.ty"
+              directTy = dir </> "direct.tydb"
               valueName = S.name "value"
               iface = [(valueName, I.NVar S.tWild)]
               directIface = I.NModule [] iface Nothing
@@ -91,11 +230,20 @@ main = do
             directModule
           (_mods, nmod, tmod, sourceMeta, srcHash, pubHash, implHash, imps, nameHashes, roots, tests, mdoc) <-
             InterfaceFiles.readFile directTy
-          BL.writeFile directTy $
-            Binary.encode
-              ( (map (+ 1) S.version, sourceMeta, srcHash, pubHash, implHash)
-              , imps, nameHashes, roots, tests, mdoc, nmod, tmod
-              )
+          InterfaceFiles.writeFileWithVersion
+            (map (+ 1) S.version)
+            directTy
+            srcHash
+            pubHash
+            implHash
+            sourceMeta
+            imps
+            nameHashes
+            roots
+            tests
+            mdoc
+            nmod
+            tmod
           (_env2, te) <- Acton.Env.doImp [dir] env1 directMod
           map fst te `shouldBe` [valueName]
 
@@ -449,8 +597,8 @@ main = do
           withSystemTempDirectory "acton-completion" $ \dir -> do
             let directMod = S.modName ["direct"]
                 staleMod = S.modName ["stale"]
-                directTy = dir </> "direct.ty"
-                staleTy = dir </> "stale.ty"
+                directTy = dir </> "direct.tydb"
+                staleTy = dir </> "stale.tydb"
                 inputName = S.name "LocalInput"
                 routerName = S.name "Router"
                 inputType = S.tCon (S.TC (S.NoQ inputName) [])
@@ -475,7 +623,8 @@ main = do
                   , "        i.<CURSOR>"
                   ]
             createDirectoryIfMissing True dir
-            B8.writeFile staleTy "not a current ty file"
+            createDirectoryIfMissing True staleTy
+            B8.writeFile (staleTy </> "data.mdb") "not a current ty db"
             InterfaceFiles.writeFile
               directTy
               B8.empty

--- a/compiler/stack.yaml
+++ b/compiler/stack.yaml
@@ -51,6 +51,11 @@ extra-deps:
 # Extra package databases containing global packages
 # extra-package-dbs: []
 
+extra-include-dirs:
+  - ../bdeps/out/include
+extra-lib-dirs:
+  - ../bdeps/out/lib
+
 # Control whether we use the GHC we find on the path
 # NOTE: this is disabled so we can use a stack GHC in local dev environments but
 # we rewrite this in our Homebrew recipe to use the system GHC. Do NOT remove

--- a/compiler/tools/ld-wrapper.sh
+++ b/compiler/tools/ld-wrapper.sh
@@ -73,19 +73,9 @@ esac
 args=()
 args+=("-Wl,-Bstatic")
 
-gcc_lib_path() {
-  local lib="$1"
-  local lib_path
-  lib_path="$(gcc -print-file-name="$lib" 2>/dev/null || true)"
-  if [[ -n "$lib_path" && "$lib_path" != "$lib" ]]; then
-    echo "$lib_path"
-    return 0
-  fi
-  return 1
-}
-
-# Prefer static archives we build ourselves under bdeps/out over the host's
-# apt-installed .a files, so the link targets our chosen libc version.
+# Static archives we build ourselves under bdeps/out (libz, libgmp, libtinfo,
+# liblmdb, ...). Linked by full path so the binary targets our chosen libc
+# version rather than the host's apt-installed .a files.
 bdeps_lib_path() {
   local archive="$1"
   if [[ -n "${ACTON_BDEPS_DIR:-}" && -f "${ACTON_BDEPS_DIR}/lib/${archive}" ]]; then
@@ -93,19 +83,6 @@ bdeps_lib_path() {
     return 0
   fi
   return 1
-}
-
-add_static_lib() {
-  local archive="$1"
-  local fallback="$2"
-  local archive_path
-  if archive_path="$(bdeps_lib_path "$archive")"; then
-    args+=("$archive_path")
-  elif archive_path="$(gcc_lib_path "$archive")"; then
-    args+=("$archive_path")
-  else
-    args+=("-l:$fallback")
-  fi
 }
 
 normalize_lib() {
@@ -128,42 +105,28 @@ handle_lib() {
   local lib="$1"
   local lib_key
   lib_key="$(normalize_lib "$lib")"
-  if [[ "$lib_key" == "z" ]]; then
-    if [[ "$state" != "static" ]]; then
-      args+=("-Wl,-Bstatic")
-      state="static"
-    fi
-    add_static_lib libz.a libz.a
-    return
-  fi
-  if [[ "$lib_key" == "gmp" ]]; then
-    if [[ "$state" != "static" ]]; then
-      args+=("-Wl,-Bstatic")
-      state="static"
-    fi
-    add_static_lib libgmp.a libgmp.a
-    return
-  fi
+  # The C++ runtime and gcc's unwinder are replaced with zig's bundled libc++ and
+  # libunwind (not taken from bdeps/out or the host) so they target our chosen
+  # libc version. libc++ needs libunwind for the _Unwind_* symbols; -lunwind is
+  # listed explicitly so it is available regardless of archive ordering.
   if [[ "$lib_key" == "stdc++" ]]; then
     if [[ "$state" != "static" ]]; then
       args+=("-Wl,-Bstatic")
       state="static"
     fi
-    # Use zig's bundled static libc++ instead of the host's libstdc++.a so the
-    # C++ runtime targets our chosen libc version. libc++ pulls in zig's
-    # libunwind for the _Unwind_* symbols; -lunwind is listed explicitly so it
-    # is available regardless of archive ordering.
     args+=("-lc++" "-lunwind")
     return
   fi
-  if [[ "$lib_key" == "tinfo" ]]; then
+  if [[ "$lib_key" == "gcc_s" || "$lib_key" == "gcc_eh" ]]; then
     if [[ "$state" != "static" ]]; then
       args+=("-Wl,-Bstatic")
       state="static"
     fi
-    add_static_lib libtinfo.a libtinfo.a
+    args+=("-lunwind")
     return
   fi
+  # glibc libraries stay dynamic -- we target a chosen glibc version, not a fully
+  # static libc.
   if [[ "$allow_dynamic_glibc" == true ]]; then
     case "$lib_key" in
       c|m|dl|pthread|rt|util)
@@ -176,12 +139,16 @@ handle_lib() {
         ;;
     esac
   fi
-  if [[ "$lib_key" == "gcc_s" || "$lib_key" == "gcc_eh" ]]; then
+  # Everything we build under bdeps/out (libz, libgmp, libtinfo, liblmdb, ...) is
+  # linked statically by its full path. A new compiler lib needs no case here --
+  # just its .a present in bdeps/out/lib -- mirroring the macOS block above.
+  local bdeps_archive
+  if bdeps_archive="$(bdeps_lib_path "lib${lib_key}.a")"; then
     if [[ "$state" != "static" ]]; then
       args+=("-Wl,-Bstatic")
       state="static"
     fi
-    args+=("-lunwind")
+    args+=("$bdeps_archive")
     return
   fi
   if [[ "$state" != "static" ]]; then

--- a/docs/acton-dev-guide/src/SUMMARY.md
+++ b/docs/acton-dev-guide/src/SUMMARY.md
@@ -8,6 +8,7 @@
   - [Debugging](getting_started/debugging.md)
 - [Compiler](compiler/index.md)
   - [Incremental compilation](compiler/incremental_compilation.md)
+  - [Interface caches](compiler/interface_caches.md)
   - [Imports and environments](compiler/imports_and_envs.md)
   - [Project dependencies](compiler/project_dependencies.md)
   - [Test result cache](compiler/test_cache.md)

--- a/docs/acton-dev-guide/src/compiler/imports_and_envs.md
+++ b/docs/acton-dev-guide/src/compiler/imports_and_envs.md
@@ -9,7 +9,7 @@ distinction is that there are two related but different mechanisms:
   available to kinds/type checking
 
 If those two are conflated, it becomes hard to reason about missing imports,
-stale `.ty` reuse, or why a module can be present in the scheduler but still
+stale `.tydb` reuse, or why a module can be present in the scheduler but still
 need more imports loaded into the active environment.
 
 ## Environment layers
@@ -20,7 +20,7 @@ compiler.
 ### Base environment
 
 `Acton.Env.initEnv` constructs the base `Env0`. It always contains `prim`, and
-in normal compilation it also loads `__builtin__` from `__builtin__.ty`.
+in normal compilation it also loads `__builtin__` from `__builtin__.tydb`.
 
 This base environment is not tied to any one module. It is the starting point
 for later compilation work.
@@ -64,7 +64,7 @@ module into the active environment.
 
 Instead it does header-first discovery:
 
-- `readModuleTask` reads the `.ty` header when possible and produces a cheap
+- `readModuleTask` reads the `.tydb` header when possible and produces a cheap
   `TyTask`
 - otherwise it parses the source and produces an `ActonTask`
 - `buildGlobalTasks` uses the task's direct imports to build provider edges
@@ -77,9 +77,9 @@ This matters for standard library modules and any other imports that are not
 represented as in-graph provider tasks. Such modules still have to be made
 available later through `Acton.Env`.
 
-## When `.ty` headers are read
+## When `.tydb` headers are read
 
-The compiler reads `.ty` data in two different modes.
+The compiler reads `.tydb` data in two different modes.
 
 ### Header-only reads
 
@@ -94,7 +94,7 @@ Header reads are used for cheap decisions:
 This is the path used by `readModuleTask` and the various cache lookups in
 `Acton.Compile`.
 
-### Full `.ty` reads
+### Full `.tydb` reads
 
 Full reads are used when the compiler needs actual interface contents or the
 typed module:
@@ -103,7 +103,7 @@ typed module:
 - implementation-hash refresh
 - codegen refresh
 
-Reading a full `.ty` does not by itself reconstruct the import closure in the
+Reading a full `.tydb` does not by itself reconstruct the import closure in the
 active environment. It only gives the caller the stored interface and typed
 module payload.
 
@@ -116,7 +116,7 @@ When a module imports another module:
 
 1. `mkEnv` walks the AST import list
 2. `impModule` delegates to `doImp`
-3. `doImp` finds the imported module's `.ty`
+3. `doImp` finds the imported module's `.tydb`
 4. `doImp` follows the imported module's recorded imports
 5. only then does it return the imported module interface
 
@@ -126,7 +126,7 @@ closure suitable for kinds and type checking.
 An important invariant is that a cached direct module must still restore its own
 recorded imports. The shared scheduler env stores interfaces in `modules`, but
 that cache does not itself contain the imported module's import list. For that
-reason, `doImp` must still consult the cached module's `.ty` header and recurse
+reason, `doImp` must still consult the cached module's `.tydb` header and recurse
 through its recorded imports even when the direct module is already present in
 `modules`.
 
@@ -142,12 +142,12 @@ Without that step, the compiler can end up in a state where:
 When debugging import failures, it helps to ask which layer is failing:
 
 - Is the module missing from graph discovery? Then look at `readModuleTask`,
-  `.ty` headers, and `buildGlobalTasks`.
+  `.tydb` headers, and `buildGlobalTasks`.
 - Is the module outside the project graph but still needed for type checking?
   Then look at `mkEnv` and `doImp`.
 - Is a cached module present but its transitives missing? Then the issue is in
   environment materialization, not scheduler ordering.
-- Is a full `.ty` being read but imports still not appearing? Then check
+- Is a full `.tydb` being read but imports still not appearing? Then check
   whether the caller is only decoding interface payload rather than invoking the
   import loader.
 
@@ -155,4 +155,5 @@ When debugging import failures, it helps to ask which layer is failing:
 
 - [Compiler overview](index.md)
 - [Incremental compilation](incremental_compilation.md)
+- [Interface caches](interface_caches.md)
 - [Type check](passes/type_check.md)

--- a/docs/acton-dev-guide/src/compiler/incremental_compilation.md
+++ b/docs/acton-dev-guide/src/compiler/incremental_compilation.md
@@ -16,14 +16,14 @@ old generation, so we can react to new changes without waiting for obsolete
 work to finish.
 
 Interface files and content hashes tell the scheduler what work it can safely
-reuse. `.ty` interface headers store hashes and snapshots of dependencies and
+reuse. `.tydb` interface headers store hashes and snapshots of dependencies and
 their hashes. It is cheap both to compute hashes and to read and compare them.
 If the hashes show no relevant change, the compiler can skip parsing, type
 checking, or back passes for large parts of the graph.
 
 At the module level we store **moduleSrcBytesHash**, **modulePubHash**, and
 **moduleImplHash**. The source-bytes hash (**moduleSrcBytesHash**) is the
-SHA-256 of the raw source bytes and is used to decide whether a cached `.ty`
+SHA-256 of the raw source bytes and is used to decide whether a cached `.tydb`
 header is still valid; if it changes, we must re-parse the `.act` file and rerun
 front passes for that module. Reading the file is done at GB/s on modern NVMe
 hardware and hashing is typically running at roughly the same speed on modern
@@ -32,7 +32,7 @@ CPUs.
 The public hash (**modulePubHash**) is derived from the module's public-name
 `pubHash` values (which already include any external signature dependencies).
 The implementation hash (**moduleImplHash**) is derived from per-name
-`implHash` values; it is stored in the `.ty` header and written into generated
+`implHash` values; it is stored in the `.tydb` header and written into generated
 `.c`/`.h` files as an "Acton impl hash" tag. If the tag is missing or
 mismatched, we rerun back passes even if no other hashes changed.
 
@@ -65,10 +65,10 @@ generated names (for example, protocol lowering emits classes such as
 their `NameInfo` with `QuickType.envOf`. Conversely, `envOf` omits `Protocol`
 and `Extension` entries because type inference translates them away. To cover
 both, hashing uses the union of `teAll` and `QuickType.envOf` as its name-info
-map, ensuring generated names appear in `.ty` and still keeping protocol and
+map, ensuring generated names appear in `.tydb` and still keeping protocol and
 extension hashes intact.
 
-To detect changes without recompiling, each per-name entry in `.ty` stores
+To detect changes without recompiling, each per-name entry in `.tydb` stores
 dependency snapshots. **pubDeps** is a list of `(QName, pubHash)` for external
 declarations referenced from the unit's type signature and from value-level
 uses, which is what triggers re-typechecking when a provider's public interface
@@ -82,19 +82,17 @@ We compute `selfPubHash`/`selfImplHash` for each unit, compute a `groupHash`
 from the sorted self-hashes plus all external dependency hashes of the group,
 and then finalize each unit as `H(selfHash || groupHash || unitKey)`.
 
-The `.ty` header stays ordered for fast reads:
+The `.tydb` header stays ordered for deterministic reads. See
+[Interface caches](interface_caches.md) for the LMDB key layout.
 
 ```
 version
-moduleSrcBytesHash
-modulePubHash
-moduleImplHash
+meta              -- source metadata + module src/pub/impl hashes
 imports
 nameHashInfo      -- per-name src/pub/impl hash + dep snapshots
 roots
+tests
 docstring
-nameInfo
-typedModule
 ```
 
 A source change always re-runs front passes for that module. Downstream modules

--- a/docs/acton-dev-guide/src/compiler/index.md
+++ b/docs/acton-dev-guide/src/compiler/index.md
@@ -10,7 +10,10 @@ The same AST data type is used throughout all compiler passes, making it easy to
 read and understand what each transformation does.
 
 See [Imports and environments](imports_and_envs.md) for how the scheduler,
-`.ty` headers, and the active type-checker environment fit together.
+`.tydb` headers, and the active type-checker environment fit together.
+
+See [Interface caches](interface_caches.md) for the LMDB-backed on-disk cache
+format used to store typed module interfaces.
 
 See [Project dependencies](project_dependencies.md) for how Acton package
 dependencies and zig dependencies are discovered, fetched, and emitted into the

--- a/docs/acton-dev-guide/src/compiler/interface_caches.md
+++ b/docs/acton-dev-guide/src/compiler/interface_caches.md
@@ -1,0 +1,133 @@
+# Interface Caches
+
+Acton writes one compiled interface cache per module under `out/types`. The
+cache path follows the module path and ends in `.tydb`, for example
+`out/types/pkg/mod.tydb/`. A `.tydb` artifact is an LMDB environment directory
+in normal LMDB directory mode, with `data.mdb` as the durable payload and
+`lock.mdb` as LMDB runtime lock state.
+
+The compiler code should not construct these paths directly. Use the
+`InterfaceFiles` helpers, especially `interfacePath`, for cache paths.
+
+## Compatibility Boundary
+
+`InterfaceFiles` deliberately preserves the old interface-cache API:
+
+- `writeFile` writes the cache for one module.
+- `readHeader` reads only metadata, imports, roots, tests, docstring, and
+  per-name hash records.
+- `readFile` reconstructs the full cached payload: imports, `NameInfo`, typed
+  module, metadata, module hashes, per-name hashes, roots, tests, and docstring.
+- `readHeaderMaybe` and `readFileMaybe` turn missing, corrupt, unreadable, or
+  version-mismatched caches into cache misses.
+
+That boundary lets the rest of the compiler keep treating cache access as a
+plain lookup while the on-disk representation moves from one binary blob to a
+keyed store. Current full reads still rebuild the same payload as before.
+More selective lookup by imported name is future work.
+
+## LMDB Key Layout
+
+All values are Binary-encoded Haskell values. The values are not compressed;
+the layout splits the payload so readers can avoid decoding unrelated sections.
+
+Metadata and module-level keys:
+
+| Key | Value type |
+| --- | --- |
+| `version` | `[Int]` |
+| `meta` | `(Maybe SourceFileMeta, ByteString, ByteString, ByteString)` |
+| `imports` | `[(ModName, ByteString)]` |
+| `roots` | `[Name]` |
+| `tests` | `[String]` |
+| `doc` | `Maybe String` |
+| `module-header` | `(ModName, [Import], Maybe String)` |
+| `name-count` | `Int` |
+| `stmt-count` | `Int` |
+
+The three `ByteString` hashes in `meta` are the module source-bytes hash, module
+public hash, and module implementation hash. The `ByteString` stored with each
+import is that imported module's public hash.
+
+Per-name keys:
+
+| Key | Value type |
+| --- | --- |
+| `name-order/<index>` | `ByteString` suffix for a `name-info` key |
+| `name-info/p/<name>` | `(Name, NameInfo)` |
+| `name-info/h/<hash>` | `(Name, NameInfo)` |
+| `name-hash/p/<name>` | `NameHashInfo` |
+| `name-hash/h/<hash>` | `NameHashInfo` |
+
+Short safe source names are stored directly in key suffixes. Names longer than
+400 bytes and names containing unsafe path-like bytes use SHA-256 based key
+suffixes. Source names use their source text; derived and internal names use
+the compiler-generated text from `rawstr`. `TEnv` entries are unique by `Name`;
+`name-order/<index>` stores the name suffix so full reads reconstruct the
+original `TEnv` order without depending on LMDB cursor order.
+
+Typed statements are stored by module order:
+
+| Key | Value type |
+| --- | --- |
+| `stmt/<index>` | `Stmt` |
+
+Statement order is preserved for full typed-module reconstruction.
+
+For example, `base/src/base64.act` contains top-level `encode` and `decode`
+definitions. Its `.tydb` uses these keys:
+
+```text
+name-count                        -> 2
+stmt-count                        -> 2
+
+name-order/000000000000           -> p/encode
+name-info/p/encode                -> (Name "encode", NameInfo for encode)
+name-order/000000000001           -> p/decode
+name-info/p/decode                -> (Name "decode", NameInfo for decode)
+
+name-hash/p/decode                -> NameHashInfo for decode
+name-hash/p/encode                -> NameHashInfo for encode
+
+stmt/000000000000                 -> typed Stmt for encode
+stmt/000000000001                 -> typed Stmt for decode
+```
+
+## Read And Write Behavior
+
+`readHeader` opens a read-only LMDB transaction and reads the header keys plus
+the `name-hash` entries. It does not decode `NameInfo` entries or typed
+statements.
+
+`readFile` opens a read-only transaction and reconstructs the full payload by
+following the explicit order keys for ordered sections. It does not depend on
+LMDB cursor order for `TEnv` or typed statement reconstruction.
+
+`writeFile` writes the full environment in one write transaction. The compiler
+has one writer for a module cache, while multiple readers may run in parallel.
+The raw Haskell LMDB binding can race when several threads open the same
+environment at once, so `InterfaceFiles` serializes only environment opening.
+The read transactions themselves are still independent.
+
+`copyInterface` uses LMDB's environment copy API. It copies durable data without
+copying a stale `lock.mdb`, so copied `--ty` artifacts reopen with fresh LMDB
+runtime lock state.
+
+## Performance Snapshot
+
+The initial comparison used the generated `concurrent_typecheck_class_heavy`
+fixture with a 5.0 MiB source file. On that local run:
+
+```text
+artifact size:     .ty 72 MiB, .tydb 101 MiB (+40%)
+header read:       .ty 56.9 ms/read, .tydb 73.0 ms/read (+28%)
+full read:         .ty 2.77 s/read, .tydb 2.91 s/read (+5%)
+write:             .ty 1.68 s/write, .tydb 1.12 s/write (-33%)
+```
+
+The current `.tydb` format is larger because LMDB stores page-structured data
+and we keep values uncompressed. Header and full reads are still close to the
+old binary blob path because the compiler still reads all per-name hash records
+for cache decisions. The useful change is the storage boundary: names and typed
+statements now have explicit keys, so future work can load only the imported
+names a dependent module actually needs.

--- a/docs/acton-dev-guide/src/compiler/passes/index.md
+++ b/docs/acton-dev-guide/src/compiler/passes/index.md
@@ -40,7 +40,7 @@ Front passes (1–3) are:
 - Type check
 
 These passes produce all user-facing diagnostics, write the module interface
-header (`.ty`), and compute public hashes used for incremental rebuilds. They
+cache (`.tydb`), and compute public hashes used for incremental rebuilds. They
 also define the cross-module dependency edges: a module can only start once its
 imports have completed the front passes.
 

--- a/docs/acton-dev-guide/src/compiler/passes/type_check.md
+++ b/docs/acton-dev-guide/src/compiler/passes/type_check.md
@@ -6,4 +6,4 @@ Implementation lives in `compiler/lib/src/Acton/Types.hs` and `compiler/lib/src/
 The type checker runs on top of an import-augmented environment produced by
 `Acton.Env.mkEnv`, not directly on the scheduler's raw module graph. See
 [Imports and environments](../imports_and_envs.md) for the environment layers
-and how transitive imports are materialized from `.ty` files.
+and how transitive imports are materialized from `.tydb` files.

--- a/docs/acton-dev-guide/src/compiler/test_cache.md
+++ b/docs/acton-dev-guide/src/compiler/test_cache.md
@@ -25,10 +25,10 @@ Each test’s run hash is SHA-256 over:
 implHash || depsHash || contextHash
 ```
 
-Where `implHash` is the per-name implementation hash from the module’s `.ty`
+Where `implHash` is the per-name implementation hash from the module's `.tydb`
 header. `depsHash` is a hash of the test’s current implementation dependencies
-(`implDeps`), resolved to their latest impl hashes via the `.ty` headers on the
-search path. Test name resolution uses the `.ty` name hash map, and applies
+(`implDeps`), resolved to their latest impl hashes via the `.tydb` headers on the
+search path. Test name resolution uses the `.tydb` name hash map, and applies
 simple fallbacks for generated actor wrappers:
 
 - try the test name as-is


### PR DESCRIPTION
The old interface cache stored each compiled module as one `.ty` blob encoded with Data.Binary. The disk format was coarse: consuming anything beyond the cheap header path meant decoding the blob, and future selective import/name loading had no stable key boundary.

Replace those `.ty` files with normal LMDB directory environments named `.tydb`. The implementation preserves the `InterfaceFiles` boundary (`readHeader`, `readFile`, `writeFile`, the Maybe readers, and path helpers), so the rest of the compiler keeps the same cache interface while the payload is split into keys.

The LMDB layout stores version, source metadata, module hashes, imports, roots, tests, docstring, counts, and the typed module header under module-level keys. Per-name hashes live under `name-hash/<suffix>`; `NameInfo` entries live under `name-info/<suffix>` with `name-order/...`; typed statements live under ordered `stmt/...` keys. Plain safe names use a `p/` suffix with the compiler-rendered name text, while long or unsafe names use an `h/` suffix with a SHA-256 hash of that text. Full reads reconstruct ordered `TEnv` and typed module data from explicit order keys, not LMDB cursor order.

Unreadable, corrupt, missing, and version-mismatched `.tydb` directories remain cache misses. Copy and cleanup paths handle directory artifacts, environment opens are serialized for the raw LMDB binding's open race, and copies use LMDB's environment copy API so they do not carry `lock.mdb`.

Add the Haskell LMDB dependency and build the native LMDB library from a pinned upstream source package through `bdeps/lmdb`. The generated `liblmdb.a` and `lmdb.h` live under `bdeps/lmdb/out`; `compiler/stack.yaml` points at that build-dependency output, and the compiler tool wrappers rewrite `-llmdb` to the exact bdeps archive so Stack/GHC builds do not resolve LMDB from the host. The wrappers invoke bundled Zig for C and C++ compilation, including on macOS, and translate GHC's Darwin target and linker flags where Zig uses different spellings. Stack also passes `CPP` through the bundled Zig wrapper so Cabal/autotools configure checks do not fall back to `/lib/cpp`. `dist/bin/acton` links LMDB statically, and the build keeps LMDB's key-size limit explicit at 512 bytes.

Add a developer guide page for the cache layout.

On the generated `concurrent_typecheck_class_heavy` fixture with a 5.0 MiB source file, `.tydb` was 101 MiB versus `.ty` at 72 MiB (+40%). Header reads were 73.0 ms versus 56.9 ms per read (+28%), full reads were 2.91 s versus 2.77 s per read (+5%), and writes were 1.12 s versus 1.68 s per write (-33%). This keeps current full-cache behavior close enough while giving future work a keyed store for selective imported-name loading.