### PR TITLE
Add golden accept Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -397,6 +397,7 @@ dist/deps/libyyjson: deps/libyyjson $(DIST_ZIG)
 
 # top level targets
 .PHONY: test test-builtins test-compiler test-db test-examples test-lang test-regressions test-rts test-stdlib online-tests
+.PHONY: test-compiler-accept test-lib-accept test-acton-goldens-accept test-goldens-accept
 test: dist/bin/acton
 	cd compiler && stack test libacton acton:test_acton acton:incremental
 	$(MAKE) test-stdlib
@@ -410,8 +411,15 @@ test-compiler:
 	cd compiler && stack test libacton
 	cd compiler && stack test acton --ta '-p "compiler"'
 
-test-compiler-accept:
-	cd compiler && stack test acton --test-arguments "--golden-start --golden-reset"
+test-compiler-accept: test-lib-accept test-acton-goldens-accept
+
+test-lib-accept:
+	cd compiler && stack test libacton:test_lib --test-arguments "--golden-start --golden-reset"
+
+test-acton-goldens-accept:
+	cd compiler && stack test acton:test_acton --test-arguments "--accept"
+
+test-goldens-accept: test-compiler-accept test-incremental-accept test-syntaxerrors-accept test-typeerrors-accept
 
 test-cross-compile:
 	cd compiler && stack test acton --ta '-p "cross-compilation"'

--- a/docs/acton-dev-guide/src/getting_started/tests.md
+++ b/docs/acton-dev-guide/src/getting_started/tests.md
@@ -30,6 +30,10 @@ make test-backend
 Some compiler suites have explicit accept targets that update expected output:
 
 ```sh
+make test-goldens-accept
+make test-compiler-accept
+make test-lib-accept
+make test-acton-goldens-accept
 make test-incremental
 make test-incremental-accept
 make test-syntaxerrors
@@ -38,6 +42,9 @@ make test-typeerrors
 make test-typeerrors-accept
 ```
 
+`test-goldens-accept` runs the compiler golden and snapshot accept targets.
+`test-lib-accept` updates Sydtest goldens. `test-acton-goldens-accept` and
+the other `acton` package accept targets update Tasty goldens with `--accept`.
 `test-incremental*` requires `dist/bin/acton` (it is built automatically by the target).
 `test-rebuild*` remains as an alias for the incremental suite.
 


### PR DESCRIPTION
Add Makefile targets for updating compiler golden and snapshot expected files.

The new targets cover libacton Sydtest goldens, acton:test_acton Tasty goldens, and an aggregate golden accept workflow. The developer test guide now lists the update commands.
