### PR TITLE
Build host-linked C libs with zig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,15 @@ deps/*
 !deps/*/build.zig.zon
 deps-download
 
+bdeps/*
+!bdeps/*/
+!bdeps/*/build.zig
+!bdeps/*/build.zig.zon
+!bdeps/*/*.c
+bdeps/out
+bdeps/**/zig-out
+bdeps/**/zig-pkg
+
 dist/*
 
 builder/deps/*

--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,21 @@ else
 ACTON_STACK_PREREQS=
 endif
 
+# bdeps: static libs we build ourselves and link into the acton compiler. These
+# variables must be defined here, before the dist/bin/acton rule, because GNU
+# make expands a rule's prerequisite list when the rule is read -- defining
+# BDEPS later would leave $(BDEPS) empty there and the archives would never be
+# built. The build rules and the full rationale live in the /bdeps section below.
+# Linux only (macOS links acton with GHC's native toolchain; see /bdeps).
+# ACTON_BDEPS_DIR must be absolute since the GHC link wrappers run from varying
+# working directories.
+ifeq ($(OS),linux)
+export ACTON_BDEPS_DIR := $(TD)/bdeps/out
+BDEPS += bdeps/out/lib/libz.a
+BDEPS += bdeps/out/lib/libgmp.a
+BDEPS += bdeps/out/lib/libtinfo.a
+endif
+
 .PHONY: test-backend
 test-backend: $(BACKEND_TESTS)
 	@echo DISABLED TEST: backend/failure_detector/db_messages_test
@@ -144,7 +159,7 @@ test-backend: $(BACKEND_TESTS)
 # /compiler ----------------------------------------------
 ACTONC_HS=$(wildcard compiler/lib/src/*.hs compiler/lib/src/*/*.hs compiler/acton/*.hs compiler/acton/*/*.hs)
 ACTONLSP_HS=$(wildcard compiler/lsp-server/*.hs)
-dist/bin/acton: compiler/lib/package.yaml.in compiler/acton/package.yaml.in compiler/lsp-server/package.yaml.in compiler/stack.yaml $(ACTONC_HS) $(ACTONLSP_HS) version.mk dist/builder $(ACTON_STACK_PREREQS)
+dist/bin/acton: compiler/lib/package.yaml.in compiler/acton/package.yaml.in compiler/lsp-server/package.yaml.in compiler/stack.yaml $(ACTONC_HS) $(ACTONLSP_HS) version.mk dist/builder $(ACTON_STACK_PREREQS) $(BDEPS)
 	mkdir -p dist/bin
 	rm -f dist/bin/actonc
 	cd compiler && sed 's,^version: BUILD_VERSION,version: "$(VERSION)",' < lib/package.yaml.in > lib/package.yaml
@@ -221,6 +236,44 @@ DEPS += dist/deps/libsnappy_c
 .PHONE: clean-downloads
 clean-downloads:
 	rm -rf deps-download
+
+# /bdeps -------------------------------------------------
+# Build-time dependencies of the acton compiler executable itself. These are
+# libraries that GHC statically links into `acton` and which we otherwise would
+# pull as host .a files via `gcc -print-file-name` (see compiler/tools/*.sh).
+# Building them ourselves with zig lets us target an older/chosen libc instead of
+# inheriting whatever the build machine has installed. Each bdeps/<name> is a
+# standalone zig project that fetches its upstream source via build.zig.zon and
+# installs (via zig --prefix) into the shared bdeps/out prefix. They are
+# statically linked into `acton`, so nothing here is ever shipped in dist/. The
+# GHC link wrappers find the archives/headers under bdeps/out (ACTON_BDEPS_DIR).
+#
+# This takes effect on Linux only. The -pgml=ld-wrapper.sh linker override (see
+# compiler/acton/package.yaml.in) and ACTON_REAL_LD are both gated to os(linux),
+# so on macOS the acton binary is linked by GHC's native toolchain and these
+# archives are neither built nor linked. The problem this solves -- pinning the
+# glibc version of the statically-linked host libs so we can target an older
+# glibc with zig -- is Linux-specific; macOS has no glibc.
+#
+# The BDEPS list and ACTON_BDEPS_DIR are defined earlier (near
+# ACTON_STACK_PREREQS) so they're in scope when the dist/bin/acton rule is read;
+# only the build rules live here.
+
+# /bdeps/zlib --------------------------------------------
+bdeps/out/lib/libz.a: bdeps/zlib/build.zig bdeps/zlib/build.zig.zon $(DIST_ZIG)
+	cd bdeps/zlib && "$(ZIG)" build -Doptimize=ReleaseFast --prefix "$(TD)/bdeps/out" \
+		$(if $(ACTON_ZIG_TARGET),-Dtarget=$(ACTON_ZIG_TARGET))
+
+# /bdeps/gmp ---------------------------------------------
+bdeps/out/lib/libgmp.a: bdeps/gmp/build.zig bdeps/gmp/build.zig.zon $(DIST_ZIG)
+	cd bdeps/gmp && "$(ZIG)" build -Doptimize=ReleaseFast --prefix "$(TD)/bdeps/out" \
+		$(if $(ACTON_ZIG_TARGET),-Dtarget=$(ACTON_ZIG_TARGET))
+
+# /bdeps/ncurses (libtinfo) ------------------------------
+bdeps/out/lib/libtinfo.a: bdeps/ncurses/build.zig bdeps/ncurses/build.zig.zon \
+		bdeps/ncurses/gencaps.c bdeps/ncurses/tinfo.c $(DIST_ZIG)
+	cd bdeps/ncurses && "$(ZIG)" build -Doptimize=ReleaseFast --prefix "$(TD)/bdeps/out" \
+		$(if $(ACTON_ZIG_TARGET),-Dtarget=$(ACTON_ZIG_TARGET))
 
 
 # /deps/libargp --------------------------------------------
@@ -467,8 +520,8 @@ online-tests: dist/bin/actonc
 	cd compiler && stack test acton:test_acton_online
 
 
-.PHONY: clean clean-all clean-base clean-std
-clean: clean-distribution clean-base clean-std
+.PHONY: clean clean-all clean-base clean-std clean-bdeps
+clean: clean-distribution clean-base clean-std clean-bdeps
 
 clean-all: clean clean-compiler
 	rm -rf $(ZIG_LOCAL_CACHE_DIR)
@@ -478,6 +531,9 @@ clean-base:
 
 clean-std:
 	rm -rf std/out
+
+clean-bdeps:
+	rm -rf bdeps/out bdeps/*/zig-out bdeps/*/zig-pkg bdeps/*/.zig-cache
 
 # == DIST ==
 #

--- a/bdeps/gmp/build.zig
+++ b/bdeps/gmp/build.zig
@@ -1,0 +1,691 @@
+const std = @import("std");
+
+// Builds a static libgmp.a from the upstream GMP source tarball, pure C only
+// (assembly disabled), so the same build works for both x86_64 and aarch64
+// linux targets and we control the target glibc version. Adapted from
+// Rexicon226/zig-gmp, upgraded to zig 0.16 and stripped of asm / C++ (gmpxx).
+pub fn build(b: *std.Build) !void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const src = b.dependency("gmp_src", .{});
+
+    const lib = b.addLibrary(.{
+        .linkage = .static,
+        .name = "gmp",
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    const mod = lib.root_module;
+    mod.link_libc = true;
+
+    const limb_bits: i64 = switch (target.result.cpu.arch) {
+        .x86_64, .aarch64 => 64,
+        else => |t| std.debug.panic("unsupported gmp target arch: {s}", .{@tagName(t)}),
+    };
+
+    // Public gmp.h, generated from gmp-h.in (@VAR@ / cmake style).
+    const gmp_header = b.addConfigHeader(.{
+        .style = .{ .cmake = src.path("gmp-h.in") },
+        .include_path = "gmp.h",
+    }, .{
+        .HAVE_HOST_CPU_FAMILY_power = false,
+        .HAVE_HOST_CPU_FAMILY_powerpc = false,
+        .GMP_LIMB_BITS = limb_bits,
+        .GMP_NAIL_BITS = 0,
+        .DEFN_LONG_LONG_LIMB = .@"#define _LONG_LONG_LIMB 1",
+        .LIBGMP_DLL = 0,
+        .CC = "zigcc",
+        .CFLAGS = "",
+    });
+    mod.addConfigHeader(gmp_header);
+    lib.installConfigHeader(gmp_header);
+
+    // Internal config.h, generated from config.in (#undef / autoconf style).
+    mod.addConfigHeader(makeConfigHeader(b, src, target));
+
+    // gmp-impl.h pulls in gmp.h, config.h (both from the ConfigHeader output
+    // dirs, added automatically), gmp-mparam.h (per-arch) and the generated
+    // tables below.
+    mod.addIncludePath(src.path("."));
+    mod.addIncludePath(src.path(switch (target.result.cpu.arch) {
+        .x86_64 => "mpn/x86_64",
+        .aarch64 => "mpn/arm64",
+        else => unreachable,
+    }));
+
+    // Generated lookup tables. Each gen-*.c is built and run for the host, its
+    // stdout captured into a header placed in a shared WriteFiles dir that is
+    // then on the include path.
+    const gen = b.addWriteFiles();
+    mod.addIncludePath(gen.getDirectory());
+    _ = gen.addCopyFile(try genTable(b, src, "gen-fib", "header", 0, limb_bits), "fib_table.h");
+    _ = gen.addCopyFile(try genTable(b, src, "gen-fac", null, 0, limb_bits), "fac_table.h");
+    _ = gen.addCopyFile(try genTable(b, src, "gen-sieve", null, null, limb_bits), "sieve_table.h");
+    _ = gen.addCopyFile(try genTable(b, src, "gen-bases", "header", 0, limb_bits), "mp_bases.h");
+    _ = gen.addCopyFile(try genTable(b, src, "gen-jacobitab", null, null, null), "jacobitab.h");
+    _ = gen.addCopyFile(try genTable(b, src, "gen-psqr", null, 0, limb_bits), "perfsqr.h");
+    _ = gen.addCopyFile(try genTable(b, src, "gen-trialdivtab", null, 8000, limb_bits), "trialdivtab.h");
+
+    mod.addCSourceFiles(.{
+        .root = src.path("."),
+        .files = &top_level_files,
+        .flags = &.{"-DCOUNT_LEADING_ZEROS_NEED_CLZ_TAB"},
+    });
+    // mp_bases.c is also generated (table form of gen-bases).
+    mod.addCSourceFile(.{
+        .file = gen.addCopyFile(try genTable(b, src, "gen-bases", "table", 0, limb_bits), "mp_bases.c"),
+    });
+    // fib_table.c (table form of gen-fib) defines __gmp_fib_table[], used by
+    // mpn fib2_ui; the header form above only emits the FIB_TABLE_LIMIT macros.
+    mod.addCSourceFile(.{
+        .file = gen.addCopyFile(try genTable(b, src, "gen-fib", "table", 0, limb_bits), "fib_table.c"),
+    });
+
+    mod.addCSourceFiles(.{ .root = src.path("mpz"), .files = &mpz_files });
+    mod.addCSourceFiles(.{ .root = src.path("mpq"), .files = &mpq_files });
+    mod.addCSourceFiles(.{ .root = src.path("mpf"), .files = &mpf_files });
+    mod.addCSourceFiles(.{ .root = src.path("printf"), .files = &printf_files });
+    mod.addCSourceFiles(.{ .root = src.path("scanf"), .files = &scanf_files });
+    mod.addCSourceFiles(.{ .root = src.path("rand"), .files = &rand_files });
+
+    mod.addCSourceFiles(.{
+        .root = src.path("mpn/generic"),
+        .files = &mpn_generic_files,
+        .flags = &.{"-DLONGLONG_STANDALONE"},
+    });
+
+    // The 5 OPERATION_-templated mpn files are compiled once per operation,
+    // each producing a distinct object via a distinct -DOPERATION_* flag.
+    addOpFiles(b, mod, src, "mpn/generic/sec_div.c", &.{ "sec_div_qr", "sec_div_r" });
+    addOpFiles(b, mod, src, "mpn/generic/popham.c", &.{ "popcount", "hamdist" });
+    addOpFiles(b, mod, src, "mpn/generic/sec_pi1_div.c", &.{ "sec_pi1_div_qr", "sec_pi1_div_r" });
+    addOpFiles(b, mod, src, "mpn/generic/logops_n.c", &.{ "and_n", "andn_n", "nand_n", "ior_n", "iorn_n", "nior_n", "xor_n", "xnor_n" });
+    addOpFiles(b, mod, src, "mpn/generic/sec_aors_1.c", &.{ "sec_add_1", "sec_sub_1" });
+
+    b.installArtifact(lib);
+}
+
+fn addOpFiles(
+    b: *std.Build,
+    mod: *std.Build.Module,
+    src: *std.Build.Dependency,
+    file: []const u8,
+    ops: []const []const u8,
+) void {
+    for (ops) |op| {
+        mod.addCSourceFile(.{
+            .file = src.path(file),
+            .flags = &.{ "-DLONGLONG_STANDALONE", b.fmt("-DOPERATION_{s}", .{op}) },
+        });
+    }
+}
+
+fn genTable(
+    b: *std.Build,
+    src: *std.Build.Dependency,
+    name: []const u8,
+    maybe_arg: ?[]const u8,
+    maybe_nail_bits: ?i64,
+    maybe_limb_bits: ?i64,
+) !std.Build.LazyPath {
+    const exe = b.addExecutable(.{
+        .name = name,
+        .root_module = b.createModule(.{
+            .target = b.graph.host,
+            .optimize = .ReleaseSafe,
+        }),
+    });
+    exe.root_module.link_libc = true;
+    exe.root_module.addCSourceFile(.{ .file = src.path(b.fmt("{s}.c", .{name})) });
+    const run = b.addRunArtifact(exe);
+    if (maybe_arg) |arg| run.addArg(arg);
+    if (maybe_limb_bits) |lb| run.addArg(b.fmt("{d}", .{lb}));
+    if (maybe_nail_bits) |nb| run.addArg(b.fmt("{d}", .{nb}));
+    return run.captureStdOut(.{});
+}
+
+fn makeConfigHeader(
+    b: *std.Build,
+    src: *std.Build.Dependency,
+    target: std.Build.ResolvedTarget,
+) *std.Build.Step.ConfigHeader {
+    const t = target.result;
+    return b.addConfigHeader(.{
+        .style = .{ .autoconf_undef = src.path("config.in") },
+        .include_path = "config.h",
+    }, .{
+        .AC_APPLE_UNIVERSAL_BUILD = null,
+        .GMP_MPARAM_H_SUGGEST = null,
+        .HAVE_ALARM = 1,
+        .HAVE_ALLOCA = 1,
+        .HAVE_ALLOCA_H = 1,
+        .HAVE_ATTRIBUTE_CONST = 1,
+        .HAVE_ATTRIBUTE_MALLOC = 1,
+        .HAVE_ATTRIBUTE_MODE = 1,
+        .HAVE_ATTRIBUTE_NORETURN = 1,
+        .HAVE_ATTR_GET = null,
+        .HAVE_CALLING_CONVENTIONS = null,
+        .HAVE_CLOCK = 1,
+        .HAVE_CLOCK_GETTIME = 1,
+        .HAVE_CPUTIME = null,
+        .HAVE_DECL_FGETC = 1,
+        .HAVE_DECL_FSCANF = 1,
+        .HAVE_DECL_OPTARG = 1,
+        .HAVE_DECL_SYS_ERRLIST = 1,
+        .HAVE_DECL_SYS_NERR = 1,
+        .HAVE_DECL_UNGETC = 1,
+        .HAVE_DECL_VFPRINTF = 1,
+        .HAVE_DLFCN_H = 1,
+        .HAVE_DOUBLE_CRAY_CFP = null,
+        .HAVE_DOUBLE_IEEE_BIG_ENDIAN = null,
+        .HAVE_DOUBLE_IEEE_LITTLE_ENDIAN = 1,
+        .HAVE_DOUBLE_IEEE_LITTLE_SWAPPED = null,
+        .HAVE_DOUBLE_VAX_D = null,
+        .HAVE_DOUBLE_VAX_G = null,
+        .HAVE_FCNTL_H = 1,
+        .HAVE_FLOAT_H = 1,
+        .HAVE_GETPAGESIZE = 1,
+        .HAVE_GETRUSAGE = 1,
+        .HAVE_GETSYSINFO = null,
+        .HAVE_GETTIMEOFDAY = 1,
+        .HAVE_HIDDEN_ALIAS = 1,
+        .HAVE_HOST_CPU_FAMILY_alpha = null,
+        .HAVE_HOST_CPU_FAMILY_m68k = null,
+        .HAVE_HOST_CPU_FAMILY_power = null,
+        .HAVE_HOST_CPU_FAMILY_powerpc = null,
+        .HAVE_HOST_CPU_FAMILY_x86 = has(t.cpu.arch == .x86),
+        .HAVE_HOST_CPU_FAMILY_x86_64 = has(t.cpu.arch == .x86_64),
+        .HAVE_HOST_CPU_alphaev67 = null,
+        .HAVE_HOST_CPU_alphaev68 = null,
+        .HAVE_HOST_CPU_alphaev7 = null,
+        .HAVE_HOST_CPU_bobcat = null,
+        .HAVE_HOST_CPU_broadwell = null,
+        .HAVE_HOST_CPU_bulldozer = null,
+        .HAVE_HOST_CPU_core2 = null,
+        .HAVE_HOST_CPU_excavator = null,
+        .HAVE_HOST_CPU_goldmont = null,
+        .HAVE_HOST_CPU_haswell = null,
+        .HAVE_HOST_CPU_i386 = null,
+        .HAVE_HOST_CPU_i586 = null,
+        .HAVE_HOST_CPU_i686 = null,
+        .HAVE_HOST_CPU_ivybridge = null,
+        .HAVE_HOST_CPU_jaguar = null,
+        .HAVE_HOST_CPU_k10 = null,
+        .HAVE_HOST_CPU_k8 = null,
+        .HAVE_HOST_CPU_m68020 = null,
+        .HAVE_HOST_CPU_m68030 = null,
+        .HAVE_HOST_CPU_m68040 = null,
+        .HAVE_HOST_CPU_m68060 = null,
+        .HAVE_HOST_CPU_m68360 = null,
+        .HAVE_HOST_CPU_nehalem = null,
+        .HAVE_HOST_CPU_pentium = null,
+        .HAVE_HOST_CPU_pentium2 = null,
+        .HAVE_HOST_CPU_pentium3 = null,
+        .HAVE_HOST_CPU_pentium4 = null,
+        .HAVE_HOST_CPU_pentiummmx = null,
+        .HAVE_HOST_CPU_pentiumpro = null,
+        .HAVE_HOST_CPU_piledriver = null,
+        .HAVE_HOST_CPU_powerpc604 = null,
+        .HAVE_HOST_CPU_powerpc604e = null,
+        .HAVE_HOST_CPU_powerpc7400 = null,
+        .HAVE_HOST_CPU_powerpc750 = null,
+        .HAVE_HOST_CPU_s390_z10 = null,
+        .HAVE_HOST_CPU_s390_z13 = null,
+        .HAVE_HOST_CPU_s390_z14 = null,
+        .HAVE_HOST_CPU_s390_z15 = null,
+        .HAVE_HOST_CPU_s390_z196 = null,
+        .HAVE_HOST_CPU_s390_z9 = null,
+        .HAVE_HOST_CPU_s390_z900 = null,
+        .HAVE_HOST_CPU_s390_z990 = null,
+        .HAVE_HOST_CPU_s390_zarch = null,
+        .HAVE_HOST_CPU_sandybridge = null,
+        .HAVE_HOST_CPU_silvermont = null,
+        .HAVE_HOST_CPU_skylake = null,
+        .HAVE_HOST_CPU_steamroller = null,
+        .HAVE_HOST_CPU_supersparc = null,
+        .HAVE_HOST_CPU_tremont = null,
+        .HAVE_HOST_CPU_westmere = null,
+        .HAVE_HOST_CPU_zen = null,
+        .HAVE_INTMAX_T = 1,
+        .HAVE_INTPTR_T = 1,
+        .HAVE_INTTYPES_H = 1,
+        .HAVE_INVENT_H = null,
+        .HAVE_LANGINFO_H = 1,
+        .HAVE_LIMB_BIG_ENDIAN = null,
+        .HAVE_LIMB_LITTLE_ENDIAN = 1,
+        .HAVE_LOCALECONV = 1,
+        .HAVE_LOCALE_H = 1,
+        .HAVE_LONG_DOUBLE = 1,
+        .HAVE_LONG_LONG = 1,
+        .HAVE_MACHINE_HAL_SYSINFO_H = null,
+        .HAVE_MEMORY_H = 1,
+        .HAVE_MEMSET = 1,
+        .HAVE_MMAP = 1,
+        .HAVE_MPROTECT = 1,
+        .HAVE_NATIVE_mpn_add_n = null,
+        .HAVE_NATIVE_mpn_add_n_sub_n = null,
+        .HAVE_NATIVE_mpn_add_nc = null,
+        .HAVE_NATIVE_mpn_addaddmul_1msb0 = null,
+        .HAVE_NATIVE_mpn_addlsh1_n = null,
+        .HAVE_NATIVE_mpn_addlsh1_n_ip1 = null,
+        .HAVE_NATIVE_mpn_addlsh1_n_ip2 = null,
+        .HAVE_NATIVE_mpn_addlsh1_nc = null,
+        .HAVE_NATIVE_mpn_addlsh1_nc_ip1 = null,
+        .HAVE_NATIVE_mpn_addlsh1_nc_ip2 = null,
+        .HAVE_NATIVE_mpn_addlsh2_n = null,
+        .HAVE_NATIVE_mpn_addlsh2_n_ip1 = null,
+        .HAVE_NATIVE_mpn_addlsh2_n_ip2 = null,
+        .HAVE_NATIVE_mpn_addlsh2_nc = null,
+        .HAVE_NATIVE_mpn_addlsh2_nc_ip1 = null,
+        .HAVE_NATIVE_mpn_addlsh2_nc_ip2 = null,
+        .HAVE_NATIVE_mpn_addlsh_n = null,
+        .HAVE_NATIVE_mpn_addlsh_n_ip1 = null,
+        .HAVE_NATIVE_mpn_addlsh_n_ip2 = null,
+        .HAVE_NATIVE_mpn_addlsh_nc = null,
+        .HAVE_NATIVE_mpn_addlsh_nc_ip1 = null,
+        .HAVE_NATIVE_mpn_addlsh_nc_ip2 = null,
+        .HAVE_NATIVE_mpn_addmul_1c = null,
+        .HAVE_NATIVE_mpn_addmul_2 = null,
+        .HAVE_NATIVE_mpn_addmul_2s = null,
+        .HAVE_NATIVE_mpn_addmul_3 = null,
+        .HAVE_NATIVE_mpn_addmul_4 = null,
+        .HAVE_NATIVE_mpn_addmul_5 = null,
+        .HAVE_NATIVE_mpn_addmul_6 = null,
+        .HAVE_NATIVE_mpn_addmul_7 = null,
+        .HAVE_NATIVE_mpn_addmul_8 = null,
+        .HAVE_NATIVE_mpn_and_n = null,
+        .HAVE_NATIVE_mpn_andn_n = null,
+        .HAVE_NATIVE_mpn_bdiv_dbm1c = null,
+        .HAVE_NATIVE_mpn_bdiv_q_1 = null,
+        .HAVE_NATIVE_mpn_cnd_add_n = null,
+        .HAVE_NATIVE_mpn_cnd_sub_n = null,
+        .HAVE_NATIVE_mpn_com = null,
+        .HAVE_NATIVE_mpn_copyd = null,
+        .HAVE_NATIVE_mpn_copyi = null,
+        .HAVE_NATIVE_mpn_div_qr_1n_pi1 = null,
+        .HAVE_NATIVE_mpn_div_qr_2 = null,
+        .HAVE_NATIVE_mpn_divexact_1 = null,
+        .HAVE_NATIVE_mpn_divexact_by3c = null,
+        .HAVE_NATIVE_mpn_divrem_1 = null,
+        .HAVE_NATIVE_mpn_divrem_1c = null,
+        .HAVE_NATIVE_mpn_divrem_2 = null,
+        .HAVE_NATIVE_mpn_gcd_1 = null,
+        .HAVE_NATIVE_mpn_gcd_11 = null,
+        .HAVE_NATIVE_mpn_gcd_22 = null,
+        .HAVE_NATIVE_mpn_hamdist = null,
+        .HAVE_NATIVE_mpn_invert_limb = null,
+        .HAVE_NATIVE_mpn_ior_n = null,
+        .HAVE_NATIVE_mpn_iorn_n = null,
+        .HAVE_NATIVE_mpn_lshift = null,
+        .HAVE_NATIVE_mpn_lshiftc = null,
+        .HAVE_NATIVE_mpn_lshsub_n = null,
+        .HAVE_NATIVE_mpn_mod_1 = null,
+        .HAVE_NATIVE_mpn_mod_1_1p = null,
+        .HAVE_NATIVE_mpn_mod_1c = null,
+        .HAVE_NATIVE_mpn_mod_1s_2p = null,
+        .HAVE_NATIVE_mpn_mod_1s_4p = null,
+        .HAVE_NATIVE_mpn_mod_34lsub1 = null,
+        .HAVE_NATIVE_mpn_modexact_1_odd = null,
+        .HAVE_NATIVE_mpn_modexact_1c_odd = null,
+        .HAVE_NATIVE_mpn_mul_1 = null,
+        .HAVE_NATIVE_mpn_mul_1c = null,
+        .HAVE_NATIVE_mpn_mul_2 = null,
+        .HAVE_NATIVE_mpn_mul_3 = null,
+        .HAVE_NATIVE_mpn_mul_4 = null,
+        .HAVE_NATIVE_mpn_mul_5 = null,
+        .HAVE_NATIVE_mpn_mul_6 = null,
+        .HAVE_NATIVE_mpn_mul_basecase = null,
+        .HAVE_NATIVE_mpn_mullo_basecase = null,
+        .HAVE_NATIVE_mpn_nand_n = null,
+        .HAVE_NATIVE_mpn_nior_n = null,
+        .HAVE_NATIVE_mpn_pi1_bdiv_q_1 = null,
+        .HAVE_NATIVE_mpn_popcount = null,
+        .HAVE_NATIVE_mpn_preinv_divrem_1 = null,
+        .HAVE_NATIVE_mpn_preinv_mod_1 = null,
+        .HAVE_NATIVE_mpn_redc_1 = null,
+        .HAVE_NATIVE_mpn_redc_2 = null,
+        .HAVE_NATIVE_mpn_rsblsh1_n = null,
+        .HAVE_NATIVE_mpn_rsblsh1_nc = null,
+        .HAVE_NATIVE_mpn_rsblsh2_n = null,
+        .HAVE_NATIVE_mpn_rsblsh2_nc = null,
+        .HAVE_NATIVE_mpn_rsblsh_n = null,
+        .HAVE_NATIVE_mpn_rsblsh_nc = null,
+        .HAVE_NATIVE_mpn_rsh1add_n = null,
+        .HAVE_NATIVE_mpn_rsh1add_nc = null,
+        .HAVE_NATIVE_mpn_rsh1sub_n = null,
+        .HAVE_NATIVE_mpn_rsh1sub_nc = null,
+        .HAVE_NATIVE_mpn_rshift = null,
+        .HAVE_NATIVE_mpn_sbpi1_bdiv_r = null,
+        .HAVE_NATIVE_mpn_sqr_basecase = null,
+        .HAVE_NATIVE_mpn_sqr_diag_addlsh1 = null,
+        .HAVE_NATIVE_mpn_sqr_diagonal = null,
+        .HAVE_NATIVE_mpn_sub_n = null,
+        .HAVE_NATIVE_mpn_sub_nc = null,
+        .HAVE_NATIVE_mpn_sublsh1_n = null,
+        .HAVE_NATIVE_mpn_sublsh1_n_ip1 = null,
+        .HAVE_NATIVE_mpn_sublsh1_nc = null,
+        .HAVE_NATIVE_mpn_sublsh1_nc_ip1 = null,
+        .HAVE_NATIVE_mpn_sublsh2_n = null,
+        .HAVE_NATIVE_mpn_sublsh2_n_ip1 = null,
+        .HAVE_NATIVE_mpn_sublsh2_nc = null,
+        .HAVE_NATIVE_mpn_sublsh2_nc_ip1 = null,
+        .HAVE_NATIVE_mpn_sublsh_n = null,
+        .HAVE_NATIVE_mpn_sublsh_n_ip1 = null,
+        .HAVE_NATIVE_mpn_sublsh_nc = null,
+        .HAVE_NATIVE_mpn_sublsh_nc_ip1 = null,
+        .HAVE_NATIVE_mpn_submul_1c = null,
+        .HAVE_NATIVE_mpn_tabselect = null,
+        .HAVE_NATIVE_mpn_udiv_qrnnd = null,
+        .HAVE_NATIVE_mpn_udiv_qrnnd_r = null,
+        .HAVE_NATIVE_mpn_umul_ppmm = null,
+        .HAVE_NATIVE_mpn_umul_ppmm_r = null,
+        .HAVE_NATIVE_mpn_xnor_n = null,
+        .HAVE_NATIVE_mpn_xor_n = null,
+        .HAVE_NL_LANGINFO = 1,
+        .HAVE_NL_TYPES_H = 1,
+        .HAVE_OBSTACK_VPRINTF = 1,
+        .HAVE_POPEN = 1,
+        .HAVE_PROCESSOR_INFO = null,
+        .HAVE_PSP_ITICKSPERCLKTICK = null,
+        .HAVE_PSTAT_GETPROCESSOR = null,
+        .HAVE_PTRDIFF_T = 1,
+        .HAVE_QUAD_T = 1,
+        .HAVE_RAISE = 1,
+        .HAVE_READ_REAL_TIME = null,
+        .HAVE_SIGACTION = 1,
+        .HAVE_SIGALTSTACK = 1,
+        .HAVE_SIGSTACK = null,
+        .HAVE_SPEED_CYCLECOUNTER = null,
+        .HAVE_SSTREAM = null,
+        .HAVE_STACK_T = 1,
+        .HAVE_STDINT_H = 1,
+        .HAVE_STDLIB_H = 1,
+        .HAVE_STD__LOCALE = null,
+        .HAVE_STRCHR = 1,
+        .HAVE_STRERROR = 1,
+        .HAVE_STRINGS_H = 1,
+        .HAVE_STRING_H = 1,
+        .HAVE_STRNLEN = 1,
+        .HAVE_STRTOL = 1,
+        .HAVE_STRTOUL = 1,
+        .HAVE_SYSCONF = 1,
+        .HAVE_SYSCTL = null,
+        .HAVE_SYSCTLBYNAME = null,
+        .HAVE_SYSSGI = null,
+        .HAVE_SYS_ATTRIBUTES_H = null,
+        .HAVE_SYS_IOGRAPH_H = null,
+        .HAVE_SYS_MMAN_H = 1,
+        .HAVE_SYS_PARAM_H = 1,
+        .HAVE_SYS_PROCESSOR_H = null,
+        .HAVE_SYS_PSTAT_H = null,
+        .HAVE_SYS_RESOURCE_H = 1,
+        .HAVE_SYS_STAT_H = 1,
+        .HAVE_SYS_SYSCTL_H = null,
+        .HAVE_SYS_SYSINFO_H = 1,
+        .HAVE_SYS_SYSSGI_H = null,
+        .HAVE_SYS_SYSTEMCFG_H = null,
+        .HAVE_SYS_TIMES_H = 1,
+        .HAVE_SYS_TIME_H = 1,
+        .HAVE_SYS_TYPES_H = 1,
+        .HAVE_TIMES = 1,
+        .HAVE_UINT_LEAST32_T = 1,
+        .HAVE_UNISTD_H = 1,
+        .HAVE_VSNPRINTF = 1,
+        .HOST_DOS64 = null,
+        .LSYM_PREFIX = ".L",
+        .LT_OBJDIR = ".libs/",
+        .NO_ASM = 1,
+        .PACKAGE = "gmp",
+        .PACKAGE_BUGREPORT = "gmp-bugs@gmplib.org (see https://gmplib.org/manual/Reporting-Bugs.html)",
+        .PACKAGE_NAME = "GNU MP",
+        .PACKAGE_STRING = "GNU MP 6.3.0",
+        .PACKAGE_TARNAME = "gmp",
+        .PACKAGE_URL = "http://www.gnu.org/software/gmp/",
+        .PACKAGE_VERSION = "6.3.0",
+        .RETSIGTYPE = .void,
+        .SIZEOF_MP_LIMB_T = 8,
+        .SIZEOF_UNSIGNED = 4,
+        .SIZEOF_UNSIGNED_LONG = 8,
+        .SIZEOF_UNSIGNED_SHORT = 2,
+        .SIZEOF_VOID_P = 8,
+        .SSCANF_WRITABLE_INPUT = null,
+        .STDC_HEADERS = 1,
+        .TIME_WITH_SYS_TIME = 1,
+        .TUNE_SQR_TOOM2_MAX = .SQR_TOOM2_MAX_GENERIC,
+        .VERSION = "6.3.0",
+        .WANT_ASSERT = null,
+        .WANT_FAKE_CPUID = null,
+        .WANT_FAT_BINARY = null,
+        .WANT_FFT = 1,
+        .WANT_OLD_FFT_FULL = null,
+        .WANT_PROFILING_GPROF = null,
+        .WANT_PROFILING_INSTRUMENT = null,
+        .WANT_PROFILING_PROF = null,
+        .WANT_TMP_ALLOCA = 1,
+        .WANT_TMP_DEBUG = null,
+        .WANT_TMP_NOTREENTRANT = null,
+        .WANT_TMP_REENTRANT = null,
+        .WORDS_BIGENDIAN = null,
+        .X86_ASM_MULX = null,
+        .YYTEXT_POINTER = 1,
+        .@"inline" = null,
+        .@"restrict" = .__restrict,
+        .@"volatile" = null,
+    });
+}
+
+fn has(pred: bool) ?u1 {
+    return if (pred) 1 else null;
+}
+
+const top_level_files = [_][]const u8{
+    "assert.c",
+    "compat.c",
+    "errno.c",
+    "extract-dbl.c",
+    "invalid.c",
+    "memory.c",
+    "mp_bpl.c",
+    "mp_clz_tab.c",
+    "mp_dv_tab.c",
+    "mp_get_fns.c",
+    "mp_minv_tab.c",
+    "mp_set_fns.c",
+    "nextprime.c",
+    "primesieve.c",
+    "tal-reent.c",
+    "version.c",
+};
+
+const mpz_files = [_][]const u8{
+    "2fac_ui.c",     "abs.c",         "add.c",         "add_ui.c",
+    "and.c",         "aorsmul.c",     "aorsmul_i.c",   "array_init.c",
+    "bin_ui.c",      "bin_uiui.c",    "cdiv_q.c",      "cdiv_q_ui.c",
+    "cdiv_qr.c",     "cdiv_qr_ui.c",  "cdiv_r.c",      "cdiv_r_ui.c",
+    "cdiv_ui.c",     "cfdiv_q_2exp.c", "cfdiv_r_2exp.c", "clear.c",
+    "clears.c",      "clrbit.c",      "cmp.c",         "cmp_d.c",
+    "cmp_si.c",      "cmp_ui.c",      "cmpabs.c",      "cmpabs_d.c",
+    "cmpabs_ui.c",   "com.c",         "combit.c",      "cong.c",
+    "cong_2exp.c",   "cong_ui.c",     "dive_ui.c",     "divegcd.c",
+    "divexact.c",    "divis.c",       "divis_2exp.c",  "divis_ui.c",
+    "dump.c",        "export.c",      "fac_ui.c",      "fdiv_q.c",
+    "fdiv_q_ui.c",   "fdiv_qr.c",     "fdiv_qr_ui.c",  "fdiv_r.c",
+    "fdiv_r_ui.c",   "fdiv_ui.c",     "fib2_ui.c",     "fib_ui.c",
+    "fits_sint.c",   "fits_slong.c",  "fits_sshort.c", "fits_uint.c",
+    "fits_ulong.c",  "fits_ushort.c", "gcd.c",         "gcd_ui.c",
+    "gcdext.c",      "get_d.c",       "get_d_2exp.c",  "get_si.c",
+    "get_str.c",     "get_ui.c",      "getlimbn.c",    "hamdist.c",
+    "import.c",      "init.c",        "init2.c",       "inits.c",
+    "inp_raw.c",     "inp_str.c",     "invert.c",      "ior.c",
+    "iset.c",        "iset_d.c",      "iset_si.c",     "iset_str.c",
+    "iset_ui.c",     "jacobi.c",      "kronsz.c",      "kronuz.c",
+    "kronzs.c",      "kronzu.c",      "lcm.c",         "lcm_ui.c",
+    "limbs_finish.c", "limbs_modify.c", "limbs_read.c", "limbs_write.c",
+    "lucmod.c",      "lucnum2_ui.c",  "lucnum_ui.c",   "mfac_uiui.c",
+    "millerrabin.c", "mod.c",         "mul.c",         "mul_2exp.c",
+    "mul_si.c",      "mul_ui.c",      "n_pow_ui.c",    "neg.c",
+    "nextprime.c",   "oddfac_1.c",    "out_raw.c",     "out_str.c",
+    "perfpow.c",     "perfsqr.c",     "popcount.c",    "pow_ui.c",
+    "powm.c",        "powm_sec.c",    "powm_ui.c",     "pprime_p.c",
+    "primorial_ui.c", "prodlimbs.c",  "random.c",      "random2.c",
+    "realloc.c",     "realloc2.c",    "remove.c",      "roinit_n.c",
+    "root.c",        "rootrem.c",     "rrandomb.c",    "scan0.c",
+    "scan1.c",       "set.c",         "set_d.c",       "set_f.c",
+    "set_q.c",       "set_si.c",      "set_str.c",     "set_ui.c",
+    "setbit.c",      "size.c",        "sizeinbase.c",  "sqrt.c",
+    "sqrtrem.c",     "stronglucas.c", "sub.c",         "sub_ui.c",
+    "swap.c",        "tdiv_q.c",      "tdiv_q_2exp.c", "tdiv_q_ui.c",
+    "tdiv_qr.c",     "tdiv_qr_ui.c",  "tdiv_r.c",      "tdiv_r_2exp.c",
+    "tdiv_r_ui.c",   "tdiv_ui.c",     "tstbit.c",      "ui_pow_ui.c",
+    "ui_sub.c",      "urandomb.c",    "urandomm.c",    "xor.c",
+};
+
+const mpq_files = [_][]const u8{
+    "abs.c",          "aors.c",   "canonicalize.c", "clear.c",
+    "clears.c",       "cmp.c",    "cmp_si.c",       "cmp_ui.c",
+    "div.c",          "equal.c",  "get_d.c",        "get_den.c",
+    "get_num.c",      "get_str.c", "init.c",        "inits.c",
+    "inp_str.c",      "inv.c",    "md_2exp.c",      "mul.c",
+    "neg.c",          "out_str.c", "set.c",         "set_d.c",
+    "set_den.c",      "set_f.c",  "set_num.c",      "set_si.c",
+    "set_str.c",      "set_ui.c", "set_z.c",        "swap.c",
+};
+
+const mpf_files = [_][]const u8{
+    "abs.c",         "add.c",        "add_ui.c",      "ceilfloor.c",
+    "clear.c",       "clears.c",     "cmp.c",         "cmp_d.c",
+    "cmp_si.c",      "cmp_ui.c",     "cmp_z.c",       "div.c",
+    "div_2exp.c",    "div_ui.c",     "dump.c",        "eq.c",
+    "fits_sint.c",   "fits_slong.c", "fits_sshort.c", "fits_uint.c",
+    "fits_ulong.c",  "fits_ushort.c", "get_d.c",      "get_d_2exp.c",
+    "get_dfl_prec.c", "get_prc.c",   "get_si.c",      "get_str.c",
+    "get_ui.c",      "init.c",       "init2.c",       "inits.c",
+    "inp_str.c",     "int_p.c",      "iset.c",        "iset_d.c",
+    "iset_si.c",     "iset_str.c",   "iset_ui.c",     "mul.c",
+    "mul_2exp.c",    "mul_ui.c",     "neg.c",         "out_str.c",
+    "pow_ui.c",      "random2.c",    "reldiff.c",     "set.c",
+    "set_d.c",       "set_dfl_prec.c", "set_prc.c",   "set_prc_raw.c",
+    "set_q.c",       "set_si.c",     "set_str.c",     "set_ui.c",
+    "set_z.c",       "size.c",       "sqrt.c",        "sqrt_ui.c",
+    "sub.c",         "sub_ui.c",     "swap.c",        "trunc.c",
+    "ui_div.c",      "ui_sub.c",     "urandomb.c",
+};
+
+const printf_files = [_][]const u8{
+    "asprintf.c",    "asprntffuns.c", "doprnt.c",      "doprntf.c",
+    "doprnti.c",     "fprintf.c",     "obprintf.c",    "obprntffuns.c",
+    "obvprintf.c",   "printf.c",      "printffuns.c",  "repl-vsnprintf.c",
+    "snprintf.c",    "snprntffuns.c", "sprintf.c",     "sprintffuns.c",
+    "vasprintf.c",   "vfprintf.c",    "vprintf.c",     "vsnprintf.c",
+    "vsprintf.c",
+};
+
+const scanf_files = [_][]const u8{
+    "doscan.c",    "fscanf.c",     "fscanffuns.c", "scanf.c",
+    "sscanf.c",    "sscanffuns.c", "vfscanf.c",    "vscanf.c",
+    "vsscanf.c",
+};
+
+const rand_files = [_][]const u8{
+    "rand.c",      "randbui.c",  "randclr.c",   "randdef.c",
+    "randiset.c",  "randlc2s.c", "randlc2x.c",  "randmt.c",
+    "randmts.c",   "randmui.c",  "rands.c",     "randsd.c",
+    "randsdui.c",
+};
+
+const mpn_generic_files = [_][]const u8{
+    "add.c",                          "add_1.c",
+    "add_err1_n.c",                   "add_err2_n.c",
+    "add_err3_n.c",                   "add_n.c",
+    "add_n_sub_n.c",                  "addmul_1.c",
+    "bdiv_dbm1c.c",                   "bdiv_q.c",
+    "bdiv_q_1.c",                     "bdiv_qr.c",
+    "binvert.c",                      "broot.c",
+    "brootinv.c",                     "bsqrt.c",
+    "bsqrtinv.c",                     "cmp.c",
+    "cnd_add_n.c",                    "cnd_sub_n.c",
+    "cnd_swap.c",                     "com.c",
+    "comb_tables.c",                  "compute_powtab.c",
+    "copyd.c",                        "copyi.c",
+    "dcpi1_bdiv_q.c",                 "dcpi1_bdiv_qr.c",
+    "dcpi1_div_q.c",                  "dcpi1_div_qr.c",
+    "dcpi1_divappr_q.c",              "div_q.c",
+    "div_qr_1.c",                     "div_qr_1n_pi1.c",
+    "div_qr_1n_pi2.c",                "div_qr_1u_pi2.c",
+    "div_qr_2.c",                     "div_qr_2n_pi1.c",
+    "div_qr_2u_pi1.c",                "dive_1.c",
+    "diveby3.c",                      "divexact.c",
+    "divis.c",                        "divrem.c",
+    "divrem_1.c",                     "divrem_2.c",
+    "dump.c",                         "fib2_ui.c",
+    "fib2m.c",                        "gcd.c",
+    "gcd_1.c",                        "gcd_11.c",
+    "gcd_22.c",                       "gcd_subdiv_step.c",
+    "gcdext.c",                       "gcdext_1.c",
+    "gcdext_lehmer.c",                "get_d.c",
+    "get_str.c",                      "hgcd.c",
+    "hgcd2.c",                        "hgcd2_jacobi.c",
+    "hgcd_appr.c",                    "hgcd_jacobi.c",
+    "hgcd_matrix.c",                  "hgcd_reduce.c",
+    "hgcd_step.c",                    "invert.c",
+    "invertappr.c",                   "jacbase.c",
+    "jacobi.c",                       "jacobi_2.c",
+    "lshift.c",                       "lshiftc.c",
+    "matrix22_mul.c",                 "matrix22_mul1_inverse_vector.c",
+    "mod_1.c",                        "mod_1_1.c",
+    "mod_1_2.c",                      "mod_1_3.c",
+    "mod_1_4.c",                      "mod_34lsub1.c",
+    "mode1o.c",                       "mu_bdiv_q.c",
+    "mu_bdiv_qr.c",                   "mu_div_q.c",
+    "mu_div_qr.c",                    "mu_divappr_q.c",
+    "mul.c",                          "mul_1.c",
+    "mul_basecase.c",                 "mul_fft.c",
+    "mul_n.c",                        "mullo_basecase.c",
+    "mullo_n.c",                      "mulmid.c",
+    "mulmid_basecase.c",              "mulmid_n.c",
+    "mulmod_bknp1.c",                 "mulmod_bnm1.c",
+    "neg.c",                          "nussbaumer_mul.c",
+    "perfpow.c",                      "perfsqr.c",
+    "pow_1.c",                        "powlo.c",
+    "powm.c",                         "pre_divrem_1.c",
+    "pre_mod_1.c",                    "random.c",
+    "random2.c",                      "redc_1.c",
+    "redc_2.c",                       "redc_n.c",
+    "remove.c",                       "rootrem.c",
+    "rshift.c",                       "sbpi1_bdiv_q.c",
+    "sbpi1_bdiv_qr.c",                "sbpi1_bdiv_r.c",
+    "sbpi1_div_q.c",                  "sbpi1_div_qr.c",
+    "sbpi1_divappr_q.c",              "scan0.c",
+    "scan1.c",                        "sec_invert.c",
+    "sec_mul.c",                      "sec_powm.c",
+    "sec_sqr.c",                      "sec_tabselect.c",
+    "set_str.c",                      "sizeinbase.c",
+    "sqr.c",                          "sqr_basecase.c",
+    "sqrlo.c",                        "sqrlo_basecase.c",
+    "sqrmod_bnm1.c",                  "sqrtrem.c",
+    "strongfibo.c",                   "sub.c",
+    "sub_1.c",                        "sub_err1_n.c",
+    "sub_err2_n.c",                   "sub_err3_n.c",
+    "sub_n.c",                        "submul_1.c",
+    "tdiv_qr.c",                      "toom22_mul.c",
+    "toom2_sqr.c",                    "toom32_mul.c",
+    "toom33_mul.c",                   "toom3_sqr.c",
+    "toom42_mul.c",                   "toom42_mulmid.c",
+    "toom43_mul.c",                   "toom44_mul.c",
+    "toom4_sqr.c",                    "toom52_mul.c",
+    "toom53_mul.c",                   "toom54_mul.c",
+    "toom62_mul.c",                   "toom63_mul.c",
+    "toom6_sqr.c",                    "toom6h_mul.c",
+    "toom8_sqr.c",                    "toom8h_mul.c",
+    "toom_couple_handling.c",         "toom_eval_dgr3_pm1.c",
+    "toom_eval_dgr3_pm2.c",           "toom_eval_pm1.c",
+    "toom_eval_pm2.c",                "toom_eval_pm2exp.c",
+    "toom_eval_pm2rexp.c",            "toom_interpolate_12pts.c",
+    "toom_interpolate_16pts.c",       "toom_interpolate_5pts.c",
+    "toom_interpolate_6pts.c",        "toom_interpolate_7pts.c",
+    "toom_interpolate_8pts.c",        "trialdiv.c",
+    "zero.c",                         "zero_p.c",
+};

--- a/bdeps/gmp/build.zig.zon
+++ b/bdeps/gmp/build.zig.zon
@@ -1,0 +1,13 @@
+.{
+    .name = .gmp,
+    .version = "6.3.0",
+    .fingerprint = 0x328f606142c2788c,
+    .minimum_zig_version = "0.16.0",
+    .dependencies = .{
+        .gmp_src = .{
+            .url = "https://ftp.gnu.org/gnu/gmp/gmp-6.3.0.tar.xz",
+            .hash = "N-V-__8AAE5fAwHUYgLBeqNatYSKf3qBK3l8nwdpjyY8igK0",
+        },
+    },
+    .paths = .{""},
+}

--- a/bdeps/ncurses/build.zig
+++ b/bdeps/ncurses/build.zig
@@ -1,0 +1,49 @@
+const std = @import("std");
+
+// Builds a minimal static libtinfo.a: just enough of the terminfo API to
+// satisfy the symbols GHC's `terminfo` boot package pulls into the acton
+// compiler link. The implementation lives in tinfo.c; the capability
+// name->index tables are generated from the upstream ncurses Caps file so the
+// indices match compiled terminfo databases. We do not build the rest of
+// ncurses (curses/screen handling) since none of it is linked.
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const src = b.dependency("ncurses_src", .{});
+
+    // caps_table.h: built and run on the host, reading include/Caps.
+    const gencaps = b.addExecutable(.{
+        .name = "gencaps",
+        .root_module = b.createModule(.{
+            .target = b.graph.host,
+            .optimize = .ReleaseSafe,
+        }),
+    });
+    gencaps.root_module.link_libc = true;
+    gencaps.root_module.addCSourceFile(.{ .file = b.path("gencaps.c") });
+    const run = b.addRunArtifact(gencaps);
+    run.addFileArg(src.path("include/Caps"));
+    const caps_h = run.captureStdOut(.{});
+
+    const gen = b.addWriteFiles();
+    _ = gen.addCopyFile(caps_h, "caps_table.h");
+
+    const lib = b.addLibrary(.{
+        .linkage = .static,
+        .name = "tinfo",
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    const mod = lib.root_module;
+    mod.link_libc = true;
+    mod.addIncludePath(gen.getDirectory());
+    mod.addCSourceFile(.{
+        .file = b.path("tinfo.c"),
+        .flags = &.{ "-std=c11", "-Wall" },
+    });
+
+    b.installArtifact(lib);
+}

--- a/bdeps/ncurses/build.zig.zon
+++ b/bdeps/ncurses/build.zig.zon
@@ -1,0 +1,13 @@
+.{
+    .name = .ncurses,
+    .version = "6.5.0",
+    .fingerprint = 0xbfb0fbf7716da869,
+    .minimum_zig_version = "0.16.0",
+    .dependencies = .{
+        .ncurses_src = .{
+            .url = "https://ftp.gnu.org/gnu/ncurses/ncurses-6.5.tar.gz",
+            .hash = "N-V-__8AAMZOFwGYoq9VA4jW9LOy4Ud9bufE7x2ep88NNqFr",
+        },
+    },
+    .paths = .{""},
+}

--- a/bdeps/ncurses/gencaps.c
+++ b/bdeps/ncurses/gencaps.c
@@ -1,0 +1,94 @@
+/* gencaps: emit terminfo capability name/index tables from ncurses' Caps file.
+ *
+ * The compiled terminfo binary format stores boolean/number/string capabilities
+ * in a fixed predefined order. ncurses assigns those indices by reading the
+ * master "Caps" table top-to-bottom (see include/MKterm.h.awk). We reproduce
+ * that exact assignment here so tigetflag/tigetnum/tigetstr resolve a capability
+ * name to the same index the database was compiled with.
+ *
+ * Usage: gencaps <path-to-Caps>   (writes caps_table.h to stdout)
+ *
+ * Caps columns (whitespace separated): variable_name  ti_name  type  tc_name ...
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Upper bounds on the number of capabilities of each kind. ncurses 6.5 has
+ * ~44 booleans, ~39 numbers and ~414 strings; these leave generous headroom
+ * but we still guard against a future Caps file outgrowing them rather than
+ * silently writing past the arrays. */
+#define MAX_BOOL 128
+#define MAX_NUM  128
+#define MAX_STR  1024
+#define CAP_NAME_LEN 32
+
+static void emit_array(const char *name, char names[][CAP_NAME_LEN], int n) {
+    printf("static const char *const %s[] = {\n", name);
+    for (int i = 0; i < n; i++)
+        printf("    \"%s\",\n", names[i]);
+    printf("};\n");
+    printf("#define %s_count %d\n\n", name, n);
+}
+
+int main(int argc, char **argv) {
+    if (argc < 2) {
+        fprintf(stderr, "usage: %s <Caps>\n", argv[0]);
+        return 2;
+    }
+    FILE *f = fopen(argv[1], "r");
+    if (!f) {
+        fprintf(stderr, "gencaps: cannot open %s\n", argv[1]);
+        return 1;
+    }
+
+    static char bool_ti[MAX_BOOL][CAP_NAME_LEN], bool_tc[MAX_BOOL][CAP_NAME_LEN];
+    static char num_ti[MAX_NUM][CAP_NAME_LEN], num_tc[MAX_NUM][CAP_NAME_LEN];
+    static char str_ti[MAX_STR][CAP_NAME_LEN], str_tc[MAX_STR][CAP_NAME_LEN];
+    int nb = 0, nn = 0, ns = 0;
+
+    char line[1024];
+    while (fgets(line, sizeof line, f)) {
+        if (line[0] == '#' || line[0] == '\n' || line[0] == ' ' || line[0] == '\t')
+            continue;
+        char var[64], ti[64], type[64], tc[64];
+        if (sscanf(line, "%63s %63s %63s %63s", var, ti, type, tc) < 4)
+            continue;
+        const char *tcp = (strcmp(tc, "-") == 0) ? "" : tc;
+        if (strcmp(type, "bool") == 0) {
+            if (nb >= MAX_BOOL) {
+                fprintf(stderr, "gencaps: too many bool caps (raise MAX_BOOL)\n");
+                return 1;
+            }
+            snprintf(bool_ti[nb], CAP_NAME_LEN, "%s", ti);
+            snprintf(bool_tc[nb], CAP_NAME_LEN, "%s", tcp);
+            nb++;
+        } else if (strcmp(type, "num") == 0) {
+            if (nn >= MAX_NUM) {
+                fprintf(stderr, "gencaps: too many num caps (raise MAX_NUM)\n");
+                return 1;
+            }
+            snprintf(num_ti[nn], CAP_NAME_LEN, "%s", ti);
+            snprintf(num_tc[nn], CAP_NAME_LEN, "%s", tcp);
+            nn++;
+        } else if (strcmp(type, "str") == 0) {
+            if (ns >= MAX_STR) {
+                fprintf(stderr, "gencaps: too many str caps (raise MAX_STR)\n");
+                return 1;
+            }
+            snprintf(str_ti[ns], CAP_NAME_LEN, "%s", ti);
+            snprintf(str_tc[ns], CAP_NAME_LEN, "%s", tcp);
+            ns++;
+        }
+    }
+    fclose(f);
+
+    printf("/* Generated from ncurses Caps - do not edit. */\n\n");
+    emit_array("boolnames", bool_ti, nb);
+    emit_array("boolcodes", bool_tc, nb);
+    emit_array("numnames", num_ti, nn);
+    emit_array("numcodes", num_tc, nn);
+    emit_array("strnames", str_ti, ns);
+    emit_array("strcodes", str_tc, ns);
+    return 0;
+}

--- a/bdeps/ncurses/tinfo.c
+++ b/bdeps/ncurses/tinfo.c
@@ -1,0 +1,618 @@
+/* Minimal libtinfo: enough of the terminfo API for GHC's `terminfo` boot
+ * package (which is what pulls -ltinfo into the acton compiler link).
+ *
+ * Implements the documented terminfo(5) entry reader, capability lookups
+ * (tigetflag/tigetnum/tigetstr and the termcap-name variants), the tparm
+ * parameter machine and tputs. Capability name->index tables are generated
+ * from ncurses' own Caps file (see caps_table.h / gencaps.c) so the indices
+ * match the predefined order used in compiled terminfo databases.
+ *
+ * This deliberately does not implement curses/screen handling; only the
+ * terminfo subset (libtinfo) is needed at link time.
+ */
+#define _DEFAULT_SOURCE 1
+#define _POSIX_C_SOURCE 200809L
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <ctype.h>
+
+#include "caps_table.h"
+
+#define TI_OK 0
+#define TI_ERR (-1)
+
+#define TI_MAGIC  0x011A /* octal 0432  - 16-bit numbers */
+#define TI_MAGIC2 0x021E /* octal 01036 - 32-bit numbers */
+
+typedef struct TERMINAL {
+    char *term_name;
+    char *str_table;
+    int bool_count, num_count, str_count;
+    char bools[boolnames_count];
+    int nums[numnames_count];
+    char *strs[strnames_count];
+} TERMINAL;
+
+TERMINAL *cur_term = NULL;
+
+/* ------------------------------------------------------------------ */
+/* terminfo entry reader                                              */
+/* ------------------------------------------------------------------ */
+
+static int rd16(const unsigned char *p) {
+    int v = (int) (p[0] | (p[1] << 8));
+    if (v & 0x8000)
+        v -= 0x10000; /* sign-extend */
+    return v;
+}
+
+static long rd32(const unsigned char *p) {
+    uint32_t v = (uint32_t) p[0] | ((uint32_t) p[1] << 8) |
+                 ((uint32_t) p[2] << 16) | ((uint32_t) p[3] << 24);
+    return (long) (int32_t) v;
+}
+
+static unsigned char *read_file(const char *path, size_t *out_len) {
+    int fd = open(path, O_RDONLY);
+    if (fd < 0)
+        return NULL;
+    size_t cap = 65536;
+    unsigned char *buf = malloc(cap);
+    if (!buf) {
+        close(fd);
+        return NULL;
+    }
+    size_t total = 0;
+    ssize_t r;
+    while (total < cap && (r = read(fd, buf + total, cap - total)) > 0)
+        total += (size_t) r;
+    close(fd);
+    *out_len = total;
+    return buf;
+}
+
+static TERMINAL *parse_terminfo(const unsigned char *d, size_t len,
+                                const char *name) {
+    if (len < 12)
+        return NULL;
+    int magic = rd16(d);
+    if (magic != TI_MAGIC && magic != TI_MAGIC2)
+        return NULL;
+    int name_size = rd16(d + 2);
+    int bool_count = rd16(d + 4);
+    int num_count = rd16(d + 6);
+    int str_count = rd16(d + 8);
+    int str_size = rd16(d + 10);
+    if (name_size < 0 || bool_count < 0 || num_count < 0 || str_count < 0 ||
+        str_size < 0)
+        return NULL;
+
+    int num_sz = (magic == TI_MAGIC2) ? 4 : 2;
+    size_t off = 12;
+    const unsigned char *names = d + off;
+    off += (size_t) name_size;
+    const unsigned char *bools = d + off;
+    off += (size_t) bool_count;
+    if ((name_size + bool_count) & 1)
+        off += 1; /* numbers align on even boundary */
+    const unsigned char *nums = d + off;
+    off += (size_t) num_count * (size_t) num_sz;
+    const unsigned char *soff = d + off;
+    off += (size_t) str_count * 2;
+    const unsigned char *stbl = d + off;
+    if (off + (size_t) str_size > len)
+        return NULL;
+    (void) names;
+
+    TERMINAL *t = calloc(1, sizeof *t);
+    if (!t)
+        return NULL;
+    t->str_table = malloc((size_t) str_size + 1);
+    if (!t->str_table) {
+        free(t);
+        return NULL;
+    }
+    memcpy(t->str_table, stbl, (size_t) str_size);
+    t->str_table[str_size] = '\0';
+
+    t->bool_count = bool_count < boolnames_count ? bool_count : boolnames_count;
+    for (int i = 0; i < t->bool_count; i++)
+        t->bools[i] = (char) bools[i];
+
+    t->num_count = num_count < numnames_count ? num_count : numnames_count;
+    for (int i = 0; i < t->num_count; i++)
+        t->nums[i] = (num_sz == 2) ? rd16(nums + 2 * i) : (int) rd32(nums + 4 * i);
+
+    t->str_count = str_count < strnames_count ? str_count : strnames_count;
+    for (int i = 0; i < t->str_count; i++) {
+        int o = rd16(soff + 2 * i);
+        t->strs[i] = (o >= 0 && o < str_size) ? t->str_table + o : NULL;
+    }
+
+    t->term_name = strdup(name);
+    return t;
+}
+
+/* Try "<dir>/<c>/<name>" and "<dir>/<hex>/<name>". */
+static TERMINAL *try_dir(const char *dir, const char *name) {
+    if (!dir || !*dir)
+        return NULL;
+    char path[4096];
+    snprintf(path, sizeof path, "%s/%c/%s", dir, name[0], name);
+    size_t len = 0;
+    unsigned char *d = read_file(path, &len);
+    if (!d) {
+        snprintf(path, sizeof path, "%s/%02x/%s", dir, (unsigned char) name[0],
+                 name);
+        d = read_file(path, &len);
+    }
+    if (!d)
+        return NULL;
+    TERMINAL *t = parse_terminfo(d, len, name);
+    free(d);
+    return t;
+}
+
+static TERMINAL *find_terminfo(const char *name) {
+    if (!name || !*name || strchr(name, '/'))
+        return NULL;
+    TERMINAL *t;
+    const char *env;
+
+    if ((env = getenv("TERMINFO")) && (t = try_dir(env, name)))
+        return t;
+
+    const char *home = getenv("HOME");
+    if (home) {
+        char hdir[4096];
+        snprintf(hdir, sizeof hdir, "%s/.terminfo", home);
+        if ((t = try_dir(hdir, name)))
+            return t;
+    }
+
+    if ((env = getenv("TERMINFO_DIRS")) && *env) {
+        char *dirs = strdup(env);
+        if (dirs) {
+            for (char *p = strtok(dirs, ":"); p; p = strtok(NULL, ":")) {
+                const char *d = (*p == '\0') ? "/usr/share/terminfo" : p;
+                if ((t = try_dir(d, name))) {
+                    free(dirs);
+                    return t;
+                }
+            }
+            free(dirs);
+        }
+    }
+
+    static const char *const defaults[] = {
+        "/etc/terminfo",          "/lib/terminfo",
+        "/usr/share/terminfo",    "/usr/lib/terminfo",
+        "/usr/local/share/terminfo", "/usr/local/lib/terminfo",
+        "/usr/share/lib/terminfo",
+    };
+    for (size_t i = 0; i < sizeof defaults / sizeof defaults[0]; i++)
+        if ((t = try_dir(defaults[i], name)))
+            return t;
+    return NULL;
+}
+
+/* ------------------------------------------------------------------ */
+/* setup / curterm                                                    */
+/* ------------------------------------------------------------------ */
+
+int setupterm(const char *term, int filedes, int *errret) {
+    (void) filedes;
+    if (!term)
+        term = getenv("TERM");
+    if (!term || !*term) {
+        if (errret)
+            *errret = 0;
+        return TI_ERR;
+    }
+    TERMINAL *t = find_terminfo(term);
+    if (!t) {
+        if (errret)
+            *errret = 0;
+        return TI_ERR;
+    }
+    cur_term = t;
+    if (errret)
+        *errret = 1;
+    return TI_OK;
+}
+
+int restartterm(const char *term, int filedes, int *errret) {
+    return setupterm(term, filedes, errret);
+}
+
+TERMINAL *set_curterm(TERMINAL *t) {
+    TERMINAL *prev = cur_term;
+    cur_term = t;
+    return prev;
+}
+
+int del_curterm(TERMINAL *t) {
+    if (t) {
+        if (t == cur_term)
+            cur_term = NULL;
+        free(t->str_table);
+        free(t->term_name);
+        free(t);
+    }
+    return TI_OK;
+}
+
+/* ------------------------------------------------------------------ */
+/* capability lookups                                                 */
+/* ------------------------------------------------------------------ */
+
+static int find_name(const char *const *arr, int n, const char *name) {
+    for (int i = 0; i < n; i++)
+        if (strcmp(arr[i], name) == 0)
+            return i;
+    return -1;
+}
+
+int tigetflag(const char *name) {
+    int i = find_name(boolnames, boolnames_count, name);
+    if (i < 0)
+        return -1; /* not a boolean capability */
+    if (!cur_term || i >= cur_term->bool_count)
+        return 0;
+    return cur_term->bools[i] > 0 ? 1 : 0;
+}
+
+int tigetnum(const char *name) {
+    int i = find_name(numnames, numnames_count, name);
+    if (i < 0)
+        return -2; /* not a numeric capability */
+    if (!cur_term || i >= cur_term->num_count)
+        return -1;
+    int v = cur_term->nums[i];
+    return v >= 0 ? v : -1;
+}
+
+char *tigetstr(const char *name) {
+    int i = find_name(strnames, strnames_count, name);
+    if (i < 0)
+        return (char *) -1; /* not a string capability */
+    if (!cur_term || i >= cur_term->str_count)
+        return NULL;
+    return cur_term->strs[i];
+}
+
+int tgetflag(const char *id) {
+    int i = find_name(boolcodes, boolnames_count, id);
+    if (i < 0 || !cur_term || i >= cur_term->bool_count)
+        return 0;
+    return cur_term->bools[i] > 0 ? 1 : 0;
+}
+
+int tgetnum(const char *id) {
+    int i = find_name(numcodes, numnames_count, id);
+    if (i < 0 || !cur_term || i >= cur_term->num_count)
+        return -1;
+    int v = cur_term->nums[i];
+    return v >= 0 ? v : -1;
+}
+
+char *tgetstr(const char *id, char **area) {
+    (void) area;
+    int i = find_name(strcodes, strnames_count, id);
+    if (i < 0 || !cur_term || i >= cur_term->str_count)
+        return NULL;
+    return cur_term->strs[i];
+}
+
+int tgetent(char *bp, const char *name) {
+    (void) bp;
+    int err = 0;
+    return setupterm(name, 1, &err) == TI_OK ? 1 : 0;
+}
+
+/* ------------------------------------------------------------------ */
+/* tparm                                                              */
+/* ------------------------------------------------------------------ */
+
+/* tparm is non-reentrant, like ncurses' own: the formatted result lives in a
+ * single static buffer (tp_out) and the %P/%g dynamic variables persist in a
+ * static array (vars) across calls. Callers must consume the result before the
+ * next tparm call. This matches GHC terminfo's single-threaded usage. */
+#define TPARM_STACK   64   /* operand stack depth */
+#define TPARM_OUTBUF  4096 /* max expanded capability length */
+#define TPARM_VARS    52   /* %P/%g dynamic vars: a-z = 0..25, A-Z = 26..51 */
+#define TPARM_MAXPARM 9    /* %p1..%p9 */
+
+static char tp_out[TPARM_OUTBUF];
+
+static const char *tparm_skip(const char *s, int stop_at_else) {
+    int level = 0;
+    while (*s) {
+        if (*s == '%') {
+            char k = s[1];
+            if (k == '\0')
+                break;
+            if (k == '?') {
+                level++;
+                s += 2;
+                continue;
+            }
+            if (k == ';') {
+                if (level == 0)
+                    return s + 2;
+                level--;
+                s += 2;
+                continue;
+            }
+            if (k == 'e' && level == 0 && stop_at_else)
+                return s + 2;
+            s += 2;
+            continue;
+        }
+        s++;
+    }
+    return s;
+}
+
+static char *tparm_eval(const char *s, long *param) {
+    long stack[TPARM_STACK];
+    int sp = 0;
+    static long vars[TPARM_VARS];
+    size_t outi = 0;
+
+#define PUSH(v) do { if (sp < TPARM_STACK) stack[sp++] = (v); } while (0)
+#define POP() (sp > 0 ? stack[--sp] : 0)
+#define OUTC(c) do { if (outi < sizeof tp_out - 1) tp_out[outi++] = (char)(c); } while (0)
+
+    while (*s) {
+        if (*s != '%') {
+            OUTC(*s);
+            s++;
+            continue;
+        }
+        s++;
+        char c = *s;
+        /* formatted conversion: %[:][flags][width[.prec]]<doxXsc> */
+        if (c == ':' || c == '#' || c == ' ' || c == '.' || isdigit((unsigned char) c) ||
+            ((c == '-' || c == '+') &&
+             (isdigit((unsigned char) s[1]) || s[1] == ' ' || s[1] == '#'))) {
+            char fmt[32];
+            int fi = 0;
+            fmt[fi++] = '%';
+            if (c == ':') {
+                s++;
+                c = *s;
+            }
+            while ((c == '-' || c == '+' || c == ' ' || c == '#' || c == '0') &&
+                   fi < 28) {
+                fmt[fi++] = c;
+                s++;
+                c = *s;
+            }
+            while (isdigit((unsigned char) c) && fi < 28) {
+                fmt[fi++] = c;
+                s++;
+                c = *s;
+            }
+            if (c == '.' && fi < 28) {
+                fmt[fi++] = c;
+                s++;
+                c = *s;
+                while (isdigit((unsigned char) c) && fi < 28) {
+                    fmt[fi++] = c;
+                    s++;
+                    c = *s;
+                }
+            }
+            char tmp[256];
+            if (c == 's') {
+                fmt[fi++] = 's';
+                fmt[fi] = '\0';
+                char *str = (char *) POP();
+                snprintf(tmp, sizeof tmp, fmt, str ? str : "");
+            } else if (c == 'd' || c == 'o' || c == 'x' || c == 'X') {
+                fmt[fi++] = c;
+                fmt[fi] = '\0';
+                snprintf(tmp, sizeof tmp, fmt, (int) POP());
+            } else if (c == 'c') {
+                tmp[0] = (char) POP();
+                tmp[1] = '\0';
+            } else {
+                tmp[0] = '\0';
+            }
+            for (char *q = tmp; *q; q++)
+                OUTC(*q);
+            s++;
+            continue;
+        }
+        s++;
+        switch (c) {
+        case '%':
+            OUTC('%');
+            break;
+        case 'c': {
+            OUTC((char) POP());
+            break;
+        }
+        case 'd':
+        case 'o':
+        case 'x':
+        case 'X': {
+            char tmp[64];
+            char f[3] = {'%', c, '\0'};
+            snprintf(tmp, sizeof tmp, f, (int) POP());
+            for (char *q = tmp; *q; q++)
+                OUTC(*q);
+            break;
+        }
+        case 's': {
+            char *str = (char *) POP();
+            if (str)
+                for (; *str; str++)
+                    OUTC(*str);
+            break;
+        }
+        case 'p': {
+            int n = *s - '1';
+            s++;
+            if (n >= 0 && n < TPARM_MAXPARM)
+                PUSH(param[n]);
+            else
+                PUSH(0);
+            break;
+        }
+        case 'P': {
+            int idx = (*s >= 'a' && *s <= 'z') ? (*s - 'a')
+                      : (*s >= 'A' && *s <= 'Z') ? (26 + *s - 'A')
+                                                 : -1;
+            s++;
+            if (idx >= 0)
+                vars[idx] = POP();
+            break;
+        }
+        case 'g': {
+            int idx = (*s >= 'a' && *s <= 'z') ? (*s - 'a')
+                      : (*s >= 'A' && *s <= 'Z') ? (26 + *s - 'A')
+                                                 : -1;
+            s++;
+            PUSH(idx >= 0 ? vars[idx] : 0);
+            break;
+        }
+        case '\'': {
+            PUSH((long) (unsigned char) *s);
+            if (*s)
+                s++;
+            if (*s == '\'')
+                s++;
+            break;
+        }
+        case '{': {
+            long v = 0;
+            int neg = 0;
+            if (*s == '-') {
+                neg = 1;
+                s++;
+            }
+            while (isdigit((unsigned char) *s)) {
+                v = v * 10 + (*s - '0');
+                s++;
+            }
+            if (*s == '}')
+                s++;
+            PUSH(neg ? -v : v);
+            break;
+        }
+        case 'l': {
+            char *str = (char *) POP();
+            PUSH(str ? (long) strlen(str) : 0);
+            break;
+        }
+        case '+': { long b = POP(), a = POP(); PUSH(a + b); break; }
+        case '-': { long b = POP(), a = POP(); PUSH(a - b); break; }
+        case '*': { long b = POP(), a = POP(); PUSH(a * b); break; }
+        case '/': { long b = POP(), a = POP(); PUSH(b ? a / b : 0); break; }
+        case 'm': { long b = POP(), a = POP(); PUSH(b ? a % b : 0); break; }
+        case '&': { long b = POP(), a = POP(); PUSH(a & b); break; }
+        case '|': { long b = POP(), a = POP(); PUSH(a | b); break; }
+        case '^': { long b = POP(), a = POP(); PUSH(a ^ b); break; }
+        case '=': { long b = POP(), a = POP(); PUSH(a == b); break; }
+        case '<': { long b = POP(), a = POP(); PUSH(a < b); break; }
+        case '>': { long b = POP(), a = POP(); PUSH(a > b); break; }
+        case 'A': { long b = POP(), a = POP(); PUSH(a && b); break; }
+        case 'O': { long b = POP(), a = POP(); PUSH(a || b); break; }
+        case '!': { long a = POP(); PUSH(!a); break; }
+        case '~': { long a = POP(); PUSH(~a); break; }
+        case 'i':
+            param[0]++;
+            param[1]++;
+            break;
+        case '?':
+            break; /* start if */
+        case 't': {
+            long cond = POP();
+            if (!cond)
+                s = tparm_skip(s, 1); /* skip to %e or %; */
+            break;
+        }
+        case 'e':
+            s = tparm_skip(s, 0); /* executed then-branch; skip else to %; */
+            break;
+        case ';':
+            break; /* end if */
+        default:
+            break;
+        }
+    }
+    tp_out[outi] = '\0';
+    return tp_out;
+#undef PUSH
+#undef POP
+#undef OUTC
+}
+
+/* Read the (up to 9) parameters and run the evaluator. We pull each parameter
+ * as a `long`: ncurses' classic tparm signature is varargs of long/int, and on
+ * the LP64 targets we build for (x86_64 and aarch64 Linux) int args are widened
+ * to the 64-bit slot, so reading them as `long` is correct. */
+static char *tparm_va(const char *str, va_list ap) {
+    long param[TPARM_MAXPARM];
+    for (int i = 0; i < TPARM_MAXPARM; i++)
+        param[i] = va_arg(ap, long);
+    if (!str || str == (char *) -1) {
+        tp_out[0] = '\0';
+        return tp_out;
+    }
+    return tparm_eval(str, param);
+}
+
+char *tparm(const char *str, ...) {
+    va_list ap;
+    va_start(ap, str);
+    char *r = tparm_va(str, ap);
+    va_end(ap);
+    return r;
+}
+
+char *tiparm(const char *str, ...) {
+    va_list ap;
+    va_start(ap, str);
+    char *r = tparm_va(str, ap);
+    va_end(ap);
+    return r;
+}
+
+char *tgoto(const char *cap, int col, int row) {
+    return tparm(cap, (long) row, (long) col);
+}
+
+/* ------------------------------------------------------------------ */
+/* tputs                                                              */
+/* ------------------------------------------------------------------ */
+
+int tputs(const char *str, int affcnt, int (*outc)(int)) {
+    (void) affcnt;
+    if (!str || str == (char *) -1)
+        return TI_ERR;
+    for (const char *p = str; *p;) {
+        if (p[0] == '$' && p[1] == '<') {
+            const char *q = strchr(p, '>');
+            if (q) { /* drop padding spec; modern terminals don't need it */
+                p = q + 1;
+                continue;
+            }
+        }
+        outc((unsigned char) *p);
+        p++;
+    }
+    return TI_OK;
+}
+
+int putp(const char *str) {
+    return tputs(str, 1, putchar);
+}

--- a/bdeps/zlib/build.zig
+++ b/bdeps/zlib/build.zig
@@ -1,0 +1,51 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const optimize = b.standardOptimizeOption(.{});
+    const target = b.standardTargetOptions(.{});
+
+    // Upstream zlib source, fetched via build.zig.zon.
+    const src = b.dependency("zlib_src", .{});
+
+    const lib = b.addLibrary(.{
+        .name = "z",
+        .linkage = .static,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+
+    const source_files = [_][]const u8{
+        "adler32.c",
+        "compress.c",
+        "crc32.c",
+        "deflate.c",
+        "gzclose.c",
+        "gzlib.c",
+        "gzread.c",
+        "gzwrite.c",
+        "infback.c",
+        "inffast.c",
+        "inflate.c",
+        "inftrees.c",
+        "trees.c",
+        "uncompr.c",
+        "zutil.c",
+    };
+
+    lib.root_module.addCSourceFiles(.{
+        .root = src.path("."),
+        .files = &source_files,
+        .flags = &[_][]const u8{
+            "-DHAVE_HIDDEN",
+            "-D_LARGEFILE64_SOURCE=1",
+        },
+    });
+    lib.root_module.link_libc = true;
+
+    lib.installHeader(src.path("zlib.h"), "zlib.h");
+    lib.installHeader(src.path("zconf.h"), "zconf.h");
+
+    b.installArtifact(lib);
+}

--- a/bdeps/zlib/build.zig.zon
+++ b/bdeps/zlib/build.zig.zon
@@ -1,0 +1,13 @@
+.{
+    .name = .zlib,
+    .version = "1.3.1",
+    .fingerprint = 0x73887d3a1d6c5392,
+    .minimum_zig_version = "0.16.0",
+    .dependencies = .{
+        .zlib_src = .{
+            .url = "https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz",
+            .hash = "N-V-__8AAJj_QgDBhU17TCtcvdjOZZPDfkvxrEAyZkc14VN8",
+        },
+    },
+    .paths = .{""},
+}

--- a/compiler/tools/ld-wrapper.sh
+++ b/compiler/tools/ld-wrapper.sh
@@ -25,11 +25,24 @@ gcc_lib_path() {
   return 1
 }
 
-add_static_gcc_lib() {
+# Prefer static archives we build ourselves under bdeps/out over the host's
+# apt-installed .a files, so the link targets our chosen libc version.
+bdeps_lib_path() {
+  local archive="$1"
+  if [[ -n "${ACTON_BDEPS_DIR:-}" && -f "${ACTON_BDEPS_DIR}/lib/${archive}" ]]; then
+    echo "${ACTON_BDEPS_DIR}/lib/${archive}"
+    return 0
+  fi
+  return 1
+}
+
+add_static_lib() {
   local archive="$1"
   local fallback="$2"
   local archive_path
-  if archive_path="$(gcc_lib_path "$archive")"; then
+  if archive_path="$(bdeps_lib_path "$archive")"; then
+    args+=("$archive_path")
+  elif archive_path="$(gcc_lib_path "$archive")"; then
     args+=("$archive_path")
   else
     args+=("-l:$fallback")
@@ -61,7 +74,7 @@ handle_lib() {
       args+=("-Wl,-Bstatic")
       state="static"
     fi
-    add_static_gcc_lib libz.a libz.a
+    add_static_lib libz.a libz.a
     return
   fi
   if [[ "$lib_key" == "gmp" ]]; then
@@ -69,7 +82,7 @@ handle_lib() {
       args+=("-Wl,-Bstatic")
       state="static"
     fi
-    add_static_gcc_lib libgmp.a libgmp.a
+    add_static_lib libgmp.a libgmp.a
     return
   fi
   if [[ "$lib_key" == "stdc++" ]]; then
@@ -77,8 +90,11 @@ handle_lib() {
       args+=("-Wl,-Bstatic")
       state="static"
     fi
-    add_static_gcc_lib libstdc++.a libstdc++.a
-    add_static_gcc_lib libgcc_eh.a libgcc_eh.a
+    # Use zig's bundled static libc++ instead of the host's libstdc++.a so the
+    # C++ runtime targets our chosen libc version. libc++ pulls in zig's
+    # libunwind for the _Unwind_* symbols; -lunwind is listed explicitly so it
+    # is available regardless of archive ordering.
+    args+=("-lc++" "-lunwind")
     return
   fi
   if [[ "$lib_key" == "tinfo" ]]; then
@@ -86,7 +102,7 @@ handle_lib() {
       args+=("-Wl,-Bstatic")
       state="static"
     fi
-    add_static_gcc_lib libtinfo.a libtinfo.a
+    add_static_lib libtinfo.a libtinfo.a
     return
   fi
   if [[ "$allow_dynamic_glibc" == true ]]; then
@@ -101,12 +117,12 @@ handle_lib() {
         ;;
     esac
   fi
-  if [[ "$lib_key" == "gcc_s" ]]; then
+  if [[ "$lib_key" == "gcc_s" || "$lib_key" == "gcc_eh" ]]; then
     if [[ "$state" != "static" ]]; then
       args+=("-Wl,-Bstatic")
       state="static"
     fi
-    add_static_gcc_lib libgcc_eh.a libgcc_eh.a
+    args+=("-lunwind")
     return
   fi
   if [[ "$state" != "static" ]]; then

--- a/compiler/tools/zig-cc.sh
+++ b/compiler/tools/zig-cc.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# NOTE: this script is intentionally near-identical to its sibling zig-cxx.sh
+# (the only meaningful difference is `zig cc` vs `zig c++`). Keep the lib/header
+# rewriting helpers below in sync between the two when editing either.
+
 ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
 ZIG="${ROOT}/dist/zig/zig"
 
@@ -26,6 +30,24 @@ gcc_lib_path() {
   return 1
 }
 
+# Static archives we build ourselves under bdeps/out take precedence over the
+# host's apt-installed .a files, so the acton binary links against libs targeting
+# our chosen libc version rather than the build machine's.
+bdeps_lib_path() {
+  local archive="$1"
+  if [[ -n "${ACTON_BDEPS_DIR:-}" && -f "${ACTON_BDEPS_DIR}/lib/${archive}" ]]; then
+    echo "${ACTON_BDEPS_DIR}/lib/${archive}"
+    return 0
+  fi
+  return 1
+}
+
+add_bdeps_include_dirs() {
+  if [[ -n "${ACTON_BDEPS_DIR:-}" && -d "${ACTON_BDEPS_DIR}/include" ]]; then
+    args+=("-I" "${ACTON_BDEPS_DIR}/include")
+  fi
+}
+
 add_system_include_dirs() {
   local multiarch
   args+=("-idirafter" "/usr/include")
@@ -48,28 +70,35 @@ rewrite_lib_arg() {
   local lib_path
   case "$arg" in
     -lgmp|-l:libgmp.a)
-      if lib_path="$(gcc_lib_path libgmp.a)"; then
+      if lib_path="$(bdeps_lib_path libgmp.a)"; then
+        echo "$lib_path"
+      elif lib_path="$(gcc_lib_path libgmp.a)"; then
         echo "$lib_path"
       else
         echo "$arg"
       fi
       ;;
     -lz|-l:libz.a)
-      if lib_path="$(gcc_lib_path libz.a)"; then
+      if lib_path="$(bdeps_lib_path libz.a)"; then
+        echo "$lib_path"
+      elif lib_path="$(gcc_lib_path libz.a)"; then
         echo "$lib_path"
       else
         echo "$arg"
       fi
       ;;
     -lstdc++|-l:libstdc++.a)
-      if lib_path="$(gcc_lib_path libstdc++.a)"; then
-        echo "$lib_path"
-      else
-        echo "$arg"
-      fi
+      # zig's bundled static libc++ replaces the host libstdc++.a.
+      echo "-lc++"
+      ;;
+    -lgcc_s|-l:libgcc_s.so*|-lgcc_eh|-l:libgcc_eh.a)
+      # zig's bundled libunwind provides the _Unwind_* symbols.
+      echo "-lunwind"
       ;;
     -ltinfo|-l:libtinfo.a)
-      if lib_path="$(gcc_lib_path libtinfo.a)"; then
+      if lib_path="$(bdeps_lib_path libtinfo.a)"; then
+        echo "$lib_path"
+      elif lib_path="$(gcc_lib_path libtinfo.a)"; then
         echo "$lib_path"
       else
         echo "$arg"
@@ -117,6 +146,7 @@ case "$(uname -s)" in
     esac
     GLIBC_VERSION="${ACTON_ZIG_GLIBC_VERSION:-2.31}"
     args=()
+    add_bdeps_include_dirs
     add_system_include_dirs
     add_arch_feature_args
     for arg in "$@"; do

--- a/compiler/tools/zig-cxx.sh
+++ b/compiler/tools/zig-cxx.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# NOTE: this script is intentionally near-identical to its sibling zig-cc.sh
+# (the only meaningful difference is `zig c++` vs `zig cc`). Keep the lib/header
+# rewriting helpers below in sync between the two when editing either.
+
 ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
 ZIG="${ROOT}/dist/zig/zig"
 
@@ -26,6 +30,24 @@ gcc_lib_path() {
   return 1
 }
 
+# Static archives we build ourselves under bdeps/out take precedence over the
+# host's apt-installed .a files, so the acton binary links against libs targeting
+# our chosen libc version rather than the build machine's.
+bdeps_lib_path() {
+  local archive="$1"
+  if [[ -n "${ACTON_BDEPS_DIR:-}" && -f "${ACTON_BDEPS_DIR}/lib/${archive}" ]]; then
+    echo "${ACTON_BDEPS_DIR}/lib/${archive}"
+    return 0
+  fi
+  return 1
+}
+
+add_bdeps_include_dirs() {
+  if [[ -n "${ACTON_BDEPS_DIR:-}" && -d "${ACTON_BDEPS_DIR}/include" ]]; then
+    args+=("-I" "${ACTON_BDEPS_DIR}/include")
+  fi
+}
+
 add_system_include_dirs() {
   local multiarch
   args+=("-idirafter" "/usr/include")
@@ -48,28 +70,35 @@ rewrite_lib_arg() {
   local lib_path
   case "$arg" in
     -lgmp|-l:libgmp.a)
-      if lib_path="$(gcc_lib_path libgmp.a)"; then
+      if lib_path="$(bdeps_lib_path libgmp.a)"; then
+        echo "$lib_path"
+      elif lib_path="$(gcc_lib_path libgmp.a)"; then
         echo "$lib_path"
       else
         echo "$arg"
       fi
       ;;
     -lz|-l:libz.a)
-      if lib_path="$(gcc_lib_path libz.a)"; then
+      if lib_path="$(bdeps_lib_path libz.a)"; then
+        echo "$lib_path"
+      elif lib_path="$(gcc_lib_path libz.a)"; then
         echo "$lib_path"
       else
         echo "$arg"
       fi
       ;;
     -lstdc++|-l:libstdc++.a)
-      if lib_path="$(gcc_lib_path libstdc++.a)"; then
-        echo "$lib_path"
-      else
-        echo "$arg"
-      fi
+      # zig's bundled static libc++ replaces the host libstdc++.a.
+      echo "-lc++"
+      ;;
+    -lgcc_s|-l:libgcc_s.so*|-lgcc_eh|-l:libgcc_eh.a)
+      # zig's bundled libunwind provides the _Unwind_* symbols.
+      echo "-lunwind"
       ;;
     -ltinfo|-l:libtinfo.a)
-      if lib_path="$(gcc_lib_path libtinfo.a)"; then
+      if lib_path="$(bdeps_lib_path libtinfo.a)"; then
+        echo "$lib_path"
+      elif lib_path="$(gcc_lib_path libtinfo.a)"; then
         echo "$lib_path"
       else
         echo "$arg"
@@ -117,6 +146,7 @@ case "$(uname -s)" in
     esac
     GLIBC_VERSION="${ACTON_ZIG_GLIBC_VERSION:-2.31}"
     args=()
+    add_bdeps_include_dirs
     add_system_include_dirs
     add_arch_feature_args
     for arg in "$@"; do


### PR DESCRIPTION
The `acton` compiler statically links `libz`, `libgmp`, `libstdc++` and
`libtinfo`. These were previously pulled from the build machine's apt-installed
`.a` files via `gcc -print-file-name`, which can reference symbols from the host
glibc and defeat our attempt to target an older glibc with zig. This builds them
ourselves under `bdeps/<name>/` so we control the target libc version.

This is **Linux-only**: the `-pgml=ld-wrapper.sh` linker override and
`ACTON_REAL_LD` are gated to `os(linux)`, so on macOS the `acton` binary is
linked by GHC's native toolchain and these archives are neither built nor
linked. The glibc-pinning problem it solves doesn't exist on macOS.

- **`bdeps/zlib`, `bdeps/gmp`** — `build.zig` + `build.zig.zon` fetch the
  upstream source and produce static `libz.a` / `libgmp.a`. gmp is built pure-C
  (`NO_ASM`) so it cross-compiles to both `x86_64` and `aarch64`.
- **`bdeps/ncurses`** — a minimal hand-written `libtinfo` (terminfo DB reader,
  capability lookups, `tparm` machine, `tputs`) covering just the GHC `terminfo`
  boot-package ABI. Cap name/index tables are generated from ncurses' own `Caps`
  file (`gencaps.c`) so indices match compiled databases. Avoids pulling in
  ncurses' configure/awk codegen machinery.
- **`stdc++` / `gcc_eh` / `gcc_s`** now map to zig's bundled static `libc++` and
  `libunwind`.
- **`ld-wrapper.sh`, `zig-cc.sh`, `zig-cxx.sh`** prefer the `bdeps/out` archives
  over the host's and pick up bdeps headers; everything installs into a shared
  `bdeps/out` prefix.
- bdeps are build-time only and statically linked into `acton`; nothing here
  ships in `dist/`.