### PR TITLE
Statically link bdeps into acton on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,12 +137,19 @@ endif
 # make expands a rule's prerequisite list when the rule is read -- defining
 # BDEPS later would leave $(BDEPS) empty there and the archives would never be
 # built. The build rules and the full rationale live in the /bdeps section below.
-# Linux only (macOS links acton with GHC's native toolchain; see /bdeps).
-# ACTON_BDEPS_DIR must be absolute since the GHC link wrappers run from varying
-# working directories.
-ifeq ($(OS),linux)
-export ACTON_BDEPS_DIR := $(TD)/bdeps/out
+# ACTON_BDEPS_DIR must be absolute since compiler/tools/ld-wrapper.sh (the GHC
+# -pgml link wrapper, used on both Linux and macOS) reads it from the environment
+# and needs a fixed location independent of the directory the link runs from.
+ACTON_BDEPS_DIR := $(TD)/bdeps/out
+export ACTON_BDEPS_DIR
+# libz is the one bdeps lib that GHC actually links into acton on every platform,
+# so we build and statically link it everywhere. The ld-wrapper rewrites -lz to
+# this archive's full path; dropping any future lib's .a into bdeps/out/lib (e.g.
+# liblmdb.a) makes it link statically the same way, with no per-lib wiring.
 BDEPS += bdeps/out/lib/libz.a
+ifeq ($(OS),linux)
+# gmp and tinfo are only pulled in by GHC on Linux (macOS GHC uses the native
+# bignum backend and the SDK's libncurses), so they are Linux-only bdeps.
 BDEPS += bdeps/out/lib/libgmp.a
 BDEPS += bdeps/out/lib/libtinfo.a
 endif
@@ -248,32 +255,62 @@ clean-downloads:
 # statically linked into `acton`, so nothing here is ever shipped in dist/. The
 # GHC link wrappers find the archives/headers under bdeps/out (ACTON_BDEPS_DIR).
 #
-# This takes effect on Linux only. The -pgml=ld-wrapper.sh linker override (see
-# compiler/acton/package.yaml.in) and ACTON_REAL_LD are both gated to os(linux),
-# so on macOS the acton binary is linked by GHC's native toolchain and these
-# archives are neither built nor linked. The problem this solves -- pinning the
-# glibc version of the statically-linked host libs so we can target an older
-# glibc with zig -- is Linux-specific; macOS has no glibc.
+# Both platforms link acton through the -pgml=ld-wrapper.sh override (see
+# compiler/acton/package.yaml.in). On Linux the wrapper additionally uses GNU ld
+# -Bstatic/-Bdynamic toggling and ACTON_REAL_LD (zig cc) to target an older
+# chosen glibc -- a Linux-specific problem. On macOS ld64 has no -Bstatic, so the
+# wrapper instead rewrites each -lfoo to the full path of bdeps/out/lib/libfoo.a
+# (a positional arg ld64 links statically) and execs the system clang/ld64 GHC is
+# configured for; zig only builds the archive, since its bundled linker rejects
+# the ld64 flags GHC emits. gmp and tinfo are not linked into a macOS acton
+# (native bignum backend; libncurses comes from the SDK), so only the zlib rule
+# below runs there. The mechanism generalises: any .a placed in bdeps/out/lib
+# links statically on either platform, which is how future compiler libs (e.g.
+# LMDB) will be linked.
 #
 # The BDEPS list and ACTON_BDEPS_DIR are defined earlier (near
 # ACTON_STACK_PREREQS) so they're in scope when the dist/bin/acton rule is read;
 # only the build rules live here.
+#
+# bdeps_align_macho repacks a zig-built archive ($(1), absolute path) so the
+# final acton link succeeds on macOS. Apple's newer ld64 (Xcode 16 / macOS 26+)
+# requires every 64-bit Mach-O archive member to start at an 8-byte-aligned
+# offset; zig's archiver does not guarantee that, so the link otherwise fails with
+#   ld: 64-bit mach-o member '...' not 8-byte aligned in 'lib....a'
+# zig ar's darwin format pads members to 8 bytes. Extracted members come out with
+# 0 permissions, hence the chmod before re-archiving. No-op off macOS (GNU ld does
+# not care), and generic so any future bdeps lib gets the same treatment.
+ifeq ($(OS),macos)
+define bdeps_align_macho
+	rm -rf "$(1).repack" && mkdir -p "$(1).repack" && cd "$(1).repack" && \
+		"$(ZIG)" ar x --output=. "$(1)" && chmod u+rw *.o && \
+		"$(ZIG)" ar --format=darwin rcs "$(1).aligned" *.o && cd "$(TD)" && \
+		mv "$(1).aligned" "$(1)" && rm -rf "$(1).repack"
+endef
+else
+define bdeps_align_macho
+	@:
+endef
+endif
 
 # /bdeps/zlib --------------------------------------------
 bdeps/out/lib/libz.a: bdeps/zlib/build.zig bdeps/zlib/build.zig.zon $(DIST_ZIG)
 	cd bdeps/zlib && "$(ZIG)" build -Doptimize=ReleaseFast --prefix "$(TD)/bdeps/out" \
 		$(if $(ACTON_ZIG_TARGET),-Dtarget=$(ACTON_ZIG_TARGET))
+	$(call bdeps_align_macho,$(abspath $@))
 
 # /bdeps/gmp ---------------------------------------------
 bdeps/out/lib/libgmp.a: bdeps/gmp/build.zig bdeps/gmp/build.zig.zon $(DIST_ZIG)
 	cd bdeps/gmp && "$(ZIG)" build -Doptimize=ReleaseFast --prefix "$(TD)/bdeps/out" \
 		$(if $(ACTON_ZIG_TARGET),-Dtarget=$(ACTON_ZIG_TARGET))
+	$(call bdeps_align_macho,$(abspath $@))
 
 # /bdeps/ncurses (libtinfo) ------------------------------
 bdeps/out/lib/libtinfo.a: bdeps/ncurses/build.zig bdeps/ncurses/build.zig.zon \
 		bdeps/ncurses/gencaps.c bdeps/ncurses/tinfo.c $(DIST_ZIG)
 	cd bdeps/ncurses && "$(ZIG)" build -Doptimize=ReleaseFast --prefix "$(TD)/bdeps/out" \
 		$(if $(ACTON_ZIG_TARGET),-Dtarget=$(ACTON_ZIG_TARGET))
+	$(call bdeps_align_macho,$(abspath $@))
 
 
 # /deps/libargp --------------------------------------------

--- a/bdeps/gmp/build.zig
+++ b/bdeps/gmp/build.zig
@@ -88,6 +88,10 @@ pub fn build(b: *std.Build) !void {
     mod.addCSourceFiles(.{ .root = src.path("mpq"), .files = &mpq_files });
     mod.addCSourceFiles(.{ .root = src.path("mpf"), .files = &mpf_files });
     mod.addCSourceFiles(.{ .root = src.path("printf"), .files = &printf_files });
+    // obstack-based printf variants need glibc's <obstack.h>; skip on macOS/musl.
+    if (target.result.isGnuLibC()) {
+        mod.addCSourceFiles(.{ .root = src.path("printf"), .files = &printf_obstack_files });
+    }
     mod.addCSourceFiles(.{ .root = src.path("scanf"), .files = &scanf_files });
     mod.addCSourceFiles(.{ .root = src.path("rand"), .files = &rand_files });
 
@@ -576,11 +580,17 @@ const mpf_files = [_][]const u8{
 
 const printf_files = [_][]const u8{
     "asprintf.c",    "asprntffuns.c", "doprnt.c",      "doprntf.c",
-    "doprnti.c",     "fprintf.c",     "obprintf.c",    "obprntffuns.c",
-    "obvprintf.c",   "printf.c",      "printffuns.c",  "repl-vsnprintf.c",
-    "snprintf.c",    "snprntffuns.c", "sprintf.c",     "sprintffuns.c",
-    "vasprintf.c",   "vfprintf.c",    "vprintf.c",     "vsnprintf.c",
-    "vsprintf.c",
+    "doprnti.c",     "fprintf.c",     "printf.c",      "printffuns.c",
+    "repl-vsnprintf.c", "snprintf.c", "snprntffuns.c", "sprintf.c",
+    "sprintffuns.c", "vasprintf.c",   "vfprintf.c",    "vprintf.c",
+    "vsnprintf.c",   "vsprintf.c",
+};
+
+// The obstack-based printf variants (gmp_obstack_*printf) include <obstack.h>,
+// a glibc extension that is absent on macOS (and musl). GHC never calls them,
+// so they are only compiled when targeting glibc (see have_obstack in build()).
+const printf_obstack_files = [_][]const u8{
+    "obprintf.c", "obprntffuns.c", "obvprintf.c",
 };
 
 const scanf_files = [_][]const u8{

--- a/bdeps/zlib/build.zig
+++ b/bdeps/zlib/build.zig
@@ -2,7 +2,19 @@ const std = @import("std");
 
 pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
-    const target = b.standardTargetOptions(.{});
+    var target = b.standardTargetOptions(.{});
+
+    // On a native macOS build zig defaults the deployment target to the build
+    // host's SDK version. That tags the archive with whatever the build machine
+    // happens to run and makes ld64 warn "object built for newer macOS version"
+    // when GHC later links acton against an older minos. Pin a conservative floor
+    // so the archive is reproducible across hosts and links cleanly. An explicit
+    // -Dtarget=...-macos.<ver> still wins.
+    if (target.result.os.tag == .macos and target.query.os_version_min == null) {
+        var query = target.query;
+        query.os_version_min = .{ .semver = .{ .major = 11, .minor = 0, .patch = 0 } };
+        target = b.resolveTargetQuery(query);
+    }
 
     // Upstream zlib source, fetched via build.zig.zon.
     const src = b.dependency("zlib_src", .{});

--- a/compiler/acton/package.yaml.in
+++ b/compiler/acton/package.yaml.in
@@ -76,11 +76,21 @@ executables:
       - -threaded
       - -rtsopts
       - '"-with-rtsopts=-N -A64M"'
+    # Route the link through our wrapper so host libs are replaced with our
+    # self-built static archives under bdeps/out/lib (libz.a, future LMDB, ...).
+    # Gated per-OS rather than applied unconditionally so an unvalidated platform
+    # (e.g. Windows, where this bash wrapper would not run) falls back to the
+    # default linker instead of breaking. The script branches internally: GNU ld
+    # -Bstatic toggling on Linux, an -lfoo -> libfoo.a rewrite for ld64 on macOS.
     when:
     - condition: os(linux)
+      # -no-pie is required on Linux but invalid on macOS (executables are PIE).
       ghc-options:
         - -no-pie
         - -optl-no-pie
+        - -pgml=../tools/ld-wrapper.sh
+    - condition: os(darwin)
+      ghc-options:
         - -pgml=../tools/ld-wrapper.sh
 
 tests:

--- a/compiler/tools/ld-wrapper.sh
+++ b/compiler/tools/ld-wrapper.sh
@@ -2,6 +2,65 @@
 set -euo pipefail
 
 real_linker="${ACTON_REAL_LD:-gcc}"
+
+# -- macOS (ld64) -------------------------------------------------------------
+# ld64 has no -Bstatic/-Bdynamic and prefers libfoo.dylib over libfoo.a for a
+# given -lfoo, so the GNU-ld toggling strategy below does not apply. Instead we
+# rewrite each -lfoo whose libfoo.a we built under bdeps/out/lib to that
+# archive's full path -- a positional arg ld64 links statically -- while every
+# other argument passes through untouched: system -l flags keep resolving to
+# dylibs, and GHC's ld64-specific flags (-no_fixup_chains, -U <sym>, ...) reach
+# the real linker intact. That real linker is the system clang/ld64 GHC is
+# configured for (ACTON_REAL_LD is left unset on macOS); zig's bundled linker
+# rejects those ld64 flags, so it builds our archives but cannot do this link.
+# Any future bdeps lib links statically just by having its .a present here -- no
+# per-library list to maintain.
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  macos_args=()
+  macos_process_arg() {
+    local arg="$1"
+    case "$arg" in
+      @*)
+        local rsp="${arg#@}"
+        if [[ -f "$rsp" ]]; then
+          local line
+          while IFS= read -r line || [[ -n "$line" ]]; do
+            [[ -z "$line" ]] && continue
+            if [[ "$line" == \"*\" && "$line" == *\" ]]; then
+              line="${line:1:${#line}-2}"
+              line="${line//\\\\/\\}"
+              line="${line//\\\"/\"}"
+            fi
+            macos_process_arg "$line"
+          done < "$rsp"
+        else
+          macos_args+=("$arg")
+        fi
+        ;;
+      -l*)
+        local name="${arg#-l}"
+        # Normalise -l:libfoo.a / -l:libfoo.dylib to the bare library name.
+        if [[ "$name" == :* ]]; then
+          name="${name#:}"; name="${name#lib}"
+          name="${name%.a}"; name="${name%.dylib}"
+        fi
+        if [[ -n "${ACTON_BDEPS_DIR:-}" && -f "${ACTON_BDEPS_DIR}/lib/lib${name}.a" ]]; then
+          macos_args+=("${ACTON_BDEPS_DIR}/lib/lib${name}.a")
+        else
+          macos_args+=("$arg")
+        fi
+        ;;
+      *)
+        macos_args+=("$arg")
+        ;;
+    esac
+  }
+  for arg in "$@"; do
+    macos_process_arg "$arg"
+  done
+  exec "$real_linker" "${macos_args[@]}"
+fi
+
 state="static"
 arch="$(uname -m 2>/dev/null || true)"
 allow_dynamic_glibc=false


### PR DESCRIPTION
Extend the -pgml=ld-wrapper.sh static-linking mechanism, previously gated os(linux), to macOS so the compiler links our self-built static archives under bdeps/out/lib instead of system dylibs. Only libz is linked into a macOS acton today, but any future .a dropped into bdeps/out/lib links statically the same way.

- ld-wrapper.sh: add a Darwin branch. ld64 has no -Bstatic/-Bdynamic, so rewrite each -lfoo whose libfoo.a exists under $ACTON_BDEPS_DIR/lib to that archive's full path and exec the system linker. zig builds the archives but its linker rejects GHC's ld64 flags, so the final link uses the system clang/ld64.
- package.yaml.in: add an os(darwin) condition routing the link through the wrapper (no -no-pie; macOS executables must be PIE).
- Makefile: export ACTON_BDEPS_DIR on all platforms and build libz.a everywhere; keep gmp/tinfo Linux-only.
- bdeps/zlib: pin minos 11.0 so the archive is reproducible across hosts and links without "object built for newer macOS" warnings.
- bdeps/gmp: compile obstack printf files only under glibc so the source builds on macOS/musl.