### PR TITLE
Lower Linux glibc floor to 2.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,11 @@
   instead of rejecting the default stop position. [#2801]
 
 ### Packages & Distribution
+- Lower the Linux glibc floor from 2.31 to 2.28 so released binaries run on
+  OracleLinux 8 / RHEL 8 (and Debian 10, Ubuntu 18.04+). The target is set via
+  Zig's `-target <arch>-linux-gnu.2.28`, so the floor is independent of the build
+  host's glibc; the existing `make ldd` check verifies the maximum required GLIBC
+  symbol stays within the target for `acton`, `lsp-server-acton`, and `actondb`.
 - Change x86_64 Linux builds from statically linked GNU libc to dynamically
   linked GNU libc while keeping other libraries statically linked. [#2774,
   #2781]

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ endif
 # -- Linux ---------------------------------------------------------------------
 ifeq ($(shell uname -s),Linux)
 OS:=linux
-ACTON_ZIG_GLIBC_VERSION ?= 2.31
+ACTON_ZIG_GLIBC_VERSION ?= 2.28
 export ACTON_ZIG_GLIBC_VERSION
 ACTON_STACK_NEEDS_ZIG=1
 STACK=CC="$(ACTON_STACK_CC)" CXX="$(ACTON_STACK_CXX)" CFLAGS= CPPFLAGS= LDFLAGS= ACTON_REAL_LD="$(ACTON_STACK_CC)" stack --with-gcc="$(ACTON_STACK_CC)"

--- a/compiler/tools/zig-cc.sh
+++ b/compiler/tools/zig-cc.sh
@@ -144,7 +144,7 @@ case "$(uname -s)" in
       aarch64|arm64) ZIG_ARCH=aarch64 ;;
       *) echo "Unsupported architecture for Linux: ${ARCH}" >&2; exit 1 ;;
     esac
-    GLIBC_VERSION="${ACTON_ZIG_GLIBC_VERSION:-2.31}"
+    GLIBC_VERSION="${ACTON_ZIG_GLIBC_VERSION:-2.28}"
     args=()
     add_bdeps_include_dirs
     add_system_include_dirs

--- a/compiler/tools/zig-cxx.sh
+++ b/compiler/tools/zig-cxx.sh
@@ -144,7 +144,7 @@ case "$(uname -s)" in
       aarch64|arm64) ZIG_ARCH=aarch64 ;;
       *) echo "Unsupported architecture for Linux: ${ARCH}" >&2; exit 1 ;;
     esac
-    GLIBC_VERSION="${ACTON_ZIG_GLIBC_VERSION:-2.31}"
+    GLIBC_VERSION="${ACTON_ZIG_GLIBC_VERSION:-2.28}"
     args=()
     add_bdeps_include_dirs
     add_system_include_dirs


### PR DESCRIPTION
Target glibc 2.28 instead of 2.31 so released Linux binaries run on OracleLinux 8 / RHEL 8 (and Debian 10, Ubuntu 18.04+). 2.28 was Acton's historical floor; the 2.31 bump was only to match the Debian 11 release host and was never a hard promise.

The floor is set through Zig's -target <arch>-linux-gnu.2.28, so it is independent of the build host's glibc. The existing `make ldd` check fails the build if acton, lsp-server-acton, or actondb require a GLIBC symbol newer than the target, so the ceiling stays enforced.