### PR TITLE
Hash generated names without building strings

### DIFF
--- a/compiler/lib/src/Acton/Syntax.hs
+++ b/compiler/lib/src/Acton/Syntax.hs
@@ -121,7 +121,7 @@ data Pattern    = PWild         { ploc::SrcLoc, pann::Maybe Type }
 type Target     = Expr
 
 data Prefix     = Globvar | Xistvar | Tempvar | Witness | NormPass | CPSPass | LLiftPass | BoxPass
-                deriving (Eq,Ord,Show,Read,Generic,NFData)
+                deriving (Eq,Ord,Show,Read,Enum,Generic,NFData)
 
 data Name       = Name SrcLoc String | Derived Name Name | Internal Prefix String Int deriving (Generic,Show,NFData)
 
@@ -433,8 +433,8 @@ type Substitution       = [(TVar,Type)]
 
 instance Data.Hashable.Hashable Name where
     hashWithSalt s (Name _ nstr)    = Data.Hashable.hashWithSalt s nstr
-    hashWithSalt s (Derived  n1 n2) = Data.Hashable.hashWithSalt s (n1,n2)
-    hashWithSalt s (Internal pre str n) = Data.Hashable.hashWithSalt s (show pre,str,n)
+    hashWithSalt s (Derived  n1 n2) = s `Data.Hashable.hashWithSalt` n1 `Data.Hashable.hashWithSalt` n2
+    hashWithSalt s (Internal pre str n) = s `Data.Hashable.hashWithSalt` (fromEnum pre) `Data.Hashable.hashWithSalt` str `Data.Hashable.hashWithSalt` n
 
 
 -- Finding type leaves -----


### PR DESCRIPTION
Hashing derived and internal names used to allocate temporary tuple and string values, including show output for the internal-name prefix. This happens in hot hash-map and hash-set paths throughout parsing and type checking.

Hash derived names and internal names field by field instead. Internal name prefixes are hashed through their Enum value, avoiding a second manual prefix table while keeping the hash consistent with Name equality.

On the 250-tree compiler pipeline benchmark, type checking improved from about 8.72s to about 7.91s on top of the previous stack. Front-pass allocation dropped from about 61.7 GB to about 55.5 GB.