### PR TITLE
Bump GHC to 9.8.4 to fix arm64 segfault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,12 +43,14 @@
 - Fix quantified type-variable scope cleanup so leaving an inner quantifier only
   drops witnesses associated with the removed variables, preserving unrelated
   witnesses for later type checking. [#2802]
-- Bump the GHC toolchain to 9.6.7 (Stackage lts-22.44), fixing a rare arm64
+- Bump the GHC toolchain to 9.8.4 (Stackage lts-23.28), fixing a rare arm64
   segfault in the compiler. GHC 9.6.6's runtime could crash in the garbage
-  collector when collecting black holes in large objects (GHC #24791); the
-  static LMDB interface cache shifted the binary layout enough to expose it on
-  glibc>=2.34 source builds, producing intermittent SIGSEGVs during `pkg`
-  operations and other commands.
+  collector by following a NULL closure pointer (GHC #24791, black holes in
+  large objects); the static LMDB interface cache shifted the binary layout
+  enough to expose it, producing intermittent SIGSEGVs on arm64 (Linux and
+  macOS) during `pkg` operations and when compiling some programs. 9.6.7
+  reduced the crash rate and 9.8.4 eliminates it (0 crashes across thousands of
+  builds that reproduced it on 9.6.x).
 
 ### CLI & Project Workflow
 - It is now possible to customize project library output in `Build.act` by

--- a/compiler/stack.yaml
+++ b/compiler/stack.yaml
@@ -4,10 +4,12 @@
 
 # NOTE: do not forget to update homebrew/Formula/acton.rb with the version of
 # GHC that corresponds to the stack LTS release, like lts-18.28 -> ghc@8.10
-# lts-22.44 uses GHC 9.6.7, which fixes an aarch64 RTS GC crash (GHC #24791,
-# compacting GC over black holes in large objects) that surfaced as a rare
-# segfault in the compiler on glibc>=2.34 source builds.
-snapshot: lts-22.44
+# lts-23.28 uses GHC 9.8.4. GHC 9.6.6 had an aarch64 RTS crash where the GC
+# could follow a NULL closure pointer (GHC #24791, black holes in large
+# objects); 9.6.7 reduced it and 9.8.4 eliminates it. It surfaced as rare
+# compiler segfaults on arm64 (Linux and macOS), e.g. building optional-chaining
+# code, and was exposed/amplified by binary layout (the static LMDB link).
+snapshot: lts-23.28
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/compiler/stack.yaml.lock
+++ b/compiler/stack.yaml.lock
@@ -83,7 +83,7 @@ packages:
     hackage: unix-2.8.2.1
 snapshots:
 - completed:
-    sha256: 238fa745b64f91184f9aa518fe04bdde6552533d169b0da5256670df83a0f1a9
-    size: 721141
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/44.yaml
-  original: lts-22.44
+    sha256: 7e724f347d5969cb5e8dde9f9aae30996e3231c29d1dafd45f21f1700d4c4fcb
+    size: 684460
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/23/28.yaml
+  original: lts-23.28

--- a/homebrew/Formula/acton.rb
+++ b/homebrew/Formula/acton.rb
@@ -6,7 +6,7 @@ class Acton < Formula
   license "BSD-3-Clause"
   head "https://github.com/actonlang/acton.git", branch: "main"
 
-  depends_on "ghc@9.6" => :build
+  depends_on "ghc@9.8" => :build
   depends_on "haskell-stack" => :build
 
   def install


### PR DESCRIPTION
lts-23.28 ships GHC 9.8.4, which eliminates a rare arm64 RTS crash where the garbage collector could follow a NULL closure pointer (GHC #24791 family, black holes in large objects). 9.6.7 reduced the rate; 9.8.4 removes it (0 crashes across thousands of builds that reproduced it on 9.6.x, on both Linux and macOS arm64). Update the homebrew formula to depend on ghc@9.8.