### PR TITLE
Drop restore-keys from stack caches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,9 +144,12 @@ jobs:
         with:
           path: |
             ~/.stack
+          # Content-keyed on stack.yaml, with NO restore-keys fallback on purpose:
+          # a deps/GHC change misses cleanly and starts from an empty ~/.stack, so
+          # we never end up with two GHC toolchains stacked in one cache (which was
+          # blowing the per-job VM disk). The cold Haskell rebuild only happens on
+          # the run that actually changes stack.yaml.
           key: stack-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.arch }}-${{ hashFiles('compiler/stack.yaml', 'compiler/stack.yaml.lock') }}
-          restore-keys: |
-            stack-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.arch }}-
       # Restore the Acton/zig compile cache for non-nightly runs (PRs and pushes).
       # The nightly (schedule) run intentionally skips this so it builds cold and
       # produces a clean, complete snapshot (saved after tests below) that PRs and
@@ -269,9 +272,12 @@ jobs:
         with:
           path: |
             ~/.stack
+          # Content-keyed on stack.yaml, with NO restore-keys fallback on purpose:
+          # a deps/GHC change misses cleanly and starts from an empty ~/.stack, so
+          # we never end up with two GHC toolchains stacked in one cache (which was
+          # blowing the per-job VM disk). The cold Haskell rebuild only happens on
+          # the run that actually changes stack.yaml.
           key: stack-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.arch }}-${{ hashFiles('compiler/stack.yaml', 'compiler/stack.yaml.lock') }}
-          restore-keys: |
-            stack-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.arch }}-
       # Restore the Acton/zig compile cache for non-nightly runs (PRs and pushes).
       # The nightly (schedule) run skips this so it builds cold and saves a clean,
       # complete snapshot (after tests below) that PRs and pushes restore the next
@@ -399,9 +405,9 @@ jobs:
         with:
           path: |
             ${{ env.STACK_ROOT }}
+          # No restore-keys fallback (see test-macos): a miss starts from an empty
+          # stack root rather than inheriting an old cache with a stale GHC.
           key: build-debs-${{ matrix.arch }}-${{ hashFiles('compiler/stack.yaml', 'compiler/stack.yaml.lock', 'debian/control') }}
-          restore-keys: |
-            build-debs-${{ matrix.arch }}-
       - name: "locale en_US.UTF-8"
         run: |
           apt-get install -qy locales


### PR DESCRIPTION
Some test-linux jobs were failing by running out of disk on the runner VM. The stack/build-debs Haskell caches used a content key plus a restore-keys prefix fallback, and that fallback was quietly doubling the cache.

When the GHC version bumps, the content hash changes and the new key misses. restore-keys then pulls the previous cache (which has the old GHC), stack installs the new GHC alongside it (GHC dirs are version-keyed so the old one stays), and the saved cache ends up containing two full toolchains - an extra ~2.5-3 GB. Every job then restores all of that onto a VM with limited disk, which is what tips the linux containers over. I confirmed it in a failing job log: .stack/programs had both ghc-9.6.6 and ghc-9.6.7, and the live stack caches had grown from ~0.5 GB to ~1.7-1.9 GB.

This drops restore-keys from all three stack caches (test-macos, test-linux, build-debs) and keeps the content key. Now a deps/GHC change misses cleanly and starts from an empty stack root, so there is exactly one GHC and never a transient two-toolchain state on the VM. The tradeoff is that when stack.yaml changes the Haskell deps rebuild cold on that one run, but that is rare and the user is fine with it.

This does not shrink the already-saved bloated caches, so they should be deleted so the next runs rebuild clean single-GHC ones.