### PR TITLE
Widen test_time tolerance to avoid CI flakes

### DIFF
--- a/test/stdlib/test_time.act
+++ b/test/stdlib/test_time.act
@@ -6,7 +6,12 @@ actor main(env):
     d = n.since(et)
     print("duration:", d)
 
-    if abs(d.second) > 15:
+    # Generous tolerance on purpose: this guards against time.time() being grossly
+    # wrong (a real bug would be off by hours/days, not seconds). The gap between
+    # the timestamp passed in at launch and time.time() here is dominated by
+    # compile/startup latency on slow, oversubscribed CI runners, which has been
+    # seen to exceed 15s. Keep it wide enough not to flake on those.
+    if abs(d.second) > 300:
         print("ERROR: diff seems too large, time.time*() should be roughly same as provided UNIX timestamp input")
         await async env.exit(1)
 


### PR DESCRIPTION
test/stdlib/test_time.act compared time.time() against the UNIX timestamp passed in at launch and failed if they differed by more than 15s. On slow, oversubscribed CI runners the compile/startup gap before time.time() runs has been exceeding 15s, so the test was flaking across unrelated PRs (seen on test-macos and test-linux on several branches that touch neither time nor caching).

Widen the tolerance to 300s. This still catches a grossly wrong clock — a real bug would be off by hours or days, not a few seconds — while no longer flaking when a runner is slow.

This is the dominant cause of the current wave of red CI; it is independent of the cache/disk work in #2836.