### PR TITLE
Simplify mapModules callback

### DIFF
--- a/compiler/lib/src/Acton/Converter.hs
+++ b/compiler/lib/src/Acton/Converter.hs
@@ -240,15 +240,15 @@ fixupSelf s                             = s
 
 convEnvProtos env                       = mapModules conv env
   where
-    conv env1 m (n, NDef sc d doc)      = [(n, NDef (convS sc) d doc)]
-    conv env1 m (n, NSig sc d doc)      = [(n, NSig (convS sc) d doc)]
-    conv env1 m (n, NAct q p k te doc)  = [(n, NAct (noqual env q) (qualWRow env q p) k (concat $ map (conv env m) te) doc)]
-    conv env1 m ni@(n, NProto q us te doc)
+    conv m (n, NDef sc d doc)           = [(n, NDef (convS sc) d doc)]
+    conv m (n, NSig sc d doc)           = [(n, NSig (convS sc) d doc)]
+    conv m (n, NAct q p k te doc)       = [(n, NAct (noqual env q) (qualWRow env q p) k (concat $ map (conv m) te) doc)]
+    conv m ni@(n, NProto q us te doc)
                                         = map (fromClass env) $ convProtocol (define [ni] env) n q us [] [] (fromTEnv te)
-    conv env1 m ni@(n, NExt q c us te opts doc)
+    conv m ni@(n, NExt q c us te opts doc)
                                         = map (fromClass env) $ convExtension (define [ni] env) n c q us [] [] (fromTEnv te) opts
-    conv env1 m (n, NClass q us te doc) = [(n, NClass (noqual env q) us (convClassTEnv env q te) doc)]
-    conv env1 m ni                      = [ni]
+    conv m (n, NClass q us te doc)      = [(n, NClass (noqual env q) us (convClassTEnv env q te) doc)]
+    conv m ni                           = [ni]
     convS (TSchema l q t)               = TSchema l (noqual env q) (convT q t)
     convT q (TFun l x p k t)            = TFun l x (qualWRow env q p) k t
     convT q t                           = t

--- a/compiler/lib/src/Acton/Deactorizer.hs
+++ b/compiler/lib/src/Acton/Deactorizer.hs
@@ -361,10 +361,10 @@ instance LambdaFree Elem where
 
 -- Convert types and environments -----------------------------------------------------------------------
 
-conv env m (n, NAct q p k te' doc)  = (n, NClass q (leftpath [TC primActor [], cValue]) (convActorEnv q p k te') doc) :
+conv m (n, NAct q p k te' doc)      = (n, NClass q (leftpath [TC primActor [], cValue]) (convActorEnv q p k te') doc) :
                                       (newactName n, NDef (tSchema q (tFun fxProc p k t)) NoDec Nothing) :
                                       []
   where convActorEnv q0 p k te'     = (initKW, NDef t0 NoDec Nothing) : te'
           where t0                  = tSchema q0 (tFun fxProc p k tNone)
         t                           = tCon $ TC (GName m n) (map tVar $ qbound q)
-conv env m ni                       = [ni]
+conv m ni                           = [ni]

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -106,9 +106,9 @@ inLoop env                  = contextIs env CtxLoop
 
 
 mapModules1                 :: ((Name,NameInfo) -> (Name,NameInfo)) -> Env0 -> Env0
-mapModules1 f env           = mapModules (\_ _ ni -> [f ni]) env
+mapModules1 f env           = mapModules (\_ ni -> [f ni]) env
 
-mapModules                  :: (Env0 -> ModName -> (Name,NameInfo) -> TEnv) -> Env0 -> Env0
+mapModules                  :: (ModName -> (Name,NameInfo) -> TEnv) -> Env0 -> Env0
 mapModules f env            = env' { hmodules = convTEnv2HTEnv mods' }
  where env'                 = env { modules = mods' }
        prim : mods          = modules env
@@ -118,7 +118,7 @@ mapModules f env            = env' { hmodules = convTEnv2HTEnv mods' }
 
        go ns (n, NModule ms te doc)
                             = [(n, NModule ms (walk (ns ++ [n]) te) doc)]
-       go ns ni             = f env (ModName ns) ni
+       go ns ni             = f (ModName ns) ni
 
 instance (Pretty x) => Pretty (EnvF x) where
     pretty env                  = text "--- modules:"  $+$

--- a/compiler/lib/src/Acton/Normalizer.hs
+++ b/compiler/lib/src/Acton/Normalizer.hs
@@ -656,7 +656,7 @@ instance Norm Assoc where
 
 -- Convert function types ---------------------------------------------------------------------------------
 
-convEnv env m (n, i)                = [(n, conv i)]
+convEnv m (n, i)                    = [(n, conv i)]
 
 
 class Conv a where


### PR DESCRIPTION
The linear mapModules implementation no longer threads an updated environment through each callback. Keeping Env0 in the callback type implies lookup behavior that the traversal does not provide.

Pass only the containing module name plus the current entry. Existing callers either ignore the environment or close over their own stage environment, so the API now matches the behavior they need.