### PR TITLE
Add Acton REPL

### DIFF
--- a/builder/build.zig
+++ b/builder/build.zig
@@ -221,8 +221,13 @@ pub fn build(b: *std.Build) void {
 
     var explicit_libraries = ArrayList(*std.Build.Step.Compile).empty;
     var explicit_static_libraries = ArrayList(*std.Build.Step.Compile).empty;
+    var explicit_dynamic_library_names = ArrayList([]const u8).empty;
+    var explicit_dynamic_library_installs = ArrayList(*std.Build.Step).empty;
+    var has_dynamic_libraries = false;
     defer explicit_libraries.deinit(b.allocator);
     defer explicit_static_libraries.deinit(b.allocator);
+    defer explicit_dynamic_library_names.deinit(b.allocator);
+    defer explicit_dynamic_library_installs.deinit(b.allocator);
 
     var lib_it = std.mem.splitScalar(u8, acton_libraries, '|');
     while (lib_it.next()) |raw_lib| {
@@ -236,6 +241,7 @@ pub fn build(b: *std.Build) void {
         if (lib_name.len == 0 or lib_sources.len == 0) continue;
 
         const lib_dynamic = std.mem.eql(u8, lib_linkage, "dynamic");
+        has_dynamic_libraries = has_dynamic_libraries or lib_dynamic;
         const libActonExplicit = b.addLibrary(.{
             .name = lib_name,
             .linkage = if (lib_dynamic) .dynamic else .static,
@@ -285,7 +291,18 @@ pub fn build(b: *std.Build) void {
     for (explicit_libraries.items) |libActonExplicit| {
         libActonExplicit.root_module.link_libc = true;
         libActonExplicit.root_module.link_libcpp = true;
-        b.installArtifact(libActonExplicit);
+        const install_lib = b.addInstallArtifact(libActonExplicit, .{});
+        b.getInstallStep().dependOn(&install_lib.step);
+        if (libActonExplicit.linkage == .dynamic) {
+            explicit_dynamic_library_names.append(b.allocator, libActonExplicit.name) catch |err| {
+                std.log.err("Error appending explicit dynamic library name: {}", .{err});
+                std.process.exit(1);
+            };
+            explicit_dynamic_library_installs.append(b.allocator, &install_lib.step) catch |err| {
+                std.log.err("Error appending explicit dynamic library install step: {}", .{err});
+                std.process.exit(1);
+            };
+        }
     }
 
     // Register the produced header files in out/types using
@@ -368,12 +385,14 @@ pub fn build(b: *std.Build) void {
             executable.root_module.linkLibrary(libActonProject);
             for (explicit_libraries.items) |libActonExplicit| {
                 if (libActonExplicit.linkage == .dynamic) {
-                    executable.root_module.addObjectFile(libActonExplicit.getEmittedBin());
+                    if (target.result.os.tag != .linux) {
+                        executable.root_module.addObjectFile(libActonExplicit.getEmittedBin());
+                    }
                 } else {
                     executable.root_module.linkLibrary(libActonExplicit);
                 }
             }
-            if (explicit_libraries.items.len > 0) {
+            if (has_dynamic_libraries) {
                 switch (target.result.os.tag) {
                     .macos => {
                         executable.root_module.addRPathSpecial("@executable_path/../lib");
@@ -381,6 +400,18 @@ pub fn build(b: *std.Build) void {
                         executable.root_module.addRPathSpecial("@executable_path");
                     },
                     .linux => {
+                        executable.rdynamic = true;
+                        executable.root_module.addLibraryPath(b.path("out/lib"));
+                        for (explicit_dynamic_library_installs.items) |install_step| {
+                            executable.step.dependOn(install_step);
+                        }
+                        for (explicit_dynamic_library_names.items) |lib_name| {
+                            executable.root_module.linkSystemLibrary(lib_name, .{
+                                .needed = true,
+                                .use_pkg_config = .no,
+                                .preferred_link_mode = .dynamic,
+                            });
+                        }
                         executable.root_module.addRPathSpecial("$ORIGIN/../lib");
                         executable.root_module.addRPathSpecial("$ORIGIN/lib");
                         executable.root_module.addRPathSpecial("$ORIGIN");

--- a/compiler/acton/FileUtil.hs
+++ b/compiler/acton/FileUtil.hs
@@ -1,0 +1,67 @@
+{-# LANGUAGE CPP #-}
+-- Copyright (C) 2026 Centor AB
+--
+-- Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+--
+-- 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+--
+-- 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+--
+-- 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+--
+-- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
+
+module FileUtil(readFile, writeFile, writeFileAtomic, writeFileChanged, writeFileIfChanged) where
+
+import Prelude hiding (readFile, writeFile)
+
+import Control.Exception (IOException, bracketOnError, catch, evaluate, try)
+import Control.Monad (void)
+import System.Directory (removeFile, renameFile)
+import System.FilePath (takeDirectory)
+import System.IO hiding (readFile, writeFile)
+import Utils (writeFileUtf8Atomic)
+
+readFile :: FilePath -> IO String
+readFile f = do
+    h <- openFile f ReadMode
+    hSetEncoding h utf8
+    c <- hGetContents h
+    return c
+
+writeFile :: FilePath -> String -> IO ()
+writeFile = writeFileUtf8Atomic
+
+ignoreIOException :: IOException -> IO ()
+ignoreIOException _ = return ()
+
+writeFileAtomic :: FilePath -> String -> IO ()
+writeFileAtomic f c = do
+    let dir = takeDirectory f
+    bracketOnError
+      (openTempFile dir ".acton-tmp")
+      (\(tmpPath, tmpHandle) -> do
+          hClose tmpHandle `catch` ignoreIOException
+          removeFile tmpPath `catch` ignoreIOException)
+      (\(tmpPath, tmpHandle) -> do
+          hSetEncoding tmpHandle utf8
+          hPutStr tmpHandle c
+          hClose tmpHandle
+          renameFile tmpPath f `catch` handleRenameError tmpPath)
+  where
+    handleRenameError :: FilePath -> IOException -> IO ()
+    handleRenameError tmpPath _ = do
+        removeFile f `catch` ignoreIOException
+        renameFile tmpPath f
+
+writeFileIfChanged :: FilePath -> String -> IO ()
+writeFileIfChanged f c = void (writeFileChanged f c)
+
+writeFileChanged :: FilePath -> String -> IO Bool
+writeFileChanged f c = do
+    same <- try (do old <- readFile f
+                    evaluate (old == c)) :: IO (Either IOException Bool)
+    case same of
+      Right True -> return False
+      _          -> writeFileAtomic f c >> return True

--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -16,7 +16,6 @@ module Main where
 
 import Prelude hiding (readFile, writeFile)
 
-import qualified Acton.Parser
 import qualified Acton.Syntax as A
 import qualified Acton.NameInfo as I
 import Text.Megaparsec.Error (ParseErrorBundle)
@@ -46,10 +45,11 @@ import Utils
 import qualified Pretty
 import qualified InterfaceFiles
 import qualified PkgCommands
+import qualified Repl
+import FileUtil (readFile, writeFile, writeFileAtomic)
 
 import Control.Concurrent.MVar
-import Control.Exception (throw,catch,finally,IOException,try,SomeException,bracket,bracket_,onException,evaluate)
-import Control.Exception (bracketOnError)
+import Control.Exception (throw,catch,finally,IOException,try,SomeException,onException,evaluate)
 import Control.Concurrent (ThreadId, forkIO, killThread, threadDelay)
 import Control.Concurrent.Chan (Chan, newChan, writeChan, readChan)
 import Control.Monad
@@ -57,7 +57,7 @@ import Data.Bits
 import Data.Default.Class (def)
 import Data.List.Split
 import Data.IORef
-import Data.Maybe (catMaybes, isJust)
+import Data.Maybe (catMaybes, isJust, isNothing)
 import Data.Monoid ((<>))
 import Data.Word (Word32)
 import Data.Graph
@@ -85,9 +85,9 @@ import System.FileLock
 import System.FilePath ((</>), addTrailingPathSeparator)
 import System.FilePath.Posix
 import System.IO hiding (readFile, writeFile)
+import System.IO.Temp (writeSystemTempFile)
 import Text.PrettyPrint (renderStyle, style, Style(..), Mode(PageMode))
 import Text.Show.Pretty (ppDoc)
-import System.IO.Temp
 import System.IO.Unsafe (unsafePerformIO)
 import System.Info
 import System.Posix.Files
@@ -114,6 +114,11 @@ main = do
           C.CmdOpt g _ -> g
           C.CompileOpt _ g _ -> g
     ensureCapabilities gopts
+    let replHooks = Repl.Hooks
+          { Repl.hooksCacheDir = actonCacheDir
+          , Repl.hooksWithPersistentScratchDirLock = withPersistentScratchDirLock
+          , Repl.hooksCompileFiles = compileReplHook
+          }
     let run = case arg of
           C.CmdOpt gopts (C.New opts)         -> createProject (C.file opts)
           C.CmdOpt gopts (C.Build bopts)      ->
@@ -126,6 +131,7 @@ main = do
           C.CmdOpt gopts (C.Uninstall opts)    -> PkgCommands.uninstallCommand gopts opts
           C.CmdOpt gopts (C.Sig opts)          -> sigCommand gopts opts
           C.CmdOpt gopts (C.Test tcmd)        -> runTests gopts tcmd
+          C.CmdOpt gopts (C.Repl opts)        -> Repl.runRepl replHooks gopts opts
           C.CmdOpt gopts C.Fetch             -> fetchCommand gopts
           C.CmdOpt gopts C.PkgShow           -> pkgShow gopts
           C.CmdOpt gopts (C.PkgAdd opts)     -> PkgCommands.pkgAddCommand gopts opts
@@ -199,38 +205,6 @@ findAvailableScratch basePath = go [0..31]  -- 32 possible scratch directories
 printErrorAndExit msg = do
                   errorWithoutStackTrace msg
                   System.Exit.exitFailure
-
--- our own readFile & writeFile with hard-coded utf-8 encoding (atomic writes)
-readFile f = do
-    h <- openFile f ReadMode
-    hSetEncoding h utf8
-    c <- hGetContents h
-    return c
-
-writeFile :: FilePath -> String -> IO ()
-writeFile = writeFileUtf8Atomic
-
-ignoreIOException :: IOException -> IO ()
-ignoreIOException _ = return ()
-
-writeFileAtomic :: FilePath -> String -> IO ()
-writeFileAtomic f c = do
-    let dir = takeDirectory f
-    bracketOnError
-      (openTempFile dir ".acton-tmp")
-      (\(tmpPath, tmpHandle) -> do
-          hClose tmpHandle `catch` ignoreIOException
-          removeFile tmpPath `catch` ignoreIOException)
-      (\(tmpPath, tmpHandle) -> do
-          hSetEncoding tmpHandle utf8
-          hPutStr tmpHandle c
-          hClose tmpHandle
-          renameFile tmpPath f `catch` handleRenameError tmpPath)
-  where
-    handleRenameError :: FilePath -> IOException -> IO ()
-    handleRenameError tmpPath _ = do
-        removeFile f `catch` ignoreIOException
-        renameFile tmpPath f
 
 -- | Format a TimeSpec as seconds with millisecond precision.
 fmtTimePrecise :: TimeSpec -> String
@@ -552,10 +526,17 @@ requireProjectConfigPath curDir = do
 ignoreNotExists :: IOException -> IO ()
 ignoreNotExists _ = return ()
 
+actonCacheDir :: IO FilePath
+actonCacheDir = do
+    home <- getHomeDirectory
+    let basePath = joinPath [home, ".cache", "acton"]
+    createDirectoryIfMissing True basePath
+    return basePath
+
 withScratchDirLock :: (FilePath -> IO a) -> IO a
 withScratchDirLock action = do
-    home <- getHomeDirectory
-    let basePath = joinPath [home, ".cache", "acton", "scratch"]
+    cacheDir <- actonCacheDir
+    let basePath = cacheDir </> "scratch"
     createDirectoryIfMissing True basePath
     maybeLockInfo <- findAvailableScratch basePath
     case maybeLockInfo of
@@ -563,6 +544,17 @@ withScratchDirLock action = do
       Just (lock, lockPath) -> do
         let scratchDir = dropExtension lockPath
         removeDirectoryRecursive scratchDir `catch` ignoreNotExists
+        action scratchDir `finally` unlockFile lock
+
+withPersistentScratchDirLock :: FilePath -> (FilePath -> IO a) -> IO a
+withPersistentScratchDirLock basePath action = do
+    createDirectoryIfMissing True basePath
+    maybeLockInfo <- findAvailableScratch basePath
+    case maybeLockInfo of
+      Nothing -> error "Could not acquire any scratch directory lock"
+      Just (lock, lockPath) -> do
+        let scratchDir = dropExtension lockPath
+        createDirectoryIfMissing True scratchDir
         action scratchDir `finally` unlockFile lock
 
 withTempDirOpts :: C.CompileOptions -> (C.CompileOptions -> Bool -> IO a) -> IO a
@@ -1322,6 +1314,11 @@ printDocs gopts opts = do
 
           _ -> printErrorAndExit ("Unknown filetype: " ++ filename)
 
+
+compileReplHook :: C.GlobalOptions -> C.CompileOptions -> FilePath -> [FilePath] -> IO Bool
+compileReplHook gopts opts projDir srcFiles =
+    withProjectLockNotice gopts projDir $
+      compileFilesChanged Source.diskSourceProvider gopts opts srcFiles False Nothing Nothing Nothing
 
 -- Compile Acton files ---------------------------------------------------------------------------------------------
 

--- a/compiler/acton/PkgCommands.hs
+++ b/compiler/acton/PkgCommands.hs
@@ -17,6 +17,7 @@ module PkgCommands
   , decodePackageIndex
   , decodeAppPackageIndex
   , matchesAllTerms
+  , resolveLibraryDependency
   ) where
 
 import Prelude hiding (readFile, writeFile)
@@ -184,6 +185,24 @@ pkgAddCommand _ opts = do
           ensureGithubUrl "pkg add" repoUrl
           archive <- requireRight =<< resolveGithubArchiveUrl manager token repoUrl repoRefArg
           return (archive, Just repoUrl, repoRefArg)
+
+resolveLibraryDependency :: String -> IO BuildSpec.PkgDep
+resolveLibraryDependency depName = do
+    validateDepName depName
+    manager <- newTlsManager
+    token <- resolveGithubToken Nothing
+    repoUrl <- lookupRepoUrlFromIndex depName ""
+    ensureGithubUrl "repl :dep add" repoUrl
+    archive <- requireRight =<< resolveGithubArchiveUrl manager token repoUrl Nothing
+    zigExe <- getZigExe
+    depHash <- requireRight =<< zigFetchHash zigExe archive
+    return BuildSpec.PkgDep
+      { BuildSpec.url = Just archive
+      , BuildSpec.hash = Just depHash
+      , BuildSpec.path = Nothing
+      , BuildSpec.repo_url = Just repoUrl
+      , BuildSpec.repo_ref = Nothing
+      }
 
 pkgRemoveCommand :: C.GlobalOptions -> C.PkgRemoveOptions -> IO ()
 pkgRemoveCommand _ opts = do

--- a/compiler/acton/Repl.hs
+++ b/compiler/acton/Repl.hs
@@ -1,0 +1,666 @@
+-- Copyright (C) 2026 Centor AB
+--
+-- Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+--
+-- 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+--
+-- 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+--
+-- 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+--
+-- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--
+
+module Repl(Hooks(..), runRepl) where
+
+import Prelude hiding (readFile, writeFile)
+
+import qualified Acton.Parser
+import qualified Acton.Syntax as A
+import qualified Acton.BuildSpec as BuildSpec
+import qualified Acton.CommandLineParser as C
+import Acton.Compile (ProjectError(..), findProjectDir)
+import qualified Acton.Fingerprint as Fingerprint
+import qualified PkgCommands
+import FileUtil (readFile, writeFile, writeFileChanged, writeFileIfChanged)
+
+import Control.Concurrent (forkIO)
+import Control.Concurrent.MVar
+import Control.Exception (IOException, SomeException, finally, fromException, try)
+import Control.Monad
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Data.Char (isSpace)
+import qualified Data.List
+import Data.List (isPrefixOf, isSuffixOf)
+import Data.List.Split (splitOn)
+import qualified Data.Map as M
+import System.Directory
+import System.Exit
+import System.FilePath ((</>), (<.>), joinPath, takeDirectory)
+import System.IO (hFlush, hIsTerminalDevice, hPutStr, hPutStrLn, isEOF, stderr, stdin, stdout)
+import System.Process
+import qualified System.Console.Haskeline as HL
+
+data Hooks = Hooks
+  { hooksCacheDir                         :: IO FilePath
+  , hooksWithPersistentScratchDirLock     :: FilePath -> (FilePath -> IO ()) -> IO ()
+  , hooksCompileFiles                     :: C.GlobalOptions -> C.CompileOptions -> FilePath -> [FilePath] -> IO Bool
+  }
+
+
+data ReplState = ReplState
+  { replImports      :: [String]
+  , replDecls        :: [ReplDecl]
+  , replReplay       :: [String]
+  , replDeps         :: M.Map String BuildSpec.PkgDep
+  , replUseProject   :: Bool
+  }
+
+data ReplDecl = ReplDecl [String] String
+
+data ReplEval = ReplExpr String | ReplStmt String | ReplNoop
+
+data ReplInput = ReplTop ReplTop | ReplEvalInput ReplEval
+
+data ReplTop = ReplImport
+             | ReplDeclTop [String]
+             | ReplReplay
+
+data ReplContext = ReplContext
+  { replRoot           :: FilePath
+  , replProject        :: Maybe FilePath
+  , replMainSrcFile    :: FilePath
+  , replSessionSrcFile :: FilePath
+  , replEvalSrcFile    :: FilePath
+  , replBinFile        :: FilePath
+  , replGopts          :: C.GlobalOptions
+  , replOpts           :: C.CompileOptions
+  , replWarmup         :: MVar Bool
+  , replHooks          :: Hooks
+  }
+
+data ReplShell m = ReplShell
+  { replReadLine        :: String -> m (Maybe String)
+  , replHandleInterrupt :: m () -> m () -> m ()
+  }
+
+runRepl :: Hooks -> C.GlobalOptions -> C.CompileOptions -> IO ()
+runRepl hooks gopts opts = do
+    curDir <- getCurrentDirectory
+    mproj0 <- findProjectDir curDir
+    mproj <- mapM canonicalizePath mproj0
+    withReplRoot hooks opts mproj $ \scratchDir -> do
+      interactive <- hIsTerminalDevice stdin
+      warmup <- newEmptyMVar
+      let srcRoot = scratchDir </> "src"
+          mainSrcFile = srcRoot </> replMainModuleName <.> "act"
+          sessionSrcFile = srcRoot </> replSessionModuleName <.> "act"
+          evalSrcFile = srcRoot </> replEvalModuleName <.> "act"
+          opts' = normalizeReplCompileOptions opts
+          gopts' = gopts { C.quiet = not (C.verbose gopts)
+                         , C.noProgress = True
+                         }
+          binBase = if isWindowsOS (C.target opts') then replMainModuleName ++ ".exe" else replMainModuleName
+          ctx = ReplContext
+                { replRoot = scratchDir
+                , replProject = mproj
+                , replMainSrcFile = mainSrcFile
+                , replSessionSrcFile = sessionSrcFile
+                , replEvalSrcFile = evalSrcFile
+                , replBinFile = scratchDir </> "out" </> "bin" </> binBase
+                , replGopts = gopts'
+                , replOpts = opts'
+                , replWarmup = warmup
+                , replHooks = hooks
+                }
+      createDirectoryIfMissing True srcRoot
+      startReplWarmup ctx
+      when (interactive && not (C.quiet gopts)) $ do
+        putStrLn "Acton REPL. Type :help for commands, :quit to exit."
+        when (C.verbose gopts) $
+          putStrLn ("REPL directory: " ++ scratchDir)
+      cacheDir <- hooksCacheDir hooks
+      (if interactive
+         then HL.runInputT (replSettings cacheDir) (HL.withInterrupt (replLoop haskelineReplShell ctx emptyReplState))
+         else replLoop plainReplShell ctx emptyReplState)
+        `finally` finishReplWarmup ctx
+
+haskelineReplShell :: ReplShell (HL.InputT IO)
+haskelineReplShell = ReplShell
+  { replReadLine = HL.getInputLine
+  , replHandleInterrupt = HL.handleInterrupt
+  }
+
+plainReplShell :: ReplShell IO
+plainReplShell = ReplShell
+  { replReadLine = plainGetInputLine
+  , replHandleInterrupt = \_ body -> body
+  }
+
+plainGetInputLine :: String -> IO (Maybe String)
+plainGetInputLine prompt = do
+    hPutStr stdout prompt
+    hFlush stdout
+    eof <- isEOF
+    if eof
+      then return Nothing
+      else Just <$> getLine
+
+normalizeReplCompileOptions :: C.CompileOptions -> C.CompileOptions
+normalizeReplCompileOptions opts =
+    opts { C.parse = False
+         , C.parse_ast = False
+         , C.kinds = False
+         , C.types = False
+         , C.sigs = False
+         , C.norm = False
+         , C.deact = False
+         , C.cps = False
+         , C.llift = False
+         , C.box = False
+         , C.hgen = False
+         , C.cgen = False
+         , C.ccmd = False
+         , C.ty = False
+         , C.root = replMainModuleName ++ ".main"
+         , C.skip_build = False
+         , C.only_build = False
+         , C.watch = False
+         , C.test = False
+         }
+
+startReplWarmup :: ReplContext -> IO ()
+startReplWarmup ctx = do
+    _ <- forkIO $ do
+      res <- try (compileReplRunnerNow ctx emptyReplState ReplNoop) :: IO (Either SomeException Bool)
+      ok <- case res of
+              Left err -> hPutStrLn stderr (show err) >> return False
+              Right ok -> return ok
+      putMVar (replWarmup ctx) ok
+    return ()
+
+waitReplWarmup :: ReplContext -> IO Bool
+waitReplWarmup ctx = readMVar (replWarmup ctx)
+
+finishReplWarmup :: ReplContext -> IO ()
+finishReplWarmup ctx = void (readMVar (replWarmup ctx))
+
+withReplRoot :: Hooks -> C.CompileOptions -> Maybe FilePath -> (FilePath -> IO ()) -> IO ()
+withReplRoot hooks opts mproj action
+  | C.tempdir opts /= "" = do
+      createDirectoryIfMissing True (C.tempdir opts)
+      let root = C.tempdir opts </> replExplicitRootName
+      createDirectoryIfMissing True root
+      action root
+  | otherwise = do
+      cacheDir <- hooksCacheDir hooks
+      hooksWithPersistentScratchDirLock hooks (cacheDir </> "repl" </> replScratchKey mproj) action
+
+replExplicitRootName :: FilePath
+replExplicitRootName = ".acton-repl"
+
+replScratchKey :: Maybe FilePath -> FilePath
+replScratchKey Nothing = "global"
+replScratchKey (Just p) = "project-" ++ drop 2 (Fingerprint.formatFingerprintPrefix (Fingerprint.fingerprintPrefixForName p))
+
+replSettings :: FilePath -> HL.Settings IO
+replSettings cacheDir =
+    (HL.defaultSettings :: HL.Settings IO)
+      { HL.historyFile = Just (cacheDir </> "repl_history")
+      , HL.complete = replCompletion
+      }
+
+replCompletion :: HL.CompletionFunc IO
+replCompletion =
+    HL.completeWordWithPrev Nothing " \t" completeReplWord
+
+completeReplWord :: String -> String -> IO [HL.Completion]
+completeReplWord prevRev word
+  | prevWords == [":dep"] = return (matching replDepCompletions)
+  | null prevWords && ":" `isPrefixOf` word = return (matching replCommandCompletions)
+  | otherwise = return []
+  where
+    prevWords = words (reverse prevRev)
+    matching candidates =
+      map HL.simpleCompletion (filter (word `isPrefixOf`) candidates)
+
+replCommandCompletions :: [String]
+replCommandCompletions =
+    [ ":help", ":quit", ":q", ":reset", ":show", ":dep" ]
+
+replDepCompletions :: [String]
+replDepCompletions =
+    [ "list", "add", "rm", "remove" ]
+
+replMainModuleName :: String
+replMainModuleName = "repl_main"
+
+replSessionModuleName :: String
+replSessionModuleName = "repl_session"
+
+replEvalModuleName :: String
+replEvalModuleName = "repl_eval"
+
+isWindowsOS :: String -> Bool
+isWindowsOS targetTriple = case splitOn "-" targetTriple of
+    (_:os:_) -> os == "windows"
+    _        -> False
+
+emptyReplState :: ReplState
+emptyReplState = ReplState [] [] [] M.empty False
+
+renderReplBuildAct :: M.Map String BuildSpec.PkgDep -> Maybe FilePath -> String
+renderReplBuildAct deps mproj =
+    BuildSpec.renderBuildAct BuildSpec.BuildSpec
+      { BuildSpec.specName = "acton_repl"
+      , BuildSpec.specDescription = Nothing
+      , BuildSpec.fingerprint = "0x81091a566daa4f54"
+      , BuildSpec.dependencies = deps'
+      , BuildSpec.zig_dependencies = M.empty
+      , BuildSpec.libraries = M.fromList
+          [ (replEvalModuleName, BuildSpec.Library [replEvalModuleName] "dynamic")
+          , (replSessionModuleName, BuildSpec.Library [replSessionModuleName] "dynamic")
+          ]
+      }
+  where
+    deps' =
+      case mproj of
+        Nothing -> deps
+        Just p ->
+          M.insert "repl_project" replProjectDep deps
+          where
+            replProjectDep = BuildSpec.PkgDep
+              { BuildSpec.url = Nothing
+              , BuildSpec.hash = Nothing
+              , BuildSpec.path = Just p
+              , BuildSpec.repo_url = Nothing
+              , BuildSpec.repo_ref = Nothing
+              }
+
+replLoop :: MonadIO m => ReplShell m -> ReplContext -> ReplState -> m ()
+replLoop shell ctx st = do
+    replHandleInterrupt shell (liftIO (putStrLn "") >> replLoop shell ctx st) $ do
+      mraw <- readReplInput shell "acton> "
+      case mraw of
+        Nothing -> liftIO (putStrLn "")
+        Just raw -> do
+          block <- readReplContinuation shell raw
+          handleReplInput shell ctx st block
+
+readReplInput :: MonadIO m => ReplShell m -> String -> m (Maybe String)
+readReplInput shell prompt = replReadLine shell prompt
+
+readReplContinuation :: MonadIO m => ReplShell m -> String -> m String
+readReplContinuation shell first
+  | ":" `isPrefixOf` trim first = return first
+  | replStartsBlock first = go [first]
+  | otherwise = return first
+  where
+    go acc = do
+      mline <- readReplInput shell "... "
+      case mline of
+        Nothing -> return (unlines (reverse acc))
+        Just line
+          | null (trim line) -> return (unlines (reverse acc))
+          | otherwise -> go (line : acc)
+
+handleReplInput :: MonadIO m => ReplShell m -> ReplContext -> ReplState -> String -> m ()
+handleReplInput shell ctx st raw =
+    case words (trim raw) of
+      [] -> replLoop shell ctx st
+      [":q"] -> return ()
+      [":quit"] -> return ()
+      [":help"] -> liftIO printReplHelp >> replLoop shell ctx st
+      [":reset"] -> do
+        ok <- liftIO $ compileReplRunner ctx emptyReplState
+        if ok
+          then do
+            liftIO $ putStrLn "Session reset."
+            replLoop shell ctx emptyReplState
+          else do
+            liftIO $ hPutStrLn stderr "Session reset failed."
+            replLoop shell ctx st
+      [":show"] -> do
+        liftIO $ putStr (renderReplState st)
+        replLoop shell ctx st
+      ":dep":args ->
+        handleReplDep shell ctx st args
+      _ | ":" `isPrefixOf` trim raw -> do
+            liftIO $ hPutStrLn stderr ("Unknown REPL command: " ++ trim raw)
+            replLoop shell ctx st
+        | otherwise -> do
+            input <- liftIO $ classifyReplInput st raw
+            case input of
+              ReplTop top -> acceptReplTop shell ctx st raw top
+              ReplEvalInput eval -> runReplEval shell ctx st eval
+
+printReplHelp :: IO ()
+printReplHelp = do
+    putStrLn "Commands:"
+    putStrLn "  :help          Show this help"
+    putStrLn "  :quit, :q      Exit"
+    putStrLn "  :reset         Clear retained imports, definitions, and dependencies"
+    putStrLn "  :show          Show retained session source"
+    putStrLn "  :dep list      Show online package dependencies"
+    putStrLn "  :dep add NAME  Add an online package dependency"
+    putStrLn "  :dep rm NAME   Remove an online package dependency"
+    putStrLn ""
+    putStrLn "Definitions, imports, actors, and classes are retained as session source."
+    putStrLn "Top-level assignments are setup lines: they are replayed before each evaluation."
+    putStrLn "Expressions display non-None results. Blocks ending in ':' read continuation lines until a blank line."
+
+handleReplDep :: MonadIO m => ReplShell m -> ReplContext -> ReplState -> [String] -> m ()
+handleReplDep shell ctx st args =
+    case args of
+      [] -> liftIO (printReplDeps st) >> replLoop shell ctx st
+      ["list"] -> liftIO (printReplDeps st) >> replLoop shell ctx st
+      ["add", depName] -> addReplDep shell ctx st depName
+      ["rm", depName] -> removeReplDep shell ctx st depName
+      ["remove", depName] -> removeReplDep shell ctx st depName
+      _ -> do
+        liftIO $ hPutStrLn stderr "Usage: :dep list | :dep add NAME | :dep rm NAME"
+        replLoop shell ctx st
+
+printReplDeps :: ReplState -> IO ()
+printReplDeps st =
+    if M.null (replDeps st)
+      then putStrLn "No dependencies."
+      else forM_ (M.toList (replDeps st)) $ \(name, dep) ->
+             putStrLn (name ++ renderDepSource dep)
+  where
+    renderDepSource dep =
+      case BuildSpec.repo_url dep of
+        Just repo -> " (" ++ repo ++ ")"
+        Nothing -> ""
+
+addReplDep :: MonadIO m => ReplShell m -> ReplContext -> ReplState -> String -> m ()
+addReplDep shell ctx st depName = do
+    res <- liftIO (try (PkgCommands.resolveLibraryDependency depName) :: IO (Either ProjectError BuildSpec.PkgDep))
+    case res of
+      Left (ProjectError msg) -> do
+        liftIO $ hPutStrLn stderr msg
+        replLoop shell ctx st
+      Right dep -> do
+        let st' = st { replDeps = M.insert depName dep (replDeps st) }
+        ok <- liftIO $ compileReplRunner ctx st'
+        if ok
+          then do
+            liftIO $ putStrLn ("Added dependency " ++ depName)
+            replLoop shell ctx st'
+          else do
+            liftIO $ hPutStrLn stderr ("Dependency " ++ depName ++ " was not added.")
+            replLoop shell ctx st
+
+removeReplDep :: MonadIO m => ReplShell m -> ReplContext -> ReplState -> String -> m ()
+removeReplDep shell ctx st depName =
+    if M.member depName (replDeps st)
+      then do
+        let st' = st { replDeps = M.delete depName (replDeps st) }
+        ok <- liftIO $ compileReplRunner ctx st'
+        if ok
+          then do
+            liftIO $ putStrLn ("Removed dependency " ++ depName)
+            replLoop shell ctx st'
+          else do
+            liftIO $ hPutStrLn stderr ("Dependency " ++ depName ++ " was not removed.")
+            replLoop shell ctx st
+      else do
+        liftIO $ putStrLn ("Dependency " ++ depName ++ " not found.")
+        replLoop shell ctx st
+
+acceptReplTop :: MonadIO m => ReplShell m -> ReplContext -> ReplState -> String -> ReplTop -> m ()
+acceptReplTop shell ctx st src top = do
+    let st' = addReplTop st top src
+    okRunner <- liftIO $
+      case top of
+        ReplImport -> compileReplRunner ctx st'
+        _ | replUseProject st' && not (replUseProject st) -> compileReplRunner ctx st'
+        _ -> return True
+    if not okRunner
+      then do
+        liftIO $ hPutStrLn stderr "Input was not added to the session."
+        replLoop shell ctx st
+      else case top of
+        ReplImport -> replLoop shell ctx st'
+        ReplReplay -> do
+          ok <- liftIO $ compileReplEval ctx st' ReplNoop
+          if ok
+            then do
+              ran <- liftIO $ runReplBinary ctx
+              if ran
+                then replLoop shell ctx st'
+                else do
+                  liftIO $ hPutStrLn stderr "Input was not added to the session."
+                  replLoop shell ctx st
+            else do
+              liftIO $ hPutStrLn stderr "Input was not added to the session."
+              replLoop shell ctx st
+        _ -> do
+          ok <- liftIO $ compileReplSession ctx st'
+          if ok
+            then replLoop shell ctx st'
+            else do
+              liftIO $ hPutStrLn stderr "Input was not added to the session."
+              replLoop shell ctx st
+
+runReplEval :: MonadIO m => ReplShell m -> ReplContext -> ReplState -> ReplEval -> m ()
+runReplEval shell ctx st eval = do
+    ok <- liftIO $ compileReplEval ctx st eval
+    when ok (void (liftIO $ runReplBinary ctx))
+    replLoop shell ctx st
+
+compileReplSession :: ReplContext -> ReplState -> IO Bool
+compileReplSession ctx st = do
+    warmed <- waitReplWarmup ctx
+    ensureReplBuildAct ctx st
+    createDirectoryIfMissing True (takeDirectory (replSessionSrcFile ctx))
+    writeFileIfChanged (replSessionSrcFile ctx) (renderReplSessionSource st)
+    if warmed
+      then do
+        let opts = (replOpts ctx) { C.root = "" }
+        compileReplFiles ctx opts [replSessionSrcFile ctx]
+      else compileReplRunnerNow ctx st ReplNoop
+
+compileReplEval :: ReplContext -> ReplState -> ReplEval -> IO Bool
+compileReplEval ctx st eval = do
+    warmed <- waitReplWarmup ctx
+    ensureReplBuildAct ctx st
+    createDirectoryIfMissing True (takeDirectory (replEvalSrcFile ctx))
+    sessionChanged <- writeFileChanged (replSessionSrcFile ctx) (renderReplSessionSource st)
+    writeFile (replEvalSrcFile ctx) (renderReplEvalSource st eval)
+    if warmed
+      then do
+        let opts = (replOpts ctx) { C.root = "" }
+        sessionOk <- if sessionChanged
+                       then compileReplFiles ctx opts [replSessionSrcFile ctx]
+                       else return True
+        if sessionOk
+          then compileReplFiles ctx opts [replEvalSrcFile ctx]
+          else return False
+      else compileReplRunnerNow ctx st eval
+
+compileReplRunner :: ReplContext -> ReplState -> IO Bool
+compileReplRunner ctx st = do
+    _ <- waitReplWarmup ctx
+    compileReplRunnerNow ctx st ReplNoop
+
+compileReplRunnerNow :: ReplContext -> ReplState -> ReplEval -> IO Bool
+compileReplRunnerNow ctx st eval = do
+    ensureReplBuildAct ctx st
+    createDirectoryIfMissing True (takeDirectory (replMainSrcFile ctx))
+    writeFileIfChanged (replMainSrcFile ctx) (renderReplMainSource st)
+    writeFileIfChanged (replSessionSrcFile ctx) (renderReplSessionSource st)
+    writeFileIfChanged (replEvalSrcFile ctx) (renderReplEvalSource st eval)
+    compileReplFiles ctx (replOpts ctx) [replMainSrcFile ctx]
+
+ensureReplBuildAct :: ReplContext -> ReplState -> IO ()
+ensureReplBuildAct ctx st =
+    writeFileIfChanged (replRoot ctx </> "Build.act") (renderReplBuildAct (replDeps st) mproj)
+  where
+    mproj
+      | replUseProject st = replProject ctx
+      | otherwise         = Nothing
+
+compileReplFiles :: ReplContext -> C.CompileOptions -> [FilePath] -> IO Bool
+compileReplFiles ctx opts srcFiles = do
+    res <- try (hooksCompileFiles (replHooks ctx) (replGopts ctx) opts (replRoot ctx) srcFiles) :: IO (Either SomeException Bool)
+    case res of
+      Left err ->
+        case fromException err of
+          Just ExitSuccess -> return True
+          Just (ExitFailure _) -> return False
+          Nothing -> hPutStrLn stderr (show err) >> return False
+      Right hadErrors -> return (not hadErrors)
+
+runReplBinary :: ReplContext -> IO Bool
+runReplBinary ctx = do
+    exists <- doesFileExist (replBinFile ctx)
+    if not exists
+      then hPutStrLn stderr ("REPL binary not found: " ++ replBinFile ctx) >> return False
+      else do
+        (ec, out, err) <- readCreateProcessWithExitCode (proc (replBinFile ctx) []){ cwd = Just (replRoot ctx) } ""
+        putStr out
+        hPutStr stderr err
+        case ec of
+          ExitSuccess -> return True
+          ExitFailure code -> hPutStrLn stderr ("Process exited with status " ++ show code) >> return False
+
+renderReplState :: ReplState -> String
+renderReplState st =
+    let body = replImports st ++ map replDeclSource (replDecls st) ++ replReplay st
+    in if null body
+         then "<empty>\n"
+         else unlines (concatMap blockLines body)
+
+renderReplSessionSource :: ReplState -> String
+renderReplSessionSource st =
+    unlines (concatMap blockLines (replImports st ++ map replDeclSource (replDecls st)))
+
+renderReplMainSource :: ReplState -> String
+renderReplMainSource st =
+    unlines (concatMap blockLines (replImports st) ++
+      [ "import " ++ replEvalModuleName
+      , ""
+      , "actor main(env: Env):"
+      , "    try:"
+      , "        " ++ replEvalModuleName ++ ".eval()"
+      , "        env.exit(0)"
+      , "    except Exception as exc:"
+      , "        print(exc)"
+      , "        env.exit(1)"
+      ])
+
+renderReplEvalPlaceholderSource :: String
+renderReplEvalPlaceholderSource =
+    unlines
+      [ "from " ++ replSessionModuleName ++ " import *"
+      , ""
+      , "proc def eval():"
+      , "    pass"
+      ]
+
+renderReplEvalSource :: ReplState -> ReplEval -> String
+renderReplEvalSource st eval =
+    renderReplEvalImports st
+    ++ "proc def eval():\n"
+    ++ renderReplEvalBody st eval
+
+renderReplEvalImports :: ReplState -> String
+renderReplEvalImports st =
+    unlines (concatMap blockLines (replImports st) ++ ["from " ++ replSessionModuleName ++ " import *", ""])
+
+renderReplEvalBody :: ReplState -> ReplEval -> String
+renderReplEvalBody st eval =
+    case replay ++ current of
+      []    -> "    pass\n"
+      lines -> unlines (map ("    " ++) lines)
+  where
+    replay = concatMap blockLines (replReplay st)
+    current =
+      case eval of
+        ReplExpr src -> renderReplExprBody src
+        ReplStmt src -> blockLines src
+        ReplNoop    -> []
+
+renderReplExprBody :: String -> [String]
+renderReplExprBody src =
+    [ replValueName ++ " = " ++ trim src
+    , "if " ++ replValueName ++ " is not None:"
+    , "    print(" ++ replValueName ++ ")"
+    ]
+
+replValueName :: String
+replValueName = "__repl_value"
+
+addReplTop :: ReplState -> ReplTop -> String -> ReplState
+addReplTop st top src =
+    case top of
+      ReplImport -> st { replImports = replImports st ++ [src], replUseProject = True }
+      ReplDeclTop ns -> st { replDecls = replaceReplDecl ns src (replDecls st) }
+      ReplReplay -> st { replReplay = replReplay st ++ [src] }
+
+replaceReplDecl :: [String] -> String -> [ReplDecl] -> [ReplDecl]
+replaceReplDecl ns src decls
+  | null ns   = decls ++ [ReplDecl ns src]
+  | otherwise = filter (not . any (`elem` ns) . replDeclNames) decls ++ [ReplDecl ns src]
+
+replDeclNames :: ReplDecl -> [String]
+replDeclNames (ReplDecl ns _) = ns
+
+replDeclSource :: ReplDecl -> String
+replDeclSource (ReplDecl _ src) = src
+
+classifyReplInput :: ReplState -> String -> IO ReplInput
+classifyReplInput _ src = do
+    moduleRes <- parseReplModule src
+    case moduleRes of
+      Right (A.Module _ is _ body)
+        | not (null is) && null body -> return (ReplTop ReplImport)
+        | null is && replAllDecls body ->
+            return (ReplTop (ReplDeclTop (concatMap replStmtNames body)))
+        | null is && replAllReplay body -> return (ReplTop ReplReplay)
+      _ -> do
+        exprRes <- parseReplExpr src
+        case exprRes of
+          Right _ -> return (ReplEvalInput (ReplExpr src))
+          Left _  -> return (ReplEvalInput (ReplStmt src))
+
+parseReplModule :: String -> IO (Either SomeException A.Module)
+parseReplModule src =
+    try (Acton.Parser.parseModule (A.modName [replEvalModuleName]) "repl_input.act" src Nothing)
+
+parseReplExpr :: String -> IO (Either SomeException A.Expr)
+parseReplExpr src =
+    try (Acton.Parser.parseExpression "repl_input.act" src)
+
+replAllDecls :: A.Suite -> Bool
+replAllDecls ss = not (null ss) && all replIsDeclStmt ss
+
+replIsDeclStmt :: A.Stmt -> Bool
+replIsDeclStmt A.Signature{} = True
+replIsDeclStmt A.Decl{}      = True
+replIsDeclStmt _             = False
+
+replAllReplay :: A.Suite -> Bool
+replAllReplay ss = not (null ss) && all replIsReplayStmt ss
+
+replIsReplayStmt :: A.Stmt -> Bool
+replIsReplayStmt A.Assign{} = True
+replIsReplayStmt _          = False
+
+replStmtNames :: A.Stmt -> [String]
+replStmtNames A.Signature{A.vars=ns} = map A.rawstr ns
+replStmtNames A.Decl{A.decls=ds}     = map (A.rawstr . A.dname) ds
+replStmtNames _                      = []
+
+replStartsBlock :: String -> Bool
+replStartsBlock src = ":" `isSuffixOf` trimRight src
+
+blockLines :: String -> [String]
+blockLines src = lines (trimRight src)
+
+trim :: String -> String
+trim = trimRight . dropWhile isSpace
+
+trimRight :: String -> String
+trimRight = Data.List.dropWhileEnd isSpace

--- a/compiler/acton/package.yaml.in
+++ b/compiler/acton/package.yaml.in
@@ -35,6 +35,7 @@ dependencies:
   - filelock
   - filepath
   - fsnotify
+  - haskeline
   - http-client
   - http-client-tls
   - http-types
@@ -64,7 +65,9 @@ executables:
     main:                Main.hs
     source-dirs:         .
     other-modules:
+      - FileUtil
       - PkgCommands
+      - Repl
       - Paths_acton
       - TerminalProgress
       - TerminalSize

--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -165,6 +165,204 @@ compilerTests =
           assertBool "dynamic executable should not search Zig cache directory"
             (not ("zig-local-cache" `isInfixOf` rpathOut))
 #endif
+  , testCase "repl retains common definitions and replays setup" $ do
+        withSystemTempDirectory "acton-repl-assignment" $ \proj -> do
+          actonExe <- canonicalizePath "../../dist/bin/acton"
+          let replRoot = proj </> ".acton-repl"
+          let input = unlines
+                [ "def label() -> str:"
+                , "    return \"old function\""
+                , ""
+                , "def label() -> str:"
+                , "    return \"new function\""
+                , ""
+                , "label()"
+                , "answer = 42"
+                , "answer"
+                , "import math"
+                , "math.sqrt(9.0)"
+                , "print(\"direct print\")"
+                , "proc def log():"
+                , "    print(\"proc call\")"
+                , ""
+                , "log()"
+                , "class Box(object):"
+                , "    def __init__(self, name: str):"
+                , "        self.name = name"
+                , "    def describe(self) -> str:"
+                , "        return \"class \" + self.name"
+                , ""
+                , "Box(\"method\").describe()"
+                , "class Speaker(object):"
+                , "    def __init__(self):"
+                , "        pass"
+                , "    proc def say(self):"
+                , "        print(\"method proc\")"
+                , ""
+                , "Speaker().say()"
+                , "class Other(object):"
+                , "    def __init__(self):"
+                , "        pass"
+                , "    def say(self) -> str:"
+                , "        return \"pure method\""
+                , ""
+                , "Other().say()"
+                , "actor Foo():"
+                , "    print(\"old Foo\")"
+                , ""
+                , "actor Foo():"
+                , "    print(\"hello from Foo\")"
+                , ""
+                , "f = Foo()"
+                , ":q"
+                ]
+          (returnCode, cmdOut, cmdErr) <- readCreateProcessWithExitCode
+            (proc actonExe ["repl", "--color", "never", "--tempdir", proj]) input
+          assertEqual ("acton repl should exit successfully: " ++ cmdErr) ExitSuccess returnCode
+          assertBool "repl should evaluate retained functions"
+            ("new function\n" `isInfixOf` cmdOut)
+          assertBool "repl should replace redefined functions"
+            (not ("old function\n" `isInfixOf` cmdOut))
+          assertBool "repl should evaluate retained local names"
+            ("42\n" `isInfixOf` cmdOut)
+          assertBool "repl should make retained imports visible to eval"
+            ("3\n" `isInfixOf` cmdOut)
+          assertBool "repl should run direct print calls without printing None"
+            ("direct print\n" `isInfixOf` cmdOut)
+          assertBool "repl should run retained proc calls without printing None"
+            ("proc call\n" `isInfixOf` cmdOut)
+          assertBool "repl should evaluate retained class methods"
+            ("class method\n" `isInfixOf` cmdOut)
+          assertBool "repl should run effectful retained methods without printing None"
+            ("method proc\n" `isInfixOf` cmdOut)
+          assertBool "repl should still print unrelated pure methods with the same name"
+            ("pure method\n" `isInfixOf` cmdOut)
+          assertBool "repl should not print None for None-valued expressions"
+            (not ("None\n" `isInfixOf` cmdOut))
+          assertBool "repl should run effectful retained assignments"
+            ("hello from Foo\n" `isInfixOf` cmdOut)
+          assertBool "repl should replace redefined declarations"
+            (not ("old Foo\n" `isInfixOf` cmdOut))
+          assertBool "repl should not retain effectful assignments at module top level"
+            (not ("Constraint violation" `isInfixOf` cmdErr))
+          sessionSrc <- readFile (replRoot </> "src" </> "repl_session.act")
+          evalSrc <- readFile (replRoot </> "src" </> "repl_eval.act")
+          assertBool "repl should retain declarations in session module"
+            ("actor Foo():" `isInfixOf` sessionSrc)
+          assertBool "repl should retain classes in session module"
+            ("class Box(object):" `isInfixOf` sessionSrc)
+          assertBool "repl should retain latest function definition in session module"
+            ("return \"new function\"" `isInfixOf` sessionSrc)
+          assertBool "repl should drop replaced function definitions"
+            (not ("return \"old function\"" `isInfixOf` sessionSrc))
+          assertBool "repl eval should import session module"
+            ("from repl_session import *" `isInfixOf` evalSrc)
+          assertBool "repl eval should retain imports used by expressions"
+            ("import math" `isInfixOf` evalSrc)
+          assertBool "repl eval should not duplicate retained declarations"
+            (not ("actor Foo():" `isInfixOf` evalSrc))
+          assertBool "repl eval should not duplicate retained classes"
+            (not ("class Box(object):" `isInfixOf` evalSrc))
+  , testCase "repl reset clears generated session" $ do
+        withSystemTempDirectory "acton-repl-reset" $ \proj -> do
+          actonExe <- canonicalizePath "../../dist/bin/acton"
+          let replRoot = proj </> ".acton-repl"
+          let input = unlines
+                [ "def gone() -> str:"
+                , "    return \"leak\""
+                , ""
+                , "gone()"
+                , ":reset"
+                , ":show"
+                , "gone()"
+                , "2 + 2"
+                , ":q"
+                ]
+          (returnCode, cmdOut, cmdErr) <- readCreateProcessWithExitCode
+            (proc actonExe ["repl", "--color", "never", "--parse", "--tempdir", proj]) input
+          assertEqual ("acton repl should exit successfully: " ++ cmdErr) ExitSuccess returnCode
+          assertEqual "repl should only see pre-reset definitions before reset"
+            1 (length (splitOn "leak\n" cmdOut) - 1)
+          assertBool "repl should report empty session after reset"
+            ("<empty>\n" `isInfixOf` cmdOut)
+          assertBool "repl should continue evaluating after reset"
+            ("4\n" `isInfixOf` cmdOut)
+          sessionSrc <- readFile (replRoot </> "src" </> "repl_session.act")
+          assertBool "repl reset should rewrite session source"
+            (not ("def gone()" `isInfixOf` sessionSrc))
+  , testCase "repl reused scratch starts with empty session" $ do
+        withSystemTempDirectory "acton-repl-reuse" $ \proj -> do
+          actonExe <- canonicalizePath "../../dist/bin/acton"
+          let replRoot = proj </> ".acton-repl"
+          let firstInput = unlines
+                [ "def gone() -> str:"
+                , "    return \"leak\""
+                , ""
+                , "gone()"
+                , ":q"
+                ]
+              secondInput = unlines
+                [ ":show"
+                , "gone()"
+                , "2 + 2"
+                , ":q"
+                ]
+          (firstCode, firstOut, firstErr) <- readCreateProcessWithExitCode
+            (proc actonExe ["repl", "--color", "never", "--tempdir", proj]) firstInput
+          assertEqual ("first acton repl should exit successfully: " ++ firstErr) ExitSuccess firstCode
+          assertEqual "first repl should see retained definition"
+            1 (length (splitOn "leak\n" firstOut) - 1)
+          (secondCode, secondOut, secondErr) <- readCreateProcessWithExitCode
+            (proc actonExe ["repl", "--color", "never", "--tempdir", proj]) secondInput
+          assertEqual ("second acton repl should exit successfully: " ++ secondErr) ExitSuccess secondCode
+          assertBool "reused repl should show empty in-memory session"
+            ("<empty>\n" `isInfixOf` secondOut)
+          assertEqual "reused repl should not call stale session definition"
+            0 (length (splitOn "leak\n" secondOut) - 1)
+          assertBool "reused repl should continue after stale name rejection"
+            ("4\n" `isInfixOf` secondOut)
+          sessionSrc <- readFile (replRoot </> "src" </> "repl_session.act")
+          assertBool "reused repl should rewrite stale session source"
+            (not ("def gone()" `isInfixOf` sessionSrc))
+  , testCase "repl tempdir does not clobber parent project" $ do
+        withSystemTempDirectory "acton-repl-tempdir-parent" $ \proj -> do
+          actonExe <- canonicalizePath "../../dist/bin/acton"
+          let input = unlines
+                [ "2 + 2"
+                , ":q"
+                ]
+              buildAct = proj </> "Build.act"
+          writeFile buildAct "name = \"real_project\"\n"
+          (returnCode, cmdOut, cmdErr) <- readCreateProcessWithExitCode
+            (proc actonExe ["repl", "--color", "never", "--tempdir", proj]) input
+          assertEqual ("acton repl should exit successfully: " ++ cmdErr) ExitSuccess returnCode
+          assertBool "repl should evaluate in owned tempdir"
+            ("4\n" `isInfixOf` cmdOut)
+          parentBuildAct <- readFile buildAct
+          assertEqual "repl should not overwrite parent Build.act"
+            "name = \"real_project\"\n" parentBuildAct
+          replBuildActExists <- doesFileExist (proj </> ".acton-repl" </> "Build.act")
+          assertBool "repl should write Build.act in owned subdir" replBuildActExists
+  , testCase "repl rejects failing setup assignments" $ do
+        withSystemTempDirectory "acton-repl-failing-assignment" $ \proj -> do
+          actonExe <- canonicalizePath "../../dist/bin/acton"
+          let input = unlines
+                [ "x = 1 / 0"
+                , "2 + 2"
+                , ":show"
+                , ":q"
+                ]
+          (returnCode, cmdOut, cmdErr) <- readCreateProcessWithExitCode
+            (proc actonExe ["repl", "--color", "never", "--tempdir", proj]) input
+          assertEqual ("acton repl should exit successfully: " ++ cmdErr) ExitSuccess returnCode
+          assertBool "repl should report runtime assignment failure"
+            ("Process exited with status 1\n" `isInfixOf` cmdErr)
+          assertBool "repl should reject failing setup line"
+            ("Input was not added to the session.\n" `isInfixOf` cmdErr)
+          assertBool "repl should continue after failing setup line"
+            ("4\n" `isInfixOf` cmdOut)
+          assertBool "repl should not retain failing setup line"
+            ("<empty>\n" `isInfixOf` cmdOut)
   , testCase "deps" $ do
         (returnCode, cmdOut, cmdErr) <- readCreateProcessWithExitCode (shell $ "rm -rf ../../test/compiler/test_deps/build.zig*") ""
         (returnCode, cmdOut, cmdErr) <- readCreateProcessWithExitCode (shell $ "rm -rf ../../test/compiler/test_deps/out") ""

--- a/compiler/lib/src/Acton/CommandLineParser.hs
+++ b/compiler/lib/src/Acton/CommandLineParser.hs
@@ -45,6 +45,7 @@ data Command        = New NewOptions
                     | Uninstall UninstallOptions
                     | Sig SigOptions
                     | Test TestCommand
+                    | Repl CompileOptions
                     | Fetch
                     | PkgShow
                     | PkgAdd PkgAddOptions
@@ -213,6 +214,7 @@ cmdLineParser       = hsubparser
                         <> command "uninstall" (info (CmdOpt <$> globalOptions <*> (Uninstall <$> uninstallOptions)) (progDesc "Uninstall an Acton application package"))
                         <> command "sig"     (info (CmdOpt <$> globalOptions <*> (Sig <$> sigOptions)) (progDesc "Show inferred type signatures"))
                         <> command "test"    (info (CmdOpt <$> globalOptions <*> (Test <$> testCommand)) (progDesc "Build and run project tests"))
+                        <> command "repl"    (info (CmdOpt <$> globalOptions <*> (Repl <$> compileOptions)) (progDesc "Run an interactive Acton shell"))
                         <> command "fetch"   (info (CmdOpt <$> globalOptions <*> pure Fetch) (progDesc "Fetch project dependencies (offline prep)"))
                         <> command "pkg"     (info (CmdOpt <$> globalOptions <*> pkgSubcommands) (progDesc "Library package/dependency commands"))
                         <> command "zig-pkg" (info (CmdOpt <$> globalOptions <*> zigPkgSubcommands) (progDesc "Zig package dependency commands"))

--- a/compiler/lib/src/Acton/Parser.hs
+++ b/compiler/lib/src/Acton/Parser.hs
@@ -155,6 +155,13 @@ parseModuleHeader fileName fileContent =
         Left err -> Control.Exception.throw err
         Right res -> return res
 
+parseExpression :: String -> String -> IO S.Expr
+parseExpression fileName fileContent =
+    let contentWithNewline = addFinalNewline fileContent
+    in case runParser (St.evalStateT (rhs <* sc2 <* eof) initState) fileName contentWithNewline of
+        Left err -> Control.Exception.throw err
+        Right res -> return res
+
 addFinalNewline :: String -> String
 addFinalNewline s
     | null s || last s == '\n' = s

--- a/compiler/stack.yaml
+++ b/compiler/stack.yaml
@@ -43,6 +43,7 @@ extra-deps:
   - dir-traverse-0.2.3.0
   - directory-1.3.8.5
   - filepath-1.4.300.1
+  - haskeline-0.8.4.1@sha256:349296dd2e58dc9d2daabaa3fcacc2de9af5828ce8491c07f3f392ae65a98f7a,6178
   - lsp-2.7.0.0
   - lsp-types-2.3.0.0
   - parsec-3.1.17.0@sha256:8407cbd428d7f640a0fff8891bd2f7aca13cebe70a5e654856f8abec9a648b56

--- a/compiler/stack.yaml.lock
+++ b/compiler/stack.yaml.lock
@@ -40,6 +40,13 @@ packages:
   original:
     hackage: filepath-1.4.300.1
 - completed:
+    hackage: haskeline-0.8.4.1@sha256:349296dd2e58dc9d2daabaa3fcacc2de9af5828ce8491c07f3f392ae65a98f7a,6178
+    pantry-tree:
+      sha256: 43b5325128eea82943bc0f9dbaf4f19c9e6af26dcce571938459313c7fc7e6b1
+      size: 2968
+  original:
+    hackage: haskeline-0.8.4.1@sha256:349296dd2e58dc9d2daabaa3fcacc2de9af5828ce8491c07f3f392ae65a98f7a,6178
+- completed:
     hackage: lsp-2.7.0.0@sha256:cec57fe8924368ab3f431726b0ca0c9d76fad025161fc3d2fde71ed814d0bf7e,3998
     pantry-tree:
       sha256: 93f62225c8d50459fb05346630aaf3934d7a4000dcfe5109e7ff45d94d8a283f

--- a/docs/acton-dev-guide/src/SUMMARY.md
+++ b/docs/acton-dev-guide/src/SUMMARY.md
@@ -11,6 +11,7 @@
   - [Interface caches](compiler/interface_caches.md)
   - [Imports and environments](compiler/imports_and_envs.md)
   - [Project dependencies](compiler/project_dependencies.md)
+  - [REPL implementation](compiler/repl.md)
   - [Test result cache](compiler/test_cache.md)
   - [Passes](compiler/passes/index.md)
     - [Parse](compiler/passes/parse.md)

--- a/docs/acton-dev-guide/src/compiler/index.md
+++ b/docs/acton-dev-guide/src/compiler/index.md
@@ -19,5 +19,8 @@ See [Project dependencies](project_dependencies.md) for how Acton package
 dependencies and zig dependencies are discovered, fetched, and emitted into the
 generated Zig build files.
 
+See [REPL implementation](repl.md) for how `acton repl` maps interactive input
+onto generated Acton modules and dynamic-library builds.
+
 See [Passes](passes/index.md) for the stage-by-stage pipeline and how front and
 back passes split the work.

--- a/docs/acton-dev-guide/src/compiler/repl.md
+++ b/docs/acton-dev-guide/src/compiler/repl.md
@@ -1,0 +1,185 @@
+# REPL Implementation
+
+The REPL implementation lives in `compiler/acton/Repl.hs`. The command-line
+parser maps `acton repl` to `C.Repl`, and `Main.main` dispatches that command
+to `Repl.runRepl` with a small hook record for compiler-driver operations.
+
+The design is deliberately compiler-backed. The REPL does not maintain a live
+Acton VM and does not evaluate AST nodes directly. Instead it owns a small
+scratch Acton project, rewrites generated source files for each accepted input,
+compiles the changed module, and runs a stable executable runner. This keeps
+the REPL behavior close to ordinary compilation at the cost of compile latency.
+
+## Generated project
+
+`runRepl` creates a `ReplContext` with paths for a generated project:
+
+- `src/repl_session.act`
+- `src/repl_eval.act`
+- `src/repl_main.act`
+- `out/bin/repl_main`
+
+`renderReplBuildAct` writes a `Build.act` that declares `repl_session` and
+`repl_eval` as dynamic libraries. `repl_main` links against those libraries and
+is the executable run after each successful evaluation.
+
+The generated modules have fixed roles:
+
+- `repl_session` contains retained imports and declarations.
+- `repl_eval` renders retained imports, imports `repl_session`, and exposes one
+  stable entry point, `proc def eval()`.
+- `repl_main` renders retained imports, imports `repl_eval`, calls
+  `repl_eval.eval()`, reports failure by exiting non-zero, and otherwise exits
+  successfully.
+
+The fixed `eval` symbol is the ABI between the runner executable and the
+current evaluation module. User input can change the body of `eval`, but not the
+entry point that `repl_main` calls.
+
+## State model
+
+`ReplState` is the in-memory source model for the current interactive session:
+
+- `replImports` stores retained import source blocks.
+- `replDecls` stores retained declaration source blocks plus their top-level
+  names.
+- `replReplay` stores accepted top-level assignment blocks.
+- `replDeps` stores online dependencies added with `:dep`.
+- `replUseProject` records whether the user's containing project should be
+  added as a path dependency to the scratch project.
+
+Retained declarations are replaced by top-level name. If a user enters a new
+definition for `foo`, `replaceReplDecl` removes older retained declaration
+blocks that provided `foo` before appending the new block. This avoids duplicate
+C symbols after redefinition.
+
+Assignments are not retained as module-level source. They are replayed inside
+`repl_eval.eval()` before the current input. This is why setup such as
+`f = Foo()` can run actor construction or other effectful code without placing
+effectful statements at Acton module top level.
+
+When an accepted assignment fails at runtime, `acceptReplTop` does not move to
+the new `ReplState`. The source line is therefore not replayed by later inputs.
+
+## Input classification
+
+The REPL classifies input with the normal Acton parser, not by string matching.
+`classifyReplInput` first tries to parse the input as a module-shaped top-level
+chunk:
+
+- imports become `ReplImport`
+- signatures and declarations become `ReplDeclTop`
+- assignment-only chunks become `ReplReplay`
+
+If the module parse does not produce one of those accepted top-level shapes, the
+REPL parses the input as an assignment-right-hand-side expression. A successful
+expression parse becomes `ReplExpr`; otherwise the input becomes `ReplStmt` and
+is inserted directly into `eval`.
+
+`ReplExpr` does not try to classify effectful calls. It renders the expression
+through a local result binding:
+
+```python
+__repl_value = EXPR
+if __repl_value is not None:
+    print(__repl_value)
+```
+
+This keeps display behavior in ordinary Acton code instead of maintaining a
+parallel type or object model in the REPL. Expressions that produce a value are
+shown. Calls that return `None`, including `print(...)` and `proc def` calls,
+run without printing an extra `None`.
+
+## Compile flow
+
+Runner creation and evaluation use three paths:
+
+- `compileReplRunnerNow` writes all generated sources and builds
+  `repl_main`.
+- `compileReplSession` rewrites `repl_session` and, after the startup runner
+  build has succeeded, rebuilds only that source.
+- `compileReplEval` rewrites `repl_eval`, rebuilds `repl_session` first if the
+  rendered session source changed, and then rebuilds only `repl_eval`.
+
+`compileReplFiles` calls the compiler-driver hook supplied by `Main`. That hook
+wraps `compileFilesChanged` with the scratch project root.
+
+Accepted imports rebuild the runner. The runner needs the retained imports so
+symbols referenced from the dynamic evaluation library are resolvable by the
+process that loads it.
+
+`startReplWarmup` compiles a placeholder runner in the background as soon as the
+REPL starts. The first user input waits for that warmup through
+`waitReplWarmup` before it edits or compiles the generated sources. If the
+warmup succeeds, later expression evaluations can use the single-module fast
+path.
+
+The REPL does not inspect platform-specific dynamic-library artifacts to decide
+whether a cached runner is valid. It relies on the normal compiler and Zig build
+paths to decide which generated outputs are stale.
+
+## Scratch directories
+
+Without `--tempdir`, the REPL uses a persistent cache directory under
+`actonCacheDir/repl`. The key is either `global` for standalone REPLs or a
+fingerprint-derived key for a containing project. That lets a later `acton repl`
+start by running the normal placeholder runner build against existing scratch
+outputs while still beginning with an empty in-memory session.
+
+With `--tempdir DIR`, `DIR` is treated as a parent directory. The generated
+project is written under `DIR/.acton-repl` so a command such as
+`acton repl --tempdir .` does not overwrite a real project's `Build.act` or
+`src` tree.
+
+## Dependencies
+
+`:dep add NAME` uses `PkgCommands.resolveLibraryDependency`, renders a scratch
+`Build.act` with the updated dependency set, and immediately rebuilds the
+runner. The dependency is retained in `replDeps` only if that compile succeeds.
+
+Imports also matter for local project access. `runRepl` detects whether the
+current directory is inside an Acton project, but the scratch project only adds
+that project dependency once the session has accepted an import. This is a
+coarse activation point; the import may be from the project or from another
+dependency.
+
+## Compile options
+
+`normalizeReplCompileOptions` clears compiler inspection and build-shape flags
+that do not make sense for the generated runner, such as parse dumps, signature
+dumps, `--skip-build`, `--only-build`, continuous rebuild mode, and test mode.
+It also fixes the root actor to `repl_main.main`.
+
+This normalization is part of the REPL runtime contract: user-supplied compile
+options may still affect target and optimization choices, but they must not
+turn an evaluation into a parser dump or suppress the runner build.
+
+## Shell behavior
+
+The interactive shell is Haskeline-based. It keeps command history in the Acton
+cache directory, enables interrupt handling, and exposes completion for REPL
+commands and `:dep` subcommands. File-path completion is intentionally not
+enabled.
+
+Continuation reading is simple: a line ending in `:` enters continuation mode,
+and a blank continuation line ends the block. This is easy to reason about but
+does not try to be a full paste parser for every multiline expression shape.
+
+## Tests
+
+The focused tests are in `compiler/acton/test.hs` under the compiler test group.
+They cover:
+
+- retained functions, classes, proc functions, actors, and proc methods
+- top-level assignment replay inside `eval`
+- declaration redefinition removing old source
+- `:reset` clearing generated session source
+- persistent scratch reuse starting from an empty in-memory session
+- explicit `--tempdir` writing under `.acton-repl`
+- rejection of failing setup assignments
+
+Use this focused command while working on REPL behavior:
+
+```console
+stack test acton --ta '-p "repl"'
+```

--- a/docs/acton-guide/src/SUMMARY.md
+++ b/docs/acton-guide/src/SUMMARY.md
@@ -2,6 +2,7 @@
 
 - [Getting started](index.md)
   - [Hello World](hello.md)
+  - [Acton REPL](repl.md)
   - [Installation](install.md)
     - [Tip / Nightly](install_tip.md)
   - [Acton scripts](hello/shebang.md)

--- a/docs/acton-guide/src/repl.md
+++ b/docs/acton-guide/src/repl.md
@@ -1,0 +1,160 @@
+# Acton REPL
+
+`acton repl` starts an interactive shell for trying Acton code without creating
+a normal project by hand.
+
+```console
+$ acton repl
+Acton REPL. Type :help for commands, :quit to exit.
+acton> 1 + 2
+3
+acton> :quit
+```
+
+The REPL is still compiler-backed. It writes a small scratch project, compiles
+the code you enter, and runs a small generated executable. This makes it slower
+than a bytecode interpreter, but it uses the same parser, type checker, code
+generator, and runtime as normal Acton programs.
+
+## Session source
+
+The REPL keeps a source model of the current interactive session.
+
+Imports, signatures, functions, classes, actors, and other declarations are
+retained as session source:
+
+```python
+acton> def greet(name: str) -> str:
+...     return "hello " + name
+...
+acton> greet("Ada")
+hello Ada
+```
+
+If you redefine a retained top-level name, the previous definition for that
+name is removed from the session before the next compile:
+
+```python
+acton> def greet(name: str) -> str:
+...     return "hi " + name
+...
+acton> greet("Ada")
+hi Ada
+```
+
+Top-level assignments are handled differently. They are replayed as setup code
+inside the implicit evaluation procedure before each evaluation, instead of
+being emitted at module top level. This allows effectful setup, including actor
+creation:
+
+```python
+acton> actor Foo():
+...     print("hello from Foo")
+...
+acton> f = Foo()
+hello from Foo
+```
+
+Use `:show` to inspect the retained session source and `:reset` to clear it:
+
+```console
+acton> :show
+def greet(name: str) -> str:
+    return "hi " + name
+
+acton> :reset
+Session reset.
+acton> :show
+<empty>
+```
+
+## Expressions and statements
+
+Plain expressions are evaluated and non-`None` results are printed
+automatically:
+
+```python
+acton> "ab" + "cd"
+abcd
+```
+
+The generated `eval` procedure stores the expression result in a local variable
+and prints it only when it is not `None`. Calls that already print or otherwise
+return `None` therefore do not produce an extra `None` line:
+
+```python
+acton> proc def log():
+...     print("logged")
+...
+acton> log()
+logged
+```
+
+Inputs that are not a single expression compile as statement blocks and report
+compiler errors in the usual way.
+
+Actor construction returns an actor reference, so a direct constructor
+expression displays that reference after starting the actor. Use a setup
+assignment if you want to start the actor without displaying the reference:
+
+```python
+acton> f = Foo()
+```
+
+## Scratch project
+
+By default, the REPL uses a cache-backed scratch directory so the generated
+project outputs can be reused by the normal warmup build across REPL starts.
+The scratch project contains three generated Acton modules:
+
+- `repl_session` contains retained imports and declarations.
+- `repl_eval` renders retained imports, imports `repl_session`, and defines a
+  fixed `proc def eval()` entry point with setup replay and the current input.
+- `repl_main` renders retained imports and is the executable runner that calls
+  `repl_eval.eval()` and exits.
+
+`repl_session` and `repl_eval` are built as dynamic libraries. Most evaluations
+therefore rebuild only the changed evaluation module instead of relinking the
+runner executable.
+
+If you pass `--tempdir DIR`, Acton treats `DIR` as a parent directory and writes
+the scratch project under `DIR/.acton-repl`. This avoids overwriting a real
+project's `Build.act` or `src` directory.
+
+## Dependencies and projects
+
+In a standalone REPL, use `:dep add NAME` to add a library package from the
+online package index:
+
+```console
+acton> :dep add textfsm
+Added dependency textfsm
+```
+
+Use `:dep list` to show REPL dependencies and `:dep rm NAME` to remove one.
+The REPL intentionally does not expose local path dependency commands.
+
+When started inside an Acton project, the REPL adds that project as a local
+scratch dependency after the first accepted import. The generated scratch
+project stays outside the project source tree.
+
+## Commands and editing
+
+The interactive shell supports readline-style editing, including common cursor
+movement keys such as `Ctrl-a` and `Ctrl-e`. Tab completion covers REPL commands
+and `:dep` subcommands, not filesystem paths.
+
+Available commands:
+
+```console
+:help          Show REPL help
+:quit, :q      Exit
+:reset         Clear retained imports, definitions, setup, and dependencies
+:show          Show retained session source
+:dep list      Show online package dependencies
+:dep add NAME  Add an online package dependency
+:dep rm NAME   Remove an online package dependency
+```
+
+For multi-line definitions, enter the header line ending in `:` and then
+continue at the `...` prompt. A blank line ends the block.


### PR DESCRIPTION
Introduce `acton repl` as a compiler-backed REPL command. It creates a cache-backed scratch project, builds a small runner executable, and compiles user input into a `repl_eval` dynamic library so repeated evaluations avoid relinking the full executable, thus saving time, which is rather important for a REPL. We get something like 0.2-0.3 seconds best case for "evaluating" an expression, i.e. compiling and running it. Not snappy, but sort of OK.

The REPL starts by writing placeholder generated modules and firing a normal runner build in the background. The first real input waits for that build before editing generated sources. After that, expression evaluation can usually rebuild only the changed module, while validity and stale-output decisions stay in the normal compiler and Zig build paths rather than in REPL-specific artifact probes.

The implementation lives in `compiler/acton/Repl.hs`. `Main` keeps command dispatch and passes a small hook record for cache directories, scratch locking, and compiler-driver builds, so the REPL source model and shell behavior stay out of the main command driver without moving the general compile pipeline.

The REPL keeps a small source model of the interactive session. Imports, signatures, functions, classes, actors, and other declarations are retained as session source. If a user redefines a retained top-level name, the previous definition for that name is removed before the next compile. Top-level assignments are handled differently: they are treated as setup code and replayed inside the implicit `eval` procedure before each evaluation, rather than being emitted at module top level. That lets inputs like `f = Foo()` create actors or run other effectful setup without violating module-level purity rules.

The generated scratch project has three Acton modules. `repl_session` contains the retained imports and declarations. `repl_eval` renders retained imports, imports `repl_session`, and defines a fixed `proc def eval()` entry point containing the replayed setup code and the current expression or statement. `repl_main` is the stable executable runner: it renders retained imports so dynamic-library references can resolve in the loading process, calls `repl_eval.eval()`, reports failures as process failures, and then exits. `repl_session` and `repl_eval` are dynamic libraries, so most evaluations only rebuild the changed module instead of relinking the runner.

Expression input is evaluated through a local result binding. `repl_eval.eval` assigns the expression to a generated local variable and prints that value only when it is not `None`. This keeps display behavior in ordinary Acton code: value expressions are shown, while calls such as `print("x")` or a retained `proc def` run without printing an extra `None` line.

`:reset` clears the in-memory session model and rewrites the generated `repl_session` and `repl_eval` files, so old definitions from a previous session cannot leak into later evaluations. The default scratch directory is cache-backed; each REPL start runs the normal placeholder runner build against that scratch tree, so compiler and Zig incremental behavior decide what can be reused. Explicit `--tempdir` values are treated as parent directories and the REPL writes its own project under `.acton-repl`, avoiding accidental writes to a real project in the parent directory.

The interactive shell uses readline-style line editing through Haskeline and offers tab completion for REPL commands and `:dep` subcommands, not filesystem paths. Online dependencies can be added and removed with `:dep add NAME` and `:dep rm NAME`; local path controls are intentionally not exposed from the REPL. The Acton guide documents the user-facing REPL behavior, while the developer guide documents the implementation model for generated modules, input classification, compile flow, scratch directories, dependencies, and tests.