### PR TITLE
Implement deferred back passes

### DIFF
--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -998,7 +998,7 @@ compileSigTarget gopts queryGopts opts paths rootProj sysAbs depOverrides target
           , ccOnInfo = \msg -> when (C.verbose gopts) $ putStrLn msg
           , ccOnBackJob = \_ -> return ()
           }
-    compileRes <- compileTasks sp queryGopts opts' (ccPathsRoot cctx') (ccRootProj cctx') (cpNeededTasks plan) callbacks
+    compileRes <- compileTasks sp queryGopts opts' (ccPathsRoot cctx') (ccRootProj cctx') (cpNeededTasks plan) (cpDbpBlocked plan) callbacks
     case compileRes of
       Left err -> printErrorAndExit (compileFailureMessage err)
       Right (_, hadErrors) -> when hadErrors System.Exit.exitFailure
@@ -1871,9 +1871,9 @@ initCliCompileHooks progressUI progressState gopts sched gen plan = do
                     logRendered (\cols -> detailLine cols detailStmtIndentWide detailStmtIndentNarrow (inferredSignatureLine sig))
                     forM_ (lines (isigSignature sig)) $ \line ->
                       logRendered (\cols -> detailLine cols detailBindsIndentWide detailBindsIndentNarrow line)
-              case frBackJob fr of
-                Nothing -> creditBack (gtKey t)
-                Just _ -> return ()
+              case (frBackJob fr, frDeferredBackJob fr) of
+                (Nothing, Nothing) -> creditBack (gtKey t)
+                _ -> return ()
           , chOnFrontStart = \t ->
               let key = gtKey t
                   proj = tkProj key
@@ -1890,6 +1890,7 @@ initCliCompileHooks progressUI progressState gopts sched gen plan = do
               gate (progressDoneTask progressUI progressState (gtKey t))
               creditFront (gtKey t)
           , chOnBackQueued = \_ _ -> return ()
+          , chOnBackSkipped = creditBack
           , chOnBackStart = onBackStart
           , chOnBackProgress = onBackProgress
           , chOnBackDone = onBackDone

--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -171,6 +171,213 @@ compilerTests =
         (returnCode, cmdOut, cmdErr) <- readCreateProcessWithExitCode (shell $ "rm -rf ../../test/compiler/test_deps/deps/a/build.zig*") ""
         (returnCode, cmdOut, cmdErr) <- readCreateProcessWithExitCode (shell $ "rm -rf ../../test/compiler/test_deps/deps/a/out") ""
         runActon "build" ExitSuccess False "../../test/compiler/test_deps/"
+  , testCase "dbp force selects provider subset and cached header interest" $ do
+        withSystemTempDirectory "acton-dbp" $ \proj -> do
+          actonExe <- canonicalizePath "../../dist/bin/acton"
+          let name = "dbp_fixture"
+              fp = Fingerprint.formatFingerprint
+                (Fingerprint.updateFingerprintPrefix
+                  (Fingerprint.fingerprintPrefixForName name) 1)
+              srcDir = proj </> "src"
+              typesDir = proj </> "out" </> "types"
+              runBuild args = readCreateProcessWithExitCode (proc actonExe args){ cwd = Just proj } ""
+              assertOk label (code, out, err) = do
+                when (code /= ExitSuccess) $
+                  putStrLn ("\nERROR: " ++ label ++ "\nSTDOUT:\n" ++ out ++ "STDERR:\n" ++ err)
+                assertEqual label ExitSuccess code
+                return (out ++ err)
+              assertFails label (code, out, err) = do
+                when (code == ExitSuccess) $
+                  putStrLn ("\nERROR: " ++ label ++ " unexpectedly succeeded\nSTDOUT:\n" ++ out ++ "STDERR:\n" ++ err)
+                assertBool label (code /= ExitSuccess)
+                return (out ++ err)
+              removeIfExists path = removeFile path `catch` \(_ :: IOException) -> return ()
+          createDirectoryIfMissing True srcDir
+          writeFile (proj </> "Build.act") $ unlines
+            [ "name = \"" ++ name ++ "\""
+            , "fingerprint = " ++ fp
+            , ""
+            ]
+          writeFile (srcDir </> "provider.act") $ unlines
+            [ "protocol Renderable:"
+            , "    val : () -> int"
+            , ""
+            , "class Box(value):"
+            , "    def __init__(self, x: int):"
+            , "        self.x = x"
+            , ""
+            , "    def get(self) -> int:"
+            , "        return self.x"
+            , ""
+            , "extension Box(Renderable):"
+            , "    def val(self) -> int:"
+            , "        return self.get()"
+            , ""
+            , "def make_box() -> Box:"
+            , "    return Box(42)"
+            , ""
+            , "def render_box() -> int:"
+            , "    return Box(7).val()"
+            , ""
+            , "def unused_0() -> int:"
+            , "    return 0"
+            , ""
+            , "def unused_1() -> int:"
+            , "    return 1"
+            , ""
+            , "class Container:"
+            , "    def __init__(self):"
+            , "        pass"
+            , ""
+            , "def local_container_name(x: object) -> bool:"
+            , "    return isinstance(x, Container)"
+            ]
+          writeFile (srcDir </> "main.act") $ unlines
+            [ "import provider"
+            , ""
+            , "actor main(env):"
+            , "    print(provider.make_box().get())"
+            , "    env.exit(0)"
+            ]
+          firstLog <- assertOk "initial dbp build" =<<
+            runBuild ["build", "--skip-build", "--verbose", "--dbp", "provider:make_box", "--color", "never"]
+          assertBool "initial build should report DBP selection" ("DBP provider: forced by --dbp" `isInfixOf` firstLog)
+          assertBool "initial build should select a subset" ("selected closure" `isInfixOf` firstLog)
+          providerC <- readFile (typesDir </> "provider.c")
+          assertBool "selected provider C should include selected root" ("make_box" `isInfixOf` providerC)
+          assertBool "selected provider C should omit unused definitions" (not ("unused_1" `isInfixOf` providerC))
+          badSeedLog <- assertFails "bad dbp seed reports selection failure" =<<
+            runBuild ["build", "--skip-build", "--dbp", "provider:not_a_name", "--color", "never"]
+          assertBool "bad dbp seed should report selection failure"
+            ("DBP selection failed for provider" `isInfixOf` badSeedLog)
+          writeFile (srcDir </> "main.act") $ unlines
+            [ "import provider"
+            , ""
+            , "actor main(env):"
+            , "    print(provider.unused_0())"
+            , "    env.exit(0)"
+            ]
+          changedConsumerLog <- assertOk "changed consumer updates dbp selection" =<<
+            runBuild ["build", "--skip-build", "--verbose", "--dbp", "provider", "--color", "never"]
+          assertBool "changed consumer should rerun provider DBP" ("DBP provider: forced by --dbp" `isInfixOf` changedConsumerLog)
+          assertBool "changed consumer should make DBP codegen stale" ("generated code out of date" `isInfixOf` changedConsumerLog)
+          providerC1b <- readFile (typesDir </> "provider.c")
+          assertBool "changed consumer C should include newly interested root" ("unused_0" `isInfixOf` providerC1b)
+          assertBool "changed consumer C should omit previously selected root" (not ("make_box" `isInfixOf` providerC1b))
+          sameSelectionLog <- assertOk "cached dbp selection is up to date" =<<
+            runBuild ["build", "--skip-build", "--verbose", "--dbp", "provider", "--color", "never"]
+          assertBool "same selection should reuse cached consumer" ("Fresh main: using cached .ty" `isInfixOf` sameSelectionLog)
+          assertBool "same selection should skip provider back passes" ("generated code up to date" `isInfixOf` sameSelectionLog)
+          removeFile (typesDir </> "provider.c")
+          removeFile (typesDir </> "provider.h")
+          secondLog <- assertOk "cached dbp build" =<<
+            runBuild ["build", "--skip-build", "--verbose", "--dbp", "provider", "--color", "never"]
+          assertBool "cached consumer should be reused" ("Fresh main: using cached .ty" `isInfixOf` secondLog)
+          assertBool "cached build should collect provider interest from headers" ("interested names 1" `isInfixOf` secondLog)
+          assertBool "cached build should still select the dependency closure" ("selected closure" `isInfixOf` secondLog)
+          removeFile (typesDir </> "provider.c")
+          removeFile (typesDir </> "provider.h")
+          _thirdLog <- assertOk "dbp local name shadows builtin" =<<
+            runBuild ["build", "--skip-build", "--verbose", "--dbp", "provider:make_box,local_container_name", "--color", "never"]
+          providerC2 <- readFile (typesDir </> "provider.c")
+          assertBool "selected provider C should keep local Container dependency" ("providerQ_Container" `isInfixOf` providerC2)
+          removeFile (typesDir </> "provider.c")
+          removeFile (typesDir </> "provider.h")
+          fourthLog <- assertOk "dbp keeps extension" =<<
+            runBuild ["build", "--skip-build", "--verbose", "--dbp", "provider:render_box", "--color", "never"]
+          assertBool "extension selection should not fall back" (not ("fallback:" `isInfixOf` fourthLog))
+          providerC3 <- readFile (typesDir </> "provider.c")
+          assertBool "selected provider C should keep extension" ("providerQ_RenderableD_Box" `isInfixOf` providerC3)
+          removeFile (typesDir </> "provider.c")
+          removeFile (typesDir </> "provider.h")
+          writeFile (srcDir </> "main.act") $ unlines
+            [ "import provider"
+            , ""
+            , "actor main(env):"
+            , "    env.exit(0)"
+            ]
+          fifthLog <- assertOk "dbp empty interest" =<<
+            runBuild ["build", "--skip-build", "--verbose", "--dbp", "provider", "--color", "never"]
+          assertBool "empty interest should not fall back" (not ("fallback:" `isInfixOf` fifthLog))
+          assertBool "empty interest should be reported" ("interested names 0" `isInfixOf` fifthLog)
+          assertBool "empty interest should select empty closure" ("selected closure 0" `isInfixOf` fifthLog)
+          providerC4 <- readFile (typesDir </> "provider.c")
+          assertBool "empty provider C should omit provider definitions" (not ("make_box" `isInfixOf` providerC4))
+          removeIfExists (typesDir </> "main.c")
+          removeIfExists (typesDir </> "main.h")
+          removeIfExists (typesDir </> "main.root.c")
+          sixthLog <- assertOk "dbp keeps executable root actor" =<<
+            runBuild ["build", "--verbose", "--dbp", "main", "--dbp", "provider", "--color", "never"]
+          assertBool "root module should report root seed" ("DBP main: forced by --dbp" `isInfixOf` sixthLog)
+          assertBool "root module should count root name" ("root names 1" `isInfixOf` sixthLog)
+          mainC <- readFile (typesDir </> "main.c")
+          assertBool "selected main C should keep root actor" ("mainQ_main" `isInfixOf` mainC)
+          seventhLog <- assertOk "no-dbp disables forced dbp" =<<
+            runBuild ["build", "--skip-build", "--verbose", "--dbp", "provider", "--no-dbp", "--color", "never"]
+          assertBool "no-dbp should suppress provider DBP" (not ("DBP provider" `isInfixOf` seventhLog))
+          providerC5 <- readFile (typesDir </> "provider.c")
+          assertBool "no-dbp provider C should include full module definitions" ("unused_1" `isInfixOf` providerC5)
+  , testCase "dbp excludes explicit library boundary modules" $ do
+        withSystemTempDirectory "acton-dbp-library-boundary" $ \proj -> do
+          actonExe <- canonicalizePath "../../dist/bin/acton"
+          let name = "dbp_library_boundary"
+              fp = Fingerprint.formatFingerprint
+                (Fingerprint.updateFingerprintPrefix
+                  (Fingerprint.fingerprintPrefixForName name) 1)
+              srcDir = proj </> "src"
+              typesDir = proj </> "out" </> "types"
+              runBuild args = readCreateProcessWithExitCode (proc actonExe args){ cwd = Just proj } ""
+              assertOk label (code, out, err) = do
+                when (code /= ExitSuccess) $
+                  putStrLn ("\nERROR: " ++ label ++ "\nSTDOUT:\n" ++ out ++ "STDERR:\n" ++ err)
+                assertEqual label ExitSuccess code
+                return (out ++ err)
+          createDirectoryIfMissing True srcDir
+          writeFile (proj </> "Build.act") $ unlines
+            [ "name = \"" ++ name ++ "\""
+            , "fingerprint = " ++ fp
+            , "libraries = {"
+            , "    \"foo\": (modules=[\"a\", \"b\"], linkage=\"static\")"
+            , "}"
+            ]
+          writeFile (srcDir </> "a.act") $ unlines
+            [ "def used() -> int:"
+            , "    return 1"
+            , ""
+            , "def unused_a() -> int:"
+            , "    return 11"
+            ]
+          writeFile (srcDir </> "b.act") $ unlines
+            [ "import a"
+            , ""
+            , "def exposed() -> int:"
+            , "    return a.used()"
+            , ""
+            , "def unused_b() -> int:"
+            , "    return 22"
+            ]
+          writeFile (srcDir </> "c.act") $ unlines
+            [ "import b"
+            , ""
+            , "actor main(env):"
+            , "    print(b.exposed())"
+            , "    env.exit(0)"
+            ]
+          logTxt <- assertOk "dbp skips library boundary" =<<
+            runBuild ["build", "--skip-build", "--verbose", "--dbp", "a", "--dbp", "b", "--color", "never", "src/c.act"]
+          let hasBoundaryInfo = "DBP disabled for " `isInfixOf` logTxt && ":b: explicit library boundary" `isInfixOf` logTxt
+          unless hasBoundaryInfo $
+            putStrLn ("\nDBP library boundary log:\n" ++ logTxt)
+          assertBool "library boundary should explain forced DBP exclusion" hasBoundaryInfo
+          assertBool "internal library module should still run DBP"
+            ("DBP a: forced by --dbp" `isInfixOf` logTxt)
+          assertBool "boundary library module should not run DBP"
+            (not ("DBP b:" `isInfixOf` logTxt))
+          aC <- readFile (typesDir </> "a.c")
+          bC <- readFile (typesDir </> "b.c")
+          assertBool "internal DBP module should keep used name" ("used" `isInfixOf` aC)
+          assertBool "internal DBP module should omit unused name" (not ("unused_a" `isInfixOf` aC))
+          assertBool "boundary module should be compiled whole" ("unused_b" `isInfixOf` bC)
   , testCase "path dependency fetches transitive cached deps before discovery" $ do
         withSystemTempDirectory "acton-transitive-path-fetch" $ \tmp -> do
           actonExe <- canonicalizePath "../../dist/bin/acton"
@@ -568,6 +775,17 @@ parseFlagTests =
       case parsed of
         C.CmdOpt _ (C.Build buildOpts) ->
           assertBool "serial parser flag should be set" (C.parse_serial (C.buildCompile buildOpts))
+        _ ->
+          assertFailure "expected build command"
+  , testCase "build parser accepts repeatable --dbp module selection" $ do
+      parsed <- parseArgs ["build", "--dbp", "huge.provider:used,Helper", "--dbp", "other.provider", "--no-dbp"]
+      case parsed of
+        C.CmdOpt _ (C.Build buildOpts) ->
+          do
+            assertEqual "dbp option should keep module and seed specs"
+              ["huge.provider:used,Helper", "other.provider"]
+              (C.dbp (C.buildCompile buildOpts))
+            assertBool "no-dbp option should be set" (C.no_dbp (C.buildCompile buildOpts))
         _ ->
           assertFailure "expected build command"
   , testCase "build parser help includes --release alias" $ do

--- a/compiler/acton/test_incremental.hs
+++ b/compiler/acton/test_incremental.hs
@@ -41,7 +41,7 @@ import qualified Acton.SourceProvider as Source
 import qualified Acton.NameInfo as I
 import qualified Acton.Syntax as A
 import qualified InterfaceFiles
-import           Utils (prstr)
+import           Utils (SrcLoc(NoLoc), prstr)
 
 -- Paths ----------------------------------------------------------------------
 
@@ -1339,6 +1339,13 @@ p28_protocol_extension_deps = testCase "28-protocol/extension deps are recorded 
   let namesA = sort (map (prstr . InterfaceFiles.nhName) nameHashesA)
   assertBool "expected generated protocol sibling name" ("BazProtoD_BarProto" `elem` namesA)
   assertBool "expected generated extension name" ("BarProtoD_Widget" `elem` namesA)
+  let idxName n = A.Name NoLoc n
+  extensionsForWidget <- InterfaceFiles.readExtensionsByClass tyA (idxName "Widget")
+  extensionsForBarProto <- InterfaceFiles.readExtensionsByProtocol tyA (idxName "BarProto")
+  extensionsForFooProto <- InterfaceFiles.readExtensionsByProtocol tyA (idxName "FooProto")
+  assertEqual "exact extensions by class" ["BarProtoD_Widget"] (sort (map prstr extensionsForWidget))
+  assertEqual "exact extensions by protocol" ["BarProtoD_Widget"] (sort (map prstr extensionsForBarProto))
+  assertEqual "exact extensions by inherited protocol" ["BarProtoD_Widget"] (sort (map prstr extensionsForFooProto))
   (_, nmod, _, _, _, _, _, _, _, _, _, _) <- InterfaceFiles.readFile tyA
   let I.NModule _ iface _ = nmod
       extMatch (n, _) = prstr n == "BarProtoD_Widget"
@@ -1758,6 +1765,81 @@ p35_changed_path_keeps_unaffected_provider =
     let bProviders = Compile.gtImportProviders bTask
     assertBool "expected provider for changed import a" (M.member (A.modName ["a"]) bProviders)
     assertBool "expected provider for unchanged import c" (M.member (A.modName ["c"]) bProviders)
+
+p35_dbp_changed_path_includes_provider :: TestTree
+p35_dbp_changed_path_includes_provider =
+  testCase "35-dbp changed-path incremental includes dbp consumers" $ do
+    let proj = casesProjDir
+        src = casesSrcDir
+        actProvider = src </> "provider.act"
+        actA = src </> "a.act"
+        actB = src </> "b.act"
+        actMain = src </> "main.act"
+        gopts = C.GlobalOptions
+          { C.color = C.Never
+          , C.quiet = True
+          , C.noProgress = False
+          , C.timing = False
+          , C.tty = False
+          , C.verbose = False
+          , C.verboseZig = False
+          , C.jobs = 1
+          }
+        opts = Compile.defaultCompileOptions
+          { C.dbp = ["provider"]
+          , C.skip_build = True
+          }
+    ensureCasesProject
+    writeFileUtf8 actProvider $ T.unlines
+      [ "def used() -> int:"
+      , "    return 1"
+      , ""
+      , "def other() -> int:"
+      , "    return 2"
+      ]
+    writeFileUtf8 actA $ T.unlines
+      [ "import provider"
+      , ""
+      , "def fa() -> int:"
+      , "    return provider.used()"
+      ]
+    writeFileUtf8 actB $ T.unlines
+      [ "import provider"
+      , ""
+      , "def fb() -> int:"
+      , "    return provider.used()"
+      ]
+    writeFileUtf8 actMain $ T.unlines
+      [ "import a"
+      , "import b"
+      , ""
+      , "actor main(env: Env):"
+      , "    print(a.fa() + b.fb())"
+      , "    env.exit(0)"
+      ]
+    _ <- buildOutInArgs proj ["--skip-build", "--dbp", "provider"]
+    writeFileUtf8 actA $ T.unlines
+      [ "import provider"
+      , ""
+      , "def fa() -> int:"
+      , "    return provider.other()"
+      ]
+    actAAbs <- canonicalizePath actA
+    actMainAbs <- canonicalizePath actMain
+    sched <- Compile.newCompileScheduler gopts 1
+    plan <- Compile.prepareCompilePlan
+      Source.diskSourceProvider
+      gopts
+      sched
+      opts
+      [actMainAbs]
+      False
+      (Just [actAAbs])
+    let selectedMods = [ Compile.name (Compile.gtTask t) | t <- Compile.cpNeededTasks plan ]
+    assertBool "expected changed-path plan to include DBP provider"
+      (A.modName ["provider"] `elem` selectedMods)
+    assertBool "expected unchanged sibling consumer to register DBP interest"
+      (A.modName ["b"] `elem` selectedMods)
 
 p36_removed_dep_name_triggers_front_refresh :: TestTree
 p36_removed_dep_name_triggers_front_refresh =
@@ -2234,6 +2316,7 @@ main = defaultMain $ localOption (NumThreads 1) $ testGroup "incremental"
       , p33_comprehensive_hashes
       , p34_removed_import_module
       , p35_changed_path_keeps_unaffected_provider
+      , p35_dbp_changed_path_includes_provider
       , p36_removed_dep_name_triggers_front_refresh
       , p37_impl_refresh_missing_dep_hashes_reruns_front
       , p38_project_lock_blocks_build

--- a/compiler/acton/test_incremental.hs
+++ b/compiler/acton/test_incremental.hs
@@ -476,6 +476,20 @@ readTyDeps tyPath nameLabel = do
           implDeps = sort (map (prstr . fst) (InterfaceFiles.nhImplDeps nh))
       pure (pubDeps, implDeps)
 
+-- | Read pub/impl local dependency names for a binding in a .tydb file.
+readTyLocalDeps :: FilePath -> String -> IO ([String], [String])
+readTyLocalDeps tyPath nameLabel = do
+  nameHashes <- readTyNameHashes tyPath
+  let matchName nh = prstr (InterfaceFiles.nhName nh) == nameLabel
+  case find matchName nameHashes of
+    Nothing -> do
+      assertFailure ("missing name " ++ nameLabel ++ " in " ++ tyPath)
+      pure ([], [])
+    Just nh -> do
+      let pubDeps = sort (map prstr (InterfaceFiles.nhPubLocalDeps nh))
+          implDeps = sort (map prstr (InterfaceFiles.nhImplLocalDeps nh))
+      pure (pubDeps, implDeps)
+
 -- | Rewrite source hash and name-hash section of a .tydb file.
 rewriteTySrcHashAndNameHashes :: FilePath -> B.ByteString -> ([InterfaceFiles.NameHashInfo] -> [InterfaceFiles.NameHashInfo]) -> IO ()
 rewriteTySrcHashAndNameHashes tyPath srcHash' f = do
@@ -2110,6 +2124,60 @@ p44_provider_import_rename_reruns_dependent_front =
     assertBool ("expected stale-cache log for missing transitive dep hash\n" ++ T.unpack out2)
       (T.isInfixOf "missing dep hashes in" out2 && T.isInfixOf "oldpkg.ttt.TransformFunction" out2)
 
+p45_tydb_records_local_name_dependencies :: TestTree
+p45_tydb_records_local_name_dependencies =
+  testCase "45-tydb records local name dependencies" $ do
+    let proj = casesProjDir
+        src = casesSrcDir
+        tyA = proj </> "out" </> "types" </> "a.tydb"
+    ensureCasesProject
+    writeFileUtf8 (src </> "a.act") $ T.unlines
+      [ "def base() -> int:"
+      , "    return 1"
+      , ""
+      , "def mid() -> int:"
+      , "    return base()"
+      , ""
+      , "def top() -> int:"
+      , "    return mid()"
+      , ""
+      , "class Box:"
+      , "    def __init__(self, v: int):"
+      , "        self.v = v"
+      , "    def get(self) -> int:"
+      , "        return self.v"
+      , ""
+      , "def make_box() -> Box:"
+      , "    return Box(top())"
+      , ""
+      , "class Container:"
+      , "    def __init__(self):"
+      , "        pass"
+      , ""
+      , "def local_container_name(x: object) -> bool:"
+      , "    return isinstance(x, Container)"
+      ]
+    writeFileUtf8 (src </> "main.act") $ T.unlines
+      [ "import a"
+      , ""
+      , "actor main(env: Env):"
+      , "    print(a.make_box().get())"
+      , "    env.exit(0)"
+      ]
+    _ <- buildOutIn proj
+    (topPub, topImpl) <- readTyLocalDeps tyA "top"
+    assertDepsContain "top pub local deps" ["mid"] topPub
+    assertDepsContain "top impl local deps" ["mid"] topImpl
+    (midPub, midImpl) <- readTyLocalDeps tyA "mid"
+    assertDepsContain "mid pub local deps" ["base"] midPub
+    assertDepsContain "mid impl local deps" ["base"] midImpl
+    (boxPub, boxImpl) <- readTyLocalDeps tyA "make_box"
+    assertDepsContain "make_box pub local deps" ["Box", "top"] boxPub
+    assertDepsContain "make_box impl local deps" ["Box", "top"] boxImpl
+    (containerPub, containerImpl) <- readTyLocalDeps tyA "local_container_name"
+    assertDepsContain "local_container_name pub local deps" ["Container"] containerPub
+    assertDepsContain "local_container_name impl local deps" ["Container"] containerImpl
+
 -- Main -----------------------------------------------------------------------
 
 -- | Tasty entry point for incremental tests.
@@ -2177,5 +2245,6 @@ main = defaultMain $ localOption (NumThreads 1) $ testGroup "incremental"
       , p42_metadata_drift_refreshes_header
       , p43_equal_act_ty_mtime_hashes_source
       , p44_provider_import_rename_reruns_dependent_front
+      , p45_tydb_records_local_name_dependencies
       ]
   ]

--- a/compiler/lib/bench/CompilerBench.hs
+++ b/compiler/lib/bench/CompilerBench.hs
@@ -191,6 +191,7 @@ runCompilerFront buildFront runBack typesPath sourcePath = do
     res <- Compile.runFrontPasses
       benchGopts
       opts
+      False
       paths
       env0
       parsed

--- a/compiler/lib/src/Acton/CommandLineParser.hs
+++ b/compiler/lib/src/Acton/CommandLineParser.hs
@@ -85,6 +85,8 @@ data CompileOptions   = CompileOptions {
                          ty          :: Bool,
                          cpedantic   :: Bool,
                          dbg_no_lines:: Bool,
+                         dbp         :: [String],
+                         no_dbp      :: Bool,
                          optimize    :: OptimizeMode,
                          only_build  :: Bool,
                          skip_build  :: Bool,
@@ -329,6 +331,8 @@ sigCompileOptions = mkSigCompileOptions
         , ty = False
         , cpedantic = False
         , dbg_no_lines = False
+        , dbp = []
+        , no_dbp = False
         , optimize = Debug
         , only_build = False
         , skip_build = True
@@ -365,6 +369,8 @@ compileOptions = CompileOptions
         <*> switch (long "ty"           <> help "Write .tydb directory to src file directory")
         <*> switch (long "cpedantic"    <> help "Pedantic C compilation with -Werror")
         <*> switch (long "dbg-no-lines" <> help "Disable emission of C #line directives (for debugging codegen)")
+        <*> many (strOption (long "dbp" <> metavar "MOD[:NAME,...]" <> help "Force deferred back passes for a module, optionally selecting root names"))
+        <*> switch (long "no-dbp"      <> help "Disable deferred back passes")
         <*> optimizeOption
         <*> switch (long "only-build"   <> help "Only perform final build of .c files, do not compile .act files")
         <*> switch (long "skip-build"   <> help "Skip final bulid of .c files")

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -88,6 +88,7 @@ module Acton.Compile
   , CompileTask(..)
   , BackInput(..)
   , BackJob(..)
+  , DeferredBackJob(..)
   , FrontResult(..)
   , FrontTiming(..)
   , TypeStmtTiming(..)
@@ -140,6 +141,7 @@ module Acton.Compile
   , buildGlobalTasks
   , selectNeededTasks
   , selectAffectedTasks
+  , libraryBoundaryTasks
   , compileTasks
   , runFrontPasses
   , runBackPasses
@@ -227,6 +229,7 @@ import Control.Concurrent.STM (TChan, TVar, atomically, check, modifyTVar', newT
 import Control.DeepSeq (rnf)
 import Control.Exception (Exception, IOException, SomeAsyncException, SomeException, bracketOnError, catch, displayException, evaluate, finally, fromException, mask_, throwIO, try)
 import Control.Monad
+import Data.Binary (encode)
 import Data.Bits (shiftL, shiftR, (.|.))
 import Data.Char (isAlpha, isDigit, isHexDigit, isSpace, toLower)
 import Data.Either (partitionEithers)
@@ -267,6 +270,7 @@ import Text.Printf
 
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B
+import qualified Data.ByteString.Lazy as BL
 import qualified Data.ByteString.Base16 as Base16
 import qualified Crypto.Hash.SHA256 as SHA256
 
@@ -274,6 +278,11 @@ import qualified Crypto.Hash.SHA256 as SHA256
 newtype ProjectError = ProjectError String deriving (Show)
 
 instance Exception ProjectError
+
+newtype DbpSelectionError = DbpSelectionError String deriving (Show)
+
+instance Exception DbpSelectionError where
+  displayException (DbpSelectionError msg) = msg
 
 -- | Raise a ProjectError for library callers.
 -- Used by project discovery and path helpers to stop on unrecoverable errors.
@@ -395,6 +404,7 @@ data CompileCallbacks = CompileCallbacks
   , ccOnFrontDone :: GlobalTask -> C.CompileOptions -> IO ()
   , ccOnFrontProgress :: GlobalTask -> C.CompileOptions -> FrontPassProgress -> IO ()
   , ccOnBackJob :: BackJob -> IO ()
+  , ccOnBackSkipped :: TaskKey -> IO ()
   , ccOnInfo :: String -> IO ()
   }
 
@@ -411,6 +421,7 @@ defaultCompileCallbacks = CompileCallbacks
   , ccOnFrontDone = \_ _ -> return ()
   , ccOnFrontProgress = \_ _ _ -> return ()
   , ccOnBackJob = \_ -> return ()
+  , ccOnBackSkipped = \_ -> return ()
   , ccOnInfo = \_ -> return ()
   }
 
@@ -628,6 +639,7 @@ data CompilePlan = CompilePlan
   , cpProjMap :: M.Map FilePath ProjCtx
   , cpGlobalTasks :: [GlobalTask]
   , cpNeededTasks :: [GlobalTask]
+  , cpDbpBlocked :: Data.Set.Set TaskKey
   , cpRootTasks :: [CompileTask]
   , cpRootPins :: M.Map String BuildSpec.PkgDep
   , cpIncremental :: Bool
@@ -674,9 +686,10 @@ prepareCompilePlanFromContext sp gopts ctx srcFiles allowPrune mChangedPaths = d
   let hasBuildLibraries = any (not . M.null . BuildSpec.libraries . projBuildSpec) (M.elems projMap)
   (globalTasks, _) <- buildGlobalTasks sp gopts opts' projMap
     (if incremental || allowPrune || hasBuildLibraries then Nothing else Just srcFiles)
+  let dbpBlocked = libraryBoundaryTasks projMap globalTasks
   neededTasks0 <- case mChangedPaths of
     Nothing -> selectNeededTasks pathsRoot rootProj globalTasks srcFiles
-    Just changed -> selectAffectedTasks globalTasks changed
+    Just changed -> selectAffectedTasks rootProj opts' globalTasks dbpBlocked changed
   let neededTasks = expandBuildLibraryTasks projMap globalTasks neededTasks0
       rootTasks = [ gtTask t | t <- neededTasks0, tkProj (gtKey t) == rootProj ]
       rootPins = maybe M.empty (BuildSpec.dependencies . projBuildSpec) (M.lookup rootProj projMap)
@@ -685,6 +698,7 @@ prepareCompilePlanFromContext sp gopts ctx srcFiles allowPrune mChangedPaths = d
     , cpProjMap = projMap
     , cpGlobalTasks = globalTasks
     , cpNeededTasks = neededTasks
+    , cpDbpBlocked = dbpBlocked
     , cpRootTasks = rootTasks
     , cpRootPins = rootPins
     , cpIncremental = incremental
@@ -703,6 +717,7 @@ data CompileHooks = CompileHooks
   , chOnFrontProgress :: GlobalTask -> FrontPassProgress -> IO ()
   , chOnFrontResult :: GlobalTask -> FrontResult -> IO ()
   , chOnBackQueued :: TaskKey -> Bool -> IO ()
+  , chOnBackSkipped :: TaskKey -> IO ()
   , chOnBackStart :: BackJob -> IO ()
   , chOnBackProgress :: BackJob -> BackPassProgress -> IO ()
   , chOnBackDone :: BackJob -> BackJobResult -> IO ()
@@ -721,6 +736,7 @@ defaultCompileHooks =
     , chOnFrontProgress = \_ _ -> return ()
     , chOnFrontResult = \_ _ -> return ()
     , chOnBackQueued = \_ _ -> return ()
+    , chOnBackSkipped = \_ -> return ()
     , chOnBackStart = \_ -> return ()
     , chOnBackProgress = \_ _ -> return ()
     , chOnBackDone = \_ _ -> return ()
@@ -758,9 +774,10 @@ runCompilePlan sp gopts plan sched gen hooks = do
             let key = TaskKey (projPath (bjPaths job)) (A.modname (biTypedMod (bjInput job)))
             enqueued <- backQueueEnqueue backQueue gen job backCallbacks
             chOnBackQueued hooks key enqueued
+        , ccOnBackSkipped = chOnBackSkipped hooks
         , ccOnInfo = chOnInfo hooks
         }
-  compileTasks sp gopts opts' pathsRoot rootProj (cpNeededTasks plan) callbacks
+  compileTasks sp gopts opts' pathsRoot rootProj (cpNeededTasks plan) (cpDbpBlocked plan) callbacks
 -- | Baseline compile options for internal helpers and tests.
 -- This mirrors CLI defaults so path discovery and parsing behave predictably
 -- when no command-line flags are present.
@@ -786,6 +803,8 @@ defaultCompileOptions =
     , C.ty = False
     , C.cpedantic = False
     , C.dbg_no_lines = False
+    , C.dbp = []
+    , C.no_dbp = False
     , C.optimize = C.Debug
     , C.only_build = False
     , C.skip_build = False
@@ -1071,17 +1090,131 @@ data BackJob = BackJob
   , bjInput :: BackInput
   }
 
+-- Deferred jobs deliberately keep only reloadable metadata so large typed
+-- modules can be released after front passes finish.
+data DeferredBackJob = DeferredBackJob
+  { dbjPaths :: Paths
+  , dbjOpts :: C.CompileOptions
+  , dbjMod :: A.ModName
+  , dbjImplHash :: B.ByteString
+  , dbjNameCount :: Int
+  , dbjSeeds :: Data.Set.Set A.Name
+  , dbjReason :: String
+  }
+
 data FrontResult = FrontResult
   { frIfaceTE  :: [(A.Name, I.NameInfo)]
   , frImps     :: [A.ModName]
   , frDoc      :: Maybe String
   , frPubHash :: B.ByteString
   , frNameHashes :: [InterfaceFiles.NameHashInfo]
+  , frInterestDeps :: Data.Set.Set (A.ModName, A.Name)
   , frFrontTime :: Maybe TimeSpec
   , frFrontTiming :: Maybe FrontTiming
   , frInferredSigs :: [InferredSignature]
   , frBackJob  :: Maybe BackJob
+  , frDeferredBackJob :: Maybe DeferredBackJob
   }
+
+data DbpRequest = DbpRequest
+  { drMod :: A.ModName
+  , drSeeds :: Data.Set.Set A.Name
+  }
+
+type InterestMap = M.Map A.ModName (Data.Set.Set A.Name)
+
+dbpNameCountThreshold :: Int
+-- Conservative initial heuristic; --dbp can force smaller modules.
+dbpNameCountThreshold = 10000
+
+parseDbpSpec :: String -> Maybe DbpRequest
+parseDbpSpec raw = do
+  let (modPart0, seedPart0) = break (== ':') raw
+      modPart = map (\c -> if c == '/' then '.' else c) modPart0
+      modPieces = filter (not . null) (splitChar '.' modPart)
+  guard (not (null modPieces))
+  let seedPart = case seedPart0 of
+        ':' : rest -> rest
+        _ -> ""
+      seeds = Data.Set.fromList
+        [ A.Name NoLoc s
+        | s <- splitChar ',' seedPart
+        , not (null s)
+        ]
+  return DbpRequest { drMod = A.modName modPieces, drSeeds = seeds }
+
+parseDbpRequests :: C.CompileOptions -> M.Map A.ModName (Data.Set.Set A.Name)
+parseDbpRequests opts =
+  M.fromListWith Data.Set.union
+    [ (drMod req, drSeeds req)
+    | raw <- C.dbp opts
+    , Just req <- [parseDbpSpec raw]
+    ]
+
+splitChar :: Char -> String -> [String]
+splitChar sep = go
+  where
+    go "" = [""]
+    go s =
+      let (x, rest) = break (== sep) s
+      in case rest of
+           [] -> [x]
+           _ : ys -> x : go ys
+
+dbpDeferredBackJob :: Bool
+                   -> C.CompileOptions
+                   -> Paths
+                   -> A.ModName
+                   -> B.ByteString
+                   -> [InterfaceFiles.NameHashInfo]
+                   -> Maybe DeferredBackJob
+dbpDeferredBackJob blocked opts paths mn moduleImplHash nameHashes
+  | C.no_dbp opts = Nothing
+  | C.only_build opts = Nothing
+  | altOutput opts = Nothing
+  | mn == A.modName ["__builtin__"] = Nothing
+  | blocked = Nothing
+  | forced || nameCount >= dbpNameCountThreshold =
+      Just DeferredBackJob
+        { dbjPaths = paths
+        , dbjOpts = opts
+        , dbjMod = mn
+        , dbjImplHash = moduleImplHash
+        , dbjNameCount = nameCount
+        , dbjSeeds = seeds
+        , dbjReason = reason
+        }
+  | otherwise = Nothing
+  where
+    nameCount = length nameHashes
+    reqs = parseDbpRequests opts
+    forced = M.member mn reqs
+    seeds = M.findWithDefault Data.Set.empty mn reqs
+    reason
+      | forced = "forced by --dbp"
+      | otherwise = "name count " ++ show nameCount ++ " >= " ++ show dbpNameCountThreshold
+
+interestDepsFromNameHashes :: [InterfaceFiles.NameHashInfo] -> Data.Set.Set (A.ModName, A.Name)
+interestDepsFromNameHashes nameHashes =
+  Data.Set.fromList
+    [ target
+    | nh <- nameHashes
+    , (qn, _) <- InterfaceFiles.nhPubDeps nh ++ InterfaceFiles.nhImplDeps nh
+    , Just target <- [interestTarget qn]
+    ]
+  where
+    interestTarget qn =
+      case qn of
+        A.GName m n -> Just (m, n)
+        A.QName m n -> Just (m, n)
+        A.NoQ{} -> Nothing
+
+addInterestDeps :: Data.Set.Set (A.ModName, A.Name) -> InterestMap -> InterestMap
+addInterestDeps deps im =
+  foldl'
+    (\acc (mn, n) -> M.insertWith Data.Set.union mn (Data.Set.singleton n) acc)
+    im
+    (Data.Set.toList deps)
 
 data CompileTask        = ParseTask { name :: A.ModName, src :: String, srcBytes :: B.ByteString, sourceMeta :: Maybe InterfaceFiles.SourceFileMeta, parseImports :: [A.ModName] }
                         | ActonTask { name :: A.ModName, src :: String, srcBytes :: B.ByteString, sourceMeta :: Maybe InterfaceFiles.SourceFileMeta, atree:: A.Module }
@@ -1256,9 +1389,11 @@ selectNeededTasks pathsRoot rootProj globalTasks srcFiles = do
 
 -- | Select the minimal subgraph affected by a set of changed files.
 -- Computes reverse dependencies so we rebuild dependents while keeping
--- unrelated modules untouched.
-selectAffectedTasks :: [GlobalTask] -> [FilePath] -> IO [GlobalTask]
-selectAffectedTasks globalTasks changedFiles = do
+-- unrelated modules untouched. DBP-eligible providers on dependency paths from
+-- affected modules are kept too, along with their reverse dependents, because
+-- every consumer of a deferred provider can contribute selected-name interest.
+selectAffectedTasks :: FilePath -> C.CompileOptions -> [GlobalTask] -> Data.Set.Set TaskKey -> [FilePath] -> IO [GlobalTask]
+selectAffectedTasks rootProj opts globalTasks dbpBlocked changedFiles = do
     if null changedFiles
       then return globalTasks
       else do
@@ -1283,9 +1418,11 @@ selectAffectedTasks globalTasks changedFiles = do
                                 M.empty
                                 (M.toList depMap)
                 affected = reverseClosure revMap (Data.Set.fromList changedKeys)
+                dbpProviderPaths = dbpProviderPathClosure rootProj opts globalTasks dbpBlocked depMap revMap affected
+                selected = Data.Set.union affected dbpProviderPaths
             -- Keep original provider mappings so unchanged imports can still
             -- resolve via cached interfaces during incremental checks.
-            return [ t | t <- globalTasks, Data.Set.member (gtKey t) affected ]
+            return [ t | t <- globalTasks, Data.Set.member (gtKey t) selected ]
   where
     reverseClosure revMap start = go start (Data.Set.toList start)
       where
@@ -1295,6 +1432,116 @@ selectAffectedTasks globalTasks changedFiles = do
               new = filter (`Data.Set.notMember` seen) ds
               seen' = foldl' (flip Data.Set.insert) seen new
           in go seen' (ks ++ new)
+
+dbpProviderPathClosure :: FilePath
+                       -> C.CompileOptions
+                       -> [GlobalTask]
+                       -> Data.Set.Set TaskKey
+                       -> M.Map TaskKey [TaskKey]
+                       -> M.Map TaskKey [TaskKey]
+                       -> Data.Set.Set TaskKey
+                       -> Data.Set.Set TaskKey
+dbpProviderPathClosure rootProj opts globalTasks dbpBlocked depMap revMap affected =
+    Data.Set.union pathKeys dependentKeys
+  where
+    taskMap = M.fromList [ (gtKey t, t) | t <- globalTasks ]
+    depOpts = opts { C.skip_build = True, C.test = False }
+    pathKeys = go Data.Set.empty (Data.Set.toList affected)
+    dbpProviders = Data.Set.filter isDbpProvider pathKeys
+    dependentKeys = reverseReachable Data.Set.empty (Data.Set.toList dbpProviders)
+
+    optsFor k = if tkProj k == rootProj then opts else depOpts
+
+    isDbpProvider k =
+      case M.lookup k taskMap of
+        Just t ->
+          case gtTask t of
+            TyTask{ tyImplHash = implHash, tyNameHashes = nhs } ->
+              isJust (dbpDeferredBackJob (Data.Set.member k dbpBlocked) (optsFor k) (gtPaths t) (tkMod k) implHash nhs)
+            _ -> False
+        Nothing -> False
+
+    reachesDbp = reaches Data.Set.empty
+      where
+        reaches seen k
+          | Data.Set.member k seen = False
+          | isDbpProvider k = True
+          | otherwise =
+              let seen' = Data.Set.insert k seen
+              in any (reaches seen') (M.findWithDefault [] k depMap)
+
+    go seen [] = seen
+    go seen (k:ks) =
+      let deps = [ d | d <- M.findWithDefault [] k depMap, reachesDbp d ]
+          new = filter (`Data.Set.notMember` seen) deps
+          seen' = foldl' (flip Data.Set.insert) seen new
+      in go seen' (ks ++ new)
+
+    reverseReachable seen [] = seen
+    reverseReachable seen (k:ks) =
+      if Data.Set.member k seen
+        then reverseReachable seen ks
+        else
+          let deps = M.findWithDefault [] k revMap
+              seen' = Data.Set.insert k seen
+          in reverseReachable seen' (ks ++ deps)
+
+-- | DBP may prune generated C/H for internal library modules, but a module at
+-- an explicit library boundary must keep its full generated surface.
+libraryBoundaryTasks :: M.Map FilePath ProjCtx -> [GlobalTask] -> Data.Set.Set TaskKey
+libraryBoundaryTasks projMap globalTasks =
+    Data.Set.unions (map boundaryFor libraryGroups)
+  where
+    taskKeys = Data.Set.fromList (map gtKey globalTasks)
+    revMap = foldl'
+      (\acc t ->
+        foldl'
+          (\m dep -> M.insertWith (++) dep [gtKey t] m)
+          acc
+          (filter (`Data.Set.member` taskKeys) (M.elems (gtImportProviders t))))
+      M.empty
+      globalTasks
+    libraryGroups = libraryTaskGroups projMap globalTasks
+
+    boundaryFor group =
+      Data.Set.filter hasOutsideConsumer group
+      where
+        hasOutsideConsumer k =
+          any (`Data.Set.notMember` group) (M.findWithDefault [] k revMap)
+
+moduleStringToName :: String -> A.ModName
+moduleStringToName = A.modName . splitMod
+  where
+    splitMod s =
+      case break (== '.') s of
+        (p, []) -> [p]
+        (p, _:rest) -> p : splitMod rest
+
+libraryTaskGroups :: M.Map FilePath ProjCtx -> [GlobalTask] -> [Data.Set.Set TaskKey]
+libraryTaskGroups projMap globalTasks =
+    [ Data.Set.fromList keys
+    | ctx <- M.elems projMap
+    , lib <- M.elems (BuildSpec.libraries (projBuildSpec ctx))
+    , let keys = [ gtKey t
+                 | modName <- BuildSpec.libModules lib
+                 , let mn = moduleStringToName modName
+                 , t <- globalTasks
+                 , tkMod (gtKey t) == mn
+                 , taskInProject ctx t
+                 ]
+    , not (null keys)
+    ]
+  where
+    taskInProject ctx t =
+      tkProj (gtKey t) == projRoot ctx
+        || projPath (gtPaths t) == projRoot ctx
+        || projTypes (gtPaths t) == projTypesDir ctx
+        || srcUnderProject ctx t
+
+    srcUnderProject ctx t =
+      let srcRoot = addTrailingPathSeparator (projSrcDir ctx)
+          k = gtKey t
+      in srcRoot `isPrefixOf` srcFile (gtPaths t) (tkMod k)
 
 -- | Declared build libraries are artifact units: selecting any member selects
 -- every module in that library, plus their dependencies.
@@ -1307,17 +1554,7 @@ expandBuildLibraryTasks projMap globalTasks selectedTasks =
       [ (gtKey t, Data.Set.fromList (filter (`Data.Set.member` taskKeys) (M.elems (gtImportProviders t))))
       | t <- globalTasks
       ]
-    libraryGroups =
-      [ Data.Set.fromList keys
-      | ctx <- M.elems projMap
-      , lib <- M.elems (BuildSpec.libraries (projBuildSpec ctx))
-      , let keys = [ k
-                   | modName <- BuildSpec.libModules lib
-                   , let k = TaskKey (projRoot ctx) (moduleStringToName modName)
-                   , Data.Set.member k taskKeys
-                   ]
-      , not (null keys)
-      ]
+    libraryGroups = libraryTaskGroups projMap globalTasks
     selectedKeys = close (Data.Set.fromList (map gtKey selectedTasks))
 
     close keys =
@@ -1340,14 +1577,6 @@ expandBuildLibraryTasks projMap globalTasks selectedTasks =
             else
               let ds = Data.Set.toList (M.findWithDefault Data.Set.empty k deps)
               in go (ds ++ ks) (Data.Set.insert k seen)
-
-    moduleStringToName = A.modName . splitMod
-
-    splitMod s =
-      case break (== '.') s of
-        (p, []) -> [p]
-        (p, _:rest) -> p : splitMod rest
-
 
 data ModuleHead
   = TyHead
@@ -1711,6 +1940,7 @@ formatCodegenDelta status =
 -- front result plus a BackJob for later passes when compilation is needed.
 runFrontPasses :: C.GlobalOptions
                -> C.CompileOptions
+               -> Bool
                -> Paths
                -> Acton.Env.Env0
                -> A.Module
@@ -1721,7 +1951,7 @@ runFrontPasses :: C.GlobalOptions
                -> (A.ModName -> IO (Maybe (M.Map A.Name InterfaceFiles.NameHashInfo)))
                -> (FrontPassProgress -> IO ())
                -> IO (Either [Diagnostic String] FrontResult)
-runFrontPasses gopts opts paths env0 parsed srcContent srcBytes sourceMeta resolveImportHash resolveNameHashMap onFrontProgress = do
+runFrontPasses gopts opts dbpBlocked paths env0 parsed srcContent srcBytes sourceMeta resolveImportHash resolveNameHashMap onFrontProgress = do
   createDirectoryIfMissing True (getModPath (projTypes paths) mn)
   core
     `catch` handleGeneral
@@ -2004,24 +2234,256 @@ runFrontPasses gopts opts paths env0 parsed srcContent srcBytes sourceMeta resol
                                  , ftTypeStmtTimings = typeStmtTimings
                                  }
                           else Nothing
-                      backJob = Just BackJob { bjPaths = paths
-                                             , bjOpts = opts
-                                             , bjInput = BackInput { biTypeEnv = typeEnv
-                                                                  , biTypedMod = tchecked
-                                                                  , biSrc = srcContent
-                                                                  , biImplHash = moduleImplHash
-                                                                  }
-                                             }
+                      deferredBackJob = dbpDeferredBackJob dbpBlocked opts paths mn moduleImplHash nameHashes
+                      backJob =
+                        case deferredBackJob of
+                          Just _ -> Nothing
+                          Nothing ->
+                            Just BackJob { bjPaths = paths
+                                         , bjOpts = opts
+                                         , bjInput = BackInput { biTypeEnv = typeEnv
+                                                              , biTypedMod = tchecked
+                                                              , biSrc = srcContent
+                                                              , biImplHash = moduleImplHash
+                                                              }
+                                         }
                   return $ Right FrontResult { frIfaceTE = publicIface
                                              , frImps = imps
                                              , frDoc = mdoc
                                              , frPubHash = modulePubHash
                                              , frNameHashes = publicNameHashes nameHashes
+                                             , frInterestDeps = interestDepsFromNameHashes nameHashes
                                              , frFrontTime = frontTimeMaybe
                                              , frFrontTiming = frontTimingMaybe
                                              , frInferredSigs = inferredSigs
                                              , frBackJob = backJob
+                                             , frDeferredBackJob = deferredBackJob
                                              }
+
+data DbpSelection = DbpSelection
+  { dbsModule :: A.Module
+  , dbsInterestedCount :: Int
+  , dbsSelectedCount :: Int
+  , dbsFallbackReason :: Maybe String
+  }
+
+data DbpNameSelection = DbpNameSelection
+  { dnsSelectedNames :: Data.Set.Set A.Name
+  }
+
+prepareDeferredBackJob :: Source.SourceProvider
+                       -> C.GlobalOptions
+                       -> CompileCallbacks
+                       -> Acton.Env.Env0
+                       -> InterestMap
+                       -> DeferredBackJob
+                       -> IO (Maybe BackJob)
+prepareDeferredBackJob sp gopts callbacks envAcc interestMap dbj = do
+  let paths = dbjPaths dbj
+      mn = dbjMod dbj
+      tyFile = tyDbPath paths mn
+      actFile = srcFile paths mn
+  (_sourceMeta, _moduleSrcBytesHash, _modulePubHash, _moduleImplHashStored, _imps, nameHashes, roots, _tests, _mdoc) <- InterfaceFiles.readHeader tyFile
+  let explicitSeeds = dbjSeeds dbj
+      interested =
+        if Data.Set.null explicitSeeds
+          then M.findWithDefault Data.Set.empty mn interestMap
+          else explicitSeeds
+      rootSeeds = Data.Set.fromList roots
+      selectedSeeds = Data.Set.union interested rootSeeds
+  nameSelection <- selectDbpNames mn tyFile selectedSeeds nameHashes
+  let codegenHash = dbpCodegenHash (dbjImplHash dbj) (dnsSelectedNames nameSelection)
+  codegen <- codegenStatus paths mn codegenHash
+  if codegenUpToDate codegen
+    then do
+      logDbpSelection gopts callbacks mn dbj (length nameHashes) (Data.Set.size interested) (Data.Set.size rootSeeds) (Data.Set.size (dnsSelectedNames nameSelection)) Nothing "generated code up to date"
+      return Nothing
+    else do
+      (_ms, _nmod, tmod, _sourceMetaFull, _moduleSrcBytesHashFull, _modulePubHashFull, _moduleImplHashStoredFull, _impsFull, _nameHashesFull, _rootsFull, _testsFull, _mdocFull) <- InterfaceFiles.readFile tyFile
+      snap <- Source.readSource sp actFile
+      env1 <- Acton.Env.mkEnv (searchPath paths) envAcc tmod
+      let selection = selectDbpModule (length nameHashes) (Data.Set.size interested) nameSelection tmod
+      logDbpSelection gopts callbacks mn dbj (length nameHashes) (Data.Set.size interested) (Data.Set.size rootSeeds) (dbsSelectedCount selection) (dbsFallbackReason selection) "generated code out of date"
+      return $ Just BackJob
+        { bjPaths = paths
+        , bjOpts = dbjOpts dbj
+        , bjInput = BackInput
+            { biTypeEnv = Converter.convEnvProtos env1
+            , biTypedMod = dbsModule selection
+            , biSrc = Source.ssText snap
+            , biImplHash = codegenHash
+            }
+        }
+
+logDbpSelection :: C.GlobalOptions
+                -> CompileCallbacks
+                -> A.ModName
+                -> DeferredBackJob
+                -> Int
+                -> Int
+                -> Int
+                -> Int
+                -> Maybe String
+                -> String
+                -> IO ()
+logDbpSelection gopts callbacks mn dbj totalNames interestedCount rootCount selectedCount fallbackReason codegenReason =
+  when (C.verbose gopts) $
+    ccOnInfo callbacks $
+      "  DBP " ++ modNameToString mn
+      ++ ": " ++ dbjReason dbj
+      ++ ", total names " ++ show totalNames
+      ++ ", interested names " ++ show interestedCount
+      ++ ", root names " ++ show rootCount
+      ++ ", selected closure " ++ show selectedCount
+      ++ maybe "" (\reason -> ", fallback: " ++ reason) fallbackReason
+      ++ ", " ++ codegenReason
+
+dbpCodegenHash :: B.ByteString -> Data.Set.Set A.Name -> B.ByteString
+dbpCodegenHash moduleImplHash selected =
+  SHA256.hash (BL.toStrict (encode ("dbp" :: String, moduleImplHash, selectedNames)))
+  where
+    selectedNames =
+      [ Hashing.nameKey n
+      | n <- Data.List.sortOn Hashing.nameKey (Data.Set.toList selected)
+      ]
+
+selectDbpNames :: A.ModName
+               -> FilePath
+               -> Data.Set.Set A.Name
+               -> [InterfaceFiles.NameHashInfo]
+               -> IO DbpNameSelection
+selectDbpNames mn tyFile seeds nameHashes
+  | Data.Set.null seeds =
+      return DbpNameSelection
+        { dnsSelectedNames = Data.Set.empty
+        }
+  | otherwise =
+      case ( traverse (dbpOwningName topNames) (Data.Set.toList seeds)
+           , dbpLocalDepsFromNameHashes topNames nameHashes
+           ) of
+        (Left reason, _) -> dbpSelectionError mn reason
+        (_, Left reason) -> dbpSelectionError mn reason
+        (Right roots, Right localDeps) -> do
+          selected <- dbpNameClosure (dbpExtensionsForName mn tyFile topNames) localDeps (Data.Set.fromList roots)
+          return DbpNameSelection
+            { dnsSelectedNames = selected
+            }
+  where
+    topNames = dbpTopNamesFromNameHashes nameHashes
+
+dbpSelectionError :: A.ModName -> String -> IO a
+dbpSelectionError mn reason =
+  throwIO (DbpSelectionError ("DBP selection failed for " ++ modNameToString mn ++ ": " ++ reason))
+
+selectDbpModule :: Int
+                -> Int
+                -> DbpNameSelection
+                -> A.Module
+                -> DbpSelection
+selectDbpModule totalNames interestedCount nameSelection tmod@(A.Module loc imps mdoc suite)
+  | A.hasNotImpl suite = fallback "module contains NotImplemented/native extension hooks"
+  | otherwise =
+      let selected = dnsSelectedNames nameSelection
+          suite' = mapMaybe (dbpPruneTopStmt selected) suite
+      in DbpSelection
+           { dbsModule = A.Module loc imps mdoc suite'
+           , dbsInterestedCount = interestedCount
+           , dbsSelectedCount = Data.Set.size selected
+           , dbsFallbackReason = Nothing
+           }
+  where
+    fallback reason =
+      DbpSelection
+        { dbsModule = tmod
+        , dbsInterestedCount = interestedCount
+        , dbsSelectedCount = totalNames
+        , dbsFallbackReason = Just reason
+        }
+
+dbpTopNamesFromNameHashes :: [InterfaceFiles.NameHashInfo] -> Data.Set.Set A.Name
+dbpTopNamesFromNameHashes nameHashes =
+  Data.Set.fromList [ InterfaceFiles.nhName nh | nh <- nameHashes ]
+
+dbpOwningName :: Data.Set.Set A.Name -> A.Name -> Either String A.Name
+dbpOwningName topNames n
+  | Data.Set.member n topNames = Right n
+  | otherwise =
+      case n of
+        A.Derived base _ -> dbpOwningName topNames base
+        _ | Names.isWitness n -> Left ("unresolved witness owner for " ++ nameToString n)
+        _ -> Left ("no top-level owner for " ++ nameToString n)
+
+dbpLocalDepsFromNameHashes :: Data.Set.Set A.Name
+                           -> [InterfaceFiles.NameHashInfo]
+                           -> Either String (M.Map A.Name [A.Name])
+dbpLocalDepsFromNameHashes topNames nameHashes =
+  M.fromList <$> traverse depsFor nameHashes
+  where
+    depsFor nh = do
+      deps <- traverse
+                (dbpOwningName topNames)
+                (InterfaceFiles.nhPubLocalDeps nh ++ InterfaceFiles.nhImplLocalDeps nh)
+      return
+        ( InterfaceFiles.nhName nh
+        , unionNames deps []
+        )
+    unionNames xs ys = Data.List.sortOn Hashing.nameKey (Data.List.nub (xs ++ ys))
+
+dbpExtensionsForName :: A.ModName -> FilePath -> Data.Set.Set A.Name -> A.Name -> IO [A.Name]
+dbpExtensionsForName mn tyFile topNames n = do
+  byClass <- InterfaceFiles.readExtensionsByClass tyFile n
+  byProtocol <- InterfaceFiles.readExtensionsByProtocol tyFile n
+  let exts = unionNames byClass byProtocol
+      missing = [ ext | ext <- exts, Data.Set.notMember ext topNames ]
+  if null missing
+    then return exts
+    else dbpSelectionError mn $
+           "extension index for " ++ nameToString n
+           ++ " points at non-top-level extension(s) "
+           ++ Data.List.intercalate ", " (map nameToString missing)
+  where
+    unionNames xs ys = Data.List.sortOn Hashing.nameKey (Data.List.nub (xs ++ ys))
+
+dbpNameClosure :: (A.Name -> IO [A.Name])
+               -> M.Map A.Name [A.Name]
+               -> Data.Set.Set A.Name
+               -> IO (Data.Set.Set A.Name)
+dbpNameClosure extensionsForName localDeps roots = go roots (Data.Set.toList roots)
+  where
+    go seen [] = return seen
+    go seen (n:ns) = do
+      exts <- extensionsForName n
+      let deps = unionNames (M.findWithDefault [] n localDeps) exts
+          new = filter (`Data.Set.notMember` seen) deps
+          seen' = foldl' (flip Data.Set.insert) seen new
+      go seen' (new ++ ns)
+
+    unionNames xs ys = Data.List.sortOn Hashing.nameKey (Data.List.nub (xs ++ ys))
+
+dbpPruneTopStmt :: Data.Set.Set A.Name -> A.Stmt -> Maybe A.Stmt
+dbpPruneTopStmt selected stmt =
+  case stmt of
+    A.Decl l ds ->
+      case filter (\d -> Data.Set.member (Names.dname' d) selected) ds of
+        [] -> Nothing
+        ds' -> Just (A.Decl l ds')
+    A.Signature l ns typ dec ->
+      case filter (`Data.Set.member` selected) ns of
+        [] -> Nothing
+        ns' -> Just (A.Signature l ns' typ dec)
+    A.Assign{} ->
+      if any (`Data.Set.member` selected) (Names.bound stmt)
+        then Just stmt
+        else Nothing
+    A.VarAssign{} ->
+      if any (`Data.Set.member` selected) (Names.bound stmt)
+        then Just stmt
+        else Nothing
+    A.Pass{} -> Nothing
+    -- Source-level modules only admit Decl, Signature, and Assign at the top
+    -- level. VarAssign and Pass are compiler-introduced typed forms handled
+    -- above; other statement forms should not appear in a typed module suite.
+    _ -> Nothing
 
 
 -- | Run the back passes for a single module.
@@ -2213,9 +2675,10 @@ compileTasks :: Source.SourceProvider
              -> Paths                     -- root project paths (for alt output root selection)
              -> FilePath                  -- root project path
              -> [GlobalTask]
+             -> Data.Set.Set TaskKey
              -> CompileCallbacks
              -> IO (Either CompileFailure (Acton.Env.Env0, Bool))
-compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
+compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
     runningRef <- newIORef []
     let cancelRunning = readIORef runningRef >>= mapM_ cancel
     let compileMain = do
@@ -2248,11 +2711,12 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
       nCaps <- getNumCapabilities
       let maxParallel = max 1 (if C.jobs gopts > 0 then C.jobs gopts else nCaps)
 
-      (envFinal, hadErrors) <- loop runningRef stageInitialReady [] M.empty M.empty M.empty stageIndeg stagePending0 baseEnv False maxParallel cwMap
-      return (Right (envFinal, hadErrors))
+      logForcedDbpBoundaryExclusions
+      loop runningRef stageInitialReady [] M.empty M.empty M.empty M.empty Data.Set.empty M.empty stageIndeg stagePending0 baseEnv False maxParallel cwMap
 
     -- Basic maps/sets ----------------------------------------------------
     taskMap = M.fromList [ (gtKey t, t) | t <- tasks ]
+    isDbpBlocked k = Data.Set.member k dbpBlocked
     isBuiltinKey k = tkMod k == A.modName ["__builtin__"]
     builtinOrder = [ t | t <- tasks, isBuiltinKey (gtKey t) ]
     nonBuiltinTasks = [ t | t <- tasks, not (isBuiltinKey (gtKey t)) ]
@@ -2275,6 +2739,22 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
 
     depOpts = opts { C.skip_build = True, C.test = False }
     optsFor k = if tkProj k == rootProj then opts else depOpts
+
+    forcedDbpMods = M.keysSet (parseDbpRequests opts)
+
+    formatTaskKey k = tkProj k ++ ":" ++ modNameToString (tkMod k)
+
+    logForcedDbpBoundaryExclusions =
+      unless (C.no_dbp opts) $
+        forM_ forcedDbpBoundaryKeys $ \k ->
+          ccOnInfo callbacks ("  DBP disabled for " ++ formatTaskKey k ++ ": explicit library boundary")
+      where
+        forcedDbpBoundaryKeys =
+          [ k
+          | k <- Data.Set.toList dbpBlocked
+          , M.member k taskMap
+          , Data.Set.member (tkMod k) forcedDbpMods
+          ]
 
     needsParseStage t =
       case gtTask t of
@@ -2341,6 +2821,33 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
               seen' = foldl' (flip Data.Set.insert) seen new
           in go seen' (new ++ xs)
 
+    flushReadyDeferredBacks :: Acton.Env.Env0
+                            -> InterestMap
+                            -> Data.Set.Set TaskKey
+                            -> M.Map TaskKey (DeferredBackJob, Data.Set.Set TaskKey)
+                            -> IO (Either CompileFailure (M.Map TaskKey (DeferredBackJob, Data.Set.Set TaskKey)))
+    flushReadyDeferredBacks envAcc interestMap frontDone deferredBacks = do
+      let (ready, waiting) =
+            M.partitionWithKey
+              (\_ (_dbj, waitSet) -> waitSet `Data.Set.isSubsetOf` frontDone)
+              deferredBacks
+      prepared <- (try $
+        forM (M.elems ready) $ \(dbj, _waitSet) -> do
+          mJob <- prepareDeferredBackJob sp gopts callbacks envAcc interestMap dbj
+          case mJob of
+            Nothing -> ccOnBackSkipped callbacks (TaskKey (projPath (dbjPaths dbj)) (dbjMod dbj))
+            Just _ -> return ()
+          return mJob)
+        :: IO (Either SomeException [Maybe BackJob])
+      case prepared of
+        Left err ->
+          if isJust (fromException err :: Maybe SomeAsyncException)
+            then throwIO err
+            else return (Left (CompileInternalFailure (displayException err)))
+        Right jobs -> do
+          mapM_ (ccOnBackJob callbacks) (catMaybes jobs)
+          return (Right waiting)
+
     -- TODO: can we reintegrate this into the normal loop to avoid duplication?
     -- NOTE: FYI, it was originally part of the main loop but factored out for
     -- clarity when we changed to use async, front/back jobs etc. There were so
@@ -2373,6 +2880,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
               res <- runFrontPasses
                 gopts
                 optsBuiltin
+                False
                 bPaths
                 builtinEnv0
                 m
@@ -2414,17 +2922,19 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
           actFile = srcFile paths mn
           tyFile = tyDbPath paths mn
           short8 bs   = take 8 (B.unpack $ Base16.encode bs)
-          mkFrontResult imps ifaceTE mdoc pubHash nameHashes backJob =
+          mkFrontResult imps ifaceTE mdoc pubHash nameHashes interestNameHashes backJob deferredBackJob =
             FrontResult
               { frIfaceTE = ifaceTE
               , frImps = imps
               , frDoc = mdoc
               , frPubHash = pubHash
               , frNameHashes = nameHashes
+              , frInterestDeps = interestDepsFromNameHashes interestNameHashes
               , frFrontTime = Nothing
               , frFrontTiming = Nothing
               , frInferredSigs = []
               , frBackJob = backJob
+              , frDeferredBackJob = deferredBackJob
               }
           emptyFrontResult =
             FrontResult
@@ -2433,10 +2943,12 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
               , frDoc = Nothing
               , frPubHash = B.empty
               , frNameHashes = []
+              , frInterestDeps = Data.Set.empty
               , frFrontTime = Nothing
               , frFrontTiming = Nothing
               , frInferredSigs = []
               , frBackJob = Nothing
+              , frDeferredBackJob = Nothing
               }
           cacheFrontResult fr = do
             updatePubHashCache mn (frPubHash fr)
@@ -2666,10 +3178,11 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
                             ActonTask{ src = srcContent } -> readIfaceFromTy paths mn srcContent Nothing
               case ifaceRes of
                 Right (imps, ifaceTE, mdoc, ih) -> do
-                  let cachedNameHashes = case taskCurrent of
-                        TyTask{ tyNameHashes = nhs } -> publicNameHashes nhs
+                  let cachedFullNameHashes = case taskCurrent of
+                        TyTask{ tyNameHashes = nhs } -> nhs
                         _ -> []
-                      fr = mkFrontResult imps ifaceTE mdoc ih cachedNameHashes Nothing
+                      cachedNameHashes = publicNameHashes cachedFullNameHashes
+                      fr = mkFrontResult imps ifaceTE mdoc ih cachedNameHashes cachedFullNameHashes Nothing Nothing
                   cacheFrontResult fr
                 Left _ ->
                   return (key, Right emptyFrontResult)
@@ -2716,7 +3229,14 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
                   mModuleImplHash = case taskCurrent of
                     TyTask{ tyImplHash = implHash } -> Just implHash
                     _ -> Nothing
-              let canCheckCodegen = not needFront && not needByImpl && not (altOutput optsT)
+                  cachedDeferredBackJob = case taskCurrent of
+                    TyTask{ tyImplHash = implHash, tyNameHashes = nhs } -> dbpDeferredBackJob (isDbpBlocked key) optsT paths mn implHash nhs
+                    _ -> Nothing
+                  isCachedDbp =
+                    case cachedDeferredBackJob of
+                      Just _ -> True
+                      Nothing -> False
+              let canCheckCodegen = not needFront && not needByImpl && not (altOutput optsT) && not isCachedDbp
               mCodegenStatus <- case mModuleImplHash of
                 Just implHash | canCheckCodegen -> Just <$> codegenStatus paths mn implHash
                 _ -> return Nothing
@@ -2754,6 +3274,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
                         res <- runFrontPasses
                           gopts
                           optsT
+                          (isDbpBlocked key)
                           paths
                           envSnap
                           m
@@ -2835,8 +3356,12 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
                                       InterfaceFiles.writeFile tyFile moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta imps updatedNameHashes roots tests mdoc nmod tmod
                                       let I.NModule imps ifaceFull _mdoc = nmod
                                           ifaceTE = publicIfaceTE ifaceFull
-                                          backJob = Just (mkBackJob env1 tmod (Source.ssText snap) moduleImplHash)
-                                          fr = mkFrontResult imps ifaceTE mdoc modulePubHash (publicNameHashes updatedNameHashes) backJob
+                                          deferredBackJob = dbpDeferredBackJob (isDbpBlocked key) optsT paths mn moduleImplHash updatedNameHashes
+                                          backJob =
+                                            case deferredBackJob of
+                                              Just _ -> Nothing
+                                              Nothing -> Just (mkBackJob env1 tmod (Source.ssText snap) moduleImplHash)
+                                          fr = mkFrontResult imps ifaceTE mdoc modulePubHash (publicNameHashes updatedNameHashes) updatedNameHashes backJob deferredBackJob
                                       cacheFrontResult fr
                       ) `catch` handleImplRefreshException
                   runCodegenRefresh = do
@@ -2851,8 +3376,12 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
                         env1 <- Acton.Env.mkEnv (searchPath paths) envSnap tmod
                         let I.NModule imps ifaceFull _mdoc = nmod
                             ifaceTE = publicIfaceTE ifaceFull
-                            backJob = Just (mkBackJob env1 tmod (Source.ssText snap) moduleImplHashStored)
-                            fr = mkFrontResult imps ifaceTE mdoc modulePubHash (publicNameHashes nameHashes) backJob
+                            deferredBackJob = dbpDeferredBackJob (isDbpBlocked key) optsT paths mn moduleImplHashStored nameHashes
+                            backJob =
+                              case deferredBackJob of
+                                Just _ -> Nothing
+                                Nothing -> Just (mkBackJob env1 tmod (Source.ssText snap) moduleImplHashStored)
+                            fr = mkFrontResult imps ifaceTE mdoc modulePubHash (publicNameHashes nameHashes) nameHashes backJob deferredBackJob
                         cacheFrontResult fr
                   runReuse = do
                     when (C.verbose gopts) $
@@ -2863,10 +3392,11 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
                     case ifaceRes of
                       Left diags -> return (key, Left diags)
                       Right (imps, ifaceTE, mdoc, ih) -> do
-                        let cachedNameHashes = case taskCurrent of
-                              TyTask{ tyNameHashes = nhs } -> publicNameHashes nhs
+                        let cachedFullNameHashes = case taskCurrent of
+                              TyTask{ tyNameHashes = nhs } -> nhs
                               _ -> []
-                            fr = mkFrontResult imps ifaceTE mdoc ih cachedNameHashes Nothing
+                            cachedNameHashes = publicNameHashes cachedFullNameHashes
+                            fr = mkFrontResult imps ifaceTE mdoc ih cachedNameHashes cachedFullNameHashes Nothing cachedDeferredBackJob
                         cacheFrontResult fr
               case () of
                 _ | needFront -> runFront
@@ -2957,24 +3487,31 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
          -> M.Map TaskKey B.ByteString
          -> M.Map TaskKey (M.Map A.Name InterfaceFiles.NameHashInfo)
          -> M.Map TaskKey CompileTask
+         -> InterestMap
+         -> Data.Set.Set TaskKey
+         -> M.Map TaskKey (DeferredBackJob, Data.Set.Set TaskKey)
          -> M.Map StageKey Int
          -> Data.Set.Set StageKey
          -> Acton.Env.Env0
          -> Bool
          -> Int
          -> M.Map TaskKey Integer
-         -> IO (Acton.Env.Env0, Bool)
-    loop runningRef rdy running res nameRes parsedTasks ind pend envAcc hadErrors maxPar cw = do
+         -> IO (Either CompileFailure (Acton.Env.Env0, Bool))
+    loop runningRef rdy running res nameRes parsedTasks interestMap frontDone deferredBacks ind pend envAcc hadErrors maxPar cw = do
       (rdy1, running1) <- mask_ $ do
         res@(rdy1', running1') <- scheduleMore (maxPar - length running) rdy running res nameRes parsedTasks envAcc cw
         writeIORef runningRef (map fst running1')
         return res
       if null running1 && null rdy1
         then if Data.Set.null pend
-               then do
-                 writeIORef runningRef []
-                 return (envAcc, hadErrors)
-               else return (envAcc, True)
+                 then do
+                   flushRes <- flushReadyDeferredBacks envAcc interestMap frontDone deferredBacks
+                   case flushRes of
+                     Left err -> return (Left err)
+                     Right deferredBacks' -> do
+                       writeIORef runningRef []
+                       return (Right (envAcc, hadErrors || not (M.null deferredBacks')))
+                 else return (Right (envAcc, True))
         else do
           (doneA, (stageDone, outcome)) <- waitAny $ map fst running1
           let running2 = filter ((/= doneA) . fst) running1
@@ -3000,7 +3537,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
                   rdy2 = filter (`Data.Set.notMember` blockedStages) rdy1
                   dropKeys = keyDone : Data.Set.toList blockedMods
                   parsedTasks2 = foldl' (flip M.delete) parsedTasks dropKeys
-              loop runningRef rdy2 running3 res nameRes parsedTasks2 ind pend2 envAcc True maxPar cw
+              loop runningRef rdy2 running3 res nameRes parsedTasks2 interestMap frontDone deferredBacks ind pend2 envAcc True maxPar cw
             Right success -> do
               let pend2 = Data.Set.delete stageDone pend
                   ind2  = case M.lookup stageDone stageRevMap of
@@ -3017,7 +3554,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
                 StageParsed parsed mParseTime -> do
                   ccOnParseDone callbacks tDone optsDone mParseTime
                   let parsedTasks2 = M.insert keyDone parsed parsedTasks
-                  loop runningRef rdy2 running2 res nameRes parsedTasks2 ind2 pend2 envAcc hadErrors maxPar cw
+                  loop runningRef rdy2 running2 res nameRes parsedTasks2 interestMap frontDone deferredBacks ind2 pend2 envAcc hadErrors maxPar cw
                 StageFronted fr -> do
                   ccOnFrontDone callbacks tDone optsDone
                   ccOnFrontResult callbacks tDone optsDone fr
@@ -3026,7 +3563,17 @@ compileTasks sp gopts opts rootPaths rootProj tasks callbacks = do
                       nameRes2 = M.insert keyDone (nameHashMapFromList (frNameHashes fr)) nameRes
                       parsedTasks2 = M.delete keyDone parsedTasks
                       envAcc' = Acton.Env.addMod (tkMod keyDone) (frImps fr) (frIfaceTE fr) (frDoc fr) envAcc
-                  loop runningRef rdy2 running2 res2 nameRes2 parsedTasks2 ind2 pend2 envAcc' hadErrors maxPar cw
+                      interestMap2 = addInterestDeps (frInterestDeps fr) interestMap
+                      frontDone2 = Data.Set.insert keyDone frontDone
+                      deferredBacks1 =
+                        case frDeferredBackJob fr of
+                          Nothing -> deferredBacks
+                          Just dbj -> M.insert keyDone (dbj, dependentClosure keyDone) deferredBacks
+                  flushRes <- flushReadyDeferredBacks envAcc' interestMap2 frontDone2 deferredBacks1
+                  case flushRes of
+                    Left err -> return (Left err)
+                    Right deferredBacks2 ->
+                      loop runningRef rdy2 running2 res2 nameRes2 parsedTasks2 interestMap2 frontDone2 deferredBacks2 ind2 pend2 envAcc' hadErrors maxPar cw
 
 
 -- | Execute back-pass jobs in parallel while keeping output order stable.

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -1926,7 +1926,7 @@ runFrontPasses gopts opts paths env0 parsed srcContent srcBytes sourceMeta resol
               hashEnv = setMod mn env
               -- Split deps into local (same module) vs external (qualified) names.
               (pubSigLocalDeps, pubSigExtDeps) = Hashing.splitDeps mn hashEnv nameKeys pubSigDepsRaw
-              (_, pubExtDeps) = Hashing.splitDeps mn hashEnv nameKeys pubDepsRaw
+              (pubLocalDeps, pubExtDeps) = Hashing.splitDeps mn hashEnv nameKeys pubDepsRaw
               (implLocalDeps, implExtDeps) = Hashing.splitDeps mn hashEnv nameKeys implDepsRaw
               -- Load .tydb maps for any external modules referenced by deps.
               extMods = Data.Set.toList (Hashing.externalModules pubExtDeps `Data.Set.union` Hashing.externalModules implExtDeps)
@@ -1952,6 +1952,7 @@ runFrontPasses gopts opts paths env0 parsed srcContent srcBytes sourceMeta resol
                           nameInfoMap
                           pubSigLocalDeps
                           pubSigExtHashes
+                          pubLocalDeps
                           implLocalDeps
                           implExtHashes
                           pubExtHashes

--- a/compiler/lib/src/Acton/Hashing.hs
+++ b/compiler/lib/src/Acton/Hashing.hs
@@ -102,6 +102,8 @@ splitDeps :: A.ModName
           -> (M.Map A.Name [A.Name], M.Map A.Name [A.QName])
 splitDeps mn env localNames depMap =
   let toLocalExt qns = foldl' step (Data.Set.empty, Data.Set.empty) qns
+      step (locals, externals) (A.NoQ n)
+        | Data.Set.member n localNames = (Data.Set.insert n locals, externals)
       step (locals, externals) qn =
         case Env.unalias env qn of
           A.GName m _ | m == mPrim -> (locals, externals)
@@ -179,22 +181,26 @@ buildNameHashes :: Data.Set.Set A.Name
                 -> M.Map A.Name [A.Name]
                 -> M.Map A.Name [(A.QName, B.ByteString)]
                 -> M.Map A.Name [A.Name]
+                -> M.Map A.Name [A.Name]
                 -> M.Map A.Name [(A.QName, B.ByteString)]
                 -> M.Map A.Name [(A.QName, B.ByteString)]
                 -> [InterfaceFiles.NameHashInfo]
-buildNameHashes nameKeys nameSrcHashes nameImplHashes nameInfoMap pubSigLocalDeps pubSigExtHashes implLocalDeps implExtHashes pubExtHashes =
+buildNameHashes nameKeys nameSrcHashes nameImplHashes nameInfoMap pubSigLocalDeps pubSigExtHashes pubLocalDeps implLocalDeps implExtHashes pubExtHashes =
   let hashNameInfo info = SHA256.hash (BL.toStrict $ encode (I.stripLocsNI (I.stripDocsNI info)))
       selfPubHashes = M.map hashNameInfo nameInfoMap
       selfImplHashes = nameImplHashes
       pubHashes = computeHashes selfPubHashes pubSigLocalDeps pubSigExtHashes
       implHashes = computeHashes selfImplHashes implLocalDeps implExtHashes
       namesSorted = Data.List.sortOn nameKey (Data.Set.toList nameKeys)
+      localDeps m n = Data.List.sortOn nameKey (Data.List.nub (M.findWithDefault [] n m))
   in
     [ InterfaceFiles.NameHashInfo
         { InterfaceFiles.nhName = n
         , InterfaceFiles.nhSrcHash = M.findWithDefault B.empty n nameSrcHashes
         , InterfaceFiles.nhPubHash = M.findWithDefault B.empty n pubHashes
         , InterfaceFiles.nhImplHash = M.findWithDefault B.empty n implHashes
+        , InterfaceFiles.nhPubLocalDeps = localDeps pubLocalDeps n
+        , InterfaceFiles.nhImplLocalDeps = localDeps implLocalDeps n
         , InterfaceFiles.nhPubDeps = M.findWithDefault [] n pubExtHashes
         , InterfaceFiles.nhImplDeps = M.findWithDefault [] n implExtHashes
         }
@@ -214,6 +220,7 @@ refreshImplHashes nameHashes nameImplHashes implLocalDeps implExtHashes =
   in
     [ let nh = infoMap M.! n
       in nh { InterfaceFiles.nhImplHash = M.findWithDefault B.empty n implHashes
+            , InterfaceFiles.nhImplLocalDeps = Data.List.sortOn nameKey (Data.List.nub (M.findWithDefault [] n implLocalDeps))
             , InterfaceFiles.nhImplDeps = M.findWithDefault [] n implExtHashes
             }
     | n <- namesSorted

--- a/compiler/lib/src/Acton/Syntax.hs
+++ b/compiler/lib/src/Acton/Syntax.hs
@@ -25,7 +25,7 @@ import Control.DeepSeq
 import Prelude hiding((<>))
 
 version :: [Int]
-version = [0,20]
+version = [0,21]
 
 data Module     = Module        { modname::ModName, imps::[Import], mdoc::Maybe String, mbody::Suite } deriving (Eq,Show,Generic,NFData)
 

--- a/compiler/lib/src/Acton/Syntax.hs
+++ b/compiler/lib/src/Acton/Syntax.hs
@@ -25,7 +25,7 @@ import Control.DeepSeq
 import Prelude hiding((<>))
 
 version :: [Int]
-version = [0,21]
+version = [0,22]
 
 data Module     = Module        { modname::ModName, imps::[Import], mdoc::Maybe String, mbody::Suite } deriving (Eq,Show,Generic,NFData)
 

--- a/compiler/lib/src/Acton/Types.hs
+++ b/compiler/lib/src/Acton/Types.hs
@@ -133,6 +133,10 @@ showTyFile env0 m fname verbose = do
                                          putStrLn ("  src  : " ++ srcHex)
                                          putStrLn ("  pub  : " ++ pubHex)
                                          putStrLn ("  impl : " ++ implHex)
+                                         when (not (null (InterfaceFiles.nhPubLocalDeps nh))) $
+                                           putStrLn ("  pubLocalDeps : " ++ show (map prstr (InterfaceFiles.nhPubLocalDeps nh)))
+                                         when (not (null (InterfaceFiles.nhImplLocalDeps nh))) $
+                                           putStrLn ("  implLocalDeps: " ++ show (map prstr (InterfaceFiles.nhImplLocalDeps nh)))
                                          when (not (null (InterfaceFiles.nhPubDeps nh))) $
                                            putStrLn ("  pubDeps : " ++ show (map showDep (InterfaceFiles.nhPubDeps nh)))
                                          when (not (null (InterfaceFiles.nhImplDeps nh))) $

--- a/compiler/lib/src/InterfaceFiles.hs
+++ b/compiler/lib/src/InterfaceFiles.hs
@@ -47,6 +47,10 @@
 --     "name-info/<suffix>" :: (A.Name, I.NameInfo)    -- the name and its type/name environment entry
 --     "name-hash/<suffix>" :: NameHashInfo            -- per-name src/pub/impl hashes + local/external deps
 --
+--   Per-extension keys:
+--     "ext-by-class/<suffix>"       :: (A.Name, [A.Name]) -- class name to extension names
+--     "ext-by-protocol/<suffix>"    :: (A.Name, [A.Name]) -- protocol name to extension names
+--
 --   Per-statement keys (typed Module body):
 --     "stmt/<NNN>"     :: A.Stmt                      -- one typed top-level statement (NNN = padIndex)
 --
@@ -80,6 +84,8 @@ module InterfaceFiles
   , keyNameHash
   , readFile
   , readHeader
+  , readExtensionsByClass
+  , readExtensionsByProtocol
   , readFileMaybe
   , readHeaderMaybe
   , writeFile
@@ -126,6 +132,11 @@ data NameHashInfo = NameHashInfo
   } deriving (Show, Eq, Generic)
 
 instance Binary NameHashInfo
+
+data ExtensionIndex = ExtensionIndex
+  { extByClass      :: Map.Map A.Name [A.Name]
+  , extByProtocol   :: Map.Map A.Name [A.Name]
+  } deriving (Show, Eq)
 
 data SourceFileMeta = SourceFileMeta
   { sfmMTimeNs :: Integer
@@ -295,6 +306,16 @@ keyNameHashPrefix = key "name-hash/"
 keyNameHash :: A.Name -> BS.ByteString
 keyNameHash n = B.concat [keyNameHashPrefix, nameKeySuffix n]
 
+keyExtByClassPrefix, keyExtByProtocolPrefix :: BS.ByteString
+keyExtByClassPrefix      = key "ext-by-class/"
+keyExtByProtocolPrefix   = key "ext-by-protocol/"
+
+keyExtByClass :: A.Name -> BS.ByteString
+keyExtByClass n = B.concat [keyExtByClassPrefix, nameKeySuffix n]
+
+keyExtByProtocol :: A.Name -> BS.ByteString
+keyExtByProtocol n = B.concat [keyExtByProtocolPrefix, nameKeySuffix n]
+
 keyStmt :: Int -> BS.ByteString
 keyStmt i = B.pack ("stmt/" ++ padIndex i)
 
@@ -386,6 +407,13 @@ getValue label txn dbi k = do
     case mv of
       Nothing -> ioError (userError ("Missing .tydb key: " ++ label))
       Just v -> copyVal v >>= decodeStrict label
+
+getMaybeValue :: Binary a => String -> LMDB.MDB_txn -> LMDB.MDB_dbi -> BS.ByteString -> IO (Maybe a)
+getMaybeValue label txn dbi k = do
+    mv <- withVal k (LMDB.mdb_get txn dbi)
+    case mv of
+      Nothing -> return Nothing
+      Just v -> Just <$> (copyVal v >>= decodeStrict label)
 
 getValuesWithPrefix :: LMDB.MDB_txn -> LMDB.MDB_dbi -> BS.ByteString -> IO [BS.ByteString]
 getValuesWithPrefix txn dbi prefix =
@@ -533,6 +561,57 @@ readStmtEntries txn dbi = do
     forM [0 .. count - 1] $ \i ->
       getValue ("stmt " ++ show i) txn dbi (keyStmt i)
 
+emptyExtensionIndex :: ExtensionIndex
+emptyExtensionIndex =
+    ExtensionIndex
+      { extByClass = Map.empty
+      , extByProtocol = Map.empty
+      }
+
+extensionIndexFromNameInfo :: A.ModName -> I.NameInfo -> ExtensionIndex
+extensionIndexFromNameInfo mn nmod =
+    case nmod of
+      I.NModule _ te _ -> foldl addExt emptyExtensionIndex te
+      _ -> emptyExtensionIndex
+  where
+    addExt acc (ext, I.NExt _ c ps _ _ _) =
+      let cls = localQName (A.tcname c)
+          protos = [ p | (_, pcon) <- ps, Just p <- [localQName (A.tcname pcon)] ]
+          withClass =
+            case cls of
+              Nothing -> acc
+              Just n -> acc { extByClass = insertMany n [ext] (extByClass acc) }
+          withProtos =
+            foldl
+              (\idx p -> idx { extByProtocol = insertMany p [ext] (extByProtocol idx) })
+              withClass
+              protos
+      in withProtos
+    addExt acc _ = acc
+
+    localQName qn =
+      case qn of
+        A.NoQ n -> Just n
+        A.QName m n | m == mn -> Just n
+        A.GName m n | m == mn -> Just n
+        _ -> Nothing
+
+    insertMany n exts =
+      Map.insertWith unionNames n (sortNames exts)
+
+    unionNames xs ys = sortNames (xs ++ ys)
+    sortNames = Data.List.sortOn A.nstr . Data.List.nub
+
+extensionIndexEntries :: ExtensionIndex -> [(BS.ByteString, BS.ByteString)]
+extensionIndexEntries index =
+    [ (keyExtByClass n, encodeStrict (n, exts))
+    | (n, exts) <- Map.toList (extByClass index)
+    ]
+    ++
+    [ (keyExtByProtocol n, encodeStrict (n, exts))
+    | (n, exts) <- Map.toList (extByProtocol index)
+    ]
+
 interfaceEntries :: [Int] -> BS.ByteString -> BS.ByteString -> BS.ByteString -> Maybe SourceFileMeta -> [(A.ModName, BS.ByteString)] -> [NameHashInfo] -> [A.Name] -> [String] -> Maybe String -> I.NameInfo -> A.Module -> [(BS.ByteString, BS.ByteString)]
 interfaceEntries version moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta imps nameHashes roots tests mdoc nmod tchecked =
     [ (keyVersion, encodeStrict version)
@@ -552,6 +631,7 @@ interfaceEntries version moduleSrcBytesHash modulePubHash moduleImplHash sourceM
               , let suffix = nameKeySuffix n
               ]
     ++ [ (keyNameHash (nhName nh), encodeStrict nh) | nh <- nameHashes ]
+    ++ extensionIndexEntries (extensionIndexFromNameInfo tmn nmod)
     ++ [ (keyStmt i, encodeStrict stmt) | (i, stmt) <- zip [0..] body ]
   where
     I.NModule _ te _ = nmod
@@ -592,6 +672,24 @@ readHeader f =
       doc <- getValue "doc" txn dbi keyDoc
       nameHashes <- readNameHashEntries txn dbi
       return (sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash, imps, nameHashes, roots, tests, doc)
+
+readExtensionsByClass :: FilePath -> A.Name -> IO [A.Name]
+readExtensionsByClass f n =
+    withReadTxn f $ \txn dbi -> do
+      validateVersion txn dbi
+      entry <- getMaybeValue "ext-by-class" txn dbi (keyExtByClass n) :: IO (Maybe (A.Name, [A.Name]))
+      return $ case entry of
+        Nothing -> []
+        Just (_, exts) -> exts
+
+readExtensionsByProtocol :: FilePath -> A.Name -> IO [A.Name]
+readExtensionsByProtocol f n =
+    withReadTxn f $ \txn dbi -> do
+      validateVersion txn dbi
+      entry <- getMaybeValue "ext-by-protocol" txn dbi (keyExtByProtocol n) :: IO (Maybe (A.Name, [A.Name]))
+      return $ case entry of
+        Nothing -> []
+        Just (_, exts) -> exts
 
 -- Interface files are caches for most callers. If a file is missing,
 -- unreadable, corrupt, or from a different compiler interface version, the

--- a/compiler/lib/src/InterfaceFiles.hs
+++ b/compiler/lib/src/InterfaceFiles.hs
@@ -45,7 +45,7 @@
 --   Per-name keys (NameInfo / TEnv, one set per name):
 --     "name-order/<NNN>"   :: ByteString              -- name-key suffix, in TEnv order (NNN = padIndex)
 --     "name-info/<suffix>" :: (A.Name, I.NameInfo)    -- the name and its type/name environment entry
---     "name-hash/<suffix>" :: NameHashInfo            -- per-name src/pub/impl hashes + deps
+--     "name-hash/<suffix>" :: NameHashInfo            -- per-name src/pub/impl hashes + local/external deps
 --
 --   Per-statement keys (typed Module body):
 --     "stmt/<NNN>"     :: A.Stmt                      -- one typed top-level statement (NNN = padIndex)
@@ -119,6 +119,8 @@ data NameHashInfo = NameHashInfo
   , nhSrcHash  :: BS.ByteString
   , nhPubHash  :: BS.ByteString
   , nhImplHash :: BS.ByteString
+  , nhPubLocalDeps  :: [A.Name]
+  , nhImplLocalDeps :: [A.Name]
   , nhPubDeps  :: [(A.QName, BS.ByteString)]
   , nhImplDeps :: [(A.QName, BS.ByteString)]
   } deriving (Show, Eq, Generic)

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -58,6 +58,19 @@ import qualified Data.Aeson as Ae
 import qualified System.IO.Unsafe
 
 
+nameHash :: S.Name -> B8.ByteString -> B8.ByteString -> B8.ByteString -> InterfaceFiles.NameHashInfo
+nameHash n src pub impl =
+  InterfaceFiles.NameHashInfo
+    { InterfaceFiles.nhName = n
+    , InterfaceFiles.nhSrcHash = src
+    , InterfaceFiles.nhPubHash = pub
+    , InterfaceFiles.nhImplHash = impl
+    , InterfaceFiles.nhPubLocalDeps = []
+    , InterfaceFiles.nhImplLocalDeps = []
+    , InterfaceFiles.nhPubDeps = []
+    , InterfaceFiles.nhImplDeps = []
+    }
+
 
 
 main :: IO ()
@@ -85,11 +98,11 @@ main = do
                 , (longName, I.NVar S.tWild)
                 ]
               nameHashes =
-                [ InterfaceFiles.NameHashInfo derivedName "src4" "pub4" "impl4" [] []
-                , InterfaceFiles.NameHashInfo firstName "src1" "pub1" "impl1" [] []
-                , InterfaceFiles.NameHashInfo sourcePlainName "src3" "pub3" "impl3" [] []
-                , InterfaceFiles.NameHashInfo secondName "src2" "pub2" "impl2" [] []
-                , InterfaceFiles.NameHashInfo longName "src5" "pub5" "impl5" [] []
+                [ nameHash derivedName "src4" "pub4" "impl4"
+                , nameHash firstName "src1" "pub1" "impl1"
+                , nameHash sourcePlainName "src3" "pub3" "impl3"
+                , nameHash secondName "src2" "pub2" "impl2"
+                , nameHash longName "src5" "pub5" "impl5"
                 ]
               roots = [secondName, firstName]
               tests = ["test_second", "test_first"]
@@ -131,7 +144,7 @@ main = do
               tyPath = dir </> "iface.tydb"
               firstName = S.name "first"
               iface = [(firstName, I.NVar S.tWild)]
-              nameHashes = [InterfaceFiles.NameHashInfo firstName "src1" "pub1" "impl1" [] []]
+              nameHashes = [nameHash firstName "src1" "pub1" "impl1"]
               nmod = I.NModule [] iface Nothing
               tmod = S.Module mn [] Nothing []
           InterfaceFiles.writeFile tyPath "src" "pub" "impl" Nothing [] nameHashes [] [] Nothing nmod tmod
@@ -150,7 +163,7 @@ main = do
               dstPath = dir </> "iface-copy.tydb"
               firstName = S.name "first"
               iface = [(firstName, I.NVar S.tWild)]
-              nameHashes = [InterfaceFiles.NameHashInfo firstName "src1" "pub1" "impl1" [] []]
+              nameHashes = [nameHash firstName "src1" "pub1" "impl1"]
               nmod = I.NModule [] iface Nothing
               tmod = S.Module mn [] Nothing []
           InterfaceFiles.writeFile srcPath "src" "pub" "impl" Nothing [] nameHashes [] [] Nothing nmod tmod
@@ -170,7 +183,7 @@ main = do
               lockPath = tyPath </> "lock.mdb"
               firstName = S.name "first"
               iface = [(firstName, I.NVar S.tWild)]
-              nameHashes = [InterfaceFiles.NameHashInfo firstName "src1" "pub1" "impl1" [] []]
+              nameHashes = [nameHash firstName "src1" "pub1" "impl1"]
               nmod = I.NModule [] iface Nothing
               tmod = S.Module mn [] Nothing []
           InterfaceFiles.writeFile tyPath "src" "pub" "impl" Nothing [] nameHashes [] [] Nothing nmod tmod

--- a/compiler/lsp-server/Main.hs
+++ b/compiler/lsp-server/Main.hs
@@ -18,6 +18,7 @@ import qualified Data.Map.Strict as M
 import Data.Maybe (fromMaybe, listToMaybe)
 import Data.Sequence (Seq, ViewL(..), (|>))
 import qualified Data.Sequence as Seq
+import qualified Data.Set
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import GHC.Conc (getNumCapabilities)
@@ -71,6 +72,7 @@ data ProjectBuildCache = ProjectBuildCache
   { cachedCompileContext :: Compile.CompileContext
   , cachedProjectMap :: M.Map FilePath Compile.ProjCtx
   , cachedGlobalTasks :: [Compile.GlobalTask]
+  , cachedDbpBlocked :: Data.Set.Set Compile.TaskKey
   , cachedRootPins :: M.Map String BuildSpec.PkgDep
   , cachedImportKeys :: HM.HashMap FilePath String
   }
@@ -278,6 +280,7 @@ cacheCompilePlan plan = do
         { cachedCompileContext = ctx
         , cachedProjectMap = Compile.cpProjMap plan
         , cachedGlobalTasks = Compile.cpGlobalTasks plan
+        , cachedDbpBlocked = Compile.cpDbpBlocked plan
         , cachedRootPins = Compile.cpRootPins plan
         , cachedImportKeys = importKeys
         }
@@ -368,7 +371,13 @@ compilePlanFromCache ctx changedPath cache = do
   case refreshed of
     Nothing -> return Nothing
     Just (globalTasks, importKeys) -> do
-      neededTasks <- Compile.selectAffectedTasks globalTasks [changedPath]
+      let dbpBlocked = Compile.libraryBoundaryTasks (cachedProjectMap cache) globalTasks
+      neededTasks <- Compile.selectAffectedTasks
+        (Compile.ccRootProj ctx)
+        (Compile.ccOpts ctx)
+        globalTasks
+        dbpBlocked
+        [changedPath]
       let rootProj = Compile.ccRootProj ctx
           rootTasks =
             [ Compile.gtTask t
@@ -378,6 +387,7 @@ compilePlanFromCache ctx changedPath cache = do
           cache' = cache
             { cachedCompileContext = ctx
             , cachedGlobalTasks = globalTasks
+            , cachedDbpBlocked = dbpBlocked
             , cachedImportKeys = importKeys
             }
       atomicModifyIORef' projectBuildCachesRef $ \m ->
@@ -387,6 +397,7 @@ compilePlanFromCache ctx changedPath cache = do
         , Compile.cpProjMap = cachedProjectMap cache
         , Compile.cpGlobalTasks = globalTasks
         , Compile.cpNeededTasks = neededTasks
+        , Compile.cpDbpBlocked = dbpBlocked
         , Compile.cpRootTasks = rootTasks
         , Compile.cpRootPins = cachedRootPins cache
         , Compile.cpIncremental = True

--- a/docs/acton-dev-guide/src/compiler/imports_and_envs.md
+++ b/docs/acton-dev-guide/src/compiler/imports_and_envs.md
@@ -92,7 +92,9 @@ Header reads are used for cheap decisions:
 - roots, tests, and docstrings
 
 This is the path used by `readModuleTask` and the various cache lookups in
-`Acton.Compile`.
+`Acton.Compile`. It is also the first DBP path: deferred jobs read the header
+to collect per-name dependency edges, root actor seeds, and enough metadata to
+decide whether the selected generated code is already up to date.
 
 ### Full `.tydb` reads
 
@@ -102,10 +104,18 @@ typed module:
 - reusing an interface from a fresh cached module
 - implementation-hash refresh
 - codegen refresh
+- DBP back-pass execution after the selected codegen hash is stale
 
 Reading a full `.tydb` does not by itself reconstruct the import closure in the
 active environment. It only gives the caller the stored interface and typed
 module payload.
+
+DBP interest is also scheduler metadata, not an import overlay. Each completed
+front result contributes external `nhPubDeps` and `nhImplDeps` into an
+`InterestMap`, and DBP later uses that map to prune a provider's typed module.
+That does not make the selected provider names available to the active
+type-checker environment; imports still become type-checker bindings only
+through `mkEnv`/`doImp`.
 
 ## How transitive imports become available
 

--- a/docs/acton-dev-guide/src/compiler/incremental_compilation.md
+++ b/docs/acton-dev-guide/src/compiler/incremental_compilation.md
@@ -7,9 +7,11 @@ the type-checker environment.
 Acton compiles a whole program by walking a dependency graph that spans the
 root project and all of its dependencies. The scheduler in `Acton.Compile`
 builds this total graph, runs the front passes (parse, kinds, types) in
-topological order, and queues back passes as soon as a module's front passes
-finish. Front work gates downstream modules, while back jobs overlap ongoing
-front work. The scheduler runs tasks concurrently with async jobs across worker
+topological order, and normally queues back passes as soon as a module's front
+passes finish. Deferred back pass (DBP) candidates are held until all modules
+that can add interest for that candidate have completed their front passes.
+Front work gates downstream modules, while ready back jobs overlap ongoing front
+work. The scheduler runs tasks concurrently with async jobs across worker
 threads. In watch/LSP mode, each change event bumps a generation id, cancels
 in-flight tasks, and drops stale diagnostics or back jobs that still carry the
 old generation, so we can react to new changes without waiting for obsolete
@@ -32,8 +34,10 @@ CPUs.
 The public hash (**modulePubHash**) is derived from the module's public-name
 `pubHash` values (which already include any external signature dependencies).
 The implementation hash (**moduleImplHash**) is derived from per-name
-`implHash` values; it is stored in the `.tydb` header and written into generated
-`.c`/`.h` files as an "Acton impl hash" tag. If the tag is missing or
+`implHash` values; it is stored in the `.tydb` header. Normal generated
+`.c`/`.h` files are tagged with this module implementation hash as an "Acton
+impl hash". DBP generated files reuse the same tag but write a DBP codegen hash
+that also includes the selected top-level names. If the tag is missing or
 mismatched, we rerun back passes even if no other hashes changed.
 
 Hashing within a module is done per top-level name. A hashable unit is a `Def`,
@@ -73,27 +77,94 @@ dependency snapshots. **pubDeps** is a list of `(QName, pubHash)` for external
 declarations referenced from the unit's type signature and from value-level
 uses, which is what triggers re-typechecking when a provider's public interface
 changes. **implDeps** is a list of `(QName, implHash)` referenced from the body
-and is what triggers codegen and test invalidation. Only external dependencies
-are stored; local dependencies are folded into the computed hash during
-compilation.
+and is what triggers codegen and test invalidation. Local dependencies are
+stored separately as **pubLocalDeps** and **implLocalDeps** lists of `Name`s.
+Those local edges are folded into the computed hash during compilation, and
+they also give selective consumers such as DBP a cached local dependency graph.
 
 Mutually recursive groups are hashed as a unit to avoid fixed-point iteration.
 We compute `selfPubHash`/`selfImplHash` for each unit, compute a `groupHash`
 from the sorted self-hashes plus all external dependency hashes of the group,
 and then finalize each unit as `H(selfHash || groupHash || unitKey)`.
 
-The `.tydb` header stays ordered for deterministic reads. See
-[Interface caches](interface_caches.md) for the LMDB key layout.
+Header reads return the per-name hashes in deterministic name order. See
+[Interface caches](interface_caches.md) for the exact LMDB key layout.
 
 ```
 version
 meta              -- source metadata + module src/pub/impl hashes
 imports
-nameHashInfo      -- per-name src/pub/impl hash + dep snapshots
+name-hash/*       -- per-name src/pub/impl hash + dep snapshots
 roots
 tests
 docstring
 ```
+
+## Deferred Back Passes
+
+DBP is selected after type checking, when the full `NameHashInfo` list is
+available. A module becomes a DBP candidate when its top-level name count is at
+least the internal threshold (`10000` today), or when it is forced with
+`--dbp MOD[:name,...]`. The option can be repeated, and explicit seed names are
+unioned per module. DBP is disabled for `__builtin__`, `--only-build`,
+alternate-output modes such as `--cgen`/`--hgen`, and whenever `--no-dbp` is
+set. `--no-dbp` is a hard kill switch: it disables both the name-count
+heuristic and explicit `--dbp` module requests.
+
+Modules at an explicit `Build.act` library boundary are also excluded from DBP.
+A boundary module is a member of a declared library that is imported by any
+module outside that same library. The library boundary needs the full generated
+C/H surface, so even an explicit `--dbp` request compiles that module normally
+and emits an info message. Internal library modules remain DBP-eligible.
+
+When a fresh front pass produces a DBP candidate, the scheduler stores a
+`DeferredBackJob` instead of queueing a normal `BackJob`. Cached `TyTask`
+modules can also register deferred jobs on later builds. This matters because
+the provider source and implementation hash can stay unchanged while a consumer
+starts selecting a different provider name. The scheduler also records
+interested names in an `InterestMap` by folding each completed module's
+`nhPubDeps` and `nhImplDeps`.
+
+Deferred jobs do not wait for every front pass in the project. Their wait set is
+the reverse dependency closure of the deferred module in the total build graph.
+After each front stage completes, the scheduler flushes any deferred job whose
+wait set is now contained in the completed-front set. If a module in that wait
+set fails front passes, the normal failed-build path prevents the deferred back
+job from running.
+
+When a deferred job is ready, DBP first reads the candidate's `.tydb` header.
+It uses the header's `NameHashInfo` list and cached root actor names without
+decoding the typed module. The initial selection seeds are:
+
+- explicit `--dbp MOD:name,...` names, when present; otherwise the collected
+  `InterestMap` names for the module
+- cached root actor names from the `.tydb` header
+
+An empty interested-name set is valid; if the module has no root actors, DBP can
+produce an effectively empty module body. DBP maps derived names back to their
+owning top-level name, closes over `nhPubLocalDeps` and `nhImplLocalDeps`, and
+uses exact `readExtensionsByClass` / `readExtensionsByProtocol`
+lookups to keep top-level extension declarations required by selected classes
+or protocols. Selection metadata that cannot map a seed, local dependency, or
+extension back to a top-level name is a compiler error. DBP should not silently
+fall back to full-module compilation except for modules that contain
+`NotImplemented`/native hooks.
+
+Pruning happens on the typed module immediately before the normal back-pass
+chain. Selected declarations, signatures, assignments, and compiler-introduced
+`VarAssign` statements are retained by their bound top-level names; `Pass` is
+dropped. Other source-level top-level statements are not a fallback case because
+the parser rejects them before type checking.
+
+Before decoding the full typed module, DBP computes a codegen hash from the
+module implementation hash and the sorted selected top-level names. If the
+existing `.c` and `.h` files already carry that hash in their generated "Acton
+impl hash" tag, the deferred job is skipped. Otherwise DBP reads the full typed
+module with `readFile`, prunes it to the selected top-level declarations, runs
+the normal back-pass chain, and writes `.c`/`.h` tagged with that DBP codegen
+hash. A later consumer change that selects a different provider name therefore
+makes the provider's DBP output stale even when the provider source did not
+change.
 
 A source change always re-runs front passes for that module. Downstream modules
 compare recorded `pubDeps` against current provider hashes; any delta triggers

--- a/docs/acton-dev-guide/src/compiler/index.md
+++ b/docs/acton-dev-guide/src/compiler/index.md
@@ -1,9 +1,9 @@
 # Compiler
 
 The compiler runs a fixed sequence of AST-to-AST transforms before finally
-generating C.  The main entry point is `compiler/acton/Main.hs`, which wires
+generating C. The main entry point is `compiler/acton/Main.hs`, which wires
 the stages together via the `compiler/lib` modules listed below. All the real
-logic are contained in these modules and are thus accessible and usable as a
+logic is contained in these modules and is thus accessible and usable as a
 library.
 
 The same AST data type is used throughout all compiler passes, making it easy to
@@ -14,6 +14,9 @@ See [Imports and environments](imports_and_envs.md) for how the scheduler,
 
 See [Interface caches](interface_caches.md) for the LMDB-backed on-disk cache
 format used to store typed module interfaces.
+
+See [Incremental compilation](incremental_compilation.md) for the hash model,
+back-pass freshness checks, and deferred back pass scheduling.
 
 See [Project dependencies](project_dependencies.md) for how Acton package
 dependencies and zig dependencies are discovered, fetched, and emitted into the

--- a/docs/acton-dev-guide/src/compiler/interface_caches.md
+++ b/docs/acton-dev-guide/src/compiler/interface_caches.md
@@ -16,6 +16,9 @@ The compiler code should not construct these paths directly. Use the
 - `writeFile` writes the cache for one module.
 - `readHeader` reads only metadata, imports, roots, tests, docstring, and
   per-name hash records.
+- `readExtensionsByClass` and `readExtensionsByProtocol` read exact extension
+  index entries without decoding `NameInfo` entries or typed
+  statements.
 - `readFile` reconstructs the full cached payload: imports, `NameInfo`, typed
   module, metadata, module hashes, per-name hashes, roots, tests, and docstring.
 - `readHeaderMaybe` and `readFileMaybe` turn missing, corrupt, unreadable, or
@@ -49,6 +52,24 @@ The three `ByteString` hashes in `meta` are the module source-bytes hash, module
 public hash, and module implementation hash. The `ByteString` stored with each
 import is that imported module's public hash.
 
+Extension indexes use the same suffix scheme as per-name entries, so readers
+can look up one class or protocol without decoding the full index:
+
+| Key | Value type |
+| --- | --- |
+| `ext-by-class/p/<name>` | `(Name, [Name])` |
+| `ext-by-class/h/<hash>` | `(Name, [Name])` |
+| `ext-by-protocol/p/<name>` | `(Name, [Name])` |
+| `ext-by-protocol/h/<hash>` | `(Name, [Name])` |
+
+The value repeats the keyed class or protocol name and stores the synthetic
+top-level extension names produced by `extensionName`, which are also the names
+used by per-name hashes and DBP pruning. This lets selective readers keep
+extension declarations when a selected class, protocol, or local dependency
+requires extension support. A returned extension must also be present in that
+module's per-name hash records; otherwise the index is inconsistent with the
+typed module.
+
 Per-name keys:
 
 | Key | Value type |
@@ -58,6 +79,14 @@ Per-name keys:
 | `name-info/h/<hash>` | `(Name, NameInfo)` |
 | `name-hash/p/<name>` | `NameHashInfo` |
 | `name-hash/h/<hash>` | `NameHashInfo` |
+
+Each `NameHashInfo` value contains the local name, `srcHash`, `pubHash`,
+`implHash`, local public/implementation dependency names
+(`pubLocalDeps` / `implLocalDeps`), and external public/implementation
+dependency snapshots (`pubDeps` / `implDeps`) as `(QName, hash)` pairs. Header
+readers use these records for cache freshness, interest registration, and DBP
+local dependency closure without decoding the `NameInfo` entries or typed
+statements.
 
 Short safe source names are stored directly in key suffixes. Names longer than
 400 bytes and names containing unsafe path-like bytes use SHA-256 based key
@@ -97,11 +126,20 @@ stmt/000000000001                 -> typed Stmt for decode
 
 `readHeader` opens a read-only LMDB transaction and reads the header keys plus
 the `name-hash` entries. It does not decode `NameInfo` entries or typed
-statements.
+statements. DBP uses this path to get per-name hashes, local dependency edges,
+and root actor names before deciding whether the full typed module must be
+decoded.
+
+`readExtensionsByClass` and `readExtensionsByProtocol` read one class or
+protocol key directly. DBP uses these exact lookups while expanding the selected
+local dependency closure, mapping visited class/protocol names to the top-level
+extension names that the typed module can actually retain.
 
 `readFile` opens a read-only transaction and reconstructs the full payload by
 following the explicit order keys for ordered sections. It does not depend on
-LMDB cursor order for `TEnv` or typed statement reconstruction.
+LMDB cursor order for `TEnv` or typed statement reconstruction. DBP calls this
+only when its selection-sensitive codegen hash says the existing `.c`/`.h`
+output is missing or stale.
 
 `writeFile` writes the full environment in one write transaction. The compiler
 has one writer for a module cache, while multiple readers may run in parallel.

--- a/docs/acton-dev-guide/src/compiler/passes/codegen.md
+++ b/docs/acton-dev-guide/src/compiler/passes/codegen.md
@@ -1,3 +1,17 @@
 # Codegen
 
 Implementation lives in `compiler/lib/src/Acton/CodeGen.hs`.
+
+`Acton.CodeGen.generate` receives the hash string that should be stamped into
+the generated output. It writes that hash as the first line of both `.c` and
+`.h` files:
+
+```c
+/* Acton impl hash: ... */
+```
+
+For normal modules, `Acton.Compile` passes the module implementation hash. For
+DBP modules, it passes the DBP codegen hash derived from the module
+implementation hash plus the selected top-level names. The label is therefore
+historical: in DBP output it is a selection-sensitive generated-code hash, not
+just the raw module implementation hash.

--- a/docs/acton-dev-guide/src/compiler/passes/index.md
+++ b/docs/acton-dev-guide/src/compiler/passes/index.md
@@ -30,9 +30,11 @@ For how imports are loaded before these passes run, see
 
 ## Front vs back passes
 
-The pipeline is split into a front end and a back end. The scheduler runs all
-front passes across the dependency graph first, then queues back-pass work once
-type checking succeeds for a module.
+The pipeline is split into a front end and a back end. The scheduler runs front
+passes across the dependency graph, then queues back-pass work once type
+checking succeeds for a module. Normal modules queue their back job immediately.
+DBP candidates hold a deferred back job until all reverse-dependent front passes
+that can add interest have completed.
 
 Front passes (1–3) are:
 - Parse
@@ -57,6 +59,11 @@ files (`.c`, `.h`). It does not introduce new user errors, so it can run after
 front completion and even in the background. The CLI waits for all back jobs to
 finish before invoking Zig; the LSP enqueues back jobs in the background and
 does not wait for them or run Zig.
+
+DBP still runs the same back-pass sequence once it is ready. The difference is
+that it may prune the typed module to the selected top-level declarations before
+normalization, and it can skip the back job entirely when the selected DBP
+codegen hash already matches the generated `.c`/`.h` files.
 
 The shared orchestration lives in `compiler/lib/src/Acton/Compile.hs` and is
 used by both `acton` and the LSP server.

--- a/docs/acton-dev-guide/src/compiler/passes/parse.md
+++ b/docs/acton-dev-guide/src/compiler/passes/parse.md
@@ -12,6 +12,21 @@ The entry point is `parseModule`, which takes a module name, filename, and file
 contents, then returns the parsed `Module`. It also appends a trailing newline
 if the file is missing one to keep the parser consistent.
 
+## Module Top Level
+
+`parseModule` parses the module body as top-level chunks and then validates the
+result with `validateModuleSuite`. The validated source-level module suite only
+allows:
+
+- declarations (`Decl`)
+- signatures (`Signature`)
+- assignments that bind at least one top-level name (`Assign`)
+
+Any other top-level statement raises `InvalidModuleStatement`, and duplicate
+top-level assignment names raise `DuplicateTopLevelAssignment`. Later compiler
+passes can therefore assume there are no source-level top-level control-flow or
+expression statements.
+
 ## Debugging
 
 Use compiler flags to inspect the parser output:


### PR DESCRIPTION
This adds deferred back passes (DBP) for very large Acton modules. The problem this is trying to solve is that some generated modules are so large that running the full back-pass chain takes far too long and can produce C files that are too large for clang to compile. DBP moves the useful part of tree shaking earlier in the pipeline: the module still runs the normal front passes, but its back passes are held until the build has collected which provider names other modules actually use.

DBP is currently selected by top-level name count, with the automatic threshold set to 10,000 names. The temporary `--dbp MOD[:name,...]` option can force DBP for a module and optionally provide explicit seed names, which is useful for experiments and focused performance testing. `--no-dbp` is a hard kill switch that disables both heuristic and forced DBP.

Interest registration uses the existing per-name dependency metadata. It folds both public and implementation dependencies from fresh front-pass results and from reused `.tydb` headers, so a cached second build still contributes interest correctly. Deferred jobs do not wait for every front pass in the project; they wait only for the reverse-dependent part of the build graph that can import from the deferred module.

When the deferred job runs, the compiler decodes the typed module, chooses the interested provider names, keeps root actors, computes the local top-level dependency closure, adds extension dependencies keyed by class and protocol, and then sends the pruned typed module through the existing back-pass chain. Classes and actors keep their full declaration bodies so method tables, constructors, and actor support stay intact. The generated output stamp includes the selected name set, so if a consumer starts or stops using a provider name, the provider C/H files are invalidated and regenerated.

The branch also records local dependencies in `.tydb` name-hash entries. That is separate from the scheduling change but needed for DBP to compute the selected local closure without re-inferring dependency information from the typed AST. The `.tydb` extension lookup data now lets DBP find extensions for selected classes and protocols without requiring broad extension scans for closure correctness.

Modules at an explicit `Build.act` library boundary are hard-excluded from DBP. If a declared library contains modules `a` and `b`, and some module outside that library imports `b`, then `b` is the boundary and must keep its full generated C/H surface. Internal modules in the same library, such as `a`, can still use DBP. If a user forces DBP for a boundary module with `--dbp`, the compiler compiles it normally and emits an info message explaining that DBP was disabled for the explicit library boundary.

Selection failures are treated as compiler failures instead of silently falling back to a full module, except for backend cases that already cannot be represented selectively, such as `NotImplemented` or native hooks. The intended direction is that DBP should be correct enough to enable broadly, rather than relying on conservative full-module fallback.

The developer guide has been updated for DBP scheduling, interest registration, local deps in `.tydb`, extension lookup data, root actors, empty interest, selection failures, generated-output invalidation, `--dbp`, `--no-dbp`, and explicit library boundary exclusion.