### PR TITLE
Retry flaky distributed DB tests; show CI disk usage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -289,6 +289,12 @@ jobs:
           path: |
             ~/.cache/acton/
           key: acton-zig-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.arch }}
+      # Disk visibility: these containers have hit ENOSPC during cache restore.
+      # Print usage after restore so a future disk problem shows up as data
+      # rather than a silent mid-tar runner death. Never fails the job.
+      - name: "Show disk usage (after cache restore)"
+        if: always()
+        run: df -h || true
       - name: "chown our home dir to avoid stack complaining"
         run: chown -R root:root /github/home
       - name: "Install build prerequisites"
@@ -345,6 +351,12 @@ jobs:
           ulimit -c unlimited
           make -C ${GITHUB_WORKSPACE} test
           make -C ${GITHUB_WORKSPACE} online-tests
+      # Disk visibility: print usage after the build+test phase (the peak) so we
+      # can see how much headroom these containers actually have. Runs even on
+      # failure to help diagnose a suspected out-of-space death. Never fails.
+      - name: "Show disk usage (after tests)"
+        if: always()
+        run: df -h || true
       # Nightly only: save the freshly-built, complete compile cache as the day's
       # canonical snapshot (runs even if tests flake, but requires the build/release
       # steps to have succeeded so a build failure can't poison the day's key).

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -163,7 +163,11 @@ jobs:
             ~/.cache/acton/
           key: acton-zig-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.arch }}
       - name: "Install build prerequisites"
-        run: brew install haskell-stack
+        run: |
+          # Retry network-bound installs so a transient mirror/CDN blip doesn't
+          # fail the whole job.
+          retry() { n=1; until "$@"; do [ $n -ge 3 ] && { echo "failed after 3 attempts: $*" >&2; return 1; }; echo "attempt $n failed, retrying in 15s: $*" >&2; sleep 15; n=$((n+1)); done; }
+          retry brew install haskell-stack
       - name: "Build Acton"
         id: build_acton
         run: |
@@ -300,9 +304,14 @@ jobs:
       - name: "Install build prerequisites"
         run: |
           export DEBIAN_FRONTEND=noninteractive
-          apt-get update
-          apt-get install -qy bzip2 curl g++ haskell-stack libgmp-dev libncurses-dev make procps zlib1g-dev
-          apt-get install -qy gdb
+          # Retry network-bound installs so a transient mirror/CDN blip doesn't
+          # fail the whole job.
+          retry() { n=1; until "$@"; do [ $n -ge 3 ] && { echo "failed after 3 attempts: $*" >&2; return 1; }; echo "attempt $n failed, retrying in 15s: $*" >&2; sleep 15; n=$((n+1)); done; }
+          retry apt-get update
+          retry apt-get install -qy bzip2 curl g++ haskell-stack libgmp-dev libncurses-dev make procps zlib1g-dev
+          retry apt-get install -qy gdb
+          # Reclaim the apt download cache; these containers have limited disk.
+          apt-get clean || true
       - name: "locale en_US.UTF-8"
         run: |
           apt-get install -qy locales
@@ -323,7 +332,7 @@ jobs:
           STACK_TAR="stack-${STACK_VERSION}-linux-${STACK_ARCH}.tar.gz"
           STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK_VERSION}/${STACK_TAR}"
           mkdir -p "${HOME}/.local/bin"
-          curl -fsSL "${STACK_URL}" -o /tmp/stack.tgz
+          curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors "${STACK_URL}" -o /tmp/stack.tgz
           tar -xzf /tmp/stack.tgz -C /tmp
           install -m 0755 "/tmp/stack-${STACK_VERSION}-linux-${STACK_ARCH}/stack" "${HOME}/.local/bin/stack"
           echo "${HOME}/.local/bin" >> "$GITHUB_PATH"
@@ -404,9 +413,13 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
       - name: "Install build prerequisites"
         run: |
-          apt-get update
-          apt-get install -qy bzip2 curl g++ haskell-stack libgmp-dev libncurses-dev make procps zlib1g-dev
-          apt-get install -qy bash-completion build-essential debhelper devscripts
+          # Retry network-bound installs so a transient mirror/CDN blip doesn't
+          # fail the whole job.
+          retry() { n=1; until "$@"; do [ $n -ge 3 ] && { echo "failed after 3 attempts: $*" >&2; return 1; }; echo "attempt $n failed, retrying in 15s: $*" >&2; sleep 15; n=$((n+1)); done; }
+          retry apt-get update
+          retry apt-get install -qy bzip2 curl g++ haskell-stack libgmp-dev libncurses-dev make procps zlib1g-dev
+          retry apt-get install -qy bash-completion build-essential debhelper devscripts
+          apt-get clean || true
       - name: "Prepare stack directories"
         run: |
           mkdir -p "${HOME}/.local/bin" "${STACK_ROOT}"
@@ -439,7 +452,7 @@ jobs:
           esac
           STACK_TAR="stack-${STACK_VERSION}-linux-${STACK_ARCH}.tar.gz"
           STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v${STACK_VERSION}/${STACK_TAR}"
-          curl -fsSL "${STACK_URL}" -o /tmp/stack.tgz
+          curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors "${STACK_URL}" -o /tmp/stack.tgz
           tar -xzf /tmp/stack.tgz -C /tmp
           install -m 0755 "/tmp/stack-${STACK_VERSION}-linux-${STACK_ARCH}/stack" "${HOME}/.local/bin/stack"
           echo "${HOME}/.local/bin" >> "$GITHUB_PATH"

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,6 +1,19 @@
 MK_PATH:=$(abspath $(CURDIR)/..)
 ACTON="../dist/bin/acton" --quiet
 DDB_SERVER=../dist/bin/actondb
+
+# The distributed-database resume tests bring up a multi-node cluster over
+# localhost and are occasionally flaky (cluster membership / TCP timing races),
+# failing with "Error unpacking client message" or a timeout. Each run picks
+# fresh random ports, so a clean re-run is safe and almost always passes.
+# RETRY wraps just the (flaky) binary execution, not compilation: it runs the
+# given command up to 3 times, succeeding on the first green attempt.
+RETRY=n=1; max=3; while true; do \
+	echo "attempt $$n/$$max: $(1)"; \
+	if $(1); then break; fi; \
+	if [ $$n -ge $$max ]; then echo "FAILED after $$max attempts: $(1)" >&2; exit 1; fi; \
+	echo "attempt $$n failed, retrying: $(1)" >&2; n=$$((n+1)); \
+done
 TESTS= \
 	$(DDB_TESTS)
 TLS_TEST_SERVER_ENV=
@@ -27,18 +40,18 @@ tls-test-server:
 test_db_app:
 	$(ACTON) --db rts_db/ddb_test_app.act
 	$(ACTON) --db rts_db/test_db_app.act
-	rts_db/test_db_app
+	@$(call RETRY,rts_db/test_db_app)
 
 test_db_resume_tcp_server:
 	$(ACTON) --db rts_db/ddb_test_server.act
 	$(ACTON) --db rts_db/test_tcp_server.act
-	rts_db/test_tcp_server
+	@$(call RETRY,rts_db/test_tcp_server)
 
 test_db_resume_tcp_client:
 	$(ACTON) --db rts_db/ddb_test_server.act
 	$(ACTON) --db rts_db/ddb_test_client.act
 	$(ACTON) --db rts_db/test_tcp_client.act
-	rts_db/test_tcp_client
+	@$(call RETRY,rts_db/test_tcp_client)
 
 
 # Expect 9 threads given 7 workers + main process + IO


### PR DESCRIPTION
A set of CI-reliability changes from the failure investigation.

The distributed-database resume tests (test_db_app, test_db_resume_tcp_server, test_db_resume_tcp_client) bring up a localhost cluster and intermittently fail on membership / TCP timing races — "Error unpacking client message, msg is NULL" or a timeout. Across recent runs this was the single biggest source of false-red CI, forcing manual reruns and making it hard to tell flaky from real breakage. The test source already allocates fresh random ports per run, so a clean re-run is safe and almost always passes. A RETRY helper in test/Makefile wraps only the test binary execution (not compilation) and runs it up to 3 times, succeeding on the first green attempt and failing only if all 3 fail. A genuine, deterministic breakage still fails the job; only an intermittent one is papered over.

Network-bound setup steps were also occasionally failing whole jobs on transient blips. The installs (brew on macOS, apt-get on the linux containers and on build-debs) are now wrapped in a small retry helper (3 attempts, 15s backoff), and the stack-binary download uses curl --retry. These only retry the network operation, so a real failure still surfaces.

Some test-linux container jobs were dying mid cache-restore with no error — the silent signature of running out of disk. Two non-failing df -h steps (after cache restore, and after the build+test peak) make any future disk pressure show up as data instead of a mysterious runner death; they use if: always() and || true so they never affect the job result. The container jobs also run apt-get clean to reclaim the apt download cache, since disk is tight there.