### PR TITLE
Show type finalization timing and speed up signature checks

### DIFF
--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -1620,6 +1620,13 @@ initCliCompileHooks progressUI progressState gopts sched gen plan = do
           "Front timing: env " ++ fmtTimePrecise (ftEnv ft)
           ++ ", kinds " ++ fmtTimePrecise (ftKinds ft)
           ++ ", types " ++ fmtTimePrecise (ftTypes ft)
+        frontTypeTimingLine ft =
+          "Front type detail: reconstruct " ++ fmtTimePrecise (ftTypeReconstruct ft)
+          ++ " (after progress " ++ fmtTimePrecise (ftTypeAfterProgress ft) ++ ")"
+          ++ ", force " ++ fmtTimePrecise (ftTypeForce ft)
+          ++ ", hash " ++ fmtTimePrecise (ftTypeHash ft)
+          ++ ", write .tydb " ++ fmtTimePrecise (ftTypeWrite ft)
+          ++ ", docs " ++ fmtTimePrecise (ftTypeDocs ft)
         typeStmtTimingLine st =
           "Type stmt " ++ show (tstCompleted st) ++ "/" ++ show (tstTotal st)
         typeStmtBindsLine st =
@@ -1863,9 +1870,11 @@ initCliCompileHooks progressUI progressState gopts sched gen plan = do
                 when (C.timing gopts) $
                   forM_ (frFrontTiming fr) $ \ft -> do
                     logRendered (\cols -> detailLine cols detailStmtIndentWide detailStmtIndentNarrow (frontTimingLine ft))
-                    forM_ (ftTypeStmtTimings ft) $ \st -> do
-                      logRendered (\cols -> detailTimedLine cols detailStmtIndentWide detailStmtIndentNarrow (typeStmtTimingLine st) (tstTime st))
-                      logRendered (\cols -> detailLine cols detailBindsIndentWide detailBindsIndentNarrow (typeStmtBindsLine st))
+                    logRendered (\cols -> detailLine cols detailStmtIndentWide detailStmtIndentNarrow (frontTypeTimingLine ft))
+                    when (C.verbose gopts) $
+                      forM_ (ftTypeStmtTimings ft) $ \st -> do
+                        logRendered (\cols -> detailTimedLine cols detailStmtIndentWide detailStmtIndentNarrow (typeStmtTimingLine st) (tstTime st))
+                        logRendered (\cols -> detailLine cols detailBindsIndentWide detailBindsIndentNarrow (typeStmtBindsLine st))
                 when (C.timing gopts || C.verbose gopts) $
                   forM_ (frInferredSigs fr) $ \sig -> do
                     logRendered (\cols -> detailLine cols detailStmtIndentWide detailStmtIndentNarrow (inferredSignatureLine sig))

--- a/compiler/lib/bench/CompilerBench.hs
+++ b/compiler/lib/bench/CompilerBench.hs
@@ -69,6 +69,12 @@ printFrontTiming ft =
     putStrLn $ "front_timing env " ++ fmtTime (Compile.ftEnv ft)
             ++ " kinds " ++ fmtTime (Compile.ftKinds ft)
             ++ " types " ++ fmtTime (Compile.ftTypes ft)
+            ++ " reconstruct " ++ fmtTime (Compile.ftTypeReconstruct ft)
+            ++ " reconstruct_after_progress " ++ fmtTime (Compile.ftTypeAfterProgress ft)
+            ++ " force " ++ fmtTime (Compile.ftTypeForce ft)
+            ++ " hash " ++ fmtTime (Compile.ftTypeHash ft)
+            ++ " write_tydb " ++ fmtTime (Compile.ftTypeWrite ft)
+            ++ " docs " ++ fmtTime (Compile.ftTypeDocs ft)
 
 printBackTiming :: Compile.BackTiming -> IO ()
 printBackTiming bt =

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -237,7 +237,7 @@ import Data.Graph
 import Data.List (find, foldl', intercalate, intersperse, isPrefixOf, isSuffixOf, nub, partition)
 import qualified Data.List
 import Data.IORef
-import Data.Maybe (catMaybes, isJust, listToMaybe, mapMaybe)
+import Data.Maybe (catMaybes, isJust, isNothing, listToMaybe, mapMaybe)
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Map as M
 import Data.Ord (Down(..))
@@ -379,6 +379,12 @@ data FrontTiming = FrontTiming
   { ftEnv :: TimeSpec
   , ftKinds :: TimeSpec
   , ftTypes :: TimeSpec
+  , ftTypeReconstruct :: TimeSpec
+  , ftTypeAfterProgress :: TimeSpec
+  , ftTypeForce :: TimeSpec
+  , ftTypeHash :: TimeSpec
+  , ftTypeWrite :: TimeSpec
+  , ftTypeDocs :: TimeSpec
   , ftTypeStmtTimings :: [TypeStmtTiming]
   } deriving (Eq, Show)
 
@@ -2068,22 +2074,29 @@ runFrontPasses gopts opts dbpBlocked paths env0 parsed srcContent srcBytes sourc
       typeStmtTimingsRef <- newIORef ([] :: [TypeStmtTiming])
       inferredSigsRef <- newIORef ([] :: [InferredSignature])
       typeActiveRef <- newIORef Nothing
+      typeProgressDoneRef <- newIORef Nothing
+      let collectTypeStmtTimings = C.timing gopts && C.verbose gopts
       let onTypeProgress total completed current names _weight = do
             now <- getTime Monotonic
-            mActive <- readIORef typeActiveRef
-            forM_ mActive $ \(label, bindNames, activeTotal, t0) ->
-              modifyIORef' typeStmtTimingsRef
-                ( TypeStmtTiming
-                    { tstCompleted = completed
-                    , tstTotal = activeTotal
-                    , tstLabel = label
-                    , tstNames = bindNames
-                    , tstTime = now - t0
-                    }
-                : )
-            case current of
-              Just label -> writeIORef typeActiveRef (Just (label, names, total, now))
-              Nothing -> writeIORef typeActiveRef Nothing
+            when (total > 0 && completed >= total && isNothing current) $ do
+              mDone <- readIORef typeProgressDoneRef
+              when (isNothing mDone) $
+                writeIORef typeProgressDoneRef (Just now)
+            when collectTypeStmtTimings $ do
+              mActive <- readIORef typeActiveRef
+              forM_ mActive $ \(label, bindNames, activeTotal, t0) ->
+                modifyIORef' typeStmtTimingsRef
+                  ( TypeStmtTiming
+                      { tstCompleted = completed
+                      , tstTotal = activeTotal
+                      , tstLabel = label
+                      , tstNames = bindNames
+                      , tstTime = now - t0
+                      }
+                  : )
+              case current of
+                Just label -> writeIORef typeActiveRef (Just (label, names, total, now))
+                Nothing -> writeIORef typeActiveRef Nothing
             emitFrontProgress FrontPassTypes completed total current
           onInferredSignature names sig =
             modifyIORef' inferredSigsRef (InferredSignature names sig :)
@@ -2103,7 +2116,9 @@ runFrontPasses gopts opts dbpBlocked paths env0 parsed srcContent srcBytes sourc
 
       -- Type-check and return both the typed AST and the interface NameInfo.
       (nmod,tchecked,typeEnv,tests) <- Acton.Types.reconstruct (Just onTypeProgress) inferredSignatureCb env kchecked
+      timeTypeReconstruct <- getTime Monotonic
       forceTypeResult nmod tchecked typeEnv tests
+      timeTypeForce <- getTime Monotonic
       -- Module-level src hash uses raw bytes so any source edit forces re-parse.
       let moduleSrcBytesHash = SHA256.hash srcBytes
       -- Store roots so later builds can discover entry points without reparse.
@@ -2190,8 +2205,12 @@ runFrontPasses gopts opts dbpBlocked paths env0 parsed srcContent srcBytes sourc
                   -- Module-level hashes summarize the per-name hashes.
                   let modulePubHash = Hashing.modulePubHashFromIface nmod nameHashes
                       moduleImplHash = Hashing.moduleImplHashFromNameHashes nameHashes
+                  when (C.timing gopts) $
+                    evaluate (rnf (moduleSrcBytesHash, modulePubHash, moduleImplHash, nameHashes))
+                  timeTypeHash <- getTime Monotonic
                   -- Write .tydb now so later builds can reuse this front-pass work.
                   InterfaceFiles.writeFile (tyDbPath paths mn) moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta impsWithHash nameHashes roots tests mdoc nmod tchecked
+                  timeTypeWrite <- getTime Monotonic
 
                   iff (C.types opts && isRoot) $ dump mn "types" (Pretty.print tchecked)
                   iff (C.sigs opts && isRoot) $ dump mn "sigs" (Acton.Types.prettySigs env mn imps fullIface)
@@ -2215,12 +2234,18 @@ runFrontPasses gopts opts dbpBlocked paths env0 parsed srcContent srcBytes sourc
                     -- Use parsed (original AST) to preserve docstrings
                     let htmlDoc = DocP.printHtmlDoc (I.NModule imps simplifiedTypeEnv mdoc) parsed
                     writeFile docFile htmlDoc
+                  timeTypeDocs <- getTime Monotonic
 
                   timeTypeCheck <- getTime Monotonic
                   typeStmtTimings <- reverse <$> readIORef typeStmtTimingsRef
+                  typeProgressDone <- readIORef typeProgressDoneRef
 
                   timeFrontEnd <- getTime Monotonic
                   inferredSigs <- reverse <$> readIORef inferredSigsRef
+                  let typeAfterProgress =
+                        case typeProgressDone of
+                          Just t -> timeTypeReconstruct - t
+                          Nothing -> timeTypeReconstruct - timeTypeReconstruct
                   let frontTime = timeFrontEnd - timeStart
                       frontTimeMaybe = if not (quiet gopts opts)
                                          then Just frontTime
@@ -2231,6 +2256,12 @@ runFrontPasses gopts opts dbpBlocked paths env0 parsed srcContent srcBytes sourc
                                  { ftEnv = timeEnv - timeStart
                                  , ftKinds = timeKindsCheck - timeEnv
                                  , ftTypes = timeTypeCheck - timeKindsCheck
+                                 , ftTypeReconstruct = timeTypeReconstruct - timeKindsCheck
+                                 , ftTypeAfterProgress = typeAfterProgress
+                                 , ftTypeForce = timeTypeForce - timeTypeReconstruct
+                                 , ftTypeHash = timeTypeHash - timeTypeForce
+                                 , ftTypeWrite = timeTypeWrite - timeTypeHash
+                                 , ftTypeDocs = timeTypeDocs - timeTypeWrite
                                  , ftTypeStmtTimings = typeStmtTimings
                                  }
                           else Nothing

--- a/compiler/lib/src/Acton/Types.hs
+++ b/compiler/lib/src/Acton/Types.hs
@@ -43,6 +43,7 @@ import Acton.WitKnots
 import qualified InterfaceFiles
 import qualified Data.ByteString.Char8 as B
 import qualified Data.ByteString.Base16 as Base16
+import qualified Data.Set as Set
 import Data.List (foldl', intersperse, isPrefixOf, partition)
 import Data.Maybe (mapMaybe)
 import GHC.Conc (getNumCapabilities)
@@ -679,7 +680,8 @@ checkSigs env te
   | null ns                            = return ()
   | otherwise                           = err2 ns "Signature lacks subsequent binding"
   where (sigs,terms)                    = sigTerms te
-        ns                              = dom sigs \\ dom terms
+        termNames                       = Set.fromList (dom terms)
+        ns                              = [ n | n <- dom sigs, Set.notMember n termNames ]
 
 infLiveEnv env x
   | fallsthru x                         = do (cs,te,x') <- infSuiteEnv env x

--- a/compiler/lib/src/InterfaceFiles.hs
+++ b/compiler/lib/src/InterfaceFiles.hs
@@ -93,6 +93,7 @@ module InterfaceFiles
   ) where
 
 import Prelude hiding (readFile, writeFile)
+import Control.DeepSeq (NFData)
 import Data.Binary
 import qualified Control.Exception as E
 import Control.Concurrent (runInBoundThread, threadDelay)
@@ -132,6 +133,7 @@ data NameHashInfo = NameHashInfo
   } deriving (Show, Eq, Generic)
 
 instance Binary NameHashInfo
+instance NFData NameHashInfo
 
 data ExtensionIndex = ExtensionIndex
   { extByClass      :: Map.Map A.Name [A.Name]


### PR DESCRIPTION
This keeps plain --timing useful on large modules by printing one concise type detail line instead of the per-statement timing flood. The detail line breaks the type-checking tail into reconstruct, after-progress reconstruct time, forced result evaluation, hash and dependency finalization, .tydb writing, and docs. --timing --verbose still prints statement timings.

It also changes the missing-signature check to build a Set of term names before checking signatures. That avoids scanning the term list for every signature while keeping diagnostics in signature order.