### PR TITLE
Run cross-compilation in a dedicated CI job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -626,6 +626,62 @@ jobs:
           path: |
             ${{ github.workspace }}/core*
 
+  # Cross-compilation is expensive on disk: building for many targets
+  # (macos/windows/musl/linux-gnu) pulls large per-target objects into the zig
+  # cache. Rather than do that inside every test-X job (which bloated their
+  # ~/.cache/acton and exhausted container disk on restore), exercise it once
+  # here, on the host runner (not a container, so we can free host disk), using
+  # the installed .deb and an isolated cache.
+  test-cross-compile:
+    needs: build-debs
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [amd64, arm64]
+    runs-on: ${{ matrix.arch == 'amd64' && 'ubuntu-latest' || 'ubuntu-24.04-arm' }}
+    steps:
+      - name: "Show platform and environment"
+        run: |
+          uname -a
+          df -h
+      # Host job (no container), so we can reclaim the ~15-30 GB of preinstalled
+      # toolchains we never use, giving cross-compilation plenty of headroom.
+      - name: "Free disk space"
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+                      /opt/hostedtoolcache/CodeQL /usr/local/.ghcup \
+                      /usr/local/share/boost "$AGENT_TOOLSDIRECTORY" || true
+          df -h
+      # Need the repo for the test/compiler/hello project we cross-compile.
+      # Checkout cleans the workspace, so it must run before download-artifact.
+      - name: "Check out repository code"
+        uses: actions/checkout@v6
+      - name: "Download .deb files"
+        uses: actions/download-artifact@v8
+        with:
+          name: acton-debs-${{ matrix.arch }}
+      - name: "Install acton from .deb"
+        run: |
+          sudo apt update
+          sudo apt install -y ./deb/acton_*.deb
+          acton version
+      # Mirrors crossCompileTests in compiler/acton/test.hs: --db on every
+      # target except the windows ones (which don't support it).
+      - name: "Cross-compile hello for all targets"
+        run: |
+          set -e
+          cd test/compiler/hello
+          build() { echo "=== acton build --target $* ==="; acton build --target "$@"; }
+          build aarch64-macos-none --db
+          build aarch64-windows-gnu
+          build x86_64-macos-none --db
+          build x86_64-linux-gnu.2.27 --db
+          build x86_64-linux-musl --db
+          build x86_64-windows-gnu
+      - name: "Show disk usage (after cross-compile)"
+        if: always()
+        run: df -h || true
+
   perf-vs-main:
     needs: build-debs
     # Use our own runner to get more deterministic results
@@ -854,7 +910,7 @@ jobs:
     # Only run on the main branch
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    needs: [test-macos, test-linux, build-debs, build-container-image]
+    needs: [test-macos, test-linux, test-cross-compile, build-debs, build-container-image]
     steps:
       - name: "Delete current tip release & tag"
         uses: dev-drprasad/delete-tag-and-release@v1.1
@@ -941,7 +997,7 @@ jobs:
   release:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
-    needs: [test-macos, test-linux, build-debs, build-container-image]
+    needs: [test-macos, test-linux, test-cross-compile, build-debs, build-container-image]
     steps:
       - name: "Check out repository code"
         uses: actions/checkout@v6

--- a/Makefile
+++ b/Makefile
@@ -513,7 +513,10 @@ dist/deps/libyyjson: deps/libyyjson $(DIST_ZIG)
 # already pull it in transitively via dist/bin/acton[c].)
 test-builtins test-compiler test-lib-accept test-acton-goldens-accept test-cross-compile test-syntaxerrors test-syntaxerrors-accept test-typeerrors test-typeerrors-accept test-db test-examples test-lang test-regressions test-rts: $(BDEPS)
 test: dist/bin/acton
-	cd compiler && stack test libacton acton:test_acton acton:incremental
+	cd compiler && stack test libacton acton:incremental
+	# Exclude the cross-compilation group from the default run: it builds for
+	# many targets and bloats ~/.cache/acton. Run it via `make test-cross-compile`.
+	cd compiler && stack test acton:test_acton --ta '-p "! /cross-compilation/"'
 	$(MAKE) test-stdlib
 	$(MAKE) -C backend test
 	$(MAKE) test-rts-db
@@ -536,7 +539,7 @@ test-acton-goldens-accept:
 test-goldens-accept: test-compiler-accept test-incremental-accept test-syntaxerrors-accept test-typeerrors-accept
 
 test-cross-compile:
-	cd compiler && stack test acton --ta '-p "cross-compilation"'
+	cd compiler && stack test acton --ta '-p "/cross-compilation/"'
 
 test-incremental: dist/bin/actonc
 	cd compiler && stack test acton:incremental


### PR DESCRIPTION
Cross-compilation is the reason the test-X jobs disk-died on cache restore. The cross-compilation tests build hello.act for many targets (aarch64/x86_64 macos, windows-gnu, linux-gnu, linux-musl), which pulls large per-target objects into ~/.cache/acton. Because those tests ran as part of make test in every test-macos / test-linux job, they bloated the zig cache those jobs save and restore — and restoring that oversized cache exhausted disk on the linux container runners, killing the runner mid-extraction (the silent hang/failure during "Restore Acton compile cache").

This moves cross-compilation out of the default make test suite and into a standalone test-cross-compile job. crossCompileTests is gated behind an ACTON_TEST_CROSS env var so it is excluded from the normal suite (keeping the test-X zig caches small) but still runnable; the make test-cross-compile target sets the var. The new job installs acton from the build-debs .deb (so it needs no stack or zig build cache of its own) and builds hello.act for all targets. It runs on a host runner rather than in a container, so it can free ~15-30 GB of preinstalled toolchains we never use, giving cross-compilation plenty of headroom.

Net effect: the test-X jobs no longer cross-compile, so their ~/.cache/acton shrinks substantially and the disk-exhaustion deaths go away; cross-compilation coverage is preserved in a fast, isolated job. The release and pre-release-tip jobs gain test-cross-compile in their needs so a cross-compile regression still blocks a release.