### PR TITLE
Free host disk in test-linux containers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -254,6 +254,19 @@ jobs:
     runs-on: ubuntu-24.04${{ matrix.arch == 'arm64v8' && '-arm' || '' }}
     container:
       image: ${{ matrix.os }}:${{ matrix.version }}
+      # Bind-mount the host's large preinstalled toolchains so the step below
+      # can delete them from inside the container. The container's root overlay
+      # lives on the same host disk as these, so freeing them gives the cache
+      # restore + build headroom (these jobs were dying of ENOSPC mid-restore).
+      # Bind-mounting a path that doesn't exist on a given runner just yields an
+      # empty dir, so this is safe across amd64/arm64 images.
+      volumes:
+        - /usr/share/dotnet:/host-disk/dotnet
+        - /usr/local/lib/android:/host-disk/android
+        - /opt/ghc:/host-disk/ghc
+        - /usr/local/.ghcup:/host-disk/ghcup
+        - /opt/hostedtoolcache:/host-disk/hostedtoolcache
+        - /usr/local/share/boost:/host-disk/boost
     env:
       LANG: en_US.UTF-8
       LC_ALL: en_US.UTF-8
@@ -264,6 +277,15 @@ jobs:
           uname -a
           env
           cat /proc/cpuinfo
+      # Reclaim host disk (via the volumes bind-mounted above) before we restore
+      # the compile cache, which is what was exhausting disk on these containers.
+      - name: "Free host disk space"
+        run: |
+          df -h || true
+          rm -rf /host-disk/dotnet/* /host-disk/android/* /host-disk/ghc/* \
+                 /host-disk/ghcup/* /host-disk/hostedtoolcache/* \
+                 /host-disk/boost/* 2>/dev/null || true
+          df -h || true
       - name: "Set BUILD_RELEASE when we are building for a version tag"
         if: startsWith(github.ref, 'refs/tags/v')
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,9 +72,12 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: |
           # Deliberately tolerant: a transient API hiccup here must not block CI.
-          ids="$(gh cache list --key acton-zig- --limit 100 --json id --jq '.[].id' || true)"
+          # Covers both the per-platform test caches (acton-zig-) and the
+          # cross-compilation job's cache (acton-cross-).
+          ids="$( { gh cache list --key acton-zig- --limit 100 --json id --jq '.[].id'; \
+                    gh cache list --key acton-cross- --limit 100 --json id --jq '.[].id'; } || true)"
           if [ -z "${ids}" ]; then
-            echo "No acton-zig caches to evict."
+            echo "No compile caches to evict."
             exit 0
           fi
           for id in ${ids}; do
@@ -655,7 +658,7 @@ jobs:
   # here, on the host runner (not a container, so we can free host disk), using
   # the installed .deb and an isolated cache.
   test-cross-compile:
-    needs: build-debs
+    needs: [build-debs, evict-stale-caches]
     strategy:
       fail-fast: false
       matrix:
@@ -687,19 +690,40 @@ jobs:
           sudo apt update
           sudo apt install -y ./deb/acton_*.deb
           acton version
-      # Mirrors crossCompileTests in compiler/acton/test.hs: --db on every
-      # target except the windows ones (which don't support it).
+      # Cross-compiling all targets cold is slow, so cache the zig artifacts.
+      # Same producer/consumer model as the test-X jobs: PRs and pushes restore
+      # only; the nightly/manual producer builds cold (skips restore) and saves a
+      # fresh snapshot, after evict-stale-caches has cleared the old one.
+      - name: "Restore cross-compile cache (~/.cache/acton)"
+        if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
+        uses: actions/cache/restore@v5
+        with:
+          path: |
+            ~/.cache/acton/
+          key: acton-cross-${{ matrix.arch }}
+      # Cross-compile hello for each target. --db on targets that support it;
+      # Windows has no RTS thread support, so those use --no-threads (per
+      # AGENTS.md), which is the Windows build mode we actually ship.
       - name: "Cross-compile hello for all targets"
+        id: cross_compile
         run: |
           set -e
           cd test/compiler/hello
           build() { echo "=== acton build --target $* ==="; acton build --target "$@"; }
           build aarch64-macos-none --db
-          build aarch64-windows-gnu
+          build aarch64-windows-gnu --no-threads
           build x86_64-macos-none --db
           build x86_64-linux-gnu.2.27 --db
           build x86_64-linux-musl --db
-          build x86_64-windows-gnu
+          build x86_64-windows-gnu --no-threads
+      # Producer only: save the freshly-built cross-compile cache.
+      - name: "Save cross-compile cache (~/.cache/acton)"
+        if: ${{ !cancelled() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && steps.cross_compile.outcome == 'success' }}
+        uses: actions/cache/save@v5
+        with:
+          path: |
+            ~/.cache/acton/
+          key: acton-cross-${{ matrix.arch }}
       - name: "Show disk usage (after cross-compile)"
         if: always()
         run: df -h || true
@@ -835,7 +859,7 @@ jobs:
       repo_url: "actonlang/acton-http2"
 
   build-container-image:
-    needs: [test-macos, test-linux, build-debs]
+    needs: [test-macos, test-linux, test-cross-compile, build-debs]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1066,7 +1090,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: debian:experimental
-    needs: [test-macos, test-linux, build-debs]
+    needs: [test-macos, test-linux, test-cross-compile, build-debs]
     steps:
       - name: Install build prerequisites
         run: |
@@ -1120,7 +1144,7 @@ jobs:
       image: debian:experimental
     permissions:
       contents: write
-    needs: [test-macos, test-linux, build-debs]
+    needs: [test-macos, test-linux, test-cross-compile, build-debs]
     steps:
       - name: Install build prerequisites
         run: |
@@ -1166,7 +1190,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     # Depend on all test jobs so we don't update brew repo in case anything fails
-    needs: [test-macos, test-linux, build-debs]
+    needs: [test-macos, test-linux, test-cross-compile, build-debs]
     steps:
       - name: "Check out code of main acton repo"
         uses: actions/checkout@v6


### PR DESCRIPTION
The test-linux jobs run inside a container (image: debian/ubuntu), so a normal host-level disk cleanup can't reach the host's large preinstalled toolchains (dotnet, android SDK, ghc, hostedtoolcache, boost) that occupy most of the runner disk. The container's steps only see the container filesystem. But the container's root overlay lives on the same host disk as those toolchains, so if we bind-mount them in, we can delete them from within the container and reclaim real space.

This adds a volumes: block to the test-linux container mapping each big host path to /host-disk/*, and a "Free host disk space" step that runs first (before the compile-cache restore that was exhausting disk and killing the runner mid-extraction) and rm -rf's them. Removals are defensive — a path missing on a given runner is ignored, and bind-mounting a nonexistent host path just yields an empty dir — so it's safe across the amd64 and arm64 images. df -h is printed before and after so we can see how much was reclaimed.