### PR TITLE
Cache downloaded source archives

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,6 +141,11 @@ jobs:
           ulimit -c unlimited
       - name: "Check out repository code"
         uses: actions/checkout@v6
+      - name: "Cache downloaded source archives"
+        uses: actions/cache@v5
+        with:
+          path: deps-download
+          key: deps-download-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.arch }}-${{ hashFiles('Makefile', 'deps/**/build.zig', 'deps/**/build.zig.zon') }}
       - name: "Cache Haskell deps (~/.stack)"
         if: matrix.cache == true
         uses: actions/cache@v5
@@ -295,6 +300,11 @@ jobs:
           echo "BUILD_RELEASE=1" >> $GITHUB_ENV
       - name: "Check out repository code"
         uses: actions/checkout@v6
+      - name: "Cache downloaded source archives"
+        uses: actions/cache@v5
+        with:
+          path: deps-download
+          key: deps-download-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.arch }}-${{ hashFiles('Makefile', 'deps/**/build.zig', 'deps/**/build.zig.zon') }}
       - name: "Cache Haskell deps (~/.stack)"
         if: matrix.cache == true
         uses: actions/cache@v5
@@ -450,6 +460,11 @@ jobs:
           mkdir -p "${HOME}/.local/bin" "${STACK_ROOT}"
       - name: "Check out repository code"
         uses: actions/checkout@v6
+      - name: "Cache downloaded source archives"
+        uses: actions/cache@v5
+        with:
+          path: deps-download
+          key: deps-download-build-debs-${{ matrix.arch }}-${{ hashFiles('Makefile', 'deps/**/build.zig', 'deps/**/build.zig.zon') }}
       - name: "Cache Haskell deps (~/.stack)"
         uses: actions/cache@v5
         with:


### PR DESCRIPTION
Source and package builds fetch pinned tarballs into deps-download before unpacking bundled dependencies. When GitHub archive downloads return transient errors, the build can fail even though the inputs are unchanged.

This adds a content-keyed deps-download cache to the source-build and Debian package-build jobs. Successful runs can restore those archives before Make falls back to downloading them.