### PR TITLE
Back off transient LMDB read retries

### DIFF
--- a/compiler/lib/src/InterfaceFiles.hs
+++ b/compiler/lib/src/InterfaceFiles.hs
@@ -410,10 +410,10 @@ canReadWithoutLock path = do
         return (not dataWritable && not dirWritable)
 
 lmdbTransientMaxAttempts :: Int
-lmdbTransientMaxAttempts = 5
+lmdbTransientMaxAttempts = 10
 
 lmdbTransientRetryDelayUs :: Int
-lmdbTransientRetryDelayUs = 2000
+lmdbTransientRetryDelayUs = 20000
 
 withInterfaceLock :: FilePath -> IO a -> IO a
 withInterfaceLock path action = do


### PR DESCRIPTION
Concurrent `.tydb` readers can still receive raw OS-level LMDB errors while opening a read transaction or its database handle against a freshly opened environment. The existing retry path keeps semantic LMDB failures visible, but its retry window was too short for temporary lock-table races.

This keeps the same transient-error classification and gives those read transaction retries a larger window, so a temporary lock-table race can settle before we report a real LMDB failure.