### PR TITLE
Skip Zig build in package fixture tests

### DIFF
--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -712,7 +712,7 @@ compilerTests =
                   , "zig_dependencies = {}"
                   ]
               runBuild dir = readCreateProcessWithExitCode
-                (proc actonExe ["build", "--always-build"]) { cwd = Just dir, env = Just envWithHome } ""
+                (proc actonExe ["build", "--skip-build", "--always-build"]) { cwd = Just dir, env = Just envWithHome } ""
 
           createDirectoryIfMissing True homeDir
 
@@ -787,7 +787,7 @@ compilerTests =
                     , ""
                     ]
                 runBuild dir = readCreateProcessWithExitCode
-                  (proc actonExe ["build", "--always-build"]) { cwd = Just dir, env = Just envWithHome } ""
+                  (proc actonExe ["build", "--skip-build", "--always-build"]) { cwd = Just dir, env = Just envWithHome } ""
                 assertBuildOk label (code, out, err) =
                   when (code /= ExitSuccess) $
                     assertFailure (label ++ " failed:\nstdout:\n" ++ out ++ "\nstderr:\n" ++ err)


### PR DESCRIPTION
Two package-dependency tests only inspect compiler-generated package metadata and stale `out/types` behavior. They still need `--always-build` so the compiler/package paths rerun, but they do not need the final Zig compile and link step.

This adds `--skip-build` to those fixture builds so the tests keep checking the same compiler behavior without spending time building generated Zig projects.