### PR TITLE
Speed up scripted REPL tests

### DIFF
--- a/compiler/acton/Repl.hs
+++ b/compiler/acton/Repl.hs
@@ -91,7 +91,9 @@ runRepl hooks gopts opts = do
     mproj <- mapM canonicalizePath mproj0
     withReplRoot hooks opts mproj $ \scratchDir -> do
       interactive <- hIsTerminalDevice stdin
-      warmup <- newEmptyMVar
+      warmup <- if interactive
+                  then newEmptyMVar
+                  else newMVar False
       let srcRoot = scratchDir </> "src"
           mainSrcFile = srcRoot </> replMainModuleName <.> "act"
           sessionSrcFile = srcRoot </> replSessionModuleName <.> "act"
@@ -114,7 +116,7 @@ runRepl hooks gopts opts = do
                 , replHooks = hooks
                 }
       createDirectoryIfMissing True srcRoot
-      startReplWarmup ctx
+      when interactive (startReplWarmup ctx)
       when (interactive && not (C.quiet gopts)) $ do
         putStrLn "Acton REPL. Type :help for commands, :quit to exit."
         when (C.verbose gopts) $
@@ -172,7 +174,7 @@ normalizeReplCompileOptions opts =
 startReplWarmup :: ReplContext -> IO ()
 startReplWarmup ctx = do
     _ <- forkIO $ do
-      res <- try (compileReplRunnerNow ctx emptyReplState ReplNoop) :: IO (Either SomeException Bool)
+      res <- try (compileReplRunnerRaw ctx emptyReplState ReplNoop) :: IO (Either SomeException Bool)
       ok <- case res of
               Left err -> hPutStrLn stderr (show err) >> return False
               Right ok -> return ok
@@ -184,6 +186,10 @@ waitReplWarmup ctx = readMVar (replWarmup ctx)
 
 finishReplWarmup :: ReplContext -> IO ()
 finishReplWarmup ctx = void (readMVar (replWarmup ctx))
+
+markReplWarmup :: ReplContext -> IO ()
+markReplWarmup ctx =
+    modifyMVar_ (replWarmup ctx) (\_ -> return True)
 
 withReplRoot :: Hooks -> C.CompileOptions -> Maybe FilePath -> (FilePath -> IO ()) -> IO ()
 withReplRoot hooks opts mproj action
@@ -486,6 +492,12 @@ compileReplRunner ctx st = do
 
 compileReplRunnerNow :: ReplContext -> ReplState -> ReplEval -> IO Bool
 compileReplRunnerNow ctx st eval = do
+    ok <- compileReplRunnerRaw ctx st eval
+    when ok (markReplWarmup ctx)
+    return ok
+
+compileReplRunnerRaw :: ReplContext -> ReplState -> ReplEval -> IO Bool
+compileReplRunnerRaw ctx st eval = do
     ensureReplBuildAct ctx st
     createDirectoryIfMissing True (takeDirectory (replMainSrcFile ctx))
     writeFileIfChanged (replMainSrcFile ctx) (renderReplMainSource st)

--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -263,10 +263,11 @@ compilerTests =
             (not ("actor Foo():" `isInfixOf` evalSrc))
           assertBool "repl eval should not duplicate retained classes"
             (not ("class Box(object):" `isInfixOf` evalSrc))
-  , testCase "repl reset clears generated session" $ do
+  , testCase "repl reset keeps tempdir isolated and rejects bad setup" $ do
         withSystemTempDirectory "acton-repl-reset" $ \proj -> do
           actonExe <- canonicalizePath "../../dist/bin/acton"
           let replRoot = proj </> ".acton-repl"
+              buildAct = proj </> "Build.act"
           let input = unlines
                 [ "def gone() -> str:"
                 , "    return \"leak\""
@@ -275,9 +276,12 @@ compilerTests =
                 , ":reset"
                 , ":show"
                 , "gone()"
+                , "x = 1 / 0"
                 , "2 + 2"
+                , ":show"
                 , ":q"
                 ]
+          writeFile buildAct "name = \"real_project\"\n"
           (returnCode, cmdOut, cmdErr) <- readCreateProcessWithExitCode
             (proc actonExe ["repl", "--color", "never", "--parse", "--tempdir", proj]) input
           assertEqual ("acton repl should exit successfully: " ++ cmdErr) ExitSuccess returnCode
@@ -287,9 +291,18 @@ compilerTests =
             ("<empty>\n" `isInfixOf` cmdOut)
           assertBool "repl should continue evaluating after reset"
             ("4\n" `isInfixOf` cmdOut)
+          assertBool "repl should report runtime assignment failure"
+            ("Process exited with status 1\n" `isInfixOf` cmdErr)
+          assertBool "repl should reject failing setup line"
+            ("Input was not added to the session.\n" `isInfixOf` cmdErr)
           sessionSrc <- readFile (replRoot </> "src" </> "repl_session.act")
           assertBool "repl reset should rewrite session source"
             (not ("def gone()" `isInfixOf` sessionSrc))
+          parentBuildAct <- readFile buildAct
+          assertEqual "repl should not overwrite parent Build.act"
+            "name = \"real_project\"\n" parentBuildAct
+          replBuildActExists <- doesFileExist (replRoot </> "Build.act")
+          assertBool "repl should write Build.act in owned subdir" replBuildActExists
   , testCase "repl reused scratch starts with empty session" $ do
         withSystemTempDirectory "acton-repl-reuse" $ \proj -> do
           actonExe <- canonicalizePath "../../dist/bin/acton"
@@ -324,45 +337,6 @@ compilerTests =
           sessionSrc <- readFile (replRoot </> "src" </> "repl_session.act")
           assertBool "reused repl should rewrite stale session source"
             (not ("def gone()" `isInfixOf` sessionSrc))
-  , testCase "repl tempdir does not clobber parent project" $ do
-        withSystemTempDirectory "acton-repl-tempdir-parent" $ \proj -> do
-          actonExe <- canonicalizePath "../../dist/bin/acton"
-          let input = unlines
-                [ "2 + 2"
-                , ":q"
-                ]
-              buildAct = proj </> "Build.act"
-          writeFile buildAct "name = \"real_project\"\n"
-          (returnCode, cmdOut, cmdErr) <- readCreateProcessWithExitCode
-            (proc actonExe ["repl", "--color", "never", "--tempdir", proj]) input
-          assertEqual ("acton repl should exit successfully: " ++ cmdErr) ExitSuccess returnCode
-          assertBool "repl should evaluate in owned tempdir"
-            ("4\n" `isInfixOf` cmdOut)
-          parentBuildAct <- readFile buildAct
-          assertEqual "repl should not overwrite parent Build.act"
-            "name = \"real_project\"\n" parentBuildAct
-          replBuildActExists <- doesFileExist (proj </> ".acton-repl" </> "Build.act")
-          assertBool "repl should write Build.act in owned subdir" replBuildActExists
-  , testCase "repl rejects failing setup assignments" $ do
-        withSystemTempDirectory "acton-repl-failing-assignment" $ \proj -> do
-          actonExe <- canonicalizePath "../../dist/bin/acton"
-          let input = unlines
-                [ "x = 1 / 0"
-                , "2 + 2"
-                , ":show"
-                , ":q"
-                ]
-          (returnCode, cmdOut, cmdErr) <- readCreateProcessWithExitCode
-            (proc actonExe ["repl", "--color", "never", "--tempdir", proj]) input
-          assertEqual ("acton repl should exit successfully: " ++ cmdErr) ExitSuccess returnCode
-          assertBool "repl should report runtime assignment failure"
-            ("Process exited with status 1\n" `isInfixOf` cmdErr)
-          assertBool "repl should reject failing setup line"
-            ("Input was not added to the session.\n" `isInfixOf` cmdErr)
-          assertBool "repl should continue after failing setup line"
-            ("4\n" `isInfixOf` cmdOut)
-          assertBool "repl should not retain failing setup line"
-            ("<empty>\n" `isInfixOf` cmdOut)
   , testCase "deps" $ do
         (returnCode, cmdOut, cmdErr) <- readCreateProcessWithExitCode (shell $ "rm -rf ../../test/compiler/test_deps/build.zig*") ""
         (returnCode, cmdOut, cmdErr) <- readCreateProcessWithExitCode (shell $ "rm -rf ../../test/compiler/test_deps/out") ""


### PR DESCRIPTION
Scripted REPL sessions do not benefit from the empty background warmup build because there is no interactive delay to hide it. This starts that warmup only for an interactive terminal, while marking the runner warm after the first successful scripted runner build so later evals still use the incremental session path.

The reset, bad setup, and tempdir-isolation checks now run in one scripted REPL session. The same behavior stays covered with fewer compiler-backed REPL processes.