### PR TITLE
Skip final build in DBP fixture test

### DIFF
--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -505,7 +505,7 @@ compilerTests =
           removeIfExists (typesDir </> "main.h")
           removeIfExists (typesDir </> "main.root.c")
           sixthLog <- assertOk "dbp keeps executable root actor" =<<
-            runBuild ["build", "--verbose", "--dbp", "main", "--dbp", "provider", "--color", "never"]
+            runBuild ["build", "--skip-build", "--verbose", "--dbp", "main", "--dbp", "provider", "--color", "never"]
           assertBool "root module should report root seed" ("DBP main: forced by --dbp" `isInfixOf` sixthLog)
           assertBool "root module should count root name" ("root names 1" `isInfixOf` sixthLog)
           mainC <- readFile (typesDir </> "main.c")


### PR DESCRIPTION
The DBP fixture checks that the executable root actor is selected by reading generated `main.c`. It does not run the linked binary for that subcase, so the final Zig build only adds test time.

This keeps the DBP compiler work and generated-C assertion, but passes `--skip-build` for that subcase so the test stops compiling and linking a binary it never uses.