### PR TITLE
Skip perf mode for downstream app tests

### DIFF
--- a/.github/workflows/test-app.yml
+++ b/.github/workflows/test-app.yml
@@ -36,4 +36,3 @@ jobs:
           cd app
           acton build
           acton test
-          acton test perf


### PR DESCRIPTION
Downstream app checks already build each app and run the normal test suite. Running `acton test perf` there turns the compatibility gate into a benchmark-style loop for every downstream app, and we have seen orchestron pass normal tests but fail in perf mode on a timeout-sensitive test.

This keeps downstream app checks focused on build and correctness. The existing perf-vs-main job remains responsible for Acton's own perf comparison path.