### PR TITLE
Retry downstream app artifact downloads

### DIFF
--- a/.github/workflows/test-app.yml
+++ b/.github/workflows/test-app.yml
@@ -19,9 +19,20 @@ jobs:
           sudo apt update
           sudo apt install -y gdb
       - name: "Download .deb files"
-        uses: actions/download-artifact@v8
-        with:
-          name: acton-debs-${{ inputs.arch }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          artifact="acton-debs-${{ inputs.arch }}"
+          for attempt in 1 2 3; do
+            rm -rf deb
+            if gh run download "$GITHUB_RUN_ID" --repo "$GITHUB_REPOSITORY" --name "$artifact" --dir .; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            sleep $((attempt * 10))
+          done
       - name: "Install acton from .deb"
         run: |
           sudo apt install -y ./deb/acton_*.deb


### PR DESCRIPTION
Downstream app jobs need the `.deb` artifact before they can install Acton and run app tests. We saw one app job fail before checkout because the artifact service timed out while listing artifacts.

This downloads the same artifact with `gh run download` inside a small retry loop, so transient artifact-service timeouts do not force manual reruns of otherwise unrelated app checks.