### PR TITLE
Skip unused app job debugger install

### DIFF
--- a/.github/workflows/test-app.yml
+++ b/.github/workflows/test-app.yml
@@ -14,10 +14,6 @@ jobs:
   test-app:
     runs-on: ubuntu-24.04${{ inputs.arch == 'arm64' && '-arm' || '' }}
     steps:
-      - name: "Install gdb"
-        run: |
-          sudo apt update
-          sudo apt install -y gdb
       - name: "Download .deb files"
         uses: actions/download-artifact@v8
         with:


### PR DESCRIPTION
Downstream app jobs installed `gdb` before downloading the packaged Acton artifact, but those jobs do not use `gdb` or collect core files. The core-dump support lives in the separate run jobs.

This removes that apt setup step so each downstream app check starts directly with the artifact download and avoids an unused network-dependent install.