### PR TITLE
Speed up project and process tests

### DIFF
--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -1306,14 +1306,9 @@ actonProjTests =
             , "    env.exit(0)"
             ]
           (returnCode, cmdOut, cmdErr) <- readCreateProcessWithExitCode
-            (proc actonExe ["build", "--always-build", "--color", "never"]) { cwd = Just proj } ""
-          assertEqual ("project importing std.json should build\nstdout:\n" ++ cmdOut ++ "\nstderr:\n" ++ cmdErr)
+            (proc actonExe ["build", "--skip-build", "--always-build", "--color", "never"]) { cwd = Just proj } ""
+          assertEqual ("project importing std.json should compile\nstdout:\n" ++ cmdOut ++ "\nstderr:\n" ++ cmdErr)
             ExitSuccess returnCode
-          (runCode, runOut, runErr) <- readCreateProcessWithExitCode
-            (proc (proj </> "out/bin/main") []) ""
-          assertEqual ("project importing std.json should run\nstdout:\n" ++ runOut ++ "\nstderr:\n" ++ runErr)
-            ExitSuccess runCode
-          assertEqual "std.json output" "{\"answer\":42}\n" runOut
 
   , testCase "with missing src/ dir" $ do
         testBuild "" (ExitFailure 1) False "test/project/missing_src"

--- a/test/stdlib_auto/test_process_many.act
+++ b/test/stdlib_auto/test_process_many.act
@@ -11,7 +11,7 @@ actor GC(env):
 
 
 actor main(env: Env):
-    var num=1000
+    var num=100
     if len(env.argv) > 1:
         num = int(env.argv[1])
 


### PR DESCRIPTION
The std.json project import regression only needs to prove that a normal project can resolve and compile an import from std. JSON encoding behavior is covered by stdlib tests, so the project check now stops before the final Zig build.

The process fanout test still exercises many process exits and GC pressure by default, but uses 100 child processes instead of 1000. Passing an explicit count remains available for larger manual stress runs.