### PR TITLE
Skip final build in stale path dep setup

### DIFF
--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -786,8 +786,10 @@ compilerTests =
                     , "zig_dependencies = {}"
                     , ""
                     ]
-                runBuild dir = readCreateProcessWithExitCode
-                  (proc actonExe ["build", "--always-build"]) { cwd = Just dir, env = Just envWithHome } ""
+                runBuild args dir = readCreateProcessWithExitCode
+                  (proc actonExe args) { cwd = Just dir, env = Just envWithHome } ""
+                runBuildFull = runBuild ["build", "--always-build"]
+                runBuildSkipFinal = runBuild ["build", "--always-build", "--skip-build"]
                 assertBuildOk label (code, out, err) =
                   when (code /= ExitSuccess) $
                     assertFailure (label ++ " failed:\nstdout:\n" ++ out ++ "\nstderr:\n" ++ err)
@@ -833,10 +835,10 @@ compilerTests =
               , "    env.exit(0)"
               ]
 
-            assertBuildOk "initial build of mid dependency" =<< runBuild midProj
+            assertBuildOk "initial build of mid dependency" =<< runBuildSkipFinal midProj
             staleCExists <- doesFileExist (midProj </> "out" </> "types" </> "mid" </> "stale.c")
             assertBool "expected stale dependency C output to exist" staleCExists
-            assertBuildOk "build of app with transitive dep override" =<< runBuild appProj
+            assertBuildOk "build of app with transitive dep override" =<< runBuildFull appProj
   , testCase "build.zig.zon name matches Build.act" $ do
         let prefix = "acton-long-project-name-12345678901234567890-"
         withSystemTempDirectory prefix $ \proj -> do


### PR DESCRIPTION
The stale path dependency fixture only needs the first dependency build to leave behind the stale generated C output. The final Zig build is still needed for the app build, where the test verifies that stale dependency outputs are ignored.

This splits the helper so the setup dependency build uses --skip-build while the app build remains a full build. That keeps the behavioral coverage intact and avoids one expensive final build in a consistently slow test.