### PR TITLE
Avoid duplicate stdlib tests in make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -516,7 +516,9 @@ test: dist/bin/acton
 	cd compiler && stack test libacton acton:incremental
 	# Exclude the cross-compilation group from the default run: it builds for
 	# many targets and bloats ~/.cache/acton. Run it via `make test-cross-compile`.
-	cd compiler && stack test acton:test_acton --ta '-p "! /cross-compilation/"'
+	# Exclude stdlib here because `test-stdlib` below runs the same compiler
+	# stdlib group before the standalone stdlib_tests project.
+	cd compiler && stack test acton:test_acton --ta '-p "! /cross-compilation/ && ! /stdlib/"'
 	$(MAKE) test-stdlib
 	$(MAKE) -C backend test
 	$(MAKE) test-rts-db


### PR DESCRIPTION
The top-level `make test` target runs a broad `test_acton` pass and then calls `test-stdlib`. Before this change, the broad pass included the compiler stdlib groups, so the stdlib process/network/time tests ran twice in one source-test job.

This leaves `test-stdlib` as the owner for those compiler stdlib checks and the standalone `test/stdlib_tests` project, while the first broad compiler pass skips both cross-compilation and stdlib.