### PR TITLE
Cancel superseded pull request test runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,11 @@ on:
   # immediately (e.g. right after merging) instead of waiting for the next nightly.
   workflow_dispatch:
 
+concurrency:
+  # Non-PR runs use run_id so this only collapses stale pull request runs.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   ZIG_DOWNLOAD_BASE_URL: https://github.com/actonlang/zigballs/raw/main
 


### PR DESCRIPTION
Older Build, Test & Release runs for the same pull request can stay queued after a newer push exists, which wastes scarce runners and leaves stale results around.

This adds workflow-level concurrency keyed by pull request number. Only pull_request events cancel in progress; main pushes, tags, scheduled cache-producer runs, and manual runs keep running independently.