### PR TITLE
Skip post-artifact jobs on PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -521,6 +521,7 @@ jobs:
 
 
   run-macos:
+    if: github.event_name != 'pull_request'
     needs: test-macos
     strategy:
       fail-fast: false
@@ -729,6 +730,7 @@ jobs:
         run: df -h || true
 
   perf-vs-main:
+    if: github.event_name != 'pull_request'
     needs: build-debs
     # Use our own runner to get more deterministic results
     runs-on: [self-hosted, linux, X64]


### PR DESCRIPTION
Pull request test runs already build the release artifacts, run the source test matrices, cross-compile, and exercise downstream apps. The remaining macOS tarball smoke matrix and perf comparison happen after those checks and were leaving otherwise-green PRs queued on scarce runners.

This keeps those post-artifact checks on main, tags, scheduled runs, and manual runs, but skips them for normal PR feedback.