### PR TITLE
Run one cross-compile job on PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -662,7 +662,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [amd64, arm64]
+        arch: ${{ github.event_name == 'pull_request' && fromJson('["amd64"]') || fromJson('["amd64","arm64"]') }}
     runs-on: ${{ matrix.arch == 'amd64' && 'ubuntu-latest' || 'ubuntu-24.04-arm' }}
     steps:
       - name: "Show platform and environment"


### PR DESCRIPTION
Pull request runs currently cross-compile the same hello project for every target twice, once with the amd64 package and once with the arm64 package. The source-test jobs already exercise both package architectures on PRs, while this job mostly checks target coverage and spends almost all of its time in the repeated cross-target builds.

This keeps the amd64 cross-compile job in the PR loop and leaves both amd64 and arm64 cross-compile jobs on main pushes, tag pushes, scheduled runs, and manual runs.