### PR TITLE
Run one sorespo app job on PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -773,7 +773,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [amd64, arm64]
+        arch: ${{ github.event_name == 'pull_request' && fromJson('["amd64"]') || fromJson('["amd64","arm64"]') }}
     needs: build-debs
     uses: "./.github/workflows/test-app.yml"
     with:


### PR DESCRIPTION
Pull request runs currently build and test the downstream sorespo app with both amd64 and arm64 packages. It is one of the longer downstream app checks, and the source-test jobs already exercise both package architectures in the PR loop.

This keeps the amd64 sorespo downstream app check on pull requests and leaves both amd64 and arm64 sorespo checks on main pushes, tag pushes, scheduled runs, and manual runs.