### PR TITLE
Reduce process stress test default load

### DIFF
--- a/test/stdlib_auto/test_process_many.act
+++ b/test/stdlib_auto/test_process_many.act
@@ -11,14 +11,16 @@ actor GC(env):
 
 
 actor main(env: Env):
-    var num=1000
+    var num=200
     if len(env.argv) > 1:
         num = int(env.argv[1])
 
     var exited = 0
     def on_exit(p, exit_code, term_signal, stdout_buf, stderr_buf):
         exited += 1
-        print("Process exited with code: ", exit_code, " terminated with signal:", term_signal, "  exited:", exited)
+        if exit_code != 0 or term_signal != 0:
+            print("Process exited with code: ", exit_code, " terminated with signal:", term_signal)
+            env.exit(1)
         if stdout_buf != b"HELLO\n":
             print("stdout_buf is not correct, got:", stdout_buf)
             env.exit(1)
@@ -31,7 +33,6 @@ actor main(env: Env):
         await async env.exit(1)
 
     def test():
-        print("Starting process..")
         pc = process.ProcessCap(env.cap)
         p = process.RunProcess(pc, ["echo", "HELLO"], on_exit, on_error)
 


### PR DESCRIPTION
`test_process_many` currently launches 1000 processes by default while a forced-GC loop runs in the background. The auto test harness also covers it from both the broad source test pass and the stdlib pass, so the default stress level is paid repeatedly in normal test runs.

This lowers the default to 200 processes while keeping the command-line override for heavier local stress runs. It also keeps the test quiet unless a child process exits abnormally or returns unexpected output, and now treats a non-zero exit code or termination signal as a failure.