### PR TITLE
Lower DBP threshold and cap build docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,8 @@
 Acton compiler notes:
 
+- For local verification, default to running `make` unless you specifically
+  know which narrower target is correct for the change.
+
 - `acton build --no-threads` controls whether the produced Acton binary uses
   threads in Acton RTS. It does not disable threads in the Acton compiler
   process itself, so compilation still happens concurrently. This flag is only

--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -2033,7 +2033,7 @@ generateProjectDocIndex sp gopts opts paths srcFiles = do
         createDirectoryIfMissing True docDir
         entries <- catMaybes <$> forM srcFiles (\f -> do
                      p <- findPaths f opts
-                     readModuleDoc sp gopts opts p f)
+                     readModuleDocIndexEntry sp gopts opts p f)
         DocP.generateDocIndex docDir entries
 
 -- | Relative C source paths for selected tasks in one project.

--- a/compiler/acton/test_incremental.hs
+++ b/compiler/acton/test_incremental.hs
@@ -37,6 +37,7 @@ import           Test.Tasty.HUnit
 import           TestGolden (normalizeProgressTimingLine)
 import qualified Acton.Compile as Compile
 import qualified Acton.CommandLineParser as C
+import qualified Acton.DocPrinter as DocP
 import qualified Acton.SourceProvider as Source
 import qualified Acton.NameInfo as I
 import qualified Acton.Syntax as A
@@ -2270,6 +2271,28 @@ p45_tydb_records_local_name_dependencies =
     assertDepsContain "local_container_name pub local deps" ["Container"] containerPub
     assertDepsContain "local_container_name impl local deps" ["Container"] containerImpl
 
+p46_huge_module_skips_doc_output :: TestTree
+p46_huge_module_skips_doc_output =
+  testCase "46-huge module skips doc output" $ do
+    let opts = Compile.defaultCompileOptions
+        docDir = casesProjDir </> "doc-index"
+    assertBool "doc output should run at the threshold"
+      (Compile.shouldGenerateDocOutput opts False Compile.docNameCountThreshold)
+    assertBool "doc output should skip above the threshold"
+      (not (Compile.shouldGenerateDocOutput opts False (Compile.docNameCountThreshold + 1)))
+    assertBool "skip-build should skip doc output"
+      (not (Compile.shouldGenerateDocOutput opts{ C.skip_build = True } False 1))
+    assertBool "temporary builds should skip doc output"
+      (not (Compile.shouldGenerateDocOutput opts True 1))
+    removeDirIfExists docDir
+    createDirectoryIfMissing True docDir
+    DocP.generateDocIndex docDir [(A.modName ["huge"], Just "Huge module", False)]
+    index <- T.readFile (docDir </> "index.html")
+    assertBool "skipped module should remain visible"
+      ("huge" `T.isInfixOf` index)
+    assertBool "skipped module should not link to missing page"
+      (not ("href=\"huge.html\"" `T.isInfixOf` index))
+
 -- Main -----------------------------------------------------------------------
 
 -- | Tasty entry point for incremental tests.
@@ -2339,5 +2362,6 @@ main = defaultMain $ localOption (NumThreads 1) $ testGroup "incremental"
       , p43_equal_act_ty_mtime_hashes_source
       , p44_provider_import_rename_reruns_dependent_front
       , p45_tydb_records_local_name_dependencies
+      , p46_huge_module_skips_doc_output
       ]
   ]

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -141,6 +141,7 @@ module Acton.Compile
   , parseActFile
   , readModuleTask
   , readModuleDoc
+  , readModuleDocIndexEntry
   , readImports
   , buildGlobalTasks
   , selectNeededTasks
@@ -148,6 +149,8 @@ module Acton.Compile
   , libraryBoundaryTasks
   , compileTasks
   , runFrontPasses
+  , docNameCountThreshold
+  , shouldGenerateDocOutput
   , runBackPasses
   , runBackJobs
   , findProjectDir
@@ -1170,8 +1173,15 @@ data DbpRequest = DbpRequest
 type InterestMap = M.Map A.ModName (Data.Set.Set A.Name)
 
 dbpNameCountThreshold :: Int
--- Conservative initial heuristic; --dbp can force smaller modules.
-dbpNameCountThreshold = 10000
+-- Conservative heuristic; --dbp can force smaller modules.
+dbpNameCountThreshold = 1000
+
+docNameCountThreshold :: Int
+docNameCountThreshold = 10000
+
+shouldGenerateDocOutput :: C.CompileOptions -> Bool -> Int -> Bool
+shouldGenerateDocOutput opts tmp nameCount =
+  not (C.skip_build opts) && not tmp && nameCount <= docNameCountThreshold
 
 parseDbpSpec :: String -> Maybe DbpRequest
 parseDbpSpec raw = do
@@ -1959,6 +1969,20 @@ readModuleDoc sp gopts opts paths actFile = do
     SrcHead{ mhName = mn, mhDoc = mdoc } -> Just (mn, mdoc)
     HeadError{} -> Nothing
 
+readModuleDocIndexEntry :: Source.SourceProvider
+                        -> C.GlobalOptions
+                        -> C.CompileOptions
+                        -> Paths
+                        -> String
+                        -> IO (Maybe (A.ModName, Maybe String, Bool))
+readModuleDocIndexEntry sp gopts opts paths actFile = do
+  h <- readModuleHeader sp gopts opts paths actFile
+  return $ case h of
+    TyHead{ mhName = mn, mhNameHashes = nameHashes, mhDoc = mdoc } ->
+      Just (mn, mdoc, shouldGenerateDocOutput opts (isTmp paths) (length nameHashes))
+    SrcHead{ mhName = mn, mhDoc = mdoc } -> Just (mn, mdoc, True)
+    HeadError{} -> Nothing
+
 -- | Materialize a source-backed task into a fully parsed ActonTask.
 -- ParseTask reuses the snapshot captured during graph discovery; TyTask reparses
 -- from the current source file because the cached header was deemed stale.
@@ -2414,7 +2438,7 @@ runFrontPasses gopts opts dbpBlocked paths env0 parsed srcContent srcBytes sourc
                         let htmlDoc = DocP.printHtmlDoc (I.NModule imps simplifiedTypeEnv mdoc) parsed
                         writeFile docFile htmlDoc
                       docOutputActions =
-                        if not (C.skip_build opts) && not (isTmp paths)
+                        if shouldGenerateDocOutput opts (isTmp paths) (length nameHashes)
                           then [(FrontOutputDoc, writeDoc)]
                           else []
                   typeStmtTimings <- reverse <$> readIORef typeStmtTimingsRef

--- a/compiler/lib/src/Acton/DocPrinter.hs
+++ b/compiler/lib/src/Acton/DocPrinter.hs
@@ -3509,11 +3509,12 @@ docMethodSignatureHtmlWithGenericsAndClasses generics classNames vs (TSchema _ _
 modNameToString :: ModName -> String
 modNameToString (ModName names) = intercalate "." (map nstr names)
 
--- | Generate HTML documentation index for a list of modules
-generateDocIndex :: FilePath -> [(ModName, Maybe String)] -> IO ()
+-- | Generate HTML documentation index for a list of modules.
+-- The Bool marks whether a module page was generated.
+generateDocIndex :: FilePath -> [(ModName, Maybe String, Bool)] -> IO ()
 generateDocIndex docDir tasks = do
     let indexFile = docDir </> "index.html"
-        sortedTasks = sortBy (comparing (\(mn,_) -> modNameToString mn)) tasks
+        sortedTasks = sortBy (comparing (\(mn,_,_) -> modNameToString mn)) tasks
         moduleEntries = concatMap generateModuleEntry sortedTasks
         indexHtml = unlines $
             [ "<!DOCTYPE html>"
@@ -3539,18 +3540,29 @@ generateDocIndex docDir tasks = do
             ]
     writeFileUtf8Atomic indexFile indexHtml
   where
-    generateModuleEntry :: (ModName, Maybe String) -> [String]
-    generateModuleEntry (mn, mDoc) =
+    generateModuleEntry :: (ModName, Maybe String, Bool) -> [String]
+    generateModuleEntry (mn, mDoc, hasPage) =
         let modPaths = modPath mn  -- Use different name to avoid shadowing
             modName = modNameToString mn
             htmlFile = if null modPaths
                        then "unnamed.html"
                        else joinPath (init modPaths) </> last modPaths <.> "html"
             docString = maybe "" (takeWhile (/= '\n')) mDoc
-        in [ "      <li class=\"module-item\">"
-           , "        <a href=\"" ++ htmlFile ++ "\" class=\"module-link\">"
-           , "          <span class=\"module-path\">" ++ modName ++ "</span>"
-           , "          <div class=\"module-doc\">" ++ htmlEscape docString ++ "</div>"
-           , "        </a>"
-           , "      </li>"
-           ]
+            docLines =
+              [ "          <span class=\"module-path\">" ++ modName ++ "</span>"
+              , "          <div class=\"module-doc\">" ++ htmlEscape docString ++ "</div>"
+              ]
+        in if hasPage
+             then [ "      <li class=\"module-item\">"
+                  , "        <a href=\"" ++ htmlFile ++ "\" class=\"module-link\">"
+                  ] ++ docLines ++
+                  [ "        </a>"
+                  , "      </li>"
+                  ]
+             else [ "      <li class=\"module-item\">"
+                  , "        <div class=\"module-link\">"
+                  ] ++ docLines ++
+                  [ "          <div class=\"module-doc\">Documentation skipped for large module.</div>"
+                  , "        </div>"
+                  , "      </li>"
+                  ]

--- a/docs/acton-dev-guide/src/compiler/incremental_compilation.md
+++ b/docs/acton-dev-guide/src/compiler/incremental_compilation.md
@@ -100,11 +100,18 @@ tests
 docstring
 ```
 
+Fresh front passes also write HTML docs for normal project builds. To avoid
+running `DocPrinter` on huge modules, build-time doc output is skipped when the
+module records more than 10000 top-level names; `.tydb` and compilation still
+proceed. The documentation index leaves those oversized modules visible without
+linking to missing module pages. The explicit `acton doc FILE.act` command still
+prints docs for the requested file.
+
 ## Deferred Back Passes
 
 DBP is selected after type checking, when the full `NameHashInfo` list is
 available. A module becomes a DBP candidate when its top-level name count is at
-least the internal threshold (`10000` today), or when it is forced with
+least the internal threshold (`1000` today), or when it is forced with
 `--dbp MOD[:name,...]`. The option can be repeated, and explicit seed names are
 unioned per module. DBP is disabled for `__builtin__`, `--only-build`,
 alternate-output modes such as `--cgen`/`--hgen`, and whenever `--no-dbp` is


### PR DESCRIPTION
This lowers the automatic DBP name-count threshold to 1000 so large modules take the deferred back pass path earlier.

It also skips build-time DocPrinter output once a module records more than 10000 top-level names. Compilation and `.tydb` output still proceed, and the generated project documentation index keeps oversized modules visible without linking to a missing page.

Explicit `acton doc FILE.act` still generates documentation for the requested file because that command is a direct documentation request rather than incidental build output.