### PR TITLE
Switch app test to StratoWeave

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -795,11 +795,11 @@ jobs:
       repo_url: "orchestron-orchestrator/sorespo"
       arch: ${{ matrix.arch }}
 
-  test-app-orchestron:
+  test-app-stratoweave:
     needs: build-debs
     uses: "./.github/workflows/test-app.yml"
     with:
-      repo_url: "orchestron-orchestrator/orchestron"
+      repo_url: "stratoweave/stratoweave"
 
   test-app-netcli:
     needs: build-debs


### PR DESCRIPTION
The app matrix still tested the old Orchestron repository.

This points that job at stratoweave/stratoweave and renames it for StratoWeave. The existing reusable test-app workflow continues to handle the checkout.