### PR TITLE
Speed up .tydb serialization

### DIFF
--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -1526,7 +1526,7 @@ initCliCompileHooks progressUI progressState gopts sched gen plan = do
         finalDoneStatus = "Final compilation done"
         frontOutputActiveStatus kind =
           case kind of
-            FrontOutputTydb -> "Writing .tydb"
+            FrontOutputTydb -> "Preparing .tydb"
             FrontOutputTydbCopy -> "Copying .tydb"
             FrontOutputDoc -> "Generating docs"
         frontOutputDoneStatus kind =
@@ -1539,6 +1539,12 @@ initCliCompileHooks progressUI progressState gopts sched gen plan = do
             FrontOutputTydb -> ".tydb"
             FrontOutputTydbCopy -> "Copy .tydb"
             FrontOutputDoc -> "Docs"
+        frontOutputProgressShortStatus kind p =
+          case kind of
+            FrontOutputTydb
+              | "Preparing" `isPrefixOf` fopLabel p -> "Prep .tydb"
+              | "Writing" `isPrefixOf` fopLabel p -> "Write .tydb"
+            _ -> frontOutputShortStatus kind
         projMap = cpProjMap plan
         depNameMap =
           let rootDeps = maybe [] projDeps (M.lookup rootProj projMap)
@@ -1712,6 +1718,13 @@ initCliCompileHooks progressUI progressState gopts sched gen plan = do
         frontOutputActiveLine key kind =
           renderProjectLine (tkProj key) (tkMod key)
             (staticStatusRenderer (frontOutputActiveStatus kind) (frontOutputShortStatus kind))
+        frontOutputProgressLine key kind p =
+          renderProjectLine (tkProj key) (tkMod key)
+            (staticStatusRenderer (fopLabel p) (frontOutputProgressShortStatus kind p))
+        frontOutputInitialProgress kind =
+          case kind of
+            FrontOutputTydb -> Just 0
+            _ -> Nothing
         backActiveLine proj mn =
           renderProjectLine proj mn (staticStatusRenderer "Back passes" "Back")
         backProgressLine proj mn p =
@@ -1924,7 +1937,10 @@ initCliCompileHooks progressUI progressState gopts sched gen plan = do
               creditFront (gtKey t)
           , chOnFrontOutputStart = \key kind ->
               gate (progressStartTask progressUI progressState (frontOutputTaskKey key kind)
-                      (frontOutputActiveLine key kind) Nothing)
+                      (frontOutputActiveLine key kind) (frontOutputInitialProgress kind))
+          , chOnFrontOutputProgress = \key kind p ->
+              gate (progressUpdateTask progressUI progressState (frontOutputTaskKey key kind)
+                      (frontOutputProgressLine key kind p) (Just (clamp01 (fopRatio p))))
           , chOnFrontOutputDone = \key kind melapsed -> do
               gate (progressDoneTask progressUI progressState (frontOutputTaskKey key kind))
               when (not (quiet gopts optsPlan)) $

--- a/compiler/lib/bench/CompilerBench.hs
+++ b/compiler/lib/bench/CompilerBench.hs
@@ -207,6 +207,7 @@ runCompilerFront buildFront runBack typesPath sourcePath = do
       (\_ -> return ())
       (\_ _ -> return ())
       (\_ _ _ -> return ())
+      (\_ _ _ -> return ())
       (return True)
       (\_ -> return ())
     fr <- case res of

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -92,6 +92,7 @@ module Acton.Compile
   , DeferredBackJob(..)
   , FrontResult(..)
   , FrontOutputKind(..)
+  , FrontOutputProgress(..)
   , FrontOutputJob
   , waitFrontOutputJobs
   , FrontTiming(..)
@@ -393,6 +394,11 @@ data FrontOutputKind
   | FrontOutputDoc
   deriving (Eq, Ord, Show)
 
+data FrontOutputProgress = FrontOutputProgress
+  { fopLabel :: String
+  , fopRatio :: Double
+  } deriving (Eq, Show)
+
 data FrontTiming = FrontTiming
   { ftEnv :: TimeSpec
   , ftKinds :: TimeSpec
@@ -426,6 +432,7 @@ data CompileCallbacks = CompileCallbacks
   , ccOnFrontDone :: GlobalTask -> C.CompileOptions -> IO ()
   , ccOnFrontProgress :: GlobalTask -> C.CompileOptions -> FrontPassProgress -> IO ()
   , ccOnFrontOutputStart :: TaskKey -> FrontOutputKind -> IO ()
+  , ccOnFrontOutputProgress :: TaskKey -> FrontOutputKind -> FrontOutputProgress -> IO ()
   , ccOnFrontOutputDone :: TaskKey -> FrontOutputKind -> Maybe TimeSpec -> IO ()
   , ccShouldWriteFrontOutput :: IO Bool
   , ccOnBackJob :: BackJob -> IO ()
@@ -446,6 +453,7 @@ defaultCompileCallbacks = CompileCallbacks
   , ccOnFrontDone = \_ _ -> return ()
   , ccOnFrontProgress = \_ _ _ -> return ()
   , ccOnFrontOutputStart = \_ _ -> return ()
+  , ccOnFrontOutputProgress = \_ _ _ -> return ()
   , ccOnFrontOutputDone = \_ _ _ -> return ()
   , ccShouldWriteFrontOutput = return True
   , ccOnBackJob = \_ -> return ()
@@ -749,6 +757,7 @@ data CompileHooks = CompileHooks
   , chOnFrontProgress :: GlobalTask -> FrontPassProgress -> IO ()
   , chOnFrontResult :: GlobalTask -> FrontResult -> IO ()
   , chOnFrontOutputStart :: TaskKey -> FrontOutputKind -> IO ()
+  , chOnFrontOutputProgress :: TaskKey -> FrontOutputKind -> FrontOutputProgress -> IO ()
   , chOnFrontOutputDone :: TaskKey -> FrontOutputKind -> Maybe TimeSpec -> IO ()
   , chOnBackQueued :: TaskKey -> Bool -> IO ()
   , chOnBackSkipped :: TaskKey -> IO ()
@@ -770,6 +779,7 @@ defaultCompileHooks =
     , chOnFrontProgress = \_ _ -> return ()
     , chOnFrontResult = \_ _ -> return ()
     , chOnFrontOutputStart = \_ _ -> return ()
+    , chOnFrontOutputProgress = \_ _ _ -> return ()
     , chOnFrontOutputDone = \_ _ _ -> return ()
     , chOnBackQueued = \_ _ -> return ()
     , chOnBackSkipped = \_ -> return ()
@@ -807,6 +817,7 @@ runCompilePlan sp gopts plan sched gen hooks = do
         , ccOnFrontDone = \t _ -> chOnFrontDone hooks t
         , ccOnFrontProgress = \t _ p -> chOnFrontProgress hooks t p
         , ccOnFrontOutputStart = chOnFrontOutputStart hooks
+        , ccOnFrontOutputProgress = chOnFrontOutputProgress hooks
         , ccOnFrontOutputDone = chOnFrontOutputDone hooks
         , ccShouldWriteFrontOutput = do
             current <- readIORef (csGenRef sched)
@@ -1346,6 +1357,13 @@ frontOutputKindName :: FrontOutputKind -> String
 frontOutputKindName FrontOutputTydb     = "tydb"
 frontOutputKindName FrontOutputTydbCopy = "tydb-copy"
 frontOutputKindName FrontOutputDoc      = "doc"
+
+frontOutputTyDbProgress :: InterfaceFiles.TyDbWriteProgress -> FrontOutputProgress
+frontOutputTyDbProgress p =
+  FrontOutputProgress
+    { fopLabel = InterfaceFiles.tyDbWriteProgressLabel p
+    , fopRatio = InterfaceFiles.tyDbWriteProgressRatio p
+    }
 
 copyTydbInterface :: C.CompileOptions -> Paths -> A.ModName -> IO ()
 copyTydbInterface opts paths mn =
@@ -2157,11 +2175,12 @@ runFrontPasses :: C.GlobalOptions
                -> (A.ModName -> IO (Maybe (M.Map A.Name InterfaceFiles.NameHashInfo)))
                -> (FrontPassProgress -> IO ())
                -> (TaskKey -> FrontOutputKind -> IO ())
+               -> (TaskKey -> FrontOutputKind -> FrontOutputProgress -> IO ())
                -> (TaskKey -> FrontOutputKind -> Maybe TimeSpec -> IO ())
                -> IO Bool
                -> ([FrontOutputJob] -> IO ())
                -> IO (Either [Diagnostic String] FrontResult)
-runFrontPasses gopts opts dbpBlocked paths env0 parsed srcContent srcBytes sourceMeta resolveImportHash resolveNameHashMap onFrontProgress onFrontOutputStart onFrontOutputDone shouldWriteFrontOutput recordFrontOutputJobs = do
+runFrontPasses gopts opts dbpBlocked paths env0 parsed srcContent srcBytes sourceMeta resolveImportHash resolveNameHashMap onFrontProgress onFrontOutputStart onFrontOutputProgress onFrontOutputDone shouldWriteFrontOutput recordFrontOutputJobs = do
   createDirectoryIfMissing True (getModPath (projTypes paths) mn)
   core
     `catch` handleGeneral
@@ -2409,16 +2428,22 @@ runFrontPasses gopts opts dbpBlocked paths env0 parsed srcContent srcBytes sourc
                   -- Module-level hashes summarize the per-name hashes.
                   let modulePubHash = Hashing.modulePubHashFromIface nmod nameHashes
                       moduleImplHash = Hashing.moduleImplHashFromNameHashes nameHashes
-                  when (C.timing gopts) $
-                    evaluate (rnf (moduleSrcBytesHash, modulePubHash, moduleImplHash, nameHashes))
+                  evaluate (rnf (moduleSrcBytesHash, modulePubHash, moduleImplHash, sourceMeta, impsWithHash))
+                  evaluate (rnf (nameHashes, roots, tests, mdoc))
+                  evaluate (rnf nmod)
+                  evaluate (rnf tchecked)
                   timeTypeHash <- getTime Monotonic
 
                   iff (C.types opts && isRoot) $ dump mn "types" (Pretty.print tchecked)
                   iff (C.sigs opts && isRoot) $ dump mn "sigs" (Acton.Types.prettySigs env mn imps fullIface)
                   timeTypeCheck <- getTime Monotonic
 
-                  let writeTyDb = do
-                        InterfaceFiles.writeFile (tyDbPath paths mn) moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta impsWithHash nameHashes roots tests mdoc nmod tchecked
+                  let writeTyDb outputKey = do
+                        InterfaceFiles.writeFileWithProgress
+                          (\p -> onFrontOutputProgress outputKey FrontOutputTydb (frontOutputTyDbProgress p))
+                          A.version
+                          (tyDbPath paths mn)
+                          moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta impsWithHash nameHashes roots tests mdoc nmod tchecked
                       writeDoc = do
                         let docDir = joinPath [projPath paths, "out", "doc"]
                             modPathList = A.modPath mn
@@ -2486,7 +2511,7 @@ runFrontPasses gopts opts dbpBlocked paths env0 parsed srcContent srcBytes sourc
                           startFrontOutputJob onFrontOutputStart onFrontOutputDone shouldWriteFrontOutput outputKey
                         startDependentOutput =
                           startDependentFrontOutputJob onFrontOutputStart onFrontOutputDone shouldWriteFrontOutput
-                    tyDbJob <- startOutput FrontOutputTydb writeTyDb
+                    tyDbJob <- startOutput FrontOutputTydb (writeTyDb outputKey)
                     docJobs <-
                       forM docOutputActions $ uncurry startOutput
                     tyJobs <-
@@ -3162,6 +3187,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                 (getNameHashMapCached bPaths)
                 (\p -> ccOnFrontProgress callbacks t optsBuiltin p)
                 (ccOnFrontOutputStart callbacks)
+                (ccOnFrontOutputProgress callbacks)
                 (ccOnFrontOutputDone callbacks)
                 (ccShouldWriteFrontOutput callbacks)
                 (rememberFrontOutputJobList frontOutputRef)
@@ -3581,6 +3607,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                           resolveNameHashMap'
                           (\p -> ccOnFrontProgress callbacks t optsT p)
                           (ccOnFrontOutputStart callbacks)
+                          (ccOnFrontOutputProgress callbacks)
                           (ccOnFrontOutputDone callbacks)
                           (ccShouldWriteFrontOutput callbacks)
                           (rememberFrontOutputJobList frontOutputRef)
@@ -3653,20 +3680,31 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                                       let updatedNameHashes =
                                             Hashing.refreshImplHashes nameHashes nameImplHashes implLocalDeps implExtHashes
                                           moduleImplHash = Hashing.moduleImplHashFromNameHashes updatedNameHashes
+                                      evaluate (rnf (moduleSrcBytesHash, modulePubHash, moduleImplHash, sourceMeta, imps))
+                                      evaluate (rnf (updatedNameHashes, roots, tests, mdoc))
+                                      evaluate (rnf nmod)
+                                      evaluate (rnf tmod)
                                       mask_ $ do
+                                        let outputKey = TaskKey (projPath paths) mn
+                                            tyDbProgress p =
+                                              ccOnFrontOutputProgress callbacks outputKey FrontOutputTydb (frontOutputTyDbProgress p)
                                         outputJob <- startFrontOutputJob (ccOnFrontOutputStart callbacks)
                                                                          (ccOnFrontOutputDone callbacks)
                                                                          (ccShouldWriteFrontOutput callbacks)
-                                                                         (TaskKey (projPath paths) mn)
+                                                                         outputKey
                                                                          FrontOutputTydb $ do
-                                          InterfaceFiles.writeFile tyFile moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta imps updatedNameHashes roots tests mdoc nmod tmod
+                                          InterfaceFiles.writeFileWithProgress
+                                            tyDbProgress
+                                            A.version
+                                            tyFile
+                                            moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta imps updatedNameHashes roots tests mdoc nmod tmod
                                         tyJobs <-
                                           if C.tydb optsT
                                             then (:[]) <$> startDependentFrontOutputJob (ccOnFrontOutputStart callbacks)
                                                                                        (ccOnFrontOutputDone callbacks)
                                                                                        (ccShouldWriteFrontOutput callbacks)
                                                                                        outputJob
-                                                                                       (TaskKey (projPath paths) mn)
+                                                                                       outputKey
                                                                                        FrontOutputTydbCopy
                                                                                        (copyTydbInterface optsT paths mn)
                                             else return []

--- a/compiler/lib/src/InterfaceFiles.hs
+++ b/compiler/lib/src/InterfaceFiles.hs
@@ -88,17 +88,21 @@ module InterfaceFiles
   , readExtensionsByProtocol
   , readFileMaybe
   , readHeaderMaybe
+  , TyDbWriteProgress(..)
   , writeFile
+  , writeFileWithProgress
   , writeFileWithVersion
   ) where
 
 import Prelude hiding (readFile, writeFile)
-import Control.DeepSeq (NFData)
+import Control.DeepSeq (NFData, rnf)
 import Data.Binary
 import qualified Control.Exception as E
-import Control.Concurrent (runInBoundThread, threadDelay)
+import Control.Concurrent (getNumCapabilities, runInBoundThread, threadDelay)
+import Control.Concurrent.Async (mapConcurrently)
 import Control.Concurrent.MVar (MVar, modifyMVar, newMVar, withMVar)
 import Control.Monad (forM, forM_, unless, when)
+import Data.IORef (atomicModifyIORef', newIORef)
 import qualified Crypto.Hash.SHA256 as SHA256
 import qualified Data.ByteString.Base16 as Base16
 import qualified Data.ByteString as BS
@@ -149,6 +153,12 @@ data SourceFileMeta = SourceFileMeta
   } deriving (Show, Eq, Generic)
 
 instance Binary SourceFileMeta
+instance NFData SourceFileMeta
+
+data TyDbWriteProgress = TyDbWriteProgress
+  { tyDbWriteProgressLabel :: String
+  , tyDbWriteProgressRatio :: Double
+  } deriving (Show, Eq)
 
 type TyFile =
   ( [A.ModName]
@@ -542,18 +552,21 @@ isCorruptEnv err =
       _ -> False
 
 writeEntries :: FilePath -> [(BS.ByteString, BS.ByteString)] -> IO ()
-writeEntries path entries = do
+writeEntries = writeEntriesWithProgress (\_ -> return ())
+
+writeEntriesWithProgress :: (Double -> IO ()) -> FilePath -> [(BS.ByteString, BS.ByteString)] -> IO ()
+writeEntriesWithProgress onProgress path entries = do
     fileExists <- doesFileExist path
     when fileExists (removeFile path)
     createDirectoryIfMissing True path
-    entrySize <- entryMapSize entries
+    entrySize <- entryMapSize entries >>= E.evaluate
     existingSize <- readMapSize path
     go False (max entrySize existingSize)
   where
     go replaced size = do
       res <- E.try $ withWriteTxn path size $ \txn dbi -> do
         LMDB.mdb_clear txn dbi
-        forM_ entries $ \(k, v) -> putValue txn dbi k v
+        putEntries txn dbi
       case res of
         Right () -> return ()
         Left err | isMapFull err -> go replaced (size * 2)
@@ -562,6 +575,15 @@ writeEntries path entries = do
           createDirectoryIfMissing True path
           go True size
         Left (err :: E.SomeException) -> E.throwIO err
+    putEntries txn dbi = do
+      let total = length entries
+          step = max 1 (total `div` 20)
+      if total <= 0
+        then onProgress 1
+        else forM_ (zip [(1 :: Int)..] entries) $ \(i, (k, v)) -> do
+          putValue txn dbi k v
+          when (i == total || i `mod` step == 0) $
+            onProgress (fromIntegral i / fromIntegral total)
 
 setReadableInterfacePermissions :: FilePath -> IO ()
 setReadableInterfacePermissions path = do
@@ -663,37 +685,99 @@ extensionIndexEntries index =
     | (n, exts) <- Map.toList (extByProtocol index)
     ]
 
-interfaceEntries :: [Int] -> BS.ByteString -> BS.ByteString -> BS.ByteString -> Maybe SourceFileMeta -> [(A.ModName, BS.ByteString)] -> [NameHashInfo] -> [A.Name] -> [String] -> Maybe String -> I.NameInfo -> A.Module -> [(BS.ByteString, BS.ByteString)]
-interfaceEntries version moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta imps nameHashes roots tests mdoc nmod tchecked =
-    [ (keyVersion, encodeStrict version)
-    , (keyMeta, encodeStrict (sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash))
-    , (keyImports, encodeStrict imps)
-    , (keyRoots, encodeStrict roots)
-    , (keyTests, encodeStrict tests)
-    , (keyDoc, encodeStrict mdoc)
-    , (keyNameCount, encodeStrict (length te))
-    , (keyStmtCount, encodeStrict (length body))
-    , (keyModuleHeader, encodeStrict (tmn, timps, tdoc))
-    ]
-    ++ concat [ [ (keyNameOrder i, encodeStrict suffix)
-                , (keyNameInfoSuffix suffix, encodeStrict (n, info))
-                ]
-              | (i, (n, info)) <- zip [0..] te
-              , let suffix = nameKeySuffix n
-              ]
-    ++ [ (keyNameHash (nhName nh), encodeStrict nh) | nh <- nameHashes ]
-    ++ extensionIndexEntries (extensionIndexFromNameInfo tmn nmod)
-    ++ [ (keyStmt i, encodeStrict stmt) | (i, stmt) <- zip [0..] body ]
+forceEntries :: [(BS.ByteString, BS.ByteString)] -> IO [(BS.ByteString, BS.ByteString)]
+forceEntries entries = do
+    E.evaluate (rnf entries)
+    return entries
+
+entryEncodeChunkMin :: Int
+entryEncodeChunkMin = 256
+
+chunksOf :: Int -> [a] -> [[a]]
+chunksOf _ [] = []
+chunksOf n ys = let (as, bs) = splitAt n ys in as : chunksOf n bs
+
+entryChunks :: Int -> [a] -> [[a]]
+entryChunks _ [] = []
+entryChunks caps xs =
+    chunksOf chunkSize xs
+  where
+    n = length xs
+    jobs = min caps ((n + entryEncodeChunkMin - 1) `div` entryEncodeChunkMin)
+    chunkSize = max 1 ((n + jobs - 1) `div` jobs)
+
+parallelEntries :: (String -> IO ()) -> String -> (a -> [(BS.ByteString, BS.ByteString)]) -> [[a]] -> IO [(BS.ByteString, BS.ByteString)]
+parallelEntries mark label mk chunks =
+    concat <$> mapConcurrently encodeChunk chunks
+  where
+    encodeChunk chunk = do
+      entries <- forceEntries (concatMap mk chunk)
+      mark label
+      return entries
+
+interfaceEntries :: (String -> Double -> IO ()) -> [Int] -> BS.ByteString -> BS.ByteString -> BS.ByteString -> Maybe SourceFileMeta -> [(A.ModName, BS.ByteString)] -> [NameHashInfo] -> [A.Name] -> [String] -> Maybe String -> I.NameInfo -> A.Module -> IO [(BS.ByteString, BS.ByteString)]
+interfaceEntries onProgress version moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta imps nameHashes roots tests mdoc nmod tchecked = do
+    caps <- getNumCapabilities
+    let header =
+          [ (keyVersion, encodeStrict version)
+          , (keyMeta, encodeStrict (sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash))
+          , (keyImports, encodeStrict imps)
+          , (keyRoots, encodeStrict roots)
+          , (keyTests, encodeStrict tests)
+          , (keyDoc, encodeStrict mdoc)
+          , (keyNameCount, encodeStrict (length te))
+          , (keyStmtCount, encodeStrict (length body))
+          , (keyModuleHeader, encodeStrict (tmn, timps, tdoc))
+          ]
+        nameChunks = entryChunks caps (zip [0..] te)
+        nameHashChunks = entryChunks caps nameHashes
+        stmtChunks = entryChunks caps (zip [0..] body)
+        totalPrep = 2 + length nameChunks + length nameHashChunks + length stmtChunks
+    prepDone <- newIORef (0 :: Int)
+    let mark label = do
+          done <- atomicModifyIORef' prepDone $ \n ->
+            let n' = n + 1 in (n', n')
+          onProgress label (fromIntegral done / fromIntegral totalPrep)
+    onProgress "Preparing .tydb" 0
+    headerEntries <- forceEntries header
+    mark "Preparing .tydb header"
+    nameEntries <- parallelEntries mark "Preparing .tydb names" nameInfoEntries nameChunks
+    nameHashEntries <- parallelEntries mark "Preparing .tydb hashes" nameHashEntry nameHashChunks
+    extEntries <- forceEntries (extensionIndexEntries (extensionIndexFromNameInfo tmn nmod))
+    mark "Preparing .tydb extensions"
+    stmtEntries <- parallelEntries mark "Preparing .tydb statements" stmtEntry stmtChunks
+    return (headerEntries ++ nameEntries ++ nameHashEntries ++ extEntries ++ stmtEntries)
   where
     I.NModule _ te _ = nmod
     A.Module tmn timps tdoc body = tchecked
+    nameInfoEntries (i, (n, info)) =
+      [ (keyNameOrder i, encodeStrict suffix)
+      , (keyNameInfoSuffix suffix, encodeStrict (n, info))
+      ]
+      where
+        suffix = nameKeySuffix n
+    nameHashEntry nh = [(keyNameHash (nhName nh), encodeStrict nh)]
+    stmtEntry (i, stmt) = [(keyStmt i, encodeStrict stmt)]
 
 writeFile :: FilePath -> BS.ByteString -> BS.ByteString -> BS.ByteString -> Maybe SourceFileMeta -> [(A.ModName, BS.ByteString)] -> [NameHashInfo] -> [A.Name] -> [String] -> Maybe String -> I.NameInfo -> A.Module -> IO ()
 writeFile = writeFileWithVersion A.version
 
 writeFileWithVersion :: [Int] -> FilePath -> BS.ByteString -> BS.ByteString -> BS.ByteString -> Maybe SourceFileMeta -> [(A.ModName, BS.ByteString)] -> [NameHashInfo] -> [A.Name] -> [String] -> Maybe String -> I.NameInfo -> A.Module -> IO ()
 writeFileWithVersion version f moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta imps nameHashes roots tests mdoc nmod tchecked =
-    writeEntries f (interfaceEntries version moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta imps nameHashes roots tests mdoc nmod tchecked)
+    writeFileWithProgress (\_ -> return ()) version f moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta imps nameHashes roots tests mdoc nmod tchecked
+
+writeFileWithProgress :: (TyDbWriteProgress -> IO ()) -> [Int] -> FilePath -> BS.ByteString -> BS.ByteString -> BS.ByteString -> Maybe SourceFileMeta -> [(A.ModName, BS.ByteString)] -> [NameHashInfo] -> [A.Name] -> [String] -> Maybe String -> I.NameInfo -> A.Module -> IO ()
+writeFileWithProgress onProgress version f moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta imps nameHashes roots tests mdoc nmod tchecked = do
+    entries <- interfaceEntries prepProgress version moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta imps nameHashes roots tests mdoc nmod tchecked
+    writeProgress 0
+    writeEntriesWithProgress writeProgress f entries
+  where
+    prepShare = 0.80
+    writeShare = 0.20
+    prepProgress label frac =
+      onProgress (TyDbWriteProgress label (prepShare * max 0 (min 1 frac)))
+    writeProgress frac =
+      onProgress (TyDbWriteProgress "Writing .tydb" (prepShare + writeShare * max 0 (min 1 frac)))
 
 readFile :: FilePath -> IO TyFile
 readFile f =


### PR DESCRIPTION
This moves the expensive .tydb serialization work into a concurrent prep step inside the async output job, after type checking has forced the values it produces.

The writer now prepares name-info, name-hash, and typed-statement entries in strict chunks before the LMDB transaction, preserving output order. The CLI also reports .tydb progress, with preparation filling the first 80% of the output task and the LMDB write filling the final 20%.