### PR TITLE
Bump tydb version for unboxing

### DIFF
--- a/compiler/lib/src/Acton/Syntax.hs
+++ b/compiler/lib/src/Acton/Syntax.hs
@@ -25,7 +25,7 @@ import Control.DeepSeq
 import Prelude hiding((<>))
 
 version :: [Int]
-version = [0,22]
+version = [0,23]
 
 data Module     = Module        { modname::ModName, imps::[Import], mdoc::Maybe String, mbody::Suite } deriving (Eq,Show,Generic,NFData)
 


### PR DESCRIPTION
This bumps the cached interface schema version after the unboxing changes, so existing `.tydb` entries are treated as stale and rebuilt instead of being reused across the representation change.