### PR TITLE
Use persist for .tydb serialization

### DIFF
--- a/compiler/lib/package.yaml.in
+++ b/compiler/lib/package.yaml.in
@@ -49,6 +49,7 @@ dependencies:
   - random
   - scientific
   - stm
+  - persist
   - sydtest
   - sydtest-discover
   - temporary

--- a/compiler/lib/src/Acton/NameInfo.hs
+++ b/compiler/lib/src/Acton/NameInfo.hs
@@ -16,6 +16,7 @@ module Acton.NameInfo where
 
 import Control.DeepSeq
 import qualified Data.Binary
+import Data.Persist (Persist)
 import GHC.Generics (Generic)
 import Data.Typeable
 import qualified Data.HashMap.Strict as M
@@ -84,6 +85,7 @@ data HNameInfo          = HNVar      Type
                         deriving (Eq, Show, Read, Generic)
 
 instance Data.Binary.Binary NameInfo
+instance Persist NameInfo
 
 convNameInfo2HNameInfo               :: NameInfo -> HNameInfo
 convNameInfo2HNameInfo (NModule ms te mdoc)   = HNModule ms (convTEnv2HTEnv te) mdoc

--- a/compiler/lib/src/Acton/Syntax.hs
+++ b/compiler/lib/src/Acton/Syntax.hs
@@ -16,6 +16,7 @@ module Acton.Syntax where
 
 import Utils
 import qualified Data.Binary
+import Data.Persist (Persist)
 import qualified Data.Set
 import qualified Data.HashMap.Strict as M
 import qualified Data.Hashable
@@ -25,7 +26,7 @@ import Control.DeepSeq
 import Prelude hiding((<>))
 
 version :: [Int]
-version = [0,22]
+version = [0,23]
 
 data Module     = Module        { modname::ModName, imps::[Import], mdoc::Maybe String, mbody::Suite } deriving (Eq,Show,Generic,NFData)
 
@@ -478,46 +479,87 @@ instance Leaves TVar where
 
 
 instance Data.Binary.Binary Prefix
+instance Persist Prefix
 instance Data.Binary.Binary Name
+instance Persist Name
 instance Data.Binary.Binary ModName
+instance Persist ModName
 instance Data.Binary.Binary QName
+instance Persist QName
 instance Data.Binary.Binary Deco
+instance Persist Deco
 instance Data.Binary.Binary TSchema
+instance Persist TSchema
 instance Data.Binary.Binary TVar
+instance Persist TVar
 instance Data.Binary.Binary TUni
+instance Persist TUni
 instance Data.Binary.Binary TCon
+instance Persist TCon
 instance Data.Binary.Binary QBind
+instance Persist QBind
 instance Data.Binary.Binary Type
+instance Persist Type
 instance Data.Binary.Binary Kind
+instance Persist Kind
 instance Data.Binary.Binary FX
+instance Persist FX
 instance Data.Binary.Binary Expr
+instance Persist Expr
 instance Data.Binary.Binary Stmt
+instance Persist Stmt
 instance Data.Binary.Binary Decl
+instance Persist Decl
 instance Data.Binary.Binary Branch
+instance Persist Branch
 instance Data.Binary.Binary Handler
+instance Persist Handler
 instance Data.Binary.Binary Except
+instance Persist Except
 instance Data.Binary.Binary Elem
+instance Persist Elem
 instance Data.Binary.Binary Assoc
+instance Persist Assoc
 instance Data.Binary.Binary Pattern
+instance Persist Pattern
 instance Data.Binary.Binary PosPar
+instance Persist PosPar
 instance Data.Binary.Binary KwdPar
+instance Persist KwdPar
 instance Data.Binary.Binary PosArg
+instance Persist PosArg
 instance Data.Binary.Binary KwdArg
+instance Persist KwdArg
 instance Data.Binary.Binary PosPat
+instance Persist PosPat
 instance Data.Binary.Binary KwdPat
+instance Persist KwdPat
 instance Data.Binary.Binary OpArg
+instance Persist OpArg
 instance Data.Binary.Binary Sliz
+instance Persist Sliz
 instance Data.Binary.Binary Comp
+instance Persist Comp
 instance Data.Binary.Binary WithItem
+instance Persist WithItem
 instance Data.Binary.Binary Unary
+instance Persist Unary
 instance Data.Binary.Binary Binary
+instance Persist Binary
 instance Data.Binary.Binary Aug
+instance Persist Aug
 instance Data.Binary.Binary Comparison
+instance Persist Comparison
 instance Data.Binary.Binary Module
+instance Persist Module
 instance Data.Binary.Binary Import
+instance Persist Import
 instance Data.Binary.Binary ModuleItem
+instance Persist ModuleItem
 instance Data.Binary.Binary ImportItem
+instance Persist ImportItem
 instance Data.Binary.Binary ModRef
+instance Persist ModRef
 
 
 -- Locations ----------------

--- a/compiler/lib/src/InterfaceFiles.hs
+++ b/compiler/lib/src/InterfaceFiles.hs
@@ -23,8 +23,10 @@
 -- On-disk layout
 -- A .tydb is an LMDB directory environment (containing data.mdb and lock.mdb)
 -- holding a single unnamed database. Each field below is one key; values are
--- encoded with Data.Binary. Where the old .ty format wrote one blob in a fixed
--- order, here every field is an independently addressable key.
+-- encoded with persist. The persist format is used as a trusted local cache
+-- encoding, not as a stable cross-machine interchange format. Where the old
+-- .ty format wrote one blob in a fixed order, here every field is an
+-- independently addressable key.
 --
 --   Module-level keys (one each):
 --     "version"        :: [Int]                       -- Acton.Syntax.version
@@ -96,7 +98,6 @@ module InterfaceFiles
 
 import Prelude hiding (readFile, writeFile)
 import Control.DeepSeq (NFData, rnf)
-import Data.Binary
 import qualified Control.Exception as E
 import Control.Concurrent (getNumCapabilities, runInBoundThread, threadDelay)
 import Control.Concurrent.Async (mapConcurrently)
@@ -109,7 +110,7 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B
 import qualified Data.List
 import qualified Data.Map.Strict as Map
-import qualified Data.ByteString.Lazy as BL
+import qualified Data.Persist as Persist
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import Data.Time.Clock (UTCTime)
@@ -136,7 +137,7 @@ data NameHashInfo = NameHashInfo
   , nhImplDeps :: [(A.QName, BS.ByteString)]
   } deriving (Show, Eq, Generic)
 
-instance Binary NameHashInfo
+instance Persist.Persist NameHashInfo
 instance NFData NameHashInfo
 
 data ExtensionIndex = ExtensionIndex
@@ -152,7 +153,7 @@ data SourceFileMeta = SourceFileMeta
   , sfmInode   :: Maybe Integer
   } deriving (Show, Eq, Generic)
 
-instance Binary SourceFileMeta
+instance Persist.Persist SourceFileMeta
 instance NFData SourceFileMeta
 
 data TyDbWriteProgress = TyDbWriteProgress
@@ -270,14 +271,14 @@ versionMismatch :: [Int] -> IO a
 versionMismatch vs =
     E.throwIO (TyCacheInvalid (".tydb version mismatch: file has " ++ show vs ++ ", expected " ++ show A.version))
 
-decodeStrict :: Binary a => String -> BS.ByteString -> IO a
+decodeStrict :: Persist.Persist a => String -> BS.ByteString -> IO a
 decodeStrict label bs =
-    case decodeOrFail (BL.fromStrict bs) of
-      Left (_, _, err) -> E.throwIO (TyCacheInvalid ("Failed to decode .tydb " ++ label ++ ": " ++ err))
-      Right (_, _, v) -> return v
+    case Persist.decode bs of
+      Left err -> E.throwIO (TyCacheInvalid ("Failed to decode .tydb " ++ label ++ ": " ++ err))
+      Right v -> return v
 
-encodeStrict :: Binary a => a -> BS.ByteString
-encodeStrict = BL.toStrict . encode
+encodeStrict :: Persist.Persist a => a -> BS.ByteString
+encodeStrict = Persist.encode
 
 key :: String -> BS.ByteString
 key = B.pack
@@ -493,14 +494,14 @@ nextPowerOfTwo n = go minMapSize
     go x | x >= n = x
          | otherwise = go (x * 2)
 
-getValue :: Binary a => String -> LMDB.MDB_txn -> LMDB.MDB_dbi -> BS.ByteString -> IO a
+getValue :: Persist.Persist a => String -> LMDB.MDB_txn -> LMDB.MDB_dbi -> BS.ByteString -> IO a
 getValue label txn dbi k = do
     mv <- withVal k (LMDB.mdb_get txn dbi)
     case mv of
       Nothing -> E.throwIO (TyCacheInvalid ("Missing .tydb key: " ++ label))
       Just v -> copyVal v >>= decodeStrict label
 
-getMaybeValue :: Binary a => String -> LMDB.MDB_txn -> LMDB.MDB_dbi -> BS.ByteString -> IO (Maybe a)
+getMaybeValue :: Persist.Persist a => String -> LMDB.MDB_txn -> LMDB.MDB_dbi -> BS.ByteString -> IO (Maybe a)
 getMaybeValue label txn dbi k = do
     mv <- withVal k (LMDB.mdb_get txn dbi)
     case mv of

--- a/compiler/lib/src/Utils.hs
+++ b/compiler/lib/src/Utils.hs
@@ -18,6 +18,7 @@ import Debug.Trace
 import Data.List hiding ((\\))
 import Data.Maybe
 import qualified Data.Binary
+import Data.Persist (Persist)
 import qualified Control.Exception
 import Data.Typeable
 import GHC.Generics (Generic)
@@ -31,6 +32,8 @@ import System.IO (openTempFile, hSetEncoding, utf8, hPutStr, hClose)
 import System.IO.Error (catchIOError)
 
 data SrcLoc                     = Loc Int Int | NoLoc deriving (Eq,Ord,Show,Read,Generic,NFData)
+
+instance Persist SrcLoc
 
 instance Data.Binary.Binary SrcLoc where
     put NoLoc                    = Data.Binary.put False

--- a/compiler/stack.yaml
+++ b/compiler/stack.yaml
@@ -47,6 +47,7 @@ extra-deps:
   - lsp-2.7.0.0
   - lsp-types-2.3.0.0
   - parsec-3.1.17.0@sha256:8407cbd428d7f640a0fff8891bd2f7aca13cebe70a5e654856f8abec9a648b56
+  - persist-1.0.0.0@sha256:192e7df7dc9d640306d4209ca836b9cbbfaaa81c251f308b72e780c713740c12,1849
   - process-1.6.19.0
   - tasty-1.5.3
   - unix-2.8.2.1

--- a/compiler/stack.yaml.lock
+++ b/compiler/stack.yaml.lock
@@ -68,6 +68,13 @@ packages:
   original:
     hackage: parsec-3.1.17.0@sha256:8407cbd428d7f640a0fff8891bd2f7aca13cebe70a5e654856f8abec9a648b56
 - completed:
+    hackage: persist-1.0.0.0@sha256:192e7df7dc9d640306d4209ca836b9cbbfaaa81c251f308b72e780c713740c12,1849
+    pantry-tree:
+      sha256: 68723ae9b5cc641896dd648fa72239c420efd667448201cc65afd9adffcbd4f5
+      size: 504
+  original:
+    hackage: persist-1.0.0.0@sha256:192e7df7dc9d640306d4209ca836b9cbbfaaa81c251f308b72e780c713740c12,1849
+- completed:
     hackage: process-1.6.19.0@sha256:807bfa9b4038b59ae0c362bd94a783f898fbe0b42dbe1f2ede3c392bf2b8727d,3148
     pantry-tree:
       sha256: bf6056cc0e82ed9d85ab01ab57aea03c2202677a2c3015b686eb20993407816b

--- a/docs/acton-dev-guide/src/compiler/interface_caches.md
+++ b/docs/acton-dev-guide/src/compiler/interface_caches.md
@@ -31,8 +31,10 @@ More selective lookup by imported name is future work.
 
 ## LMDB Key Layout
 
-All values are Binary-encoded Haskell values. The values are not compressed;
-the layout splits the payload so readers can avoid decoding unrelated sections.
+All values are persist-encoded Haskell values. The values are trusted local cache
+data, not a stable cross-machine interchange format. The values are not
+compressed; the layout splits the payload so readers can avoid decoding
+unrelated sections.
 
 Metadata and module-level keys:
 


### PR DESCRIPTION
Switch .tydb cache values from the binary library to persist while keeping the keyed LMDB layout intact. This adds Persist instances for the cached syntax payloads and bumps the cache version so stale interface caches rebuild with the new codec.

The version row is persist-encoded too. On this first serialization transition, an old binary-encoded version value cannot be decoded with persist, but that still makes the cache invalid and forces a rebuild. Once caches have been rewritten in persist, the normal version check handles later schema changes.

On the 1000-tree heavy-class fixture, writing generated big.tydb drops from about 0.8s to about 0.5s versus main. Rebuilding only small after deleting out/types/small* exercises the cached big.tydb read path; that operation drops from about 5s to about 1.78s elapsed.