### PR TITLE
Stream structural hashes from AST

### DIFF
--- a/compiler/acton/test/parse/simple.all.golden
+++ b/compiler/acton/test/parse/simple.all.golden
@@ -66,7 +66,7 @@ pure def main () -> None:
     return None
 ===============================================
 
-/* Acton impl hash: 22a47cbee1a10db79e681bf0e78ae5d1efbbf3bb7caa8af2510cae63e951624c */
+/* Acton impl hash: d08c9793c890e917cbf7dfbd7d8d83d565b77536de5215cba908ef7093e36f72 */
 #pragma once
 #include "builtin/builtin.h"
 #include "rts/rts.h"

--- a/compiler/acton/test/parse/simple.cgen.golden
+++ b/compiler/acton/test/parse/simple.cgen.golden
@@ -1,4 +1,4 @@
-/* Acton impl hash: 22a47cbee1a10db79e681bf0e78ae5d1efbbf3bb7caa8af2510cae63e951624c */
+/* Acton impl hash: d08c9793c890e917cbf7dfbd7d8d83d565b77536de5215cba908ef7093e36f72 */
 #include "rts/common.h"
 #include "out/types/simple.h"
 B_NoneType simpleQ_main () {

--- a/compiler/acton/test/parse/simple.hgen.golden
+++ b/compiler/acton/test/parse/simple.hgen.golden
@@ -1,4 +1,4 @@
-/* Acton impl hash: 22a47cbee1a10db79e681bf0e78ae5d1efbbf3bb7caa8af2510cae63e951624c */
+/* Acton impl hash: d08c9793c890e917cbf7dfbd7d8d83d565b77536de5215cba908ef7093e36f72 */
 #pragma once
 #include "builtin/builtin.h"
 #include "rts/rts.h"

--- a/compiler/lib/bench/CompilerBench.hs
+++ b/compiler/lib/bench/CompilerBench.hs
@@ -1,6 +1,7 @@
 import qualified Acton.CommandLineParser as C
 import qualified Acton.Compile as Compile
 import qualified Acton.Env as Env
+import qualified Acton.Hashing as Hashing
 import qualified Acton.Kinds as Kinds
 import qualified Acton.NameInfo as NameInfo
 import qualified Acton.Parser as Parser
@@ -11,14 +12,18 @@ import Control.DeepSeq (rnf)
 import qualified Control.Exception as E
 import Control.Monad (forM_)
 import qualified Data.ByteString.Char8 as B
+import Data.Graph (SCC(..), stronglyConnComp)
 import qualified Data.HashMap.Strict as HashMap
+import Data.IORef (newIORef, readIORef)
 import qualified Data.Map as Map
+import qualified Data.Set as Set
 import Data.Time.Clock (diffUTCTime, getCurrentTime)
 import GHC.Stats
 import System.Clock (TimeSpec, toNanoSecs)
 import System.Environment (getArgs)
 import System.FilePath (takeDirectory)
 import System.IO (BufferMode(LineBuffering), hSetBuffering, stdout)
+import System.Mem (performGC)
 import qualified InterfaceFiles
 
 -- Usage:
@@ -26,6 +31,9 @@ import qualified InterfaceFiles
 --   stack exec compiler-bench -- --parse TYPES_PATH SOURCE.act +RTS -T -RTS
 --   stack exec compiler-bench -- --kinds TYPES_PATH SOURCE.act +RTS -T -RTS
 --   stack exec compiler-bench -- --types TYPES_PATH SOURCE.act +RTS -T -RTS
+--   stack exec compiler-bench -- --hash REPS TYPES_PATH SOURCE.act +RTS -T -RTS
+--   stack exec compiler-bench -- --hash-breakdown REPS TYPES_PATH SOURCE.act +RTS -T -RTS
+--   stack exec compiler-bench -- --hash-minimal REPS N +RTS -T -RTS
 --   stack exec compiler-bench -- --front TYPES_PATH SOURCE.act +RTS -T -RTS
 --   stack exec compiler-bench -- --front-docs TYPES_PATH SOURCE.act +RTS -T -RTS
 --   stack exec compiler-bench -- --pipeline TYPES_PATH SOURCE.act +RTS -T -RTS
@@ -55,6 +63,43 @@ getStats enabled =
 
 printStatsMaybe label (Just before) (Just after) = printStats label before after
 printStatsMaybe _ _ _                            = return ()
+
+sccSummary :: Map.Map Syntax.Name B.ByteString
+           -> Map.Map Syntax.Name [Syntax.Name]
+           -> (Int, Int, Int, Int)
+sccSummary selfHashes localDeps =
+    let nodes = [ (n, n, Map.findWithDefault [] n localDeps) | n <- Map.keys selfHashes ]
+        sccs = stronglyConnComp nodes
+        edgeCount = sum [ length ds | (_, _, ds) <- nodes ]
+        cyclicSizes =
+          [ case scc of
+              AcyclicSCC _ -> 0
+              CyclicSCC ns -> length ns
+          | scc <- sccs
+          ]
+        cyclicCount = length (filter (> 0) cyclicSizes)
+        maxCyclic = maximum (0 : cyclicSizes)
+    in (length nodes, edgeCount, cyclicCount, maxCyclic)
+
+measureRepeated :: Bool -> String -> Int -> IO Int -> IO Int
+measureRepeated statsEnabled label reps action = do
+    performGC
+    s0 <- getStats statsEnabled
+    t0 <- getCurrentTime
+    total <- loop reps 0
+    t1 <- getCurrentTime
+    performGC
+    s1 <- getStats statsEnabled
+    elapsed label t0 t1
+    printStatsMaybe (label ++ "_stats") s0 s1
+    putStrLn $ label ++ "_result reps " ++ show reps ++ " total " ++ show total
+    return total
+  where
+    loop 0 total = return total
+    loop n total = do
+      count <- action
+      let total' = total + count
+      total' `seq` loop (n - 1) total'
 
 forceHTEnv = HashMap.foldl' forceHNameInfo () where
     forceHNameInfo () (NameInfo.HNModule _ te _) = forceHTEnv te
@@ -122,6 +167,521 @@ resolveNameHashMap paths mn = do
         return $ case mh of
           Just (_, _, _, _, _, nameHashes, _, _, _) -> Just (nameHashMapFromHeader nameHashes)
           Nothing -> Nothing
+
+resolveDepHashMap :: String
+                  -> (InterfaceFiles.NameHashInfo -> B.ByteString)
+                  -> Map.Map Syntax.ModName (Map.Map Syntax.Name InterfaceFiles.NameHashInfo)
+                  -> Map.Map Syntax.Name [Syntax.QName]
+                  -> Map.Map Syntax.Name [(Syntax.QName, B.ByteString)]
+resolveDepHashMap label getHash extMaps deps =
+    Map.map (map resolveOne) deps
+  where
+    resolveOne qn =
+      case qn of
+        Syntax.GName m n -> (qn, lookupHash qn m n)
+        Syntax.QName m n -> (qn, lookupHash qn m n)
+        Syntax.NoQ n     -> error ("unexpected local " ++ label ++ " dependency " ++ Syntax.nstr n)
+
+    lookupHash qn m n =
+      case Map.lookup m extMaps >>= Map.lookup n of
+        Just info -> getHash info
+        Nothing   -> error ("missing " ++ label ++ " hash for " ++ Hashing.qnameKey qn)
+
+data HashBenchState = HashBenchState
+    { hbsModName  :: Syntax.ModName
+    , hbsEnv      :: Env.Env0
+    , hbsParsed   :: Syntax.Module
+    , hbsTChecked :: Syntax.Module
+    , hbsNMod     :: NameInfo.NameInfo
+    , hbsExtMaps  :: Map.Map Syntax.ModName (Map.Map Syntax.Name InterfaceFiles.NameHashInfo)
+    }
+
+topLevelItemName :: Hashing.TopLevelItem -> Syntax.Name
+topLevelItemName item =
+    case item of
+      Hashing.TLDecl n _ -> n
+      Hashing.TLStmt n _ -> n
+
+prepareHashBench :: FilePath -> FilePath -> IO HashBenchState
+prepareHashBench typesPath sourcePath = do
+    src <- readFile sourcePath
+    let opts = benchOpts typesPath True
+    paths <- Compile.findPaths sourcePath opts
+    env0 <- Env.initEnv typesPath False
+    let modName = Compile.modName paths
+
+    parsed <- Parser.parseModule modName sourcePath src Nothing
+    E.evaluate (rnf parsed)
+    env <- Env.mkEnv (Compile.searchPath paths) env0 parsed
+    E.evaluate (forceHTEnv (Env.hnames env))
+    E.evaluate (forceHTEnv (Env.hmodules env))
+    kchecked <- Kinds.check env parsed
+    E.evaluate (rnf kchecked)
+    (nmod, tchecked, typeEnv, tests) <- Types.reconstruct Nothing Nothing env kchecked
+    E.evaluate (rnf nmod)
+    E.evaluate (rnf tchecked)
+    E.evaluate (forceHTEnv (Env.hnames typeEnv))
+    E.evaluate (forceHTEnv (Env.hmodules typeEnv))
+    E.evaluate (length tests)
+
+    let NameInfo.NModule _ fullIface _ = nmod
+        srcItems = Hashing.topLevelItems parsed
+        implItems = Hashing.topLevelItems tchecked
+        nameKeys = Set.fromList (map topLevelItemName srcItems ++ map topLevelItemName implItems)
+        nameInfoMap = Map.fromList fullIface
+        hashEnv = Env.setMod modName env
+        (_, pubSigExtDeps) = Hashing.pubSigSplitDepsFromNameInfoMap modName hashEnv nameKeys nameInfoMap
+        (_, implExtDeps) = Hashing.implSplitDepsFromItems modName hashEnv nameKeys implItems
+        extMods = Set.toList (Hashing.externalModules pubSigExtDeps `Set.union` Hashing.externalModules implExtDeps)
+    extMaps <- fmap Map.fromList $
+      mapM (\mn -> do
+              m <- resolveNameHashMap paths mn
+              case m of
+                Just hmap -> return (mn, hmap)
+                Nothing -> error ("missing interface hashes for " ++ show (Syntax.modPath mn)))
+           extMods
+
+    return HashBenchState
+      { hbsModName = modName
+      , hbsEnv = env
+      , hbsParsed = parsed
+      , hbsTChecked = tchecked
+      , hbsNMod = nmod
+      , hbsExtMaps = extMaps
+      }
+
+hashBenchFromHashes :: Syntax.ModName
+                    -> Env.Env0
+                    -> NameInfo.NameInfo
+                    -> Map.Map Syntax.ModName (Map.Map Syntax.Name InterfaceFiles.NameHashInfo)
+                    -> [Hashing.TopLevelItem]
+                    -> Map.Map Syntax.Name B.ByteString
+                    -> Map.Map Syntax.Name B.ByteString
+                    -> Map.Map Syntax.Name B.ByteString
+                    -> (B.ByteString, B.ByteString, [InterfaceFiles.NameHashInfo])
+hashBenchFromHashes mn env nmod extMaps implItems nameSrcHashes nameImplHashes selfPubHashes =
+    let NameInfo.NModule _ fullIface _ = nmod
+        nameInfoMap = Map.fromList fullIface
+        nameSrcKeys = Map.keysSet nameSrcHashes
+        nameImplKeys = Map.keysSet nameImplHashes
+        nameKeys = Set.union nameSrcKeys nameImplKeys
+        hashEnv = Env.setMod mn env
+        (pubSigLocalDeps, pubSigExtDeps) = Hashing.pubSigSplitDepsFromNameInfoMap mn hashEnv nameKeys nameInfoMap
+        (implLocalDeps, implExtDeps) = Hashing.implSplitDepsFromItems mn hashEnv nameKeys implItems
+        (pubLocalDeps, pubExtDeps) =
+          Hashing.mergePubDeps pubSigLocalDeps pubSigExtDeps implLocalDeps implExtDeps
+        pubSigExtHashes = resolveDepHashMap "pub" InterfaceFiles.nhPubHash extMaps pubSigExtDeps
+        pubExtHashes = resolveDepHashMap "pub" InterfaceFiles.nhPubHash extMaps pubExtDeps
+        implExtHashes = resolveDepHashMap "impl" InterfaceFiles.nhImplHash extMaps implExtDeps
+        pubHashes = Hashing.computeHashesSortedDeps selfPubHashes pubSigLocalDeps pubSigExtHashes
+        implHashes = Hashing.computeHashesSortedDeps nameImplHashes implLocalDeps implExtHashes
+        nameHashes =
+          Hashing.assembleNameHashes
+            nameKeys
+            nameSrcHashes
+            pubHashes
+            implHashes
+            pubLocalDeps
+            implLocalDeps
+            pubExtHashes
+            implExtHashes
+        modulePubHash = Hashing.modulePubHashFromIface nmod nameHashes
+        moduleImplHash = Hashing.moduleImplHashFromNameHashes nameHashes
+    in (modulePubHash, moduleImplHash, nameHashes)
+
+hashBenchOnce :: Syntax.ModName
+              -> Env.Env0
+              -> Syntax.Module
+              -> Syntax.Module
+              -> NameInfo.NameInfo
+              -> Map.Map Syntax.ModName (Map.Map Syntax.Name InterfaceFiles.NameHashInfo)
+              -> (B.ByteString, B.ByteString, [InterfaceFiles.NameHashInfo])
+hashBenchOnce mn env parsed tchecked nmod extMaps =
+    let NameInfo.NModule _ fullIface _ = nmod
+        srcItems = Hashing.topLevelItems parsed
+        nameSrcHashes = Hashing.nameHashesFromItems srcItems
+        implItems = Hashing.topLevelItems tchecked
+        nameImplHashes = Hashing.nameHashesFromItems implItems
+        nameInfoMap = Map.fromList fullIface
+        selfPubHashes = Hashing.nameInfoHashes nameInfoMap
+    in hashBenchFromHashes mn env nmod extMaps implItems nameSrcHashes nameImplHashes selfPubHashes
+
+runHashBench :: Int -> FilePath -> FilePath -> IO ()
+runHashBench reps typesPath sourcePath = do
+    statsEnabled <- getRTSStatsEnabled
+    bench <- prepareHashBench typesPath sourcePath
+
+    s0 <- getStats statsEnabled
+    t0 <- getCurrentTime
+    total <- hashLoop reps 0 bench
+    t1 <- getCurrentTime
+    s1 <- getStats statsEnabled
+    elapsed "hash_only" t0 t1
+    printStatsMaybe "hash_only_stats" s0 s1
+    putStrLn $ "hash_only_result reps " ++ show reps ++ " total_names " ++ show total
+  where
+    hashLoop 0 total _ = return total
+    hashLoop n total bench = do
+      let result@(_, _, nameHashes) =
+            hashBenchOnce
+              (hbsModName bench)
+              (hbsEnv bench)
+              (hbsParsed bench)
+              (hbsTChecked bench)
+              (hbsNMod bench)
+              (hbsExtMaps bench)
+      E.evaluate (rnf result)
+      hashLoop (n - 1) (total + length nameHashes) bench
+
+runHashBreakdown :: Int -> FilePath -> FilePath -> IO ()
+runHashBreakdown reps typesPath sourcePath = do
+    statsEnabled <- getRTSStatsEnabled
+    bench <- prepareHashBench typesPath sourcePath
+
+    let parsed = hbsParsed bench
+        tchecked = hbsTChecked bench
+        nmod = hbsNMod bench
+        NameInfo.NModule _ fullIface _ = nmod
+        nameInfoMap = Map.fromList fullIface
+        srcItems = Hashing.topLevelItems parsed
+        implItems = Hashing.topLevelItems tchecked
+
+    E.evaluate (length srcItems)
+    E.evaluate (length implItems)
+    E.evaluate (Map.size nameInfoMap)
+    parsedRef <- newIORef parsed
+    tcheckedRef <- newIORef tchecked
+    fullIfaceRef <- newIORef fullIface
+    nameInfoMapRef <- newIORef nameInfoMap
+    srcItemsRef <- newIORef srcItems
+    implItemsRef <- newIORef implItems
+
+    _ <- measureRepeated statsEnabled "hash_extract_src_items" reps $ do
+      parsed' <- readIORef parsedRef
+      let items = Hashing.topLevelItems parsed'
+      E.evaluate (length items)
+
+    _ <- measureRepeated statsEnabled "hash_extract_impl_items" reps $ do
+      tchecked' <- readIORef tcheckedRef
+      let items = Hashing.topLevelItems tchecked'
+      E.evaluate (length items)
+
+    _ <- measureRepeated statsEnabled "hash_ast_src" reps $ do
+      srcItems' <- readIORef srcItemsRef
+      let hashes = Hashing.nameHashesFromItems srcItems'
+      E.evaluate (rnf hashes)
+      return (Map.size hashes)
+
+    _ <- measureRepeated statsEnabled "hash_ast_impl" reps $ do
+      implItems' <- readIORef implItemsRef
+      let hashes = Hashing.nameHashesFromItems implItems'
+      E.evaluate (rnf hashes)
+      return (Map.size hashes)
+
+    _ <- measureRepeated statsEnabled "hash_ast_src_impl" reps $ do
+      srcItems' <- readIORef srcItemsRef
+      implItems' <- readIORef implItemsRef
+      let srcHashes = Hashing.nameHashesFromItems srcItems'
+          implHashes = Hashing.nameHashesFromItems implItems'
+      E.evaluate (rnf srcHashes)
+      E.evaluate (rnf implHashes)
+      return (Map.size srcHashes + Map.size implHashes)
+
+    _ <- measureRepeated statsEnabled "hash_pub_nameinfo" reps $ do
+      nameInfoMap' <- readIORef nameInfoMapRef
+      let hashes = Hashing.nameInfoHashes nameInfoMap'
+      E.evaluate (rnf hashes)
+      return (Map.size hashes)
+
+    _ <- measureRepeated statsEnabled "hash_prepare" reps $ do
+      srcItems' <- readIORef srcItemsRef
+      implItems' <- readIORef implItemsRef
+      nameInfoMap' <- readIORef nameInfoMapRef
+      let hashEnv = Env.setMod (hbsModName bench) (hbsEnv bench)
+          inputs = Hashing.prepareNameHashInputs (hbsModName bench) hashEnv srcItems' implItems' nameInfoMap'
+      E.evaluate (rnf ( Hashing.nhiNameKeys inputs
+                      , Hashing.nhiNameSrcHashes inputs
+                      , Hashing.nhiNameImplHashes inputs
+                      , Hashing.nhiSelfPubHashes inputs
+                      , Hashing.nhiPubSigLocalDeps inputs
+                      , Hashing.nhiPubSigExtDeps inputs
+                      , Hashing.nhiImplLocalDeps inputs
+                      , Hashing.nhiImplExtDeps inputs
+                      ))
+      return (Set.size (Hashing.nhiNameKeys inputs))
+
+    let nameSrcHashes = Hashing.nameHashesFromItems srcItems
+        nameImplHashes = Hashing.nameHashesFromItems implItems
+        selfPubHashes = Hashing.nameInfoHashes nameInfoMap
+    E.evaluate (rnf nameSrcHashes)
+    E.evaluate (rnf nameImplHashes)
+    E.evaluate (rnf selfPubHashes)
+    nameSrcHashesRef <- newIORef nameSrcHashes
+    nameImplHashesRef <- newIORef nameImplHashes
+    selfPubHashesRef <- newIORef selfPubHashes
+
+    _ <- measureRepeated statsEnabled "hash_finish_nameinfo_map" reps $ do
+      fullIface' <- readIORef fullIfaceRef
+      let m = Map.fromList fullIface'
+      E.evaluate (rnf m)
+      return (Map.size m)
+
+    _ <- measureRepeated statsEnabled "hash_finish_keys" reps $ do
+      nameSrcHashes' <- readIORef nameSrcHashesRef
+      nameImplHashes' <- readIORef nameImplHashesRef
+      let nameSrcKeys = Map.keysSet nameSrcHashes'
+          nameImplKeys = Map.keysSet nameImplHashes'
+          nameKeys = Set.union nameSrcKeys nameImplKeys
+      E.evaluate (rnf nameKeys)
+      return (Set.size nameKeys)
+
+    _ <- measureRepeated statsEnabled "hash_finish_pub_sig_deps" reps $ do
+      nameInfoMap' <- readIORef nameInfoMapRef
+      let deps = Hashing.pubSigDepsFromNameInfoMap nameInfoMap'
+      E.evaluate (rnf deps)
+      return (sum (map length (Map.elems deps)))
+
+    _ <- measureRepeated statsEnabled "hash_finish_pub_sig_split_direct" reps $ do
+      nameSrcHashes' <- readIORef nameSrcHashesRef
+      nameImplHashes' <- readIORef nameImplHashesRef
+      nameInfoMap' <- readIORef nameInfoMapRef
+      let nameKeys' = Set.union (Map.keysSet nameSrcHashes') (Map.keysSet nameImplHashes')
+          hashEnv' = Env.setMod (hbsModName bench) (hbsEnv bench)
+          (localDeps, extDeps) = Hashing.pubSigSplitDepsFromNameInfoMap (hbsModName bench) hashEnv' nameKeys' nameInfoMap'
+      E.evaluate (rnf (localDeps, extDeps))
+      return (sum (map length (Map.elems localDeps)) + sum (map length (Map.elems extDeps)))
+
+    _ <- measureRepeated statsEnabled "hash_finish_impl_deps" reps $ do
+      implItems' <- readIORef implItemsRef
+      let deps = Hashing.implDepsFromItems implItems'
+      E.evaluate (rnf deps)
+      return (sum (map length (Map.elems deps)))
+
+    let nameSrcKeys = Map.keysSet nameSrcHashes
+        nameImplKeys = Map.keysSet nameImplHashes
+        nameKeys = Set.union nameSrcKeys nameImplKeys
+        pubSigDepsRaw = Hashing.pubSigDepsFromNameInfoMap nameInfoMap
+        implDepsRaw = Hashing.implDepsFromItems implItems
+        hashEnv = Env.setMod (hbsModName bench) (hbsEnv bench)
+        (pubSigLocalDepsLegacy, pubSigExtDepsLegacy) = Hashing.splitDeps (hbsModName bench) hashEnv nameKeys pubSigDepsRaw
+        (pubSigLocalDeps, pubSigExtDeps) = Hashing.pubSigSplitDepsFromNameInfoMap (hbsModName bench) hashEnv nameKeys nameInfoMap
+        (implLocalDepsSplit, implExtDepsSplit) = Hashing.splitDeps (hbsModName bench) hashEnv nameKeys implDepsRaw
+        (implLocalDeps, implExtDeps) = Hashing.implSplitDepsFromItems (hbsModName bench) hashEnv nameKeys implItems
+        (pubLocalDeps, pubExtDeps) =
+          Hashing.mergePubDeps pubSigLocalDeps pubSigExtDeps implLocalDeps implExtDeps
+        pubSigExtHashes = resolveDepHashMap "pub" InterfaceFiles.nhPubHash (hbsExtMaps bench) pubSigExtDeps
+        pubExtHashes = resolveDepHashMap "pub" InterfaceFiles.nhPubHash (hbsExtMaps bench) pubExtDeps
+        implExtHashes = resolveDepHashMap "impl" InterfaceFiles.nhImplHash (hbsExtMaps bench) implExtDeps
+        pubHashes = Hashing.computeHashesSortedDeps selfPubHashes pubSigLocalDeps pubSigExtHashes
+        implHashes = Hashing.computeHashesSortedDeps nameImplHashes implLocalDeps implExtHashes
+        nameHashes =
+          Hashing.assembleNameHashes
+            nameKeys
+            nameSrcHashes
+            pubHashes
+            implHashes
+            pubLocalDeps
+            implLocalDeps
+            pubExtHashes
+            implExtHashes
+        localDepSetMap = Map.map Set.fromList
+        extDepSetMap = Map.map Set.fromList
+        (implLocalDepsDirect, implExtDepsDirect) =
+          Hashing.implSplitDepsFromItems (hbsModName bench) hashEnv nameKeys implItems
+    if localDepSetMap pubSigLocalDeps /= localDepSetMap pubSigLocalDepsLegacy ||
+       extDepSetMap pubSigExtDeps /= extDepSetMap pubSigExtDepsLegacy
+      then error "direct pub signature dependency split does not match legacy split"
+      else pure ()
+    if localDepSetMap implLocalDepsDirect /= localDepSetMap implLocalDepsSplit ||
+       extDepSetMap implExtDepsDirect /= extDepSetMap implExtDepsSplit
+      then error "direct impl dependency split does not match legacy split"
+      else pure ()
+    E.evaluate (rnf (nameKeys, pubSigDepsRaw, implDepsRaw))
+    E.evaluate (rnf (pubSigLocalDeps, pubSigExtDeps, implLocalDeps, implExtDeps, pubLocalDeps, pubExtDeps))
+    E.evaluate (rnf (pubSigLocalDepsLegacy, pubSigExtDepsLegacy, implLocalDepsSplit, implExtDepsSplit))
+    E.evaluate (rnf (pubSigExtHashes, pubExtHashes, implExtHashes))
+    E.evaluate (rnf (pubHashes, implHashes, nameHashes))
+    nameKeysRef <- newIORef nameKeys
+    pubSigDepsRawRef <- newIORef pubSigDepsRaw
+    implDepsRawRef <- newIORef implDepsRaw
+    pubSigLocalDepsRef <- newIORef pubSigLocalDeps
+    pubSigExtDepsRef <- newIORef pubSigExtDeps
+    implLocalDepsRef <- newIORef implLocalDeps
+    implExtDepsRef <- newIORef implExtDeps
+    pubLocalDepsRef <- newIORef pubLocalDeps
+    pubExtDepsRef <- newIORef pubExtDeps
+    pubSigExtHashesRef <- newIORef pubSigExtHashes
+    pubExtHashesRef <- newIORef pubExtHashes
+    implExtHashesRef <- newIORef implExtHashes
+    pubHashesRef <- newIORef pubHashes
+    implHashesRef <- newIORef implHashes
+    nameHashesRef <- newIORef nameHashes
+
+    let (pubSccNodes, pubSccEdges, pubSccCycles, pubSccMax) = sccSummary selfPubHashes pubSigLocalDeps
+        (implSccNodes, implSccEdges, implSccCycles, implSccMax) = sccSummary nameImplHashes implLocalDeps
+    putStrLn $ "hash_scc_pub_shape nodes " ++ show pubSccNodes
+      ++ " edges " ++ show pubSccEdges
+      ++ " cyclic_sccs " ++ show pubSccCycles
+      ++ " max_cyclic " ++ show pubSccMax
+    putStrLn $ "hash_scc_impl_shape nodes " ++ show implSccNodes
+      ++ " edges " ++ show implSccEdges
+      ++ " cyclic_sccs " ++ show implSccCycles
+      ++ " max_cyclic " ++ show implSccMax
+
+    _ <- measureRepeated statsEnabled "hash_finish_split_deps" reps $ do
+      nameKeys' <- readIORef nameKeysRef
+      pubSigDepsRaw' <- readIORef pubSigDepsRawRef
+      implDepsRaw' <- readIORef implDepsRawRef
+      let hashEnv' = Env.setMod (hbsModName bench) (hbsEnv bench)
+          (pubSigLocalDeps', pubSigExtDeps') = Hashing.splitDeps (hbsModName bench) hashEnv' nameKeys' pubSigDepsRaw'
+          (implLocalDeps', implExtDeps') = Hashing.splitDeps (hbsModName bench) hashEnv' nameKeys' implDepsRaw'
+      E.evaluate (rnf (pubSigLocalDeps', pubSigExtDeps', implLocalDeps', implExtDeps'))
+      return (Map.size pubSigLocalDeps' + Map.size implLocalDeps')
+
+    _ <- measureRepeated statsEnabled "hash_finish_impl_split_direct" reps $ do
+      nameKeys' <- readIORef nameKeysRef
+      implItems' <- readIORef implItemsRef
+      let hashEnv' = Env.setMod (hbsModName bench) (hbsEnv bench)
+          (implLocalDeps', implExtDeps') = Hashing.implSplitDepsFromItems (hbsModName bench) hashEnv' nameKeys' implItems'
+      E.evaluate (rnf (implLocalDeps', implExtDeps'))
+      return (Map.size implLocalDeps')
+
+    _ <- measureRepeated statsEnabled "hash_finish_union_pub_deps" reps $ do
+      pubSigLocalDeps' <- readIORef pubSigLocalDepsRef
+      pubSigExtDeps' <- readIORef pubSigExtDepsRef
+      implLocalDeps' <- readIORef implLocalDepsRef
+      implExtDeps' <- readIORef implExtDepsRef
+      let (pubLocalDeps', pubExtDeps') =
+            Hashing.mergePubDeps pubSigLocalDeps' pubSigExtDeps' implLocalDeps' implExtDeps'
+      E.evaluate (rnf (pubLocalDeps', pubExtDeps'))
+      return (Map.size pubLocalDeps' + Map.size pubExtDeps')
+
+    _ <- measureRepeated statsEnabled "hash_finish_resolve_ext_hashes" reps $ do
+      pubSigExtDeps' <- readIORef pubSigExtDepsRef
+      pubExtDeps' <- readIORef pubExtDepsRef
+      implExtDeps' <- readIORef implExtDepsRef
+      let pubSigExtHashes' = resolveDepHashMap "pub" InterfaceFiles.nhPubHash (hbsExtMaps bench) pubSigExtDeps'
+          pubExtHashes' = resolveDepHashMap "pub" InterfaceFiles.nhPubHash (hbsExtMaps bench) pubExtDeps'
+          implExtHashes' = resolveDepHashMap "impl" InterfaceFiles.nhImplHash (hbsExtMaps bench) implExtDeps'
+      E.evaluate (rnf (pubSigExtHashes', pubExtHashes', implExtHashes'))
+      return (Map.size pubSigExtHashes' + Map.size pubExtHashes' + Map.size implExtHashes')
+
+    _ <- measureRepeated statsEnabled "hash_finish_scc_pub" reps $ do
+      selfPubHashes' <- readIORef selfPubHashesRef
+      pubSigLocalDeps' <- readIORef pubSigLocalDepsRef
+      let summary@(nodeCount, edgeCount, cyclicCount, maxCyclic) = sccSummary selfPubHashes' pubSigLocalDeps'
+      E.evaluate (rnf summary)
+      return (nodeCount + edgeCount + cyclicCount + maxCyclic)
+
+    _ <- measureRepeated statsEnabled "hash_finish_scc_impl" reps $ do
+      nameImplHashes' <- readIORef nameImplHashesRef
+      implLocalDeps' <- readIORef implLocalDepsRef
+      let summary@(nodeCount, edgeCount, cyclicCount, maxCyclic) = sccSummary nameImplHashes' implLocalDeps'
+      E.evaluate (rnf summary)
+      return (nodeCount + edgeCount + cyclicCount + maxCyclic)
+
+    _ <- measureRepeated statsEnabled "hash_finish_compute_pub" reps $ do
+      selfPubHashes' <- readIORef selfPubHashesRef
+      pubSigLocalDeps' <- readIORef pubSigLocalDepsRef
+      pubSigExtHashes' <- readIORef pubSigExtHashesRef
+      let hashes = Hashing.computeHashesSortedDeps selfPubHashes' pubSigLocalDeps' pubSigExtHashes'
+      E.evaluate (rnf hashes)
+      return (Map.size hashes)
+
+    _ <- measureRepeated statsEnabled "hash_finish_compute_impl" reps $ do
+      nameImplHashes' <- readIORef nameImplHashesRef
+      implLocalDeps' <- readIORef implLocalDepsRef
+      implExtHashes' <- readIORef implExtHashesRef
+      let hashes = Hashing.computeHashesSortedDeps nameImplHashes' implLocalDeps' implExtHashes'
+      E.evaluate (rnf hashes)
+      return (Map.size hashes)
+
+    _ <- measureRepeated statsEnabled "hash_finish_assemble" reps $ do
+      nameKeys' <- readIORef nameKeysRef
+      nameSrcHashes' <- readIORef nameSrcHashesRef
+      pubHashes' <- readIORef pubHashesRef
+      implHashes' <- readIORef implHashesRef
+      pubLocalDeps' <- readIORef pubLocalDepsRef
+      implLocalDeps' <- readIORef implLocalDepsRef
+      pubExtHashes' <- readIORef pubExtHashesRef
+      implExtHashes' <- readIORef implExtHashesRef
+      let hashes =
+            Hashing.assembleNameHashes
+              nameKeys'
+              nameSrcHashes'
+              pubHashes'
+              implHashes'
+              pubLocalDeps'
+              implLocalDeps'
+              pubExtHashes'
+              implExtHashes'
+      E.evaluate (rnf hashes)
+      return (length hashes)
+
+    _ <- measureRepeated statsEnabled "hash_finish_module_hashes" reps $ do
+      nameHashes' <- readIORef nameHashesRef
+      let modulePubHash = Hashing.modulePubHashFromIface nmod nameHashes'
+          moduleImplHash = Hashing.moduleImplHashFromNameHashes nameHashes'
+      E.evaluate (rnf (modulePubHash, moduleImplHash))
+      return (B.length modulePubHash + B.length moduleImplHash)
+
+    _ <- measureRepeated statsEnabled "hash_finish_module_hashes_from_maps" reps $ do
+      nameKeys' <- readIORef nameKeysRef
+      pubHashes' <- readIORef pubHashesRef
+      implHashes' <- readIORef implHashesRef
+      let moduleHashes = Hashing.moduleHashesFromHashMaps nmod nameKeys' pubHashes' implHashes'
+      E.evaluate (rnf moduleHashes)
+      return (B.length (fst moduleHashes) + B.length (snd moduleHashes))
+
+    _ <- measureRepeated statsEnabled "hash_finish_no_ast_hash" reps $ do
+      implItems' <- readIORef implItemsRef
+      nameSrcHashes' <- readIORef nameSrcHashesRef
+      nameImplHashes' <- readIORef nameImplHashesRef
+      selfPubHashes' <- readIORef selfPubHashesRef
+      let result@(_, _, nameHashes) =
+            hashBenchFromHashes
+              (hbsModName bench)
+              (hbsEnv bench)
+              nmod
+              (hbsExtMaps bench)
+              implItems'
+              nameSrcHashes'
+              nameImplHashes'
+              selfPubHashes'
+      E.evaluate (rnf result)
+      return (length nameHashes)
+
+    _ <- measureRepeated statsEnabled "hash_total" reps $ do
+      parsed' <- readIORef parsedRef
+      tchecked' <- readIORef tcheckedRef
+      let result@(_, _, nameHashes) =
+            hashBenchOnce
+              (hbsModName bench)
+              (hbsEnv bench)
+              parsed'
+              tchecked'
+              nmod
+              (hbsExtMaps bench)
+      E.evaluate (rnf result)
+      return (length nameHashes)
+
+    return ()
+
+runHashMinimal :: Int -> Int -> IO ()
+runHashMinimal reps count = do
+    statsEnabled <- getRTSStatsEnabled
+    let items =
+          [ Hashing.TLStmt
+              (Syntax.name ("hash_min_" ++ show i))
+              Syntax.sPass
+          | i <- [1..count]
+          ]
+    E.evaluate (length items)
+    _ <- measureRepeated statsEnabled "hash_minimal_ast" reps $ do
+      let hashes = Hashing.nameHashesFromItems items
+      E.evaluate (rnf hashes)
+      return (Map.size hashes)
+    return ()
 
 runDirect :: DirectMode -> FilePath -> FilePath -> IO ()
 runDirect mode typesPath sourcePath = do
@@ -248,6 +808,12 @@ main = do
         runDirect KindsOnly typesPath sourcePath
       ["--types", typesPath, sourcePath] ->
         runDirect TypesOnly typesPath sourcePath
+      ["--hash", reps, typesPath, sourcePath] ->
+        runHashBench (read reps) typesPath sourcePath
+      ["--hash-breakdown", reps, typesPath, sourcePath] ->
+        runHashBreakdown (read reps) typesPath sourcePath
+      ["--hash-minimal", reps, count] ->
+        runHashMinimal (read reps) (read count)
       ["--front", typesPath, sourcePath] ->
         runCompilerFront False False typesPath sourcePath
       ["--front-docs", typesPath, sourcePath] ->
@@ -255,4 +821,4 @@ main = do
       ["--pipeline", typesPath, sourcePath] ->
         runCompilerFront True True typesPath sourcePath
       _ ->
-        error "usage: compiler-bench (--parse|--kinds|--types|--front|--front-docs|--pipeline) TYPES_PATH SOURCE.act"
+        error "usage: compiler-bench (--parse|--kinds|--types|--front|--front-docs|--pipeline) TYPES_PATH SOURCE.act | (--hash|--hash-breakdown) REPS TYPES_PATH SOURCE.act | --hash-minimal REPS N"

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -2162,6 +2162,7 @@ formatCodegenDelta status =
 -- Returns the front result plus a BackJob for later passes when compilation is
 -- needed. Callers must wait for frOutputJobs before treating the compile as
 -- finished.
+
 runFrontPasses :: C.GlobalOptions
                -> C.CompileOptions
                -> Bool
@@ -2271,8 +2272,7 @@ runFrontPasses gopts opts dbpBlocked paths env0 parsed srcContent srcBytes sourc
                          else Right (Just (A.GName m n, h))
                   Nothing -> Left (missingNameHashDiagnostics (A.GName m n))
           resolveForName (n, qns) =
-            let qnsSorted = Data.List.sortOn Hashing.qnameKey (Data.Set.toList (Data.Set.fromList qns))
-                resolved = map (resolveQName n) qnsSorted
+            let resolved = map (resolveQName n) qns
                 (errs, vals) = partitionEithers resolved
             in if null errs then Right (n, catMaybes vals) else Left (concat errs)
           (errs, vals) = partitionEithers (map resolveForName (M.toList deps))
@@ -2356,16 +2356,8 @@ runFrontPasses gopts opts dbpBlocked paths env0 parsed srcContent srcBytes sourc
           -- Extract top-level items from parsed and typed ASTs for per-name hashes.
           let srcItems = Hashing.topLevelItems parsed
               implItems = Hashing.topLevelItems tchecked
-              -- src hashes come only from parsed AST fragments.
-              nameSrcHashes = Hashing.nameHashesFromItems srcItems
-              -- impl hashes are derived from the typed AST bodies. this is the
-              -- local function hash, implDeps are added later
-              nameImplHashes = Hashing.nameHashesFromItems implItems
               -- NameInfo defines the full local environment for this module.
               nameInfoMap = M.fromList fullIface
-              nameSrcKeys = M.keysSet nameSrcHashes
-              nameImplKeys = M.keysSet nameImplHashes
-              nameKeys = Data.Set.union nameSrcKeys nameImplKeys
               nameLocsParsed = M.fromListWith (\a _ -> a)
                 [ (n, A.dloc d) | Hashing.TLDecl n d <- srcItems ] `M.union`
                 M.fromListWith (\a _ -> a)
@@ -2375,27 +2367,22 @@ runFrontPasses gopts opts dbpBlocked paths env0 parsed srcContent srcBytes sourc
                 M.fromListWith (\a _ -> a)
                 [ (n, A.sloc s) | Hashing.TLStmt n s <- implItems ]
               nameLocs = M.union nameLocsParsed nameLocsTyped
-          -- pubSigDeps: signature-level deps from NameInfo (types only).
-          let isDerivedName n = case n of
-                A.Derived{} -> True
-                _ -> False
-              isDerivedQName qn = case qn of
-                A.GName _ n -> isDerivedName n
-                A.QName _ n -> isDerivedName n
-                A.NoQ n -> isDerivedName n
-              dropDerived = filter (not . isDerivedQName)
-              pubSigDepsRaw = M.fromList
-                [ (n, dropDerived (Names.freeQ info)) | (n, info) <- M.toList nameInfoMap ]
-              -- implDeps: term-level deps from typed bodies.
-              implDepsRaw = Hashing.implDepsFromItems implItems
-              -- pubDeps include signature deps plus any term-level deps for reuse in pubHash.
-              -- Derived names are internal and should never require a pub hash.
-              pubDepsRaw = M.map dropDerived (M.unionWith (++) pubSigDepsRaw implDepsRaw)
               hashEnv = setMod mn env
+          let hashInputs = Hashing.prepareNameHashInputs mn hashEnv srcItems implItems nameInfoMap
+              nameSrcHashes = Hashing.nhiNameSrcHashes hashInputs
+              nameImplHashes = Hashing.nhiNameImplHashes hashInputs
+              nameKeys = Hashing.nhiNameKeys hashInputs
               -- Split deps into local (same module) vs external (qualified) names.
-              (pubSigLocalDeps, pubSigExtDeps) = Hashing.splitDeps mn hashEnv nameKeys pubSigDepsRaw
-              (pubLocalDeps, pubExtDeps) = Hashing.splitDeps mn hashEnv nameKeys pubDepsRaw
-              (implLocalDeps, implExtDeps) = Hashing.splitDeps mn hashEnv nameKeys implDepsRaw
+              pubSigLocalDeps = Hashing.nhiPubSigLocalDeps hashInputs
+              pubSigExtDeps = Hashing.nhiPubSigExtDeps hashInputs
+              -- implDeps: term-level deps from typed bodies.
+              implLocalDeps = Hashing.nhiImplLocalDeps hashInputs
+              implExtDeps = Hashing.nhiImplExtDeps hashInputs
+              -- pubDeps include signature deps plus term-level deps for reuse
+              -- in pubHash. Derived names are internal and should never require
+              -- a pub hash.
+              (pubLocalDeps, pubExtDeps) =
+                Hashing.mergePubDeps pubSigLocalDeps pubSigExtDeps implLocalDeps implExtDeps
               -- Load .tydb maps for any external modules referenced by deps.
               extMods = Data.Set.toList (Hashing.externalModules pubExtDeps `Data.Set.union` Hashing.externalModules implExtDeps)
           extMapsRes <- resolveNameHashMaps extMods
@@ -2411,27 +2398,24 @@ runFrontPasses gopts opts dbpBlocked paths env0 parsed srcContent srcBytes sourc
                 (_, Left diags, _) -> return (Left diags)
                 (_, _, Left diags) -> return (Left diags)
                 (Right pubSigExtHashes, Right pubExtHashes, Right implExtHashes) -> do
-                  -- Build per-name hash records (src/pub/impl + deps) for .tydb.
-                  let nameHashes =
-                        Hashing.buildNameHashes
+                  let selfPubHashes = Hashing.nhiSelfPubHashes hashInputs
+                  let pubHashes = Hashing.computeHashesSortedDeps selfPubHashes pubSigLocalDeps pubSigExtHashes
+                      implHashes = Hashing.computeHashesSortedDeps nameImplHashes implLocalDeps implExtHashes
+                      (modulePubHash, moduleImplHash) = Hashing.moduleHashesFromHashMaps nmod nameKeys pubHashes implHashes
+                      nameHashes =
+                        Hashing.assembleNameHashes
                           nameKeys
                           nameSrcHashes
-                          nameImplHashes
-                          nameInfoMap
-                          pubSigLocalDeps
-                          pubSigExtHashes
+                          pubHashes
+                          implHashes
                           pubLocalDeps
                           implLocalDeps
-                          implExtHashes
                           pubExtHashes
-
-                  -- Module-level hashes summarize the per-name hashes.
-                  let modulePubHash = Hashing.modulePubHashFromIface nmod nameHashes
-                      moduleImplHash = Hashing.moduleImplHashFromNameHashes nameHashes
+                          implExtHashes
+                  evaluate (rnf (pubHashes, implHashes, modulePubHash, moduleImplHash))
+                  evaluate (rnf nameHashes)
                   evaluate (rnf (moduleSrcBytesHash, modulePubHash, moduleImplHash, sourceMeta, impsWithHash))
                   evaluate (rnf (nameHashes, roots, tests, mdoc))
-                  evaluate (rnf nmod)
-                  evaluate (rnf tchecked)
                   timeTypeHash <- getTime Monotonic
 
                   iff (C.types opts && isRoot) $ dump mn "types" (Pretty.print tchecked)
@@ -3447,11 +3431,10 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
 
           resolveDepHashes label getHash deps = do
             resolved <- traverseDiags (\(n, qns) -> do
-              let qnsSorted = Data.List.sortOn Hashing.qnameKey (Data.Set.toList (Data.Set.fromList qns))
-                  users = " (used by " ++ A.nstr n ++ ")"
+              let users = " (used by " ++ A.nstr n ++ ")"
               resolvedQns <- traverseDiags (\qn -> do
                 currE <- resolveQNameHash label getHash users qn
-                return (fmap (\curr -> (qn, curr)) currE)) qnsSorted
+                return (fmap (\curr -> (qn, curr)) currE)) qns
               return (fmap (\vals -> (n, vals)) resolvedQns)) (M.toList deps)
             return (fmap M.fromList resolved)
 
@@ -3650,14 +3633,10 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                                                | nh <- nameHashes
                                                ]
                                   nameKeys = M.keysSet nameSrcHashes
-                                  nameImplHashes0 = Hashing.nameHashesFromItems (Hashing.topLevelItems tmod)
-                                  nameImplHashes = M.filterWithKey (\k _ -> Data.Set.member k nameKeys) nameImplHashes0
+                                  implItems0 = Hashing.topLevelItems tmod
                                   localNames = nameKeys
-                                  implDepsRaw0 = Hashing.implDepsFromItems (Hashing.topLevelItems tmod)
-                                  implDepsRaw = M.fromList
-                                    [ (n, M.findWithDefault [] n implDepsRaw0)
-                                    | n <- M.keys nameSrcHashes
-                                    ]
+                              let nameImplHashes0 = Hashing.nameHashesFromItems implItems0
+                                  nameImplHashes = M.filterWithKey (\k _ -> Data.Set.member k nameKeys) nameImplHashes0
                               envRes <- (try :: IO Acton.Env.Env0 -> IO (Either SomeException Acton.Env.Env0)) $
                                 Acton.Env.mkEnv (searchPath paths) envSnap parsedMod
                               case envRes of
@@ -3665,7 +3644,15 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                                 Right env1 -> do
                                   depRes <- (try :: IO a -> IO (Either SomeException a)) $ do
                                     let hashEnv = setMod mn env1
-                                        (implLocalDeps, implExtDeps) = Hashing.splitDeps mn hashEnv localNames implDepsRaw
+                                    let (implLocalDeps0, implExtDeps0) = Hashing.implSplitDepsFromItems mn hashEnv localNames implItems0
+                                        implLocalDeps = M.fromList
+                                          [ (n, M.findWithDefault [] n implLocalDeps0)
+                                          | n <- M.keys nameSrcHashes
+                                          ]
+                                        implExtDeps = M.fromList
+                                          [ (n, M.findWithDefault [] n implExtDeps0)
+                                          | n <- M.keys nameSrcHashes
+                                          ]
                                         depCount = sum (map length (M.elems implLocalDeps))
                                                  + sum (map length (M.elems implExtDeps))
                                     -- Force dep maps now so stale aliases/missing names

--- a/compiler/lib/src/Acton/Hashing.hs
+++ b/compiler/lib/src/Acton/Hashing.hs
@@ -1,15 +1,28 @@
 module Acton.Hashing
   ( TopLevelItem(..)
   , topLevelItems
+  , NameHashInputs(..)
+    -- Production hashing pipeline
+  , prepareNameHashInputs
+  , assembleNameHashes
+  , mergePubDeps
+  , refreshImplHashes
+  , moduleHashesFromHashMaps
+  , modulePubHashFromIface
+  , moduleImplHashFromNameHashes
+    -- Benchmarks and tests use these to compare individual stages.
   , nameHashesFromItems
+  , pubSigDepsFromNameInfoMap
+  , pubSigSplitDepsFromNameInfoMap
   , implDepsFromItems
+  , implSplitDepsFromItems
   , splitDeps
   , externalModules
   , computeHashes
+  , computeHashesSortedDeps
+  , mergeSortedDistinct
+  , nameInfoHashes
   , buildNameHashes
-  , refreshImplHashes
-  , modulePubHashFromIface
-  , moduleImplHashFromNameHashes
   , nameKey
   , qnameKey
   ) where
@@ -20,20 +33,43 @@ import qualified Acton.Names as Names
 import Acton.Prim (mPrim)
 import qualified Acton.Syntax as A
 import qualified InterfaceFiles
-import Utils (SrcLoc(..))
 
-import qualified Data.Persist as Persist
 import qualified Crypto.Hash.SHA256 as SHA256
 import qualified Data.ByteString.Char8 as B
+import qualified Data.ByteString.Unsafe as BU
+import Control.Monad (foldM, when)
+import Data.Bits (shiftR, (.&.), (.|.))
+import Data.Char (ord)
 import Data.Graph (SCC(..), stronglyConnComp)
+import qualified Data.HashSet as HashSet
+import Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import Data.List (foldl', intercalate, nub)
 import qualified Data.List
 import qualified Data.Map as M
 import Data.Maybe (mapMaybe)
 import qualified Data.Set
+import Data.Word (Word8, Word64)
+import Foreign.Marshal.Alloc (alloca, allocaBytes)
+import Foreign.Ptr (Ptr, castPtr)
+import Foreign.Storable (peek, peekByteOff, poke, pokeByteOff)
+import GHC.Float (castDoubleToWord64)
+import System.IO.Unsafe (unsafePerformIO)
 
 
 data TopLevelItem = TLDecl A.Name A.Decl | TLStmt A.Name A.Stmt
+
+data TopLevelFragments = One !TopLevelItem | Many [TopLevelItem]
+
+data NameHashInputs = NameHashInputs
+  { nhiNameKeys        :: Data.Set.Set A.Name
+  , nhiNameSrcHashes   :: M.Map A.Name B.ByteString
+  , nhiNameImplHashes  :: M.Map A.Name B.ByteString
+  , nhiSelfPubHashes   :: M.Map A.Name B.ByteString
+  , nhiPubSigLocalDeps :: M.Map A.Name [A.Name]
+  , nhiPubSigExtDeps   :: M.Map A.Name [A.QName]
+  , nhiImplLocalDeps   :: M.Map A.Name [A.Name]
+  , nhiImplExtDeps     :: M.Map A.Name [A.QName]
+  }
 
 -- | Render a local name as a stable string key.
 nameKey :: A.Name -> String
@@ -65,246 +101,742 @@ topLevelItems (A.Module _ _ _ suite) = concatMap items suite
         [ TLStmt n stmt | n <- nub (Names.bound ps) ]
       _ -> []
 
--- | Collect binary-encoded, location-free AST fragments per top-level name.
-nameBytesFromItems :: [TopLevelItem] -> M.Map A.Name B.ByteString
-nameBytesFromItems items =
-  foldl' addFrag M.empty items
-  where
-    addFrag acc item =
-      let (n, frag) = case item of
-            TLDecl name decl -> (name, astFragBytes 0 (stripLocsDecl decl))
-            TLStmt name stmt -> (name, astFragBytes 1 (stripLocsStmt stmt))
-      in M.insertWith appendFrag n frag acc
-    appendFrag new old = old `B.append` B.cons '\n' new
+-- The feed-operation format is versioned: small buffered writes, bulk hash
+-- bytes, and little-endian words are distinct operations by design. Changing
+-- this format must come with a .tydb version bump so old interface hashes are
+-- not reused.
+data HashSink = HashSink !(IORef SHA256.Ctx) !(Ptr Word8) !(Ptr Int)
 
-    astFragBytes :: Persist.Persist a => Int -> a -> B.ByteString
-    astFragBytes tag x = Persist.encode (tag, x)
+type HashFeed = HashSink -> IO ()
 
--- | Hash each name's normalized AST fragments.
+-- | Hash each name's normalized AST fragments without pretty-printing them.
 nameHashesFromItems :: [TopLevelItem] -> M.Map A.Name B.ByteString
 nameHashesFromItems items =
-  M.map SHA256.hash (nameBytesFromItems items)
+  unsafePerformIO $ withHashScratch $ \sink ->
+    M.traverseWithKey (\_ frags -> hashTopLevelFragmentsWith sink frags) grouped
+  where
+    grouped = topLevelItemsByName items
 
-stripLocsStmt :: A.Stmt -> A.Stmt
-stripLocsStmt stmt = case stmt of
-  A.Expr _ e             -> A.Expr NoLoc (stripLocsExpr e)
-  A.Assign _ ps e        -> A.Assign NoLoc (map stripLocsPattern ps) (stripLocsExpr e)
-  A.MutAssign _ t e      -> A.MutAssign NoLoc (stripLocsExpr t) (stripLocsExpr e)
-  A.AugAssign _ t op e   -> A.AugAssign NoLoc (stripLocsExpr t) op (stripLocsExpr e)
-  A.Assert _ e mbe       -> A.Assert NoLoc (stripLocsExpr e) (fmap stripLocsExpr mbe)
-  A.Pass _               -> A.Pass NoLoc
-  A.Delete _ t           -> A.Delete NoLoc (stripLocsExpr t)
-  A.Return _ mbe         -> A.Return NoLoc (fmap stripLocsExpr mbe)
-  A.Raise _ e            -> A.Raise NoLoc (stripLocsExpr e)
-  A.Break _              -> A.Break NoLoc
-  A.Continue _           -> A.Continue NoLoc
-  A.If _ bs els          -> A.If NoLoc (map stripLocsBranch bs) (stripLocsSuite els)
-  A.While _ e b els      -> A.While NoLoc (stripLocsExpr e) (stripLocsSuite b) (stripLocsSuite els)
-  A.For _ p e b els      -> A.For NoLoc (stripLocsPattern p) (stripLocsExpr e) (stripLocsSuite b) (stripLocsSuite els)
-  A.Try _ b hs els fin   -> A.Try NoLoc (stripLocsSuite b) (map stripLocsHandler hs) (stripLocsSuite els) (stripLocsSuite fin)
-  A.With _ ws b          -> A.With NoLoc (map stripLocsWithItem ws) (stripLocsSuite b)
-  A.Data _ mbp b         -> A.Data NoLoc (fmap stripLocsPattern mbp) (stripLocsSuite b)
-  A.VarAssign _ ps e     -> A.VarAssign NoLoc (map stripLocsPattern ps) (stripLocsExpr e)
-  A.After _ e e'         -> A.After NoLoc (stripLocsExpr e) (stripLocsExpr e')
-  A.Signature _ ns t dec -> A.Signature NoLoc (map stripLocsName ns) (stripLocsTSchema t) dec
-  A.Decl _ ds            -> A.Decl NoLoc (map stripLocsDecl ds)
+topLevelItemsByName :: [TopLevelItem] -> M.Map A.Name TopLevelFragments
+topLevelItemsByName = foldl' addFrag M.empty
+  where
+    addFrag acc item =
+      M.insertWith addTopLevelFragment (topLevelItemName item) (One item) acc
 
-stripLocsSuite :: A.Suite -> A.Suite
-stripLocsSuite = map stripLocsStmt
+    addTopLevelFragment new old = case (new, old) of
+      (One item, One oldItem) -> Many [item, oldItem]
+      (One item, Many oldItems) -> Many (item : oldItems)
+      (Many items, One oldItem) -> Many (items ++ [oldItem])
+      (Many items, Many oldItems) -> Many (items ++ oldItems)
 
-stripLocsDecl :: A.Decl -> A.Decl
-stripLocsDecl decl = case decl of
+topLevelItemName :: TopLevelItem -> A.Name
+topLevelItemName item = case item of
+  TLDecl name _ -> name
+  TLStmt name _ -> name
+
+feedTopLevelItem :: TopLevelItem -> HashFeed
+feedTopLevelItem item sink = case item of
+  TLDecl _ decl -> feedTLDecl decl sink
+  TLStmt _ stmt -> feedTLStmt stmt sink
+
+feedTopLevelFragments :: TopLevelFragments -> HashFeed
+feedTopLevelFragments frags sink =
+  feedTag 4 sink >> feedFragments frags >> feedTag 5 sink
+  where
+    feedFragments (One item) = feedTopLevelItem item sink
+    feedFragments (Many items) = mapM_ (\item -> feedTopLevelItem item sink) (reverse items)
+
+hashTopLevelFragmentsWith :: HashSink -> TopLevelFragments -> IO B.ByteString
+hashTopLevelFragmentsWith sink frags =
+  hashFeedWith sink (feedTopLevelFragments frags)
+
+hashFeed :: HashFeed -> B.ByteString
+hashFeed feed = unsafePerformIO $ withHashScratch $ \sink ->
+  hashFeedWith sink feed
+{-# NOINLINE hashFeed #-}
+
+withHashScratch :: (HashSink -> IO a) -> IO a
+withHashScratch action =
+  do
+    statep <- newIORef SHA256.init
+    allocaBytes hashBufferSize $ \buf ->
+      alloca $ \offp -> do
+        poke offp 0
+        action (HashSink statep buf offp)
+
+hashFeedWith :: HashSink -> HashFeed -> IO B.ByteString
+hashFeedWith sink@(HashSink statep _ offp) feed = do
+  writeIORef statep SHA256.init
+  poke offp 0
+  feed sink
+  sinkFlush sink
+  SHA256.finalize <$> readIORef statep
+
+feedTLDecl :: A.Decl -> HashFeed
+feedTLDecl decl sink = feedTag 0 sink >> feedDecl decl sink
+
+feedTLStmt :: A.Stmt -> HashFeed
+feedTLStmt stmt sink = feedTag 1 sink >> feedStmt stmt sink
+
+feedTag :: Int -> HashFeed
+feedTag tag sink
+  | tag >= 0 && tag <= 255 = sinkWriteWord8 sink (fromIntegral tag)
+  | otherwise = error ("Acton.Hashing.feedTag: tag out of range: " ++ show tag)
+{-# INLINE feedTag #-}
+
+feedMaybe :: (a -> HashFeed) -> Maybe a -> HashFeed
+feedMaybe _ Nothing  sink = feedTag 2 sink
+feedMaybe f (Just x) sink = feedTag 3 sink >> f x sink
+
+feedList :: (a -> HashFeed) -> [a] -> HashFeed
+feedList f xs sink =
+  feedTag 4 sink >> mapM_ (\x -> f x sink) xs >> feedTag 5 sink
+
+feedString :: String -> HashFeed
+feedString s sink = sinkWriteString sink s
+
+feedInt :: Int -> HashFeed
+feedInt i sink = sinkWriteInt sink i
+
+feedInteger :: Integer -> HashFeed
+feedInteger i sink = sinkWriteInteger sink i
+
+feedDouble :: Double -> HashFeed
+feedDouble d sink = sinkWriteWord64LE sink (castDoubleToWord64 d)
+
+feedBool :: Bool -> HashFeed
+feedBool b sink = sinkWriteWord8 sink (if b then 1 else 0)
+{-# INLINE feedBool #-}
+
+hashBufferSize :: Int
+hashBufferSize = 32768
+
+sinkFlush :: HashSink -> IO ()
+sinkFlush (HashSink statep buf offp) = do
+  off <- peek offp
+  when (off > 0) $ do
+    st <- readIORef statep
+    -- SHA256.update consumes the bytes immediately, so the alloca-backed
+    -- scratch buffer only needs to live for this call.
+    bs <- BU.unsafePackCStringLen (castPtr buf, off)
+    writeIORef statep $! SHA256.update st bs
+    poke offp 0
+
+sinkEnsure :: HashSink -> Int -> IO Int
+sinkEnsure sink@(HashSink _ _ offp) n = do
+  off <- peek offp
+  if off + n <= hashBufferSize
+    then pure off
+    else sinkFlush sink >> pure 0
+
+sinkWriteWord8 :: HashSink -> Word8 -> IO ()
+sinkWriteWord8 sink@(HashSink _ buf offp) w = do
+  off <- peek offp
+  if off < hashBufferSize
+    then do
+      pokeByteOff buf off w
+      poke offp (off + 1)
+    else do
+      sinkFlush sink
+      pokeByteOff buf 0 w
+      poke offp 1
+{-# INLINE sinkWriteWord8 #-}
+
+sinkWriteBytes :: HashSink -> B.ByteString -> IO ()
+sinkWriteBytes sink@(HashSink statep _ _) bs = do
+  sinkFlush sink
+  st <- readIORef statep
+  writeIORef statep $! SHA256.update st bs
+
+sinkWriteInteger :: HashSink -> Integer -> IO ()
+sinkWriteInteger sink i
+  | i < 0     = sinkWriteWord8 sink 1 >> sinkWriteNatural sink (negate i)
+  | otherwise = sinkWriteWord8 sink 0 >> sinkWriteNatural sink i
+
+sinkWriteInt :: HashSink -> Int -> IO ()
+sinkWriteInt sink i
+  | i < 0     = sinkWriteWord8 sink 1 >> sinkWriteNatural sink (negate (toInteger i))
+  | otherwise = sinkWriteWord8 sink 0 >> sinkWriteNatural sink (toInteger i)
+
+sinkWriteNatural :: HashSink -> Integer -> IO ()
+sinkWriteNatural sink i
+  | i < 128   = sinkWriteWord8 sink (fromInteger i)
+  | otherwise = do
+      sinkWriteWord8 sink (fromInteger ((i .&. 0x7f) .|. 0x80))
+      sinkWriteNatural sink (i `shiftR` 7)
+
+sinkWriteWord64LE :: HashSink -> Word64 -> IO ()
+sinkWriteWord64LE sink@(HashSink _ buf offp) w = do
+  off <- sinkEnsure sink 8
+  pokeByteOff buf off     (byteAt 0)
+  pokeByteOff buf (off+1) (byteAt 8)
+  pokeByteOff buf (off+2) (byteAt 16)
+  pokeByteOff buf (off+3) (byteAt 24)
+  pokeByteOff buf (off+4) (byteAt 32)
+  pokeByteOff buf (off+5) (byteAt 40)
+  pokeByteOff buf (off+6) (byteAt 48)
+  pokeByteOff buf (off+7) (byteAt 56)
+  poke offp (off + 8)
+  where
+    byteAt shift = fromIntegral ((w `shiftR` shift) .&. 0xff) :: Word8
+
+sinkWriteString :: HashSink -> String -> IO ()
+sinkWriteString sink@(HashSink _ buf offp) s = do
+  off <- peek offp
+  off' <- go off s
+  off'' <- writeStringTerm off'
+  poke offp off''
+  where
+    go off [] = pure off
+    go off ('\0':cs) = do
+      off' <- ensureLocal off 2
+      pokeByteOff buf off' zeroByte
+      pokeByteOff buf (off'+1) zeroByte
+      go (off' + 2) cs
+    go off (c:cs)
+      | n <= 0x7f = do
+          off' <- ensureLocal off 1
+          pokeByteOff buf off' (fromIntegral n :: Word8)
+          go (off' + 1) cs
+      | otherwise = do
+          off' <- ensureLocal off 4
+          off'' <- writeUtf8Char buf off' c
+          go off'' cs
+      where
+        n = ord c
+
+    writeStringTerm off = do
+      off' <- ensureLocal off 2
+      pokeByteOff buf off' zeroByte
+      pokeByteOff buf (off'+1) oneByte
+      pure (off' + 2)
+
+    ensureLocal off n
+      | off + n <= hashBufferSize = pure off
+      | otherwise = do
+          poke offp off
+          sinkFlush sink
+          pure 0
+
+    zeroByte = 0 :: Word8
+    oneByte = 1 :: Word8
+
+writeUtf8Char :: Ptr Word8 -> Int -> Char -> IO Int
+writeUtf8Char p off c
+  | n <= 0x7f = do
+      pokeByteOff p off (fromIntegral n :: Word8)
+      pure (off + 1)
+  | n <= 0x7ff = do
+      pokeByteOff p off     (fromIntegral (0xc0 + (n `shiftR` 6)) :: Word8)
+      pokeByteOff p (off+1) (fromIntegral (0x80 + (n .&. 0x3f)) :: Word8)
+      pure (off + 2)
+  | n <= 0xffff = do
+      pokeByteOff p off     (fromIntegral (0xe0 + (n `shiftR` 12)) :: Word8)
+      pokeByteOff p (off+1) (fromIntegral (0x80 + ((n `shiftR` 6) .&. 0x3f)) :: Word8)
+      pokeByteOff p (off+2) (fromIntegral (0x80 + (n .&. 0x3f)) :: Word8)
+      pure (off + 3)
+  | otherwise = do
+      pokeByteOff p off     (fromIntegral (0xf0 + (n `shiftR` 18)) :: Word8)
+      pokeByteOff p (off+1) (fromIntegral (0x80 + ((n `shiftR` 12) .&. 0x3f)) :: Word8)
+      pokeByteOff p (off+2) (fromIntegral (0x80 + ((n `shiftR` 6) .&. 0x3f)) :: Word8)
+      pokeByteOff p (off+3) (fromIntegral (0x80 + (n .&. 0x3f)) :: Word8)
+      pure (off + 4)
+  where
+    n = ord c
+
+-- Keep the structural feed, public dependency walker, implementation
+-- dependency walker, and Names.freeQ aligned when adding AST constructors.
+feedStmt :: A.Stmt -> HashFeed
+feedStmt stmt sink = case stmt of
+  A.Expr _ e             -> feedTag 10 sink >> feedExpr e sink
+  A.Assign _ ps e        -> feedTag 11 sink >> feedList feedPattern ps sink >> feedExpr e sink
+  A.MutAssign _ t e      -> feedTag 12 sink >> feedExpr t sink >> feedExpr e sink
+  A.AugAssign _ t op e   -> feedTag 13 sink >> feedExpr t sink >> feedAug op sink >> feedExpr e sink
+  A.Assert _ e mbe       -> feedTag 14 sink >> feedExpr e sink >> feedMaybe feedExpr mbe sink
+  A.Pass _               -> feedTag 15 sink
+  A.Delete _ t           -> feedTag 16 sink >> feedExpr t sink
+  A.Return _ mbe         -> feedTag 17 sink >> feedMaybe feedExpr mbe sink
+  A.Raise _ e            -> feedTag 18 sink >> feedExpr e sink
+  A.Break _              -> feedTag 19 sink
+  A.Continue _           -> feedTag 20 sink
+  A.If _ bs els          -> feedTag 21 sink >> feedList feedBranch bs sink >> feedSuite els sink
+  A.While _ e b els      -> feedTag 22 sink >> feedExpr e sink >> feedSuite b sink >> feedSuite els sink
+  A.For _ p e b els      -> feedTag 23 sink >> feedPattern p sink >> feedExpr e sink >> feedSuite b sink >> feedSuite els sink
+  A.Try _ b hs els fin   -> feedTag 24 sink >> feedSuite b sink >> feedList feedHandler hs sink >> feedSuite els sink >> feedSuite fin sink
+  A.With _ ws b          -> feedTag 25 sink >> feedList feedWithItem ws sink >> feedSuite b sink
+  A.Data _ mbp b         -> feedTag 26 sink >> feedMaybe feedPattern mbp sink >> feedSuite b sink
+  A.VarAssign _ ps e     -> feedTag 27 sink >> feedList feedPattern ps sink >> feedExpr e sink
+  A.After _ e e'         -> feedTag 28 sink >> feedExpr e sink >> feedExpr e' sink
+  A.Signature _ ns t dec -> feedTag 29 sink >> feedList feedName ns sink >> feedTSchema t sink >> feedDeco dec sink
+  A.Decl _ ds            -> feedTag 30 sink >> feedList feedDecl ds sink
+
+feedSuite :: A.Suite -> HashFeed
+feedSuite = feedList feedStmt
+
+feedDecl :: A.Decl -> HashFeed
+feedDecl decl sink = case decl of
   A.Def _ n q p k a b dec fx doc ->
-    A.Def NoLoc (stripLocsName n) (stripLocsQBinds q) (stripLocsPosPar p) (stripLocsKwdPar k)
-      (fmap stripLocsType a) (stripLocsSuite b) dec (stripLocsType fx) doc
+    feedTag 40 sink >> feedName n sink >> feedQBinds q sink >> feedPosPar p sink >>
+    feedKwdPar k sink >> feedMaybe feedType a sink >> feedSuite b sink >>
+    feedDeco dec sink >> feedType fx sink >> feedMaybe feedString doc sink
   A.Actor _ n q p k b doc ->
-    A.Actor NoLoc (stripLocsName n) (stripLocsQBinds q) (stripLocsPosPar p) (stripLocsKwdPar k)
-      (stripLocsSuite b) doc
+    feedTag 41 sink >> feedName n sink >> feedQBinds q sink >> feedPosPar p sink >>
+    feedKwdPar k sink >> feedSuite b sink >> feedMaybe feedString doc sink
   A.Class _ n q cs b doc ->
-    A.Class NoLoc (stripLocsName n) (stripLocsQBinds q) (map stripLocsTCon cs) (stripLocsSuite b) doc
+    feedTag 42 sink >> feedName n sink >> feedQBinds q sink >> feedList feedTCon cs sink >>
+    feedSuite b sink >> feedMaybe feedString doc sink
   A.Protocol _ n q ps b doc ->
-    A.Protocol NoLoc (stripLocsName n) (stripLocsQBinds q) (map stripLocsTCon ps) (stripLocsSuite b) doc
+    feedTag 43 sink >> feedName n sink >> feedQBinds q sink >> feedList feedTCon ps sink >>
+    feedSuite b sink >> feedMaybe feedString doc sink
   A.Extension _ q c ps b doc ->
-    A.Extension NoLoc (stripLocsQBinds q) (stripLocsTCon c) (map stripLocsTCon ps) (stripLocsSuite b) doc
+    feedTag 44 sink >> feedQBinds q sink >> feedTCon c sink >> feedList feedTCon ps sink >>
+    feedSuite b sink >> feedMaybe feedString doc sink
 
-stripLocsExpr :: A.Expr -> A.Expr
-stripLocsExpr expr = case expr of
-  A.Var _ qn            -> A.Var NoLoc (stripLocsQName qn)
-  A.Int _ i s           -> A.Int NoLoc i s
-  A.Float _ d s         -> A.Float NoLoc d s
-  A.Imaginary _ d s     -> A.Imaginary NoLoc d s
-  A.Bool _ b            -> A.Bool NoLoc b
-  A.None _              -> A.None NoLoc
-  A.NotImplemented _    -> A.NotImplemented NoLoc
-  A.Ellipsis _          -> A.Ellipsis NoLoc
-  A.Strings _ ss        -> A.Strings NoLoc ss
-  A.BStrings _ ss       -> A.BStrings NoLoc ss
-  A.Call _ f ps ks      -> A.Call NoLoc (stripLocsExpr f) (stripLocsPosArg ps) (stripLocsKwdArg ks)
-  A.Let _ ss e          -> A.Let NoLoc (stripLocsSuite ss) (stripLocsExpr e)
-  A.TApp _ f ts         -> A.TApp NoLoc (stripLocsExpr f) (map stripLocsType ts)
-  A.Async _ e           -> A.Async NoLoc (stripLocsExpr e)
-  A.Await _ e           -> A.Await NoLoc (stripLocsExpr e)
-  A.Index _ e ix        -> A.Index NoLoc (stripLocsExpr e) (stripLocsExpr ix)
-  A.Slice _ e sl        -> A.Slice NoLoc (stripLocsExpr e) (stripLocsSliz sl)
-  A.Cond _ e c e'       -> A.Cond NoLoc (stripLocsExpr e) (stripLocsExpr c) (stripLocsExpr e')
-  A.IsInstance _ e c    -> A.IsInstance NoLoc (stripLocsExpr e) (stripLocsQName c)
-  A.BinOp _ e op e'     -> A.BinOp NoLoc (stripLocsExpr e) op (stripLocsExpr e')
-  A.CompOp _ e ops      -> A.CompOp NoLoc (stripLocsExpr e) (map stripLocsOpArg ops)
-  A.UnOp _ op e         -> A.UnOp NoLoc op (stripLocsExpr e)
-  A.Dot _ e n           -> A.Dot NoLoc (stripLocsExpr e) (stripLocsName n)
-  A.Rest _ e n          -> A.Rest NoLoc (stripLocsExpr e) (stripLocsName n)
-  A.DotI _ e i          -> A.DotI NoLoc (stripLocsExpr e) i
-  A.RestI _ e i         -> A.RestI NoLoc (stripLocsExpr e) i
-  A.Opt _ e b           -> A.Opt NoLoc (stripLocsExpr e) b
-  A.OptChain _ e        -> A.OptChain NoLoc (stripLocsExpr e)
-  A.Lambda _ p k e fx   -> A.Lambda NoLoc (stripLocsPosPar p) (stripLocsKwdPar k) (stripLocsExpr e) (stripLocsType fx)
-  A.Yield _ mbe         -> A.Yield NoLoc (fmap stripLocsExpr mbe)
-  A.YieldFrom _ e       -> A.YieldFrom NoLoc (stripLocsExpr e)
-  A.Tuple _ ps ks       -> A.Tuple NoLoc (stripLocsPosArg ps) (stripLocsKwdArg ks)
-  A.List _ es           -> A.List NoLoc (map stripLocsElem es)
-  A.ListComp _ e c      -> A.ListComp NoLoc (stripLocsElem e) (stripLocsComp c)
-  A.Dict _ as           -> A.Dict NoLoc (map stripLocsAssoc as)
-  A.DictComp _ a c      -> A.DictComp NoLoc (stripLocsAssoc a) (stripLocsComp c)
-  A.Set _ es            -> A.Set NoLoc (map stripLocsElem es)
-  A.SetComp _ e c       -> A.SetComp NoLoc (stripLocsElem e) (stripLocsComp c)
-  A.Paren _ e           -> A.Paren NoLoc (stripLocsExpr e)
-  A.Box t e             -> A.Box (stripLocsType t) (stripLocsExpr e)
-  A.UnBox t e           -> A.UnBox (stripLocsType t) (stripLocsExpr e)
+feedExpr :: A.Expr -> HashFeed
+feedExpr expr sink = case expr of
+  A.Var _ qn            -> feedTag 50 sink >> feedQName qn sink
+  A.Int _ i s           -> feedTag 51 sink >> feedInteger i sink >> feedString s sink
+  A.Float _ d s         -> feedTag 52 sink >> feedDouble d sink >> feedString s sink
+  A.Imaginary _ d s     -> feedTag 53 sink >> feedDouble d sink >> feedString s sink
+  A.Bool _ b            -> feedTag 54 sink >> feedBool b sink
+  A.None _              -> feedTag 55 sink
+  A.NotImplemented _    -> feedTag 56 sink
+  A.Ellipsis _          -> feedTag 57 sink
+  A.Strings _ ss        -> feedTag 58 sink >> feedList feedString ss sink
+  A.BStrings _ ss       -> feedTag 59 sink >> feedList feedString ss sink
+  A.Call _ f ps ks      -> feedTag 60 sink >> feedExpr f sink >> feedPosArg ps sink >> feedKwdArg ks sink
+  A.Let _ ss e          -> feedTag 61 sink >> feedSuite ss sink >> feedExpr e sink
+  A.TApp _ f ts         -> feedTag 62 sink >> feedExpr f sink >> feedList feedType ts sink
+  A.Async _ e           -> feedTag 63 sink >> feedExpr e sink
+  A.Await _ e           -> feedTag 64 sink >> feedExpr e sink
+  A.Index _ e ix        -> feedTag 65 sink >> feedExpr e sink >> feedExpr ix sink
+  A.Slice _ e sl        -> feedTag 66 sink >> feedExpr e sink >> feedSliz sl sink
+  A.Cond _ e c e'       -> feedTag 67 sink >> feedExpr e sink >> feedExpr c sink >> feedExpr e' sink
+  A.IsInstance _ e c    -> feedTag 68 sink >> feedExpr e sink >> feedQName c sink
+  A.BinOp _ e op e'     -> feedTag 69 sink >> feedExpr e sink >> feedBinary op sink >> feedExpr e' sink
+  A.CompOp _ e ops      -> feedTag 70 sink >> feedExpr e sink >> feedList feedOpArg ops sink
+  A.UnOp _ op e         -> feedTag 71 sink >> feedUnary op sink >> feedExpr e sink
+  A.Dot _ e n           -> feedTag 72 sink >> feedExpr e sink >> feedName n sink
+  A.Rest _ e n          -> feedTag 73 sink >> feedExpr e sink >> feedName n sink
+  A.DotI _ e i          -> feedTag 74 sink >> feedExpr e sink >> feedInteger i sink
+  A.RestI _ e i         -> feedTag 75 sink >> feedExpr e sink >> feedInteger i sink
+  A.Opt _ e b           -> feedTag 76 sink >> feedExpr e sink >> feedBool b sink
+  A.OptChain _ e        -> feedTag 77 sink >> feedExpr e sink
+  A.Lambda _ p k e fx   -> feedTag 78 sink >> feedPosPar p sink >> feedKwdPar k sink >> feedExpr e sink >> feedType fx sink
+  A.Yield _ mbe         -> feedTag 79 sink >> feedMaybe feedExpr mbe sink
+  A.YieldFrom _ e       -> feedTag 80 sink >> feedExpr e sink
+  A.Tuple _ ps ks       -> feedTag 81 sink >> feedPosArg ps sink >> feedKwdArg ks sink
+  A.List _ es           -> feedTag 82 sink >> feedList feedElem es sink
+  A.ListComp _ e c      -> feedTag 83 sink >> feedElem e sink >> feedComp c sink
+  A.Dict _ as           -> feedTag 84 sink >> feedList feedAssoc as sink
+  A.DictComp _ a c      -> feedTag 85 sink >> feedAssoc a sink >> feedComp c sink
+  A.Set _ es            -> feedTag 86 sink >> feedList feedElem es sink
+  A.SetComp _ e c       -> feedTag 87 sink >> feedElem e sink >> feedComp c sink
+  A.Paren _ e           -> feedTag 88 sink >> feedExpr e sink
+  A.Box t e             -> feedTag 89 sink >> feedType t sink >> feedExpr e sink
+  A.UnBox t e           -> feedTag 90 sink >> feedType t sink >> feedExpr e sink
 
-stripLocsPattern :: A.Pattern -> A.Pattern
-stripLocsPattern pat = case pat of
-  A.PWild _ mt       -> A.PWild NoLoc (fmap stripLocsType mt)
-  A.PVar _ n mt      -> A.PVar NoLoc (stripLocsName n) (fmap stripLocsType mt)
-  A.PParen _ p       -> A.PParen NoLoc (stripLocsPattern p)
-  A.PTuple _ ps ks   -> A.PTuple NoLoc (stripLocsPosPat ps) (stripLocsKwdPat ks)
-  A.PList _ ps tailp -> A.PList NoLoc (map stripLocsPattern ps) (fmap stripLocsPattern tailp)
-  A.PData _ n ixs    -> A.PData NoLoc (stripLocsName n) (map stripLocsExpr ixs)
+feedPattern :: A.Pattern -> HashFeed
+feedPattern pat sink = case pat of
+  A.PWild _ mt       -> feedTag 100 sink >> feedMaybe feedType mt sink
+  A.PVar _ n mt      -> feedTag 101 sink >> feedName n sink >> feedMaybe feedType mt sink
+  A.PParen _ p       -> feedTag 102 sink >> feedPattern p sink
+  A.PTuple _ ps ks   -> feedTag 103 sink >> feedPosPat ps sink >> feedKwdPat ks sink
+  A.PList _ ps tailp -> feedTag 104 sink >> feedList feedPattern ps sink >> feedMaybe feedPattern tailp sink
+  A.PData _ n ixs    -> feedTag 105 sink >> feedName n sink >> feedList feedExpr ixs sink
 
-stripLocsType :: A.Type -> A.Type
-stripLocsType t = case t of
-  A.TUni _ u          -> A.TUni NoLoc (stripLocsTUni u)
-  A.TVar _ tv         -> A.TVar NoLoc (stripLocsTVar tv)
-  A.TCon _ tc         -> A.TCon NoLoc (stripLocsTCon tc)
-  A.TFun _ fx p k r   -> A.TFun NoLoc (stripLocsType fx) (stripLocsType p) (stripLocsType k) (stripLocsType r)
-  A.TTuple _ p k      -> A.TTuple NoLoc (stripLocsType p) (stripLocsType k)
-  A.TOpt _ opt        -> A.TOpt NoLoc (stripLocsType opt)
-  A.TNone _           -> A.TNone NoLoc
-  A.TWild _           -> A.TWild NoLoc
-  A.TNil _ k          -> A.TNil NoLoc (stripLocsKind k)
-  A.TRow _ k n ty row -> A.TRow NoLoc (stripLocsKind k) (stripLocsName n) (stripLocsType ty) (stripLocsType row)
-  A.TStar _ k row     -> A.TStar NoLoc (stripLocsKind k) (stripLocsType row)
-  A.TFX _ fx          -> A.TFX NoLoc fx
-  A.TUnboxed _ ty     -> A.TUnboxed NoLoc (stripLocsType ty)
+feedType :: A.Type -> HashFeed
+feedType t sink = case t of
+  A.TUni _ u          -> feedTag 110 sink >> feedTUni u sink
+  A.TVar _ tv         -> feedTag 111 sink >> feedTVar tv sink
+  A.TCon _ tc         -> feedTag 112 sink >> feedTCon tc sink
+  A.TFun _ fx p k r   -> feedTag 113 sink >> feedType fx sink >> feedType p sink >> feedType k sink >> feedType r sink
+  A.TTuple _ p k      -> feedTag 114 sink >> feedType p sink >> feedType k sink
+  A.TOpt _ opt        -> feedTag 115 sink >> feedType opt sink
+  A.TNone _           -> feedTag 116 sink
+  A.TWild _           -> feedTag 117 sink
+  A.TNil _ k          -> feedTag 118 sink >> feedKind k sink
+  A.TRow _ k n ty row -> feedTag 119 sink >> feedKind k sink >> feedName n sink >> feedType ty sink >> feedType row sink
+  A.TStar _ k row     -> feedTag 120 sink >> feedKind k sink >> feedType row sink
+  A.TFX _ fx          -> feedTag 121 sink >> feedFX fx sink
+  A.TUnboxed _ ty     -> feedTag 122 sink >> feedType ty sink
 
-stripLocsTSchema :: A.TSchema -> A.TSchema
-stripLocsTSchema (A.TSchema _ q t) = A.TSchema NoLoc (stripLocsQBinds q) (stripLocsType t)
+feedTSchema :: A.TSchema -> HashFeed
+feedTSchema (A.TSchema _ q t) sink = feedTag 130 sink >> feedQBinds q sink >> feedType t sink
 
-stripLocsTCon :: A.TCon -> A.TCon
-stripLocsTCon (A.TC qn ts) = A.TC (stripLocsQName qn) (map stripLocsType ts)
+feedTCon :: A.TCon -> HashFeed
+feedTCon (A.TC qn ts) sink = feedTag 131 sink >> feedQName qn sink >> feedList feedType ts sink
 
-stripLocsQBind :: A.QBind -> A.QBind
-stripLocsQBind (A.QBind tv cs) = A.QBind (stripLocsTVar tv) (map stripLocsTCon cs)
+feedQBind :: A.QBind -> HashFeed
+feedQBind (A.QBind tv cs) sink = feedTag 132 sink >> feedTVar tv sink >> feedList feedTCon cs sink
 
-stripLocsQBinds :: A.QBinds -> A.QBinds
-stripLocsQBinds = map stripLocsQBind
+feedQBinds :: A.QBinds -> HashFeed
+feedQBinds = feedList feedQBind
 
-stripLocsTVar :: A.TVar -> A.TVar
-stripLocsTVar (A.TV k n) = A.TV (stripLocsKind k) (stripLocsName n)
+feedTVar :: A.TVar -> HashFeed
+feedTVar (A.TV k n) sink = feedTag 133 sink >> feedKind k sink >> feedName n sink
 
-stripLocsTUni :: A.TUni -> A.TUni
-stripLocsTUni (A.UV k l i) = A.UV (stripLocsKind k) l i
+feedTUni :: A.TUni -> HashFeed
+feedTUni (A.UV k l i) sink = feedTag 134 sink >> feedKind k sink >> feedInt l sink >> feedInt i sink
 
-stripLocsKind :: A.Kind -> A.Kind
-stripLocsKind (A.KFun ks k) = A.KFun (map stripLocsKind ks) (stripLocsKind k)
-stripLocsKind k            = k
+feedKind :: A.Kind -> HashFeed
+feedKind k sink = case k of
+  A.KType     -> feedTag 140 sink
+  A.KProto    -> feedTag 141 sink
+  A.KFX       -> feedTag 142 sink
+  A.PRow      -> feedTag 143 sink
+  A.KRow      -> feedTag 144 sink
+  A.KFun ks r -> feedTag 145 sink >> feedList feedKind ks sink >> feedKind r sink
+  A.KUni i    -> feedTag 146 sink >> feedInt i sink
+  A.KWild     -> feedTag 147 sink
 
-stripLocsPosPar :: A.PosPar -> A.PosPar
-stripLocsPosPar p = case p of
-  A.PosPar n mt me rest -> A.PosPar (stripLocsName n) (fmap stripLocsType mt) (fmap stripLocsExpr me) (stripLocsPosPar rest)
-  A.PosSTAR n mt        -> A.PosSTAR (stripLocsName n) (fmap stripLocsType mt)
-  A.PosNIL              -> A.PosNIL
+feedPosPar :: A.PosPar -> HashFeed
+feedPosPar p sink = case p of
+  A.PosPar n mt me rest -> feedTag 150 sink >> feedName n sink >> feedMaybe feedType mt sink >> feedMaybe feedExpr me sink >> feedPosPar rest sink
+  A.PosSTAR n mt        -> feedTag 151 sink >> feedName n sink >> feedMaybe feedType mt sink
+  A.PosNIL              -> feedTag 152 sink
 
-stripLocsKwdPar :: A.KwdPar -> A.KwdPar
-stripLocsKwdPar k = case k of
-  A.KwdPar n mt me rest -> A.KwdPar (stripLocsName n) (fmap stripLocsType mt) (fmap stripLocsExpr me) (stripLocsKwdPar rest)
-  A.KwdSTAR n mt        -> A.KwdSTAR (stripLocsName n) (fmap stripLocsType mt)
-  A.KwdNIL              -> A.KwdNIL
+feedKwdPar :: A.KwdPar -> HashFeed
+feedKwdPar k sink = case k of
+  A.KwdPar n mt me rest -> feedTag 153 sink >> feedName n sink >> feedMaybe feedType mt sink >> feedMaybe feedExpr me sink >> feedKwdPar rest sink
+  A.KwdSTAR n mt        -> feedTag 154 sink >> feedName n sink >> feedMaybe feedType mt sink
+  A.KwdNIL              -> feedTag 155 sink
 
-stripLocsPosArg :: A.PosArg -> A.PosArg
-stripLocsPosArg ps = case ps of
-  A.PosArg e rest -> A.PosArg (stripLocsExpr e) (stripLocsPosArg rest)
-  A.PosStar e     -> A.PosStar (stripLocsExpr e)
-  A.PosNil        -> A.PosNil
+feedPosArg :: A.PosArg -> HashFeed
+feedPosArg ps sink = case ps of
+  A.PosArg e rest -> feedTag 156 sink >> feedExpr e sink >> feedPosArg rest sink
+  A.PosStar e     -> feedTag 157 sink >> feedExpr e sink
+  A.PosNil        -> feedTag 158 sink
 
-stripLocsKwdArg :: A.KwdArg -> A.KwdArg
-stripLocsKwdArg ks = case ks of
-  A.KwdArg n e rest -> A.KwdArg (stripLocsName n) (stripLocsExpr e) (stripLocsKwdArg rest)
-  A.KwdStar e       -> A.KwdStar (stripLocsExpr e)
-  A.KwdNil          -> A.KwdNil
+feedKwdArg :: A.KwdArg -> HashFeed
+feedKwdArg ks sink = case ks of
+  A.KwdArg n e rest -> feedTag 159 sink >> feedName n sink >> feedExpr e sink >> feedKwdArg rest sink
+  A.KwdStar e       -> feedTag 160 sink >> feedExpr e sink
+  A.KwdNil          -> feedTag 161 sink
 
-stripLocsPosPat :: A.PosPat -> A.PosPat
-stripLocsPosPat ps = case ps of
-  A.PosPat p rest -> A.PosPat (stripLocsPattern p) (stripLocsPosPat rest)
-  A.PosPatStar p  -> A.PosPatStar (stripLocsPattern p)
-  A.PosPatNil     -> A.PosPatNil
+feedPosPat :: A.PosPat -> HashFeed
+feedPosPat ps sink = case ps of
+  A.PosPat p rest -> feedTag 162 sink >> feedPattern p sink >> feedPosPat rest sink
+  A.PosPatStar p  -> feedTag 163 sink >> feedPattern p sink
+  A.PosPatNil     -> feedTag 164 sink
 
-stripLocsKwdPat :: A.KwdPat -> A.KwdPat
-stripLocsKwdPat ks = case ks of
-  A.KwdPat n p rest -> A.KwdPat (stripLocsName n) (stripLocsPattern p) (stripLocsKwdPat rest)
-  A.KwdPatStar p    -> A.KwdPatStar (stripLocsPattern p)
-  A.KwdPatNil       -> A.KwdPatNil
+feedKwdPat :: A.KwdPat -> HashFeed
+feedKwdPat ks sink = case ks of
+  A.KwdPat n p rest -> feedTag 165 sink >> feedName n sink >> feedPattern p sink >> feedKwdPat rest sink
+  A.KwdPatStar p    -> feedTag 166 sink >> feedPattern p sink
+  A.KwdPatNil       -> feedTag 167 sink
 
-stripLocsBranch :: A.Branch -> A.Branch
-stripLocsBranch (A.Branch e ss) = A.Branch (stripLocsExpr e) (stripLocsSuite ss)
+feedBranch :: A.Branch -> HashFeed
+feedBranch (A.Branch e ss) sink = feedTag 168 sink >> feedExpr e sink >> feedSuite ss sink
 
-stripLocsHandler :: A.Handler -> A.Handler
-stripLocsHandler (A.Handler ex ss) = A.Handler (stripLocsExcept ex) (stripLocsSuite ss)
+feedHandler :: A.Handler -> HashFeed
+feedHandler (A.Handler ex ss) sink = feedTag 169 sink >> feedExcept ex sink >> feedSuite ss sink
 
-stripLocsExcept :: A.Except -> A.Except
-stripLocsExcept ex = case ex of
-  A.ExceptAll _    -> A.ExceptAll NoLoc
-  A.Except _ qn    -> A.Except NoLoc (stripLocsQName qn)
-  A.ExceptAs _ q n -> A.ExceptAs NoLoc (stripLocsQName q) (stripLocsName n)
+feedExcept :: A.Except -> HashFeed
+feedExcept ex sink = case ex of
+  A.ExceptAll _    -> feedTag 170 sink
+  A.Except _ qn    -> feedTag 171 sink >> feedQName qn sink
+  A.ExceptAs _ q n -> feedTag 172 sink >> feedQName q sink >> feedName n sink
 
-stripLocsElem :: A.Elem -> A.Elem
-stripLocsElem elem1 = case elem1 of
-  A.Elem e -> A.Elem (stripLocsExpr e)
-  A.Star e -> A.Star (stripLocsExpr e)
+feedElem :: A.Elem -> HashFeed
+feedElem elem1 sink = case elem1 of
+  A.Elem e -> feedTag 173 sink >> feedExpr e sink
+  A.Star e -> feedTag 174 sink >> feedExpr e sink
 
-stripLocsAssoc :: A.Assoc -> A.Assoc
-stripLocsAssoc assoc = case assoc of
-  A.Assoc k v  -> A.Assoc (stripLocsExpr k) (stripLocsExpr v)
-  A.StarStar e -> A.StarStar (stripLocsExpr e)
+feedAssoc :: A.Assoc -> HashFeed
+feedAssoc assoc sink = case assoc of
+  A.Assoc k v  -> feedTag 175 sink >> feedExpr k sink >> feedExpr v sink
+  A.StarStar e -> feedTag 176 sink >> feedExpr e sink
 
-stripLocsOpArg :: A.OpArg -> A.OpArg
-stripLocsOpArg (A.OpArg op e) = A.OpArg op (stripLocsExpr e)
+feedOpArg :: A.OpArg -> HashFeed
+feedOpArg (A.OpArg op e) sink = feedTag 177 sink >> feedComparison op sink >> feedExpr e sink
 
-stripLocsSliz :: A.Sliz -> A.Sliz
-stripLocsSliz (A.Sliz _ a b c) = A.Sliz NoLoc (fmap stripLocsExpr a) (fmap stripLocsExpr b) (fmap stripLocsExpr c)
+feedSliz :: A.Sliz -> HashFeed
+feedSliz (A.Sliz _ a b c) sink = feedTag 178 sink >> feedMaybe feedExpr a sink >> feedMaybe feedExpr b sink >> feedMaybe feedExpr c sink
 
-stripLocsComp :: A.Comp -> A.Comp
-stripLocsComp comp = case comp of
-  A.CompFor _ p e c -> A.CompFor NoLoc (stripLocsPattern p) (stripLocsExpr e) (stripLocsComp c)
-  A.CompIf _ e c    -> A.CompIf NoLoc (stripLocsExpr e) (stripLocsComp c)
-  A.NoComp          -> A.NoComp
+feedComp :: A.Comp -> HashFeed
+feedComp comp sink = case comp of
+  A.CompFor _ p e c -> feedTag 179 sink >> feedPattern p sink >> feedExpr e sink >> feedComp c sink
+  A.CompIf _ e c    -> feedTag 180 sink >> feedExpr e sink >> feedComp c sink
+  A.NoComp          -> feedTag 181 sink
 
-stripLocsWithItem :: A.WithItem -> A.WithItem
-stripLocsWithItem (A.WithItem e p) = A.WithItem (stripLocsExpr e) (fmap stripLocsPattern p)
+feedWithItem :: A.WithItem -> HashFeed
+feedWithItem (A.WithItem e p) sink = feedTag 182 sink >> feedExpr e sink >> feedMaybe feedPattern p sink
 
-stripLocsQName :: A.QName -> A.QName
-stripLocsQName qn = case qn of
-  A.QName mn n -> A.QName (stripLocsModName mn) (stripLocsName n)
-  A.NoQ n      -> A.NoQ (stripLocsName n)
-  A.GName mn n -> A.GName (stripLocsModName mn) (stripLocsName n)
+feedQName :: A.QName -> HashFeed
+feedQName qn sink = case qn of
+  A.QName mn n -> feedTag 183 sink >> feedModName mn sink >> feedName n sink
+  A.NoQ n      -> feedTag 184 sink >> feedName n sink
+  A.GName mn n -> feedTag 185 sink >> feedModName mn sink >> feedName n sink
 
-stripLocsModName :: A.ModName -> A.ModName
-stripLocsModName (A.ModName ns) = A.ModName (map stripLocsName ns)
+feedModName :: A.ModName -> HashFeed
+feedModName (A.ModName ns) sink = feedTag 186 sink >> feedList feedName ns sink
 
-stripLocsName :: A.Name -> A.Name
-stripLocsName n = case n of
-  A.Name _ s      -> A.Name NoLoc s
-  A.Derived n1 n2 -> A.Derived (stripLocsName n1) (stripLocsName n2)
-  A.Internal{}    -> n
+feedName :: A.Name -> HashFeed
+feedName n sink = case n of
+  A.Name _ s       -> feedTag 187 sink >> feedString s sink
+  A.Derived n1 n2  -> feedTag 188 sink >> feedName n1 sink >> feedName n2 sink
+  A.Internal p s i -> feedTag 189 sink >> feedPrefix p sink >> feedString s sink >> feedInt i sink
+
+feedPrefix :: A.Prefix -> HashFeed
+feedPrefix p sink = feedTag (case p of
+  A.Globvar  -> 190
+  A.Xistvar  -> 191
+  A.Tempvar  -> 192
+  A.Witness  -> 193
+  A.NormPass -> 194
+  A.CPSPass  -> 195
+  A.LLiftPass -> 196
+  A.BoxPass  -> 197) sink
+
+feedUnary :: A.Unary -> HashFeed
+feedUnary op sink = feedTag (case op of
+  A.Not    -> 198
+  A.UPlus  -> 199
+  A.UMinus -> 200
+  A.BNot   -> 201) sink
+
+feedBinary :: A.Binary -> HashFeed
+feedBinary op sink = feedTag (case op of
+  A.Or     -> 202
+  A.And    -> 203
+  A.Plus   -> 204
+  A.Minus  -> 205
+  A.Mult   -> 206
+  A.Pow    -> 207
+  A.Div    -> 208
+  A.Mod    -> 209
+  A.EuDiv  -> 210
+  A.BOr    -> 211
+  A.BXor   -> 212
+  A.BAnd   -> 213
+  A.ShiftL -> 214
+  A.ShiftR -> 215
+  A.MMult  -> 216) sink
+
+feedAug :: A.Aug -> HashFeed
+feedAug op sink = feedTag (case op of
+  A.PlusA   -> 217
+  A.MinusA  -> 218
+  A.MultA   -> 219
+  A.PowA    -> 220
+  A.DivA    -> 221
+  A.ModA    -> 222
+  A.EuDivA  -> 223
+  A.BOrA    -> 224
+  A.BXorA   -> 225
+  A.BAndA   -> 226
+  A.ShiftLA -> 227
+  A.ShiftRA -> 228
+  A.MMultA  -> 229) sink
+
+feedComparison :: A.Comparison -> HashFeed
+feedComparison op sink = feedTag (case op of
+  A.Eq    -> 230
+  A.NEq   -> 231
+  A.LtGt  -> 232
+  A.Lt    -> 233
+  A.Gt    -> 234
+  A.GE    -> 235
+  A.LE    -> 236
+  A.In    -> 237
+  A.NotIn -> 238
+  A.Is    -> 239
+  A.IsNot -> 240) sink
+
+feedDeco :: A.Deco -> HashFeed
+feedDeco dec sink = feedTag (case dec of
+  A.NoDec    -> 241
+  A.Property -> 242
+  A.Static   -> 243) sink
+
+feedFX :: A.FX -> HashFeed
+feedFX fx sink = feedTag (case fx of
+  A.FXPure   -> 244
+  A.FXMut    -> 245
+  A.FXProc   -> 246
+  A.FXAction -> 247) sink
+
+feedNameInfo :: I.NameInfo -> HashFeed
+feedNameInfo info sink = feedTag 249 sink >> case info of
+  I.NVar t           -> feedTag 0 sink >> feedType t sink
+  I.NSVar t          -> feedTag 1 sink >> feedType t sink
+  I.NDef sc dec _    -> feedTag 2 sink >> feedTSchema sc sink >> feedDeco dec sink
+  I.NSig sc dec _    -> feedTag 3 sink >> feedTSchema sc sink >> feedDeco dec sink
+  I.NAct q p k te _  -> feedTag 4 sink >> feedQBinds q sink >> feedType p sink >> feedType k sink >> feedTEnv te sink
+  I.NClass q cs te _ -> feedTag 5 sink >> feedQBinds q sink >> feedList feedWTCon cs sink >> feedTEnv te sink
+  I.NProto q ps te _ -> feedTag 6 sink >> feedQBinds q sink >> feedList feedWTCon ps sink >> feedTEnv te sink
+  I.NExt q c ps te o _ ->
+    feedTag 7 sink >> feedQBinds q sink >> feedTCon c sink >> feedList feedWTCon ps sink >>
+    feedTEnv te sink >> feedList feedName o sink
+  I.NTVar k c ps     -> feedTag 8 sink >> feedKind k sink >> feedTCon c sink >> feedList feedTCon ps sink
+  I.NAlias qn        -> feedTag 9 sink >> feedQName qn sink
+  I.NMAlias mn       -> feedTag 10 sink >> feedModName mn sink
+  I.NModule ms te _  -> feedTag 11 sink >> feedList feedModName ms sink >> feedTEnv te sink
+  I.NReserved        -> feedTag 12 sink
+
+feedTEnv :: I.TEnv -> HashFeed
+feedTEnv = feedList feedTEnvBind
+
+feedTEnvBind :: (A.Name, I.NameInfo) -> HashFeed
+feedTEnvBind (n, info) sink = feedTag 250 sink >> feedName n sink >> feedNameInfo info sink
+
+feedWTCon :: I.WTCon -> HashFeed
+feedWTCon (wpath, pcon) sink = feedTag 251 sink >> feedList feedWStep wpath sink >> feedTCon pcon sink
+
+feedWStep :: Either A.QName A.QName -> HashFeed
+feedWStep step sink = case step of
+  Left qn  -> feedTag 252 sink >> feedQName qn sink
+  Right qn -> feedTag 253 sink >> feedQName qn sink
+
+feedHashBytes :: B.ByteString -> HashFeed
+feedHashBytes bs sink = feedInt (B.length bs) sink >> sinkWriteBytes sink bs
+
+feedResolvedDepHashes :: (A.Name -> Maybe B.ByteString)
+                      -> [A.Name]
+                      -> [(A.QName, B.ByteString)]
+                      -> HashFeed
+-- Local and external deps are sorted before this point.
+feedResolvedDepHashes lookupLocal locals externals sink = do
+  feedTag 4 sink
+  mapM_ feedLocal locals
+  mapM_ feedExternal externals
+  feedTag 5 sink
+  where
+    feedLocal n =
+      case lookupLocal n of
+        Just h  -> feedHashBytes h sink
+        Nothing -> pure ()
+    feedExternal (_, h) = feedHashBytes h sink
+
+hashSelfWithDepsFromWith :: HashSink
+                         -> B.ByteString
+                         -> (A.Name -> Maybe B.ByteString)
+                         -> [A.Name]
+                         -> [(A.QName, B.ByteString)]
+                         -> IO B.ByteString
+hashSelfWithDepsFromWith sink self lookupLocal locals externals =
+  hashFeedWith sink $ \sink' ->
+    feedTag 254 sink' >> feedTag 0 sink' >> feedHashBytes self sink' >>
+    feedResolvedDepHashes lookupLocal locals externals sink'
+
+hashCycleGroupFromWith :: HashSink
+                       -> [B.ByteString]
+                       -> (A.Name -> Maybe B.ByteString)
+                       -> [A.Name]
+                       -> [(A.QName, B.ByteString)]
+                       -> IO B.ByteString
+hashCycleGroupFromWith sink selfHashes lookupLocal locals externals =
+  hashFeedWith sink $ \sink' ->
+    feedTag 254 sink' >> feedTag 1 sink' >> feedList feedHashBytes selfHashes sink' >>
+    feedResolvedDepHashes lookupLocal locals externals sink'
+
+hashCycleMemberWith :: HashSink -> B.ByteString -> B.ByteString -> A.Name -> IO B.ByteString
+hashCycleMemberWith sink self groupHash n =
+  hashFeedWith sink $ \sink' ->
+    feedTag 254 sink' >> feedTag 2 sink' >> feedHashBytes self sink' >> feedHashBytes groupHash sink' >> feedString (nameKey n) sink'
+
+hashNameHashEntries :: Int -> [(String, B.ByteString)] -> B.ByteString
+hashNameHashEntries tag entries =
+  hashNameHashEntriesWith tag entries $ \(n, h) sink ->
+    feedString n sink >> feedHashBytes h sink
+
+hashNameHashEntriesWith :: Int -> [a] -> (a -> HashFeed) -> B.ByteString
+hashNameHashEntriesWith tag entries feedEntry =
+  hashFeed $ \sink -> do
+    feedTag 254 sink
+    feedTag tag sink
+    feedTag 4 sink
+    mapM_ (\entry -> feedEntry entry sink) entries
+    feedTag 5 sink
+{-# INLINE hashNameHashEntriesWith #-}
+
+hashNameHashMapEntriesForNames :: Int -> M.Map A.Name B.ByteString -> [A.Name] -> B.ByteString
+hashNameHashMapEntriesForNames tag hashes names =
+  hashNameHashEntriesWith tag names $ \n sink ->
+    feedString (nameKey n) sink >> feedHashBytes (M.findWithDefault B.empty n hashes) sink
+
+pubSigDepsFromNameInfoMap :: M.Map A.Name I.NameInfo -> M.Map A.Name [A.QName]
+pubSigDepsFromNameInfoMap nameInfoMap =
+  M.map (Data.Set.toList . Data.Set.fromList . filter (not . isDerivedQName) . Names.freeQ) nameInfoMap
+
+pubSigSplitDepsFromNameInfoMap :: A.ModName
+                               -> Env.Env0
+                               -> Data.Set.Set A.Name
+                               -> M.Map A.Name I.NameInfo
+                               -> (M.Map A.Name [A.Name], M.Map A.Name [A.QName])
+pubSigSplitDepsFromNameInfoMap mn env localNames =
+  finishHashSplitDeps . M.map (pubSigSplitDepsFromNameInfo mn env localNames)
+
+pubSigSplitDepsFromNameInfo :: A.ModName
+                            -> Env.Env0
+                            -> Data.Set.Set A.Name
+                            -> I.NameInfo
+                            -> DepSplit
+pubSigSplitDepsFromNameInfo mn env localNames info =
+  foldNameInfoDeps addPubSigDep info emptyDepSplitDirect
+  where
+    addPubSigDep qn deps
+      | isDerivedQName qn = deps
+      | otherwise         = addSplitDepHash mn env localNames deps qn
+
+isDerivedName :: A.Name -> Bool
+isDerivedName n = case n of
+  A.Derived{} -> True
+  _           -> False
+
+isDerivedQName :: A.QName -> Bool
+isDerivedQName qn = case qn of
+  A.GName _ n -> isDerivedName n
+  A.QName _ n -> isDerivedName n
+  A.NoQ n     -> isDerivedName n
+
+-- | Public hashes include signature deps plus implementation deps, but derived
+-- implementation names are internal and should not require public hashes.
+mergePubDeps :: M.Map A.Name [A.Name]
+             -> M.Map A.Name [A.QName]
+             -> M.Map A.Name [A.Name]
+             -> M.Map A.Name [A.QName]
+             -> (M.Map A.Name [A.Name], M.Map A.Name [A.QName])
+mergePubDeps pubSigLocalDeps pubSigExtDeps implLocalDeps implExtDeps =
+  ( M.unionWith mergeSortedDistinct pubSigLocalDeps implPubLocalDeps
+  , M.unionWith mergeSortedDistinct pubSigExtDeps implPubExtDeps
+  )
+  where
+    implPubLocalDeps = M.map (filter (not . isDerivedName)) implLocalDeps
+    implPubExtDeps = M.map (filter (not . isDerivedQName)) implExtDeps
+
+foldNameInfoDeps :: (A.QName -> acc -> acc) -> I.NameInfo -> acc -> acc
+foldNameInfoDeps add info acc = case info of
+  I.NVar t             -> foldDepsType add t acc
+  I.NSVar t            -> foldDepsType add t acc
+  I.NDef sc _ _        -> foldDepsTSchema add sc acc
+  I.NSig sc _ _        -> foldDepsTSchema add sc acc
+  I.NAct q p k te _    -> foldDepsTEnv add te (foldDepsType add k (foldDepsType add p (foldDepsList (foldDepsQBind add) q acc)))
+  I.NClass q ws te _   -> foldDepsTEnv add te (foldDepsList (foldDepsWTCon add) ws (foldDepsList (foldDepsQBind add) q acc))
+  I.NProto q ws te _   -> foldDepsTEnv add te (foldDepsList (foldDepsWTCon add) ws (foldDepsList (foldDepsQBind add) q acc))
+  I.NExt q c ws te _ _ -> foldDepsTEnv add te (foldDepsList (foldDepsWTCon add) ws (foldDepsTCon add c (foldDepsList (foldDepsQBind add) q acc)))
+  I.NTVar _ c ps       -> foldDepsList (foldDepsTCon add) ps (foldDepsTCon add c acc)
+  I.NAlias qn          -> add qn acc
+  I.NMAlias _          -> acc
+  I.NModule _ te _     -> foldDepsTEnv add te acc
+  I.NReserved          -> acc
+
+foldDepsTEnv :: (A.QName -> acc -> acc) -> I.TEnv -> acc -> acc
+foldDepsTEnv add te acc =
+  foldl' (\acc' (_, info) -> foldNameInfoDeps add info acc') acc te
+
+foldDepsWTCon :: (A.QName -> acc -> acc) -> I.WTCon -> acc -> acc
+foldDepsWTCon add (wpath, pcon) acc =
+  foldDepsTCon add pcon (foldDepsWPath add wpath acc)
+
+foldDepsWPath :: (A.QName -> acc -> acc) -> I.WPath -> acc -> acc
+foldDepsWPath add wpath acc =
+  foldl' (\acc' step -> add (stepQName step) acc') acc wpath
+  where
+    stepQName step = case step of
+      Left qn  -> qn
+      Right qn -> qn
 
 -- | Collect qualified-name dependencies for each item body.
 implDepsFromItems :: [TopLevelItem] -> M.Map A.Name [A.QName]
@@ -317,6 +849,400 @@ implDepsFromItems items =
             TLStmt name stmt -> (name, Names.freeQ stmt)
       in M.insertWith (++) n deps acc
 
+type QNameSet = Data.Set.Set A.QName
+type NameSet  = Data.Set.Set A.Name
+
+boundMaybe :: (a -> NameSet -> NameSet) -> Maybe a -> NameSet -> NameSet
+boundMaybe _ Nothing  acc = acc
+boundMaybe f (Just x) acc = f x acc
+
+boundList :: (a -> NameSet -> NameSet) -> [a] -> NameSet -> NameSet
+boundList f xs acc = foldl' (\acc' x -> f x acc') acc xs
+
+foldDepsTSchema :: (A.QName -> acc -> acc) -> A.TSchema -> acc -> acc
+foldDepsTSchema add (A.TSchema _ q t) acc =
+  foldDepsType add t (foldDepsList (foldDepsQBind add) q acc)
+
+foldDepsQBind :: (A.QName -> acc -> acc) -> A.QBind -> acc -> acc
+foldDepsQBind add (A.QBind _ cs) acc =
+  foldDepsList (foldDepsTCon add) cs acc
+
+foldDepsTCon :: (A.QName -> acc -> acc) -> A.TCon -> acc -> acc
+foldDepsTCon add (A.TC qn ts) acc =
+  foldDepsList (foldDepsType add) ts (add qn acc)
+
+foldDepsType :: (A.QName -> acc -> acc) -> A.Type -> acc -> acc
+foldDepsType add t acc = case t of
+  A.TVar _ tv         -> foldDepsTVar add tv acc
+  A.TUni _ u          -> foldDepsTUni add u acc
+  A.TCon _ tc         -> foldDepsTCon add tc acc
+  A.TFun _ fx p k r   -> foldDepsType add r (foldDepsType add k (foldDepsType add p (foldDepsType add fx acc)))
+  A.TTuple _ p k      -> foldDepsType add k (foldDepsType add p acc)
+  A.TOpt _ opt        -> foldDepsType add opt acc
+  A.TNone{}           -> acc
+  A.TWild{}           -> acc
+  A.TNil{}            -> acc
+  A.TRow _ _ _ ty row -> foldDepsType add row (foldDepsType add ty acc)
+  A.TStar _ _ row     -> foldDepsType add row acc
+  A.TFX{}             -> acc
+  A.TUnboxed _ ty     -> foldDepsType add ty acc
+
+foldDepsTVar :: (A.QName -> acc -> acc) -> A.TVar -> acc -> acc
+foldDepsTVar _ _ acc = acc
+
+foldDepsTUni :: (A.QName -> acc -> acc) -> A.TUni -> acc -> acc
+foldDepsTUni _ _ acc = acc
+
+foldDepsList :: (a -> acc -> acc) -> [a] -> acc -> acc
+foldDepsList f xs acc = foldl' (\acc' x -> f x acc') acc xs
+
+boundStmt :: A.Stmt -> NameSet -> NameSet
+boundStmt stmt acc = case stmt of
+  A.Assign _ ps _      -> boundList boundPattern ps acc
+  A.VarAssign _ ps _   -> boundList boundPattern ps acc
+  A.AugAssign _ t _ _  -> depsNameSetInto (Names.free t) acc
+  A.Decl _ ds          -> boundList boundDecl ds acc
+  A.Signature _ ns _ _ -> depsNameSetInto ns acc
+  A.If _ bs els        -> boundSuite els (boundList boundBranch bs acc)
+  A.While _ _ b els    -> boundSuite els (boundSuite b acc)
+  A.With _ _ b         -> boundSuite b acc
+  _                    -> acc
+
+boundSuite :: A.Suite -> NameSet -> NameSet
+boundSuite = boundList boundStmt
+
+boundDecl :: A.Decl -> NameSet -> NameSet
+boundDecl decl acc = case decl of
+  A.Def _ n _ _ _ _ _ _ _ _ -> Data.Set.insert n acc
+  A.Actor _ n _ _ _ _ _     -> Data.Set.insert n acc
+  A.Class _ n _ _ _ _       -> Data.Set.insert n acc
+  A.Protocol _ n _ _ _ _    -> Data.Set.insert n acc
+  A.Extension{}             -> acc
+
+boundBranch :: A.Branch -> NameSet -> NameSet
+boundBranch (A.Branch _ ss) = boundSuite ss
+
+boundHandler :: A.Handler -> NameSet -> NameSet
+boundHandler (A.Handler ex ss) acc = boundExcept ex (boundSuite ss acc)
+
+boundExcept :: A.Except -> NameSet -> NameSet
+boundExcept ex acc = case ex of
+  A.ExceptAs _ _ n -> Data.Set.insert n acc
+  _                -> acc
+
+boundPattern :: A.Pattern -> NameSet -> NameSet
+boundPattern pat acc = case pat of
+  A.PVar _ n _      -> Data.Set.insert n acc
+  A.PTuple _ ps ks  -> boundKwdPat ks (boundPosPat ps acc)
+  A.PList _ ps p    -> boundMaybe boundPattern p (boundList boundPattern ps acc)
+  A.PParen _ p      -> boundPattern p acc
+  A.PData _ n _     -> Data.Set.insert n acc
+  _                 -> acc
+
+boundPosPar :: A.PosPar -> NameSet -> NameSet
+boundPosPar p acc = case p of
+  A.PosPar n _ _ rest -> boundPosPar rest (Data.Set.insert n acc)
+  A.PosSTAR n _       -> Data.Set.insert n acc
+  A.PosNIL            -> acc
+
+boundKwdPar :: A.KwdPar -> NameSet -> NameSet
+boundKwdPar k acc = case k of
+  A.KwdPar n _ _ rest -> boundKwdPar rest (Data.Set.insert n acc)
+  A.KwdSTAR n _       -> Data.Set.insert n acc
+  A.KwdNIL            -> acc
+
+boundPosPat :: A.PosPat -> NameSet -> NameSet
+boundPosPat ps acc = case ps of
+  A.PosPat p rest -> boundPosPat rest (boundPattern p acc)
+  A.PosPatStar p  -> boundPattern p acc
+  A.PosPatNil     -> acc
+
+boundKwdPat :: A.KwdPat -> NameSet -> NameSet
+boundKwdPat ks acc = case ks of
+  A.KwdPat _ p rest -> boundKwdPat rest (boundPattern p acc)
+  A.KwdPatStar p    -> boundPattern p acc
+  A.KwdPatNil       -> acc
+
+boundWithItem :: A.WithItem -> NameSet -> NameSet
+boundWithItem (A.WithItem _ p) = boundMaybe boundPattern p
+
+boundComp :: A.Comp -> NameSet -> NameSet
+boundComp comp acc = case comp of
+  A.CompFor _ pat _ c -> boundComp c (boundPattern pat acc)
+  A.CompIf _ _ c      -> boundComp c acc
+  A.NoComp            -> acc
+
+boundQBind :: A.QBind -> NameSet -> NameSet
+boundQBind _ acc = acc
+
+assignedSuite :: A.Suite -> NameSet -> NameSet
+assignedSuite = boundList assignedStmt
+
+assignedStmt :: A.Stmt -> NameSet -> NameSet
+assignedStmt stmt acc = case stmt of
+  A.While _ _ b els   -> assignedSuite els (assignedSuite b acc)
+  A.For _ p _ b els   -> boundPattern p (assignedSuite els (assignedSuite b acc))
+  A.With _ ws b       -> boundList boundWithItem ws (assignedSuite b acc)
+  A.Try _ b hs els fin ->
+    assignedSuite fin (assignedSuite els (boundList assignedHandler hs (assignedSuite b acc)))
+  A.If _ bs els       -> assignedSuite els (boundList assignedBranch bs acc)
+  A.Assign _ ps _     -> boundList boundPattern ps acc
+  A.VarAssign _ ps _  -> boundList boundPattern ps acc
+  _                   -> boundStmt stmt acc
+
+assignedBranch :: A.Branch -> NameSet -> NameSet
+assignedBranch (A.Branch _ b) = assignedSuite b
+
+assignedHandler :: A.Handler -> NameSet -> NameSet
+assignedHandler (A.Handler ex b) acc = assignedSuite b (boundExcept ex acc)
+
+depsNameSet :: [A.Name] -> NameSet
+depsNameSet ns = depsNameSetInto ns Data.Set.empty
+
+depsNameSetInto :: [A.Name] -> NameSet -> NameSet
+depsNameSetInto ns acc = foldl' (\acc' n -> Data.Set.insert n acc') acc ns
+
+type DepSplit = (HashSet.HashSet A.Name, HashSet.HashSet A.QName)
+
+emptyDepSplitDirect :: DepSplit
+emptyDepSplitDirect = (HashSet.empty, HashSet.empty)
+
+unionDepSplit :: DepSplit -> DepSplit -> DepSplit
+unionDepSplit (ls, es) (ls', es') =
+  (HashSet.union ls ls', HashSet.union es es')
+
+insertQNameDep :: A.ModName -> Env.Env0 -> Data.Set.Set A.Name -> NameSet -> A.QName -> DepSplit -> DepSplit
+insertQNameDep mn env localNames bound qn@(A.NoQ n) acc
+  | Data.Set.member n bound = acc
+  | otherwise = addSplitDepHash mn env localNames acc qn
+insertQNameDep mn env localNames _ qn acc =
+  addSplitDepHash mn env localNames acc qn
+
+splitMaybeInto :: (a -> DepSplit -> DepSplit) -> Maybe a -> DepSplit -> DepSplit
+splitMaybeInto _ Nothing  acc = acc
+splitMaybeInto f (Just x) acc = f x acc
+
+splitListInto :: (a -> DepSplit -> DepSplit) -> [a] -> DepSplit -> DepSplit
+splitListInto f xs acc = foldl' (\acc' x -> f x acc') acc xs
+
+implSplitDepsFromItems :: A.ModName
+                       -> Env.Env0
+                       -> Data.Set.Set A.Name
+                       -> [TopLevelItem]
+                       -> (M.Map A.Name [A.Name], M.Map A.Name [A.QName])
+implSplitDepsFromItems mn env localNames items =
+  finishHashSplitDeps (foldl' addDeps M.empty (map (implItemSplitDeps mn env localNames) items))
+  where
+    addDeps acc (n, deps) = M.insertWith unionDepSplit n deps acc
+
+implItemSplitDeps :: A.ModName -> Env.Env0 -> Data.Set.Set A.Name -> TopLevelItem -> (A.Name, DepSplit)
+implItemSplitDeps mn env localNames item =
+  case item of
+    TLDecl name decl -> (name, splitDeclDirect Data.Set.empty decl emptyDepSplitDirect)
+    TLStmt name stmt -> (name, splitStmtDirect Data.Set.empty stmt emptyDepSplitDirect)
+  where
+    splitQName = insertQNameDep mn env localNames
+
+    splitStmtDirect bound stmt acc = case stmt of
+      A.Expr _ e             -> splitExprDirect bound e acc
+      A.Assign _ ps e        -> splitExprDirect bound e (splitListInto (splitPatternDirect bound) ps acc)
+      A.MutAssign _ t e      -> splitExprDirect bound e (splitExprDirect bound t acc)
+      A.AugAssign _ t _ e    -> splitExprDirect bound e (splitExprDirect bound t acc)
+      A.Assert _ e mbe       -> splitMaybeInto (splitExprDirect bound) mbe (splitExprDirect bound e acc)
+      A.Pass _               -> acc
+      A.Delete _ t           -> splitExprDirect bound t acc
+      A.Return _ mbe         -> splitMaybeInto (splitExprDirect bound) mbe acc
+      A.Raise _ e            -> splitExprDirect bound e acc
+      A.Break _              -> acc
+      A.Continue _           -> acc
+      A.If _ bs els          -> splitSuiteDirect bound els (splitListInto (splitBranchDirect bound) bs acc)
+      A.While _ e b els      -> splitSuiteDirect bound els (splitSuiteDirect bound b (splitExprDirect bound e acc))
+      A.For _ p e b els      ->
+        let bound' = boundPattern p bound
+        in splitSuiteDirect bound els (splitSuiteDirect bound' b (splitExprDirect bound e (splitPatternDirect bound p acc)))
+      A.Try _ b hs els fin   -> splitSuiteDirect bound fin (splitSuiteDirect bound els (splitListInto (splitHandlerDirect bound) hs (splitSuiteDirect bound b acc)))
+      A.With _ ws b          ->
+        let bound' = boundList boundWithItem ws bound
+        in splitSuiteDirect bound' b (splitListInto (splitWithItemDirect bound) ws acc)
+      A.Data _ mbp b         -> splitSuiteDirect bound b (splitMaybeInto (splitPatternDirect bound) mbp acc)
+      A.VarAssign _ ps e     -> splitExprDirect bound e (splitListInto (splitPatternDirect bound) ps acc)
+      A.After _ e e'         -> splitExprDirect bound e' (splitExprDirect bound e acc)
+      A.Signature _ _ t _    -> splitTSchemaDirect bound t acc
+      A.Decl _ ds            -> splitListInto (splitDeclDirect bound) ds acc
+
+    splitSuiteDirect bound ss acc = splitListInto (splitStmtDirect bound) ss acc
+
+    splitDeclDirect bound decl acc = case decl of
+      A.Def _ n q ps ks _ b _ fx _ ->
+        let bound' =
+              Data.Set.insert n
+                (assignedSuite b (boundKwdPar ks (boundPosPar ps (boundList boundQBind q bound))))
+        in splitTypeDirect bound' fx (splitSuiteDirect bound' b (splitKwdParDirect bound' ks (splitPosParDirect bound' ps acc)))
+      A.Actor _ n q ps ks b _ ->
+        let bound' =
+              Data.Set.insert n
+                (Data.Set.insert Names.self
+                  (assignedSuite b (boundKwdPar ks (boundPosPar ps (boundList boundQBind q bound)))))
+        in splitSuiteDirect bound' b (splitKwdParDirect bound' ks (splitPosParDirect bound' ps acc))
+      A.Class _ n q cs b _ ->
+        let bound' = Data.Set.insert n (assignedSuite b (boundList boundQBind q bound))
+        in splitSuiteDirect bound' b (splitListInto (splitTConDirect bound') cs acc)
+      A.Protocol _ n q ps b _ ->
+        let bound' = Data.Set.insert n (assignedSuite b (boundList boundQBind q bound))
+        in splitSuiteDirect bound' b (splitListInto (splitTConDirect bound') ps acc)
+      A.Extension _ q c ps b _ ->
+        let bound' = assignedSuite b (boundList boundQBind q bound)
+        in splitSuiteDirect bound' b (splitListInto (splitTConDirect bound') ps (splitTConDirect bound' c acc))
+
+    splitBranchDirect bound (A.Branch e ss) acc =
+      splitSuiteDirect bound ss (splitExprDirect bound e acc)
+
+    splitHandlerDirect bound (A.Handler ex ss) acc =
+      let bound' = boundExcept ex bound
+      in splitSuiteDirect bound' ss (splitExceptDirect bound ex acc)
+
+    splitExprDirect bound expr acc = case expr of
+      A.Var _ qn            -> splitQName bound qn acc
+      A.Int{}               -> acc
+      A.Float{}             -> acc
+      A.Imaginary{}         -> acc
+      A.Bool{}              -> acc
+      A.None{}              -> acc
+      A.NotImplemented{}    -> acc
+      A.Ellipsis{}          -> acc
+      A.Strings{}           -> acc
+      A.BStrings{}          -> acc
+      A.Call _ f ps ks      -> splitKwdArgDirect bound ks (splitPosArgDirect bound ps (splitExprDirect bound f acc))
+      A.Let _ ss e          ->
+        let bound' = boundSuite ss bound
+        in splitExprDirect bound' e (splitSuiteDirect bound ss acc)
+      A.TApp _ f ts         -> splitListInto (splitTypeDirect bound) ts (splitExprDirect bound f acc)
+      A.Async _ e           -> splitExprDirect bound e acc
+      A.Await _ e           -> splitExprDirect bound e acc
+      A.Index _ e ix        -> splitExprDirect bound ix (splitExprDirect bound e acc)
+      A.Slice _ e sl        -> splitSlizDirect bound sl (splitExprDirect bound e acc)
+      A.Cond _ e c e'       -> splitExprDirect bound e' (splitExprDirect bound c (splitExprDirect bound e acc))
+      A.IsInstance _ e c    -> splitQName bound c (splitExprDirect bound e acc)
+      A.BinOp _ e _ e'      -> splitExprDirect bound e' (splitExprDirect bound e acc)
+      A.CompOp _ e ops      -> splitListInto (splitOpArgDirect bound) ops (splitExprDirect bound e acc)
+      A.UnOp _ _ e          -> splitExprDirect bound e acc
+      A.Dot _ e _           -> splitExprDirect bound e acc
+      A.Rest _ e _          -> splitExprDirect bound e acc
+      A.DotI _ e _          -> splitExprDirect bound e acc
+      A.RestI _ e _         -> splitExprDirect bound e acc
+      A.Opt _ e _           -> splitExprDirect bound e acc
+      A.OptChain _ e        -> splitExprDirect bound e acc
+      A.Lambda _ ps ks e _  ->
+        let bound' = boundKwdPar ks (boundPosPar ps bound)
+        in splitExprDirect bound' e (splitKwdParDirect bound ks (splitPosParDirect bound ps acc))
+      A.Yield _ mbe         -> splitMaybeInto (splitExprDirect bound) mbe acc
+      A.YieldFrom _ e       -> splitExprDirect bound e acc
+      A.Tuple _ ps ks       -> splitKwdArgDirect bound ks (splitPosArgDirect bound ps acc)
+      A.List _ es           -> splitListInto (splitElemDirect bound) es acc
+      A.ListComp _ e c      ->
+        splitCompDirect bound c (splitElemDirect (boundComp c bound) e acc)
+      A.Dict _ as           -> splitListInto (splitAssocDirect bound) as acc
+      A.DictComp _ a c      ->
+        splitCompDirect bound c (splitAssocDirect (boundComp c bound) a acc)
+      A.Set _ es            -> splitListInto (splitElemDirect bound) es acc
+      A.SetComp _ e c       ->
+        splitCompDirect bound c (splitElemDirect (boundComp c bound) e acc)
+      A.Paren _ e           -> splitExprDirect bound e acc
+      A.UnBox _ e           -> splitExprDirect bound e acc
+      A.Box _ e             -> splitExprDirect bound e acc
+
+    splitPatternDirect bound pat acc = case pat of
+      A.PWild{}        -> acc
+      A.PVar{}         -> acc
+      A.PParen _ p     -> splitPatternDirect bound p acc
+      A.PTuple _ ps ks -> splitKwdPatDirect bound ks (splitPosPatDirect bound ps acc)
+      A.PList _ ps p   -> splitMaybeInto (splitPatternDirect bound) p (splitListInto (splitPatternDirect bound) ps acc)
+      A.PData _ _ ixs  -> splitListInto (splitExprDirect bound) ixs acc
+
+    splitExceptDirect bound ex acc = case ex of
+      A.ExceptAll _    -> acc
+      A.Except _ qn    -> splitQName bound qn acc
+      A.ExceptAs _ q _ -> splitQName bound q acc
+
+    splitPosParDirect bound p acc = case p of
+      A.PosPar _ mt me rest -> splitPosParDirect bound rest (splitMaybeInto (splitExprDirect bound) me (splitMaybeInto (splitTypeDirect bound) mt acc))
+      A.PosSTAR _ mt        -> splitMaybeInto (splitTypeDirect bound) mt acc
+      A.PosNIL              -> acc
+
+    splitKwdParDirect bound k acc = case k of
+      A.KwdPar _ mt me rest -> splitKwdParDirect bound rest (splitMaybeInto (splitExprDirect bound) me (splitMaybeInto (splitTypeDirect bound) mt acc))
+      A.KwdSTAR _ mt        -> splitMaybeInto (splitTypeDirect bound) mt acc
+      A.KwdNIL              -> acc
+
+    splitPosArgDirect bound ps acc = case ps of
+      A.PosArg e rest -> splitPosArgDirect bound rest (splitExprDirect bound e acc)
+      A.PosStar e     -> splitExprDirect bound e acc
+      A.PosNil        -> acc
+
+    splitKwdArgDirect bound ks acc = case ks of
+      A.KwdArg _ e rest -> splitKwdArgDirect bound rest (splitExprDirect bound e acc)
+      A.KwdStar e       -> splitExprDirect bound e acc
+      A.KwdNil          -> acc
+
+    splitPosPatDirect bound ps acc = case ps of
+      A.PosPat p rest -> splitPosPatDirect bound rest (splitPatternDirect bound p acc)
+      A.PosPatStar p  -> splitPatternDirect bound p acc
+      A.PosPatNil     -> acc
+
+    splitKwdPatDirect bound ks acc = case ks of
+      A.KwdPat _ p rest -> splitKwdPatDirect bound rest (splitPatternDirect bound p acc)
+      A.KwdPatStar p    -> splitPatternDirect bound p acc
+      A.KwdPatNil       -> acc
+
+    splitElemDirect bound elem1 acc = case elem1 of
+      A.Elem e -> splitExprDirect bound e acc
+      A.Star e -> splitExprDirect bound e acc
+
+    splitAssocDirect bound assoc acc = case assoc of
+      A.Assoc k v  -> splitExprDirect bound v (splitExprDirect bound k acc)
+      A.StarStar e -> splitExprDirect bound e acc
+
+    splitOpArgDirect bound (A.OpArg _ e) acc = splitExprDirect bound e acc
+
+    splitSlizDirect bound (A.Sliz _ a b c) acc =
+      splitMaybeInto (splitExprDirect bound) c (splitMaybeInto (splitExprDirect bound) b (splitMaybeInto (splitExprDirect bound) a acc))
+
+    splitCompDirect bound comp acc = case comp of
+      A.CompFor _ pat e c ->
+        let bound' = boundPattern pat bound
+        in splitCompDirect bound' c (splitExprDirect bound' e acc)
+      A.CompIf _ e c      -> splitCompDirect bound c (splitExprDirect bound e acc)
+      A.NoComp            -> acc
+
+    splitWithItemDirect bound (A.WithItem e p) acc =
+      splitMaybeInto (splitPatternDirect bound) p (splitExprDirect bound e acc)
+
+    splitTSchemaDirect bound t acc =
+      case t of
+        A.TSchema _ q ty -> splitTypeDirect bound ty (splitListInto (splitQBindDirect bound) q acc)
+
+    splitQBindDirect bound (A.QBind _ cs) acc =
+      splitListInto (splitTConDirect bound) cs acc
+
+    splitTConDirect bound tc acc =
+      case tc of
+        A.TC qn ts -> splitListInto (splitTypeDirect bound) ts (splitQName bound qn acc)
+
+    splitTypeDirect bound t acc = case t of
+      A.TVar{}           -> acc
+      A.TUni{}           -> acc
+      A.TCon _ tc        -> splitTConDirect bound tc acc
+      A.TFun _ fx p k r  -> splitTypeDirect bound r (splitTypeDirect bound k (splitTypeDirect bound p (splitTypeDirect bound fx acc)))
+      A.TTuple _ p k     -> splitTypeDirect bound k (splitTypeDirect bound p acc)
+      A.TOpt _ opt       -> splitTypeDirect bound opt acc
+      A.TNone{}          -> acc
+      A.TWild{}          -> acc
+      A.TNil{}           -> acc
+      A.TRow _ _ _ ty row -> splitTypeDirect bound row (splitTypeDirect bound ty acc)
+      A.TStar _ _ row    -> splitTypeDirect bound row acc
+      A.TFX{}            -> acc
+      A.TUnboxed _ ty    -> splitTypeDirect bound ty acc
+
 -- | Split deps into locals and external qualified names for hashing.
 splitDeps :: A.ModName
           -> Env.Env0
@@ -324,28 +1250,60 @@ splitDeps :: A.ModName
           -> M.Map A.Name [A.QName]
           -> (M.Map A.Name [A.Name], M.Map A.Name [A.QName])
 splitDeps mn env localNames depMap =
-  let toLocalExt qns = foldl' step (Data.Set.empty, Data.Set.empty) qns
-      step (locals, externals) (A.NoQ n)
-        | Data.Set.member n localNames = (Data.Set.insert n locals, externals)
-      step (locals, externals) qn =
-        case Env.unalias env qn of
-          A.GName m _ | m == mPrim -> (locals, externals)
-          A.QName m _ | m == mPrim -> (locals, externals)
-          A.GName m n
-            | m == mn && Data.Set.member n localNames -> (Data.Set.insert n locals, externals)
-            | m == mn -> (locals, externals)
-            | otherwise -> (locals, Data.Set.insert (A.GName m n) externals)
-          A.QName m n
-            | m == mn && Data.Set.member n localNames -> (Data.Set.insert n locals, externals)
-            | m == mn -> (locals, externals)
-            | otherwise -> (locals, Data.Set.insert (A.GName m n) externals)
-          A.NoQ n
-            | Data.Set.member n localNames -> (Data.Set.insert n locals, externals)
-            | otherwise -> (locals, externals)
-      pairs = M.map toLocalExt depMap
-      localMap = M.map (Data.Set.toList . fst) pairs
-      extMap = M.map (Data.Set.toList . snd) pairs
-  in (localMap, extMap)
+  finishSplitDeps (M.map (foldl' (addSplitDep mn env localNames) emptyDepSplit) depMap)
+
+emptyDepSplit :: (NameSet, QNameSet)
+emptyDepSplit = (Data.Set.empty, Data.Set.empty)
+
+addSplitDep :: A.ModName -> Env.Env0 -> Data.Set.Set A.Name -> (NameSet, QNameSet) -> A.QName -> (NameSet, QNameSet)
+addSplitDep mn env localNames (locals, externals) (A.NoQ n)
+  | Data.Set.member n localNames = (Data.Set.insert n locals, externals)
+addSplitDep mn env localNames (locals, externals) qn =
+  case Env.unalias env qn of
+    A.GName m _ | m == mPrim -> (locals, externals)
+    A.QName m _ | m == mPrim -> (locals, externals)
+    A.GName m n
+      | m == mn && Data.Set.member n localNames -> (Data.Set.insert n locals, externals)
+      | m == mn -> (locals, externals)
+      | otherwise -> (locals, Data.Set.insert (A.GName m n) externals)
+    A.QName m n
+      | m == mn && Data.Set.member n localNames -> (Data.Set.insert n locals, externals)
+      | m == mn -> (locals, externals)
+      | otherwise -> (locals, Data.Set.insert (A.GName m n) externals)
+    A.NoQ n
+      | Data.Set.member n localNames -> (Data.Set.insert n locals, externals)
+      | otherwise -> (locals, externals)
+
+addSplitDepHash :: A.ModName -> Env.Env0 -> Data.Set.Set A.Name -> DepSplit -> A.QName -> DepSplit
+addSplitDepHash mn env localNames (locals, externals) (A.NoQ n)
+  | Data.Set.member n localNames = (HashSet.insert n locals, externals)
+addSplitDepHash mn env localNames (locals, externals) qn =
+  case Env.unalias env qn of
+    A.GName m _ | m == mPrim -> (locals, externals)
+    A.QName m _ | m == mPrim -> (locals, externals)
+    A.GName m n
+      | m == mn && Data.Set.member n localNames -> (HashSet.insert n locals, externals)
+      | m == mn -> (locals, externals)
+      | otherwise -> (locals, HashSet.insert (A.GName m n) externals)
+    A.QName m n
+      | m == mn && Data.Set.member n localNames -> (HashSet.insert n locals, externals)
+      | m == mn -> (locals, externals)
+      | otherwise -> (locals, HashSet.insert (A.GName m n) externals)
+    A.NoQ n
+      | Data.Set.member n localNames -> (HashSet.insert n locals, externals)
+      | otherwise -> (locals, externals)
+
+finishSplitDeps :: M.Map A.Name (NameSet, QNameSet) -> (M.Map A.Name [A.Name], M.Map A.Name [A.QName])
+finishSplitDeps pairs =
+  ( M.map (Data.Set.toList . fst) pairs
+  , M.map (Data.Set.toList . snd) pairs
+  )
+
+finishHashSplitDeps :: M.Map A.Name DepSplit -> (M.Map A.Name [A.Name], M.Map A.Name [A.QName])
+finishHashSplitDeps pairs =
+  ( M.map (Data.List.sort . HashSet.toList . fst) pairs
+  , M.map (Data.List.sort . HashSet.toList . snd) pairs
+  )
 
 -- | Collect referenced external modules from dependency lists.
 externalModules :: M.Map A.Name [A.QName] -> Data.Set.Set A.ModName
@@ -357,65 +1315,165 @@ externalModules deps =
       A.QName m _ -> Just m
       A.NoQ _ -> Nothing
 
+mergeSortedDistinct :: Ord a => [a] -> [a] -> [a]
+mergeSortedDistinct [] ys = ys
+mergeSortedDistinct xs [] = xs
+mergeSortedDistinct xs@(x:xs') ys@(y:ys') =
+  case compare x y of
+    LT -> x : mergeSortedDistinct xs' ys
+    EQ -> x : mergeSortedDistinct xs' ys'
+    GT -> y : mergeSortedDistinct xs ys'
+
 -- | Compute final hashes by folding in local and external deps.
 computeHashes :: M.Map A.Name B.ByteString
               -> M.Map A.Name [A.Name]
               -> M.Map A.Name [(A.QName, B.ByteString)]
               -> M.Map A.Name B.ByteString
 computeHashes selfHashes localDeps extDeps =
-  foldl' addScc M.empty (stronglyConnComp nodes)
+  computeHashesSortedDeps selfHashes (M.map Data.List.sort localDeps) (M.map sortExtDeps extDeps)
   where
+    sortExtDeps = Data.List.sortOn fst
+
+-- | Compute final hashes when local and external dep lists are already sorted.
+computeHashesSortedDeps :: M.Map A.Name B.ByteString
+                        -> M.Map A.Name [A.Name]
+                        -> M.Map A.Name [(A.QName, B.ByteString)]
+                        -> M.Map A.Name B.ByteString
+computeHashesSortedDeps selfHashes localDeps extDeps =
+  unsafePerformIO $ withHashScratch $ \sink -> do
+    fast <- computeAcyclic sink
+    case fast of
+      Just hashes -> pure hashes
+      Nothing     -> computeScc sink
+  where
+    computeAcyclic sink = go M.empty (M.keys selfHashes)
+      where
+        go acc [] = pure (Just acc)
+        go acc (n:ns) = do
+          acc' <- visit 0 HashSet.empty acc n
+          case acc' of
+            Just m  -> go m ns
+            Nothing -> pure Nothing
+
+        visit depth visiting acc n
+          | M.member n acc = pure (Just acc)
+          | M.notMember n selfHashes = pure (Just acc)
+          | depth > maxAcyclicHashDepth = pure Nothing
+          | HashSet.member n visiting = pure Nothing
+          | otherwise = do
+              let visiting' = HashSet.insert n visiting
+                  locals = M.findWithDefault [] n localDeps
+                  externals = M.findWithDefault [] n extDeps
+              acc' <- foldM (visitDep (depth + 1) visiting') (Just acc) locals
+              case acc' of
+                Nothing -> pure Nothing
+                Just m  -> do
+                  finalHash <-
+                    hashSelfWithDepsFromWith
+                      sink
+                      (selfHashes M.! n)
+                      (lookupLocalHash m)
+                      locals
+                      externals
+                  pure (Just (M.insert n finalHash m))
+
+        visitDep _ _ Nothing _ = pure Nothing
+        visitDep depth visiting (Just acc) n = visit depth visiting acc n
+
+    computeScc sink =
+      foldM (addScc sink) M.empty (stronglyConnComp nodes)
+
     nodes = [ (n, n, M.findWithDefault [] n localDeps) | n <- M.keys selfHashes ]
 
-    addScc acc scc = case scc of
+    addScc sink acc scc = case scc of
       AcyclicSCC n ->
-        let depHashes = depHashList acc (M.findWithDefault [] n localDeps) (M.findWithDefault [] n extDeps)
-            finalHash = SHA256.hash (Persist.encode (selfHashes M.! n, depHashes))
-        in M.insert n finalHash acc
+        let lookupHash = lookupLocalHash acc
+        in do
+          finalHash <-
+            hashSelfWithDepsFromWith
+              sink
+              (selfHashes M.! n)
+              lookupHash
+              (M.findWithDefault [] n localDeps)
+              (M.findWithDefault [] n extDeps)
+          pure (M.insert n finalHash acc)
       CyclicSCC ns ->
         let nsSet = Data.Set.fromList ns
             selfHashesSorted = [ selfHashes M.! n | n <- Data.List.sortOn nameKey ns ]
             outsideDeps = Data.Set.toList $ Data.Set.fromList
               [ d | n <- ns, d <- M.findWithDefault [] n localDeps, Data.Set.notMember d nsSet ]
             externalDeps = Data.Set.toList $ Data.Set.fromList (concat [ M.findWithDefault [] n extDeps | n <- ns ])
-            depHashes = depHashList acc outsideDeps externalDeps
-            groupHash = SHA256.hash (Persist.encode (selfHashesSorted, depHashes))
-            insertOne m n =
-              let finalHash = SHA256.hash (Persist.encode (selfHashes M.! n, groupHash, nameKey n))
-              in M.insert n finalHash m
-        in foldl' insertOne acc ns
+            lookupHash = lookupLocalHash acc
+        in do
+          groupHash <- hashCycleGroupFromWith sink selfHashesSorted lookupHash outsideDeps externalDeps
+          let insertOne m n = do
+                finalHash <- hashCycleMemberWith sink (selfHashes M.! n) groupHash n
+                pure (M.insert n finalHash m)
+          foldM insertOne acc ns
 
-    depHashList acc locals externals =
-      let lookupHash n = case M.lookup n acc of
-                           Just h -> Just h
-                           Nothing -> M.lookup n selfHashes
-          localHashes =
-            [ h | n <- Data.List.sortOn nameKey locals
-                , Just h <- [lookupHash n] ]
-          externalHashes =
-            [ h | (_, h) <- Data.List.sortOn (qnameKey . fst) externals ]
-      in localHashes ++ externalHashes
+    lookupLocalHash acc n =
+      case M.lookup n acc of
+        Just h -> Just h
+        Nothing -> M.lookup n selfHashes
+
+maxAcyclicHashDepth :: Int
+maxAcyclicHashDepth = 10000
 
 -- | Build NameHashInfo entries from per-name hashes and deps.
-buildNameHashes :: Data.Set.Set A.Name
-                -> M.Map A.Name B.ByteString
-                -> M.Map A.Name B.ByteString
-                -> M.Map A.Name I.NameInfo
-                -> M.Map A.Name [A.Name]
-                -> M.Map A.Name [(A.QName, B.ByteString)]
-                -> M.Map A.Name [A.Name]
-                -> M.Map A.Name [A.Name]
-                -> M.Map A.Name [(A.QName, B.ByteString)]
-                -> M.Map A.Name [(A.QName, B.ByteString)]
-                -> [InterfaceFiles.NameHashInfo]
-buildNameHashes nameKeys nameSrcHashes nameImplHashes nameInfoMap pubSigLocalDeps pubSigExtHashes pubLocalDeps implLocalDeps implExtHashes pubExtHashes =
-  let hashNameInfo info = SHA256.hash (Persist.encode (I.stripLocsNI (I.stripDocsNI info)))
-      selfPubHashes = M.map hashNameInfo nameInfoMap
-      selfImplHashes = nameImplHashes
-      pubHashes = computeHashes selfPubHashes pubSigLocalDeps pubSigExtHashes
-      implHashes = computeHashes selfImplHashes implLocalDeps implExtHashes
-      namesSorted = Data.List.sortOn nameKey (Data.Set.toList nameKeys)
-      localDeps m n = Data.List.sortOn nameKey (Data.List.nub (M.findWithDefault [] n m))
+nameInfoHashes :: M.Map A.Name I.NameInfo -> M.Map A.Name B.ByteString
+nameInfoHashes infos =
+  unsafePerformIO $ withHashScratch $ \sink ->
+    M.traverseWithKey (\_ info -> hashFeedWith sink (feedNameInfo info)) infos
+
+prepareNameHashInputs :: A.ModName
+                      -> Env.Env0
+                      -> [TopLevelItem]
+                      -> [TopLevelItem]
+                      -> M.Map A.Name I.NameInfo
+                      -> NameHashInputs
+prepareNameHashInputs mn env srcItems implItems nameInfoMap =
+  let nameSrcHashes = nameHashesFromItems srcItems
+      nameImplHashes = nameHashesFromItems implItems
+      nameKeys = M.keysSet nameSrcHashes `Data.Set.union` M.keysSet nameImplHashes
+      selfPubHashes = nameInfoHashes nameInfoMap
+      (pubSigLocalDeps, pubSigExtDeps) = pubSigSplitDepsFromNameInfoMap mn env nameKeys nameInfoMap
+      (implLocalDeps, implExtDeps) = implSplitDepsFromItems mn env nameKeys implItems
+  in
+  finishNameHashInputs nameKeys nameSrcHashes nameImplHashes selfPubHashes pubSigLocalDeps pubSigExtDeps implLocalDeps implExtDeps
+
+finishNameHashInputs :: Data.Set.Set A.Name
+                     -> M.Map A.Name B.ByteString
+                     -> M.Map A.Name B.ByteString
+                     -> M.Map A.Name B.ByteString
+                     -> M.Map A.Name [A.Name]
+                     -> M.Map A.Name [A.QName]
+                     -> M.Map A.Name [A.Name]
+                     -> M.Map A.Name [A.QName]
+                     -> NameHashInputs
+finishNameHashInputs nameKeys nameSrcHashes nameImplHashes selfPubHashes pubSigLocalDeps pubSigExtDeps implLocalDeps implExtDeps =
+  NameHashInputs
+    { nhiNameKeys = nameKeys
+    , nhiNameSrcHashes = nameSrcHashes
+    , nhiNameImplHashes = nameImplHashes
+    , nhiSelfPubHashes = selfPubHashes
+    , nhiPubSigLocalDeps = pubSigLocalDeps
+    , nhiPubSigExtDeps = pubSigExtDeps
+    , nhiImplLocalDeps = implLocalDeps
+    , nhiImplExtDeps = implExtDeps
+    }
+
+assembleNameHashes :: Data.Set.Set A.Name
+                   -> M.Map A.Name B.ByteString
+                   -> M.Map A.Name B.ByteString
+                   -> M.Map A.Name B.ByteString
+                   -> M.Map A.Name [A.Name]
+                   -> M.Map A.Name [A.Name]
+                   -> M.Map A.Name [(A.QName, B.ByteString)]
+                   -> M.Map A.Name [(A.QName, B.ByteString)]
+                   -> [InterfaceFiles.NameHashInfo]
+assembleNameHashes nameKeys nameSrcHashes pubHashes implHashes pubLocalDeps implLocalDeps pubExtHashes implExtHashes =
+  let namesSorted = Data.List.sortOn nameKey (Data.Set.toList nameKeys)
+      localDeps m n = Data.List.sortOn nameKey (M.findWithDefault [] n m)
   in
     [ InterfaceFiles.NameHashInfo
         { InterfaceFiles.nhName = n
@@ -430,6 +1488,24 @@ buildNameHashes nameKeys nameSrcHashes nameImplHashes nameInfoMap pubSigLocalDep
     | n <- namesSorted
     ]
 
+buildNameHashes :: Data.Set.Set A.Name
+                -> M.Map A.Name B.ByteString
+                -> M.Map A.Name B.ByteString
+                -> M.Map A.Name I.NameInfo
+                -> M.Map A.Name [A.Name]
+                -> M.Map A.Name [(A.QName, B.ByteString)]
+                -> M.Map A.Name [A.Name]
+                -> M.Map A.Name [A.Name]
+                -> M.Map A.Name [(A.QName, B.ByteString)]
+                -> M.Map A.Name [(A.QName, B.ByteString)]
+                -> [InterfaceFiles.NameHashInfo]
+buildNameHashes nameKeys nameSrcHashes nameImplHashes nameInfoMap pubSigLocalDeps pubSigExtHashes pubLocalDeps implLocalDeps implExtHashes pubExtHashes =
+  let selfPubHashes = nameInfoHashes nameInfoMap
+      selfImplHashes = nameImplHashes
+      pubHashes = computeHashes selfPubHashes pubSigLocalDeps pubSigExtHashes
+      implHashes = computeHashes selfImplHashes implLocalDeps implExtHashes
+  in assembleNameHashes nameKeys nameSrcHashes pubHashes implHashes pubLocalDeps implLocalDeps pubExtHashes implExtHashes
+
 -- | Refresh impl hashes and impl deps for existing name hashes.
 refreshImplHashes :: [InterfaceFiles.NameHashInfo]
                   -> M.Map A.Name B.ByteString
@@ -437,36 +1513,53 @@ refreshImplHashes :: [InterfaceFiles.NameHashInfo]
                   -> M.Map A.Name [(A.QName, B.ByteString)]
                   -> [InterfaceFiles.NameHashInfo]
 refreshImplHashes nameHashes nameImplHashes implLocalDeps implExtHashes =
-  let implHashes = computeHashes nameImplHashes implLocalDeps implExtHashes
+  let implHashes = computeHashesSortedDeps nameImplHashes implLocalDeps implExtHashes
       infoMap = M.fromList [ (InterfaceFiles.nhName nh, nh) | nh <- nameHashes ]
       namesSorted = Data.List.sortOn nameKey (M.keys nameImplHashes)
   in
     [ let nh = infoMap M.! n
       in nh { InterfaceFiles.nhImplHash = M.findWithDefault B.empty n implHashes
-            , InterfaceFiles.nhImplLocalDeps = Data.List.sortOn nameKey (Data.List.nub (M.findWithDefault [] n implLocalDeps))
+            , InterfaceFiles.nhImplLocalDeps = Data.List.sortOn nameKey (M.findWithDefault [] n implLocalDeps)
             , InterfaceFiles.nhImplDeps = M.findWithDefault [] n implExtHashes
             }
     | n <- namesSorted
     ]
 
+-- | Hash module-level pub/impl summaries from the final per-name hash maps.
+moduleHashesFromHashMaps :: I.NameInfo
+                         -> Data.Set.Set A.Name
+                         -> M.Map A.Name B.ByteString
+                         -> M.Map A.Name B.ByteString
+                         -> (B.ByteString, B.ByteString)
+moduleHashesFromHashMaps nmod nameKeys pubHashes implHashes =
+  (modulePubHashFromHashMap nmod pubHashes, moduleImplHashFromHashMap nameKeys implHashes)
+
 -- | Hash the module public interface entries.
 modulePubHashFromIface :: I.NameInfo -> [InterfaceFiles.NameHashInfo] -> B.ByteString
 modulePubHashFromIface nmod nameHashes =
-  let I.NModule _ iface _ = nmod
-      pubHashMap = M.fromList
+  modulePubHashFromHashMap nmod $
+    M.fromList
         [ (InterfaceFiles.nhName nh, InterfaceFiles.nhPubHash nh)
         | nh <- nameHashes
         ]
-      pubNamesSorted = Data.List.sortOn nameKey
-        [ n | (n, _) <- iface, Names.isPublicName n ]
-      pubEntries = [ (nameKey n, M.findWithDefault B.empty n pubHashMap) | n <- pubNamesSorted ]
-  in SHA256.hash (Persist.encode pubEntries)
+
+modulePubHashFromHashMap :: I.NameInfo -> M.Map A.Name B.ByteString -> B.ByteString
+modulePubHashFromHashMap nmod pubHashes =
+  let I.NModule _ iface _ = nmod
+      pubNamesSorted =
+        Data.List.sortOn nameKey [ n | (n, _) <- iface, Names.isPublicName n ]
+  in hashNameHashMapEntriesForNames 3 pubHashes pubNamesSorted
 
 -- | Hash the module impl entries from per-name impl hashes.
 moduleImplHashFromNameHashes :: [InterfaceFiles.NameHashInfo] -> B.ByteString
 moduleImplHashFromNameHashes infos =
-  let items =
-        [ (nameKey (InterfaceFiles.nhName nh), InterfaceFiles.nhImplHash nh)
-        | nh <- Data.List.sortOn (nameKey . InterfaceFiles.nhName) infos
-        ]
-  in SHA256.hash (Persist.encode items)
+  hashNameHashEntriesWith 4 infosSorted $ \nh sink ->
+    feedString (nameKey (InterfaceFiles.nhName nh)) sink >>
+    feedHashBytes (InterfaceFiles.nhImplHash nh) sink
+  where
+    infosSorted = Data.List.sortOn (nameKey . InterfaceFiles.nhName) infos
+
+moduleImplHashFromHashMap :: Data.Set.Set A.Name -> M.Map A.Name B.ByteString -> B.ByteString
+moduleImplHashFromHashMap nameKeys implHashes =
+  let namesSorted = Data.List.sortOn nameKey (Data.Set.toList nameKeys)
+  in hashNameHashMapEntriesForNames 4 implHashes namesSorted

--- a/compiler/lib/src/Acton/Names.hs
+++ b/compiler/lib/src/Acton/Names.hs
@@ -448,4 +448,5 @@ instance Vars Type where
     freeQ (TCon  _ c)               = freeQ c
     freeQ (TRow _ _ _ t r)          = freeQ t ++ freeQ r
     freeQ (TStar _ _ r)             = freeQ r
+    freeQ (TUnboxed _ t)            = freeQ t
     freeQ _                         = []

--- a/compiler/lib/src/Acton/Syntax.hs
+++ b/compiler/lib/src/Acton/Syntax.hs
@@ -26,7 +26,7 @@ import Control.DeepSeq
 import Prelude hiding((<>))
 
 version :: [Int]
-version = [0,23]
+version = [0,24]
 
 data Module     = Module        { modname::ModName, imps::[Import], mdoc::Maybe String, mbody::Suite } deriving (Eq,Show,Generic,NFData)
 
@@ -172,7 +172,15 @@ modCat (ModName ns) n = ModName (ns++[n])
 instance Ord ModName where
     compare a b = compare (modPath a) (modPath b)
 
+instance Data.Hashable.Hashable ModName where
+    hashWithSalt s (ModName ns) = Data.Hashable.hashWithSalt s ns
+
 data QName      = QName { mname::ModName, noq::Name } | NoQ { noq::Name } | GName { mname::ModName, noq::Name } deriving (Show,Read,Eq,Ord,Generic,NFData)
+
+instance Data.Hashable.Hashable QName where
+    hashWithSalt s (QName m n) = s `Data.Hashable.hashWithSalt` (0 :: Int) `Data.Hashable.hashWithSalt` m `Data.Hashable.hashWithSalt` n
+    hashWithSalt s (NoQ n)    = s `Data.Hashable.hashWithSalt` (1 :: Int) `Data.Hashable.hashWithSalt` n
+    hashWithSalt s (GName m n) = s `Data.Hashable.hashWithSalt` (2 :: Int) `Data.Hashable.hashWithSalt` m `Data.Hashable.hashWithSalt` n
 
 qName ss s      = QName (modName ss) (name s)
 

--- a/compiler/lib/src/InterfaceFiles.hs
+++ b/compiler/lib/src/InterfaceFiles.hs
@@ -32,9 +32,9 @@
 --     "version"        :: [Int]                       -- Acton.Syntax.version
 --     "meta"           :: ( Maybe SourceFileMeta      -- cached source stat metadata
 --                         , ByteString                -- moduleSrcBytesHash: SHA-256 of raw source
---                         , ByteString                -- modulePubHash: SHA-256 of public NameInfo
+--                         , ByteString                -- modulePubHash: structural hash of public NameInfo
 --                                                     --   (doc-free) + imports' pub hashes
---                         , ByteString )              -- moduleImplHash: SHA-256 of per-name impl hashes
+--                         , ByteString )              -- moduleImplHash: structural hash of per-name impl hashes
 --     "imports"        :: [(A.ModName, ByteString)]   -- imported module and pub hash used
 --     "roots"          :: [A.Name]                    -- root actors (e.g. main or test_main)
 --     "tests"          :: [String]                    -- discovered test names

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -28,6 +28,7 @@ import qualified Acton.Compile as Compile
 import qualified Acton.CommandLineParser as C
 import qualified Acton.Fingerprint as Fingerprint
 import qualified Acton.Completion as Completion
+import qualified Acton.Hashing as Hashing
 import qualified InterfaceFiles
 import Pretty (print, prettyText)
 import qualified Pretty
@@ -39,8 +40,11 @@ import Text.Megaparsec.Pos (sourceLine, unPos)
 import qualified Data.Text as T
 import Data.List (isInfixOf, isPrefixOf, nub, sort)
 import qualified Data.List.NonEmpty as NE
+import qualified Data.Map as M
+import qualified Data.Set as Set
 import Data.IORef
 import Data.Bits (shiftL, (.|.))
+import qualified Data.ByteString.Base16 as Base16
 import Error.Diagnose (printDiagnostic, prettyDiagnostic, WithUnicode(..), TabSize(..), defaultStyle, addReport, addFile)
 import Error.Diagnose.Report (Report(..))
 import Prettyprinter (unAnnotate, layoutPretty, defaultLayoutOptions)
@@ -73,6 +77,66 @@ nameHash n src pub impl =
     , InterfaceFiles.nhPubDeps = []
     , InterfaceFiles.nhImplDeps = []
     }
+
+hashTestName :: S.Name
+hashTestName = S.name "value"
+
+publicHashFor :: I.NameInfo -> B8.ByteString
+publicHashFor info =
+  case Hashing.buildNameHashes
+         (Set.singleton hashTestName)
+         M.empty
+         M.empty
+         (M.singleton hashTestName info)
+         M.empty
+         M.empty
+         M.empty
+         M.empty
+         M.empty
+         M.empty of
+    [nh] -> InterfaceFiles.nhPubHash nh
+    _    -> error "expected one name hash"
+
+sourceHashFor :: S.Decl -> B8.ByteString
+sourceHashFor decl =
+  case M.lookup hashTestName (Hashing.nameHashesFromItems [Hashing.TLDecl hashTestName decl]) of
+    Just h  -> h
+    Nothing -> error "missing source hash"
+
+implSplitDepSetMaps :: Acton.Env.Env0
+                    -> S.ModName
+                    -> Set.Set S.Name
+                    -> [Hashing.TopLevelItem]
+                    -> (M.Map S.Name (Set.Set S.Name), M.Map S.Name (Set.Set S.QName))
+implSplitDepSetMaps env mn localNames items =
+  let (locals, externals) = Hashing.implSplitDepsFromItems mn env localNames items
+  in (M.map Set.fromList locals, M.map Set.fromList externals)
+
+implSplitDepSetMapsSlow :: Acton.Env.Env0
+                        -> S.ModName
+                        -> Set.Set S.Name
+                        -> [Hashing.TopLevelItem]
+                        -> (M.Map S.Name (Set.Set S.Name), M.Map S.Name (Set.Set S.QName))
+implSplitDepSetMapsSlow env mn localNames items =
+  let rawDeps = Hashing.implDepsFromItems items
+      (locals, externals) = Hashing.splitDeps mn env localNames rawDeps
+  in (M.map Set.fromList locals, M.map Set.fromList externals)
+
+locatedType :: SrcLoc -> S.Type
+locatedType l = S.TVar l (S.TV S.KType (S.Name l "T"))
+
+hashDecl :: SrcLoc -> Maybe String -> S.Decl
+hashDecl l doc =
+  S.Def l
+    (S.Name l "value")
+    []
+    S.PosNIL
+    S.KwdNIL
+    (Just (locatedType l))
+    [S.Pass l]
+    S.NoDec
+    S.fxPure
+    doc
 
 
 
@@ -220,6 +284,440 @@ main = do
           InterfaceFiles.writeFileWithVersion (map (+ 1) S.version) tyPath "" "" "" Nothing [] [] [] [] Nothing nmod tmod
           InterfaceFiles.readHeaderMaybe tyPath `shouldReturn` Nothing
           InterfaceFiles.readFileMaybe tyPath `shouldReturn` Nothing
+
+    describe "Hashing" $ do
+      it "keeps public hashes independent of docs and source locations" $ do
+        let infoA = I.NDef (S.TSchema (Loc 1 3) [] (locatedType (Loc 4 5))) S.NoDec (Just "old docs")
+            infoB = I.NDef (S.TSchema (Loc 50 60) [] (locatedType (Loc 70 80))) S.NoDec (Just "new docs")
+        publicHashFor infoA `shouldBe` publicHashFor infoB
+
+      it "keeps source AST hashes independent of source locations" $ do
+        sourceHashFor (hashDecl (Loc 1 3) (Just "doc")) `shouldBe`
+          sourceHashFor (hashDecl (Loc 100 130) (Just "doc"))
+
+      it "keeps source AST hashes sensitive to docstrings" $ do
+        sourceHashFor (hashDecl NoLoc (Just "doc A")) `shouldNotBe`
+          sourceHashFor (hashDecl NoLoc (Just "doc B"))
+
+      it "keeps source AST hashes sensitive to unicode and nul bytes in strings" $ do
+        sourceHashFor (hashDecl NoLoc (Just "doc ä\0x")) `shouldNotBe`
+          sourceHashFor (hashDecl NoLoc (Just "doc äx"))
+
+      it "pins the source AST feed-operation hash format" $ do
+        Base16.encode (sourceHashFor (hashDecl NoLoc (Just "doc"))) `shouldBe`
+          "8c47274762de31c4eadf30ef3a01a17d2253a4514ab67745699c7989f8888b5b"
+
+      it "hashes Int fields at minBound without overflowing" $ do
+        let n = S.Internal S.Tempvar "tmp" (minBound :: Int)
+            decl =
+              S.Def NoLoc n [] S.PosNIL S.KwdNIL (Just S.tWild) [S.Pass NoLoc] S.NoDec S.fxPure Nothing
+            h = case M.lookup n (Hashing.nameHashesFromItems [Hashing.TLDecl n decl]) of
+                  Just hash -> hash
+                  Nothing   -> error "missing source hash"
+        Base16.encode h `shouldBe`
+          "789782467b319c383a544eb7e882f9b07d9580bf638fa9df6294ab02be71b62c"
+
+      it "keeps same-name source fragments in input order" $ do
+        let sig = Hashing.TLStmt hashTestName (S.Signature NoLoc [hashTestName] (S.tSchema [] S.tWild) S.NoDec)
+            decl = Hashing.TLDecl hashTestName (hashDecl NoLoc (Just "doc"))
+            hashItems items =
+              case M.lookup hashTestName (Hashing.nameHashesFromItems items) of
+                Just h  -> h
+                Nothing -> error "missing source hash"
+        hashItems [sig, decl] `shouldNotBe` hashItems [decl, sig]
+
+      it "prepares structural hash inputs for all local names" $ do
+        let mn = S.modName ["hash_structural_inputs"]
+            env = Acton.Env.setMod mn env0
+            names = [S.name ("value" ++ show i) | i <- [1 :: Int .. 8]]
+            deps = [S.GName (S.modName ["dep"]) (S.name ("dep_value" ++ show i)) | i <- [1 :: Int .. 8]]
+            nextNames = tail names ++ take 1 names
+            decl name dep localName =
+              S.Def
+                NoLoc
+                name
+                []
+                S.PosNIL
+                S.KwdNIL
+                Nothing
+                [ S.Expr NoLoc (S.Var NoLoc dep)
+                , S.Expr NoLoc (S.Var NoLoc (S.NoQ localName))
+                ]
+                S.NoDec
+                S.fxPure
+                Nothing
+            sig name dep =
+              S.Signature NoLoc [name] (S.tSchema [] (S.tCon (S.TC dep []))) S.NoDec
+            srcItems =
+              concat
+                [ [ Hashing.TLStmt name (sig name dep)
+                  , Hashing.TLDecl name (decl name dep localName)
+                  ]
+                | (name, dep, localName) <- zip3 names deps nextNames
+                ]
+            implItems =
+              [ Hashing.TLDecl name (decl name dep localName)
+              | (name, dep, localName) <- zip3 names deps nextNames
+              ]
+            info dep = I.NDef (S.tSchema [] (S.tCon (S.TC dep []))) S.NoDec Nothing
+            infos = M.fromList [(name, info dep) | (name, dep) <- zip names deps]
+            nameKeys = Set.fromList names
+            depSet = Set.fromList deps
+        let inputs = Hashing.prepareNameHashInputs mn env srcItems implItems infos
+        Hashing.nhiNameKeys inputs `shouldBe` nameKeys
+        M.keysSet (Hashing.nhiNameSrcHashes inputs) `shouldBe` nameKeys
+        M.keysSet (Hashing.nhiNameImplHashes inputs) `shouldBe` nameKeys
+        M.keysSet (Hashing.nhiSelfPubHashes inputs) `shouldBe` nameKeys
+        M.map Set.fromList (Hashing.nhiPubSigExtDeps inputs) `shouldBe`
+          M.fromList [(name, Set.singleton dep) | (name, dep) <- zip names deps]
+        M.map Set.fromList (Hashing.nhiImplLocalDeps inputs) `shouldBe`
+          M.fromList [(name, Set.singleton localName) | (name, localName) <- zip names nextNames]
+        Set.unions (M.elems (M.map Set.fromList (Hashing.nhiImplExtDeps inputs))) `shouldBe` depSet
+
+      it "collects public signature dependencies without derived names" $ do
+        let depMod = S.modName ["dep"]
+            depA = S.GName depMod (S.name "a")
+            depB = S.GName depMod (S.name "b")
+            depC = S.GName depMod (S.name "c")
+            depD = S.GName depMod (S.name "d")
+            localDepName = S.name "local_dep"
+            localDep = S.NoQ localDepName
+            derived = S.GName depMod (S.Derived (S.name "a") (S.name "generated"))
+            qbind = S.QBind (S.TV S.KType (S.name "T")) [S.TC depB []]
+            depAType = S.tCon (S.TC depA [S.tCon (S.TC derived [])])
+            depBType = S.tCon (S.TC depB [])
+            depCType = S.tCon (S.TC depC [S.tCon (S.TC localDep [])])
+            depDType = S.TUnboxed NoLoc (S.tCon (S.TC depD []))
+            info =
+              I.NModule
+                []
+                [ ( hashTestName
+                  , I.NExt
+                      [qbind]
+                      (S.TC depA [depBType])
+                      [([Left depB, Right depC], S.TC depC [depAType])]
+                      [ (S.name "alias", I.NAlias depB)
+                      , (S.name "field", I.NSig (S.tSchema [] depCType) S.NoDec Nothing)
+                      , (S.name "unboxed_field", I.NSig (S.tSchema [] depDType) S.NoDec Nothing)
+                      ]
+                      []
+                      Nothing
+                  )
+                , (S.name "derived_alias", I.NAlias derived)
+                ]
+                Nothing
+            infos = M.singleton hashTestName info
+            expectedDeps = M.singleton hashTestName (Set.fromList [depA, depB, depC, depD, localDep])
+            mn = S.modName ["hash_pub_sig"]
+            env = Acton.Env.setMod mn env0
+            localNames = Set.fromList [hashTestName, localDepName]
+            legacyRaw = Hashing.pubSigDepsFromNameInfoMap infos
+            (legacyLocalDeps, legacyExtDeps) = Hashing.splitDeps mn env localNames legacyRaw
+            (directLocalDeps, directExtDeps) = Hashing.pubSigSplitDepsFromNameInfoMap mn env localNames infos
+        M.map Set.fromList legacyRaw `shouldBe` expectedDeps
+        M.map Set.fromList directLocalDeps `shouldBe` M.map Set.fromList legacyLocalDeps
+        M.map Set.fromList directExtDeps `shouldBe` M.map Set.fromList legacyExtDeps
+
+      it "propagates acyclic local dependency hashes" $ do
+        let a = S.name "a"
+            b = S.name "b"
+            c = S.name "c"
+            selfA = M.fromList [(a, "a"), (b, "b"), (c, "c")]
+            selfB = M.fromList [(a, "a"), (b, "b"), (c, "changed")]
+            localDeps = M.fromList [(a, [b]), (b, [c]), (c, [])]
+            hashesA = Hashing.computeHashes selfA localDeps M.empty
+            hashesB = Hashing.computeHashes selfB localDeps M.empty
+        M.lookup a hashesA `shouldNotBe` M.lookup a hashesB
+        M.lookup b hashesA `shouldNotBe` M.lookup b hashesB
+        M.lookup c hashesA `shouldNotBe` M.lookup c hashesB
+
+      it "handles cyclic local dependency hashes" $ do
+        let a = S.name "a"
+            b = S.name "b"
+            selfHashes = M.fromList [(a, "a"), (b, "b")]
+            localDeps = M.fromList [(a, [b]), (b, [a])]
+            hashes = Hashing.computeHashes selfHashes localDeps M.empty
+        M.keysSet hashes `shouldBe` Set.fromList [a, b]
+        all (not . B8.null) (M.elems hashes) `shouldBe` True
+
+      it "propagates finalized outside dependencies into cyclic local hashes" $ do
+        let a = S.name "a"
+            b = S.name "b"
+            c = S.name "c"
+            d = S.name "d"
+            selfA = M.fromList [(a, "a"), (b, "b"), (c, "c"), (d, "d")]
+            selfB = M.fromList [(a, "a"), (b, "b"), (c, "c"), (d, "changed")]
+            localDeps = M.fromList [(a, [b, c]), (b, [a]), (c, [d]), (d, [])]
+            hashesA = Hashing.computeHashes selfA localDeps M.empty
+            hashesB = Hashing.computeHashes selfB localDeps M.empty
+        M.lookup a hashesA `shouldNotBe` M.lookup a hashesB
+        M.lookup b hashesA `shouldNotBe` M.lookup b hashesB
+        M.lookup c hashesA `shouldNotBe` M.lookup c hashesB
+        M.lookup d hashesA `shouldNotBe` M.lookup d hashesB
+
+      it "keeps external dependency order canonical" $ do
+        let a = S.name "a"
+            q1 = S.GName (S.modName ["dep", "z"]) (S.name "z")
+            q2 = S.GName (S.modName ["dep", "a"]) (S.name "a")
+            selfHashes = M.singleton a "a"
+            extDepsA = M.singleton a [(q1, "h1"), (q2, "h2")]
+            extDepsB = M.singleton a [(q2, "h2"), (q1, "h1")]
+        Hashing.computeHashes selfHashes M.empty extDepsA `shouldBe`
+          Hashing.computeHashes selfHashes M.empty extDepsB
+
+      it "hashes module summaries from maps like assembled name hashes" $ do
+        let publicName = S.name "public_value"
+            privateName = S.name "__private_value"
+            missingImplName = S.name "missing_impl"
+            nmod =
+              I.NModule
+                []
+                [ (publicName, I.NVar Builtin.tInt)
+                , (privateName, I.NVar Builtin.tInt)
+                ]
+                Nothing
+            nameKeys = Set.fromList [publicName, privateName, missingImplName]
+            pubHashes = M.fromList [(publicName, "pub-public"), (privateName, "pub-private")]
+            implHashes = M.fromList [(publicName, "impl-public"), (privateName, "impl-private")]
+            nameHashes =
+              [ nameHash publicName "src-public" "pub-public" "impl-public"
+              , nameHash privateName "src-private" "pub-private" "impl-private"
+              , nameHash missingImplName "src-missing" "pub-missing" ""
+              ]
+        Hashing.moduleHashesFromHashMaps nmod nameKeys pubHashes implHashes `shouldBe`
+          ( Hashing.modulePubHashFromIface nmod nameHashes
+          , Hashing.moduleImplHashFromNameHashes nameHashes
+          )
+
+      it "hashes public interface names outside implementation keys" $ do
+        let publicName = S.name "public_value"
+            ifaceOnlyName = S.name "iface_only"
+            nmod =
+              I.NModule
+                []
+                [ (publicName, I.NVar Builtin.tInt)
+                , (ifaceOnlyName, I.NVar Builtin.tInt)
+                ]
+                Nothing
+            nameKeys = Set.singleton publicName
+            pubHashes = M.fromList [(publicName, "pub-public"), (ifaceOnlyName, "pub-iface-only")]
+            implHashes = M.singleton publicName "impl-public"
+            (modulePubHash, moduleImplHash) =
+              Hashing.moduleHashesFromHashMaps nmod nameKeys pubHashes implHashes
+            publicNameHashes =
+              [ nameHash publicName "src-public" "pub-public" "impl-public"
+              , nameHash ifaceOnlyName "" "pub-iface-only" ""
+              ]
+            implNameHashes =
+              [ nameHash publicName "src-public" "pub-public" "impl-public" ]
+        modulePubHash `shouldBe` Hashing.modulePubHashFromIface nmod publicNameHashes
+        modulePubHash `shouldNotBe`
+          Hashing.modulePubHashFromIface nmod implNameHashes
+        moduleImplHash `shouldBe` Hashing.moduleImplHashFromNameHashes implNameHashes
+
+      it "merges canonical dependency lists without rebuilding sets" $ do
+        let a = S.name "a"
+            b = S.name "b"
+            c = S.name "c"
+            d = S.name "d"
+            q1 = S.GName (S.modName ["dep", "a"]) a
+            q2 = S.GName (S.modName ["dep", "b"]) b
+            q3 = S.GName (S.modName ["dep", "c"]) c
+        Hashing.mergeSortedDistinct [a, c, d] [b, c] `shouldBe`
+          Set.toList (Set.fromList [a, b, c, d])
+        Hashing.mergeSortedDistinct [q1, q3] [q2, q3] `shouldBe`
+          Set.toList (Set.fromList [q1, q2, q3])
+
+      it "returns canonical dependency lists from splitDeps" $ do
+        let owner = hashTestName
+            mn = S.modName ["hash_split_order"]
+            env = Acton.Env.setMod mn env0
+            a = S.name "a"
+            b = S.name "b"
+            extA = S.GName (S.modName ["dep"]) a
+            extB = S.GName (S.modName ["dep"]) b
+            rawDeps = M.singleton owner [extB, S.NoQ b, extA, S.NoQ a, extB, S.NoQ b]
+            localNames = Set.fromList [owner, a, b]
+            (localDeps, extDeps) = Hashing.splitDeps mn env localNames rawDeps
+        M.lookup owner localDeps `shouldBe` Just [a, b]
+        M.lookup owner extDeps `shouldBe` Just [extA, extB]
+
+      it "matches list-based impl dependency extraction after deduplication" $ do
+        let value = hashTestName
+            x = S.name "x"
+            y = S.name "y"
+            z = S.name "z"
+            aDep = S.name "a"
+            depA = S.GName (S.modName ["dep"]) aDep
+            depB = S.GName (S.modName ["dep"]) (S.name "b")
+            depZ = S.GName (S.modName ["dep"]) z
+            body =
+              [ S.For NoLoc
+                  (S.PVar NoLoc y Nothing)
+                  (S.Var NoLoc depZ)
+                  [ S.Expr NoLoc (S.Var NoLoc (S.NoQ y))
+                  , S.Expr NoLoc (S.Var NoLoc (S.NoQ z))
+                  ]
+                  []
+              , S.With NoLoc
+                  [S.WithItem (S.Var NoLoc (S.NoQ z)) (Just (S.PVar NoLoc x Nothing))]
+                  [ S.Expr NoLoc (S.Var NoLoc (S.NoQ x))
+                  , S.Expr NoLoc (S.Var NoLoc (S.NoQ z))
+                  ]
+              , S.Expr NoLoc (S.Var NoLoc depA)
+              , S.Expr NoLoc (S.Var NoLoc depA)
+              ]
+            decl =
+              S.Def
+                NoLoc
+                value
+                []
+                (S.PosPar x (Just (S.TUnboxed NoLoc (S.tCon (S.TC depB [])))) Nothing S.PosNIL)
+                S.KwdNIL
+                Nothing
+                body
+                S.NoDec
+                S.fxPure
+                Nothing
+            items = [Hashing.TLDecl value decl]
+        let mn = S.modName ["hash_split"]
+            env = Acton.Env.setMod mn env0
+            localNames = Set.fromList [value, z]
+            (directLocalDeps, directExtDeps) = Hashing.implSplitDepsFromItems mn env localNames items
+        implSplitDepSetMaps env mn localNames items `shouldBe`
+          implSplitDepSetMapsSlow env mn localNames items
+        M.lookup value directLocalDeps `shouldBe` Just [z]
+        M.lookup value directExtDeps `shouldBe` Just (sort [depA, depB, depZ])
+
+      it "merges same-name impl dependency splits across worker chunks" $ do
+        let value = hashTestName
+            localA = S.name "local_a"
+            localB = S.name "local_b"
+            extA = S.GName (S.modName ["dep"]) (S.name "ext_a")
+            extB = S.GName (S.modName ["dep"]) (S.name "ext_b")
+            mn = S.modName ["hash_split_chunks"]
+            env = Acton.Env.setMod mn env0
+            mkDecl dep =
+              S.Def
+                NoLoc
+                value
+                []
+                S.PosNIL
+                S.KwdNIL
+                Nothing
+                [S.Expr NoLoc (S.Var NoLoc dep)]
+                S.NoDec
+                S.fxPure
+                Nothing
+            items =
+              [ Hashing.TLDecl value (mkDecl (S.NoQ localA))
+              , Hashing.TLDecl value (mkDecl extA)
+              , Hashing.TLDecl value (mkDecl (S.NoQ localB))
+              , Hashing.TLDecl value (mkDecl extB)
+              ]
+            localNames = Set.fromList [value, localA, localB]
+            expected =
+              ( M.singleton value (Set.fromList [localA, localB])
+              , M.singleton value (Set.fromList [extA, extB])
+              )
+        implSplitDepSetMaps env mn localNames items `shouldBe` expected
+
+      it "keeps lexical local shadowing separate from qualified deps" $ do
+        let value = hashTestName
+            z = S.name "z"
+            ext = S.GName (S.modName ["dep"]) (S.name "ext")
+            mn = S.modName ["hash_shadow_local"]
+            env = Acton.Env.setMod mn env0
+            decl =
+              S.Def
+                NoLoc
+                value
+                []
+                (S.PosPar z Nothing Nothing S.PosNIL)
+                S.KwdNIL
+                Nothing
+                [ S.Expr NoLoc (S.Var NoLoc (S.NoQ z))
+                , S.Expr NoLoc (S.Var NoLoc ext)
+                ]
+                S.NoDec
+                S.fxPure
+                Nothing
+            items = [Hashing.TLDecl value decl]
+            localNames = Set.fromList [value, z]
+            (directLocalDeps, directExtDeps) = Hashing.implSplitDepsFromItems mn env localNames items
+        implSplitDepSetMaps env mn localNames items `shouldBe`
+          implSplitDepSetMapsSlow env mn localNames items
+        M.lookup value directLocalDeps `shouldBe` Just []
+        M.lookup value directExtDeps `shouldBe` Just [ext]
+
+      it "keeps shadowed imported aliases out of impl dependencies" $ do
+        let value = hashTestName
+            shadowed = S.name "shadowed"
+            dep = S.name "dep_value"
+            mn = S.modName ["hash_shadow"]
+            env =
+              Acton.Env.addActiveNames
+                [(shadowed, I.NAlias (S.GName (S.modName ["dep"]) dep))]
+                (Acton.Env.setMod mn env0)
+            decl =
+              S.Def
+                NoLoc
+                value
+                []
+                (S.PosPar shadowed Nothing Nothing S.PosNIL)
+                S.KwdNIL
+                Nothing
+                [S.Expr NoLoc (S.Var NoLoc (S.NoQ shadowed))]
+                S.NoDec
+                S.fxPure
+                Nothing
+            items = [Hashing.TLDecl value decl]
+            localNames = Set.singleton value
+        implSplitDepSetMaps env mn localNames items `shouldBe`
+          implSplitDepSetMapsSlow env mn localNames items
+        snd (Hashing.implSplitDepsFromItems mn env localNames items) `shouldBe`
+          M.singleton value []
+
+      it "keeps enclosing bindings across nested declarations" $ do
+        let value = hashTestName
+            inner = S.name "inner"
+            shadowed = S.name "shadowed"
+            dep = S.name "dep_value"
+            mn = S.modName ["hash_nested_shadow"]
+            env =
+              Acton.Env.addActiveNames
+                [(shadowed, I.NAlias (S.GName (S.modName ["dep"]) dep))]
+                (Acton.Env.setMod mn env0)
+            nested =
+              S.Def
+                NoLoc
+                inner
+                []
+                S.PosNIL
+                S.KwdNIL
+                Nothing
+                [S.Expr NoLoc (S.Var NoLoc (S.NoQ shadowed))]
+                S.NoDec
+                S.fxPure
+                Nothing
+            decl =
+              S.Def
+                NoLoc
+                value
+                []
+                (S.PosPar shadowed Nothing Nothing S.PosNIL)
+                S.KwdNIL
+                Nothing
+                [S.Decl NoLoc [nested]]
+                S.NoDec
+                S.fxPure
+                Nothing
+            items = [Hashing.TLDecl value decl]
+            localNames = Set.fromList [value, inner]
+        implSplitDepSetMaps env mn localNames items `shouldBe`
+          implSplitDepSetMapsSlow env mn localNames items
+        snd (Hashing.implSplitDepsFromItems mn env localNames items) `shouldBe`
+          M.singleton value []
 
     describe "CompileScheduler" $ do
       it "waits for canceled generation cleanup before launching the replacement" $ do


### PR DESCRIPTION
The compiler hashes source AST fragments, typed implementation fragments, and public NameInfo for incremental rebuild decisions. The previous Persist path normalized those values, stripping srcLoc etc, materialized encoded bytes and then hashed the resulting ByteStrings to produce the final hash.

This rewrites those hashes as an explicit structural feed into the existing SHA-256 digest. Each constructor, scalar, list boundary, and digest dependency is written directly through a fixed sized scratch buffer, while preserving the old normalization rules: source locations are omitted, docs are excluded from public NameInfo, and docs remain in the source and implementation fragments where they already affected the hashes.

Name-level dependency handling now uses the same direct splitters as the feed, the feed format is covered by the .tydb version bump, and the benchmark path uses the production public-dependency merge. The digest remains SHA-256 and the hashing path remains serial so Blake and concurrency can be measured separately.

Real build (--skip-build) measurements compare main, which already includes the Persist serialization change, against this branch.

--trees 1000:
  main:   type check 15.250s, wall 22.08s, user/sys 98.89s/7.63s.
  branch: type check  9.015s, wall 15.11s, user/sys 89.76s/3.59s.
  speedup: wall 31.6%, type check 40.9%.

--trees 3000:
  main:   type check 52.923s, wall 73.06s, user/sys 355.21s/30.81s.
  branch: type check 33.610s, wall 53.59s, user/sys 327.03s/23.96s.
  speedup: wall 26.6%, type check 36.5%.