### PR TITLE
Align build timing durations

### DIFF
--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -1564,7 +1564,7 @@ initCliCompileHooks progressUI progressState gopts sched gen plan = do
         statusWidth = 68
         nameWidth = labelWidth + 2 + statusWidth
         timePadWidth = nameWidth + length timeSep
-        timerMinWidth = length "999.999 s"
+        timerMinWidth = length "99999.999 s"
         plainLogWidth = timePadWidth + timerMinWidth
         detailStmtIndentWide = replicate 5 ' '
         detailBindsIndentWide = replicate 7 ' '
@@ -1577,7 +1577,7 @@ initCliCompileHooks progressUI progressState gopts sched gen plan = do
           ++ padRight statusWidth (abbreviateRight statusWidth status)
         plainDoneTimedLine modLbl status t =
           padRight timePadWidth (plainDoneIndent ++ plainStatusColumns modLbl status)
-          ++ fmtTimePrecise t
+          ++ padLeft timerMinWidth (fmtTimePrecise t)
         plainDoneLine modLbl status =
           plainDoneIndent ++ plainStatusColumns modLbl status
         pickBestLine candidates =

--- a/compiler/acton/test/rebuild/golden/file_02-initial-build.golden
+++ b/compiler/acton/test/rebuild/golden/file_02-initial-build.golden
@@ -1,20 +1,20 @@
 Building file src/c.act in project .
 Resolving dependencies (fetching if missing)...
-   a  Parse done                                                            0.000 s
+   a  Parse done                                                               0.000 s
   Stale a: source changed
-   a  Type check done                                                       0.000 s
+   a  Type check done                                                          0.000 s
      Non-total inferred signature: aaa
        aaa : int
-   b  Parse done                                                            0.000 s
+   b  Parse done                                                               0.000 s
   Stale b: source changed
-   b  Type check done                                                       0.000 s
+   b  Type check done                                                          0.000 s
      Non-total inferred signature: baa
        baa : () -> int
-   c  Parse done                                                            0.000 s
+   c  Parse done                                                               0.000 s
   Stale c: source changed
-   c  Type check done                                                       0.000 s
-   a  Wrote .tydb                                                           0.000 s
-   a  Generated docs                                                        0.000 s
+   c  Type check done                                                          0.000 s
+   a  Wrote .tydb                                                              0.000 s
+   a  Generated docs                                                           0.000 s
      Back normalize done: a                                                 0.000 s
      Back deactorize done: a                                                0.000 s
      Back cps done: a                                                       0.000 s
@@ -23,9 +23,9 @@ Resolving dependencies (fetching if missing)...
      Back codegen done: a                                                   0.000 s
      Back render done: a                                                    0.000 s
      Back write done: a                                                     0.000 s
-   a  Compilation done                                                      0.000 s
-   b  Wrote .tydb                                                           0.000 s
-   b  Generated docs                                                        0.000 s
+   a  Compilation done                                                         0.000 s
+   b  Wrote .tydb                                                              0.000 s
+   b  Generated docs                                                           0.000 s
      Back normalize done: b                                                 0.000 s
      Back deactorize done: b                                                0.000 s
      Back cps done: b                                                       0.000 s
@@ -34,9 +34,9 @@ Resolving dependencies (fetching if missing)...
      Back codegen done: b                                                   0.000 s
      Back render done: b                                                    0.000 s
      Back write done: b                                                     0.000 s
-   b  Compilation done                                                      0.000 s
-   c  Wrote .tydb                                                           0.000 s
-   c  Generated docs                                                        0.000 s
+   b  Compilation done                                                         0.000 s
+   c  Wrote .tydb                                                              0.000 s
+   c  Generated docs                                                           0.000 s
      Back normalize done: c                                                 0.000 s
      Back deactorize done: c                                                0.000 s
      Back cps done: c                                                       0.000 s
@@ -45,5 +45,5 @@ Resolving dependencies (fetching if missing)...
      Back codegen done: c                                                   0.000 s
      Back render done: c                                                    0.000 s
      Back write done: c                                                     0.000 s
-   c  Compilation done                                                      0.000 s
-      Final compilation done                                                0.000 s
+   c  Compilation done                                                         0.000 s
+      Final compilation done                                                   0.000 s

--- a/compiler/acton/test/rebuild/golden/file_03-up-to-date.golden
+++ b/compiler/acton/test/rebuild/golden/file_03-up-to-date.golden
@@ -3,4 +3,4 @@ Resolving dependencies (fetching if missing)...
   Fresh a: using cached .tydb
   Fresh b: using cached .tydb
   Fresh c: using cached .tydb
-      Final compilation done                                                0.000 s
+      Final compilation done                                                   0.000 s

--- a/compiler/acton/test/rebuild/golden/file_04-touch-no-rebuild.golden
+++ b/compiler/acton/test/rebuild/golden/file_04-touch-no-rebuild.golden
@@ -3,4 +3,4 @@ Resolving dependencies (fetching if missing)...
   Fresh a: using cached .tydb
   Fresh b: using cached .tydb
   Fresh c: using cached .tydb
-      Final compilation done                                                0.000 s
+      Final compilation done                                                   0.000 s

--- a/compiler/acton/test/rebuild/golden/file_06-change-a-impl.golden
+++ b/compiler/acton/test/rebuild/golden/file_06-change-a-impl.golden
@@ -1,15 +1,15 @@
 Building file src/c.act in project .
 Resolving dependencies (fetching if missing)...
-   a  Parse done                                                            0.000 s
+   a  Parse done                                                               0.000 s
   Stale a: source changed
   Hash deltas a: ~aaa{src HASH1 -> HASH2, impl HASH1 -> HASH2}
-   a  Type check done                                                       0.000 s
+   a  Type check done                                                          0.000 s
      Non-total inferred signature: aaa
        aaa : int
   Stale b: impl changes in a.aaa HASH1 → HASH2 (used by baa)
   Stale c: impl changes in b.baa HASH1 → HASH2 (used by main)
-   a  Wrote .tydb                                                           0.000 s
-   a  Generated docs                                                        0.000 s
+   a  Wrote .tydb                                                              0.000 s
+   a  Generated docs                                                           0.000 s
      Back normalize done: a                                                 0.000 s
      Back deactorize done: a                                                0.000 s
      Back cps done: a                                                       0.000 s
@@ -18,8 +18,8 @@ Resolving dependencies (fetching if missing)...
      Back codegen done: a                                                   0.000 s
      Back render done: a                                                    0.000 s
      Back write done: a                                                     0.000 s
-   a  Compilation done                                                      0.000 s
-   b  Wrote .tydb                                                           0.000 s
+   a  Compilation done                                                         0.000 s
+   b  Wrote .tydb                                                              0.000 s
      Back normalize done: b                                                 0.000 s
      Back deactorize done: b                                                0.000 s
      Back cps done: b                                                       0.000 s
@@ -28,8 +28,8 @@ Resolving dependencies (fetching if missing)...
      Back codegen done: b                                                   0.000 s
      Back render done: b                                                    0.000 s
      Back write done: b                                                     0.000 s
-   b  Compilation done                                                      0.000 s
-   c  Wrote .tydb                                                           0.000 s
+   b  Compilation done                                                         0.000 s
+   c  Wrote .tydb                                                              0.000 s
      Back normalize done: c                                                 0.000 s
      Back deactorize done: c                                                0.000 s
      Back cps done: c                                                       0.000 s
@@ -38,5 +38,5 @@ Resolving dependencies (fetching if missing)...
      Back codegen done: c                                                   0.000 s
      Back render done: c                                                    0.000 s
      Back write done: c                                                     0.000 s
-   c  Compilation done                                                      0.000 s
-      Final compilation done                                                0.000 s
+   c  Compilation done                                                         0.000 s
+      Final compilation done                                                   0.000 s

--- a/compiler/acton/test/rebuild/golden/file_08-change-b-impl.golden
+++ b/compiler/acton/test/rebuild/golden/file_08-change-b-impl.golden
@@ -1,10 +1,10 @@
 Building file src/c.act in project .
 Resolving dependencies (fetching if missing)...
   Fresh a: using cached .tydb
-   b  Parse done                                                            0.000 s
+   b  Parse done                                                               0.000 s
   Stale b: source changed
   Hash deltas b: +DocInfo, ~baa{src HASH1 -> HASH2, impl HASH1 -> HASH2}
-   b  Type check done                                                       0.000 s
+   b  Type check done                                                          0.000 s
      Non-total inferred signature: baa
        baa : () -> int
      Non-total inferred signature: DocInfo
@@ -12,8 +12,8 @@ Resolving dependencies (fetching if missing)...
            G_init : () -> None
            get : () -> int
   Stale c: impl changes in b.baa HASH1 → HASH2 (used by main)
-   b  Wrote .tydb                                                           0.000 s
-   b  Generated docs                                                        0.000 s
+   b  Wrote .tydb                                                              0.000 s
+   b  Generated docs                                                           0.000 s
      Back normalize done: b                                                 0.000 s
      Back deactorize done: b                                                0.000 s
      Back cps done: b                                                       0.000 s
@@ -22,8 +22,8 @@ Resolving dependencies (fetching if missing)...
      Back codegen done: b                                                   0.000 s
      Back render done: b                                                    0.000 s
      Back write done: b                                                     0.000 s
-   b  Compilation done                                                      0.000 s
-   c  Wrote .tydb                                                           0.000 s
+   b  Compilation done                                                         0.000 s
+   c  Wrote .tydb                                                              0.000 s
      Back normalize done: c                                                 0.000 s
      Back deactorize done: c                                                0.000 s
      Back cps done: c                                                       0.000 s
@@ -32,5 +32,5 @@ Resolving dependencies (fetching if missing)...
      Back codegen done: c                                                   0.000 s
      Back render done: c                                                    0.000 s
      Back write done: c                                                     0.000 s
-   c  Compilation done                                                      0.000 s
-      Final compilation done                                                0.000 s
+   c  Compilation done                                                         0.000 s
+      Final compilation done                                                   0.000 s

--- a/compiler/acton/test/rebuild/golden/project_02-initial-build.golden
+++ b/compiler/acton/test/rebuild/golden/project_02-initial-build.golden
@@ -1,23 +1,23 @@
 Resolving dependencies (fetching if missing)...
-   a  Parse done                                                            0.000 s
+   a  Parse done                                                               0.000 s
   Stale a: source changed
-   a  Type check done                                                       0.000 s
+   a  Type check done                                                          0.000 s
      Non-total inferred signature: aaa
        aaa : int
-   b  Parse done                                                            0.000 s
+   b  Parse done                                                               0.000 s
   Stale b: source changed
-   b  Type check done                                                       0.000 s
+   b  Type check done                                                          0.000 s
      Non-total inferred signature: baa
        baa : () -> int
      Non-total inferred signature: DocInfo
        class DocInfo (value):
            G_init : () -> None
            get : () -> int
-   c  Parse done                                                            0.000 s
+   c  Parse done                                                               0.000 s
   Stale c: source changed
-   c  Type check done                                                       0.000 s
-   a  Wrote .tydb                                                           0.000 s
-   a  Generated docs                                                        0.000 s
+   c  Type check done                                                          0.000 s
+   a  Wrote .tydb                                                              0.000 s
+   a  Generated docs                                                           0.000 s
      Back normalize done: a                                                 0.000 s
      Back deactorize done: a                                                0.000 s
      Back cps done: a                                                       0.000 s
@@ -26,9 +26,9 @@ Resolving dependencies (fetching if missing)...
      Back codegen done: a                                                   0.000 s
      Back render done: a                                                    0.000 s
      Back write done: a                                                     0.000 s
-   a  Compilation done                                                      0.000 s
-   b  Wrote .tydb                                                           0.000 s
-   b  Generated docs                                                        0.000 s
+   a  Compilation done                                                         0.000 s
+   b  Wrote .tydb                                                              0.000 s
+   b  Generated docs                                                           0.000 s
      Back normalize done: b                                                 0.000 s
      Back deactorize done: b                                                0.000 s
      Back cps done: b                                                       0.000 s
@@ -37,9 +37,9 @@ Resolving dependencies (fetching if missing)...
      Back codegen done: b                                                   0.000 s
      Back render done: b                                                    0.000 s
      Back write done: b                                                     0.000 s
-   b  Compilation done                                                      0.000 s
-   c  Wrote .tydb                                                           0.000 s
-   c  Generated docs                                                        0.000 s
+   b  Compilation done                                                         0.000 s
+   c  Wrote .tydb                                                              0.000 s
+   c  Generated docs                                                           0.000 s
      Back normalize done: c                                                 0.000 s
      Back deactorize done: c                                                0.000 s
      Back cps done: c                                                       0.000 s
@@ -48,5 +48,5 @@ Resolving dependencies (fetching if missing)...
      Back codegen done: c                                                   0.000 s
      Back render done: c                                                    0.000 s
      Back write done: c                                                     0.000 s
-   c  Compilation done                                                      0.000 s
-      Final compilation done                                                0.000 s
+   c  Compilation done                                                         0.000 s
+      Final compilation done                                                   0.000 s

--- a/compiler/acton/test/rebuild/golden/project_03-up-to-date.golden
+++ b/compiler/acton/test/rebuild/golden/project_03-up-to-date.golden
@@ -2,4 +2,4 @@ Resolving dependencies (fetching if missing)...
   Fresh a: using cached .tydb
   Fresh b: using cached .tydb
   Fresh c: using cached .tydb
-      Final compilation done                                                0.000 s
+      Final compilation done                                                   0.000 s

--- a/compiler/acton/test/rebuild/golden/project_04-touch-no-rebuild.golden
+++ b/compiler/acton/test/rebuild/golden/project_04-touch-no-rebuild.golden
@@ -2,4 +2,4 @@ Resolving dependencies (fetching if missing)...
   Fresh a: using cached .tydb
   Fresh b: using cached .tydb
   Fresh c: using cached .tydb
-      Final compilation done                                                0.000 s
+      Final compilation done                                                   0.000 s

--- a/compiler/acton/test/rebuild/golden/project_06-change-a-impl.golden
+++ b/compiler/acton/test/rebuild/golden/project_06-change-a-impl.golden
@@ -1,14 +1,14 @@
 Resolving dependencies (fetching if missing)...
-   a  Parse done                                                            0.000 s
+   a  Parse done                                                               0.000 s
   Stale a: source changed
   Hash deltas a: ~aaa{src HASH1 -> HASH2, impl HASH1 -> HASH2}
-   a  Type check done                                                       0.000 s
+   a  Type check done                                                          0.000 s
      Non-total inferred signature: aaa
        aaa : int
   Stale b: impl changes in a.aaa HASH1 → HASH2 (used by baa)
   Stale c: impl changes in b.baa HASH1 → HASH2 (used by main)
-   a  Wrote .tydb                                                           0.000 s
-   a  Generated docs                                                        0.000 s
+   a  Wrote .tydb                                                              0.000 s
+   a  Generated docs                                                           0.000 s
      Back normalize done: a                                                 0.000 s
      Back deactorize done: a                                                0.000 s
      Back cps done: a                                                       0.000 s
@@ -17,8 +17,8 @@ Resolving dependencies (fetching if missing)...
      Back codegen done: a                                                   0.000 s
      Back render done: a                                                    0.000 s
      Back write done: a                                                     0.000 s
-   a  Compilation done                                                      0.000 s
-   b  Wrote .tydb                                                           0.000 s
+   a  Compilation done                                                         0.000 s
+   b  Wrote .tydb                                                              0.000 s
      Back normalize done: b                                                 0.000 s
      Back deactorize done: b                                                0.000 s
      Back cps done: b                                                       0.000 s
@@ -27,8 +27,8 @@ Resolving dependencies (fetching if missing)...
      Back codegen done: b                                                   0.000 s
      Back render done: b                                                    0.000 s
      Back write done: b                                                     0.000 s
-   b  Compilation done                                                      0.000 s
-   c  Wrote .tydb                                                           0.000 s
+   b  Compilation done                                                         0.000 s
+   c  Wrote .tydb                                                              0.000 s
      Back normalize done: c                                                 0.000 s
      Back deactorize done: c                                                0.000 s
      Back cps done: c                                                       0.000 s
@@ -37,5 +37,5 @@ Resolving dependencies (fetching if missing)...
      Back codegen done: c                                                   0.000 s
      Back render done: c                                                    0.000 s
      Back write done: c                                                     0.000 s
-   c  Compilation done                                                      0.000 s
-      Final compilation done                                                0.000 s
+   c  Compilation done                                                         0.000 s
+      Final compilation done                                                   0.000 s

--- a/compiler/acton/test/rebuild/golden/project_08-change-b-impl.golden
+++ b/compiler/acton/test/rebuild/golden/project_08-change-b-impl.golden
@@ -1,9 +1,9 @@
 Resolving dependencies (fetching if missing)...
   Fresh a: using cached .tydb
-   b  Parse done                                                            0.000 s
+   b  Parse done                                                               0.000 s
   Stale b: source changed
   Hash deltas b: ~baa{src HASH1 -> HASH2, impl HASH1 -> HASH2}
-   b  Type check done                                                       0.000 s
+   b  Type check done                                                          0.000 s
      Non-total inferred signature: baa
        baa : () -> int
      Non-total inferred signature: DocInfo
@@ -11,8 +11,8 @@ Resolving dependencies (fetching if missing)...
            G_init : () -> None
            get : () -> int
   Stale c: impl changes in b.baa HASH1 → HASH2 (used by main)
-   b  Wrote .tydb                                                           0.000 s
-   b  Generated docs                                                        0.000 s
+   b  Wrote .tydb                                                              0.000 s
+   b  Generated docs                                                           0.000 s
      Back normalize done: b                                                 0.000 s
      Back deactorize done: b                                                0.000 s
      Back cps done: b                                                       0.000 s
@@ -21,8 +21,8 @@ Resolving dependencies (fetching if missing)...
      Back codegen done: b                                                   0.000 s
      Back render done: b                                                    0.000 s
      Back write done: b                                                     0.000 s
-   b  Compilation done                                                      0.000 s
-   c  Wrote .tydb                                                           0.000 s
+   b  Compilation done                                                         0.000 s
+   c  Wrote .tydb                                                              0.000 s
      Back normalize done: c                                                 0.000 s
      Back deactorize done: c                                                0.000 s
      Back cps done: c                                                       0.000 s
@@ -31,5 +31,5 @@ Resolving dependencies (fetching if missing)...
      Back codegen done: c                                                   0.000 s
      Back render done: c                                                    0.000 s
      Back write done: c                                                     0.000 s
-   c  Compilation done                                                      0.000 s
-      Final compilation done                                                0.000 s
+   c  Compilation done                                                         0.000 s
+      Final compilation done                                                   0.000 s

--- a/compiler/acton/test/rebuild/golden/project_10-change-a-iface.golden
+++ b/compiler/acton/test/rebuild/golden/project_10-change-a-iface.golden
@@ -1,13 +1,13 @@
 Resolving dependencies (fetching if missing)...
-   a  Parse done                                                            0.000 s
+   a  Parse done                                                               0.000 s
   Stale a: source changed
   Hash deltas a: -W_aaa_3, ~aaa{src HASH1 -> HASH2, pub HASH1 -> HASH2, impl HASH1 -> HASH2}
-   a  Type check done                                                       0.000 s
+   a  Type check done                                                          0.000 s
      Non-total inferred signature: aaa
        aaa : str
   Stale b: pub changes in a.aaa HASH1 → HASH2 (used by baa)
   Hash deltas b: ~baa{pub HASH1 -> HASH2, impl HASH1 -> HASH2}
-   b  Type check done                                                       0.000 s
+   b  Type check done                                                          0.000 s
      Non-total inferred signature: baa
        baa : () -> str
      Non-total inferred signature: DocInfo
@@ -16,9 +16,9 @@ Resolving dependencies (fetching if missing)...
            get : () -> int
   Stale c: pub changes in b.baa HASH1 → HASH2 (used by main)
   Hash deltas c: ~main{impl HASH1 -> HASH2}
-   c  Type check done                                                       0.000 s
-   a  Wrote .tydb                                                           0.000 s
-   a  Generated docs                                                        0.000 s
+   c  Type check done                                                          0.000 s
+   a  Wrote .tydb                                                              0.000 s
+   a  Generated docs                                                           0.000 s
      Back normalize done: a                                                 0.000 s
      Back deactorize done: a                                                0.000 s
      Back cps done: a                                                       0.000 s
@@ -27,9 +27,9 @@ Resolving dependencies (fetching if missing)...
      Back codegen done: a                                                   0.000 s
      Back render done: a                                                    0.000 s
      Back write done: a                                                     0.000 s
-   a  Compilation done                                                      0.000 s
-   b  Wrote .tydb                                                           0.000 s
-   b  Generated docs                                                        0.000 s
+   a  Compilation done                                                         0.000 s
+   b  Wrote .tydb                                                              0.000 s
+   b  Generated docs                                                           0.000 s
      Back normalize done: b                                                 0.000 s
      Back deactorize done: b                                                0.000 s
      Back cps done: b                                                       0.000 s
@@ -38,9 +38,9 @@ Resolving dependencies (fetching if missing)...
      Back codegen done: b                                                   0.000 s
      Back render done: b                                                    0.000 s
      Back write done: b                                                     0.000 s
-   b  Compilation done                                                      0.000 s
-   c  Wrote .tydb                                                           0.000 s
-   c  Generated docs                                                        0.000 s
+   b  Compilation done                                                         0.000 s
+   c  Wrote .tydb                                                              0.000 s
+   c  Generated docs                                                           0.000 s
      Back normalize done: c                                                 0.000 s
      Back deactorize done: c                                                0.000 s
      Back cps done: c                                                       0.000 s
@@ -49,5 +49,5 @@ Resolving dependencies (fetching if missing)...
      Back codegen done: c                                                   0.000 s
      Back render done: c                                                    0.000 s
      Back write done: c                                                     0.000 s
-   c  Compilation done                                                      0.000 s
-      Final compilation done                                                0.000 s
+   c  Compilation done                                                         0.000 s
+      Final compilation done                                                   0.000 s

--- a/compiler/acton/test/rebuild/golden/project_11-change-b-doc.golden
+++ b/compiler/acton/test/rebuild/golden/project_11-change-b-doc.golden
@@ -1,9 +1,9 @@
 Resolving dependencies (fetching if missing)...
   Fresh a: using cached .tydb
-   b  Parse done                                                            0.000 s
+   b  Parse done                                                               0.000 s
   Stale b: source changed
   Hash deltas b: ~DocInfo{src HASH1 -> HASH2, impl HASH1 -> HASH2}
-   b  Type check done                                                       0.000 s
+   b  Type check done                                                          0.000 s
      Non-total inferred signature: baa
        baa : () -> str
      Non-total inferred signature: DocInfo
@@ -11,8 +11,8 @@ Resolving dependencies (fetching if missing)...
            G_init : () -> None
            get : () -> int
   Fresh c: using cached .tydb
-   b  Wrote .tydb                                                           0.000 s
-   b  Generated docs                                                        0.000 s
+   b  Wrote .tydb                                                              0.000 s
+   b  Generated docs                                                           0.000 s
      Back normalize done: b                                                 0.000 s
      Back deactorize done: b                                                0.000 s
      Back cps done: b                                                       0.000 s
@@ -21,5 +21,5 @@ Resolving dependencies (fetching if missing)...
      Back codegen done: b                                                   0.000 s
      Back render done: b                                                    0.000 s
      Back write done: b                                                     0.000 s
-   b  Compilation done                                                      0.000 s
-      Final compilation done                                                0.000 s
+   b  Compilation done                                                         0.000 s
+      Final compilation done                                                   0.000 s

--- a/compiler/acton/test/rebuild/golden/project_12-codegen-stale.golden
+++ b/compiler/acton/test/rebuild/golden/project_12-codegen-stale.golden
@@ -10,5 +10,5 @@ Resolving dependencies (fetching if missing)...
      Back codegen done: b                                                   0.000 s
      Back render done: b                                                    0.000 s
      Back write done: b                                                     0.000 s
-   b  Compilation done                                                      0.000 s
-      Final compilation done                                                0.000 s
+   b  Compilation done                                                         0.000 s
+      Final compilation done                                                   0.000 s

--- a/compiler/acton/test/typeerrors/actor_self_reserved_assignment.golden
+++ b/compiler/acton/test/typeerrors/actor_self_reserved_assignment.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/actor_self_reserved_assignment.act using temporary scratch directory
-   actor_self_reserved_assignment  Parse done                                                            0.000 s
+   actor_self_reserved_assignment  Parse done                                                               0.000 s
 [error Compilation error]: 'self' cannot be used as a parameter name in actors.
      +--> actor_self_reserved_assignment.act@2:5-2:9
      |

--- a/compiler/acton/test/typeerrors/actor_self_reserved_constructor_param.golden
+++ b/compiler/acton/test/typeerrors/actor_self_reserved_constructor_param.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/actor_self_reserved_constructor_param.act using temporary scratch directory
-   actor_self_reserved_constructor_param  Parse done                                                            0.000 s
+   actor_self_reserved_constructor_param  Parse done                                                               0.000 s
 [error Compilation error]: 'self' cannot be used as a parameter name in actors.
      +--> actor_self_reserved_constructor_param.act@1:19-1:23
      |

--- a/compiler/acton/test/typeerrors/actor_self_reserved_except_as.golden
+++ b/compiler/acton/test/typeerrors/actor_self_reserved_except_as.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/actor_self_reserved_except_as.act using temporary scratch directory
-   actor_self_reserved_except_as  Parse done                                                            0.000 s
+   actor_self_reserved_except_as  Parse done                                                               0.000 s
 [error Compilation error]: 'self' cannot be used as a parameter name in actors.
      +--> actor_self_reserved_except_as.act@4:26-4:30
      |

--- a/compiler/acton/test/typeerrors/actor_self_reserved_loop_var.golden
+++ b/compiler/acton/test/typeerrors/actor_self_reserved_loop_var.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/actor_self_reserved_loop_var.act using temporary scratch directory
-   actor_self_reserved_loop_var  Parse done                                                            0.000 s
+   actor_self_reserved_loop_var  Parse done                                                               0.000 s
 [error Compilation error]: 'self' cannot be used as a parameter name in actors.
      +--> actor_self_reserved_loop_var.act@2:9-2:13
      |

--- a/compiler/acton/test/typeerrors/actor_self_reserved_method_name.golden
+++ b/compiler/acton/test/typeerrors/actor_self_reserved_method_name.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/actor_self_reserved_method_name.act using temporary scratch directory
-   actor_self_reserved_method_name  Parse done                                                            0.000 s
+   actor_self_reserved_method_name  Parse done                                                               0.000 s
 [error Compilation error]: 'self' cannot be used as a parameter name in actors.
      +--> actor_self_reserved_method_name.act@2:9-2:13
      |

--- a/compiler/acton/test/typeerrors/actor_self_reserved_method_param.golden
+++ b/compiler/acton/test/typeerrors/actor_self_reserved_method_param.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/actor_self_reserved_method_param.act using temporary scratch directory
-   actor_self_reserved_method_param  Parse done                                                            0.000 s
+   actor_self_reserved_method_param  Parse done                                                               0.000 s
 [error Compilation error]: 'self' cannot be used as a parameter name in actors.
      +--> actor_self_reserved_method_param.act@2:28-2:32
      |

--- a/compiler/acton/test/typeerrors/actor_self_reserved_method_param2.golden
+++ b/compiler/acton/test/typeerrors/actor_self_reserved_method_param2.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/actor_self_reserved_method_param2.act using temporary scratch directory
-   actor_self_reserved_method_param2  Parse done                                                            0.000 s
+   actor_self_reserved_method_param2  Parse done                                                               0.000 s
 [error Compilation error]: 'self' cannot be used as a parameter name in actors.
      +--> actor_self_reserved_method_param2.act@3:32-3:36
      |

--- a/compiler/acton/test/typeerrors/actor_self_reserved_variable.golden
+++ b/compiler/acton/test/typeerrors/actor_self_reserved_variable.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/actor_self_reserved_variable.act using temporary scratch directory
-   actor_self_reserved_variable  Parse done                                                            0.000 s
+   actor_self_reserved_variable  Parse done                                                               0.000 s
 [error Compilation error]: 'self' cannot be used as a parameter name in actors.
      +--> actor_self_reserved_variable.act@2:9-2:13
      |

--- a/compiler/acton/test/typeerrors/ex1.golden
+++ b/compiler/acton/test/typeerrors/ex1.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex1.act using temporary scratch directory
-   ex1  Parse done                                                            0.000 s
+   ex1  Parse done                                                               0.000 s
 [error]: Incompatible types
      +--> ex1.act@4:5-4:9
      |

--- a/compiler/acton/test/typeerrors/ex10.golden
+++ b/compiler/acton/test/typeerrors/ex10.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex10.act using temporary scratch directory
-   ex10  Parse done                                                            0.000 s
+   ex10  Parse done                                                               0.000 s
 [error]: Constraint violation
      +--> ex10.act@4:5-4:15
      |

--- a/compiler/acton/test/typeerrors/ex11.golden
+++ b/compiler/acton/test/typeerrors/ex11.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex11.act using temporary scratch directory
-   ex11  Parse done                                                            0.000 s
+   ex11  Parse done                                                               0.000 s
 [error]: Constraint violation
      +--> ex11.act@4:5-4:11
      |

--- a/compiler/acton/test/typeerrors/ex13.golden
+++ b/compiler/acton/test/typeerrors/ex13.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex13.act using temporary scratch directory
-   ex13  Parse done                                                            0.000 s
+   ex13  Parse done                                                               0.000 s
 [error]: Incompatible types
      +--> ex13.act@2:7-2:13
      |

--- a/compiler/acton/test/typeerrors/ex14.golden
+++ b/compiler/acton/test/typeerrors/ex14.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex14.act using temporary scratch directory
-   ex14  Parse done                                                            0.000 s
+   ex14  Parse done                                                               0.000 s
 [error]: Incompatible types
      +--> ex14.act@2:12-2:16
      |

--- a/compiler/acton/test/typeerrors/ex15.golden
+++ b/compiler/acton/test/typeerrors/ex15.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex15.act using temporary scratch directory
-   ex15  Parse done                                                            0.000 s
+   ex15  Parse done                                                               0.000 s
 [error]: Cannot satisfy the following simultaneous constraints for the unknown types
      +--> ex15.act@2:9-2:10
      |

--- a/compiler/acton/test/typeerrors/ex16.golden
+++ b/compiler/acton/test/typeerrors/ex16.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex16.act using temporary scratch directory
-   ex16  Parse done                                                            0.000 s
+   ex16  Parse done                                                               0.000 s
 [error]: Constraint violation
      +--> ex16.act@6:9-6:22
      |

--- a/compiler/acton/test/typeerrors/ex17.golden
+++ b/compiler/acton/test/typeerrors/ex17.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex17.act using temporary scratch directory
-   ex17  Parse done                                                            0.000 s
+   ex17  Parse done                                                               0.000 s
 [error]: Cannot satisfy the following simultaneous constraints for the unknown types
      +--> ex17.act@2:9-2:10
      |

--- a/compiler/acton/test/typeerrors/ex18.golden
+++ b/compiler/acton/test/typeerrors/ex18.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex18.act using temporary scratch directory
-   ex18  Parse done                                                            0.000 s
+   ex18  Parse done                                                               0.000 s
 [error]: Cannot satisfy the following simultaneous constraints for the unknown type t0
      +--> ex18.act@2:12-2:27
      |

--- a/compiler/acton/test/typeerrors/ex19.golden
+++ b/compiler/acton/test/typeerrors/ex19.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex19.act using temporary scratch directory
-   ex19  Parse done                                                            0.000 s
+   ex19  Parse done                                                               0.000 s
 [error]: Cannot satisfy the following simultaneous constraints for the unknown types
      +--> ex19.act@1:5-1:6
      |

--- a/compiler/acton/test/typeerrors/ex2.golden
+++ b/compiler/acton/test/typeerrors/ex2.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex2.act using temporary scratch directory
-   ex2  Parse done                                                            0.000 s
+   ex2  Parse done                                                               0.000 s
 [error]: Incompatible types
      +--> ex2.act@4:5-4:13
      |

--- a/compiler/acton/test/typeerrors/ex20.golden
+++ b/compiler/acton/test/typeerrors/ex20.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex20.act using temporary scratch directory
-   ex20  Parse done                                                            0.000 s
+   ex20  Parse done                                                               0.000 s
 [error]: Constraint violation
      +--> ex20.act@1:1-1:2
      |

--- a/compiler/acton/test/typeerrors/ex21.golden
+++ b/compiler/acton/test/typeerrors/ex21.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex21.act using temporary scratch directory
-   ex21  Parse done                                                            0.000 s
+   ex21  Parse done                                                               0.000 s
 [error]: Constraint violation
      +--> ex21.act@4:10-4:25
      |

--- a/compiler/acton/test/typeerrors/ex22.golden
+++ b/compiler/acton/test/typeerrors/ex22.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex22.act using temporary scratch directory
-   ex22  Parse done                                                            0.000 s
+   ex22  Parse done                                                               0.000 s
 [error]: Incompatible types
      +--> ex22.act@1:1-1:2
      |

--- a/compiler/acton/test/typeerrors/ex23.golden
+++ b/compiler/acton/test/typeerrors/ex23.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex23.act using temporary scratch directory
-   ex23  Parse done                                                            0.000 s
+   ex23  Parse done                                                               0.000 s
 [error]: Cannot satisfy the following simultaneous constraints for the unknown types
      +--> ex23.act@2:11-2:12
      |

--- a/compiler/acton/test/typeerrors/ex24.golden
+++ b/compiler/acton/test/typeerrors/ex24.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex24.act using temporary scratch directory
-   ex24  Parse done                                                            0.000 s
+   ex24  Parse done                                                               0.000 s
 [error]: Type unification error
      +--> ex24.act@5:13-5:16
      |

--- a/compiler/acton/test/typeerrors/ex25.golden
+++ b/compiler/acton/test/typeerrors/ex25.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex25.act using temporary scratch directory
-   ex25  Parse done                                                            0.000 s
+   ex25  Parse done                                                               0.000 s
 [error]: Incompatible types
      +--> ex25.act@8:9-8:16
      |

--- a/compiler/acton/test/typeerrors/ex26.golden
+++ b/compiler/acton/test/typeerrors/ex26.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex26.act using temporary scratch directory
-   ex26  Parse done                                                            0.000 s
+   ex26  Parse done                                                               0.000 s
 [error]: Constraint violation
      +--> ex26.act@15:5-15:33
      |

--- a/compiler/acton/test/typeerrors/ex27.golden
+++ b/compiler/acton/test/typeerrors/ex27.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex27.act using temporary scratch directory
-   ex27  Parse done                                                            0.000 s
+   ex27  Parse done                                                               0.000 s
 [error]: Type unification error
      +--> ex27.act@5:5-6:1
      |

--- a/compiler/acton/test/typeerrors/ex4.golden
+++ b/compiler/acton/test/typeerrors/ex4.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex4.act using temporary scratch directory
-   ex4  Parse done                                                            0.000 s
+   ex4  Parse done                                                               0.000 s
 [error]: Incompatible types
      +--> ex4.act@5:22-5:26
      |

--- a/compiler/acton/test/typeerrors/ex5.golden
+++ b/compiler/acton/test/typeerrors/ex5.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex5.act using temporary scratch directory
-   ex5  Parse done                                                            0.000 s
+   ex5  Parse done                                                               0.000 s
 [error]: Incompatible types
      +--> ex5.act@7:5-7:15
      |

--- a/compiler/acton/test/typeerrors/ex6.golden
+++ b/compiler/acton/test/typeerrors/ex6.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex6.act using temporary scratch directory
-   ex6  Parse done                                                            0.000 s
+   ex6  Parse done                                                               0.000 s
 [error]: Incompatible types
      +--> ex6.act@1:9-1:16
      |

--- a/compiler/acton/test/typeerrors/ex7.golden
+++ b/compiler/acton/test/typeerrors/ex7.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex7.act using temporary scratch directory
-   ex7  Parse done                                                            0.000 s
+   ex7  Parse done                                                               0.000 s
 [error]: Constraint violation
      +--> ex7.act@4:16-4:17
      |

--- a/compiler/acton/test/typeerrors/ex8.golden
+++ b/compiler/acton/test/typeerrors/ex8.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex8.act using temporary scratch directory
-   ex8  Parse done                                                            0.000 s
+   ex8  Parse done                                                               0.000 s
 [error]: Cannot satisfy the following simultaneous constraints for the unknown type t0
      +--> ex8.act@3:14-3:15
      |

--- a/compiler/acton/test/typeerrors/ex9.golden
+++ b/compiler/acton/test/typeerrors/ex9.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/ex9.act using temporary scratch directory
-   ex9  Parse done                                                            0.000 s
+   ex9  Parse done                                                               0.000 s
 [error]: Cannot satisfy the following simultaneous constraints for the unknown types
      +--> ex9.act@1:5-1:6
      |

--- a/compiler/acton/test/typeerrors/funargs1.golden
+++ b/compiler/acton/test/typeerrors/funargs1.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/funargs1.act using temporary scratch directory
-   funargs1  Parse done                                                            0.000 s
+   funargs1  Parse done                                                               0.000 s
 [error]: Unexpected keyword argument
      +--> funargs1.act@4:9-4:10
      |

--- a/compiler/acton/test/typeerrors/funargs2.golden
+++ b/compiler/acton/test/typeerrors/funargs2.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/funargs2.act using temporary scratch directory
-   funargs2  Parse done                                                            0.000 s
+   funargs2  Parse done                                                               0.000 s
 [error]: Unexpected keyword argument
      +--> funargs2.act@4:9-4:10
      |

--- a/compiler/acton/test/typeerrors/funargs4.golden
+++ b/compiler/acton/test/typeerrors/funargs4.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/funargs4.act using temporary scratch directory
-   funargs4  Parse done                                                            0.000 s
+   funargs4  Parse done                                                               0.000 s
 [error]: Unexpected keyword argument
      +--> funargs4.act@4:9-4:10
      |

--- a/compiler/acton/test/typeerrors/funargs5.golden
+++ b/compiler/acton/test/typeerrors/funargs5.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/funargs5.act using temporary scratch directory
-   funargs5  Parse done                                                            0.000 s
+   funargs5  Parse done                                                               0.000 s
 [error]: Incompatible types
      +--> funargs5.act@4:5-4:15
      |

--- a/compiler/acton/test/typeerrors/funargs6.golden
+++ b/compiler/acton/test/typeerrors/funargs6.golden
@@ -1,5 +1,5 @@
 Building file test/typeerrors/funargs6.act using temporary scratch directory
-   funargs6  Parse done                                                            0.000 s
+   funargs6  Parse done                                                               0.000 s
 [error]: Incompatible types
      +--> funargs6.act@4:5-4:13
      |


### PR DESCRIPTION
## Summary

Widen the build progress duration column so timings with five-digit second values stay aligned with shorter timings.

The plain log formatter now reserves enough width for values up to `99999.999 s` and right-aligns precise durations in that reserved column. The affected incremental and type-error golden files have been refreshed for the new spacing.

## Validation

- `make`
- `make test`

Note: the first sandboxed `make` attempt could not resolve `ziglang.org`; rerunning with network approval completed successfully.