### PR TITLE
Fix Windows Acton program execution

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -731,6 +731,13 @@ jobs:
           build x86_64-linux-gnu.2.27 --db
           build x86_64-linux-musl --db
           build x86_64-windows-gnu --no-threads
+      - name: "Upload Windows hello executable"
+        if: matrix.arch == 'amd64'
+        uses: actions/upload-artifact@v7
+        with:
+          name: acton-hello-windows-x86_64
+          path: test/compiler/hello/out/bin/hello.exe
+          if-no-files-found: error
       # Producer only: save the freshly-built cross-compile cache.
       - name: "Save cross-compile cache (~/.cache/acton)"
         if: ${{ !cancelled() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && steps.cross_compile.outcome == 'success' }}
@@ -742,6 +749,26 @@ jobs:
       - name: "Show disk usage (after cross-compile)"
         if: always()
         run: df -h || true
+
+  test-windows:
+    needs: test-cross-compile
+    runs-on: windows-latest
+    steps:
+      - name: "Download Windows hello executable"
+        uses: actions/download-artifact@v8
+        with:
+          name: acton-hello-windows-x86_64
+      - name: "Run Windows hello executable"
+        shell: pwsh
+        run: |
+          $out = & .\hello.exe
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+          if ($out -ne "Hello World!") {
+            Write-Error "Unexpected output: '$out'"
+            exit 1
+          }
 
   perf-vs-main:
     needs: build-debs
@@ -874,7 +901,7 @@ jobs:
       repo_url: "actonlang/acton-http2"
 
   build-container-image:
-    needs: [test-macos, test-linux, test-cross-compile, build-debs]
+    needs: [test-macos, test-linux, test-cross-compile, test-windows, build-debs]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -971,7 +998,7 @@ jobs:
     # Only run on the main branch
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    needs: [test-macos, test-linux, test-cross-compile, build-debs, build-container-image]
+    needs: [test-macos, test-linux, test-cross-compile, test-windows, build-debs, build-container-image]
     steps:
       - name: "Delete current tip release & tag"
         uses: dev-drprasad/delete-tag-and-release@v1.1
@@ -1058,7 +1085,7 @@ jobs:
   release:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
-    needs: [test-macos, test-linux, test-cross-compile, build-debs, build-container-image]
+    needs: [test-macos, test-linux, test-cross-compile, test-windows, build-debs, build-container-image]
     steps:
       - name: "Check out repository code"
         uses: actions/checkout@v6
@@ -1105,7 +1132,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: debian:experimental
-    needs: [test-macos, test-linux, test-cross-compile, build-debs]
+    needs: [test-macos, test-linux, test-cross-compile, test-windows, build-debs]
     steps:
       - name: Install build prerequisites
         run: |
@@ -1159,7 +1186,7 @@ jobs:
       image: debian:experimental
     permissions:
       contents: write
-    needs: [test-macos, test-linux, test-cross-compile, build-debs]
+    needs: [test-macos, test-linux, test-cross-compile, test-windows, build-debs]
     steps:
       - name: Install build prerequisites
         run: |
@@ -1205,7 +1232,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     # Depend on all test jobs so we don't update brew repo in case anything fails
-    needs: [test-macos, test-linux, test-cross-compile, build-debs]
+    needs: [test-macos, test-linux, test-cross-compile, test-windows, build-debs]
     steps:
       - name: "Check out code of main acton repo"
         uses: actions/checkout@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -725,18 +725,28 @@ jobs:
           set -e
           cd test/compiler/hello
           build() { echo "=== acton build --target $* ==="; acton build --target "$@"; }
+          mkdir -p "$RUNNER_TEMP/acton-windows-hello/aarch64" "$RUNNER_TEMP/acton-windows-hello/x86_64"
           build aarch64-macos-none --db
           build aarch64-windows-gnu --no-threads
+          cp out/bin/hello.exe "$RUNNER_TEMP/acton-windows-hello/aarch64/hello.exe"
           build x86_64-macos-none --db
           build x86_64-linux-gnu.2.27 --db
           build x86_64-linux-musl --db
           build x86_64-windows-gnu --no-threads
-      - name: "Upload Windows hello executable"
+          cp out/bin/hello.exe "$RUNNER_TEMP/acton-windows-hello/x86_64/hello.exe"
+      - name: "Upload x86_64 Windows hello executable"
         if: matrix.arch == 'amd64'
         uses: actions/upload-artifact@v7
         with:
           name: acton-hello-windows-x86_64
-          path: test/compiler/hello/out/bin/hello.exe
+          path: ${{ runner.temp }}/acton-windows-hello/x86_64/hello.exe
+          if-no-files-found: error
+      - name: "Upload arm64 Windows hello executable"
+        if: matrix.arch == 'amd64'
+        uses: actions/upload-artifact@v7
+        with:
+          name: acton-hello-windows-arm64
+          path: ${{ runner.temp }}/acton-windows-hello/aarch64/hello.exe
           if-no-files-found: error
       # Producer only: save the freshly-built cross-compile cache.
       - name: "Save cross-compile cache (~/.cache/acton)"
@@ -752,15 +762,26 @@ jobs:
 
   test-windows:
     needs: test-cross-compile
-    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: windows-latest
+            artifact: acton-hello-windows-x86_64
+          - arch: arm64
+            runner: windows-11-arm
+            artifact: acton-hello-windows-arm64
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: "Download Windows hello executable"
         uses: actions/download-artifact@v8
         with:
-          name: acton-hello-windows-x86_64
+          name: ${{ matrix.artifact }}
       - name: "Run Windows hello executable"
         shell: pwsh
         run: |
+          Write-Host "Running ${{ matrix.arch }} Windows hello executable"
           $out = & .\hello.exe
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE

--- a/deps/libuv/build.zig
+++ b/deps/libuv/build.zig
@@ -43,6 +43,7 @@ pub fn build(b: *std.Build) void {
         flags.appendSlice(b.allocator, &.{
             "-D_FILE_OFFSET_BITS=64",
             "-D_LARGEFILE_SOURCE",
+            "-fno-sanitize=null",
         }) catch unreachable;
         if (optimize == .Debug) {
             flags.appendSlice(b.allocator, &.{


### PR DESCRIPTION
Fix Windows Acton program execution by disabling Zig/Clang's null sanitizer for vendored libuv Windows C builds.

Windows Acton programs crashed in libuv's async wakeup path because libuv's Windows `CONTAINING_RECORD`-style offset calculation was trapped by the null sanitizer. This was not caused by `uv_async_send` requiring Acton threads.

Extend CI so the cross-compilation job preserves and uploads Windows `hello.exe` artifacts for both `x86_64` and `arm64`, then runs them on matching Windows runners:

- `windows-latest` for x86_64
- `windows-11-arm` for arm64