### PR TITLE
Avoid apt update in cross-compile CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -702,8 +702,7 @@ jobs:
           name: acton-debs-${{ matrix.arch }}
       - name: "Install acton from .deb"
         run: |
-          sudo apt update
-          sudo apt install -y ./deb/acton_*.deb
+          sudo dpkg -i ./deb/acton_*.deb
           acton version
       # Cross-compiling all targets cold is slow, so cache the zig artifacts.
       # Same producer/consumer model as the test-X jobs: PRs and pushes restore


### PR DESCRIPTION
The cross-compile job installs the freshly built local Acton package on the hosted Ubuntu runner. It does not need to refresh all apt indexes first, and doing so can fail because of unrelated third-party apt repositories on the runner image.

This changes the job to install the downloaded package with `dpkg -i`, keeping the step focused on the artifact produced by `build-debs` and avoiding external apt metadata during cross-compile testing.