### PR TITLE
Index tydb dependency hashes

### DIFF
--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -692,7 +692,7 @@ readModuleImports paths mn = do
         hdrE <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readHeader tyFile
         case hdrE of
           Left _ -> return []
-          Right (_sourceMeta, _hash, _ih, _implH, imps, _nameHashes, _roots, _tests, _doc) -> return (map fst imps)
+          Right (_sourceMeta, _hash, _ih, _implH, imps, _depModules, _nameHashes, _roots, _tests, _doc) -> return (map fst imps)
 
 dependentTestModulesFromHeaders :: Paths -> [FilePath] -> [String] -> IO [String]
 dependentTestModulesFromHeaders paths srcFiles changedModules = do
@@ -1089,7 +1089,7 @@ printSigInterface paths mn mName tyFile = do
     case tyRes of
       Left err ->
         printErrorAndExit ("Could not read type interface for " ++ modNameToString mn ++ ": " ++ show err)
-      Right (ms, nmod, _, _, _, _, _, _, _, _, _, _) -> do
+      Right (ms, nmod, _, _, _, _, _, _, _, _, _, _, _) -> do
         env0 <- Acton.Env.initEnv (sysTypes paths) False
         let I.NModule imps te _ = nmod
             envImports = foldr Acton.Env.addImport env0 ms
@@ -2203,7 +2203,7 @@ expectedRootStubs paths tasks = do
             tyPath = tyDbPath paths mn
         hdrE <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readHeader tyPath
         case hdrE of
-          Right (_sourceMeta, _, _, _implH, _imps, _nameHashes, rs, _tests, _) -> return (map (mkStub outbase) rs)
+          Right (_sourceMeta, _, _, _implH, _imps, _depModules, _nameHashes, rs, _tests, _) -> return (map (mkStub outbase) rs)
           _ -> return []
     return (concat roots)
   where
@@ -2349,7 +2349,7 @@ writeRootC env gopts opts paths tasks binTask = do
         -- was rebuilt during this run.
         tyPath <- Acton.Env.findTyFile (searchPath paths) m
         rootsHeader <- case tyPath of
-                         Just ty -> do (_sourceMeta, _, _, _implH, _imps, _nameHashes, roots, _tests, _) <- InterfaceFiles.readHeader ty; return roots
+                         Just ty -> do (_sourceMeta, _, _, _implH, _imps, _depModules, _nameHashes, roots, _tests, _) <- InterfaceFiles.readHeader ty; return roots
                          Nothing -> return []
         let rootsEnv = case Acton.Env.lookupMod m env of
                          Nothing -> []
@@ -2963,7 +2963,7 @@ filterMainActor env paths binTask = do
       Just ty -> do
         hdrE <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readHeader ty
         case hdrE of
-          Right (_sourceMeta, _, _, _implH, _imps, _nameHashes, roots, _tests, _) | n `elem` roots -> return (Just binTask)
+          Right (_sourceMeta, _, _, _implH, _imps, _depModules, _nameHashes, roots, _tests, _) | n `elem` roots -> return (Just binTask)
           _ -> checkEnv
       Nothing -> checkEnv
 

--- a/compiler/acton/TestRunner.hs
+++ b/compiler/acton/TestRunner.hs
@@ -560,7 +560,7 @@ readModuleTests paths mn = do
         hdrE <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readHeader tyFile
         case hdrE of
           Left _ -> return []
-          Right (_sourceMeta, _srcH, _ih, _implH, _imps, _nameHashes, _roots, tests, _doc) ->
+          Right (_sourceMeta, _srcH, _ih, _implH, _imps, _depModules, _nameHashes, _roots, tests, _doc) ->
             return tests
 
 modNameFromString :: String -> A.ModName

--- a/compiler/acton/test_incremental.hs
+++ b/compiler/acton/test_incremental.hs
@@ -2,7 +2,7 @@
 
 module Main (main) where
 
-import           Control.Monad (unless, when)
+import           Control.Monad (foldM, forM, unless, when)
 import qualified Data.ByteString.Lazy.Char8 as LBS
 import qualified Data.ByteString as B
 import qualified Data.Text as T
@@ -470,21 +470,30 @@ buildProject = do
 -- | Read name hashes from a .tydb file.
 readTyNameHashes :: FilePath -> IO [InterfaceFiles.NameHashInfo]
 readTyNameHashes tyPath = do
-  (_, _, _, _, _, _, _, _, nameHashes, _, _, _) <- InterfaceFiles.readFile tyPath
+  (_, _, _, _, _, _, _, _, _, nameHashes, _, _, _) <- InterfaceFiles.readFile tyPath
   pure nameHashes
 
 -- | Read pub/impl dependency names for a binding in a .tydb file.
 readTyDeps :: FilePath -> String -> IO ([String], [String])
 readTyDeps tyPath nameLabel = do
-  nameHashes <- readTyNameHashes tyPath
+  (_, _, _, _, _, _, _, _, depModules, nameHashes, _, _, _) <- InterfaceFiles.readFile tyPath
   let matchName nh = prstr (InterfaceFiles.nhName nh) == nameLabel
   case find matchName nameHashes of
     Nothing -> do
       assertFailure ("missing name " ++ nameLabel ++ " in " ++ tyPath)
       pure ([], [])
     Just nh -> do
-      let pubDeps = sort (map (prstr . fst) (InterfaceFiles.nhPubDeps nh))
-          implDeps = sort (map (prstr . fst) (InterfaceFiles.nhImplDeps nh))
+      deps <- forM depModules $ \depInfo -> do
+        let depMn = InterfaceFiles.dmiModule depInfo
+        depNames <- InterfaceFiles.readDepNames tyPath depMn
+        forM depNames $ \depNameInfo -> do
+          users <- InterfaceFiles.readDepUsers tyPath depMn (InterfaceFiles.dniName depNameInfo)
+          let qn = prstr (A.GName depMn (InterfaceFiles.dniName depNameInfo))
+              isPub = InterfaceFiles.nhName nh `elem` InterfaceFiles.duPubUsers users
+              isImpl = InterfaceFiles.nhName nh `elem` InterfaceFiles.duImplUsers users
+          pure (if isPub then [qn] else [], if isImpl then [qn] else [])
+      let pubDeps = sort (concatMap fst (concat deps))
+          implDeps = sort (concatMap snd (concat deps))
       pure (pubDeps, implDeps)
 
 -- | Read pub/impl local dependency names for a binding in a .tydb file.
@@ -504,23 +513,54 @@ readTyLocalDeps tyPath nameLabel = do
 -- | Rewrite source hash and name-hash section of a .tydb file.
 rewriteTySrcHashAndNameHashes :: FilePath -> B.ByteString -> ([InterfaceFiles.NameHashInfo] -> [InterfaceFiles.NameHashInfo]) -> IO ()
 rewriteTySrcHashAndNameHashes tyPath srcHash' f = do
-  (_mods, nmod, tmod, sourceMeta, _srcHash, pubHash, implHash, imps, nameHashes, roots, tests, mdoc) <- InterfaceFiles.readFile tyPath
-  InterfaceFiles.writeFile tyPath srcHash' pubHash implHash sourceMeta imps (f nameHashes) roots tests mdoc nmod tmod
+  (_mods, nmod, tmod, sourceMeta, _srcHash, pubHash, implHash, imps, depModules, nameHashes, roots, tests, mdoc) <- InterfaceFiles.readFile tyPath
+  nameHashes' <- restoreExternalDeps tyPath depModules nameHashes
+  InterfaceFiles.writeFile tyPath srcHash' pubHash implHash sourceMeta imps depModules (f nameHashes') roots tests mdoc nmod tmod
 
 rewriteTySourceMeta :: FilePath -> Maybe InterfaceFiles.SourceFileMeta -> IO ()
 rewriteTySourceMeta tyPath sourceMeta' = do
-  (_mods, nmod, tmod, _sourceMeta, srcHash, pubHash, implHash, imps, nameHashes, roots, tests, mdoc) <- InterfaceFiles.readFile tyPath
-  InterfaceFiles.writeFile tyPath srcHash pubHash implHash sourceMeta' imps nameHashes roots tests mdoc nmod tmod
+  (_mods, nmod, tmod, _sourceMeta, srcHash, pubHash, implHash, imps, depModules, nameHashes, roots, tests, mdoc) <- InterfaceFiles.readFile tyPath
+  nameHashes' <- restoreExternalDeps tyPath depModules nameHashes
+  InterfaceFiles.writeFile tyPath srcHash pubHash implHash sourceMeta' imps depModules nameHashes' roots tests mdoc nmod tmod
 
 rewriteTyVersion :: FilePath -> [Int] -> IO ()
 rewriteTyVersion tyPath version' = do
-  (_mods, nmod, tmod, sourceMeta, srcHash, pubHash, implHash, imps, nameHashes, roots, tests, mdoc) <- InterfaceFiles.readFile tyPath
-  InterfaceFiles.writeFileWithVersion version' tyPath srcHash pubHash implHash sourceMeta imps nameHashes roots tests mdoc nmod tmod
+  (_mods, nmod, tmod, sourceMeta, srcHash, pubHash, implHash, imps, depModules, nameHashes, roots, tests, mdoc) <- InterfaceFiles.readFile tyPath
+  nameHashes' <- restoreExternalDeps tyPath depModules nameHashes
+  InterfaceFiles.writeFileWithVersion version' tyPath srcHash pubHash implHash sourceMeta imps depModules nameHashes' roots tests mdoc nmod tmod
 
 readTySourceMeta :: FilePath -> IO (Maybe InterfaceFiles.SourceFileMeta)
 readTySourceMeta tyPath = do
-  (sourceMeta, _srcHash, _pubHash, _implHash, _imps, _nameHashes, _roots, _tests, _doc) <- InterfaceFiles.readHeader tyPath
+  (sourceMeta, _srcHash, _pubHash, _implHash, _imps, _depModules, _nameHashes, _roots, _tests, _doc) <- InterfaceFiles.readHeader tyPath
   pure sourceMeta
+
+restoreExternalDeps :: FilePath -> [InterfaceFiles.DepModuleInfo] -> [InterfaceFiles.NameHashInfo] -> IO [InterfaceFiles.NameHashInfo]
+restoreExternalDeps tyPath depModules nameHashes = do
+  depMap <- foldM addModule M.empty depModules
+  pure
+    [ nh { InterfaceFiles.nhPubDeps = fst deps
+         , InterfaceFiles.nhImplDeps = snd deps
+         }
+    | nh <- nameHashes
+    , let deps = M.findWithDefault ([], []) (InterfaceFiles.nhName nh) depMap
+    ]
+  where
+    addModule acc depInfo = do
+      let depMn = InterfaceFiles.dmiModule depInfo
+      depNames <- InterfaceFiles.readDepNames tyPath depMn
+      foldM (addName depMn) acc depNames
+
+    addName depMn acc depInfo = do
+      users <- InterfaceFiles.readDepUsers tyPath depMn (InterfaceFiles.dniName depInfo)
+      let qn = A.GName depMn (InterfaceFiles.dniName depInfo)
+          pubDep = (qn, InterfaceFiles.dniPubHash depInfo)
+          implDep = (qn, InterfaceFiles.dniImplHash depInfo)
+          addPub m user =
+            M.insertWith merge user ([pubDep | not (B.null (InterfaceFiles.dniPubHash depInfo))], []) m
+          addImpl m user =
+            M.insertWith merge user ([], [implDep | not (B.null (InterfaceFiles.dniImplHash depInfo))]) m
+          merge (p1, i1) (p2, i2) = (p1 ++ p2, i1 ++ i2)
+      pure (foldl addImpl (foldl addPub acc (InterfaceFiles.duPubUsers users)) (InterfaceFiles.duImplUsers users))
 
 sourceFileMetaForPath :: FilePath -> IO InterfaceFiles.SourceFileMeta
 sourceFileMetaForPath path = do
@@ -1357,7 +1397,7 @@ p28_protocol_extension_deps = testCase "28-protocol/extension deps are recorded 
   assertEqual "exact extensions by class" ["BarProtoD_Widget"] (sort (map prstr extensionsForWidget))
   assertEqual "exact extensions by protocol" ["BarProtoD_Widget"] (sort (map prstr extensionsForBarProto))
   assertEqual "exact extensions by inherited protocol" ["BarProtoD_Widget"] (sort (map prstr extensionsForFooProto))
-  (_, nmod, _, _, _, _, _, _, _, _, _, _) <- InterfaceFiles.readFile tyA
+  (_, nmod, _, _, _, _, _, _, _, _, _, _, _) <- InterfaceFiles.readFile tyA
   let I.NModule _ iface _ = nmod
       extMatch (n, _) = prstr n == "BarProtoD_Widget"
   case find extMatch iface of

--- a/compiler/acton/test_incremental.hs
+++ b/compiler/acton/test_incremental.hs
@@ -17,6 +17,7 @@ import           Data.List (elemIndex, find, partition, sort, sortOn)
 import qualified Data.Map.Strict as M
 import           Data.Maybe (fromMaybe, isJust)
 import           System.Directory
+import           System.Environment (getEnvironment)
 import           System.Exit
 import           System.FilePath
 import           System.IO (Handle)
@@ -422,6 +423,16 @@ runActonIn cwd args = do
   (ec,out,err) <- readCreateProcessWithExitCode (proc actonExe args'){ cwd = Just cwd } ""
   pure (ec, T.pack out <> T.pack err)
 
+runActonInEnv :: [(String, String)] -> FilePath -> [String] -> IO (ExitCode, T.Text)
+runActonInEnv extraEnv cwd args = do
+  actonExe <- actonPath
+  env0 <- getEnvironment
+  let args' = args ++ ["--jobs", "1"]
+      keys = map fst extraEnv
+      env' = extraEnv ++ filter (\(k, _) -> k `notElem` keys) env0
+  (ec,out,err) <- readCreateProcessWithExitCode (proc actonExe args'){ cwd = Just cwd, env = Just env' } ""
+  pure (ec, T.pack out <> T.pack err)
+
 -- | Assert an exit success and include output on failure.
 assertExitSuccess :: String -> (ExitCode, T.Text) -> IO ()
 assertExitSuccess label (ec, out) =
@@ -453,6 +464,34 @@ buildOutInArgs proj args = do
   res@(ec, out) <- runActonIn proj (["build", "--color", "never", "--verbose"] ++ args)
   assertExitSuccess ("build in " ++ proj) res
   pure out
+
+buildTraceOutInArgs :: FilePath -> [String] -> IO T.Text
+buildTraceOutInArgs proj args = do
+  res@(ec, out) <- runActonInEnv [("ACTON_TYDB_TRACE_READS", "1")] proj (["build", "--color", "never", "--verbose"] ++ args)
+  assertExitSuccess ("traced build in " ++ proj) res
+  pure out
+
+tydbTraceLines :: T.Text -> [T.Text]
+tydbTraceLines =
+  filter (T.isPrefixOf "tydb-read ") . T.lines
+
+traceLinesForTydb :: String -> T.Text -> [T.Text]
+traceLinesForTydb modName =
+  filter (T.isInfixOf (T.pack ("out/types/" ++ modName ++ ".tydb"))) . tydbTraceLines
+
+traceHasOp :: String -> [T.Text] -> Bool
+traceHasOp op =
+  any (T.isPrefixOf (T.pack ("tydb-read " ++ op ++ " ")))
+
+assertTraceHas :: String -> String -> [T.Text] -> IO ()
+assertTraceHas label op lines' =
+  assertBool (label ++ " missing tydb-read " ++ op ++ "\n" ++ T.unpack (T.unlines lines'))
+    (traceHasOp op lines')
+
+assertTraceLacks :: String -> String -> [T.Text] -> IO ()
+assertTraceLacks label op lines' =
+  assertBool (label ++ " unexpectedly had tydb-read " ++ op ++ "\n" ++ T.unpack (T.unlines lines'))
+    (not (traceHasOp op lines'))
 
 -- | Format a module label for output comparisons.
 modLabel :: FilePath -> String -> T.Text
@@ -1926,7 +1965,7 @@ p36_removed_dep_name_triggers_front_refresh =
 
 p37_impl_refresh_missing_dep_hashes_reruns_front :: TestTree
 p37_impl_refresh_missing_dep_hashes_reruns_front =
-  testCase "37-impl refresh missing dep hashes reruns front passes" $ do
+  testCase "37-missing dep rows rerun front passes" $ do
     let proj = casesProjDir
         src = casesSrcDir
         modMain = modLabel proj "main"
@@ -1971,8 +2010,8 @@ p37_impl_refresh_missing_dep_hashes_reruns_front =
       ]
     res2@(_ec2, out2) <- runActonIn proj ["build", "--color", "never", "--verbose", "--skip-build"]
     assertExitSuccess "rebuild after impl refresh dep hash miss" res2
-    assertBool ("expected impl-refresh fallback log\n" ++ T.unpack out2)
-      (T.isInfixOf "impl refresh encountered unresolved dep hashes; rerunning front passes" out2)
+    assertBool ("expected missing dep-row fallback log\n" ++ T.unpack out2)
+      (T.isInfixOf "missing dep hashes in rows libfoo" out2)
     assertBool ("did not expect internal hash-missing diagnostic\n" ++ T.unpack out2)
       (not (T.isInfixOf "Hash info missing for libfoo.bar" out2))
     assertBool ("did not expect internal NoItem failure\n" ++ T.unpack out2)
@@ -2333,6 +2372,125 @@ p46_huge_module_skips_doc_output =
     assertBool "skipped module should not link to missing page"
       (not ("href=\"huge.html\"" `T.isInfixOf` index))
 
+p47_unchanged_dep_reads_module_hashes_only :: TestTree
+p47_unchanged_dep_reads_module_hashes_only =
+  testCase "47-unchanged dependency reads module hashes only" $ do
+    let proj = casesProjDir
+        modSmall = modLabel proj "small"
+    depDir <- ensureHashTraceProjects
+    writeHashTraceBig depDir "1" 30
+    writeHashTraceSmall
+    writeHashTraceMain
+    buildHashTraceDep depDir
+    buildHashTraceRoot
+    out <- buildTraceOutInArgs proj hashTraceBuildArgs
+    let bigTrace = traceLinesForTydb "big" out
+    assertTraceHas "big should be checked by module hash" "module-hashes" bigTrace
+    assertTraceLacks "big should not scan all name hashes" "name-hash-all" bigTrace
+    assertTraceLacks "big should not read a selected name hash" "name-hash" bigTrace
+    assertTraceLacks "big should not read a full interface" "all" bigTrace
+    assertBool ("did not expect small to type check when dependency hashes are unchanged\n" ++ T.unpack out)
+      (not (typechecked out modSmall))
+
+p48_unrelated_dep_addition_reads_used_name_only :: TestTree
+p48_unrelated_dep_addition_reads_used_name_only =
+  testCase "48-unrelated dependency addition reads used name only" $ do
+    let proj = casesProjDir
+        modSmall = modLabel proj "small"
+    depDir <- ensureHashTraceProjects
+    writeHashTraceBig depDir "1" 30
+    writeHashTraceSmall
+    writeHashTraceMain
+    buildHashTraceDep depDir
+    buildHashTraceRoot
+    writeHashTraceBig depDir "1" 31
+    buildHashTraceDep depDir
+    out <- buildTraceOutInArgs proj hashTraceBuildArgs
+    let bigTrace = traceLinesForTydb "big" out
+        smallTrace = traceLinesForTydb "small" out
+    assertTraceHas "small should read dependency-name rows" "dep-names" smallTrace
+    assertTraceLacks "small should not read dependency users for unchanged used names" "dep-users" smallTrace
+    assertTraceHas "big should read the used name hash" "name-hash" bigTrace
+    assertTraceLacks "big should not scan all name hashes" "name-hash-all" bigTrace
+    assertTraceLacks "big should not read a full interface" "all" bigTrace
+    assertBool ("did not expect small to type check when only an unused dependency name was added\n" ++ T.unpack out)
+      (not (typechecked out modSmall))
+
+p49_changed_dep_name_reads_users :: TestTree
+p49_changed_dep_name_reads_users =
+  testCase "49-changed dependency name reads users" $ do
+    let proj = casesProjDir
+        modSmall = modLabel proj "small"
+    depDir <- ensureHashTraceProjects
+    writeHashTraceBig depDir "1" 30
+    writeHashTraceSmall
+    writeHashTraceMain
+    buildHashTraceDep depDir
+    buildHashTraceRoot
+    writeHashTraceBig depDir "\"changed\"" 30
+    buildHashTraceDep depDir
+    out <- buildTraceOutInArgs proj hashTraceBuildArgs
+    let bigTrace = traceLinesForTydb "big" out
+        smallTrace = traceLinesForTydb "small" out
+    assertTraceHas "small should read dependency users for the changed name" "dep-users" smallTrace
+    assertTraceHas "big should read the changed name hash" "name-hash" bigTrace
+    assertBool ("expected small to type check when the used dependency name changes\n" ++ T.unpack out)
+      (typechecked out modSmall)
+
+ensureHashTraceProjects :: IO FilePath
+ensureHashTraceProjects = do
+  ensureCasesProject
+  depDir <- ensureDepProject casesProjDir "big"
+  pure depDir
+
+writeHashTraceBig :: FilePath -> T.Text -> Int -> IO ()
+writeHashTraceBig depDir usedResult unusedCount =
+  writeFileUtf8 (depDir </> "src" </> "big.act") $
+    T.unlines $
+      [ "def used():"
+      , "    return " <> usedResult
+      , ""
+      ]
+      ++ concatMap unusedDef [1 .. unusedCount]
+  where
+    unusedDef i =
+      [ T.pack ("def unused" ++ show i ++ "() -> int:")
+      , T.pack ("    return " ++ show i)
+      , ""
+      ]
+
+writeHashTraceSmall :: IO ()
+writeHashTraceSmall =
+  writeFileUtf8 (casesSrcDir </> "small.act") $ T.unlines
+    [ "import big"
+    , ""
+    , "def value():"
+    , "    return big.used()"
+    ]
+
+writeHashTraceMain :: IO ()
+writeHashTraceMain =
+  writeFileUtf8 (casesSrcDir </> "main.act") $ T.unlines
+    [ "import small"
+    , ""
+    , "actor main(env: Env):"
+    , "    print(small.value())"
+    , "    env.exit(0)"
+    ]
+
+buildHashTraceRoot :: IO ()
+buildHashTraceRoot = do
+  res <- runActonIn casesProjDir (["build", "--color", "never"] ++ hashTraceBuildArgs)
+  assertExitSuccess "build hash trace root" res
+
+buildHashTraceDep :: FilePath -> IO ()
+buildHashTraceDep depDir = do
+  res <- runActonIn depDir ["build", "--color", "never", "--skip-build"]
+  assertExitSuccess "build dependency big" res
+
+hashTraceBuildArgs :: [String]
+hashTraceBuildArgs = ["--skip-build", "--searchpath", "deps/big/out/types"]
+
 -- Main -----------------------------------------------------------------------
 
 -- | Tasty entry point for incremental tests.
@@ -2403,5 +2561,8 @@ main = defaultMain $ localOption (NumThreads 1) $ testGroup "incremental"
       , p44_provider_import_rename_reruns_dependent_front
       , p45_tydb_records_local_name_dependencies
       , p46_huge_module_skips_doc_output
+      , p47_unchanged_dep_reads_module_hashes_only
+      , p48_unrelated_dep_addition_reads_used_name_only
+      , p49_changed_dep_name_reads_users
       ]
   ]

--- a/compiler/lib/bench/CompilerBench.hs
+++ b/compiler/lib/bench/CompilerBench.hs
@@ -165,7 +165,7 @@ resolveNameHashMap paths mn = do
       Just ty -> do
         mh <- InterfaceFiles.readHeaderMaybe ty
         return $ case mh of
-          Just (_, _, _, _, _, nameHashes, _, _, _) -> Just (nameHashMapFromHeader nameHashes)
+          Just (_, _, _, _, _, _, nameHashes, _, _, _) -> Just (nameHashMapFromHeader nameHashes)
           Nothing -> Nothing
 
 resolveDepHashMap :: String
@@ -763,6 +763,7 @@ runCompilerFront buildFront runBack typesPath sourcePath = do
       srcBytes
       Nothing
       (Compile.getPubHashCached paths)
+      (Compile.getImplHashCached paths)
       (resolveNameHashMap paths)
       (\_ -> return ())
       (\_ _ -> return ())

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -219,6 +219,7 @@ import qualified Acton.Deactorizer
 import qualified Acton.LambdaLifter
 import qualified Acton.Boxing
 import qualified Acton.CodeGen
+import Acton.Builtin (mBuiltin)
 import Acton.Prim (mPrim)
 import qualified Acton.BuildSpec as BuildSpec
 import qualified Acton.DocPrinter as DocP
@@ -2413,7 +2414,11 @@ runFrontPasses gopts opts dbpBlocked paths env0 parsed srcContent srcBytes sourc
       let moduleSrcBytesHash = SHA256.hash srcBytes
       evaluate (rnf moduleSrcBytesHash)
       -- Import hashes are recorded in the .tydb header so dep changes can be detected.
-      impsRes <- resolveImportHashes imps
+      let hashImps =
+            if mn == mBuiltin
+              then imps
+              else nub (mBuiltin : imps)
+      impsRes <- resolveImportHashes hashImps
       case impsRes of
         Left diags -> return (Left diags)
         Right impsWithHash -> do
@@ -3376,7 +3381,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
             errsToDiagnostics "Compilation error" (modNameToFilename mn) ""
               [(NoLoc, label ++ " hash missing for " ++ prstr qn ++ users)]
 
-          checkMissingImports imps = do
+          checkImportHashes imps = do
             userSearchAbs <- mapM normalizePathSafe (C.searchpath optsT)
             systemTypesAbs <- mapM normalizePathSafe (systemTypePaths (sysPath paths) (sysTypes paths))
             searchAbs <- mapM normalizePathSafe (searchPath paths)
@@ -3394,24 +3399,30 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                       path' = normalise path
                   in Data.List.isPrefixOf dir' path'
                 isManagedTyPath path = any (\dir -> isUnder dir path) managedTypeDirs
-            missing <- foldM
-              (\acc (depMn, _depHash) ->
-                 if M.member depMn providers
-                   then return acc
-                   else do
-                     mTy <- getTyFileCached (searchPath paths) depMn
-                     case mTy of
-                       Nothing -> return (Data.Set.insert depMn acc)
-                       Just tyPath -> do
-                         tyAbs <- normalizePathSafe tyPath
-                         if isManagedTyPath tyAbs
-                           then return (Data.Set.insert depMn acc)
-                           else return acc
+            (missing, changed) <- foldM
+              (\(missingAcc, changedAcc) (depMn, depHash) -> do
+                 mh <- resolveImportHash depMn
+                 case mh of
+                   Just currentHash
+                     | currentHash == depHash -> return (missingAcc, changedAcc)
+                     | otherwise -> return (missingAcc, Data.Set.insert depMn changedAcc)
+                   Nothing ->
+                     if M.member depMn providers
+                       then return (missingAcc, Data.Set.insert depMn changedAcc)
+                       else do
+                         mTy <- getTyFileCached (searchPath paths) depMn
+                         case mTy of
+                           Nothing -> return (Data.Set.insert depMn missingAcc, changedAcc)
+                           Just tyPath -> do
+                             tyAbs <- normalizePathSafe tyPath
+                             if isManagedTyPath tyAbs
+                               then return (Data.Set.insert depMn missingAcc, changedAcc)
+                               else return (missingAcc, Data.Set.insert depMn changedAcc)
               )
-              Data.Set.empty
+              (Data.Set.empty, Data.Set.empty)
               imps
             if Data.Set.null missing
-              then return (Right ())
+              then return (Right changed)
               else do
                 let missingSorted = Data.List.sortOn modNameToString (Data.Set.toList missing)
                     diags = concatMap (\depMn -> missingIfaceDiagnostics mn "" depMn) missingSorted
@@ -3424,8 +3435,21 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                  else Left (concat errs)
           traverseDiags f items = collectDiags <$> mapM f items
 
+          qnameModule qn = case qn of
+            A.GName m _ -> Just m
+            A.QName m _ -> Just m
+            A.NoQ _ -> Nothing
+
+          depMapIf getDeps keep infos =
+            M.fromListWith (\a _ -> a)
+              [ dep
+              | info <- infos
+              , dep@(qn, _) <- getDeps info
+              , keep qn
+              ]
+
           depMap getDeps infos =
-            M.fromListWith (\a _ -> a) (concatMap getDeps infos)
+            depMapIf getDeps (const True) infos
 
           depUsers getDeps infos =
             foldl' add M.empty infos
@@ -3564,17 +3588,25 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
         _ -> do
           -- For cached .tydb tasks, compare recorded dep hashes against current deps.
           -- This is the up-to-date check that decides if we can skip work. If
-          -- any implDeps have changed we need to rerun out back passes and if
+          -- any implDeps have changed we need to rerun our back passes and if
           -- any pubDeps have changed we need to rerun front passes (and back
-          -- passes)
+          -- passes). Unchanged import pub hashes let us skip checking public
+          -- name deps from those modules.
           needByDepsRes <- case taskCurrent of
             TyTask{ tyImports = imps, tyNameHashes = nameHashes } -> do
-              missingImportsRes <- checkMissingImports imps
-              case missingImportsRes of
+              importHashRes <- checkImportHashes imps
+              case importHashRes of
                 Left diags -> return (Left diags)
-                Right () -> do
-              -- Build dep maps and reverse "used by" index for logging.
-                  let pubDeps = depMap InterfaceFiles.nhPubDeps nameHashes
+                Right changedPubImports -> do
+                  let importModules = Data.Set.fromList (map fst imps)
+                      checkPubDep qn =
+                        case qnameModule qn of
+                          Just depMn ->
+                            Data.Set.notMember depMn importModules ||
+                            Data.Set.member depMn changedPubImports
+                          Nothing -> True
+                  -- Build dep maps and reverse "used by" index for logging.
+                  let pubDeps = depMapIf InterfaceFiles.nhPubDeps checkPubDep nameHashes
                       implDeps = depMap InterfaceFiles.nhImplDeps nameHashes
                       pubUsers = depUsers InterfaceFiles.nhPubDeps nameHashes
                       implUsers = depUsers InterfaceFiles.nhImplDeps nameHashes

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -958,9 +958,9 @@ getPubHashCached paths mn = modifyMVar pubHashCache $ \m -> do
       mty <- getTyFileCached (searchPath paths) mn
       case mty of
         Just ty -> do
-          hdr <- InterfaceFiles.readHeaderMaybe ty
-          case hdr of
-            Just (_sourceMetaH, _srcH, ih, _implH, _impsH, _depModulesH, _nameHashesH, _rootsH, _testsH, _docH) -> return (M.insert mn ih m, Just ih)
+          hashes <- InterfaceFiles.readModuleHashesMaybe ty
+          case hashes of
+            Just (_srcH, ih, _implH) -> return (M.insert mn ih m, Just ih)
             Nothing -> return (m, Nothing)
         Nothing -> return (m, Nothing)
 
@@ -978,9 +978,9 @@ getImplHashCached paths mn = modifyMVar implHashCache $ \m -> do
       mty <- getTyFileCached (searchPath paths) mn
       case mty of
         Just ty -> do
-          hdr <- InterfaceFiles.readHeaderMaybe ty
-          case hdr of
-            Just (_sourceMetaH, _srcH, _pubH, ih, _impsH, _depModulesH, _nameHashesH, _rootsH, _testsH, _docH) -> return (M.insert mn ih m, Just ih)
+          hashes <- InterfaceFiles.readModuleHashesMaybe ty
+          case hashes of
+            Just (_srcH, _pubH, ih) -> return (M.insert mn ih m, Just ih)
             Nothing -> return (m, Nothing)
         Nothing -> return (m, Nothing)
 
@@ -1013,6 +1013,19 @@ getNameHashMapCached paths mn = modifyMVar nameHashCache $ \m -> do
               let hm = nameHashMapFromList (publicNameHashes nameHashes)
               return (M.insert mn hm m, Just hm)
             Nothing -> return (m, Nothing)
+        Nothing -> return (m, Nothing)
+
+-- | Read one cached name hash without decoding all per-name hash rows.
+getNameHashCached :: Paths -> A.ModName -> A.Name -> IO (Maybe InterfaceFiles.NameHashInfo)
+getNameHashCached paths mn n = modifyMVar nameHashCache $ \m -> do
+  case M.lookup mn m of
+    Just hm -> return (m, M.lookup n hm)
+    Nothing -> do
+      mty <- getTyFileCached (searchPath paths) mn
+      case mty of
+        Just ty -> do
+          nh <- InterfaceFiles.readNameHashMaybe ty n
+          return (m, nh)
         Nothing -> return (m, Nothing)
 
 -- | Update the name-hash cache after a successful compile.
@@ -3412,31 +3425,41 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
               Just depKey ->
                 case M.lookup depKey pubMap of
                   Just h  -> return (Just h)
-                  Nothing ->
-                    if M.member depKey taskMap
-                      then error ("Internal error: missing pub hash for dep " ++ modNameToString m)
-                      else getPubHashCached paths m
+                  Nothing
+                    | isBuiltinKey depKey -> getPubHashCached paths m
+                    | M.member depKey taskMap -> error ("Internal error: missing pub hash for dep " ++ modNameToString m)
+                    | otherwise -> getPubHashCached paths m
               Nothing -> getPubHashCached paths m
           resolveImportImplHash m =
             case M.lookup m providers of
               Just depKey ->
                 case M.lookup depKey implMap of
                   Just h  -> return (Just h)
-                  Nothing ->
-                    if M.member depKey taskMap
-                      then error ("Internal error: missing impl hash for dep " ++ modNameToString m)
-                      else getImplHashCached paths m
+                  Nothing
+                    | isBuiltinKey depKey -> getImplHashCached paths m
+                    | M.member depKey taskMap -> error ("Internal error: missing impl hash for dep " ++ modNameToString m)
+                    | otherwise -> getImplHashCached paths m
               Nothing -> getImplHashCached paths m
           resolveNameHashMap' m =
             case M.lookup m providers of
               Just depKey ->
                 case M.lookup depKey nameMap of
                   Just hm -> return (Just hm)
-                  Nothing ->
-                    if M.member depKey taskMap
-                      then error ("Internal error: missing name hashes for dep " ++ modNameToString m)
-                      else getNameHashMapCached paths m
+                  Nothing
+                    | isBuiltinKey depKey -> getNameHashMapCached paths m
+                    | M.member depKey taskMap -> error ("Internal error: missing name hashes for dep " ++ modNameToString m)
+                    | otherwise -> getNameHashMapCached paths m
               Nothing -> getNameHashMapCached paths m
+          resolveNameHash' m n =
+            case M.lookup m providers of
+              Just depKey ->
+                case M.lookup depKey nameMap of
+                  Just hm -> return (M.lookup n hm)
+                  Nothing
+                    | isBuiltinKey depKey -> getNameHashCached paths m n
+                    | M.member depKey taskMap -> error ("Internal error: missing name hashes for dep " ++ modNameToString m)
+                    | otherwise -> getNameHashCached paths m n
+              Nothing -> getNameHashCached paths m n
 
           missingNameHashDiagnostics qn =
             errsToDiagnostics "Compilation error" (modNameToFilename mn) ""
@@ -3652,7 +3675,10 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                           , pubH /= InterfaceFiles.dmiPubHash depInfo
                           , implH /= InterfaceFiles.dmiImplHash depInfo
                           )
-                  _ -> Left (missingIfaceDiagnostics mn "" depMn)
+                  _ ->
+                    -- Stale dep rows may mention a removed transitive provider;
+                    -- the per-name rows decide whether any used name is affected.
+                    Right (depMn, True, True)
 
               foldRows rows =
                 ( Data.Set.fromList [ depMn | (depMn, pubChanged, _implChanged) <- rows, pubChanged ]
@@ -3663,50 +3689,54 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
             let changedMods =
                   Data.List.sortOn modNameToString $
                   Data.Set.toList (Data.Set.union changedPubMods changedImplMods)
-            foldM checkModule ([], [], [], [], M.empty, M.empty) changedMods
+            foldM checkModule ([], [], [], [], M.empty, M.empty, Data.Set.empty) changedMods
             where
               checkModule acc depMn = do
                 depNames <- InterfaceFiles.readDepNames tyFile depMn
-                mhm <- resolveNameHashMap' depMn
-                foldM (checkName depMn mhm) acc depNames
+                if null depNames
+                  then return (noteMissingRows depMn acc)
+                  else foldM (checkName depMn) acc depNames
 
-              checkName depMn mhm acc depInfo = do
+              noteMissingRows depMn acc@(pubDeltas, implDeltas, pubMissing, implMissing, pubUsers, implUsers, rowMissingMods)
+                | Data.Set.member depMn changedPubMods || Data.Set.member depMn changedImplMods =
+                    (pubDeltas, implDeltas, pubMissing, implMissing, pubUsers, implUsers, Data.Set.insert depMn rowMissingMods)
+                | otherwise = acc
+
+              checkName depMn acc depInfo = do
                 let depName = InterfaceFiles.dniName depInfo
                     qn = A.GName depMn depName
-                    current getHash =
-                      case mhm >>= M.lookup depName of
-                        Nothing -> Nothing
-                        Just info ->
-                          let h = getHash info
-                          in if B.null h then Nothing else Just h
+                    current getHash info =
+                      let h = getHash info
+                      in if B.null h then Nothing else Just h
                     checkPub = Data.Set.member depMn changedPubMods && not (B.null (InterfaceFiles.dniPubHash depInfo))
                     checkImpl = Data.Set.member depMn changedImplMods && not (B.null (InterfaceFiles.dniImplHash depInfo))
+                mInfo <- resolveNameHash' depMn depName
                 acc1 <- if checkPub
-                          then addPub depMn depName qn (InterfaceFiles.dniPubHash depInfo) (current InterfaceFiles.nhPubHash) acc
+                          then addPub depMn depName qn (InterfaceFiles.dniPubHash depInfo) (mInfo >>= current InterfaceFiles.nhPubHash) acc
                           else return acc
                 if checkImpl
-                  then addImpl depMn depName qn (InterfaceFiles.dniImplHash depInfo) (current InterfaceFiles.nhImplHash) acc1
+                  then addImpl depMn depName qn (InterfaceFiles.dniImplHash depInfo) (mInfo >>= current InterfaceFiles.nhImplHash) acc1
                   else return acc1
 
-              addPub depMn depName qn old mNew acc@(pubDeltas, implDeltas, pubMissing, implMissing, pubUsers, implUsers) =
+              addPub depMn depName qn old mNew acc@(pubDeltas, implDeltas, pubMissing, implMissing, pubUsers, implUsers, rowMissingMods) =
                 case mNew of
                   Just new | new == old -> return acc
                   Just new -> do
                     users <- InterfaceFiles.readDepUsers tyFile depMn depName
-                    return ((qn, old, new) : pubDeltas, implDeltas, pubMissing, implMissing, M.insert qn (InterfaceFiles.duPubUsers users) pubUsers, implUsers)
+                    return ((qn, old, new) : pubDeltas, implDeltas, pubMissing, implMissing, M.insert qn (InterfaceFiles.duPubUsers users) pubUsers, implUsers, rowMissingMods)
                   Nothing -> do
                     users <- InterfaceFiles.readDepUsers tyFile depMn depName
-                    return (pubDeltas, implDeltas, qn : pubMissing, implMissing, M.insert qn (InterfaceFiles.duPubUsers users) pubUsers, implUsers)
+                    return (pubDeltas, implDeltas, qn : pubMissing, implMissing, M.insert qn (InterfaceFiles.duPubUsers users) pubUsers, implUsers, rowMissingMods)
 
-              addImpl depMn depName qn old mNew acc@(pubDeltas, implDeltas, pubMissing, implMissing, pubUsers, implUsers) =
+              addImpl depMn depName qn old mNew acc@(pubDeltas, implDeltas, pubMissing, implMissing, pubUsers, implUsers, rowMissingMods) =
                 case mNew of
                   Just new | new == old -> return acc
                   Just new -> do
                     users <- InterfaceFiles.readDepUsers tyFile depMn depName
-                    return (pubDeltas, (qn, old, new) : implDeltas, pubMissing, implMissing, pubUsers, M.insert qn (InterfaceFiles.duImplUsers users) implUsers)
+                    return (pubDeltas, (qn, old, new) : implDeltas, pubMissing, implMissing, pubUsers, M.insert qn (InterfaceFiles.duImplUsers users) implUsers, rowMissingMods)
                   Nothing -> do
                     users <- InterfaceFiles.readDepUsers tyFile depMn depName
-                    return (pubDeltas, implDeltas, pubMissing, qn : implMissing, pubUsers, M.insert qn (InterfaceFiles.duImplUsers users) implUsers)
+                    return (pubDeltas, implDeltas, pubMissing, qn : implMissing, pubUsers, M.insert qn (InterfaceFiles.duImplUsers users) implUsers, rowMissingMods)
 
       case taskCurrent of
         ParseErrorTask{ parseDiagnostics = diags } -> return (key, Left diags)
@@ -3745,18 +3775,18 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                     Left diags -> return (Left diags)
                     Right (changedPubMods, changedImplMods) ->
                       if Data.Set.null changedPubMods && Data.Set.null changedImplMods
-                        then return (Right ([], [], [], [], M.empty, M.empty))
+                        then return (Right ([], [], [], [], M.empty, M.empty, Data.Set.empty))
                         else Right <$> checkDepNameRows changedPubMods changedImplMods
             -- Source tasks always run front passes, so deps are irrelevant.
-            _ -> return (Right ([], [], [], [], M.empty, M.empty))
+            _ -> return (Right ([], [], [], [], M.empty, M.empty, Data.Set.empty))
 
           case needByDepsRes of
             Left diags -> return (key, Left diags)
-            Right (pubDeltas, implDeltas, pubMissing, implMissing, pubUsers, implUsers) -> do
+            Right (pubDeltas, implDeltas, pubMissing, implMissing, pubUsers, implUsers, rowMissingMods) -> do
               let needBySource = case taskCurrent of { ParseTask{} -> True; ActonTask{} -> True; _ -> False }
                   -- Public deltas require front passes; impl deltas only need back jobs.
                   needByPub = not (null pubDeltas)
-                  needByMissing = not (null pubMissing) || not (null implMissing)
+                  needByMissing = not (null pubMissing) || not (null implMissing) || not (Data.Set.null rowMissingMods)
                   needByImpl = not (null implDeltas)
                   forceAlt    = altOutput optsT && mn == rootAlt
                   forceAlways = C.alwaysbuild optsT
@@ -3800,7 +3830,11 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                                   [ "impl " ++ fmtMissing implUsers qn
                                   | qn <- Data.List.sortOn Hashing.qnameKey implMissing
                                   ]
-                            ccOnInfo callbacks ("  Stale " ++ modNameToString mn ++ ": missing dep hashes in " ++ Data.List.intercalate ", " (pubMissingItems ++ implMissingItems))
+                                rowMissingItems =
+                                  [ "rows " ++ modNameToString depMn
+                                  | depMn <- Data.List.sortOn modNameToString (Data.Set.toList rowMissingMods)
+                                  ]
+                            ccOnInfo callbacks ("  Stale " ++ modNameToString mn ++ ": missing dep hashes in " ++ Data.List.intercalate ", " (pubMissingItems ++ implMissingItems ++ rowMissingItems))
                     t' <- case taskCurrent of
                             ActonTask{} -> return taskCurrent
                             _ -> materializeTask optsT sp mn actFile Nothing taskCurrent

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -188,6 +188,7 @@ module Acton.Compile
   , altOutput
   , missingIfaceDiagnostics
   , getPubHashCached
+  , getImplHashCached
   , updatePubHashCache
   , rootEligible
   , normalizePathSafe
@@ -903,7 +904,8 @@ getModPath path mn =
 -- this process see the new public hash.
 --
 -- tyPathCache    :: ModName -> absolute .tydb path (resolved from searchPath)
--- pubHashCache :: ModName -> current public hash (from header or compile)
+-- pubHashCache   :: ModName -> current public hash (from header or compile)
+-- implHashCache  :: ModName -> current implementation hash (from header or compile)
 -- nameHashCache  :: ModName -> per-name hash info (from header or compile)
 {-# NOINLINE tyPathCache #-}
 tyPathCache :: MVar (M.Map A.ModName FilePath)
@@ -912,6 +914,10 @@ tyPathCache = unsafePerformIO (newMVar M.empty)
 {-# NOINLINE pubHashCache #-}
 pubHashCache :: MVar (M.Map A.ModName B.ByteString)
 pubHashCache = unsafePerformIO (newMVar M.empty)
+
+{-# NOINLINE implHashCache #-}
+implHashCache :: MVar (M.Map A.ModName B.ByteString)
+implHashCache = unsafePerformIO (newMVar M.empty)
 
 {-# NOINLINE nameHashCache #-}
 nameHashCache :: MVar (M.Map A.ModName (M.Map A.Name InterfaceFiles.NameHashInfo))
@@ -954,7 +960,7 @@ getPubHashCached paths mn = modifyMVar pubHashCache $ \m -> do
         Just ty -> do
           hdr <- InterfaceFiles.readHeaderMaybe ty
           case hdr of
-            Just (_sourceMetaH, _srcH, ih, _implH, _impsH, _nameHashesH, _rootsH, _testsH, _docH) -> return (M.insert mn ih m, Just ih)
+            Just (_sourceMetaH, _srcH, ih, _implH, _impsH, _depModulesH, _nameHashesH, _rootsH, _testsH, _docH) -> return (M.insert mn ih m, Just ih)
             Nothing -> return (m, Nothing)
         Nothing -> return (m, Nothing)
 
@@ -962,6 +968,25 @@ getPubHashCached paths mn = modifyMVar pubHashCache $ \m -> do
 -- Keeps in-process dependency checks consistent for later modules.
 updatePubHashCache :: A.ModName -> B.ByteString -> IO ()
 updatePubHashCache mn ih = modifyMVar_ pubHashCache $ \m -> return (M.insert mn ih m)
+
+-- | Read a module's implementation hash using the cache and .tydb header.
+getImplHashCached :: Paths -> A.ModName -> IO (Maybe B.ByteString)
+getImplHashCached paths mn = modifyMVar implHashCache $ \m -> do
+  case M.lookup mn m of
+    Just ih -> return (m, Just ih)
+    Nothing -> do
+      mty <- getTyFileCached (searchPath paths) mn
+      case mty of
+        Just ty -> do
+          hdr <- InterfaceFiles.readHeaderMaybe ty
+          case hdr of
+            Just (_sourceMetaH, _srcH, _pubH, ih, _impsH, _depModulesH, _nameHashesH, _rootsH, _testsH, _docH) -> return (M.insert mn ih m, Just ih)
+            Nothing -> return (m, Nothing)
+        Nothing -> return (m, Nothing)
+
+-- | Update the implementation-hash cache after a successful compile.
+updateImplHashCache :: A.ModName -> B.ByteString -> IO ()
+updateImplHashCache mn ih = modifyMVar_ implHashCache $ \m -> return (M.insert mn ih m)
 
 -- | Build a name hash map keyed by Name.
 nameHashMapFromList :: [InterfaceFiles.NameHashInfo] -> M.Map A.Name InterfaceFiles.NameHashInfo
@@ -984,7 +1009,7 @@ getNameHashMapCached paths mn = modifyMVar nameHashCache $ \m -> do
         Just ty -> do
           hdr <- InterfaceFiles.readHeaderMaybe ty
           case hdr of
-            Just (_sourceMetaH, _srcH, _ih, _implH, _impsH, nameHashes, _rootsH, _testsH, _docH) -> do
+            Just (_sourceMetaH, _srcH, _ih, _implH, _impsH, _depModulesH, nameHashes, _rootsH, _testsH, _docH) -> do
               let hm = nameHashMapFromList (publicNameHashes nameHashes)
               return (M.insert mn hm m, Just hm)
             Nothing -> return (m, Nothing)
@@ -1168,6 +1193,7 @@ data FrontResult = FrontResult
   , frImps     :: [A.ModName]
   , frDoc      :: Maybe String
   , frPubHash :: B.ByteString
+  , frImplHash :: B.ByteString
   , frNameHashes :: [InterfaceFiles.NameHashInfo]
   , frInterestDeps :: Data.Set.Set (A.ModName, A.Name)
   , frFrontTime :: Maybe TimeSpec
@@ -1433,6 +1459,7 @@ data CompileTask        = ParseTask { name :: A.ModName, src :: String, srcBytes
                                     , tyPubHash :: B.ByteString          -- module public hash
                                     , tyImplHash :: B.ByteString         -- module impl hash
                                     , tyImports :: [(A.ModName, B.ByteString)] -- imports with pub hash used
+                                    , tyDepModules :: [InterfaceFiles.DepModuleInfo]
                                     , tyNameHashes :: [InterfaceFiles.NameHashInfo]
                                     , tyRoots :: [A.Name]
                                     , tyTests :: [String]
@@ -1795,6 +1822,7 @@ data ModuleHead
       , mhPubHash    :: B.ByteString
       , mhImplHash   :: B.ByteString
       , mhTyImports  :: [(A.ModName, B.ByteString)]
+      , mhDepModules :: [InterfaceFiles.DepModuleInfo]
       , mhNameHashes :: [InterfaceFiles.NameHashInfo]
       , mhRoots      :: [A.Name]
       , mhTests      :: [String]
@@ -1834,7 +1862,7 @@ readModuleHeader sp gopts opts paths actFile = do
         hdrE <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readHeader tyFile
         case hdrE of
           Left _ -> readSourceHead mn
-          Right (cachedSourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash, imps, nameHashes, roots, tests, mdoc) -> do
+          Right (cachedSourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash, imps, depModules, nameHashes, roots, tests, mdoc) -> do
             tyMTimeNs <- InterfaceFiles.interfaceModifiedTimeNs tyFile
             newCompiler <- compilerNewerThan tyMTimeNs
             mOverlay <- Source.spReadOverlay sp actFile
@@ -1842,27 +1870,28 @@ readModuleHeader sp gopts opts paths actFile = do
               Just snap ->
                 if newCompiler
                   then sourceHeadFromSnapshot mn snap
-                  else verifyOrParse mn snap moduleSrcBytesHash modulePubHash moduleImplHash cachedSourceMeta Nothing imps nameHashes roots tests mdoc
+                  else verifyOrParse mn snap moduleSrcBytesHash modulePubHash moduleImplHash cachedSourceMeta Nothing imps depModules nameHashes roots tests mdoc
               Nothing -> do
                 if newCompiler
                   then readSourceHead mn
                   else do
                     currentSourceMeta <- readSourceFileMeta actFile
                     if canReuseHeader cachedSourceMeta currentSourceMeta tyMTimeNs
-                      then return (mkTyHead mn moduleSrcBytesHash modulePubHash moduleImplHash imps nameHashes roots tests mdoc)
+                      then return (mkTyHead mn moduleSrcBytesHash modulePubHash moduleImplHash imps depModules nameHashes roots tests mdoc)
                       else do
                         snap <- Source.spReadFile sp actFile
-                        verifyOrParse mn snap moduleSrcBytesHash modulePubHash moduleImplHash cachedSourceMeta (Just currentSourceMeta) imps nameHashes roots tests mdoc
+                        verifyOrParse mn snap moduleSrcBytesHash modulePubHash moduleImplHash cachedSourceMeta (Just currentSourceMeta) imps depModules nameHashes roots tests mdoc
   where
     fileStatusMTimeNs st = floor (toRational (modificationTimeHiRes st) * 1000000000)
 
-    mkTyHead mn moduleSrcBytesHash modulePubHash moduleImplHash imps nameHashes roots tests mdoc =
+    mkTyHead mn moduleSrcBytesHash modulePubHash moduleImplHash imps depModules nameHashes roots tests mdoc =
       TyHead
         { mhName       = mn
         , mhSrcHash    = moduleSrcBytesHash
         , mhPubHash    = modulePubHash
         , mhImplHash   = moduleImplHash
         , mhTyImports  = imps
+        , mhDepModules = depModules
         , mhNameHashes = nameHashes
         , mhRoots      = roots
         , mhTests      = tests
@@ -1911,10 +1940,10 @@ readModuleHeader sp gopts opts paths actFile = do
       tyRes <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readFile tyFilePath
       case tyRes of
         Left _ -> return ()
-        Right (_ms, nmod, tmod, _oldSourceMeta, srcHash, pubHash, implHash, imps, nameHashes, roots, tests, mdoc) ->
-          InterfaceFiles.writeFile tyFilePath srcHash pubHash implHash currentSourceMeta imps nameHashes roots tests mdoc nmod tmod
+        Right (_ms, nmod, tmod, _oldSourceMeta, srcHash, pubHash, implHash, imps, depModules, nameHashes, roots, tests, mdoc) ->
+          InterfaceFiles.writeFile tyFilePath srcHash pubHash implHash currentSourceMeta imps depModules nameHashes roots tests mdoc nmod tmod
 
-    verifyOrParse mn snap moduleSrcBytesHash modulePubHash moduleImplHash cachedSourceMeta currentSourceMeta imps nameHashes roots tests mdoc = do
+    verifyOrParse mn snap moduleSrcBytesHash modulePubHash moduleImplHash cachedSourceMeta currentSourceMeta imps depModules nameHashes roots tests mdoc = do
       let curHash = SHA256.hash (Source.ssBytes snap)
           short8 bs = take 8 (B.unpack $ Base16.encode bs)
           same = curHash == moduleSrcBytesHash
@@ -1933,7 +1962,7 @@ readModuleHeader sp gopts opts paths actFile = do
         then do
           when (currentSourceMeta /= Nothing && currentSourceMeta /= cachedSourceMeta) $
             refreshCachedSourceMeta currentSourceMeta
-          return (mkTyHead mn moduleSrcBytesHash modulePubHash moduleImplHash imps nameHashes roots tests mdoc)
+          return (mkTyHead mn moduleSrcBytesHash modulePubHash moduleImplHash imps depModules nameHashes roots tests mdoc)
         else sourceHeadFromSnapshot mn snap
 
 -- | Prepare a task for dependency graph construction.
@@ -1948,6 +1977,7 @@ readModuleTask sp gopts opts paths actFile = do
           , mhPubHash = pubHash
           , mhImplHash = implHash
           , mhTyImports = imps
+          , mhDepModules = depModules
           , mhNameHashes = nameHashes
           , mhRoots = roots
           , mhTests = tests
@@ -1960,6 +1990,7 @@ readModuleTask sp gopts opts paths actFile = do
                 , tyPubHash  = pubHash
                 , tyImplHash = implHash
                 , tyImports  = imps
+                , tyDepModules = depModules
                 , tyNameHashes = nameHashes
                 , tyRoots   = roots
                 , tyTests   = tests
@@ -2076,9 +2107,9 @@ readImports sp gopts opts paths tasks = do
 quiet :: C.GlobalOptions -> C.CompileOptions -> Bool
 quiet gopts opts = C.quiet gopts || altOutput opts
 
--- | Read an interface from a .tydb file and return its NameInfo and public hash.
+-- | Read an interface from a .tydb file and return its NameInfo and module hashes.
 -- This is used when a module is deemed fresh and we want to avoid reparsing.
-readIfaceFromTy :: Paths -> A.ModName -> String -> Maybe B.ByteString -> IO (Either [Diagnostic String] ([A.ModName], [(A.Name, I.NameInfo)], Maybe String, B.ByteString))
+readIfaceFromTy :: Paths -> A.ModName -> String -> Maybe B.ByteString -> IO (Either [Diagnostic String] ([A.ModName], [(A.Name, I.NameInfo)], Maybe String, B.ByteString, B.ByteString))
 readIfaceFromTy paths mn src mHash = do
     mty <- Acton.Env.findTyFile (searchPath paths) mn
     case mty of
@@ -2087,17 +2118,13 @@ readIfaceFromTy paths mn src mHash = do
         fileRes <- InterfaceFiles.readFileMaybe tyF
         case fileRes of
           Nothing -> return $ Left (missingIfaceDiagnostics mn src mn)
-          Just (_ms, nmod, _tmod, _sourceMeta, _srcH, _pubH, _implH, _imps, _nameHashes, _roots, _tests, _tm) -> do
+          Just (_ms, nmod, _tmod, _sourceMeta, _srcH, pubH, implH, _imps, _depModules, _nameHashes, _roots, _tests, _tm) -> do
             let I.NModule ms teFull mdoc = nmod
                 te = publicIfaceTE teFull
             ih <- case mHash of
                     Just h -> return h
-                    Nothing -> do
-                      hdr <- InterfaceFiles.readHeaderMaybe tyF
-                      case hdr of
-                        Just (_sourceMetaH, _srcH, ihash, _implH, _impsH, _nameHashesH, _rootsH, _testsH, _docH) -> return ihash
-                        Nothing -> return B.empty
-            return $ Right (ms, te, mdoc, ih)
+                    Nothing -> return pubH
+            return $ Right (ms, te, mdoc, ih, implH)
 
 
 -- | Snapshot of expected/recorded impl hashes for generated code.
@@ -2175,6 +2202,7 @@ runFrontPasses :: C.GlobalOptions
                -> B.ByteString
                -> Maybe InterfaceFiles.SourceFileMeta
                -> (A.ModName -> IO (Maybe B.ByteString))
+               -> (A.ModName -> IO (Maybe B.ByteString))
                -> (A.ModName -> IO (Maybe (M.Map A.Name InterfaceFiles.NameHashInfo)))
                -> (FrontPassProgress -> IO ())
                -> (TaskKey -> FrontOutputKind -> IO ())
@@ -2183,7 +2211,7 @@ runFrontPasses :: C.GlobalOptions
                -> IO Bool
                -> ([FrontOutputJob] -> IO ())
                -> IO (Either [Diagnostic String] FrontResult)
-runFrontPasses gopts opts dbpBlocked paths env0 parsed srcContent srcBytes sourceMeta resolveImportHash resolveNameHashMap onFrontProgress onFrontOutputStart onFrontOutputProgress onFrontOutputDone shouldWriteFrontOutput recordFrontOutputJobs = do
+runFrontPasses gopts opts dbpBlocked paths env0 parsed srcContent srcBytes sourceMeta resolveImportHash resolveImportImplHash resolveNameHashMap onFrontProgress onFrontOutputStart onFrontOutputProgress onFrontOutputDone shouldWriteFrontOutput recordFrontOutputJobs = do
   createDirectoryIfMissing True (getModPath (projTypes paths) mn)
   core
     `catch` handleGeneral
@@ -2223,6 +2251,24 @@ runFrontPasses gopts opts dbpBlocked paths env0 parsed srcContent srcBytes sourc
         case mh of
           Just ih -> return (Right (mref, ih))
           Nothing -> return (Left (missingIfaceDiagnostics mn srcContent mref))
+      let (errs, vals) = partitionEithers resolved
+      if null errs
+        then return (Right vals)
+        else return (Left (concat errs))
+
+    resolveDepModuleHashes :: [A.ModName] -> IO (Either [Diagnostic String] [InterfaceFiles.DepModuleInfo])
+    resolveDepModuleHashes mrefs = do
+      resolved <- forM mrefs $ \mref -> do
+        mpub <- resolveImportHash mref
+        mimpl <- resolveImportImplHash mref
+        case (mpub, mimpl) of
+          (Just pubH, Just implH) ->
+            return (Right InterfaceFiles.DepModuleInfo
+                      { InterfaceFiles.dmiModule = mref
+                      , InterfaceFiles.dmiPubHash = pubH
+                      , InterfaceFiles.dmiImplHash = implH
+                      })
+          _ -> return (Left (missingIfaceDiagnostics mn srcContent mref))
       let (errs, vals) = partitionEithers resolved
       if null errs
         then return (Right vals)
@@ -2460,9 +2506,11 @@ runFrontPasses gopts opts dbpBlocked paths env0 parsed srcContent srcBytes sourc
               extMods = Data.Set.toList (Hashing.externalModules pubExtDeps `Data.Set.union` Hashing.externalModules implExtDeps)
           evaluate (rnf (pubLocalDeps, pubExtDeps, extMods))
           extMapsRes <- resolveNameHashMaps extMods
-          case extMapsRes of
-            Left diags -> return (Left diags)
-            Right extMaps -> do
+          depModulesRes <- resolveDepModuleHashes extMods
+          case (extMapsRes, depModulesRes) of
+            (Left diags, _) -> return (Left diags)
+            (_, Left diags) -> return (Left diags)
+            (Right extMaps, Right depModules) -> do
               -- Resolve external deps to their recorded hashes.
               let pubSigExtRes = resolveDepHashes "pub" InterfaceFiles.nhPubHash pubSigExtDeps extMaps nameLocs
                   pubExtRes = resolveDepHashes "pub" InterfaceFiles.nhPubHash pubExtDeps extMaps nameLocs
@@ -2502,7 +2550,7 @@ runFrontPasses gopts opts dbpBlocked paths env0 parsed srcContent srcBytes sourc
                           (\p -> onFrontOutputProgress outputKey FrontOutputTydb (frontOutputTyDbProgress p))
                           A.version
                           (tyDbPath paths mn)
-                          moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta impsWithHash nameHashes roots tests mdoc nmod tchecked
+                          moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta impsWithHash depModules nameHashes roots tests mdoc nmod tchecked
                       writeDoc = do
                         let docDir = joinPath [projPath paths, "out", "doc"]
                             modPathList = A.modPath mn
@@ -2587,6 +2635,7 @@ runFrontPasses gopts opts dbpBlocked paths env0 parsed srcContent srcBytes sourc
                                                , frImps = imps
                                                , frDoc = mdoc
                                                , frPubHash = modulePubHash
+                                               , frImplHash = moduleImplHash
                                                , frNameHashes = publicNameHashes nameHashes
                                                , frInterestDeps = interestDepsFromNameHashes nameHashes
                                                , frFrontTime = frontTimeMaybe
@@ -2621,7 +2670,7 @@ prepareDeferredBackJob sp gopts callbacks envAcc interestMap dbj = do
       mn = dbjMod dbj
       tyFile = tyDbPath paths mn
       actFile = srcFile paths mn
-  (_sourceMeta, _moduleSrcBytesHash, _modulePubHash, _moduleImplHashStored, _imps, nameHashes, roots, _tests, _mdoc) <- InterfaceFiles.readHeader tyFile
+  (_sourceMeta, _moduleSrcBytesHash, _modulePubHash, _moduleImplHashStored, _imps, _depModules, nameHashes, roots, _tests, _mdoc) <- InterfaceFiles.readHeader tyFile
   let explicitSeeds = dbjSeeds dbj
       interested =
         if Data.Set.null explicitSeeds
@@ -2637,7 +2686,7 @@ prepareDeferredBackJob sp gopts callbacks envAcc interestMap dbj = do
       logDbpSelection gopts callbacks mn dbj (length nameHashes) (Data.Set.size interested) (Data.Set.size rootSeeds) (Data.Set.size (dnsSelectedNames nameSelection)) Nothing "generated code up to date"
       return Nothing
     else do
-      (_ms, _nmod, tmod, _sourceMetaFull, _moduleSrcBytesHashFull, _modulePubHashFull, _moduleImplHashStoredFull, _impsFull, _nameHashesFull, _rootsFull, _testsFull, _mdocFull) <- InterfaceFiles.readFile tyFile
+      (_ms, _nmod, tmod, _sourceMetaFull, _moduleSrcBytesHashFull, _modulePubHashFull, _moduleImplHashStoredFull, _impsFull, _depModulesFull, _nameHashesFull, _rootsFull, _testsFull, _mdocFull) <- InterfaceFiles.readFile tyFile
       snap <- Source.readSource sp actFile
       env1 <- Acton.Env.mkEnv (searchPath paths) envAcc tmod
       let selection = selectDbpModule (length nameHashes) (Data.Set.size interested) nameSelection tmod
@@ -3067,7 +3116,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
       let maxParallel = max 1 (if C.jobs gopts > 0 then C.jobs gopts else nCaps)
 
       logForcedDbpBoundaryExclusions
-      loop frontOutputRef runningRef stageInitialReady [] M.empty M.empty M.empty M.empty Data.Set.empty M.empty stageIndeg stagePending0 baseEnv False maxParallel cwMap
+      loop frontOutputRef runningRef stageInitialReady [] M.empty M.empty M.empty M.empty M.empty Data.Set.empty M.empty stageIndeg stagePending0 baseEnv False maxParallel cwMap
 
     -- Basic maps/sets ----------------------------------------------------
     taskMap = M.fromList [ (gtKey t, t) | t <- tasks ]
@@ -3243,6 +3292,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                 srcBytes
                 mSourceMeta
                 (getPubHashCached bPaths)
+                (getImplHashCached bPaths)
                 (getNameHashMapCached bPaths)
                 (\p -> ccOnFrontProgress callbacks t optsBuiltin p)
                 (ccOnFrontOutputStart callbacks)
@@ -3263,6 +3313,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                       ccOnFrontDone callbacks t optsBuiltin
                       ccOnFrontResult callbacks t optsBuiltin fr
                       updatePubHashCache mn (frPubHash fr)
+                      updateImplHashCache mn (frImplHash fr)
                       updateNameHashCache mn (frNameHashes fr)
                       forM_ (frBackJob fr) $ ccOnBackJob callbacks
                       return (Right ())
@@ -3271,11 +3322,12 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
     doOne :: Acton.Env.Env0
           -> IORef [FrontOutputJob]
           -> M.Map TaskKey B.ByteString
+          -> M.Map TaskKey B.ByteString
           -> M.Map TaskKey (M.Map A.Name InterfaceFiles.NameHashInfo)
           -> M.Map TaskKey CompileTask
           -> TaskKey
           -> IO (TaskKey, Either [Diagnostic String] FrontResult)
-    doOne envSnap frontOutputRef pubMap nameMap parsedTasks key = do
+    doOne envSnap frontOutputRef pubMap implMap nameMap parsedTasks key = do
       t <- case M.lookup key taskMap of
              Just x -> return x
              Nothing -> error ("Internal error: missing task for key " ++ show key)
@@ -3287,12 +3339,13 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
           actFile = srcFile paths mn
           tyFile = tyDbPath paths mn
           short8 bs   = take 8 (B.unpack $ Base16.encode bs)
-          mkFrontResult imps ifaceTE mdoc pubHash nameHashes interestNameHashes backJob deferredBackJob =
+          mkFrontResult imps ifaceTE mdoc pubHash implHash nameHashes interestNameHashes backJob deferredBackJob =
             FrontResult
               { frIfaceTE = ifaceTE
               , frImps = imps
               , frDoc = mdoc
               , frPubHash = pubHash
+              , frImplHash = implHash
               , frNameHashes = nameHashes
               , frInterestDeps = interestDepsFromNameHashes interestNameHashes
               , frFrontTime = Nothing
@@ -3308,6 +3361,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
               , frImps = []
               , frDoc = Nothing
               , frPubHash = B.empty
+              , frImplHash = B.empty
               , frNameHashes = []
               , frInterestDeps = Data.Set.empty
               , frFrontTime = Nothing
@@ -3333,6 +3387,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
           cacheFrontResult fr0 = do
             fr <- addCachedTyOutputJob fr0
             updatePubHashCache mn (frPubHash fr)
+            updateImplHashCache mn (frImplHash fr)
             updateNameHashCache mn (frNameHashes fr)
             return (key, Right fr)
           readTyFile = do
@@ -3362,6 +3417,16 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                       then error ("Internal error: missing pub hash for dep " ++ modNameToString m)
                       else getPubHashCached paths m
               Nothing -> getPubHashCached paths m
+          resolveImportImplHash m =
+            case M.lookup m providers of
+              Just depKey ->
+                case M.lookup depKey implMap of
+                  Just h  -> return (Just h)
+                  Nothing ->
+                    if M.member depKey taskMap
+                      then error ("Internal error: missing impl hash for dep " ++ modNameToString m)
+                      else getImplHashCached paths m
+              Nothing -> getImplHashCached paths m
           resolveNameHashMap' m =
             case M.lookup m providers of
               Just depKey ->
@@ -3435,28 +3500,6 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                  else Left (concat errs)
           traverseDiags f items = collectDiags <$> mapM f items
 
-          qnameModule qn = case qn of
-            A.GName m _ -> Just m
-            A.QName m _ -> Just m
-            A.NoQ _ -> Nothing
-
-          depMapIf getDeps keep infos =
-            M.fromListWith (\a _ -> a)
-              [ dep
-              | info <- infos
-              , dep@(qn, _) <- getDeps info
-              , keep qn
-              ]
-
-          depMap getDeps infos =
-            depMapIf getDeps (const True) infos
-
-          depUsers getDeps infos =
-            foldl' add M.empty infos
-            where
-              add acc info =
-                foldl' (\m (qn, _) -> M.insertWith (++) qn [InterfaceFiles.nhName info] m) acc (getDeps info)
-
           fmtUsers users qn =
             case M.lookup qn users of
               Nothing -> ""
@@ -3466,6 +3509,69 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                 in if null names
                      then ""
                      else " (used by " ++ intercalate ", " names ++ ")"
+
+          interestDepsFromDepRows depModules = do
+            depSets <- forM depModules $ \depInfo -> do
+              let depMn = InterfaceFiles.dmiModule depInfo
+              depNames <- InterfaceFiles.readDepNames tyFile depMn
+              return (Data.Set.fromList [ (depMn, InterfaceFiles.dniName depName) | depName <- depNames ])
+            return (Data.Set.unions depSets)
+
+          cachedInterestDeps = case taskCurrent of
+            TyTask{ tyDepModules = depModules } -> interestDepsFromDepRows depModules
+            _ -> return Data.Set.empty
+
+          restorePubDepsFromRows depModules nameHashes = do
+            byOwner <- foldM addModule M.empty depModules
+            return
+              [ nh { InterfaceFiles.nhPubDeps = M.findWithDefault [] (InterfaceFiles.nhName nh) byOwner }
+              | nh <- nameHashes
+              ]
+            where
+              addModule acc depInfo = do
+                let depMn = InterfaceFiles.dmiModule depInfo
+                depNames <- InterfaceFiles.readDepNames tyFile depMn
+                foldM (addName depMn) acc depNames
+
+              addName depMn acc depInfo = do
+                users <- InterfaceFiles.readDepUsers tyFile depMn (InterfaceFiles.dniName depInfo)
+                let dep =
+                      ( A.GName depMn (InterfaceFiles.dniName depInfo)
+                      , InterfaceFiles.dniPubHash depInfo
+                      )
+                    addUser m user =
+                      M.insertWith (++) user [dep] m
+                if B.null (InterfaceFiles.dniPubHash depInfo)
+                  then return acc
+                  else return (foldl' addUser acc (InterfaceFiles.duPubUsers users))
+
+          depModulesFromNameHashes nameHashes = do
+            let depMods =
+                  Data.List.sortOn modNameToString $
+                  Data.Set.toList $
+                  Data.Set.fromList
+                    [ depMn
+                    | nh <- nameHashes
+                    , (qn, _) <- InterfaceFiles.nhPubDeps nh ++ InterfaceFiles.nhImplDeps nh
+                    , depMn <- case qn of
+                        A.GName m _ -> [m]
+                        A.QName m _ -> [m]
+                        A.NoQ{} -> []
+                    ]
+            resolved <- traverseDiags resolveDepModule depMods
+            return resolved
+            where
+              resolveDepModule depMn = do
+                mpub <- resolveImportHash depMn
+                mimpl <- resolveImportImplHash depMn
+                return $ case (mpub, mimpl) of
+                  (Just pubH, Just implH) ->
+                    Right InterfaceFiles.DepModuleInfo
+                      { InterfaceFiles.dmiModule = depMn
+                      , InterfaceFiles.dmiPubHash = pubH
+                      , InterfaceFiles.dmiImplHash = implH
+                      }
+                  _ -> Left (missingIfaceDiagnostics mn "" depMn)
 
           nameHashSummary prevMap newInfos =
             let newMap = nameHashMapFromList newInfos
@@ -3532,41 +3638,75 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
               return (fmap (\vals -> (n, vals)) resolvedQns)) (M.toList deps)
             return (fmap M.fromList resolved)
 
-          -- For stale checks on cached .tydb tasks we treat missing names/hashes
-          -- as "stale cache" signals and force front passes, instead of failing
-          -- early with internal hash diagnostics.
-          resolveQNameHashForStaleCheck getHash qn =
-            case qn of
-              A.GName m n -> resolveNameHashMap' m >>= \hm ->
-                return $ case hm of
-                  Nothing -> Right Nothing
-                  Just hmap ->
-                    case M.lookup n hmap of
-                      Nothing -> Right Nothing
-                      Just info ->
-                        let h = getHash info
-                        in if B.null h then Right Nothing else Right (Just h)
-              A.QName m n -> resolveNameHashMap' m >>= \hm ->
-                return $ case hm of
-                  Nothing -> Right Nothing
-                  Just hmap ->
-                    case M.lookup n hmap of
-                      Nothing -> Right Nothing
-                      Just info ->
-                        let h = getHash info
-                        in if B.null h then Right Nothing else Right (Just h)
-              A.NoQ _ -> return (Right Nothing)
+          checkDepModuleRows depModules = do
+            resolved <- traverseDiags checkOne depModules
+            return $ fmap foldRows resolved
+            where
+              checkOne depInfo = do
+                let depMn = InterfaceFiles.dmiModule depInfo
+                mpub <- resolveImportHash depMn
+                mimpl <- resolveImportImplHash depMn
+                return $ case (mpub, mimpl) of
+                  (Just pubH, Just implH) ->
+                    Right ( depMn
+                          , pubH /= InterfaceFiles.dmiPubHash depInfo
+                          , implH /= InterfaceFiles.dmiImplHash depInfo
+                          )
+                  _ -> Left (missingIfaceDiagnostics mn "" depMn)
 
-          checkDeps _label getHash _users deps = do
-            resolved <- traverseDiags (\(qn, recorded) -> do
-              currE <- resolveQNameHashForStaleCheck getHash qn
-              return (fmap (\curr -> (qn, recorded, curr)) currE)) (M.toList deps)
-            return (fmap
-              (\triples ->
-                let deltas = [ (qn, old, new) | (qn, old, Just new) <- triples, old /= new ]
-                    missing = [ qn | (qn, _old, Nothing) <- triples ]
-                in (deltas, missing))
-              resolved)
+              foldRows rows =
+                ( Data.Set.fromList [ depMn | (depMn, pubChanged, _implChanged) <- rows, pubChanged ]
+                , Data.Set.fromList [ depMn | (depMn, _pubChanged, implChanged) <- rows, implChanged ]
+                )
+
+          checkDepNameRows changedPubMods changedImplMods = do
+            let changedMods =
+                  Data.List.sortOn modNameToString $
+                  Data.Set.toList (Data.Set.union changedPubMods changedImplMods)
+            foldM checkModule ([], [], [], [], M.empty, M.empty) changedMods
+            where
+              checkModule acc depMn = do
+                depNames <- InterfaceFiles.readDepNames tyFile depMn
+                mhm <- resolveNameHashMap' depMn
+                foldM (checkName depMn mhm) acc depNames
+
+              checkName depMn mhm acc depInfo = do
+                let depName = InterfaceFiles.dniName depInfo
+                    qn = A.GName depMn depName
+                    current getHash =
+                      case mhm >>= M.lookup depName of
+                        Nothing -> Nothing
+                        Just info ->
+                          let h = getHash info
+                          in if B.null h then Nothing else Just h
+                    checkPub = Data.Set.member depMn changedPubMods && not (B.null (InterfaceFiles.dniPubHash depInfo))
+                    checkImpl = Data.Set.member depMn changedImplMods && not (B.null (InterfaceFiles.dniImplHash depInfo))
+                acc1 <- if checkPub
+                          then addPub depMn depName qn (InterfaceFiles.dniPubHash depInfo) (current InterfaceFiles.nhPubHash) acc
+                          else return acc
+                if checkImpl
+                  then addImpl depMn depName qn (InterfaceFiles.dniImplHash depInfo) (current InterfaceFiles.nhImplHash) acc1
+                  else return acc1
+
+              addPub depMn depName qn old mNew acc@(pubDeltas, implDeltas, pubMissing, implMissing, pubUsers, implUsers) =
+                case mNew of
+                  Just new | new == old -> return acc
+                  Just new -> do
+                    users <- InterfaceFiles.readDepUsers tyFile depMn depName
+                    return ((qn, old, new) : pubDeltas, implDeltas, pubMissing, implMissing, M.insert qn (InterfaceFiles.duPubUsers users) pubUsers, implUsers)
+                  Nothing -> do
+                    users <- InterfaceFiles.readDepUsers tyFile depMn depName
+                    return (pubDeltas, implDeltas, qn : pubMissing, implMissing, M.insert qn (InterfaceFiles.duPubUsers users) pubUsers, implUsers)
+
+              addImpl depMn depName qn old mNew acc@(pubDeltas, implDeltas, pubMissing, implMissing, pubUsers, implUsers) =
+                case mNew of
+                  Just new | new == old -> return acc
+                  Just new -> do
+                    users <- InterfaceFiles.readDepUsers tyFile depMn depName
+                    return (pubDeltas, (qn, old, new) : implDeltas, pubMissing, implMissing, pubUsers, M.insert qn (InterfaceFiles.duImplUsers users) implUsers)
+                  Nothing -> do
+                    users <- InterfaceFiles.readDepUsers tyFile depMn depName
+                    return (pubDeltas, implDeltas, pubMissing, qn : implMissing, pubUsers, M.insert qn (InterfaceFiles.duImplUsers users) implUsers)
 
       case taskCurrent of
         ParseErrorTask{ parseDiagnostics = diags } -> return (key, Left diags)
@@ -3576,12 +3716,14 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                             ParseTask{ src = srcContent } -> readIfaceFromTy paths mn srcContent Nothing
                             ActonTask{ src = srcContent } -> readIfaceFromTy paths mn srcContent Nothing
               case ifaceRes of
-                Right (imps, ifaceTE, mdoc, ih) -> do
+                Right (imps, ifaceTE, mdoc, ih, implH) -> do
                   let cachedFullNameHashes = case taskCurrent of
                         TyTask{ tyNameHashes = nhs } -> nhs
                         _ -> []
                       cachedNameHashes = publicNameHashes cachedFullNameHashes
-                      fr = mkFrontResult imps ifaceTE mdoc ih cachedNameHashes cachedFullNameHashes Nothing Nothing
+                  interestDeps <- cachedInterestDeps
+                  let fr = (mkFrontResult imps ifaceTE mdoc ih implH cachedNameHashes cachedFullNameHashes Nothing Nothing)
+                             { frInterestDeps = interestDeps }
                   cacheFrontResult fr
                 Left _ ->
                   return (key, Right emptyFrontResult)
@@ -3593,31 +3735,18 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
           -- passes). Unchanged import pub hashes let us skip checking public
           -- name deps from those modules.
           needByDepsRes <- case taskCurrent of
-            TyTask{ tyImports = imps, tyNameHashes = nameHashes } -> do
+            TyTask{ tyImports = imps, tyDepModules = depModules } -> do
               importHashRes <- checkImportHashes imps
               case importHashRes of
                 Left diags -> return (Left diags)
-                Right changedPubImports -> do
-                  let importModules = Data.Set.fromList (map fst imps)
-                      checkPubDep qn =
-                        case qnameModule qn of
-                          Just depMn ->
-                            Data.Set.notMember depMn importModules ||
-                            Data.Set.member depMn changedPubImports
-                          Nothing -> True
-                  -- Build dep maps and reverse "used by" index for logging.
-                  let pubDeps = depMapIf InterfaceFiles.nhPubDeps checkPubDep nameHashes
-                      implDeps = depMap InterfaceFiles.nhImplDeps nameHashes
-                      pubUsers = depUsers InterfaceFiles.nhPubDeps nameHashes
-                      implUsers = depUsers InterfaceFiles.nhImplDeps nameHashes
-                  -- Resolve current hashes for each dep and report any deltas.
-                  pubRes <- checkDeps "pub" InterfaceFiles.nhPubHash pubUsers pubDeps
-                  implRes <- checkDeps "impl" InterfaceFiles.nhImplHash implUsers implDeps
-                  case (pubRes, implRes) of
-                    (Left diags, _) -> return (Left diags)
-                    (_, Left diags) -> return (Left diags)
-                    (Right (pubDeltas, pubMissing), Right (implDeltas, implMissing)) ->
-                      return (Right (pubDeltas, implDeltas, pubMissing, implMissing, pubUsers, implUsers))
+                Right _ -> do
+                  depModuleRes <- checkDepModuleRows depModules
+                  case depModuleRes of
+                    Left diags -> return (Left diags)
+                    Right (changedPubMods, changedImplMods) ->
+                      if Data.Set.null changedPubMods && Data.Set.null changedImplMods
+                        then return (Right ([], [], [], [], M.empty, M.empty))
+                        else Right <$> checkDepNameRows changedPubMods changedImplMods
             -- Source tasks always run front passes, so deps are irrelevant.
             _ -> return (Right ([], [], [], [], M.empty, M.empty))
 
@@ -3689,6 +3818,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                           srcBytes
                           mSourceMeta
                           resolveImportHash
+                          resolveImportImplHash
                           resolveNameHashMap'
                           (\p -> ccOnFrontProgress callbacks t optsT p)
                           (ccOnFrontOutputStart callbacks)
@@ -3725,7 +3855,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                       tyRes <- readTyFile
                       case tyRes of
                         Left diags -> return (key, Left diags)
-                        Right (_ms, nmod, tmod, sourceMeta, moduleSrcBytesHash, modulePubHash, _moduleImplHash, imps, nameHashes, roots, tests, mdoc) -> do
+                        Right (_ms, nmod, tmod, sourceMeta, moduleSrcBytesHash, modulePubHash, _moduleImplHash, imps, depModules, nameHashes, roots, tests, mdoc) -> do
                           parsedRes <- parseActFile optsT sp mn actFile Nothing
                           case parsedRes of
                             Left diags -> return (key, Left diags)
@@ -3766,50 +3896,54 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                                     Left err -> handleSyncFailure err
                                     Right (_, Left _) -> rerunFront
                                     Right (implLocalDeps, Right implExtHashes) -> do
+                                      nameHashesWithPubDeps <- restorePubDepsFromRows depModules nameHashes
                                       let updatedNameHashes =
-                                            Hashing.refreshImplHashes nameHashes nameImplHashes implLocalDeps implExtHashes
+                                            Hashing.refreshImplHashes nameHashesWithPubDeps nameImplHashes implLocalDeps implExtHashes
                                           moduleImplHash = Hashing.moduleImplHashFromNameHashes updatedNameHashes
-                                      evaluate (rnf (moduleSrcBytesHash, modulePubHash, moduleImplHash, sourceMeta, imps))
-                                      evaluate (rnf (updatedNameHashes, roots, tests, mdoc))
-                                      evaluate (rnf nmod)
-                                      evaluate (rnf tmod)
-                                      mask_ $ do
-                                        let outputKey = TaskKey (projPath paths) mn
-                                            tyDbProgress p =
-                                              ccOnFrontOutputProgress callbacks outputKey FrontOutputTydb (frontOutputTyDbProgress p)
-                                        outputJob <- startFrontOutputJob (ccOnFrontOutputStart callbacks)
-                                                                         (ccOnFrontOutputDone callbacks)
-                                                                         (ccShouldWriteFrontOutput callbacks)
-                                                                         outputKey
-                                                                         FrontOutputTydb $ do
-                                          InterfaceFiles.writeFileWithProgress
-                                            tyDbProgress
-                                            A.version
-                                            tyFile
-                                            moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta imps updatedNameHashes roots tests mdoc nmod tmod
-                                        tyJobs <-
-                                          if C.tydb optsT
-                                            then (:[]) <$> startDependentFrontOutputJob (ccOnFrontOutputStart callbacks)
-                                                                                       (ccOnFrontOutputDone callbacks)
-                                                                                       (ccShouldWriteFrontOutput callbacks)
-                                                                                       outputJob
-                                                                                       outputKey
-                                                                                       FrontOutputTydbCopy
-                                                                                       (copyTydbInterface optsT paths mn)
-                                            else return []
-                                        let outputJobs = outputJob : tyJobs
-                                        rememberFrontOutputJobList frontOutputRef outputJobs
-                                        let I.NModule imps ifaceFull _mdoc = nmod
-                                            ifaceTE = publicIfaceTE ifaceFull
-                                            deferredBackJob0 = dbpDeferredBackJob (isDbpBlocked key) optsT paths mn moduleImplHash updatedNameHashes
-                                            deferredBackJob = fmap (\dbj -> dbj{ dbjOutputJobs = [outputJob] }) deferredBackJob0
-                                            backJob =
-                                              case deferredBackJob of
-                                                Just _ -> Nothing
-                                                Nothing -> Just (mkBackJob env1 tmod (Source.ssText snap) moduleImplHash)
-                                            fr = (mkFrontResult imps ifaceTE mdoc modulePubHash (publicNameHashes updatedNameHashes) updatedNameHashes backJob deferredBackJob)
-                                              { frOutputJobs = outputJobs }
-                                        cacheFrontResult fr
+                                      depModulesRes <- depModulesFromNameHashes updatedNameHashes
+                                      case depModulesRes of
+                                        Left _ -> rerunFront
+                                        Right updatedDepModules -> mask_ $ do
+                                          evaluate (rnf (moduleSrcBytesHash, modulePubHash, moduleImplHash, sourceMeta, imps))
+                                          evaluate (rnf (updatedDepModules, updatedNameHashes, roots, tests, mdoc))
+                                          evaluate (rnf nmod)
+                                          evaluate (rnf tmod)
+                                          let outputKey = TaskKey (projPath paths) mn
+                                              tyDbProgress p =
+                                                ccOnFrontOutputProgress callbacks outputKey FrontOutputTydb (frontOutputTyDbProgress p)
+                                          outputJob <- startFrontOutputJob (ccOnFrontOutputStart callbacks)
+                                                                           (ccOnFrontOutputDone callbacks)
+                                                                           (ccShouldWriteFrontOutput callbacks)
+                                                                           outputKey
+                                                                           FrontOutputTydb $ do
+                                            InterfaceFiles.writeFileWithProgress
+                                              tyDbProgress
+                                              A.version
+                                              tyFile
+                                              moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta imps updatedDepModules updatedNameHashes roots tests mdoc nmod tmod
+                                          tyJobs <-
+                                            if C.tydb optsT
+                                              then (:[]) <$> startDependentFrontOutputJob (ccOnFrontOutputStart callbacks)
+                                                                                         (ccOnFrontOutputDone callbacks)
+                                                                                         (ccShouldWriteFrontOutput callbacks)
+                                                                                         outputJob
+                                                                                         outputKey
+                                                                                         FrontOutputTydbCopy
+                                                                                         (copyTydbInterface optsT paths mn)
+                                              else return []
+                                          let outputJobs = outputJob : tyJobs
+                                          rememberFrontOutputJobList frontOutputRef outputJobs
+                                          let I.NModule imps ifaceFull _mdoc = nmod
+                                              ifaceTE = publicIfaceTE ifaceFull
+                                              deferredBackJob0 = dbpDeferredBackJob (isDbpBlocked key) optsT paths mn moduleImplHash updatedNameHashes
+                                              deferredBackJob = fmap (\dbj -> dbj{ dbjOutputJobs = [outputJob] }) deferredBackJob0
+                                              backJob =
+                                                case deferredBackJob of
+                                                  Just _ -> Nothing
+                                                  Nothing -> Just (mkBackJob env1 tmod (Source.ssText snap) moduleImplHash)
+                                              fr = (mkFrontResult imps ifaceTE mdoc modulePubHash moduleImplHash (publicNameHashes updatedNameHashes) updatedNameHashes backJob deferredBackJob)
+                                                { frOutputJobs = outputJobs }
+                                          cacheFrontResult fr
                       ) `catch` handleImplRefreshException
                   runCodegenRefresh = do
                     when (C.verbose gopts) $ do
@@ -3818,9 +3952,10 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                     tyRes <- readTyFile
                     case tyRes of
                       Left diags -> return (key, Left diags)
-                      Right (_ms, nmod, tmod, _sourceMeta, _moduleSrcBytesHash, modulePubHash, moduleImplHashStored, _imps, nameHashes, _roots, _tests, mdoc) -> do
+                      Right (_ms, nmod, tmod, _sourceMeta, _moduleSrcBytesHash, modulePubHash, moduleImplHashStored, _imps, _depModules, nameHashes, _roots, _tests, mdoc) -> do
                         snap <- Source.readSource sp actFile
                         env1 <- Acton.Env.mkEnv (searchPath paths) envSnap tmod
+                        interestDeps <- cachedInterestDeps
                         let I.NModule imps ifaceFull _mdoc = nmod
                             ifaceTE = publicIfaceTE ifaceFull
                             deferredBackJob = dbpDeferredBackJob (isDbpBlocked key) optsT paths mn moduleImplHashStored nameHashes
@@ -3828,7 +3963,8 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                               case deferredBackJob of
                                 Just _ -> Nothing
                                 Nothing -> Just (mkBackJob env1 tmod (Source.ssText snap) moduleImplHashStored)
-                            fr = mkFrontResult imps ifaceTE mdoc modulePubHash (publicNameHashes nameHashes) nameHashes backJob deferredBackJob
+                            fr = (mkFrontResult imps ifaceTE mdoc modulePubHash moduleImplHashStored (publicNameHashes nameHashes) nameHashes backJob deferredBackJob)
+                                   { frInterestDeps = interestDeps }
                         cacheFrontResult fr
                   runReuse = do
                     when (C.verbose gopts) $
@@ -3838,12 +3974,14 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                                   _ -> readIfaceFromTy paths mn "" Nothing
                     case ifaceRes of
                       Left diags -> return (key, Left diags)
-                      Right (imps, ifaceTE, mdoc, ih) -> do
+                      Right (imps, ifaceTE, mdoc, ih, implH) -> do
                         let cachedFullNameHashes = case taskCurrent of
                               TyTask{ tyNameHashes = nhs } -> nhs
                               _ -> []
                             cachedNameHashes = publicNameHashes cachedFullNameHashes
-                            fr = mkFrontResult imps ifaceTE mdoc ih cachedNameHashes cachedFullNameHashes Nothing cachedDeferredBackJob
+                        interestDeps <- cachedInterestDeps
+                        let fr = (mkFrontResult imps ifaceTE mdoc ih implH cachedNameHashes cachedFullNameHashes Nothing cachedDeferredBackJob)
+                                   { frInterestDeps = interestDeps }
                         cacheFrontResult fr
               case () of
                 _ | needFront -> runFront
@@ -3892,17 +4030,19 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
     runFrontStage :: Acton.Env.Env0
                   -> IORef [FrontOutputJob]
                   -> M.Map TaskKey B.ByteString
+                  -> M.Map TaskKey B.ByteString
                   -> M.Map TaskKey (M.Map A.Name InterfaceFiles.NameHashInfo)
                   -> M.Map TaskKey CompileTask
                   -> TaskKey
                   -> IO (StageKey, Either [Diagnostic String] StageSuccess)
-    runFrontStage envSnap frontOutputRef res nameRes parsedTasks key = do
-      (doneKey, outcome) <- doOne envSnap frontOutputRef res nameRes parsedTasks key
+    runFrontStage envSnap frontOutputRef res implRes nameRes parsedTasks key = do
+      (doneKey, outcome) <- doOne envSnap frontOutputRef res implRes nameRes parsedTasks key
       return (FrontStage doneKey, fmap StageFronted outcome)
 
     scheduleMore :: Int -> [StageKey]
                  -> [(Async (StageKey, Either [Diagnostic String] StageSuccess), StageKey)]
                  -> IORef [FrontOutputJob]
+                 -> M.Map TaskKey B.ByteString
                  -> M.Map TaskKey B.ByteString
                  -> M.Map TaskKey (M.Map A.Name InterfaceFiles.NameHashInfo)
                  -> M.Map TaskKey CompileTask
@@ -3910,7 +4050,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                  -> M.Map TaskKey Integer
                  -> IO ([StageKey]
                        , [(Async (StageKey, Either [Diagnostic String] StageSuccess), StageKey)])
-    scheduleMore k rdy running frontOutputRef res nameRes parsedTasks envSnap cw = do
+    scheduleMore k rdy running frontOutputRef res implRes nameRes parsedTasks envSnap cw = do
       let rdySorted = Data.List.sortOn (Down . stagePriority cw) rdy
           (toStart, rdy') = splitAt k rdySorted
       new <- forM toStart $ \sk -> do
@@ -3926,7 +4066,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                 a <- async $
                   case sk of
                     ParseStage key -> runParseStage key
-                    FrontStage key -> runFrontStage envSnap frontOutputRef res nameRes parsedTasks key
+                    FrontStage key -> runFrontStage envSnap frontOutputRef res implRes nameRes parsedTasks key
                 return (a, sk)
       return (rdy', new ++ running)
 
@@ -3934,6 +4074,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
          -> IORef [Async (StageKey, Either [Diagnostic String] StageSuccess)]
          -> [StageKey]
          -> [(Async (StageKey, Either [Diagnostic String] StageSuccess), StageKey)]
+         -> M.Map TaskKey B.ByteString
          -> M.Map TaskKey B.ByteString
          -> M.Map TaskKey (M.Map A.Name InterfaceFiles.NameHashInfo)
          -> M.Map TaskKey CompileTask
@@ -3947,9 +4088,9 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
          -> Int
          -> M.Map TaskKey Integer
          -> IO (Either CompileFailure (Acton.Env.Env0, Bool))
-    loop frontOutputRef runningRef rdy running res nameRes parsedTasks interestMap frontDone deferredBacks ind pend envAcc hadErrors maxPar cw = do
+    loop frontOutputRef runningRef rdy running res implRes nameRes parsedTasks interestMap frontDone deferredBacks ind pend envAcc hadErrors maxPar cw = do
       (rdy1, running1) <- mask_ $ do
-        res@(rdy1', running1') <- scheduleMore (maxPar - length running) rdy running frontOutputRef res nameRes parsedTasks envAcc cw
+        res@(rdy1', running1') <- scheduleMore (maxPar - length running) rdy running frontOutputRef res implRes nameRes parsedTasks envAcc cw
         writeIORef runningRef (map fst running1')
         return res
       if null running1 && null rdy1
@@ -3987,7 +4128,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                   rdy2 = filter (`Data.Set.notMember` blockedStages) rdy1
                   dropKeys = keyDone : Data.Set.toList blockedMods
                   parsedTasks2 = foldl' (flip M.delete) parsedTasks dropKeys
-              loop frontOutputRef runningRef rdy2 running3 res nameRes parsedTasks2 interestMap frontDone deferredBacks ind pend2 envAcc True maxPar cw
+              loop frontOutputRef runningRef rdy2 running3 res implRes nameRes parsedTasks2 interestMap frontDone deferredBacks ind pend2 envAcc True maxPar cw
             Right success -> do
               let pend2 = Data.Set.delete stageDone pend
                   ind2  = case M.lookup stageDone stageRevMap of
@@ -4004,12 +4145,13 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                 StageParsed parsed mParseTime -> do
                   ccOnParseDone callbacks tDone optsDone mParseTime
                   let parsedTasks2 = M.insert keyDone parsed parsedTasks
-                  loop frontOutputRef runningRef rdy2 running2 res nameRes parsedTasks2 interestMap frontDone deferredBacks ind2 pend2 envAcc hadErrors maxPar cw
+                  loop frontOutputRef runningRef rdy2 running2 res implRes nameRes parsedTasks2 interestMap frontDone deferredBacks ind2 pend2 envAcc hadErrors maxPar cw
                 StageFronted fr -> do
                   ccOnFrontDone callbacks tDone optsDone
                   ccOnFrontResult callbacks tDone optsDone fr
                   forM_ (frBackJob fr) $ ccOnBackJob callbacks
                   let res2  = M.insert keyDone (frPubHash fr) res
+                      implRes2 = M.insert keyDone (frImplHash fr) implRes
                       nameRes2 = M.insert keyDone (nameHashMapFromList (frNameHashes fr)) nameRes
                       parsedTasks2 = M.delete keyDone parsedTasks
                       envAcc' = Acton.Env.addMod (tkMod keyDone) (frImps fr) (frIfaceTE fr) (frDoc fr) envAcc
@@ -4023,7 +4165,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                   case flushRes of
                     Left err -> return (Left err)
                     Right deferredBacks2 ->
-                      loop frontOutputRef runningRef rdy2 running2 res2 nameRes2 parsedTasks2 interestMap2 frontDone2 deferredBacks2 ind2 pend2 envAcc' hadErrors maxPar cw
+                      loop frontOutputRef runningRef rdy2 running2 res2 implRes2 nameRes2 parsedTasks2 interestMap2 frontDone2 deferredBacks2 ind2 pend2 envAcc' hadErrors maxPar cw
 
 
 -- | Execute back-pass jobs in parallel while keeping output order stable.

--- a/compiler/lib/src/Acton/Completion.hs
+++ b/compiler/lib/src/Acton/Completion.hs
@@ -635,7 +635,7 @@ readModuleInterface searchPath m = do
       res <- (Just <$> IF.readFile ty) `E.catch` \(_ :: E.SomeException) ->
         return Nothing
       case res of
-        Just (_, I.NModule imps te mdoc, _, _, _, _, _, _, _, _, _, _) ->
+        Just (_, I.NModule imps te mdoc, _, _, _, _, _, _, _, _, _, _, _) ->
           return (Just (imps, te, mdoc))
         _ ->
           return Nothing

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -251,7 +251,7 @@ initEnv path True          = return $ EnvF{ activeNames = [],
                                             qlevel = 0,
                                             gtypes = [],
                                             envX = () }
-initEnv path False         = do (_,nmod,_,_,_,_,_,_,_,_,_,_) <- InterfaceFiles.readFile (InterfaceFiles.interfacePath path (modName ["__builtin__"]))
+initEnv path False         = do (_,nmod,_,_,_,_,_,_,_,_,_,_,_) <- InterfaceFiles.readFile (InterfaceFiles.interfacePath path (modName ["__builtin__"]))
                                 let NModule _ envBuiltin builtinDocstring = nmod
                                     envBuiltinPublic = publicTEnv envBuiltin
                                     initialNames = [(nPrim,NMAlias mPrim), (nBuiltin,NMAlias mBuiltin)]
@@ -1167,7 +1167,7 @@ doImp spath env m            = do (env', te, _) <- doImpSeen S.empty env m
               ty <- readFoundTy InterfaceFiles.readFileMaybe m
               case ty of
                 Nothing -> fileNotFound m
-                Just (ms,nmod,_,_,_,_,_,_,_,_,_,_) -> do
+                Just (ms,nmod,_,_,_,_,_,_,_,_,_,_,_) -> do
                   (env', seen'') <- subImpSeen seen' env ms
                   let NModule ms' teFull mdoc = nmod
                       te = publicTEnv teFull

--- a/compiler/lib/src/Acton/Testing.hs
+++ b/compiler/lib/src/Acton/Testing.hs
@@ -453,7 +453,7 @@ readModuleNameHashesByModName paths mn = do
         hdrE <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readHeader tyFile
         case hdrE of
           Left _ -> return M.empty
-          Right (_sourceMeta, _srcH, _ih, _implH, _imps, nameHashes, _roots, _tests, _doc) ->
+          Right (_sourceMeta, _srcH, _ih, _implH, _imps, _depModules, nameHashes, _roots, _tests, _doc) ->
             return $ M.fromList [ (A.nstr (InterfaceFiles.nhName nh), nh) | nh <- nameHashes ]
 
 -- | Cache-aware wrapper for reading name hashes.

--- a/compiler/lib/src/Acton/Types.hs
+++ b/compiler/lib/src/Acton/Types.hs
@@ -98,9 +98,10 @@ reconstruct progressCb inferredCb env0 (Module m i mdoc ss)    = do --traceM ("#
 
 -- | Print a .tydb header and interface; include name hashes when verbose.
 showTyFile env0 m fname verbose = do
-                                     (_,nmod,_,sourceMeta,srcH,pubH,implH,imps,nameHashes,roots,tests,mdocH) <- InterfaceFiles.readFile fname
+                                     (_,nmod,_,sourceMeta,srcH,pubH,implH,imps,depModules,nameHashes,roots,tests,mdocH) <- InterfaceFiles.readFile fname
                                      putStrLn ("\n############### Header ###############")
                                      putStrLn ("Imports: " ++ (show [ (prstr mn, take 16 (B.unpack $ Base16.encode h)) | (mn,h) <- imps ]))
+                                     putStrLn ("Deps   : " ++ (show [ (prstr mn, take 16 (B.unpack $ Base16.encode pubH'), take 16 (B.unpack $ Base16.encode implH')) | InterfaceFiles.DepModuleInfo mn pubH' implH' <- depModules ]))
                                      putStrLn ("Roots  : " ++ (show (map prstr roots)))
                                      putStrLn ("Tests  : " ++ (show tests))
                                      case mdocH of

--- a/compiler/lib/src/InterfaceFiles.hs
+++ b/compiler/lib/src/InterfaceFiles.hs
@@ -36,6 +36,7 @@
 --                                                     --   (doc-free) + imports' pub hashes
 --                         , ByteString )              -- moduleImplHash: structural hash of per-name impl hashes
 --     "imports"        :: [(A.ModName, ByteString)]   -- dependency module and pub hash used
+--     "deps"           :: [DepModuleInfo]              -- dependency modules with pub/impl hashes
 --     "roots"          :: [A.Name]                    -- root actors (e.g. main or test_main)
 --     "tests"          :: [String]                    -- discovered test names
 --     "doc"            :: Maybe String                -- module docstring
@@ -47,7 +48,11 @@
 --   Per-name keys (NameInfo / TEnv, one set per name):
 --     "name-order/<NNN>"   :: ByteString              -- name-key suffix, in TEnv order (NNN = padIndex)
 --     "name-info/<suffix>" :: (A.Name, I.NameInfo)    -- the name and its type/name environment entry
---     "name-hash/<suffix>" :: NameHashInfo            -- per-name src/pub/impl hashes + local/external deps
+--     "name-hash/<suffix>" :: NameHashInfo            -- per-name src/pub/impl hashes + local deps
+--
+--   Per-dependency keys:
+--     "deps/<module>"          :: [DepNameInfo]        -- dependency names with pub/impl hashes
+--     "deps/<module>/<suffix>" :: DepUsers             -- local names that use one dependency name
 --
 --   Per-extension keys:
 --     "ext-by-class/<suffix>"       :: (A.Name, [A.Name]) -- class name to extension names
@@ -72,6 +77,9 @@
 
 module InterfaceFiles
   ( NameHashInfo(..)
+  , DepModuleInfo(..)
+  , DepNameInfo(..)
+  , DepUsers(..)
   , SourceFileMeta(..)
   , TyFile
   , TyHeader
@@ -84,6 +92,8 @@ module InterfaceFiles
   , listInterfaceDirsRecursive
   , keyNameInfo
   , keyNameHash
+  , readDepNames
+  , readDepUsers
   , readFile
   , readHeader
   , readExtensionsByClass
@@ -109,6 +119,7 @@ import qualified Data.ByteString.Base16 as Base16
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as B
 import qualified Data.List
+import Data.List (foldl')
 import qualified Data.Map.Strict as Map
 import qualified Data.Persist as Persist
 import qualified Data.Text as T
@@ -140,6 +151,35 @@ data NameHashInfo = NameHashInfo
 instance Persist.Persist NameHashInfo
 instance NFData NameHashInfo
 
+data DepModuleInfo = DepModuleInfo
+  { dmiModule   :: A.ModName
+  , dmiPubHash  :: BS.ByteString
+  , dmiImplHash :: BS.ByteString
+  } deriving (Show, Eq, Generic)
+
+instance Persist.Persist DepModuleInfo
+instance NFData DepModuleInfo
+
+data DepNameInfo = DepNameInfo
+  { dniName     :: A.Name
+  , dniPubHash  :: BS.ByteString
+  , dniImplHash :: BS.ByteString
+  } deriving (Show, Eq, Generic)
+
+instance Persist.Persist DepNameInfo
+instance NFData DepNameInfo
+
+data DepUsers = DepUsers
+  { duPubUsers  :: [A.Name]
+  , duImplUsers :: [A.Name]
+  } deriving (Show, Eq, Generic)
+
+instance Persist.Persist DepUsers
+instance NFData DepUsers
+
+emptyDepUsers :: DepUsers
+emptyDepUsers = DepUsers [] []
+
 data ExtensionIndex = ExtensionIndex
   { extByClass      :: Map.Map A.Name [A.Name]
   , extByProtocol   :: Map.Map A.Name [A.Name]
@@ -170,6 +210,7 @@ type TyFile =
   , BS.ByteString
   , BS.ByteString
   , [(A.ModName, BS.ByteString)]
+  , [DepModuleInfo]
   , [NameHashInfo]
   , [A.Name]
   , [String]
@@ -182,6 +223,7 @@ type TyHeader =
   , BS.ByteString
   , BS.ByteString
   , [(A.ModName, BS.ByteString)]
+  , [DepModuleInfo]
   , [NameHashInfo]
   , [A.Name]
   , [String]
@@ -283,10 +325,11 @@ encodeStrict = Persist.encode
 key :: String -> BS.ByteString
 key = B.pack
 
-keyVersion, keyMeta, keyImports, keyRoots, keyTests, keyDoc, keyNameCount, keyStmtCount, keyModuleHeader :: BS.ByteString
+keyVersion, keyMeta, keyImports, keyDeps, keyRoots, keyTests, keyDoc, keyNameCount, keyStmtCount, keyModuleHeader :: BS.ByteString
 keyVersion      = key "version"
 keyMeta         = key "meta"
 keyImports      = key "imports"
+keyDeps         = key "deps"
 keyRoots        = key "roots"
 keyTests        = key "tests"
 keyDoc          = key "doc"
@@ -302,17 +345,29 @@ padIndex i =
 plainNameKeyLimit :: Int
 plainNameKeyLimit = 400
 
-nameKeySuffix :: A.Name -> BS.ByteString
-nameKeySuffix n =
-    let raw = TE.encodeUtf8 (T.pack (A.rawstr n))
-    in if plainNameKey raw
-         then B.concat [key "p/", raw]
-         else B.concat [key "h/", Base16.encode (SHA256.hash raw)]
+plainKeyRaw :: BS.ByteString -> Bool
+plainKeyRaw raw =
+    BS.length raw <= plainNameKeyLimit && BS.all safe raw
   where
-    plainNameKey raw =
-        BS.length raw <= plainNameKeyLimit && BS.all safe raw
     safe w =
         w > 32 && w < 127 && w /= 47
+
+safeKeySuffix :: BS.ByteString -> BS.ByteString
+safeKeySuffix raw =
+    if plainKeyRaw raw
+      then B.concat [key "p/", raw]
+      else B.concat [key "h/", Base16.encode (SHA256.hash raw)]
+
+nameKeySuffix :: A.Name -> BS.ByteString
+nameKeySuffix n =
+    safeKeySuffix (TE.encodeUtf8 (T.pack (A.rawstr n)))
+
+moduleKeySuffix :: A.ModName -> BS.ByteString
+moduleKeySuffix mn =
+    let raw = TE.encodeUtf8 (T.pack (Data.List.intercalate "." (A.modPath mn)))
+    in if plainKeyRaw raw
+         then raw
+         else B.concat [key "h/", Base16.encode (SHA256.hash raw)]
 
 keyNameInfo :: A.Name -> BS.ByteString
 keyNameInfo n = B.concat [key "name-info/", nameKeySuffix n]
@@ -328,6 +383,12 @@ keyNameHashPrefix = key "name-hash/"
 
 keyNameHash :: A.Name -> BS.ByteString
 keyNameHash n = B.concat [keyNameHashPrefix, nameKeySuffix n]
+
+keyDepModule :: A.ModName -> BS.ByteString
+keyDepModule mn = B.concat [key "deps/", moduleKeySuffix mn]
+
+keyDepName :: A.ModName -> A.Name -> BS.ByteString
+keyDepName mn n = B.concat [keyDepModule mn, key "/", nameKeySuffix n]
 
 keyExtByClassPrefix, keyExtByProtocolPrefix :: BS.ByteString
 keyExtByClassPrefix      = key "ext-by-class/"
@@ -716,8 +777,80 @@ parallelEntries mark label mk chunks =
       mark label
       return entries
 
-interfaceEntries :: (String -> Double -> IO ()) -> [Int] -> BS.ByteString -> BS.ByteString -> BS.ByteString -> Maybe SourceFileMeta -> [(A.ModName, BS.ByteString)] -> [NameHashInfo] -> [A.Name] -> [String] -> Maybe String -> I.NameInfo -> A.Module -> IO [(BS.ByteString, BS.ByteString)]
-interfaceEntries onProgress version moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta imps nameHashes roots tests mdoc nmod tchecked = do
+stripExternalDeps :: NameHashInfo -> NameHashInfo
+stripExternalDeps nh =
+    nh { nhPubDeps = [], nhImplDeps = [] }
+
+depIndexEntries :: [DepModuleInfo] -> [NameHashInfo] -> [(BS.ByteString, BS.ByteString)]
+depIndexEntries depModules nameHashes =
+    (keyDeps, encodeStrict depModules)
+    : [ (keyDepModule mn, encodeStrict infos)
+      | (mn, infos) <- moduleRows
+      ]
+    ++
+    [ (keyDepName mn n, encodeStrict users)
+    | ((mn, n), users) <- userRows
+    ]
+  where
+    moduleNameKey = A.modPath
+    nameKey = A.nstr
+    sortModRows = Data.List.sortOn (moduleNameKey . fst)
+    sortNameInfos = Data.List.sortOn (nameKey . dniName)
+    sortUserRows = Data.List.sortOn (\((mn, n), _) -> (moduleNameKey mn, nameKey n))
+
+    depTarget qn =
+      case qn of
+        A.GName m n -> Just (m, n)
+        A.QName m n -> Just (m, n)
+        A.NoQ{} -> Nothing
+
+    addDep isPub owner acc (qn, h) =
+      case depTarget qn of
+        Nothing -> acc
+        Just key' -> Map.alter (Just . addToEntry) key' acc
+      where
+        addToEntry Nothing =
+          if isPub
+            then (Just h, Nothing, [owner], [])
+            else (Nothing, Just h, [], [owner])
+        addToEntry (Just (pubH, implH, pubUsers, implUsers)) =
+          if isPub
+            then (Just h, implH, owner : pubUsers, implUsers)
+            else (pubH, Just h, pubUsers, owner : implUsers)
+
+    depMap =
+      foldl' addInfo Map.empty nameHashes
+
+    addInfo acc nh =
+      let owner = nhName nh
+          withPub = foldl' (addDep True owner) acc (nhPubDeps nh)
+      in foldl' (addDep False owner) withPub (nhImplDeps nh)
+
+    depNameInfo ((mn, n), (pubH, implH, _pubUsers, _implUsers)) =
+      (mn, DepNameInfo n (maybe BS.empty id pubH) (maybe BS.empty id implH))
+
+    moduleRows =
+      [ (mn, sortNameInfos infos)
+      | (mn, infos) <-
+          sortModRows $
+          Map.toList $
+          Map.fromListWith (++)
+            [ (mn, [info])
+            | entry <- Map.toList depMap
+            , let (mn, info) = depNameInfo entry
+            ]
+      ]
+
+    cleanNames = Data.List.sortOn nameKey . Data.List.nub
+
+    userRows =
+      sortUserRows
+        [ (key', DepUsers (cleanNames pubUsers) (cleanNames implUsers))
+        | (key', (_pubH, _implH, pubUsers, implUsers)) <- Map.toList depMap
+        ]
+
+interfaceEntries :: (String -> Double -> IO ()) -> [Int] -> BS.ByteString -> BS.ByteString -> BS.ByteString -> Maybe SourceFileMeta -> [(A.ModName, BS.ByteString)] -> [DepModuleInfo] -> [NameHashInfo] -> [A.Name] -> [String] -> Maybe String -> I.NameInfo -> A.Module -> IO [(BS.ByteString, BS.ByteString)]
+interfaceEntries onProgress version moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta imps depModules nameHashes roots tests mdoc nmod tchecked = do
     caps <- getNumCapabilities
     let header =
           [ (keyVersion, encodeStrict version)
@@ -733,7 +866,7 @@ interfaceEntries onProgress version moduleSrcBytesHash modulePubHash moduleImplH
         nameChunks = entryChunks caps (zip [0..] te)
         nameHashChunks = entryChunks caps nameHashes
         stmtChunks = entryChunks caps (zip [0..] body)
-        totalPrep = 2 + length nameChunks + length nameHashChunks + length stmtChunks
+        totalPrep = 3 + length nameChunks + length nameHashChunks + length stmtChunks
     prepDone <- newIORef (0 :: Int)
     let mark label = do
           done <- atomicModifyIORef' prepDone $ \n ->
@@ -742,12 +875,14 @@ interfaceEntries onProgress version moduleSrcBytesHash modulePubHash moduleImplH
     onProgress "Preparing .tydb" 0
     headerEntries <- forceEntries header
     mark "Preparing .tydb header"
+    depEntries <- forceEntries (depIndexEntries depModules nameHashes)
+    mark "Preparing .tydb deps"
     nameEntries <- parallelEntries mark "Preparing .tydb names" nameInfoEntries nameChunks
     nameHashEntries <- parallelEntries mark "Preparing .tydb hashes" nameHashEntry nameHashChunks
     extEntries <- forceEntries (extensionIndexEntries (extensionIndexFromNameInfo tmn nmod))
     mark "Preparing .tydb extensions"
     stmtEntries <- parallelEntries mark "Preparing .tydb statements" stmtEntry stmtChunks
-    return (headerEntries ++ nameEntries ++ nameHashEntries ++ extEntries ++ stmtEntries)
+    return (headerEntries ++ depEntries ++ nameEntries ++ nameHashEntries ++ extEntries ++ stmtEntries)
   where
     I.NModule _ te _ = nmod
     A.Module tmn timps tdoc body = tchecked
@@ -757,19 +892,19 @@ interfaceEntries onProgress version moduleSrcBytesHash modulePubHash moduleImplH
       ]
       where
         suffix = nameKeySuffix n
-    nameHashEntry nh = [(keyNameHash (nhName nh), encodeStrict nh)]
+    nameHashEntry nh = [(keyNameHash (nhName nh), encodeStrict (stripExternalDeps nh))]
     stmtEntry (i, stmt) = [(keyStmt i, encodeStrict stmt)]
 
-writeFile :: FilePath -> BS.ByteString -> BS.ByteString -> BS.ByteString -> Maybe SourceFileMeta -> [(A.ModName, BS.ByteString)] -> [NameHashInfo] -> [A.Name] -> [String] -> Maybe String -> I.NameInfo -> A.Module -> IO ()
+writeFile :: FilePath -> BS.ByteString -> BS.ByteString -> BS.ByteString -> Maybe SourceFileMeta -> [(A.ModName, BS.ByteString)] -> [DepModuleInfo] -> [NameHashInfo] -> [A.Name] -> [String] -> Maybe String -> I.NameInfo -> A.Module -> IO ()
 writeFile = writeFileWithVersion A.version
 
-writeFileWithVersion :: [Int] -> FilePath -> BS.ByteString -> BS.ByteString -> BS.ByteString -> Maybe SourceFileMeta -> [(A.ModName, BS.ByteString)] -> [NameHashInfo] -> [A.Name] -> [String] -> Maybe String -> I.NameInfo -> A.Module -> IO ()
-writeFileWithVersion version f moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta imps nameHashes roots tests mdoc nmod tchecked =
-    writeFileWithProgress (\_ -> return ()) version f moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta imps nameHashes roots tests mdoc nmod tchecked
+writeFileWithVersion :: [Int] -> FilePath -> BS.ByteString -> BS.ByteString -> BS.ByteString -> Maybe SourceFileMeta -> [(A.ModName, BS.ByteString)] -> [DepModuleInfo] -> [NameHashInfo] -> [A.Name] -> [String] -> Maybe String -> I.NameInfo -> A.Module -> IO ()
+writeFileWithVersion version f moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta imps depModules nameHashes roots tests mdoc nmod tchecked =
+    writeFileWithProgress (\_ -> return ()) version f moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta imps depModules nameHashes roots tests mdoc nmod tchecked
 
-writeFileWithProgress :: (TyDbWriteProgress -> IO ()) -> [Int] -> FilePath -> BS.ByteString -> BS.ByteString -> BS.ByteString -> Maybe SourceFileMeta -> [(A.ModName, BS.ByteString)] -> [NameHashInfo] -> [A.Name] -> [String] -> Maybe String -> I.NameInfo -> A.Module -> IO ()
-writeFileWithProgress onProgress version f moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta imps nameHashes roots tests mdoc nmod tchecked = do
-    entries <- interfaceEntries prepProgress version moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta imps nameHashes roots tests mdoc nmod tchecked
+writeFileWithProgress :: (TyDbWriteProgress -> IO ()) -> [Int] -> FilePath -> BS.ByteString -> BS.ByteString -> BS.ByteString -> Maybe SourceFileMeta -> [(A.ModName, BS.ByteString)] -> [DepModuleInfo] -> [NameHashInfo] -> [A.Name] -> [String] -> Maybe String -> I.NameInfo -> A.Module -> IO ()
+writeFileWithProgress onProgress version f moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta imps depModules nameHashes roots tests mdoc nmod tchecked = do
+    entries <- interfaceEntries prepProgress version moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta imps depModules nameHashes roots tests mdoc nmod tchecked
     writeProgress 0
     writeEntriesWithProgress writeProgress f entries
   where
@@ -785,6 +920,7 @@ readFile f =
     withReadTxn f $ \txn dbi -> do
       (sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash) <- readMeta txn dbi
       imps <- getValue "imports" txn dbi keyImports
+      depModules <- getValue "deps" txn dbi keyDeps
       roots <- getValue "roots" txn dbi keyRoots
       tests <- getValue "tests" txn dbi keyTests
       mdoc <- getValue "doc" txn dbi keyDoc
@@ -794,7 +930,7 @@ readFile f =
       let tmod = A.Module tmn timps tdoc stmts
           sourceImps = A.importsOf tmod
           nmod = I.NModule sourceImps te mdoc
-      return (sourceImps, nmod, tmod, sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash, imps, nameHashes, roots, tests, mdoc)
+      return (sourceImps, nmod, tmod, sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash, imps, depModules, nameHashes, roots, tests, mdoc)
 
 -- Read only cached header fields from .tydb. This avoids decoding the large
 -- NameInfo and typed Module statement sections and is much faster than readFile
@@ -804,11 +940,25 @@ readHeader f =
     withReadTxn f $ \txn dbi -> do
       (sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash) <- readMeta txn dbi
       imps <- getValue "imports" txn dbi keyImports
+      depModules <- getValue "deps" txn dbi keyDeps
       roots <- getValue "roots" txn dbi keyRoots
       tests <- getValue "tests" txn dbi keyTests
       doc <- getValue "doc" txn dbi keyDoc
       nameHashes <- readNameHashEntries txn dbi
-      return (sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash, imps, nameHashes, roots, tests, doc)
+      return (sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash, imps, depModules, nameHashes, roots, tests, doc)
+
+readDepNames :: FilePath -> A.ModName -> IO [DepNameInfo]
+readDepNames f mn =
+    withReadTxn f $ \txn dbi -> do
+      validateVersion txn dbi
+      getValue ("deps/" ++ Data.List.intercalate "." (A.modPath mn)) txn dbi (keyDepModule mn)
+
+readDepUsers :: FilePath -> A.ModName -> A.Name -> IO DepUsers
+readDepUsers f mn n =
+    withReadTxn f $ \txn dbi -> do
+      validateVersion txn dbi
+      mUsers <- getMaybeValue ("deps/" ++ Data.List.intercalate "." (A.modPath mn) ++ "/" ++ A.rawstr n) txn dbi (keyDepName mn n)
+      return (maybe emptyDepUsers id mUsers)
 
 readExtensionsByClass :: FilePath -> A.Name -> IO [A.Name]
 readExtensionsByClass f n =

--- a/compiler/lib/src/InterfaceFiles.hs
+++ b/compiler/lib/src/InterfaceFiles.hs
@@ -94,6 +94,8 @@ module InterfaceFiles
   , keyNameHash
   , readDepNames
   , readDepUsers
+  , readNameHashMaybe
+  , readModuleHashesMaybe
   , readFile
   , readHeader
   , readExtensionsByClass
@@ -132,7 +134,9 @@ import Foreign.Ptr (castPtr)
 import Foreign.Storable (peek)
 import GHC.Generics (Generic)
 import System.Directory (canonicalizePath, createDirectoryIfMissing, doesDirectoryExist, doesFileExist, getFileSize, getModificationTime, listDirectory, removeFile, removePathForcibly)
+import System.Environment (lookupEnv)
 import System.FilePath ((</>), takeExtension)
+import System.IO (hPutStrLn, stderr)
 import System.IO.Error (isDoesNotExistError)
 import System.IO.Unsafe (unsafePerformIO)
 import System.Posix.Files (fileAccess, getFileStatus, modificationTimeHiRes, setFileMode)
@@ -262,6 +266,16 @@ lmdbOpenLock = unsafePerformIO (newMVar ())
 interfaceLocks :: MVar (Map.Map FilePath (MVar ()))
 {-# NOINLINE interfaceLocks #-}
 interfaceLocks = unsafePerformIO (newMVar Map.empty)
+
+traceTydbReads :: Bool
+traceTydbReads =
+    unsafePerformIO $ maybe False (not . null) <$> lookupEnv "ACTON_TYDB_TRACE_READS"
+{-# NOINLINE traceTydbReads #-}
+
+traceTydbRead :: String -> FilePath -> String -> IO ()
+traceTydbRead op path detail =
+    when traceTydbReads $
+      hPutStrLn stderr (unwords ["tydb-read", op, path, detail])
 
 interfaceExists :: FilePath -> IO Bool
 interfaceExists = doesDirectoryExist
@@ -670,6 +684,13 @@ readMeta txn dbi = do
     validateVersion txn dbi
     getValue "meta" txn dbi keyMeta
 
+readModuleHashes :: FilePath -> IO (BS.ByteString, BS.ByteString, BS.ByteString)
+readModuleHashes f =
+    withReadTxn f $ \txn dbi -> do
+      (_sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash) <- readMeta txn dbi
+      traceTydbRead "module-hashes" f "meta"
+      return (moduleSrcBytesHash, modulePubHash, moduleImplHash)
+
 readNameEntries :: LMDB.MDB_txn -> LMDB.MDB_dbi -> IO ([(A.Name, I.NameInfo)], [NameHashInfo])
 readNameEntries txn dbi = do
     te <- readNameInfoEntries txn dbi
@@ -927,6 +948,7 @@ readFile f =
       (te, nameHashes) <- readNameEntries txn dbi
       (tmn, timps, tdoc) <- getValue "module-header" txn dbi keyModuleHeader
       stmts <- readStmtEntries txn dbi
+      traceTydbRead "all" f ("names " ++ show (length te) ++ " stmts " ++ show (length stmts))
       let tmod = A.Module tmn timps tdoc stmts
           sourceImps = A.importsOf tmod
           nmod = I.NModule sourceImps te mdoc
@@ -945,20 +967,42 @@ readHeader f =
       tests <- getValue "tests" txn dbi keyTests
       doc <- getValue "doc" txn dbi keyDoc
       nameHashes <- readNameHashEntries txn dbi
+      traceTydbRead "header" f "cached"
+      traceTydbRead "name-hash-all" f (show (length nameHashes))
       return (sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash, imps, depModules, nameHashes, roots, tests, doc)
 
 readDepNames :: FilePath -> A.ModName -> IO [DepNameInfo]
 readDepNames f mn =
     withReadTxn f $ \txn dbi -> do
       validateVersion txn dbi
-      getValue ("deps/" ++ Data.List.intercalate "." (A.modPath mn)) txn dbi (keyDepModule mn)
+      mDeps <- getMaybeValue ("deps/" ++ Data.List.intercalate "." (A.modPath mn)) txn dbi (keyDepModule mn)
+      let deps = maybe [] id mDeps
+      traceTydbRead "dep-names" f (Data.List.intercalate "." (A.modPath mn) ++ " " ++ show (length deps))
+      return deps
 
 readDepUsers :: FilePath -> A.ModName -> A.Name -> IO DepUsers
 readDepUsers f mn n =
     withReadTxn f $ \txn dbi -> do
       validateVersion txn dbi
       mUsers <- getMaybeValue ("deps/" ++ Data.List.intercalate "." (A.modPath mn) ++ "/" ++ A.rawstr n) txn dbi (keyDepName mn n)
+      traceTydbRead "dep-users" f (Data.List.intercalate "." (A.modPath mn) ++ "." ++ A.rawstr n)
       return (maybe emptyDepUsers id mUsers)
+
+readNameHash :: FilePath -> A.Name -> IO (Maybe NameHashInfo)
+readNameHash f n =
+    withReadTxn f $ \txn dbi -> do
+      validateVersion txn dbi
+      mInfo <- getMaybeValue ("name-hash/" ++ A.rawstr n) txn dbi (keyNameHash n)
+      traceTydbRead (case mInfo of { Just _ -> "name-hash"; Nothing -> "name-hash-miss" }) f (A.rawstr n)
+      return mInfo
+
+readNameHashMaybe :: FilePath -> A.Name -> IO (Maybe NameHashInfo)
+readNameHashMaybe f n =
+    readNameHash f n `E.catch` tyCacheMiss
+
+readModuleHashesMaybe :: FilePath -> IO (Maybe (BS.ByteString, BS.ByteString, BS.ByteString))
+readModuleHashesMaybe =
+    readTyMaybe readModuleHashes
 
 readExtensionsByClass :: FilePath -> A.Name -> IO [A.Name]
 readExtensionsByClass f n =

--- a/compiler/lib/src/InterfaceFiles.hs
+++ b/compiler/lib/src/InterfaceFiles.hs
@@ -35,7 +35,7 @@
 --                         , ByteString                -- modulePubHash: structural hash of public NameInfo
 --                                                     --   (doc-free) + imports' pub hashes
 --                         , ByteString )              -- moduleImplHash: structural hash of per-name impl hashes
---     "imports"        :: [(A.ModName, ByteString)]   -- imported module and pub hash used
+--     "imports"        :: [(A.ModName, ByteString)]   -- dependency module and pub hash used
 --     "roots"          :: [A.Name]                    -- root actors (e.g. main or test_main)
 --     "tests"          :: [String]                    -- discovered test names
 --     "doc"            :: Maybe String                -- module docstring
@@ -60,7 +60,7 @@
 -- the key verbatim) or "h/<sha256hex>" for long or unsafe names. See nameKeySuffix.
 --
 -- Rationale for the keyed layout
--- - Keep the small validity/header fields (version, meta, imports, roots, tests,
+-- - Keep the small validity/header fields (version, meta, dependency hashes, roots, tests,
 --   doc, name-hashes) as their own keys so callers can validate and reuse a cache
 --   entry, or do freshness/dependency checks, without decoding the large NameInfo
 --   and typed Module sections (readHeader vs readFile).
@@ -791,9 +791,10 @@ readFile f =
       (te, nameHashes) <- readNameEntries txn dbi
       (tmn, timps, tdoc) <- getValue "module-header" txn dbi keyModuleHeader
       stmts <- readStmtEntries txn dbi
-      let nmod = I.NModule (map fst imps) te mdoc
-          tmod = A.Module tmn timps tdoc stmts
-      return (map fst imps, nmod, tmod, sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash, imps, nameHashes, roots, tests, mdoc)
+      let tmod = A.Module tmn timps tdoc stmts
+          sourceImps = A.importsOf tmod
+          nmod = I.NModule sourceImps te mdoc
+      return (sourceImps, nmod, tmod, sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash, imps, nameHashes, roots, tests, mdoc)
 
 -- Read only cached header fields from .tydb. This avoids decoding the large
 -- NameInfo and typed Module statement sections and is much faster than readFile

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -175,14 +175,14 @@ main = do
               tests = ["test_second", "test_first"]
               nmod = I.NModule [] iface (Just "module docs")
               tmod = S.Module mn [] (Just "typed docs") []
-          InterfaceFiles.writeFile tyPath "src" "pub" "impl" Nothing [] nameHashes roots tests (Just "module docs") nmod tmod
+          InterfaceFiles.writeFile tyPath "src" "pub" "impl" Nothing [] [] nameHashes roots tests (Just "module docs") nmod tmod
           InterfaceFiles.keyNameInfo firstName `shouldBe` "name-info/p/first"
           InterfaceFiles.keyNameInfo firstName `shouldNotBe` InterfaceFiles.keyNameInfo firstishName
           InterfaceFiles.keyNameHash secondName `shouldBe` "name-hash/p/second"
           InterfaceFiles.keyNameInfo sourcePlainName `shouldBe` "name-info/p/foo_bar"
           InterfaceFiles.keyNameInfo derivedName `shouldBe` "name-info/p/encodeD_witness"
           InterfaceFiles.keyNameInfo longName `shouldSatisfy` B8.isPrefixOf "name-info/h/"
-          (_mods, I.NModule _ te mdoc, tmod', sourceMeta, srcHash, pubHash, implHash, imps, nameHashes', roots', tests', doc') <-
+          (_mods, I.NModule _ te mdoc, tmod', sourceMeta, srcHash, pubHash, implHash, imps, depModules, nameHashes', roots', tests', doc') <-
             InterfaceFiles.readFile tyPath
           te `shouldBe` iface
           mdoc `shouldBe` Just "module docs"
@@ -190,16 +190,18 @@ main = do
           sourceMeta `shouldBe` Nothing
           (srcHash, pubHash, implHash) `shouldBe` ("src", "pub", "impl")
           imps `shouldBe` []
+          depModules `shouldBe` []
           nameHashes' `shouldBe` nameHashes
           roots' `shouldBe` roots
           tests' `shouldBe` tests
           doc' `shouldBe` Just "module docs"
 
-          (sourceMetaH, srcHashH, pubHashH, implHashH, impsH, nameHashesH, rootsH, testsH, docH) <-
+          (sourceMetaH, srcHashH, pubHashH, implHashH, impsH, depModulesH, nameHashesH, rootsH, testsH, docH) <-
             InterfaceFiles.readHeader tyPath
           sourceMetaH `shouldBe` Nothing
           (srcHashH, pubHashH, implHashH) `shouldBe` ("src", "pub", "impl")
           impsH `shouldBe` []
+          depModulesH `shouldBe` []
           nameHashesH `shouldBe` nameHashes
           rootsH `shouldBe` roots
           testsH `shouldBe` tests
@@ -214,10 +216,10 @@ main = do
               nameHashes = [nameHash firstName "src1" "pub1" "impl1"]
               nmod = I.NModule [] iface Nothing
               tmod = S.Module mn [] Nothing []
-          InterfaceFiles.writeFile tyPath "src" "pub" "impl" Nothing [] nameHashes [] [] Nothing nmod tmod
+          InterfaceFiles.writeFile tyPath "src" "pub" "impl" Nothing [] [] nameHashes [] [] Nothing nmod tmod
           mapConcurrently_
             (\_ -> do
-                (_sourceMetaH, srcHashH, pubHashH, implHashH, _impsH, nameHashesH, _rootsH, _testsH, _docH) <-
+                (_sourceMetaH, srcHashH, pubHashH, implHashH, _impsH, _depModulesH, nameHashesH, _rootsH, _testsH, _docH) <-
                   InterfaceFiles.readHeader tyPath
                 (srcHashH, pubHashH, implHashH) `shouldBe` ("src", "pub", "impl")
                 nameHashesH `shouldBe` nameHashes)
@@ -233,11 +235,11 @@ main = do
               nameHashes = [nameHash firstName "src1" "pub1" "impl1"]
               nmod = I.NModule [] iface Nothing
               tmod = S.Module mn [] Nothing []
-          InterfaceFiles.writeFile srcPath "src" "pub" "impl" Nothing [] nameHashes [] [] Nothing nmod tmod
+          InterfaceFiles.writeFile srcPath "src" "pub" "impl" Nothing [] [] nameHashes [] [] Nothing nmod tmod
           InterfaceFiles.copyInterface srcPath dstPath
           doesFileExist (dstPath </> "data.mdb") `shouldReturn` True
           doesFileExist (dstPath </> "lock.mdb") `shouldReturn` False
-          (_sourceMetaH, srcHashH, pubHashH, implHashH, _impsH, nameHashesH, _rootsH, _testsH, _docH) <-
+          (_sourceMetaH, srcHashH, pubHashH, implHashH, _impsH, _depModulesH, nameHashesH, _rootsH, _testsH, _docH) <-
             InterfaceFiles.readHeader dstPath
           (srcHashH, pubHashH, implHashH) `shouldBe` ("src", "pub", "impl")
           nameHashesH `shouldBe` nameHashes
@@ -253,7 +255,7 @@ main = do
               nameHashes = [nameHash firstName "src1" "pub1" "impl1"]
               nmod = I.NModule [] iface Nothing
               tmod = S.Module mn [] Nothing []
-          InterfaceFiles.writeFile tyPath "src" "pub" "impl" Nothing [] nameHashes [] [] Nothing nmod tmod
+          InterfaceFiles.writeFile tyPath "src" "pub" "impl" Nothing [] [] nameHashes [] [] Nothing nmod tmod
           let restore = do
                 setFileMode tyPath 0o755
                 setFileMode dataPath 0o644
@@ -261,7 +263,7 @@ main = do
           (do setFileMode tyPath 0o555
               setFileMode dataPath 0o444
               setFileMode lockPath 0o444
-              (_sourceMetaH, srcHashH, pubHashH, implHashH, _impsH, nameHashesH, _rootsH, _testsH, _docH) <-
+              (_sourceMetaH, srcHashH, pubHashH, implHashH, _impsH, _depModulesH, nameHashesH, _rootsH, _testsH, _docH) <-
                 InterfaceFiles.readHeader tyPath
               (srcHashH, pubHashH, implHashH) `shouldBe` ("src", "pub", "impl")
               nameHashesH `shouldBe` nameHashes)
@@ -281,7 +283,7 @@ main = do
               tyPath = dir </> "iface_version.tydb"
               nmod = I.NModule [] [] Nothing
               tmod = S.Module mn [] Nothing []
-          InterfaceFiles.writeFileWithVersion (map (+ 1) S.version) tyPath "" "" "" Nothing [] [] [] [] Nothing nmod tmod
+          InterfaceFiles.writeFileWithVersion (map (+ 1) S.version) tyPath "" "" "" Nothing [] [] [] [] [] Nothing nmod tmod
           InterfaceFiles.readHeaderMaybe tyPath `shouldReturn` Nothing
           InterfaceFiles.readFileMaybe tyPath `shouldReturn` Nothing
 
@@ -770,10 +772,11 @@ main = do
             []
             []
             []
+            []
             Nothing
             directIface
             directModule
-          (_mods, nmod, tmod, sourceMeta, srcHash, pubHash, implHash, imps, nameHashes, roots, tests, mdoc) <-
+          (_mods, nmod, tmod, sourceMeta, srcHash, pubHash, implHash, imps, depModules, nameHashes, roots, tests, mdoc) <-
             InterfaceFiles.readFile directTy
           InterfaceFiles.writeFileWithVersion
             (map (+ 1) S.version)
@@ -783,6 +786,7 @@ main = do
             implHash
             sourceMeta
             imps
+            depModules
             nameHashes
             roots
             tests
@@ -1177,6 +1181,7 @@ main = do
               B8.empty
               Nothing
               [(staleMod, B8.empty)]
+              []
               []
               []
               []

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -33,6 +33,7 @@ import qualified InterfaceFiles
 import Pretty (print, prettyText)
 import qualified Pretty
 import Test.Syd
+import Test.Syd.Modify (sequential)
 import Test.Syd.Def.Golden (goldenTextFile)
 import qualified Control.Monad.Trans.State.Strict as St
 import Text.Megaparsec (ParseErrorBundle, PosState(..), bundleErrors, bundlePosState, errorOffset, reachOffset, runParser, errorBundlePretty, ShowErrorComponent(..))
@@ -146,7 +147,7 @@ main = do
   env0 <- Acton.Env.initEnv sysTypesPath False
 
   sydTest $ do
-    describe "InterfaceFiles" $ do
+    sequential $ describe "InterfaceFiles" $ do
       it "round-trips payloads and preserves ordered name entries" $ do
         withSystemTempDirectory "acton-iface" $ \dir -> do
           let mn = S.modName ["iface"]

--- a/docs/acton-dev-guide/src/compiler/imports_and_envs.md
+++ b/docs/acton-dev-guide/src/compiler/imports_and_envs.md
@@ -112,11 +112,11 @@ active environment. It only gives the caller the stored interface and typed
 module payload.
 
 DBP interest is also scheduler metadata, not an import overlay. Each completed
-front result contributes external `nhPubDeps` and `nhImplDeps` into an
-`InterestMap`, and DBP later uses that map to prune a provider's typed module.
-That does not make the selected provider names available to the active
-type-checker environment; imports still become type-checker bindings only
-through `mkEnv`/`doImp`.
+front result contributes external dependency names into an `InterestMap`; for
+cached modules those names are reconstructed from the `.tydb` dependency rows.
+DBP later uses that map to prune a provider's typed module. That does not make
+the selected provider names available to the active type-checker environment;
+imports still become type-checker bindings only through `mkEnv`/`doImp`.
 
 ## How transitive imports become available
 

--- a/docs/acton-dev-guide/src/compiler/incremental_compilation.md
+++ b/docs/acton-dev-guide/src/compiler/incremental_compilation.md
@@ -129,8 +129,9 @@ When a fresh front pass produces a DBP candidate, the scheduler stores a
 modules can also register deferred jobs on later builds. This matters because
 the provider source and implementation hash can stay unchanged while a consumer
 starts selecting a different provider name. The scheduler also records
-interested names in an `InterestMap` by folding each completed module's
-`nhPubDeps` and `nhImplDeps`.
+interested names in an `InterestMap`. Fresh front results contribute the
+external dependency facts they just computed; cached modules reconstruct the
+same interest set from the `.tydb` dependency rows.
 
 Deferred jobs do not wait for every front pass in the project. Their wait set is
 the reverse dependency closure of the deferred module in the total build graph.

--- a/docs/acton-dev-guide/src/compiler/interface_caches.md
+++ b/docs/acton-dev-guide/src/compiler/interface_caches.md
@@ -43,6 +43,7 @@ Metadata and module-level keys:
 | `version` | `[Int]` |
 | `meta` | `(Maybe SourceFileMeta, ByteString, ByteString, ByteString)` |
 | `imports` | `[(ModName, ByteString)]` |
+| `deps` | `[DepModuleInfo]` |
 | `roots` | `[Name]` |
 | `tests` | `[String]` |
 | `doc` | `Maybe String` |
@@ -53,6 +54,12 @@ Metadata and module-level keys:
 The three `ByteString` hashes in `meta` are the module source-bytes hash, module
 public hash, and module implementation hash. The `ByteString` stored with each
 import is that imported module's public hash.
+
+The `deps` row stores every module whose names this module depends on, together
+with the recorded public and implementation hash for that dependency module.
+This row is the cheap stale-check gate: if both recorded module hashes still
+match the current dependency module hashes, the compiler does not need to read
+any per-name dependency rows for that module.
 
 Extension indexes use the same suffix scheme as per-name entries, so readers
 can look up one class or protocol without decoding the full index:
@@ -84,11 +91,23 @@ Per-name keys:
 
 Each `NameHashInfo` value contains the local name, `srcHash`, `pubHash`,
 `implHash`, local public/implementation dependency names
-(`pubLocalDeps` / `implLocalDeps`), and external public/implementation
-dependency snapshots (`pubDeps` / `implDeps`) as `(QName, hash)` pairs. Header
-readers use these records for cache freshness, interest registration, and DBP
-local dependency closure without decoding the `NameInfo` entries or typed
-statements.
+(`pubLocalDeps` / `implLocalDeps`). External dependency snapshots are stored in
+dependency rows instead of being repeated inside every `NameHashInfo`.
+
+Dependency rows:
+
+| Key | Value type |
+| --- | --- |
+| `deps/<module>` | `[DepNameInfo]` |
+| `deps/<module>/p/<name>` | `DepUsers` |
+| `deps/<module>/h/<hash>` | `DepUsers` |
+
+`deps/<module>` stores the dependency names used from that module and the
+recorded public and implementation hash for each name. `DepUsers` stores the
+local names that use one dependency name in their public and implementation
+hashes. A stale check reads `deps/<module>` only when the module-level hash gate
+changed, then reads `deps/<module>/<name>` only for names whose hashes actually
+changed or went missing.
 
 Short safe source names are stored directly in key suffixes. Names longer than
 400 bytes and names containing unsafe path-like bytes use SHA-256 based key
@@ -120,6 +139,10 @@ name-info/p/decode                -> (Name "decode", NameInfo for decode)
 name-hash/p/decode                -> NameHashInfo for decode
 name-hash/p/encode                -> NameHashInfo for encode
 
+deps                              -> dependency modules and module hashes
+deps/__builtin__                  -> dependency names and name hashes
+deps/__builtin__/p/bytes          -> local names using __builtin__.bytes
+
 stmt/000000000000                 -> typed Stmt for encode
 stmt/000000000001                 -> typed Stmt for decode
 ```
@@ -127,10 +150,11 @@ stmt/000000000001                 -> typed Stmt for decode
 ## Read And Write Behavior
 
 `readHeader` opens a read-only LMDB transaction and reads the header keys plus
-the `name-hash` entries. It does not decode `NameInfo` entries or typed
-statements. DBP uses this path to get per-name hashes, local dependency edges,
-and root actor names before deciding whether the full typed module must be
-decoded.
+the `deps` row and `name-hash` entries. It does not decode `NameInfo` entries
+or typed statements. Stale checks first compare the dependency module hashes in
+`deps`; DBP uses the header path to get per-name hashes, local dependency
+edges, and root actor names before deciding whether the full typed module must
+be decoded.
 
 `readExtensionsByClass` and `readExtensionsByProtocol` read one class or
 protocol key directly. DBP uses these exact lookups while expanding the selected


### PR DESCRIPTION
Cached module reuse currently has to inspect dependency name-hash data too broadly when checking whether an upstream module change affects a downstream module. This change adds module-level hash gates and stores dependency hashes by provider module and name so unchanged providers are skipped cheaply and changed providers only resolve the dependency names the cached module actually used.

It also adds opt-in .tydb read tracing and incremental coverage for the key cases: unchanged dependencies, unrelated public additions, and changed used names.