### PR TITLE
Move mbedtls + tlsuv off GC-heap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -405,7 +405,7 @@ dist/deps/libprotobuf_c: deps-download/$(LIBPROTOBUF_C_REF).tar.gz $(LIBPROTOBUF
 	touch "$(TD)/$@"
 
 # /deps/tlsuv ---------------------------------------------
-TLSUV_REF=5af699b033776ec6a21b32c90e7aa7bf08c9929f
+TLSUV_REF=e5765922d95c48937a5caecdd391ff0ad3bc16cd
 TLSUV_BUILD_ZIG=deps/tlsuv/build.zig
 TLSUV_BUILD_ZON=deps/tlsuv/build.zig.zon
 deps-download/$(TLSUV_REF).tar.gz:

--- a/base/rts/common.c
+++ b/base/rts/common.c
@@ -5,7 +5,6 @@
 #include <dlfcn.h>
 #endif
 
-#include <mbedtls/platform.h>
 #define LIBXML_STATIC
 #include <libxml/xmlmemory.h>
 #include <tlsuv/tlsuv.h>
@@ -53,19 +52,54 @@ void *GC_calloc(size_t count, size_t size) {
     return GC_malloc(count*size);
 }
 
+static void *uv_gc_malloc(size_t size) {
+    return GC_malloc_uncollectable(size);
+}
+static void *uv_gc_calloc(size_t count, size_t size) {
+    return GC_malloc_uncollectable(count * size);
+}
+
 void acton_init_alloc() {
-    // UV & TLSUV are used for IO, which is always done on the GC-heap. We don't
-    // have any constants related to UV, so we can always use the GC
+    // Allocator regimes for the native IO stack:
+    //
+    // tlsuv and mbedtls live on the libc heap with real malloc/free. tlsuv
+    // objects (the per-connection TLS engine especially) are reachable only
+    // through libc-allocated structs owned by net.ext.c, and Boehm GC does
+    // not scan libc memory: a GC-allocated engine looks unreachable and is
+    // collected mid-connection, leaving a dangling pointer behind. Real
+    // malloc/free ties their lifetimes to explicit close calls (with GC
+    // finalizers via __cleanup__ as a safety net) instead of GC reachability.
+    //
+    // libuv's internal allocations use GC_malloc_uncollectable + GC_free:
+    // they must be GC-SCANNED because they are load-bearing GC roots - the
+    // loop's watchers array holds the only reference to idle GC-allocated uv
+    // handles (and through handle->data, their actors) once an application
+    // retains a connection only via its callbacks. They must also never be
+    // collected, because tlsuv now stores libuv allocations (e.g. the
+    // getaddrinfo request buffer) inside its own libc structs where the
+    // collector cannot see them. libuv pairs every internal allocation with
+    // a free, so GC_free reclaims them deterministically.
+    //
+    // uv handles and requests allocated by Acton code remain ordinary GC
+    // memory; libuv never frees those (caller-owned).
+    //
+    // mbedtls needs no setup: with MBEDTLS_PLATFORM_MEMORY its allocator
+    // hooks default to calloc/free, which is the regime we want, and nothing
+    // may re-point them mid-run - mbedtls allocates and frees on widely
+    // separated code paths, so an allocator change frees objects through the
+    // wrong regime. (acton_replace_allocator used to re-point them on every
+    // call.) tlsuv_set_allocator passes its calloc/free pair through to
+    // mbedtls and also re-points libuv (tlsuv src/alloc.c), so it runs first
+    // and uv_replace_allocator then overrides libuv.
+    tlsuv_set_allocator(malloc,
+                        realloc,
+                        calloc,
+                        free);
 
-    uv_replace_allocator(GC_malloc,
+    uv_replace_allocator(uv_gc_malloc,
                          GC_realloc,
-                         GC_calloc,
-                         acton_noop_free);
-
-    tlsuv_set_allocator(GC_malloc,
-                            GC_realloc,
-                            GC_calloc,
-                            acton_noop_free);
+                         uv_gc_calloc,
+                         GC_free);
 }
 
 int acton_replace_allocator(acton_malloc_func malloc_func,
@@ -99,9 +133,6 @@ int acton_replace_allocator(acton_malloc_func malloc_func,
                 acton__allocator.malloc,
                 acton__allocator.realloc,
                 acton__allocator.strdup);
-
-    mbedtls_platform_set_calloc_free(acton__allocator.calloc,
-                                     acton_noop_free);
 
     return 0;
 }

--- a/base/rts/rts.c
+++ b/base/rts/rts.c
@@ -212,10 +212,19 @@ pthread_cond_t rts_exit_signal = PTHREAD_COND_INITIALIZER;
 
 #define NUM_THREADS num_wthreads+1
 
+WorkerCtx get_wctx() {
+    WorkerCtx wctx = GET_WCTX();
+    assert(wctx != NULL);
+    return wctx;
+}
+
+int get_wtid() {
+    return (int)get_wctx()->id;
+}
+
 void pin_actor_affinity() {
     $Actor a = ($Actor)pthread_getspecific(self_key);
-    WorkerCtx wctx = (WorkerCtx)pthread_getspecific(pkey_wctx);
-    long i = wctx->id;
+    long i = get_wctx()->id;
     log_debug("Pinning affinity for %s actor %ld to current WT %d", a->$class->$GCINFO, a->$globkey, i);
     a->$affinity = i;
 }
@@ -230,6 +239,8 @@ $Actor self_actor;
 
 #define NUM_THREADS 1
 
+WorkerCtx get_wctx() { return GET_WCTX(); }
+int get_wtid() { return (int)get_wctx()->id; }
 void pin_actor_affinity() { }
 void set_actor_affinity(int wthread_id) { }
 #endif // ACTON_THREADS
@@ -2479,6 +2490,7 @@ int main(int argc, char **argv) {
         log_fatal("Unable to get CPU info");
         exit(1);
     }
+    uv_free_cpu_info(cpu_infos, num_cores);
     bool mon_on_exit = false;
     bool auto_backtrace = true;
     bool interactive_backtrace = false;

--- a/base/rts/rts.h
+++ b/base/rts/rts.h
@@ -266,6 +266,9 @@ struct WorkerCtx {
 };
 extern WorkerCtx wctxs[MAX_WTHREADS];
 
+WorkerCtx get_wctx();
+int get_wtid();
+
 JumpBuf $PUSH_BUF();
 B_BaseException $POP();
 void $DROP();

--- a/base/src/net.act
+++ b/base/src/net.act
@@ -292,7 +292,7 @@ actor TCPListener(cap: TCPListenCap, address: str, port: int, on_listen: action(
         NotImplemented
     _init()
 
-actor TLSListenConnection(cap: _TCPListenConnectCap, server_stream: int):
+actor TLSListenConnection(cap: _TCPListenConnectCap, server_stream: int, tls_owner: int, worker_id: int):
     """TLS Listener Connection"""
     var _stream = -1
     var on_receive: ?action(TLSListenConnection, bytes) -> None = None
@@ -321,6 +321,9 @@ actor TLSListenConnection(cap: _TCPListenConnectCap, server_stream: int):
         """Write data to remote"""
         NotImplemented
 
+    action def __cleanup__() -> None:
+        NotImplemented
+
     mut def __resume__() -> None:
         NotImplemented
 
@@ -332,11 +335,18 @@ actor TLSListenConnection(cap: _TCPListenConnectCap, server_stream: int):
 actor TLSListener(cap: TCPListenCap, address: str, port: int, cert_pem: bytes, key_pem: bytes, on_listen: action(TLSListener, ?str) -> None, on_accept: action(TLSListenConnection) -> None):
     """TLS Listener"""
     _stream = -1
-    _tls_ctx = -1
-    def create_tls_listen_connection(cap: _TCPListenConnectCap, stream: int):
+    _tls_owner = -1
+    def create_tls_listen_connection(cap: _TCPListenConnectCap, stream: int, tls_owner: int, worker_id: int):
         """Implementation internal"""
-        c = TLSListenConnection(cap, stream)
+        c = TLSListenConnection(cap, stream, tls_owner, worker_id)
         on_accept(c)
+
+    action def close() -> None:
+        """Close listener"""
+        NotImplemented
+
+    action def __cleanup__() -> None:
+        NotImplemented
 
     mut def __resume__() -> None:
         NotImplemented
@@ -381,6 +391,9 @@ actor TLSConnection(cap: TCPConnectCap, address: str, port: int, on_connect: act
 
     action def write(data: bytes) -> None:
         """Write data to remote"""
+        NotImplemented
+
+    action def __cleanup__() -> None:
         NotImplemented
 
     def reconnect():

--- a/base/src/net.ext.c
+++ b/base/src/net.ext.c
@@ -5,10 +5,13 @@
 #include <gc.h>
 
 #include <stdint.h>
+#include <stdatomic.h>
+#include <stdbool.h>
 #include <tlsuv/tlsuv.h>
 #include <uv.h>
 #include <errno.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #ifndef _WIN32
 #include <unistd.h>
@@ -39,8 +42,11 @@ B_bool netQ_is_ipv6 (B_str address) {
     }
 }
 
+// Holds GC pointers (callback closures, hostname bytes) but is referenced only
+// from the libc-allocated uv request while a lookup is in flight, so it must
+// be GC_malloc_uncollectable: GC-scanned (keeping the closures alive) with an
+// explicit lifetime ending in the resolve callback.
 struct dns_cb_data {
-    struct addrinfo *hints;
     char* hostname;
     $action on_resolve;
     $action2 on_error;
@@ -56,11 +62,9 @@ static void _lookup_a__on_resolve (uv_getaddrinfo_t *req, int status, struct add
         $action2 f = ($action2)cb_data->on_error;
         f->$class->__asyn__(f, to$str(cb_data->hostname), to$str(errmsg));
 
-        // No free with GC, but maybe one day we do this explicitly?
-        //uv_freeaddrinfo(dns_res);
-        //free(cb_data->hints);
-        //free(cb_data);
-        //free(req);
+        uv_freeaddrinfo(dns_res);
+        GC_free(cb_data);
+        free(req);
         return;
     }
 
@@ -74,37 +78,50 @@ static void _lookup_a__on_resolve (uv_getaddrinfo_t *req, int status, struct add
     $action f = ($action)cb_data->on_resolve;
     f->$class->__asyn__(f, $res);
 
-    // No free with GC, but maybe one day we do this explicitly?
-    //uv_freeaddrinfo(dns_res);
-    //free(cb_data->hints);
-    //free(cb_data);
-    //free(req);
+    uv_freeaddrinfo(dns_res);
+    GC_free(cb_data);
+    free(req);
 }
 
 B_NoneType netQ__lookup_a (B_str name, $action on_resolve, $action on_error) {
-    struct addrinfo *hints = (struct addrinfo *)acton_malloc(sizeof(struct addrinfo));
-    hints->ai_family = PF_INET;
-    hints->ai_socktype = SOCK_STREAM;
-    hints->ai_protocol = IPPROTO_TCP;
-    hints->ai_flags = 0;
+    // libuv copies node/service/hints synchronously into its own request
+    // buffer, so hints can live on the stack.
+    struct addrinfo hints = {0};
+    hints.ai_family = PF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_protocol = IPPROTO_TCP;
 
-    struct dns_cb_data *cb_data = (struct dns_cb_data *)acton_malloc(sizeof(struct dns_cb_data));
-    cb_data->hints = hints;
+    struct dns_cb_data *cb_data = (struct dns_cb_data *)GC_malloc_uncollectable(sizeof(struct dns_cb_data));
+    if (cb_data == NULL) {
+        $action2 f = ($action2)on_error;
+        f->$class->__asyn__(f, name, to$str("Unable to run DNS query: out of memory"));
+        return B_None;
+    }
     cb_data->hostname = (char *)fromB_str(name);
     cb_data->on_resolve = on_resolve;
     cb_data->on_error = ($action2) on_error;
 
-    uv_getaddrinfo_t *req = (uv_getaddrinfo_t*)acton_malloc(sizeof(uv_getaddrinfo_t));
+    // The request enters libuv's threadpool work queue, whose intrusive links
+    // pass through libc-allocated nodes (tlsuv connects); a GC-allocated
+    // request would be invisible to the collector while queued behind one.
+    uv_getaddrinfo_t *req = (uv_getaddrinfo_t*)malloc(sizeof(uv_getaddrinfo_t));
+    if (req == NULL) {
+        GC_free(cb_data);
+        $action2 f = ($action2)on_error;
+        f->$class->__asyn__(f, name, to$str("Unable to run DNS query: out of memory"));
+        return B_None;
+    }
     req->data = cb_data;
 
-    int r = uv_getaddrinfo(get_uv_loop(), req, _lookup_a__on_resolve, (const char *)fromB_str(name), NULL, hints);
+    int r = uv_getaddrinfo(get_uv_loop(), req, _lookup_a__on_resolve, (const char *)fromB_str(name), NULL, &hints);
     if (r != 0) {
         char errmsg[1024] = "Unable to run DNS query: ";
         uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
         log_warn(errmsg);
         $action2 f = ($action2)cb_data->on_error;
         f->$class->__asyn__(f, name, to$str(errmsg));
-        // NOTE: free() here if do manual memory management in I/O one day
+        GC_free(cb_data);
+        free(req);
         return B_None;
     }
 
@@ -121,11 +138,9 @@ static void _lookup_aaaa__on_resolve (uv_getaddrinfo_t *req, int status, struct 
         $action2 f = ($action2)cb_data->on_error;
         f->$class->__asyn__(f, to$str(cb_data->hostname), to$str(errmsg));
 
-        // No free with GC, but maybe one day we do this explicitly?
-        //uv_freeaddrinfo(dns_res);
-        //free(cb_data->hints);
-        //free(cb_data);
-        //free(req);
+        uv_freeaddrinfo(dns_res);
+        GC_free(cb_data);
+        free(req);
         return;
     }
 
@@ -139,37 +154,45 @@ static void _lookup_aaaa__on_resolve (uv_getaddrinfo_t *req, int status, struct 
     $action f = ($action)cb_data->on_resolve;
     f->$class->__asyn__(f, $res);
 
-    // No free with GC, but maybe one day we do this explicitly?
-    //uv_freeaddrinfo(dns_res);
-    //free(cb_data->hints);
-    //free(cb_data);
-    //free(req);
+    uv_freeaddrinfo(dns_res);
+    GC_free(cb_data);
+    free(req);
 }
 
 B_NoneType netQ__lookup_aaaa (B_str name, $action on_resolve, $action on_error) {
-    struct addrinfo *hints = (struct addrinfo *)acton_malloc(sizeof(struct addrinfo));
-    hints->ai_family = PF_INET6;
-    hints->ai_socktype = SOCK_STREAM;
-    hints->ai_protocol = IPPROTO_TCP;
-    hints->ai_flags = 0;
+    struct addrinfo hints = {0};
+    hints.ai_family = PF_INET6;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_protocol = IPPROTO_TCP;
 
-    struct dns_cb_data *cb_data = (struct dns_cb_data *)acton_malloc(sizeof(struct dns_cb_data));
-    cb_data->hints = hints;
+    struct dns_cb_data *cb_data = (struct dns_cb_data *)GC_malloc_uncollectable(sizeof(struct dns_cb_data));
+    if (cb_data == NULL) {
+        $action2 f = ($action2)on_error;
+        f->$class->__asyn__(f, name, to$str("Unable to run DNS query: out of memory"));
+        return B_None;
+    }
     cb_data->hostname = (char *)fromB_str(name);
     cb_data->on_resolve = on_resolve;
     cb_data->on_error = ($action2)on_error;
 
-    uv_getaddrinfo_t *req = (uv_getaddrinfo_t*)acton_malloc(sizeof(uv_getaddrinfo_t));
+    uv_getaddrinfo_t *req = (uv_getaddrinfo_t*)malloc(sizeof(uv_getaddrinfo_t));
+    if (req == NULL) {
+        GC_free(cb_data);
+        $action2 f = ($action2)on_error;
+        f->$class->__asyn__(f, name, to$str("Unable to run DNS query: out of memory"));
+        return B_None;
+    }
     req->data = cb_data;
 
-    int r = uv_getaddrinfo(get_uv_loop(), req, _lookup_aaaa__on_resolve, (const char *)fromB_str(name), NULL, hints);
+    int r = uv_getaddrinfo(get_uv_loop(), req, _lookup_aaaa__on_resolve, (const char *)fromB_str(name), NULL, &hints);
     if (r != 0) {
         char errmsg[1024] = "Unable to run DNS query: ";
         uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
         log_warn(errmsg);
         $action2 f = ($action2)cb_data->on_error;
         f->$class->__asyn__(f, name, to$str(errmsg));
-        // NOTE: free() here if do manual memory management in I/O one day
+        GC_free(cb_data);
+        free(req);
         return B_None;
     }
 
@@ -609,95 +632,446 @@ B_NoneType netQ_TCPListenConnectionD___resume__ (netQ_TCPListenConnection self) 
     return B_None;
 }
 
+struct tls_listener_server_state;
+
 struct tls_listener_conn {
-    netQ_TLSListener listener;
+    struct tls_listener_server_state *listener_state;
     tlsuv_stream_t *stream;
+    struct tls_listener_stream_state *state;
 };
+
+struct tls_listener_server_state {
+    _Atomic int refs;
+    netQ_TLSListener actor;
+};
+
+struct tls_listener_owner {
+    _Atomic int refs;
+    tls_context *tls;
+    tlsuv_private_key_t key;
+    tlsuv_certificate_t cert;
+};
+
+struct tls_listener_stream_state {
+    struct tls_listener_owner *owner;
+    netQ_TLSListenConnection actor;
+};
+
+struct tls_client_state {
+    netQ_TLSConnection actor;
+    bool connected;
+    int alpn_count;
+    char **alpn_protocols;
+};
+
+struct tls_write_req_state {
+    char *buf;
+};
+
+static void tls_listener_release_resources(tls_context *tls,
+                                           tlsuv_private_key_t key,
+                                           tlsuv_certificate_t cert);
+static void tls_listener_owner_release(struct tls_listener_owner *owner);
+static struct tls_listener_stream_state *tls_listener_stream_state_new(struct tls_listener_owner *owner);
+static void tls_listener_release_connection_owner(netQ_TLSListenConnection self);
+static struct tls_listener_server_state *tls_listener_server_state_new(netQ_TLSListener actor);
+static void tls_listener_server_state_retain(struct tls_listener_server_state *state);
+static void tls_listener_server_state_release(struct tls_listener_server_state *state);
+static struct tls_client_state *tls_client_state_new(netQ_TLSConnection actor);
+static void tls_client_state_free(struct tls_client_state *state);
+static struct tls_write_req_state *tls_write_req_state_new(B_bytes data);
+static void tls_write_req_state_free(struct tls_write_req_state *state);
+
+static void close_uv_socket(uv_os_sock_t sock) {
+#ifdef _WIN32
+    closesocket(sock);
+#else
+    close((int)sock);
+#endif
+}
+
+static void uv_handle_free_on_close(uv_handle_t *handle) {
+    free(handle);
+}
+
+static void tls_listener_server_on_close(uv_handle_t *server) {
+    log_debug("TLS listener server handle closed: %p", server);
+    struct tls_listener_server_state *state = (struct tls_listener_server_state *)server->data;
+    server->data = NULL;
+    tls_listener_server_state_release(state);
+    free(server);
+}
 
 static void tls_listener_on_close(uv_handle_t *stream) {
     log_debug("TLS listener handle closed, stream: %p  stream->data: %p", stream, stream->data);
+    struct tls_listener_stream_state *state = (struct tls_listener_stream_state *)stream->data;
+    if (state != NULL) {
+        netQ_TLSListenConnection self = state->actor;
+        if (self != NULL) {
+            self->server_stream = -1LL;
+            self->_stream = -1LL;
+            state->actor = NULL;
+        }
+        tls_listener_owner_release(state->owner);
+        free(state);
+    }
+    stream->data = NULL;
+    free(stream);
+}
+
+static void tls_listener_release_resources(tls_context *tls,
+                                           tlsuv_private_key_t key,
+                                           tlsuv_certificate_t cert) {
+    if (tls != NULL && (intptr_t)tls != -1 && tls->set_own_cert != NULL) {
+        tls->set_own_cert(tls, NULL, NULL);
+    }
+    if (cert != NULL && (intptr_t)cert != -1 && cert->free != NULL) {
+        cert->free(cert);
+    }
+    if (key != NULL && (intptr_t)key != -1 && key->free != NULL) {
+        key->free(key);
+    }
+    if (tls != NULL && (intptr_t)tls != -1 && tls->free_ctx != NULL) {
+        tls->free_ctx(tls);
+    }
+}
+
+static struct tls_listener_owner *tls_listener_owner_new(tls_context *tls,
+                                                         tlsuv_private_key_t key,
+                                                         tlsuv_certificate_t cert) {
+    struct tls_listener_owner *owner = GC_malloc_uncollectable(sizeof(*owner));
+    if (owner == NULL) {
+        return NULL;
+    }
+    atomic_init(&owner->refs, 1);
+    owner->tls = tls;
+    owner->key = key;
+    owner->cert = cert;
+    return owner;
+}
+
+static void tls_listener_owner_retain(struct tls_listener_owner *owner) {
+    if (owner != NULL && (intptr_t)owner != -1) {
+        atomic_fetch_add(&owner->refs, 1);
+    }
+}
+
+static void tls_listener_owner_release(struct tls_listener_owner *owner) {
+    if (owner == NULL || (intptr_t)owner == -1) {
+        return;
+    }
+    int prev = atomic_fetch_sub(&owner->refs, 1);
+    if (prev == 1) {
+        tls_listener_release_resources(owner->tls, owner->key, owner->cert);
+        GC_free(owner);
+    }
+}
+
+static struct tls_listener_stream_state *tls_listener_stream_state_new(struct tls_listener_owner *owner) {
+    struct tls_listener_stream_state *state = malloc(sizeof(*state));
+    if (state == NULL) {
+        return NULL;
+    }
+    state->owner = owner;
+    state->actor = NULL;
+    return state;
+}
+
+static struct tls_listener_server_state *tls_listener_server_state_new(netQ_TLSListener actor) {
+    struct tls_listener_server_state *state = malloc(sizeof(*state));
+    if (state == NULL) {
+        return NULL;
+    }
+    atomic_init(&state->refs, 1);
+    state->actor = actor;
+    return state;
+}
+
+static void tls_listener_server_state_retain(struct tls_listener_server_state *state) {
+    if (state != NULL) {
+        atomic_fetch_add(&state->refs, 1);
+    }
+}
+
+static void tls_listener_server_state_release(struct tls_listener_server_state *state) {
+    if (state == NULL) {
+        return;
+    }
+    int prev = atomic_fetch_sub(&state->refs, 1);
+    if (prev == 1) {
+        free(state);
+    }
+}
+
+static struct tls_client_state *tls_client_state_new(netQ_TLSConnection actor) {
+    struct tls_client_state *state = malloc(sizeof(*state));
+    if (state == NULL) {
+        return NULL;
+    }
+    state->actor = actor;
+    state->connected = false;
+    state->alpn_count = 0;
+    state->alpn_protocols = NULL;
+    return state;
+}
+
+static void tls_client_state_free(struct tls_client_state *state) {
+    if (state == NULL) {
+        return;
+    }
+
+    if (state->alpn_protocols != NULL) {
+        for (int i = 0; i < state->alpn_count; i++) {
+            free(state->alpn_protocols[i]);
+        }
+        free(state->alpn_protocols);
+    }
+    free(state);
+}
+
+static struct tls_write_req_state *tls_write_req_state_new(B_bytes data) {
+    struct tls_write_req_state *state = malloc(sizeof(*state));
+    if (state == NULL) {
+        return NULL;
+    }
+
+    size_t len = data->nbytes;
+    state->buf = malloc(len > 0 ? len : 1);
+    if (state->buf == NULL) {
+        free(state);
+        return NULL;
+    }
+    if (len > 0) {
+        memcpy(state->buf, data->str, len);
+    }
+    return state;
+}
+
+static void tls_write_req_state_free(struct tls_write_req_state *state) {
+    if (state != NULL) {
+        free(state->buf);
+        free(state);
+    }
+}
+
+static void tls_listener_release_actor_resources(netQ_TLSListener self) {
+    struct tls_listener_owner *owner = (struct tls_listener_owner *)(intptr_t)self->_tls_owner;
+    self->_tls_owner = -1LL;
+    tls_listener_owner_release(owner);
+}
+
+static void tls_listener_release_connection_owner(netQ_TLSListenConnection self) {
+    struct tls_listener_owner *owner = (struct tls_listener_owner *)(intptr_t)self->tls_owner;
+    self->tls_owner = -1LL;
+    tls_listener_owner_release(owner);
+}
+
+static bool tls_listener_stream_is_closing(tlsuv_stream_t *stream) {
+    if (stream == NULL || (intptr_t)stream == -1) {
+        return false;
+    }
+    uv_handle_t *watcher = (uv_handle_t *)&stream->watcher;
+    return uv_handle_get_type(watcher) != UV_UNKNOWN_HANDLE && uv_is_closing(watcher);
+}
+
+static void tls_listener_close_server(netQ_TLSListener self) {
+    uv_tcp_t *server = (uv_tcp_t *)(intptr_t)self->_stream;
+    self->_stream = -1LL;
+
+    if ((intptr_t)server != -1) {
+        struct tls_listener_server_state *state = (struct tls_listener_server_state *)server->data;
+        if (state != NULL) {
+            state->actor = NULL;
+        }
+        if (uv_is_closing((uv_handle_t *)server) == 0) {
+            uv_close((uv_handle_t *)server, tls_listener_server_on_close);
+        }
+    }
+
+    tls_listener_release_actor_resources(self);
 }
 
 static void tls_listener_close_stream(tlsuv_stream_t *stream) {
+    if (stream == NULL) {
+        return;
+    }
+    if (tls_listener_stream_is_closing(stream)) {
+        return;
+    }
+    tlsuv_stream_read_stop(stream);
     tlsuv_stream_close(stream, tls_listener_on_close);
 }
 
 static void tls_listener_on_connect(uv_connect_t *creq, int status) {
     struct tls_listener_conn *conn = (struct tls_listener_conn *)creq->data;
-    netQ_TLSListener listener = conn->listener;
+    if (conn == NULL) {
+        return;
+    }
+
+    struct tls_listener_server_state *listener_state = conn->listener_state;
+    netQ_TLSListener listener = listener_state != NULL ? listener_state->actor : NULL;
     tlsuv_stream_t *stream = conn->stream;
+    struct tls_listener_stream_state *state = conn->state;
+    struct tls_listener_owner *owner = state != NULL ? state->owner : NULL;
+
+    if (listener == NULL) {
+        tls_listener_close_stream(stream);
+        tls_listener_server_state_release(listener_state);
+        free(conn);
+        free(creq);
+        return;
+    }
 
     if (status != 0) {
         char errmsg[1024] = "TLS handshake failed: ";
         uv_strerror_r(status, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
         log_warn(errmsg);
-        $action2 f = ($action2)listener->on_listen;
-        f->$class->__asyn__(f, listener, to$str(errmsg));
+        if (listener->on_listen != NULL) {
+            $action2 f = ($action2)listener->on_listen;
+            f->$class->__asyn__(f, listener, to$str(errmsg));
+        }
         tls_listener_close_stream(stream);
+        tls_listener_server_state_release(listener_state);
+        free(conn);
+        free(creq);
         return;
     }
 
-    listener->$class->create_tls_listen_connection(listener, B_None, (int64_t)(intptr_t)stream);
+    if (listener->on_accept == NULL) {
+        tls_listener_close_stream(stream);
+        tls_listener_server_state_release(listener_state);
+        free(conn);
+        free(creq);
+        return;
+    }
+
+    tls_listener_owner_retain(owner);
+    listener->$class->create_tls_listen_connection(listener,
+                                                   B_None,
+                                                   (int64_t)(intptr_t)stream,
+                                                   (int64_t)(intptr_t)owner,
+                                                   get_wtid());
+    tls_listener_server_state_release(listener_state);
+    free(conn);
+    free(creq);
 }
 
 static void tls_listener_on_receive(uv_stream_t *stream, ssize_t nread, const uv_buf_t *buf) {
-    netQ_TLSListenConnection self = ((tlsuv_stream_t *)stream)->data;
+    struct tls_listener_stream_state *state = (struct tls_listener_stream_state *)((tlsuv_stream_t *)stream)->data;
+    netQ_TLSListenConnection self = state != NULL ? state->actor : NULL;
+    if (self == NULL) {
+        return;
+    }
+
     if (nread > 0) {
-        if (stream->data) {
+        if (stream->data && self->on_receive != NULL) {
             $action2 f = ($action2)self->on_receive;
             B_bytes data = to$bytesD_len(buf->base, nread);
             f->$class->__asyn__(f, self, data);
         }
     } else if (nread == UV_EOF) {
         log_debug("TLS listen connection closed %p", stream);
-        tls_listener_close_stream((tlsuv_stream_t *)stream);
         self->_stream = -1LL;
+        tls_listener_close_stream((tlsuv_stream_t *)stream);
         if (self->on_remote_close) {
             $action f = ($action)self->on_remote_close;
             f->$class->__asyn__(f, self);
         }
     } else if (nread < 0) {
-        log_debug("TLS listen read error %ld: %s", nread, uv_strerror((int)nread));
+        char errmsg[1024] = "TLS listen read error: ";
+        uv_strerror_r((int)nread, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
+        log_debug("%s", errmsg);
+        self->_stream = -1LL;
         tls_listener_close_stream((tlsuv_stream_t *)stream);
-        if (stream->data) {
-            self->_stream = -1LL;
+        if (self->on_error != NULL) {
+            $action2 on_error = ($action2)self->on_error;
+            on_error->$class->__asyn__(on_error, self, to$str(errmsg));
         }
     }
 }
 
 static void tls_listener_write_cb(uv_write_t *wreq, int status) {
-    if (status < 0) {
+    struct tls_write_req_state *write_state = (struct tls_write_req_state *)wreq->data;
+    // ECANCELED means the stream is already being torn down (tlsuv flushes
+    // queued writes from its close path); reporting it or re-closing would
+    // surface an error for a deliberate close.
+    if (status < 0 && status != UV_ECANCELED) {
         char errmsg[1024] = "Failed to write to TLS listen socket: ";
         uv_strerror_r(status, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
         log_warn(errmsg);
-        netQ_TLSListenConnection self = (netQ_TLSListenConnection)wreq->data;
-        $action2 on_error = ($action2)self->on_error;
-        on_error->$class->__asyn__(on_error, self, to$str(errmsg));
+        struct tls_listener_stream_state *state = NULL;
+        if (wreq->handle != NULL) {
+            state = (struct tls_listener_stream_state *)((tlsuv_stream_t *)wreq->handle)->data;
+        }
+        netQ_TLSListenConnection self = state != NULL ? state->actor : NULL;
+        if (self != NULL && self->on_error != NULL) {
+            $action2 on_error = ($action2)self->on_error;
+            on_error->$class->__asyn__(on_error, self, to$str(errmsg));
+        }
         tls_listener_close_stream((tlsuv_stream_t *)wreq->handle);
     }
+    tls_write_req_state_free(write_state);
+    free(wreq);
 }
 
 static void on_new_tls_connection(uv_stream_t *server, int status) {
-    netQ_TLSListener self = (netQ_TLSListener)server->data;
+    struct tls_listener_server_state *listener_state = (struct tls_listener_server_state *)server->data;
+    netQ_TLSListener self = listener_state != NULL ? listener_state->actor : NULL;
+    if (self == NULL) {
+        return;
+    }
 
     if (status != 0) {
         char errmsg[1024] = "Error on new TLS client connection: ";
         uv_strerror_r(status, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
         log_warn(errmsg);
-        $action2 f = ($action2)self->on_listen;
-        f->$class->__asyn__(f, self, to$str(errmsg));
+        if (self->on_listen != NULL) {
+            $action2 f = ($action2)self->on_listen;
+            f->$class->__asyn__(f, self, to$str(errmsg));
+        }
+        // No release here: this callback borrows the server handle's own
+        // reference (server->data); only the retain below, taken for an
+        // in-flight handshake, is ever paired with a release.
         return;
     }
 
-    uv_tcp_t *client = (uv_tcp_t *)acton_malloc(sizeof(uv_tcp_t));
-    uv_tcp_init(get_uv_loop(), client);
-    int r = uv_accept(server, (uv_stream_t *)client);
+    tls_listener_server_state_retain(listener_state);
+
+    uv_tcp_t *client = (uv_tcp_t *)malloc(sizeof(uv_tcp_t));
+    if (client == NULL) {
+        if (self->on_listen != NULL) {
+            $action2 f = ($action2)self->on_listen;
+            f->$class->__asyn__(f, self, to$str("Failed to allocate TLS client handle"));
+        }
+        tls_listener_server_state_release(listener_state);
+        return;
+    }
+
+    int r = uv_tcp_init(get_uv_loop(), client);
+    if (r != 0) {
+        char errmsg[1024] = "Failed to initialize TLS client handle: ";
+        uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
+        log_warn("%s", errmsg);
+        if (self->on_listen != NULL) {
+            $action2 f = ($action2)self->on_listen;
+            f->$class->__asyn__(f, self, to$str(errmsg));
+        }
+        free(client);
+        tls_listener_server_state_release(listener_state);
+        return;
+    }
+
+    r = uv_accept(server, (uv_stream_t *)client);
     if (r != 0) {
         char errmsg[1024] = "Error in accepting TLS client connection: ";
         uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
         log_warn(errmsg);
-        $action2 f = ($action2)self->on_listen;
-        f->$class->__asyn__(f, self, to$str(errmsg));
+        if (self->on_listen != NULL) {
+            $action2 f = ($action2)self->on_listen;
+            f->$class->__asyn__(f, self, to$str(errmsg));
+        }
+        uv_close((uv_handle_t *)client, uv_handle_free_on_close);
+        tls_listener_server_state_release(listener_state);
         return;
     }
 
@@ -707,8 +1081,12 @@ static void on_new_tls_connection(uv_stream_t *server, int status) {
         char errmsg[1024] = "Error getting TLS client socket fd: ";
         uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
         log_warn(errmsg);
-        $action2 f = ($action2)self->on_listen;
-        f->$class->__asyn__(f, self, to$str(errmsg));
+        if (self->on_listen != NULL) {
+            $action2 f = ($action2)self->on_listen;
+            f->$class->__asyn__(f, self, to$str(errmsg));
+        }
+        uv_close((uv_handle_t *)client, uv_handle_free_on_close);
+        tls_listener_server_state_release(listener_state);
         return;
     }
 
@@ -720,48 +1098,134 @@ static void on_new_tls_connection(uv_stream_t *server, int status) {
         char errmsg[1024] = "Error duplicating TLS client socket: ";
         snprintf(errmsg + strlen(errmsg), sizeof(errmsg) - strlen(errmsg), "WSA error %d", WSAGetLastError());
         log_warn(errmsg);
-        $action2 f = ($action2)self->on_listen;
-        f->$class->__asyn__(f, self, to$str(errmsg));
-        uv_close((uv_handle_t *)client, NULL);
+        if (self->on_listen != NULL) {
+            $action2 f = ($action2)self->on_listen;
+            f->$class->__asyn__(f, self, to$str(errmsg));
+        }
+        uv_close((uv_handle_t *)client, uv_handle_free_on_close);
+        tls_listener_server_state_release(listener_state);
         return;
     }
     SOCKET dup_sock = WSASocket(FROM_PROTOCOL_INFO, FROM_PROTOCOL_INFO, FROM_PROTOCOL_INFO,
                                 &dup_info, 0, WSA_FLAG_OVERLAPPED);
-    uv_close((uv_handle_t *)client, NULL);
+    uv_close((uv_handle_t *)client, uv_handle_free_on_close);
     if (dup_sock == INVALID_SOCKET) {
         char errmsg[1024] = "Error duplicating TLS client socket: ";
         snprintf(errmsg + strlen(errmsg), sizeof(errmsg) - strlen(errmsg), "WSA error %d", WSAGetLastError());
         log_warn(errmsg);
-        $action2 f = ($action2)self->on_listen;
-        f->$class->__asyn__(f, self, to$str(errmsg));
+        if (self->on_listen != NULL) {
+            $action2 f = ($action2)self->on_listen;
+            f->$class->__asyn__(f, self, to$str(errmsg));
+        }
+        tls_listener_server_state_release(listener_state);
         return;
     }
     uv_os_sock_t sock = (uv_os_sock_t)dup_sock;
 #else
     int dup_fd = dup((int)fd);
-    uv_close((uv_handle_t *)client, NULL);
+    uv_close((uv_handle_t *)client, uv_handle_free_on_close);
     if (dup_fd < 0) {
         char errmsg[1024] = "Error duplicating TLS client socket: ";
         snprintf(errmsg + strlen(errmsg), sizeof(errmsg) - strlen(errmsg), "%s", strerror(errno));
         log_warn(errmsg);
-        $action2 f = ($action2)self->on_listen;
-        f->$class->__asyn__(f, self, to$str(errmsg));
+        if (self->on_listen != NULL) {
+            $action2 f = ($action2)self->on_listen;
+            f->$class->__asyn__(f, self, to$str(errmsg));
+        }
+        tls_listener_server_state_release(listener_state);
         return;
     }
     uv_os_sock_t sock = (uv_os_sock_t)dup_fd;
 #endif
 
-    tls_context *tls = (tls_context *)(intptr_t)self->_tls_ctx;
-    tlsuv_stream_t *stream = (tlsuv_stream_t *)acton_malloc(sizeof(tlsuv_stream_t));
-    tlsuv_stream_init(get_uv_loop(), stream, tls);
+    struct tls_listener_owner *owner = (struct tls_listener_owner *)(intptr_t)self->_tls_owner;
+    if (owner == NULL || (intptr_t)owner == -1 || owner->tls == NULL) {
+        if (self->on_listen != NULL) {
+            $action2 f = ($action2)self->on_listen;
+            f->$class->__asyn__(f, self, to$str("TLS listener resources unavailable"));
+        }
+        close_uv_socket(sock);
+        tls_listener_server_state_release(listener_state);
+        return;
+    }
+    tls_listener_owner_retain(owner);
+    tls_context *tls = owner->tls;
+    tlsuv_stream_t *stream = (tlsuv_stream_t *)malloc(sizeof(tlsuv_stream_t));
+    if (stream == NULL) {
+        if (self->on_listen != NULL) {
+            $action2 f = ($action2)self->on_listen;
+            f->$class->__asyn__(f, self, to$str("Failed to allocate TLS listener stream"));
+        }
+        tls_listener_owner_release(owner);
+        close_uv_socket(sock);
+        tls_listener_server_state_release(listener_state);
+        return;
+    }
+    struct tls_listener_stream_state *state = tls_listener_stream_state_new(owner);
+    if (state == NULL) {
+        if (self->on_listen != NULL) {
+            $action2 f = ($action2)self->on_listen;
+            f->$class->__asyn__(f, self, to$str("Failed to allocate TLS listener stream state"));
+        }
+        tls_listener_owner_release(owner);
+        free(stream);
+        close_uv_socket(sock);
+        tls_listener_server_state_release(listener_state);
+        return;
+    }
+    r = tlsuv_stream_init(get_uv_loop(), stream, tls);
+    if (r != 0) {
+        char errmsg[1024] = "Failed to initialize TLS listener stream: ";
+        uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
+        log_warn("%s", errmsg);
+        if (self->on_listen != NULL) {
+            $action2 f = ($action2)self->on_listen;
+            f->$class->__asyn__(f, self, to$str(errmsg));
+        }
+        free(state);
+        tls_listener_owner_release(owner);
+        free(stream);
+        close_uv_socket(sock);
+        tls_listener_server_state_release(listener_state);
+        return;
+    }
     tlsuv_stream_set_server(stream, 1);
     stream->authmode = 0;
+    stream->data = state;
 
-    struct tls_listener_conn *conn = (struct tls_listener_conn *)acton_malloc(sizeof(*conn));
-    conn->listener = self;
+    struct tls_listener_conn *conn = (struct tls_listener_conn *)malloc(sizeof(*conn));
+    if (conn == NULL) {
+        if (self->on_listen != NULL) {
+            $action2 f = ($action2)self->on_listen;
+            f->$class->__asyn__(f, self, to$str("Failed to allocate TLS listener connect state"));
+        }
+        stream->data = NULL;
+        free(state);
+        tls_listener_owner_release(owner);
+        free(stream);
+        close_uv_socket(sock);
+        tls_listener_server_state_release(listener_state);
+        return;
+    }
+    conn->listener_state = listener_state;
     conn->stream = stream;
+    conn->state = state;
 
-    uv_connect_t *connect_req = (uv_connect_t *)acton_calloc(1, sizeof(uv_connect_t));
+    uv_connect_t *connect_req = (uv_connect_t *)calloc(1, sizeof(uv_connect_t));
+    if (connect_req == NULL) {
+        if (self->on_listen != NULL) {
+            $action2 f = ($action2)self->on_listen;
+            f->$class->__asyn__(f, self, to$str("Failed to allocate TLS handshake request"));
+        }
+        free(conn);
+        stream->data = NULL;
+        free(state);
+        tls_listener_owner_release(owner);
+        free(stream);
+        close_uv_socket(sock);
+        tls_listener_server_state_release(listener_state);
+        return;
+    }
     connect_req->data = conn;
 
     r = tlsuv_stream_open(connect_req, stream, sock, tls_listener_on_connect);
@@ -769,9 +1233,17 @@ static void on_new_tls_connection(uv_stream_t *server, int status) {
         char errmsg[1024] = "Failed to start TLS handshake: ";
         uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
         log_warn(errmsg);
-        $action2 f = ($action2)self->on_listen;
-        f->$class->__asyn__(f, self, to$str(errmsg));
+        if (self->on_listen != NULL) {
+            $action2 f = ($action2)self->on_listen;
+            f->$class->__asyn__(f, self, to$str(errmsg));
+        }
+        // tlsuv only adopts the fd once its poll watcher is initialized; on
+        // failure the dup'd socket is still ours to close.
+        close_uv_socket(sock);
         tls_listener_close_stream(stream);
+        tls_listener_server_state_release(listener_state);
+        free(conn);
+        free(connect_req);
         return;
     }
 }
@@ -780,14 +1252,19 @@ $R netQ_TLSListenerD__initG_local (netQ_TLSListener self, $Cont c$cont) {
     pin_actor_affinity();
 
     tls_context *tls = default_tls_context(NULL, 0);
+    tlsuv_private_key_t key = NULL;
+    tlsuv_certificate_t cert = NULL;
+    struct tls_listener_owner *owner = NULL;
+    uv_tcp_t *server = NULL;
+    int r;
+    struct sockaddr_in addr4;
+    struct sockaddr_in6 addr6;
     if (tls == NULL) {
         $action2 f = ($action2)self->on_listen;
         f->$class->__asyn__(f, self, to$str("Failed to initialize TLS context"));
         return $R_CONT(c$cont, B_None);
     }
 
-    tlsuv_private_key_t key = NULL;
-    tlsuv_certificate_t cert = NULL;
     int rc = tls->load_key(&key, (const char *)self->key_pem->str, self->key_pem->nbytes);
     if (rc != 0) {
         const char *err = tls->strerror(rc);
@@ -795,6 +1272,7 @@ $R netQ_TLSListenerD__initG_local (netQ_TLSListener self, $Cont c$cont) {
         log_warn((const char *)fromB_str(errmsg));
         $action2 f = ($action2)self->on_listen;
         f->$class->__asyn__(f, self, errmsg);
+        tls_listener_release_resources(tls, key, cert);
         return $R_CONT(c$cont, B_None);
     }
 
@@ -805,6 +1283,7 @@ $R netQ_TLSListenerD__initG_local (netQ_TLSListener self, $Cont c$cont) {
         log_warn((const char *)fromB_str(errmsg));
         $action2 f = ($action2)self->on_listen;
         f->$class->__asyn__(f, self, errmsg);
+        tls_listener_release_resources(tls, key, cert);
         return $R_CONT(c$cont, B_None);
     }
 
@@ -812,17 +1291,48 @@ $R netQ_TLSListenerD__initG_local (netQ_TLSListener self, $Cont c$cont) {
     if (rc != 0) {
         $action2 f = ($action2)self->on_listen;
         f->$class->__asyn__(f, self, to$str("Failed to set TLS certificate"));
+        tls_listener_release_resources(tls, key, cert);
         return $R_CONT(c$cont, B_None);
     }
 
-    self->_tls_ctx = (int64_t)(intptr_t)tls;
+    owner = tls_listener_owner_new(tls, key, cert);
+    if (owner == NULL) {
+        $action2 f = ($action2)self->on_listen;
+        f->$class->__asyn__(f, self, to$str("Failed to allocate TLS listener owner"));
+        tls_listener_release_resources(tls, key, cert);
+        return $R_CONT(c$cont, B_None);
+    }
 
-    uv_tcp_t *server = (uv_tcp_t *)acton_malloc(sizeof(uv_tcp_t));
-    uv_tcp_init(get_uv_loop(), server);
-    server->data = (void *)self;
-    int r;
-    struct sockaddr_in addr4;
-    struct sockaddr_in6 addr6;
+    struct tls_listener_server_state *server_state = tls_listener_server_state_new(self);
+    if (server_state == NULL) {
+        $action2 f = ($action2)self->on_listen;
+        f->$class->__asyn__(f, self, to$str("Failed to allocate TLS listener server state"));
+        tls_listener_owner_release(owner);
+        return $R_CONT(c$cont, B_None);
+    }
+
+    server = (uv_tcp_t *)malloc(sizeof(uv_tcp_t));
+    if (server == NULL) {
+        $action2 f = ($action2)self->on_listen;
+        f->$class->__asyn__(f, self, to$str("Failed to allocate TLS listener server handle"));
+        free(server_state);
+        tls_listener_owner_release(owner);
+        return $R_CONT(c$cont, B_None);
+    }
+
+    r = uv_tcp_init(get_uv_loop(), server);
+    if (r != 0) {
+        char errmsg[1024] = "Failed to initialize TLS listener server handle: ";
+        uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
+        log_warn("%s", errmsg);
+        $action2 f = ($action2)self->on_listen;
+        f->$class->__asyn__(f, self, to$str(errmsg));
+        free(server_state);
+        free(server);
+        tls_listener_owner_release(owner);
+        return $R_CONT(c$cont, B_None);
+    }
+    server->data = (void *)server_state;
     if (inet_pton(AF_INET, (const char *)fromB_str(self->address), &(addr4.sin_addr)) == 1) {
         r = uv_ip4_addr((const char *)fromB_str(self->address), (int)self->port, &addr4);
     } else if (inet_pton(AF_INET6, (const char *)fromB_str(self->address), &(addr6.sin6_addr)) == 1) {
@@ -832,6 +1342,8 @@ $R netQ_TLSListenerD__initG_local (netQ_TLSListener self, $Cont c$cont) {
         log_warn((const char *)fromB_str(errmsg));
         $action2 f = ($action2)self->on_listen;
         f->$class->__asyn__(f, self, errmsg);
+        uv_close((uv_handle_t *)server, tls_listener_server_on_close);
+        tls_listener_owner_release(owner);
         return $R_CONT(c$cont, B_None);
     }
     if (r != 0) {
@@ -840,6 +1352,8 @@ $R netQ_TLSListenerD__initG_local (netQ_TLSListener self, $Cont c$cont) {
         log_warn(errmsg);
         $action2 f = ($action2)self->on_listen;
         f->$class->__asyn__(f, self, to$str(errmsg));
+        uv_close((uv_handle_t *)server, tls_listener_server_on_close);
+        tls_listener_owner_release(owner);
         return $R_CONT(c$cont, B_None);
     }
 
@@ -854,6 +1368,8 @@ $R netQ_TLSListenerD__initG_local (netQ_TLSListener self, $Cont c$cont) {
         log_warn(errmsg);
         $action2 f = ($action2)self->on_listen;
         f->$class->__asyn__(f, self, to$str(errmsg));
+        uv_close((uv_handle_t *)server, tls_listener_server_on_close);
+        tls_listener_owner_release(owner);
         return $R_CONT(c$cont, B_None);
     }
 
@@ -864,29 +1380,60 @@ $R netQ_TLSListenerD__initG_local (netQ_TLSListener self, $Cont c$cont) {
         log_warn(errmsg);
         $action2 f = ($action2)self->on_listen;
         f->$class->__asyn__(f, self, to$str(errmsg));
+        uv_close((uv_handle_t *)server, tls_listener_server_on_close);
+        tls_listener_owner_release(owner);
         return $R_CONT(c$cont, B_None);
     }
 
+    self->_tls_owner = (int64_t)(intptr_t)owner;
     self->_stream = (int64_t)(intptr_t)server;
     $action2 f = ($action2)self->on_listen;
     f->$class->__asyn__(f, self, B_None);
     return $R_CONT(c$cont, B_None);
 }
 
+$R netQ_TLSListenerD_closeG_local (netQ_TLSListener self, $Cont c$cont) {
+    self->on_listen = NULL;
+    self->on_accept = NULL;
+    tls_listener_close_server(self);
+    return $R_CONT(c$cont, B_None);
+}
+
+$R netQ_TLSListenerD___cleanup__G_local (netQ_TLSListener self, $Cont c$cont) {
+    self->on_listen = NULL;
+    self->on_accept = NULL;
+    tls_listener_close_server(self);
+    return $R_CONT(c$cont, B_None);
+}
+
 B_NoneType netQ_TLSListenerD___resume__ (netQ_TLSListener self) {
     self->_stream = -1LL;
-    self->_tls_ctx = -1LL;
-    $action2 f = ($action2)self->on_listen;
-    f->$class->__asyn__(f, self, to$str("resume"));
+    self->_tls_owner = -1LL;
+    // on_listen is NULL once close()/__cleanup__ has run.
+    if (self->on_listen != NULL) {
+        $action2 f = ($action2)self->on_listen;
+        f->$class->__asyn__(f, self, to$str("resume"));
+    }
     return B_None;
 }
 
 $R netQ_TLSListenConnectionD__initG_local (netQ_TLSListenConnection self, $Cont c$cont) {
-    pin_actor_affinity();
+    set_actor_affinity(self->worker_id);
 
     tlsuv_stream_t *stream = (tlsuv_stream_t *)(intptr_t)self->server_stream;
-    stream->data = self;
-    self->_stream = (int64_t)(intptr_t)stream;
+    if ((intptr_t)stream != -1) {
+        struct tls_listener_stream_state *state = (struct tls_listener_stream_state *)stream->data;
+        if (state != NULL) {
+            state->actor = self;
+            self->_stream = (int64_t)(intptr_t)stream;
+        } else {
+            self->server_stream = -1LL;
+            self->_stream = -1LL;
+        }
+    } else {
+        self->server_stream = -1LL;
+        self->_stream = -1LL;
+    }
 
     return $R_CONT(c$cont, B_None);
 }
@@ -901,8 +1448,10 @@ $R netQ_TLSListenConnectionD__read_startG_local (netQ_TLSListenConnection self, 
         char errmsg[1024] = "Failed to start reading from TLS listen socket: ";
         uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
         log_warn(errmsg);
-        $action2 f = ($action2)self->on_error;
-        f->$class->__asyn__(f, self, to$str(errmsg));
+        if (self->on_error != NULL) {
+            $action2 f = ($action2)self->on_error;
+            f->$class->__asyn__(f, self, to$str(errmsg));
+        }
         return $R_CONT(c$cont, B_None);
     }
 
@@ -914,33 +1463,89 @@ $R netQ_TLSListenConnectionD_writeG_local (netQ_TLSListenConnection self, $Cont 
     if ((intptr_t)stream == -1)
         return $R_CONT(c$cont, B_None);
 
-    uv_write_t *wreq = (uv_write_t *)acton_malloc(sizeof(uv_write_t));
-    wreq->data = self;
-    uv_buf_t buf = uv_buf_init((char *)data->str, data->nbytes);
+    uv_write_t *wreq = (uv_write_t *)malloc(sizeof(uv_write_t));
+    if (wreq == NULL) {
+        if (self->on_error != NULL) {
+            $action2 f = ($action2)self->on_error;
+            f->$class->__asyn__(f, self, to$str("Failed to allocate TLS listen write request"));
+        }
+        return $R_CONT(c$cont, B_None);
+    }
+
+    struct tls_write_req_state *write_state = tls_write_req_state_new(data);
+    if (write_state == NULL) {
+        if (self->on_error != NULL) {
+            $action2 f = ($action2)self->on_error;
+            f->$class->__asyn__(f, self, to$str("Failed to allocate TLS listen write buffer"));
+        }
+        free(wreq);
+        return $R_CONT(c$cont, B_None);
+    }
+
+    wreq->data = write_state;
+    uv_buf_t buf = uv_buf_init(write_state->buf, data->nbytes);
     int r = tlsuv_stream_write(wreq, stream, &buf, tls_listener_write_cb);
     if (r < 0) {
         char errmsg[1024] = "Failed to write to TLS listen socket: ";
         uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
         log_warn(errmsg);
-        $action2 f = ($action2)self->on_error;
-        f->$class->__asyn__(f, self, to$str(errmsg));
+        if (self->on_error != NULL) {
+            $action2 f = ($action2)self->on_error;
+            f->$class->__asyn__(f, self, to$str(errmsg));
+        }
+        tls_write_req_state_free(write_state);
+        free(wreq);
     }
     return $R_CONT(c$cont, B_None);
 }
 
+// Detach the actor backref before an actor-initiated asynchronous close: the
+// close and pending-write callbacks run after the current message completes,
+// by which point nothing may be keeping the actor alive (the GC pointer lives
+// in a libc struct the collector cannot see).
+static void tls_listener_stream_detach_actor(tlsuv_stream_t *stream) {
+    struct tls_listener_stream_state *state = (struct tls_listener_stream_state *)stream->data;
+    if (state != NULL) {
+        state->actor = NULL;
+    }
+}
+
 $R netQ_TLSListenConnectionD_closeG_local (netQ_TLSListenConnection self, $Cont c$cont) {
     tlsuv_stream_t *stream = (tlsuv_stream_t *)(intptr_t)self->_stream;
-    if ((intptr_t)stream == -1)
+    if ((intptr_t)stream == -1) {
+        tls_listener_release_connection_owner(self);
         return $R_CONT(c$cont, B_None);
+    }
 
-    tls_listener_close_stream(stream);
     self->_stream = -1LL;
+    self->server_stream = -1LL;
+    tls_listener_stream_detach_actor(stream);
+    tls_listener_close_stream(stream);
+    tls_listener_release_connection_owner(self);
+    return $R_CONT(c$cont, B_None);
+}
+
+$R netQ_TLSListenConnectionD___cleanup__G_local (netQ_TLSListenConnection self, $Cont c$cont) {
+    tlsuv_stream_t *stream = (tlsuv_stream_t *)(intptr_t)self->_stream;
+    self->_stream = -1LL;
+    self->server_stream = -1LL;
+    self->on_receive = NULL;
+    self->on_error = NULL;
+    self->on_remote_close = NULL;
+
+    if ((intptr_t)stream != -1) {
+        tls_listener_stream_detach_actor(stream);
+        tls_listener_close_stream(stream);
+    }
+    tls_listener_release_connection_owner(self);
     return $R_CONT(c$cont, B_None);
 }
 
 B_NoneType netQ_TLSListenConnectionD___resume__ (netQ_TLSListenConnection self) {
     self->server_stream = -1LL;
     self->_stream = -1LL;
+    self->tls_owner = -1LL;
+    self->worker_id = -1LL;
     return B_None;
 }
 
@@ -951,22 +1556,52 @@ B_NoneType netQ_TLSListenConnectionD___resume__ (netQ_TLSListenConnection self) 
 
 static void tls_on_close(uv_handle_t* stream) {
     log_debug("TLS handle closed, stream: %p  stream->data: %p", stream, stream->data);
+    struct tls_client_state *state = (struct tls_client_state *)stream->data;
+    if (state != NULL) {
+        if (state->actor != NULL) {
+            state->actor->_stream = -1LL;
+            state->actor = NULL;
+        }
+        tls_client_state_free(state);
+    }
+    stream->data = NULL;
+    free(stream);
 }
 
 static void tls_close(tlsuv_stream_t *stream) {
+    if (stream == NULL) {
+        return;
+    }
+    uv_handle_t *watcher = (uv_handle_t *)&stream->watcher;
+    if (uv_handle_get_type(watcher) != UV_UNKNOWN_HANDLE && uv_is_closing(watcher)) {
+        return;
+    }
+
     log_debug("Closing TLS stream: %p  stream->data: %p", stream, stream->data);
-    netQ_TLSConnection self = (netQ_TLSConnection)stream->data;
-    $action on_close = self->_on_close;
-    if (on_close)
-        on_close->$class->__asyn__(on_close, self);
+    struct tls_client_state *state = (struct tls_client_state *)stream->data;
+    netQ_TLSConnection self = state != NULL ? state->actor : NULL;
+    if (self != NULL) {
+        $action on_close = self->_on_close;
+        self->_on_close = NULL;
+        self->_stream = -1LL;
+        state->actor = NULL;
+        if (on_close) {
+            on_close->$class->__asyn__(on_close, self);
+        }
+    }
+    tlsuv_stream_read_stop(stream);
     tlsuv_stream_close(stream, tls_on_close);
-    self->_stream = -1LL;
 }
 
 void tls_on_receive(uv_stream_t *stream, ssize_t nread, const uv_buf_t* buf) {
-    netQ_TLSConnection self = ((tlsuv_stream_t *)stream)->data;
+    struct tls_client_state *state = (struct tls_client_state *)((tlsuv_stream_t *)stream)->data;
+    netQ_TLSConnection self = state != NULL ? state->actor : NULL;
+    if (self == NULL) {
+        return;
+    }
+
     if (nread > 0) {
-        if (stream->data) {
+        if (stream->data && self->on_receive != NULL) {
             $action2 f = ($action2)self->on_receive;
             B_bytes data = to$bytesD_len(buf->base, nread);
             f->$class->__asyn__(f, self, data);
@@ -981,22 +1616,37 @@ void tls_on_receive(uv_stream_t *stream, ssize_t nread, const uv_buf_t* buf) {
         }
     }
     else if (nread < 0) {
-        log_debug("TLS read error %ld: %s", nread, uv_strerror((int) nread));
+        char errmsg[1024] = "TLS read error: ";
+        uv_strerror_r((int)nread, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
+        log_debug("%s", errmsg);
         tls_close((tlsuv_stream_t *)stream);
+        if (self->on_error != NULL) {
+            self->$class->_on_tls_error(self, -1LL, (int64_t)nread, to$str(errmsg));
+        }
     }
 }
 
 void tls_write_cb(uv_write_t *wreq, int status) {
-    if (status < 0) {
+    struct tls_write_req_state *write_state = (struct tls_write_req_state *)wreq->data;
+    // ECANCELED: queued write flushed by the stream's own close path.
+    if (status < 0 && status != UV_ECANCELED) {
         log_debug("TLS write error %d: %s", status, uv_strerror(status));
         char errmsg[1024] = "Failed to write to TLS TCP socket: ";
         uv_strerror_r(status, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
         log_debug(errmsg);
-        netQ_TLSConnection self = (netQ_TLSConnection)wreq->data;
-        $action2 on_error = ($action2)self->on_error;
-        on_error->$class->__asyn__(on_error, self, to$str(errmsg));
+        struct tls_client_state *state = NULL;
+        if (wreq->handle != NULL) {
+            state = (struct tls_client_state *)((tlsuv_stream_t *)wreq->handle)->data;
+        }
+        netQ_TLSConnection self = state != NULL ? state->actor : NULL;
+        if (self != NULL && self->on_error != NULL) {
+            $action2 on_error = ($action2)self->on_error;
+            on_error->$class->__asyn__(on_error, self, to$str(errmsg));
+        }
         tls_close((tlsuv_stream_t *)wreq->handle);
     }
+    tls_write_req_state_free(write_state);
+    free(wreq);
 }
 
 $R netQ_TLSConnectionD_closeG_local (netQ_TLSConnection self, $Cont c$cont, $action on_close) {
@@ -1021,16 +1671,49 @@ $R netQ_TLSConnectionD_writeG_local (netQ_TLSConnection self, $Cont c$cont, B_by
     if ((intptr_t)stream == -1)
         return $R_CONT(c$cont, B_None);
 
-    uv_write_t *wreq = (uv_write_t *)acton_malloc(sizeof(uv_write_t));
-    wreq->data = self;
-    uv_buf_t buf = uv_buf_init((char *)data->str, data->nbytes);
+    // Writes before the handshake completed would reach into a TLS engine
+    // that does not exist yet (tlsuv creates it during connect).
+    struct tls_client_state *state = (struct tls_client_state *)stream->data;
+    if (state == NULL || !state->connected) {
+        if (self->on_error != NULL) {
+            $action2 f = ($action2)self->on_error;
+            f->$class->__asyn__(f, self, to$str("TLS connection not established"));
+        }
+        return $R_CONT(c$cont, B_None);
+    }
+
+    uv_write_t *wreq = (uv_write_t *)malloc(sizeof(uv_write_t));
+    if (wreq == NULL) {
+        if (self->on_error != NULL) {
+            $action2 f = ($action2)self->on_error;
+            f->$class->__asyn__(f, self, to$str("Failed to allocate TLS write request"));
+        }
+        return $R_CONT(c$cont, B_None);
+    }
+
+    struct tls_write_req_state *write_state = tls_write_req_state_new(data);
+    if (write_state == NULL) {
+        if (self->on_error != NULL) {
+            $action2 f = ($action2)self->on_error;
+            f->$class->__asyn__(f, self, to$str("Failed to allocate TLS write buffer"));
+        }
+        free(wreq);
+        return $R_CONT(c$cont, B_None);
+    }
+
+    wreq->data = write_state;
+    uv_buf_t buf = uv_buf_init(write_state->buf, data->nbytes);
     int r = tlsuv_stream_write(wreq, stream, &buf, tls_write_cb);
     if (r < 0) {
         char errmsg[1024] = "Failed to write to TLS TCP socket: ";
         uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
         log_debug(errmsg);
-        $action2 f = ($action2)self->on_error;
-        f->$class->__asyn__(f, self, to$str(errmsg));
+        if (self->on_error != NULL) {
+            $action2 f = ($action2)self->on_error;
+            f->$class->__asyn__(f, self, to$str(errmsg));
+        }
+        tls_write_req_state_free(write_state);
+        free(wreq);
     }
     self->_bytes_out += data->nbytes;
     return $R_CONT(c$cont, B_None);
@@ -1038,20 +1721,47 @@ $R netQ_TLSConnectionD_writeG_local (netQ_TLSConnection self, $Cont c$cont, B_by
 
 
 static void tls_on_connect(uv_connect_t *creq, int status) {
-    netQ_TLSConnection self = (netQ_TLSConnection)creq->data;
+    struct tls_client_state *state = (struct tls_client_state *)creq->data;
+    netQ_TLSConnection self = state != NULL ? state->actor : NULL;
+    if (self == NULL) {
+        tls_close((tlsuv_stream_t *)creq->handle);
+        free(creq);
+        return;
+    }
+
     if (status != 0) {
         char errmsg[1024] = "Error in TLS TCP connect: ";
         uv_strerror_r(status, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
         log_debug(errmsg);
         tls_close((tlsuv_stream_t *)creq->handle);
-        self->$class->_on_tls_error(self, -1LL, (int64_t)status, to$str(errmsg));
+        if (self->on_error != NULL) {
+            self->$class->_on_tls_error(self, -1LL, (int64_t)status, to$str(errmsg));
+        }
+        free(creq);
         return;
     }
 
     tlsuv_stream_t *stream = (tlsuv_stream_t *) creq->handle;
-    tlsuv_stream_read_start(stream, alloc_buffer, tls_on_receive);
+    int r = tlsuv_stream_read_start(stream, alloc_buffer, tls_on_receive);
+    if (r < 0) {
+        char errmsg[1024] = "Failed to start reading from TLS TCP socket: ";
+        uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
+        log_debug(errmsg);
+        tls_close(stream);
+        if (self->on_error != NULL) {
+            self->$class->_on_tls_error(self, -1LL, (int64_t)r, to$str(errmsg));
+        }
+        free(creq);
+        return;
+    }
 
-    self->$class->_on_tls_connect(self);
+    state->connected = true;
+    if (self->on_connect != NULL) {
+        self->$class->_on_tls_connect(self);
+    } else {
+        tls_close(stream);
+    }
+    free(creq);
 }
 
 void tlsuv_logger(int level, const char *file, unsigned int line, const char *msg) {
@@ -1078,12 +1788,46 @@ void tlsuv_logger(int level, const char *file, unsigned int line, const char *ms
 }
 
 $R netQ_TLSConnectionD__connect_tlsG_local (netQ_TLSConnection self, $Cont c$cont) {
-    uv_connect_t* connect_req = (uv_connect_t*)acton_calloc(1, sizeof(uv_connect_t));
-    connect_req->data = (void *)self;
+    uv_connect_t* connect_req = (uv_connect_t*)calloc(1, sizeof(uv_connect_t));
+    if (connect_req == NULL) {
+        if (self->on_error != NULL) {
+            self->$class->_on_tls_error(self, -1LL, (int64_t)UV_ENOMEM, to$str("Failed to allocate TLS connect request"));
+        }
+        return $R_CONT(c$cont, B_None);
+    }
 
     //tlsuv_set_debug(5, tlsuv_logger);
-    tlsuv_stream_t *stream = (tlsuv_stream_t *)acton_malloc(sizeof(tlsuv_stream_t));
-    tlsuv_stream_init(get_uv_loop(), stream, NULL);
+    tlsuv_stream_t *stream = (tlsuv_stream_t *)malloc(sizeof(tlsuv_stream_t));
+    if (stream == NULL) {
+        free(connect_req);
+        if (self->on_error != NULL) {
+            self->$class->_on_tls_error(self, -1LL, (int64_t)UV_ENOMEM, to$str("Failed to allocate TLS stream"));
+        }
+        return $R_CONT(c$cont, B_None);
+    }
+    struct tls_client_state *state = tls_client_state_new(self);
+    if (state == NULL) {
+        free(stream);
+        free(connect_req);
+        if (self->on_error != NULL) {
+            self->$class->_on_tls_error(self, -1LL, -1LL, to$str("Failed to allocate TLS client state"));
+        }
+        return $R_CONT(c$cont, B_None);
+    }
+    connect_req->data = (void *)state;
+    int r = tlsuv_stream_init(get_uv_loop(), stream, NULL);
+    if (r != 0) {
+        char errmsg[1024] = "Failed to initialize TLS stream: ";
+        uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
+        log_warn("%s", errmsg);
+        tls_client_state_free(state);
+        free(stream);
+        free(connect_req);
+        if (self->on_error != NULL) {
+            self->$class->_on_tls_error(self, -1LL, (int64_t)r, to$str(errmsg));
+        }
+        return $R_CONT(c$cont, B_None);
+    }
 
     // Default is to verify TLS certificate. Should we disable verification?
     if (fromB_bool(self->verify_tls) == false) {
@@ -1096,21 +1840,76 @@ $R netQ_TLSConnectionD__connect_tlsG_local (netQ_TLSConnection self, $Cont c$con
     int num_protocols = self->protocols->length;
 
     if (num_protocols > 0) {
-        const char **protocols = (const char **)acton_calloc(num_protocols, sizeof(char*));
-
-        for(int i = 0; i < num_protocols; ++i) {
-            protocols[i] = (const char *)fromB_str(self->protocols->data[i]);
+        state->alpn_protocols = calloc((size_t)num_protocols, sizeof(char *));
+        if (state->alpn_protocols == NULL) {
+            tls_client_state_free(state);
+            free(stream);
+            free(connect_req);
+            if (self->on_error != NULL) {
+                self->$class->_on_tls_error(self, -1LL, (int64_t)UV_ENOMEM, to$str("Failed to allocate TLS ALPN protocol list"));
+            }
+            return $R_CONT(c$cont, B_None);
         }
-        tlsuv_stream_set_protocols(stream, num_protocols, protocols);
-    }
-    //tlsuv_stream_set_protocols(stream, 1, alpn);
-    // No ALPN for now.
-    // TODO: take SNI as input to TLSConnection actor
-    stream->data = (void *)self;
+        // Count covers the whole zero-filled array from the start so a
+        // partial strdup failure still frees the strings already duplicated.
+        state->alpn_count = num_protocols;
 
-    tlsuv_stream_connect(connect_req, stream, (const char *)fromB_str(self->address), (int)self->port, tls_on_connect);
+        for (int i = 0; i < num_protocols; ++i) {
+            const char *proto = (const char *)fromB_str(self->protocols->data[i]);
+            state->alpn_protocols[i] = strdup(proto);
+            if (state->alpn_protocols[i] == NULL) {
+                tls_client_state_free(state);
+                free(stream);
+                free(connect_req);
+                if (self->on_error != NULL) {
+                    self->$class->_on_tls_error(self, -1LL, (int64_t)UV_ENOMEM, to$str("Failed to allocate TLS ALPN protocol"));
+                }
+                return $R_CONT(c$cont, B_None);
+            }
+        }
+        tlsuv_stream_set_protocols(stream, state->alpn_count, (const char **)state->alpn_protocols);
+    }
+    // TODO: take SNI as input to TLSConnection actor
+    stream->data = (void *)state;
+
+    // _stream must be armed BEFORE the connect call: tlsuv may fail the
+    // connect through its callback path, and tls_close run from the callback
+    // resets _stream to -1 - assigning afterwards would re-arm a dangling
+    // pointer to an already-torn-down stream.
     self->_stream = (int64_t)(intptr_t)stream;
 
+    r = tlsuv_stream_connect(connect_req, stream, (const char *)fromB_str(self->address), (int)self->port, tls_on_connect);
+    if (r != 0) {
+        char errmsg[1024] = "Failed to start TLS TCP connect: ";
+        uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg)-strlen(errmsg));
+        log_warn("%s", errmsg);
+        self->_stream = -1LL;
+        stream->data = NULL;
+        state->actor = NULL;
+        tls_client_state_free(state);
+        tlsuv_stream_close(stream, tls_on_close);
+        free(connect_req);
+        if (self->on_error != NULL) {
+            self->$class->_on_tls_error(self, -1LL, (int64_t)r, to$str(errmsg));
+        }
+        return $R_CONT(c$cont, B_None);
+    }
+
+    return $R_CONT(c$cont, B_None);
+}
+
+$R netQ_TLSConnectionD___cleanup__G_local (netQ_TLSConnection self, $Cont c$cont) {
+    tlsuv_stream_t *stream = (tlsuv_stream_t *)(intptr_t)self->_stream;
+    self->_stream = -1LL;
+    self->_on_close = NULL;
+    self->on_connect = NULL;
+    self->on_receive = NULL;
+    self->on_error = NULL;
+    self->on_remote_close = NULL;
+
+    if ((intptr_t)stream != -1) {
+        tls_close(stream);
+    }
     return $R_CONT(c$cont, B_None);
 }
 

--- a/docs/acton-dev-guide/src/SUMMARY.md
+++ b/docs/acton-dev-guide/src/SUMMARY.md
@@ -32,6 +32,7 @@
   - [RTS sync pause](runtime/sync_pause.md)
   - [Actors](runtime/actors.md)
   - [Memory and GC](runtime/memory.md)
+  - [IO memory management](runtime/io_memory.md)
 - [Tooling](tooling/index.md)
   - [Testing harness](tooling/testing.md)
 - [Design notes](design/index.md)

--- a/docs/acton-dev-guide/src/runtime/index.md
+++ b/docs/acton-dev-guide/src/runtime/index.md
@@ -7,3 +7,4 @@ that the compiler targets.
 - [RTS sync pause](sync_pause.md)
 - [Actors](actors.md)
 - [Memory and GC](memory.md)
+- [IO memory management](io_memory.md)

--- a/docs/acton-dev-guide/src/runtime/io_memory.md
+++ b/docs/acton-dev-guide/src/runtime/io_memory.md
@@ -1,0 +1,246 @@
+# IO memory management
+
+This page describes how memory is managed across the native IO stack: which
+allocator each library uses, why, and the ownership patterns `.ext.c` modules
+must follow. The design was established when the TLS stack moved off the GC
+heap, but it generalizes to all IO.
+
+The background rule from [Memory and GC](memory.md) drives everything here:
+Boehm GC does not scan libc-heap memory, so **a GC pointer stored in a libc
+allocation does not keep its referent alive**, and a libc pointer stored in a
+GC object is invisible to the collector in the harmless direction (the
+collector never frees libc memory) but creates an ownership obligation —
+somebody must `free()` it on every path.
+
+## Allocator regimes
+
+| Component | Allocator | Freed by |
+|---|---|---|
+| Acton objects (actors, builtins) | GC via `acton__allocator` | collector |
+| uv handles/requests allocated by Acton code (TCP path) | GC (`acton_malloc`) | collector |
+| libuv internals (watcher arrays, request buffers, ...) | `GC_malloc_uncollectable` | libuv itself, via `GC_free` |
+| tlsuv (streams' engines, write queue, connectors, ...) | libc `malloc`/`free` | tlsuv itself |
+| mbedtls (TLS state, X.509, bignums, ...) | libc `calloc`/`free` | mbedtls itself |
+| TLS-path native objects in `net.ext.c` (streams, requests, state structs, payload copies) | libc `malloc`/`free` | `net.ext.c`, in close/completion callbacks |
+| DNS `uv_getaddrinfo_t` requests in `net.ext.c` | libc `malloc`/`free` | the resolve callback |
+| Read buffers (`alloc_buffer`, `base/rts/io.c`) | `GC_malloc_atomic` | collector |
+
+The wiring lives in `acton_init_alloc()` (`base/rts/common.c`), called from
+`main()` right after `GC_INIT()` and before any uv/tlsuv/mbedtls allocation.
+Order matters: `tlsuv_set_allocator()` also re-points libuv's and mbedtls's
+allocators (tlsuv `src/alloc.c`), so it runs first and `uv_replace_allocator()`
+then overrides libuv. mbedtls needs no explicit setup: with
+`MBEDTLS_PLATFORM_MEMORY` its allocator hooks default to `calloc`/`free`,
+which is exactly the regime we want — and nothing may re-point them mid-run,
+because mbedtls allocates and frees on widely separated code paths, so an
+allocator change frees objects through the wrong regime.
+
+### Why tlsuv and mbedtls are on libc
+
+A TLS connection's engine (mbedtls session state) is allocated by tlsuv and
+referenced only from the `tlsuv_stream_t`. The stream struct is owned by
+`net.ext.c` and is libc memory. If the engine were GC-allocated, its only
+reference would live inside libc memory: the collector would see it as
+unreachable and collect it mid-connection — a use-after-free deep inside
+mbedtls. This is not hypothetical; it was reproduced and proven (9/10 crash
+rate under churn with the collector enabled, 0/10 with the collector pinned)
+during the conversion. Keeping the whole native TLS chain on one heap ties its
+lifetime to explicit close calls, with GC finalizers as the safety net.
+
+### Why libuv is uncollectable, not libc
+
+libuv's internal allocations might look like a candidate for plain libc too,
+but they are **load-bearing GC roots**. The loop's `watchers` array (one entry
+per registered fd, holding interior pointers into the handles) is, for an idle
+connection that the application retains only through its callbacks, the *only*
+reference chain that keeps the GC-allocated uv handle — and through
+`handle->data`, its actor — alive. Moving libuv internals to libc severs that
+chain and the collector frees handles whose fds are still registered with the
+kernel: a use-after-free inside `uv_run` on the next poll event.
+
+`GC_malloc_uncollectable` gives all three properties at once:
+
+- blocks are **scanned**, so the watchers array keeps rooting handles;
+- blocks are **never collected**, so libuv allocations referenced only from
+  libc tlsuv structs (e.g. the hostname buffer inside a connector's embedded
+  `uv_getaddrinfo_t`) cannot disappear mid-operation;
+- blocks are freed **explicitly** via `GC_free` — libuv pairs every internal
+  allocation with a free, so nothing leaks.
+
+### Why frees used to be no-ops, and what that masked
+
+Historically everything (uv, tlsuv, mbedtls) was GC-allocated with
+`acton_noop_free`, so the whole IO loop was traceable from the root set and
+`free()` could never be wrong — because it did nothing. The price was that the
+no-op regime *masked* every lifetime bug: double frees, frees of objects still
+in use, leaks of caller-owned outputs. Real `free()` converts each of those
+into heap corruption or RSS growth. When converting a library to real frees,
+expect to surface latent bugs in both the library and our usage of it; the
+tlsuv fork's `harden` branch exists for exactly this reason.
+
+## Hazard catalogue
+
+When writing or reviewing `.ext.c` IO code, these are the failure classes to
+check for. Each one was found (and is now guarded against) in the TLS stack.
+
+1. **GC object referenced only from libc memory.** The referent gets
+   collected while in use. Instances: a TLS engine hanging off a libc stream;
+   a `B_bytes` write payload referenced only from tlsuv's libc write queue; a
+   GC `uv_write_t` referenced only from that same queue; a GC DNS request
+   whose only reference is libuv's threadpool work queue once libc nodes
+   interleave in the chain. Remedies: move the object to libc with explicit
+   ownership, copy the data (write payloads), or use
+   `GC_malloc_uncollectable` when the object must stay GC-visible (see the
+   DNS callback data below).
+2. **Actor backref dereferenced after collection.** `handle->data` pointing
+   at an actor does not keep the actor alive once the handle is libc memory.
+   Any callback that runs after the actor's last message completes may
+   dereference a dangling pointer. Remedy: nullable backrefs in a state
+   struct, detached *before* an actor-initiated asynchronous close (see
+   patterns below).
+3. **Wrong-regime free.** `free()` on GC memory, `GC_free` on libc memory, or
+   an allocator re-pointed between an object's allocation and its free.
+   The mbedtls hook is the cautionary tale: it used to be re-pointed three
+   times during startup.
+4. **Use-after-free unmasked by real free.** Late callbacks (cancelled
+   writes, poll events after close) touching objects that an earlier callback
+   already freed. Remedy: free only in the terminal callback of an object's
+   lifecycle, guard close paths for idempotence.
+5. **Leaks of caller-owned outputs.** Library functions that transfer
+   ownership of a buffer to the caller (PEM writers, error strings) used to be
+   "freed" by the no-op; under real frees every path must free them.
+6. **Zero-initialization assumptions.** `acton_malloc` zeroes (it is
+   calloc-based) and `GC_malloc` zeroes; plain `malloc` does not. Code moved
+   from the GC regime to libc must use `calloc` where it relied on zeroed
+   memory.
+
+## Ownership patterns for `.ext.c` IO code
+
+The TLS implementation in `base/src/net.ext.c` is the reference
+implementation for these patterns.
+
+### State structs with nullable actor backrefs
+
+Do not store an actor pointer directly in `handle->data`. Store a small libc
+state struct whose `actor` field may be NULL:
+
+```c
+struct tls_client_state {
+    netQ_TLSConnection actor;   // nullable backref, GC pointer in libc memory
+    ...
+};
+```
+
+Every callback fetches the state, checks `actor != NULL`, and no-ops
+otherwise. The actor does not own the state; the native object's lifecycle
+does — the state is freed in the handle's close callback.
+
+### Detach before actor-initiated close
+
+When the *actor* initiates an asynchronous close (explicit `close()` or
+`__cleanup__`), it must NULL the backref synchronously, before the close
+completes:
+
+```c
+self->_stream = -1LL;
+state->actor = NULL;           // detach: callbacks after this message ends
+tls_listener_close_stream(stream);   // must not reach for the actor
+```
+
+The close and cancelled-write callbacks run after the current message
+completes, by which time nothing may be keeping the actor alive. When the
+close is initiated *by the network* (EOF, read error), the backref stays set:
+the error/remote-close message enqueued to the actor keeps it alive past the
+close callback.
+
+### Never free a uv handle before its close callback
+
+`uv_close()` is asynchronous; libuv touches the handle until the close
+callback runs. All frees of handles, their state structs and embedded
+resources belong in the close callback (`uv_handle_free_on_close` is the
+trivial helper for plain handles).
+
+### Copy write payloads
+
+A `B_bytes` passed to a write must not be referenced only from a libc queue
+while the write is pending. Copy the payload into the (libc) write request
+state and free it in the write callback — on every status, including
+`UV_ECANCELED` (which means the stream's close path flushed the queue; treat
+it as teardown, not as an error to report).
+
+### Refcount shared native resources
+
+When several native objects alias one resource — the TLS listener's
+`tls_context`/key/cert are wired into every accepted connection's engine —
+give the resource an atomically refcounted owner struct. The listener holds
+one reference, each in-flight handshake and each accepted connection holds
+one; the last release frees in dependency order. Make every error path
+release exactly what it retained; an unpaired release (or a missing one) is a
+heap corruption or a permanent leak under real frees.
+
+### `GC_malloc_uncollectable` for GC-visible bridge data
+
+When a struct must hold GC pointers (callback closures) but is itself
+referenced only from libc memory or from nothing the collector scans,
+allocate it with `GC_malloc_uncollectable` and free it with `GC_free` in its
+terminal callback. The DNS lookup callback data is the canonical example: the
+uv request is libc (it sits in the threadpool work queue), but its
+`on_resolve`/`on_error` closures must stay alive, so they live in an
+uncollectable block the collector scans.
+
+### `__cleanup__` finalizers as the safety net
+
+Explicit `close()` is the primary lifecycle; `action def __cleanup__` is the
+safety net for actors dropped without closing. Because it is an `action`, the
+GC finalizer only enqueues a message and the body runs on the actor's pinned
+worker thread — the thread that owns the uv loop — so it may safely call
+libuv/tlsuv functions. Cleanup bodies must be idempotent with explicit close
+(guard on the `-1` handle sentinel), detach backrefs, NULL the callback
+fields, and release owner references.
+
+### Pin actors to the loop that owns their handles
+
+libuv objects are single-threaded; every callback runs on the loop's worker
+thread, and actor methods that touch the handle must run there too. Actors
+call `pin_actor_affinity()` in `__init__`. For natively-created objects
+adopted by a new actor (accepted connections), capture the worker id where
+the native object lives (`get_wtid()`) and pass it through the constructor so
+the actor pins to the owning loop's thread, not to whichever worker happens
+to run its `__init__`.
+
+## Testing and debugging
+
+The TLS test modules (`test/stdlib_tests/src/test_net_tls.act`,
+`test_net_tls_gc.act`) are written to attack the hazards above: byte-exact
+queued-write roundtrips, listener drops with forced GC under live
+connections, and actor-drop churn that exercises the finalizer path. Useful
+instruments when hunting lifetime bugs in this area:
+
+- **Stress mode**: `acton test stress --module test_net_tls
+  --stress-workers 8` runs each test concurrently from drift-calibrated
+  workers in one process; it is the most effective interleaving sweep.
+- **Churn loops**: repeatedly running a test binary (`for i in $(seq 40); do
+  ./out/bin/.test_test_net_tls test; done`) catches crashes that single runs
+  miss; count exit codes above 128.
+- **The GC discriminator**: run the reproducer with `GC_DONT_GC=1
+  GC_INITIAL_HEAP_SIZE=1500000000`. A crash that disappears when the
+  collector is pinned is a GC-visibility bug, not a memory-corruption bug.
+- **MallocScribble**: `MallocScribble=1 MallocPreScribble=1` (macOS) poisons
+  freed/fresh libc memory and converts silent use-after-free into crashes.
+- **RSS plateau**: sustained connection churn must show flat RSS; growth
+  means a leak that the no-op-free era would have hidden.
+- **macOS crash reports**: in-process observers (instrumentation, attached
+  debuggers) perturb these races. The non-perturbing method: remove stale
+  reports from `~/Library/Logs/DiagnosticReports` (they deduplicate), run
+  with `--rts-no-bt`, and read the fresh `.ips` report's faulting-thread
+  backtrace and registers.
+- ASan is not usable together with Boehm GC.
+
+## Direction
+
+The end state this design works toward is stricter per-actor heap management,
+where memory that escapes a single actor turn (anything a native library may
+touch asynchronously) cannot live on an actor-scoped heap at all. Moving IO
+lifetimes from GC reachability to explicit ownership is the prerequisite:
+synchronous, non-escaping native calls can keep using GC memory, while
+everything with an asynchronous lifetime is owned and freed deterministically.

--- a/docs/acton-dev-guide/src/runtime/memory.md
+++ b/docs/acton-dev-guide/src/runtime/memory.md
@@ -1,4 +1,54 @@
 # Memory and GC
 
-Describe allocation strategy, garbage collection, and ownership conventions.
-Include debugging tips for leaks or performance regressions.
+Acton processes contain two heaps with fundamentally different rules:
+
+- **The GC heap**, managed by Boehm GC (`libgc`). Collection is conservative:
+  the collector scans the GC heap, all thread stacks and registers, the data
+  segment, and `GC_malloc_uncollectable` blocks for anything that looks like a
+  pointer into the GC heap. `ALL_INTERIOR_POINTERS` is enabled, so a pointer
+  into the middle of an object keeps the whole object alive. Conservatism cuts
+  both ways: an `int64_t` actor field holding a cast pointer value pins the
+  object it points to, even though the type system thinks it is an integer.
+- **The libc heap**, managed by `malloc`/`free`. The collector never scans
+  libc memory. A GC-heap object whose only reference is stored inside a
+  libc-heap allocation is unreachable as far as the collector is concerned and
+  will be collected while still in use.
+
+That second bullet is the single most important rule when working on the
+runtime or on `.ext.c` modules: **a GC pointer stored in libc memory does not
+keep its referent alive.**
+
+## The Acton allocator
+
+Acton objects (actors, builtin values, everything the compiler generates
+allocations for) go through the `acton__allocator` function table
+(`base/rts/common.c`), reached via `acton_malloc`/`acton_calloc`/etc. `main()`
+re-points the table during startup (`base/rts/rts.c`):
+
+1. After `GC_INIT()`, the table points at the GC (`GC_malloc`,
+   `GC_malloc_atomic`, ... with `acton_noop_free`).
+2. During module constant initialization it briefly points at libc, so that
+   module-level constants live outside the GC heap.
+3. Before the worker loops start it points back at the GC for the lifetime of
+   the process.
+
+`free` is deliberately a no-op in the GC regime: the collector reclaims
+memory, and explicit frees of GC memory would be double-management.
+
+## Finalizers
+
+Actors that override `__cleanup__` get a GC finalizer: code generation emits a
+guarded `$InstallFinalizer` (a thin wrapper around `GC_register_finalizer`,
+`base/rts/rts.h`) in the actor constructor. Declaring `__cleanup__` as an
+`action` means the finalizer merely enqueues a message; the cleanup body then
+runs on the actor's affinity-pinned worker thread like any other message. The
+message resurrects the actor for the duration of the cleanup; Boehm finalizers
+are one-shot, so after the cleanup message has been processed and the last
+reference dropped, the actor is collected without the finalizer running again.
+
+## IO and native libraries
+
+The native IO stack (libuv, tlsuv, mbedtls and the native objects owned by
+`.ext.c` modules) spans the boundary between the two heaps, and getting object
+lifetimes right across that boundary has its own design, hazard catalogue and
+ownership patterns. See [IO memory management](io_memory.md).

--- a/test/stdlib_tests/src/test_net_tls.act
+++ b/test/stdlib_tests/src/test_net_tls.act
@@ -1,6 +1,8 @@
+import acton.rts
 import net
 import random
 import testing
+import time
 
 
 CERT_PEM = """-----BEGIN CERTIFICATE-----
@@ -55,47 +57,543 @@ TB6l9VGoxJL4fyHnZb8L5gGvnB1bbD8cL6YPaDiOhcRseC9vBiEuVg==
 """
 
 
-actor TLSClient(env: Env, host: str, port: int, on_success, on_failure):
+def _force_gc(t: testing.EnvT):
+    acton.rts.gc(t.env.syscap)
+    acton.rts.gc(t.env.syscap)
+
+
+ALPN_PROTOCOLS = ["h2", "http/1.1"]
+WATCHDOG_INTERVAL_S = 0.25
+TLS_TEST_TIMEOUT_S = 30.0
+
+
+actor TLSClientServerProbe(t: testing.EnvT, protocols: list[str]=[]):
     var done = False
+    var started = False
+    var port = 0
+    var attempts = 0
+    var listener_refs: list[net.TLSListener] = []
+    var client_refs: list[net.TLSConnection] = []
+    var server_conn_refs: list[net.TLSListenConnection] = []
+    timeout_sw = time.Stopwatch()
+    listen_cap = net.TCPListenCap(net.TCPCap(net.NetCap(t.env.cap)))
+    conn_cap = net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap)))
+
+    def _close_client_ref(conn: net.TLSConnection):
+        def _noop(c: net.TLSConnection):
+            pass
+        conn.close(_noop)
+
+    def _close_listener():
+        if listener_refs:
+            listener_refs.pop(0).close()
+
+    def _close_client():
+        if client_refs:
+            _close_client_ref(client_refs.pop(0))
+
+    def _close_server_conn():
+        if server_conn_refs:
+            server_conn_refs.pop(0).close()
 
     def _finish_success():
-        if not done:
-            done = True
-            on_success()
+        if done:
+            return
+        done = True
+        _close_listener()
+        _close_client()
+        _close_server_conn()
+        t.success()
 
     def _finish_failure(msg: str):
-        if not done:
-            done = True
-            on_failure(msg)
+        if done:
+            return
+        done = True
+        _close_listener()
+        _close_client()
+        _close_server_conn()
+        t.failure(AssertionError(msg))
 
-    def on_connect(c):
+    def _finish_error(msg: str):
+        if done:
+            return
+        done = True
+        _close_listener()
+        _close_client()
+        _close_server_conn()
+        t.error(Exception(msg))
+
+    def _start_client(port: int):
+        conn = net.TLSConnection(conn_cap, "127.0.0.1", port, _on_client_connect, _on_client_receive, _on_client_error, _on_client_remote_close, False, protocols)
+        if client_refs:
+            client_refs[0] = conn
+        else:
+            client_refs.append(conn)
+
+    def _on_client_connect(c: net.TLSConnection):
+        if client_refs:
+            client_refs[0] = c
+        else:
+            client_refs.append(c)
         await async c.write(b"PING")
 
-    def on_receive(c, data):
+    def _on_client_receive(c: net.TLSConnection, data: bytes):
         if data == b"PONG":
+            _finish_success()
+        else:
+            _finish_failure("Unexpected response: " + str(data))
+
+    def _on_client_error(c: net.TLSConnection, msg: str):
+        _finish_failure("TLS client error: " + msg)
+
+    def _on_client_remote_close(c: net.TLSConnection):
+        if not done:
+            _finish_failure("TLS server closed before response")
+
+    def _on_server_receive(c: net.TLSListenConnection, data: bytes):
+        if server_conn_refs:
+            server_conn_refs[0] = c
+        else:
+            server_conn_refs.append(c)
+        if data == b"PING":
+            await async c.write(b"PONG")
+        else:
+            _finish_failure("Unexpected request: " + str(data))
+
+    def _on_server_error(c: net.TLSListenConnection, error: str):
+        _finish_error("TLS server error: " + error)
+
+    def _on_server_close(c: net.TLSListenConnection):
+        if server_conn_refs and server_conn_refs[0] is c:
+            server_conn_refs.pop(0)
+
+    def _on_accept(c: net.TLSListenConnection):
+        if server_conn_refs:
+            server_conn_refs[0] = c
+        else:
+            server_conn_refs.append(c)
+        c.cb_install(_on_server_receive, _on_server_error, _on_server_close)
+
+    def _on_listen(listener, err):
+        if err is not None:
+            if attempts < 10:
+                attempts += 1
+                _start_listener()
+            else:
+                _finish_error("TLS listen failed: " + err)
+            return
+        if started:
+            return
+        started = True
+        after 0: _start_client(port)
+
+    def _timeout():
+        _finish_error("timeout")
+
+    def _watchdog():
+        if done:
+            return
+        if timeout_sw.elapsed().to_float() >= TLS_TEST_TIMEOUT_S:
+            _timeout()
+        else:
+            after WATCHDOG_INTERVAL_S: _watchdog()
+
+    def _start_listener():
+        port = random.randint(20000, 45000)
+        l = net.TLSListener(
+            listen_cap,
+            "127.0.0.1",
+            port,
+            CERT_PEM.encode(),
+            KEY_PEM.encode(),
+            _on_listen,
+            _on_accept
+        )
+        if listener_refs:
+            listener_refs[0] = l
+        else:
+            listener_refs.append(l)
+
+    _start_listener()
+    _watchdog()
+
+
+actor _TLSClientServer(t: testing.EnvT):
+    TLSClientServerProbe(t)
+
+
+actor _TLSClientServerALPNProtocols(t: testing.EnvT):
+    TLSClientServerProbe(t, ALPN_PROTOCOLS)
+
+
+actor _TLSQueuedWriteRoundtrip(t: testing.EnvT):
+    """Queued TLS writes must keep their payload alive until completion"""
+    CHUNK = b"Q" * 65536
+    CHUNK_COUNT = 6
+    REQUEST_PAYLOAD = CHUNK * CHUNK_COUNT
+    RESPONSE_CHUNK = b"R" * 65536
+    RESPONSE_PAYLOAD = RESPONSE_CHUNK * CHUNK_COUNT
+
+    var done = False
+    var started = False
+    var port = 0
+    var attempts = 0
+    var client_connected = False
+    var request_started = False
+    var listener_refs: list[net.TLSListener] = []
+    var client_refs: list[net.TLSConnection] = []
+    var server_conn_refs: list[net.TLSListenConnection] = []
+    var server_recv: list[bytes] = []
+    var client_recv: list[bytes] = []
+    var server_recv_len = 0
+    var client_recv_len = 0
+    timeout_sw = time.Stopwatch()
+    listen_cap = net.TCPListenCap(net.TCPCap(net.NetCap(t.env.cap)))
+    conn_cap = net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap)))
+
+    def _close_client_ref(conn: net.TLSConnection):
+        def _noop(c: net.TLSConnection):
+            pass
+        conn.close(_noop)
+
+    def _close_listener():
+        if listener_refs:
+            listener_refs.pop(0).close()
+
+    def _close_client():
+        if client_refs:
+            _close_client_ref(client_refs.pop(0))
+
+    def _close_server_conn():
+        if server_conn_refs:
+            server_conn_refs.pop(0).close()
+
+    def _finish_success():
+        if done:
+            return
+        done = True
+        _close_listener()
+        _close_client()
+        _close_server_conn()
+        t.success()
+
+    def _finish_failure(msg: str):
+        if done:
+            return
+        done = True
+        _close_listener()
+        _close_client()
+        _close_server_conn()
+        t.failure(AssertionError(msg))
+
+    def _finish_error(msg: str):
+        if done:
+            return
+        done = True
+        _close_listener()
+        _close_client()
+        _close_server_conn()
+        t.error(Exception(msg))
+
+    def _start_client(port: int):
+        conn = net.TLSConnection(conn_cap, "127.0.0.1", port, _on_client_connect, _on_client_receive, _on_client_error, _on_client_remote_close, False)
+        if client_refs:
+            client_refs[0] = conn
+        else:
+            client_refs.append(conn)
+
+    def _start_request():
+        if done or request_started:
+            return
+        if not client_connected or not client_refs or not server_conn_refs:
+            return
+        request_started = True
+        c = client_refs[0]
+        for _ in range(CHUNK_COUNT):
+            await async c.write(CHUNK)
+
+    def _on_client_connect(c: net.TLSConnection):
+        client_connected = True
+        if client_refs:
+            client_refs[0] = c
+        else:
+            client_refs.append(c)
+        _start_request()
+
+    def _on_client_receive(c: net.TLSConnection, data: bytes):
+        client_recv.append(data)
+        client_recv_len += len(data)
+        if client_recv_len > len(RESPONSE_PAYLOAD):
+            _finish_failure("TLS client received too much data: " + str(client_recv_len))
+            return
+        if client_recv_len == len(RESPONSE_PAYLOAD):
+            recv = bytes([]).join(client_recv)
+            if recv != RESPONSE_PAYLOAD:
+                _finish_failure("Unexpected queued TLS response payload")
+                return
+            _finish_success()
+
+    def _on_client_error(c: net.TLSConnection, msg: str):
+        _finish_failure("TLS client error: " + msg)
+
+    def _on_client_remote_close(c: net.TLSConnection):
+        if not done:
+            _finish_failure("TLS server closed before queued response completed")
+
+    def _on_server_receive(c: net.TLSListenConnection, data: bytes):
+        if server_conn_refs:
+            server_conn_refs[0] = c
+        else:
+            server_conn_refs.append(c)
+        server_recv.append(data)
+        server_recv_len += len(data)
+        if server_recv_len > len(REQUEST_PAYLOAD):
+            _finish_failure("TLS server received too much data: " + str(server_recv_len))
+            return
+        if server_recv_len == len(REQUEST_PAYLOAD):
+            recv = bytes([]).join(server_recv)
+            if recv != REQUEST_PAYLOAD:
+                _finish_failure("Unexpected queued TLS request payload")
+                return
+            for _ in range(CHUNK_COUNT):
+                await async c.write(RESPONSE_CHUNK)
+
+    def _on_server_error(c: net.TLSListenConnection, error: str):
+        _finish_error("TLS server error: " + error)
+
+    def _on_server_close(c: net.TLSListenConnection):
+        if server_conn_refs and server_conn_refs[0] is c:
+            server_conn_refs.pop(0)
+
+    def _on_accept(c: net.TLSListenConnection):
+        if server_conn_refs:
+            server_conn_refs[0] = c
+        else:
+            server_conn_refs.append(c)
+        c.cb_install(_on_server_receive, _on_server_error, _on_server_close)
+        _start_request()
+
+    def _on_listen(listener, err):
+        if err is not None:
+            if attempts < 10:
+                attempts += 1
+                _start_listener()
+            else:
+                _finish_error("TLS listen failed: " + err)
+            return
+        if started:
+            return
+        started = True
+        _start_client(port)
+
+    def _timeout():
+        _finish_error("timeout")
+
+    def _watchdog():
+        if done:
+            return
+        if timeout_sw.elapsed().to_float() >= TLS_TEST_TIMEOUT_S:
+            _timeout()
+        else:
+            after WATCHDOG_INTERVAL_S: _watchdog()
+
+    def _start_listener():
+        port = random.randint(20000, 45000)
+        client_connected = False
+        request_started = False
+        server_recv = []
+        client_recv = []
+        server_recv_len = 0
+        client_recv_len = 0
+        l = net.TLSListener(
+            listen_cap,
+            "127.0.0.1",
+            port,
+            CERT_PEM.encode(),
+            KEY_PEM.encode(),
+            _on_listen,
+            _on_accept
+        )
+        if listener_refs:
+            listener_refs[0] = l
+        else:
+            listener_refs.append(l)
+
+    _start_listener()
+    _watchdog()
+
+
+actor _TLSListenerDropKeepsAcceptedConnection(t: testing.EnvT):
+    """Accepted TLS connection must outlive the listener actor"""
+    TIMEOUT_S = TLS_TEST_TIMEOUT_S
+    var done = False
+    var started = False
+    var port = 0
+    var attempts = 0
+    var phase = "init"
+    var ping1_started = False
+    var client_connected = False
+    var listener: ?net.TLSListener = None
+    var client_refs: list[net.TLSConnection] = []
+    var server_conn: ?net.TLSListenConnection = None
+    timeout_sw = time.Stopwatch()
+    listen_cap = net.TCPListenCap(net.TCPCap(net.NetCap(t.env.cap)))
+    conn_cap = net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap)))
+
+    def _finish_success():
+        if done:
+            return
+        done = True
+        t.success()
+
+    def _finish_failure(msg: str):
+        if done:
+            return
+        done = True
+        t.failure(AssertionError(msg + " [phase=" + phase + "]"))
+
+    def _finish_error(msg: str):
+        if done:
+            return
+        done = True
+        t.error(Exception(msg + " [phase=" + phase + "]"))
+
+    def _start_client_conn():
+        c = net.TLSConnection(conn_cap, "127.0.0.1", port, _on_client_connect, _on_client_receive, _on_client_error, _on_client_remote_close, False)
+        if client_refs:
+            client_refs[0] = c
+        else:
+            client_refs.append(c)
+
+    def _start_ping1():
+        if done or ping1_started:
+            return
+        if not client_connected or not client_refs or server_conn is None:
+            return
+        ping1_started = True
+        c = client_refs[0]
+        phase = "client-ping1-sending"
+        await async c.write(b"PING1")
+        phase = "client-ping1-sent"
+
+    def _on_client_connect(c: net.TLSConnection):
+        client_connected = True
+        if not ping1_started:
+            phase = "client-connected"
+        if client_refs:
+            client_refs[0] = c
+        else:
+            client_refs.append(c)
+        _start_ping1()
+
+    def _on_client_receive(c: net.TLSConnection, data: bytes):
+        if data == b"PONG1":
+            if phase != "client-ping1-sending" and phase != "client-ping1-sent" and phase != "server-pong1-sent":
+                _finish_failure("Unexpected first response phase")
+                return
+            phase = "client-pong1"
+            phase = "client-ping2-sending"
+            await async c.write(b"PING2")
+            phase = "client-ping2-sent"
+        elif data == b"PONG2":
+            if phase != "client-ping2-sending" and phase != "client-ping2-sent" and phase != "server-pong2-sent":
+                _finish_failure("Unexpected second response phase")
+                return
+            phase = "client-pong2"
             _finish_success()
             c.close(lambda c: None)
         else:
             _finish_failure("Unexpected response: " + str(data))
 
-    def on_error(c, msg):
+    def _on_client_error(c: net.TLSConnection, msg: str):
         _finish_failure("TLS client error: " + msg)
 
-    def on_remote_close(c):
-        _finish_failure("TLS server closed before response")
+    def _on_client_remote_close(c: net.TLSConnection):
+        if not done:
+            _finish_failure("TLS server closed before response")
 
-    connect_cap = net.TCPConnectCap(net.TCPCap(net.NetCap(env.cap)))
-    client = net.TLSConnection(connect_cap, host, port, on_connect, on_receive, on_error, on_remote_close, False)
+    def _on_server_receive(c: net.TLSListenConnection, data: bytes):
+        server_conn = c
+        if data == b"PING1":
+            phase = "server-ping1"
+            listener = None
+            phase = "listener-dropped"
+            _force_gc(t)
+            await async c.write(b"PONG1")
+            phase = "server-pong1-sent"
+        elif data == b"PING2":
+            phase = "server-ping2"
+            _force_gc(t)
+            await async c.write(b"PONG2")
+            phase = "server-pong2-sent"
+            c.close()
+        else:
+            _finish_failure("Unexpected request: " + str(data))
+
+    def _on_server_error(c: net.TLSListenConnection, error: str):
+        _finish_error("TLS server error: " + error)
+
+    def _on_server_close(c: net.TLSListenConnection):
+        server_conn = None
+
+    def _on_accept(c: net.TLSListenConnection):
+        phase = "server-accepted"
+        server_conn = c
+        c.cb_install(_on_server_receive, _on_server_error, _on_server_close)
+        _start_ping1()
+
+    def _on_listen(listener_ref, err):
+        if err is not None:
+            if attempts < 10:
+                attempts += 1
+                _start_listener()
+            else:
+                _finish_error("TLS listen failed: " + err)
+            return
+        if started:
+            return
+        started = True
+        phase = "listener-ready"
+        listener = listener_ref
+        phase = "client-connecting"
+        after 0: _start_client_conn()
+
+    def _timeout():
+        _finish_error("timeout")
+
+    def _watchdog():
+        if done:
+            return
+        if timeout_sw.elapsed().to_float() >= TIMEOUT_S:
+            _timeout()
+        else:
+            after WATCHDOG_INTERVAL_S: _watchdog()
+
+    def _start_listener():
+        phase = "listener-starting"
+        port = random.randint(20000, 45000)
+        listener = net.TLSListener(
+            listen_cap,
+            "127.0.0.1",
+            port,
+            CERT_PEM.encode(),
+            KEY_PEM.encode(),
+            _on_listen,
+            _on_accept
+        )
+
+    _start_listener()
+    _watchdog()
 
 
-actor _TLSClientServer(t: testing.EnvT):
+actor _TLSImmediateConnectError(t: testing.EnvT):
+    """Immediate TLS connect setup errors must surface via on_error"""
+    TIMEOUT_S = 10.0
     var done = False
-    var started = False
-    var port = 0
-    var attempts = 0
-    var listener = None
-    var client = None
-    listen_cap = net.TCPListenCap(net.TCPCap(net.NetCap(t.env.cap)))
+    var saw_error = False
+    var client_refs: list[net.TLSConnection] = []
+    timeout_sw = time.Stopwatch()
+    conn_cap = net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap)))
 
     def _finish_success():
         if done:
@@ -115,63 +613,37 @@ actor _TLSClientServer(t: testing.EnvT):
         done = True
         t.error(Exception(msg))
 
-    def _on_client_success():
+    def _on_connect(c: net.TLSConnection):
+        _finish_failure("TLS client unexpectedly connected with invalid port")
+
+    def _on_receive(c: net.TLSConnection, data: bytes):
+        _finish_failure("TLS client unexpectedly received data: " + str(data))
+
+    def _on_error(c: net.TLSConnection, msg: str):
+        if saw_error:
+            return
+        saw_error = True
+        # The error surfaces synchronously ("Failed to start TLS TCP
+        # connect") with the current tlsuv, but a future tlsuv may defer port
+        # validation and report it asynchronously instead.
+        if not (msg.startswith("Failed to start TLS TCP connect: ") or msg.startswith("Error in TLS TCP connect: ")):
+            _finish_failure("Unexpected TLS connect error: " + msg)
+            return
         _finish_success()
 
-    def _on_client_failure(msg: str):
-        _finish_failure(msg)
+    def _on_remote_close(c: net.TLSConnection):
+        _finish_failure("TLS client unexpectedly saw remote close on immediate connect error")
 
-    def _start_client(port: int):
-        client = TLSClient(t.env, "127.0.0.1", port, _on_client_success, _on_client_failure)
+    def _start_client():
+        client_refs.append(net.TLSConnection(conn_cap, "127.0.0.1", 0, _on_connect, _on_receive, _on_error, _on_remote_close, False))
 
-    def _on_server_receive(c, data):
-        if data == b"PING":
-            await async c.write(b"PONG")
-            c.close()
+    def _watchdog():
+        if done:
+            return
+        if timeout_sw.elapsed().to_float() >= TIMEOUT_S:
+            _finish_error("timeout waiting for immediate TLS connect error")
         else:
-            _finish_failure("Unexpected request: " + str(data))
+            after WATCHDOG_INTERVAL_S: _watchdog()
 
-    def _on_server_error(c, error):
-        _finish_error("TLS server error: " + error)
-
-    def _on_server_close(c):
-        if not done:
-            _finish_error("TLS server closed before response")
-
-    def _on_accept(c):
-        c.cb_install(_on_server_receive, _on_server_error, _on_server_close)
-
-    def _on_listen(listener, err):
-        if err is not None:
-            if attempts < 10:
-                attempts += 1
-                _start_listener()
-            else:
-                _finish_error("TLS listen failed: " + err)
-            return
-        if started:
-            return
-        started = True
-        _start_client(port)
-
-    def _timeout():
-        _finish_error("timeout")
-
-    def _start_listener():
-        port = random.randint(20000, 45000)
-        listener = net.TLSListener(
-            listen_cap,
-            "127.0.0.1",
-            port,
-            CERT_PEM.encode(),
-            KEY_PEM.encode(),
-            _on_listen,
-            _on_accept
-        )
-
-    _start_listener()
-    after 10: _timeout()
-
-
-def _test_net_tls(t: testing.EnvT):
-    _TLSClientServer(t)
+    after 0: _start_client()
+    _watchdog()

--- a/test/stdlib_tests/src/test_net_tls_gc.act
+++ b/test/stdlib_tests/src/test_net_tls_gc.act
@@ -1,0 +1,170 @@
+import acton.rts
+import net
+import random
+import test_net_tls
+import testing
+import time
+
+
+def _force_gc(t: testing.EnvT):
+    acton.rts.gc(t.env.syscap)
+    acton.rts.gc(t.env.syscap)
+
+WATCHDOG_INTERVAL_S = 0.25
+TLS_GC_TEST_TIMEOUT_S = 10.0
+
+
+actor _TLSDroppedActorChurn(t: testing.EnvT):
+    """Dropped TLS actors must survive a GC-driven cleanup cycle"""
+    TARGET_ROUNDS = 1
+
+    var done = False
+    var round = 0
+    var port = 0
+    var bind_attempts = 0
+    var phase = "start"
+    var listener: ?net.TLSListener = None
+    var client: ?net.TLSConnection = None
+    var server_conn: ?net.TLSListenConnection = None
+    timeout_sw = time.Stopwatch()
+    listen_cap = net.TCPListenCap(net.TCPCap(net.NetCap(t.env.cap)))
+    conn_cap = net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap)))
+
+    def _finish_success():
+        if done:
+            return
+        done = True
+        t.success()
+
+    def _finish_failure(msg: str):
+        if done:
+            return
+        done = True
+        t.failure(AssertionError(msg))
+
+    def _finish_error(msg: str):
+        if done:
+            return
+        done = True
+        t.error(Exception(msg))
+
+    def _cleanup_round():
+        if done:
+            return
+        round += 1
+        phase = "cleanup-drop-client"
+        listener = None
+        client = None
+        after 0: _cleanup_drain_1()
+
+    def _cleanup_drain_1():
+        if done:
+            return
+        phase = "cleanup-gc1"
+        _force_gc(t)
+        after 0.01: _cleanup_drain_2()
+
+    def _cleanup_drain_2():
+        if done:
+            return
+        phase = "cleanup-drop-server"
+        server_conn = None
+        after 0: _cleanup_drain_3()
+
+    def _cleanup_drain_3():
+        if done:
+            return
+        phase = "cleanup-gc2"
+        _force_gc(t)
+        if round >= TARGET_ROUNDS:
+            _finish_success()
+        else:
+            after 0.01: _start_round()
+
+    def _on_client_connect(c: net.TLSConnection):
+        phase = "client-connected"
+        client = c
+        await async c.write(b"PING")
+        phase = "client-write-complete"
+
+    def _on_client_receive(c: net.TLSConnection, data: bytes):
+        phase = "client-received"
+        if data != b"PONG":
+            _finish_failure("Unexpected response: " + str(data))
+            return
+        after 0: _cleanup_round()
+
+    def _on_client_error(c: net.TLSConnection, msg: str):
+        _finish_failure("TLS client error on round " + str(round + 1) + " during " + phase + ": " + msg)
+
+    def _on_client_remote_close(c: net.TLSConnection):
+        if not done:
+            if phase.startswith("cleanup"):
+                return
+            _finish_failure("TLS client closed before response on round " + str(round + 1) + " during " + phase)
+
+    def _on_server_receive(c: net.TLSListenConnection, data: bytes):
+        phase = "server-received"
+        server_conn = c
+        if data != b"PING":
+            _finish_failure("Unexpected request: " + str(data))
+            return
+        phase = "server-writing"
+        await async c.write(b"PONG")
+        phase = "server-write-complete"
+
+    def _on_server_error(c: net.TLSListenConnection, error: str):
+        _finish_error("TLS server error on round " + str(round + 1) + " during " + phase + ": " + error)
+
+    def _on_server_close(c: net.TLSListenConnection):
+        server_conn = None
+        if not done and not phase.startswith("cleanup"):
+            _finish_failure("TLS server connection closed before cleanup on round " + str(round + 1) + " during " + phase)
+
+    def _on_accept(c: net.TLSListenConnection):
+        phase = "accepted"
+        server_conn = c
+        c.cb_install(_on_server_receive, _on_server_error, _on_server_close)
+
+    def _on_listen(listener_ref, err):
+        phase = "listening"
+        if err is not None:
+            if bind_attempts < 10:
+                bind_attempts += 1
+                after 0: _start_round()
+            else:
+                _finish_error("TLS listen failed on round " + str(round + 1) + ": " + err)
+            return
+        bind_attempts = 0
+        listener = listener_ref
+        phase = "connecting"
+        client = net.TLSConnection(conn_cap, "127.0.0.1", port, _on_client_connect, _on_client_receive, _on_client_error, _on_client_remote_close, False, test_net_tls.ALPN_PROTOCOLS)
+
+    def _start_round():
+        if done:
+            return
+        phase = "binding"
+        port = random.randint(20000, 45000)
+        listener = net.TLSListener(
+            listen_cap,
+            "127.0.0.1",
+            port,
+            test_net_tls.CERT_PEM.encode(),
+            test_net_tls.KEY_PEM.encode(),
+            _on_listen,
+            _on_accept
+        )
+
+    def _timeout():
+        _finish_error("timeout during " + phase)
+
+    def _watchdog():
+        if done:
+            return
+        if timeout_sw.elapsed().to_float() >= TLS_GC_TEST_TIMEOUT_S:
+            _timeout()
+        else:
+            after WATCHDOG_INTERVAL_S: _watchdog()
+
+    _start_round()
+    _watchdog()


### PR DESCRIPTION
This branch moves TLS I/O from GC reachability to explicit lifetimes. tlsuv and mbedtls now allocate from the libc heap with real free, tied to explicit close calls. libuv's internal allocations use GC_malloc_uncollectable + GC_free: they must stay GC-scanned because the loop's watchers array is the root that keeps idle GC uv handles and their actors alive, they must never be collected since tlsuv stores libuv allocations inside libc structs the collector cannot see, and libuv pairs every allocation with a free. uv handles allocated by Acton code remain GC memory, except the TLS path and DNS getaddrinfo requests, which are now libc with frees on every path. net.ext.c is reworked to match: state structs with detachable actor backrefs in handle->data, write payloads copied for the queued-write window, the listener's TLS context/key/cert refcounted across accepted connections, and connect errors surfaced instead of ignored. The TLS actors get action __cleanup__ finalizers as a safety net that closes native streams when an actor is dropped without close(); cleanup runs as a message on the actor's pinned worker thread. TLSListener gains close(), and accepted connections pin to the worker thread whose loop owns the stream. The tlsuv fork ref is bumped to pick up seven hardening fixes that close use-after-free and hang windows the no-op free regime had been masking.

New tests target the specific hazards: byte-exact queued-write roundtrips, dropping the listener with forced GC under a live connection, immediate connect errors, and an actor-drop churn test exercising the finalizers. A new dev-guide page documents the allocator regimes, the hazard catalogue and the ownership patterns .ext.c IO code should follow. Validated with the full stdlib suite, acton test stress with 8 workers (~87k iterations across the TLS tests), repeated-run churn loops both threaded and single-threaded, runs with the collector disabled and with MallocScribble, and flat RSS over sustained connection churn.