### PR TITLE
Selective tydb reads for imported modules

### DIFF
--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -2353,9 +2353,9 @@ writeRootC env gopts opts paths tasks binTask = do
         rootsHeader <- case tyPath of
                          Just ty -> do (_sourceMeta, _, _, _implH, _imps, _depModules, _nameHashes, roots, _tests, _) <- InterfaceFiles.readHeader ty; return roots
                          Nothing -> return []
-        let rootsEnv = case Acton.Env.lookupMod m env of
+        let rootsEnv = case Acton.Env.lookupModuleInfo m env of
                          Nothing -> []
-                         Just te -> [ n' | (n', i) <- te, rootEligible i ]
+                         Just mi -> [ n' | (n', i) <- Acton.Env.modulePublicTEnv mi, rootEligible i ]
             shouldGen = n `elem` rootsHeader || n `elem` rootsEnv
         if shouldGen
           then do
@@ -2955,10 +2955,10 @@ normalizeZigDep b dep =
 filterMainActor :: Acton.Env.Env0 -> Paths -> BinTask -> IO (Maybe BinTask)
 filterMainActor env paths binTask = do
     let qn@(A.GName m n) = rootActor binTask
-    let checkEnv = case Acton.Env.lookupMod m env of
+    let checkEnv = case Acton.Env.lookupModuleInfo m env of
                      Nothing -> return Nothing
-                     Just te -> do
-                       let rootsEnv = [ n' | (n', i) <- te, rootEligible i ]
+                     Just mi -> do
+                       let rootsEnv = [ n' | (n', i) <- Acton.Env.modulePublicTEnv mi, rootEligible i ]
                        if n `elem` rootsEnv then return (Just binTask) else return Nothing
     mty <- Acton.Env.findTyFile (searchPath paths) m
     case mty of

--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -692,10 +692,10 @@ readModuleImports paths mn = do
     if not exists
       then return []
       else do
-        hdrE <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readHeader tyFile
+        hdrE <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readHeaderSummary tyFile
         case hdrE of
           Left _ -> return []
-          Right (_sourceMeta, _hash, _ih, _implH, imps, _depModules, _nameHashes, _roots, _tests, _doc) -> return (map fst imps)
+          Right (_sourceMeta, _hash, _ih, _implH, imps, _depModules, _nameCount, _roots, _tests, _doc) -> return (map fst imps)
 
 dependentTestModulesFromHeaders :: Paths -> [FilePath] -> [String] -> IO [String]
 dependentTestModulesFromHeaders paths srcFiles changedModules = do
@@ -2203,9 +2203,9 @@ expectedRootStubs paths tasks = do
         let mn     = name t
             outbase = outBase paths mn
             tyPath = tyDbPath paths mn
-        hdrE <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readHeader tyPath
+        hdrE <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readHeaderSummary tyPath
         case hdrE of
-          Right (_sourceMeta, _, _, _implH, _imps, _depModules, _nameHashes, rs, _tests, _) -> return (map (mkStub outbase) rs)
+          Right (_sourceMeta, _, _, _implH, _imps, _depModules, _nameCount, rs, _tests, _) -> return (map (mkStub outbase) rs)
           _ -> return []
     return (concat roots)
   where
@@ -2351,7 +2351,7 @@ writeRootC env gopts opts paths tasks binTask = do
         -- was rebuilt during this run.
         tyPath <- Acton.Env.findTyFile (searchPath paths) m
         rootsHeader <- case tyPath of
-                         Just ty -> do (_sourceMeta, _, _, _implH, _imps, _depModules, _nameHashes, roots, _tests, _) <- InterfaceFiles.readHeader ty; return roots
+                         Just ty -> do (_sourceMeta, _, _, _implH, _imps, _depModules, _nameCount, roots, _tests, _) <- InterfaceFiles.readHeaderSummary ty; return roots
                          Nothing -> return []
         let rootsEnv = case Acton.Env.lookupModuleInfo m env of
                          Nothing -> []
@@ -2963,9 +2963,9 @@ filterMainActor env paths binTask = do
     mty <- Acton.Env.findTyFile (searchPath paths) m
     case mty of
       Just ty -> do
-        hdrE <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readHeader ty
+        hdrE <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readHeaderSummary ty
         case hdrE of
-          Right (_sourceMeta, _, _, _implH, _imps, _depModules, _nameHashes, roots, _tests, _) | n `elem` roots -> return (Just binTask)
+          Right (_sourceMeta, _, _, _implH, _imps, _depModules, _nameCount, roots, _tests, _) | n `elem` roots -> return (Just binTask)
           _ -> checkEnv
       Nothing -> checkEnv
 

--- a/compiler/acton/TestRunner.hs
+++ b/compiler/acton/TestRunner.hs
@@ -557,10 +557,10 @@ readModuleTests paths mn = do
     if not exists
       then return []
       else do
-        hdrE <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readHeader tyFile
+        hdrE <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readHeaderSummary tyFile
         case hdrE of
           Left _ -> return []
-          Right (_sourceMeta, _srcH, _ih, _implH, _imps, _depModules, _nameHashes, _roots, tests, _doc) ->
+          Right (_sourceMeta, _srcH, _ih, _implH, _imps, _depModules, _nameCount, _roots, tests, _doc) ->
             return tests
 
 modNameFromString :: String -> A.ModName

--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -104,6 +104,9 @@ compilerTests =
         (returnCode, cmdOut, cmdErr) <- readCreateProcessWithExitCode (shell $ "rm -rf ../../test/compiler/subdash/out") ""
         testBuild "" ExitSuccess False "../../test/compiler/subdash/"
         testBuild "" ExitSuccess False "../../test/compiler/subdash/"
+  , testCase "module lookup exact imports" $ do
+        (returnCode, cmdOut, cmdErr) <- readCreateProcessWithExitCode (shell $ "rm -rf ../../test/compiler/module_lookup/out") ""
+        testBuild "--skip-build" ExitSuccess False "../../test/compiler/module_lookup/"
   , testCase "dynamic module library build" $ do
         withSystemTempDirectory "acton-dynamic-module-build" $ \proj -> do
           actonExe <- canonicalizePath "../../dist/bin/acton"

--- a/compiler/acton/test_incremental.hs
+++ b/compiler/acton/test_incremental.hs
@@ -8,12 +8,12 @@ import qualified Data.ByteString as B
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import qualified Data.Text.Encoding as TE
-import           Data.Char (isHexDigit, isSpace)
+import           Data.Char (isHexDigit, isSpace, toLower)
 import           Data.Bits (shiftL, (.|.))
 import           Data.Word (Word64)
 import qualified Acton.Fingerprint as Fingerprint
 import qualified Crypto.Hash.SHA256 as SHA256
-import           Data.List (elemIndex, find, partition, sort, sortOn)
+import           Data.List (elemIndex, find, isPrefixOf, partition, sort, sortOn)
 import qualified Data.Map.Strict as M
 import           Data.Maybe (fromMaybe, isJust)
 import           System.Directory
@@ -548,6 +548,88 @@ readTyLocalDeps tyPath nameLabel = do
       let pubDeps = sort (map prstr (InterfaceFiles.nhPubLocalDeps nh))
           implDeps = sort (map prstr (InterfaceFiles.nhImplLocalDeps nh))
       pure (pubDeps, implDeps)
+
+-- | Generate a class-heavy module with the same shape as the
+-- test/compiler/concurrent_typecheck_class_heavy fixture generator. Ported
+-- here rather than invoking generate_heavy.py so the tests do not depend on
+-- python3 being installed.
+writeHeavyClassModule :: FilePath -> Int -> IO ()
+writeHeavyClassModule outPath trees =
+  writeFileUtf8 outPath (T.pack (heavyClassModule trees))
+
+heavyClassModule :: Int -> String
+heavyClassModule trees =
+    unlines (header ++ concat (zipWith emitClass [1 ..] classSites))
+  where
+    header =
+      [ "# Generated class-heavy fixture (Haskell port of generate_heavy.py)."
+      , ""
+      ]
+    classSites = [ (tree, shape) | tree <- [0 .. trees - 1], shape <- shapes ]
+    roots = "ABCDEFGH"
+    shapes =
+      [ ("", Nothing), ("1", Just ""), ("2", Just ""), ("2A", Just "2")
+      , ("2A1", Just "2A"), ("2A2", Just "2A"), ("2B", Just "2")
+      , ("3", Just ""), ("3A", Just "3"), ("3A1", Just "3A")
+      ]
+    pad w n = let str = show (n :: Int) in replicate (w - length str) '0' ++ str
+    className tree suffix =
+      "Node" ++ pad 3 (tree `div` length roots) ++ [roots !! (tree `mod` length roots)] ++ suffix
+    emitClass n (tree, (suffix, parentSuffix)) =
+      [ "class " ++ name ++ "(" ++ parent ++ "):" ]
+      ++ (if rootClass then [ "    seed: int", "    total: int", "    weight: int" ] else [])
+      ++
+      [ "    " ++ branch ++ ": int"
+      , "    " ++ extra ++ ": int"
+      , "    __init__ : (int) -> None"
+      , "    fold_" ++ method ++ " : (int, int, int) -> int"
+      , "    score_" ++ method ++ " : (int) -> int"
+      , ""
+      , "    def __init__(self, seed):"
+      ]
+      ++ (if rootClass
+            then [ "        self.seed = seed + " ++ show n
+                 , "        self.total = self.seed + seed + " ++ show (n + 1)
+                 , "        self.weight = self.total + self.seed + " ++ show (n + 2)
+                 , "        self." ++ branch ++ " = seed + self.seed + self.total + " ++ show (n + 3)
+                 , "        self." ++ extra ++ " = self." ++ branch ++ " + self.weight + " ++ show (n + 4)
+                 ]
+            else [ "        self." ++ branch ++ " = seed + " ++ show (n + 4)
+                 , "        self." ++ extra ++ " = self." ++ branch ++ " + seed + " ++ show (n + 5)
+                 , "        " ++ parent ++ ".__init__(self, seed + " ++ show (n + 1) ++ ")"
+                 ])
+      ++
+      [ ""
+      , "    def fold_" ++ method ++ "(self, x, y, z):"
+      , "        v0: int = x + y + z + self.seed + " ++ show n
+      ]
+      ++ [ "        v" ++ show i ++ ": int = v" ++ show (i - 1) ++ " + self."
+             ++ (if odd i then branch else extra) ++ " + self.total + " ++ show (n + i)
+         | i <- [1 .. 14 :: Int]
+         ]
+      ++
+      [ "        return v14"
+      , ""
+      , "    def score_" ++ method ++ "(self, bonus):"
+      , "        r0: int = self.fold_" ++ method ++ "(self.seed, self.total, self.weight) + bonus"
+      ]
+      ++ [ "        r" ++ show i ++ ": int = r" ++ show (i - 1) ++ " + self."
+             ++ (if odd i then extra else branch) ++ " + self.weight + " ++ show (n + i)
+         | i <- [1 .. 10 :: Int]
+         ]
+      ++
+      [ "        return r10"
+      , ""
+      , "_sep_" ++ pad 5 n ++ ": int = " ++ show n
+      , ""
+      ]
+      where
+        name = className tree suffix
+        parent = maybe "object" (className tree) parentSuffix
+        rootClass = parentSuffix == Nothing
+        method = map toLower name
+        branch = "branch_" ++ pad 5 n
+        extra = "extra_" ++ pad 5 n
 
 -- | Rewrite source hash and name-hash section of a .tydb file.
 rewriteTySrcHashAndNameHashes :: FilePath -> B.ByteString -> ([InterfaceFiles.NameHashInfo] -> [InterfaceFiles.NameHashInfo]) -> IO ()
@@ -2491,6 +2573,264 @@ buildHashTraceDep depDir = do
 hashTraceBuildArgs :: [String]
 hashTraceBuildArgs = ["--skip-build", "--searchpath", "deps/big/out/types"]
 
+-- Broad .tydb reads decode whole sections (every name, every constructor);
+-- these tests pin down that dependent-module compiles stay on keyed reads.
+broadReadMarkers :: [T.Text]
+broadReadMarkers =
+  [ "tydb-read all"
+  , "tydb-read public-names"
+  , "tydb-read constructors"
+  , "tydb-read name-hash-all"
+  ]
+
+p50_big_dep_added_name_keeps_small_fresh :: TestTree
+p50_big_dep_added_name_keeps_small_fresh =
+  testCase "50-added name in big dependency keeps small fresh" $ do
+    let proj = casesProjDir
+        src = casesSrcDir
+        modSmall = modLabel proj "small"
+        tySmall = proj </> "out" </> "types" </> "small.tydb"
+    ensureCasesProjectWithDeps [("big", "deps/big")]
+    depDir <- ensureDepProject proj "big"
+    let bigSrc = depDir </> "src" </> "big.act"
+    writeHeavyClassModule bigSrc 20
+    writeFileUtf8 (src </> "small.act") $ T.unlines
+      [ "import big"
+      , ""
+      , "def use_one() -> int:"
+      , "    return big.Node000A(1).score_node000a(2)"
+      , ""
+      , "actor main(env: Env):"
+      , "    print(use_one())"
+      , "    env.exit(0)"
+      ]
+    _ <- buildOutInArgs proj ["--skip-build"]
+    (pubDeps, implDeps) <- readTyDeps tySmall "use_one"
+    let bigPubDeps = sort [ dep | dep <- pubDeps, "big." `isPrefixOf` dep ]
+        bigImplDeps = sort [ dep | dep <- implDeps, "big." `isPrefixOf` dep ]
+    assertEqual "small pub deps into big" ["big.Node000A"] bigPubDeps
+    assertEqual "small impl deps into big" ["big.Node000A"] bigImplDeps
+    bigV1 <- T.readFile bigSrc
+    writeFileUtf8 bigSrc $ bigV1 <> T.unlines
+      [ ""
+      , "def unrelated_added_name() -> int:"
+      , "    return 123"
+      ]
+    res@(_ec, out) <- runActonInEnv [("ACTON_TYDB_TRACE_READS", "1")] proj ["build", "--color", "never", "--verbose", "--skip-build"]
+    assertExitSuccess "selective unchanged dependency build" res
+    -- big itself recompiles here, and the verbose delta report reads big's
+    -- own previous hashes; only reads serving small's freshness are pinned.
+    let traceLines = filter (T.isPrefixOf "tydb-read ") (T.lines out)
+        bigLines = filter (T.isInfixOf "big.tydb") traceLines
+        bigForbiddenLines = filter (\line -> any (`T.isInfixOf` line) (filter (/= "tydb-read name-hash-all") broadReadMarkers)) bigLines
+    assertBool ("expected small.act to stay fresh\n" ++ T.unpack out)
+      (T.isInfixOf "Fresh small: using cached .tydb" out)
+    assertBool "did not expect small.act to type check" (not (typechecked out modSmall))
+    assertEqual ("did not expect broad big.tydb reads\ntrace:\n" ++ T.unpack (T.unlines traceLines))
+      [] bigForbiddenLines
+
+p51_imported_lookup_stays_selective :: TestTree
+p51_imported_lookup_stays_selective =
+  testCase "51-imported .tydb lookup stays selective" $ do
+    let proj = casesProjDir
+        src = casesSrcDir
+        modSmall = modLabel proj "small"
+        writeSmall offset = writeFileUtf8 (src </> "small.act") $ T.unlines
+          [ "import big"
+          , ""
+          , "def use_one() -> int:"
+          , T.pack ("    return big.used_value() + " ++ show (offset :: Int))
+          , ""
+          , "actor main(env: Env):"
+          , "    print(use_one())"
+          , "    env.exit(0)"
+          ]
+    ensureCasesProjectWithDeps [("big", "deps/big")]
+    depDir <- ensureDepProject proj "big"
+    let bigSrc = depDir </> "src" </> "big.act"
+    writeHeavyClassModule bigSrc 20
+    bigV1 <- T.readFile bigSrc
+    writeFileUtf8 bigSrc $ bigV1 <> T.unlines
+      [ ""
+      , "def used_value() -> int:"
+      , "    return Node000A(1).score_node000a(2)"
+      ]
+    writeSmall 1
+    _ <- buildOutInArgs proj ["--skip-build"]
+    writeSmall 2
+    res@(_ec, out) <- runActonInEnv [("ACTON_TYDB_TRACE_READS", "1")] proj ["build", "--color", "never", "--verbose", "--skip-build"]
+    assertExitSuccess "selective .tydb trace build" res
+    let traceLines = filter (T.isPrefixOf "tydb-read ") (T.lines out)
+        bigLines = filter (T.isInfixOf "big.tydb") traceLines
+        bigForbiddenLines = filter (\line -> any (`T.isInfixOf` line) broadReadMarkers) bigLines
+        bigUsedValueLines = filter (\line -> T.isInfixOf "name-hit" line && T.isInfixOf "used_value" line) bigLines
+    assertBool ("expected small.act to type check\n" ++ T.unpack out) (typechecked out modSmall)
+    assertBool ("expected exact used_value lookup in big.tydb\ntrace:\n" ++ T.unpack (T.unlines traceLines))
+      (not (null bigUsedValueLines))
+    assertEqual ("did not expect broad big.tydb reads\ntrace:\n" ++ T.unpack (T.unlines traceLines))
+      [] bigForbiddenLines
+
+p52_imported_witness_lookup_stays_selective :: TestTree
+p52_imported_witness_lookup_stays_selective =
+  testCase "52-imported .tydb witness lookup stays selective" $ do
+    let proj = casesProjDir
+        src = casesSrcDir
+        modSmall = modLabel proj "small"
+        writeSmall offset = writeFileUtf8 (src </> "small.act") $ T.unlines
+          [ "import big"
+          , ""
+          , "actor main(env: Env):"
+          , "    box = big.Box(1)"
+          , "    other = big.Box(1)"
+          , "    ordered = big.OrderedBox(1)"
+          , T.pack ("    ordered2 = big.OrderedBox(" ++ show (offset :: Int) ++ ")")
+          , "    worker = big.Worker()"
+          , "    direct = big.Box(1).value"
+          , "    if box == other and ordered == ordered and ordered < ordered2 and direct == 1:"
+          , "        env.exit(0)"
+          , "    else:"
+          , "        env.exit(1)"
+          ]
+    ensureCasesProjectWithDeps [("big", "deps/big")]
+    depDir <- ensureDepProject proj "big"
+    let bigSrc = depDir </> "src" </> "big.act"
+    writeHeavyClassModule bigSrc 20
+    bigV1 <- T.readFile bigSrc
+    writeFileUtf8 bigSrc $ bigV1 <> T.unlines
+      [ ""
+      , "class Box:"
+      , "    value: int"
+      , "    __init__ : (int) -> None"
+      , ""
+      , "    def __init__(self, value):"
+      , "        self.value = value"
+      , ""
+      , "extension Box (Eq):"
+      , "    def __eq__(x, y):"
+      , "        return x.value == y.value"
+      , ""
+      , "class OrderedBox:"
+      , "    value: int"
+      , "    __init__ : (int) -> None"
+      , ""
+      , "    def __init__(self, value):"
+      , "        self.value = value"
+      , ""
+      , "extension OrderedBox (Ord):"
+      , "    def __eq__(x, y):"
+      , "        return x.value == y.value"
+      , ""
+      , "    def __lt__(x, y):"
+      , "        return x.value < y.value"
+      , ""
+      , "actor Worker():"
+      , "    def ping():"
+      , "        return 1"
+      ]
+    writeSmall 2
+    _ <- buildOutInArgs proj ["--skip-build"]
+    writeSmall 3
+    res@(_ec, out) <- runActonInEnv [("ACTON_TYDB_TRACE_READS", "1")] proj ["build", "--color", "never", "--verbose", "--skip-build"]
+    assertExitSuccess "selective .tydb witness trace build" res
+    let traceLines = filter (T.isPrefixOf "tydb-read ") (T.lines out)
+        bigLines = filter (T.isInfixOf "big.tydb") traceLines
+        bigForbiddenLines = filter (\line -> any (`T.isInfixOf` line) broadReadMarkers) bigLines
+        bigBoxLines = filter (\line -> T.isInfixOf "name-hit" line && T.isInfixOf "Box" line) bigLines
+        bigWorkerLines = filter (\line -> T.isInfixOf "name-hit" line && T.isInfixOf "Worker" line) bigLines
+        bigWitnessLines = filter (\line -> T.isInfixOf "ext-" line) bigLines
+    assertBool ("expected small.act to type check\n" ++ T.unpack out) (typechecked out modSmall)
+    assertBool ("expected exact Box lookup in big.tydb\ntrace:\n" ++ T.unpack (T.unlines traceLines))
+      (not (null bigBoxLines))
+    assertBool ("expected exact Worker lookup in big.tydb\ntrace:\n" ++ T.unpack (T.unlines traceLines))
+      (not (null bigWorkerLines))
+    assertBool ("expected keyed extension index lookups in big.tydb\ntrace:\n" ++ T.unpack (T.unlines traceLines))
+      (not (null bigWitnessLines))
+    assertEqual ("did not expect broad big.tydb reads\ntrace:\n" ++ T.unpack (T.unlines traceLines))
+      [] bigForbiddenLines
+
+p53_imported_attr_inference_stays_selective :: TestTree
+p53_imported_attr_inference_stays_selective =
+  testCase "53-imported .tydb attr inference stays selective" $ do
+    let proj = casesProjDir
+        src = casesSrcDir
+        modSmall = modLabel proj "small"
+        writeSmall offset = writeFileUtf8 (src </> "small.act") $ T.unlines
+          [ "import big"
+          , ""
+          , "def read_flag(args):"
+          , "    return args.get_bool(\"flag\")"
+          , ""
+          , "actor main(env: Env):"
+          , T.pack ("    if read_flag(big.Args()) and " ++ show (offset :: Int) ++ " > 0:")
+          , "        env.exit(0)"
+          , "    else:"
+          , "        env.exit(1)"
+          ]
+    ensureCasesProjectWithDeps [("big", "deps/big")]
+    depDir <- ensureDepProject proj "big"
+    let bigSrc = depDir </> "src" </> "big.act"
+    writeHeavyClassModule bigSrc 20
+    bigV1 <- T.readFile bigSrc
+    writeFileUtf8 bigSrc $ bigV1 <> T.unlines
+      [ ""
+      , "class Args:"
+      , "    def __init__(self):"
+      , "        pass"
+      , ""
+      , "    def get_bool(self, name: str) -> bool:"
+      , "        return True"
+      ]
+    writeSmall 1
+    _ <- buildOutInArgs proj ["--skip-build"]
+    writeSmall 2
+    res@(_ec, out) <- runActonInEnv [("ACTON_TYDB_TRACE_READS", "1")] proj ["build", "--color", "never", "--verbose", "--skip-build"]
+    assertExitSuccess "selective .tydb attr inference trace build" res
+    let traceLines = filter (T.isPrefixOf "tydb-read ") (T.lines out)
+        bigLines = filter (T.isInfixOf "big.tydb") traceLines
+        bigForbiddenLines = filter (\line -> any (`T.isInfixOf` line) broadReadMarkers) bigLines
+        bigArgsLines = filter (\line -> T.isInfixOf "name-hit" line && T.isInfixOf "Args" line) bigLines
+        bigAttrLines = filter (\line -> T.isInfixOf "con-attr" line && T.isInfixOf "get_bool" line) bigLines
+    assertBool ("expected small.act to type check\n" ++ T.unpack out) (typechecked out modSmall)
+    assertBool ("expected attr-index get_bool lookup in big.tydb\ntrace:\n" ++ T.unpack (T.unlines traceLines))
+      (not (null bigAttrLines))
+    assertBool ("expected exact Args lookup in big.tydb\ntrace:\n" ++ T.unpack (T.unlines traceLines))
+      (not (null bigArgsLines))
+    assertEqual ("did not expect broad big.tydb reads\ntrace:\n" ++ T.unpack (T.unlines traceLines))
+      [] bigForbiddenLines
+
+p54_unused_import_reads_no_names :: TestTree
+p54_unused_import_reads_no_names =
+  testCase "54-unused import full build reads no .tydb names" $ do
+    let proj = casesProjDir
+        src = casesSrcDir
+        modSmall = modLabel proj "small"
+    ensureCasesProject
+    let bigSrc = src </> "big.act"
+    writeHeavyClassModule bigSrc 10
+    bigRes <- runActonIn proj ["build", "--color", "never", "--skip-build", "src/big.act"]
+    assertExitSuccess "build cached big dependency" bigRes
+    writeFileUtf8 (src </> "small.act") $ T.unlines
+      [ "import big"
+      , ""
+      , "def use_none() -> int:"
+      , "    return 42"
+      ]
+    res@(_ec, out) <- runActonInEnv [("ACTON_TYDB_TRACE_READS", "1")] proj ["build", "--color", "never", "--verbose", "--skip-build", "src/small.act"]
+    assertExitSuccess "unused import .tydb trace build" res
+    let traceLines = filter (T.isPrefixOf "tydb-read ") (T.lines out)
+        bigLines = filter (T.isInfixOf "big.tydb") traceLines
+        -- Solver witness queries may still probe each import's keyed
+        -- extension indexes; those reads are per-module, not per-size.
+        bigForbiddenLines = filter (\line -> any (`T.isInfixOf` line)
+                                     (broadReadMarkers ++
+                                      [ "tydb-read name-hit"
+                                      , "tydb-read name-miss"
+                                      , "tydb-read name-hash"
+                                      ])) bigLines
+    assertBool ("expected small.act to type check\n" ++ T.unpack out) (typechecked out modSmall)
+    assertEqual ("did not expect any broad or name reads from unused big.tydb\ntrace:\n" ++ T.unpack (T.unlines traceLines))
+      [] bigForbiddenLines
+
 -- Main -----------------------------------------------------------------------
 
 -- | Tasty entry point for incremental tests.
@@ -2564,5 +2904,10 @@ main = defaultMain $ localOption (NumThreads 1) $ testGroup "incremental"
       , p47_unchanged_dep_reads_module_hashes_only
       , p48_unrelated_dep_addition_reads_used_name_only
       , p49_changed_dep_name_reads_users
+      , p50_big_dep_added_name_keeps_small_fresh
+      , p51_imported_lookup_stays_selective
+      , p52_imported_witness_lookup_stays_selective
+      , p53_imported_attr_inference_stays_selective
+      , p54_unused_import_reads_no_names
       ]
   ]

--- a/compiler/lib/bench/CompilerBench.hs
+++ b/compiler/lib/bench/CompilerBench.hs
@@ -168,6 +168,13 @@ resolveNameHashMap paths mn = do
           Just (_, _, _, _, _, _, nameHashes, _, _, _) -> Just (nameHashMapFromHeader nameHashes)
           Nothing -> Nothing
 
+resolveNameHash :: Compile.Paths -> Syntax.ModName -> Syntax.Name -> IO (Maybe InterfaceFiles.NameHashInfo)
+resolveNameHash paths mn n = do
+    mty <- Env.findTyFile (Compile.searchPath paths) mn
+    case mty of
+      Nothing -> return Nothing
+      Just ty -> InterfaceFiles.readNameHashMaybe ty n
+
 resolveDepHashMap :: String
                   -> (InterfaceFiles.NameHashInfo -> B.ByteString)
                   -> Map.Map Syntax.ModName (Map.Map Syntax.Name InterfaceFiles.NameHashInfo)
@@ -764,7 +771,7 @@ runCompilerFront buildFront runBack typesPath sourcePath = do
       Nothing
       (Compile.getPubHashCached paths)
       (Compile.getImplHashCached paths)
-      (resolveNameHashMap paths)
+      (resolveNameHash paths)
       (\_ -> return ())
       (\_ _ -> return ())
       (\_ _ _ -> return ())

--- a/compiler/lib/bench/CompilerBench.hs
+++ b/compiler/lib/bench/CompilerBench.hs
@@ -105,6 +105,9 @@ forceHTEnv = HashMap.foldl' forceHNameInfo () where
     forceHNameInfo () (NameInfo.HNModule _ te _) = forceHTEnv te
     forceHNameInfo () hni                        = hni `seq` ()
 
+forceModuleInfos = Map.foldl' forceModuleInfo () where
+    forceModuleInfo () mi = rnf (Env.modulePublicTEnv mi)
+
 fmtTime :: TimeSpec -> String
 fmtTime t = show seconds ++ "s"
   where seconds = (fromIntegral (toNanoSecs t) / 1000000000.0 :: Double)
@@ -221,14 +224,14 @@ prepareHashBench typesPath sourcePath = do
     E.evaluate (rnf parsed)
     env <- Env.mkEnv (Compile.searchPath paths) env0 parsed
     E.evaluate (forceHTEnv (Env.hnames env))
-    E.evaluate (forceHTEnv (Env.hmodules env))
+    E.evaluate (forceModuleInfos (Env.modules env))
     kchecked <- Kinds.check env parsed
     E.evaluate (rnf kchecked)
     (nmod, tchecked, typeEnv, tests) <- Types.reconstruct Nothing Nothing env kchecked
     E.evaluate (rnf nmod)
     E.evaluate (rnf tchecked)
     E.evaluate (forceHTEnv (Env.hnames typeEnv))
-    E.evaluate (forceHTEnv (Env.hmodules typeEnv))
+    E.evaluate (forceModuleInfos (Env.modules typeEnv))
     E.evaluate (length tests)
 
     let NameInfo.NModule _ fullIface _ = nmod
@@ -713,7 +716,7 @@ runDirect mode typesPath sourcePath = do
       _ -> do
         env <- Env.mkEnv [typesPath] env0 parsed
         E.evaluate (forceHTEnv (Env.hnames env))
-        E.evaluate (forceHTEnv (Env.hmodules env))
+        E.evaluate (forceModuleInfos (Env.modules env))
         t2 <- getCurrentTime
         s2 <- getStats statsEnabled
         elapsed "env" t1 t2
@@ -733,7 +736,7 @@ runDirect mode typesPath sourcePath = do
             E.evaluate (rnf nmod)
             E.evaluate (rnf tchecked)
             E.evaluate (forceHTEnv (Env.hnames typeEnv))
-            E.evaluate (forceHTEnv (Env.hmodules typeEnv))
+            E.evaluate (forceModuleInfos (Env.modules typeEnv))
             E.evaluate (length tests)
             t4 <- getCurrentTime
             s4 <- getStats statsEnabled

--- a/compiler/lib/bench/KindsBench.hs
+++ b/compiler/lib/bench/KindsBench.hs
@@ -60,7 +60,6 @@ main = do
 
         env <- Env.mkEnv [typesPath] env0 parsed
         E.evaluate (forceHTEnv (Env.hnames env))
-        E.evaluate (forceHTEnv (Env.hmodules env))
         t2 <- getCurrentTime
         s2 <- getStats statsEnabled
         elapsed "env" t1 t2

--- a/compiler/lib/bench/TypesBench.hs
+++ b/compiler/lib/bench/TypesBench.hs
@@ -61,7 +61,6 @@ main = do
 
         env <- Env.mkEnv [typesPath] env0 parsed
         E.evaluate (forceHTEnv (Env.hnames env))
-        E.evaluate (forceHTEnv (Env.hmodules env))
         t2 <- getCurrentTime
         s2 <- getStats statsEnabled
         elapsed "env" t1 t2
@@ -78,7 +77,6 @@ main = do
         E.evaluate (rnf nmod)
         E.evaluate (rnf tchecked)
         E.evaluate (forceHTEnv (Env.hnames typeEnv))
-        E.evaluate (forceHTEnv (Env.hmodules typeEnv))
         E.evaluate (length tests)
         t4 <- getCurrentTime
         s4 <- getStats statsEnabled

--- a/compiler/lib/src/Acton/CPS.hs
+++ b/compiler/lib/src/Acton/CPS.hs
@@ -29,7 +29,7 @@ import Acton.Env
 import Acton.QuickType
 
 convert                                 :: Env0 -> Module -> IO (Module, Env0)
-convert env0 m                          = return (runCpsM (convMod m), mapModules1 (conv env) env0)
+convert env0 m                          = return (runCpsM (convMod m), convertModules1 (conv env) env0)
   where env                             = cpsEnv env0
         convMod (Module m imps mdoc ss) = do ss' <- preSuite env ss
                                              --traceM ("######## preCPS:\n" ++ render (vcat $ map pretty ss') ++ "\n########")

--- a/compiler/lib/src/Acton/CodeGen.hs
+++ b/compiler/lib/src/Acton/CodeGen.hs
@@ -672,7 +672,7 @@ allClasses env                      = active ++ closed ++ mods
         closed                      = [ (NoQ n, q) | (n, NClass q _ _ _) <- closedNames env ]
         -- modulePublicTEnv resolves through each module's lookup function, so
         -- entries rewritten by earlier passes are seen in converted form.
-        mods                        = [ (GName m n, q) | (m, mi) <- Map.toList (moduleInfos env),
+        mods                        = [ (GName m n, q) | (m, mi) <- Map.toList (modules env),
                                                          (n, NClass q _ _ _) <- modulePublicTEnv mi ]
 
 nullConArgs env qn                  = case findQName qn env of

--- a/compiler/lib/src/Acton/CodeGen.hs
+++ b/compiler/lib/src/Acton/CodeGen.hs
@@ -17,6 +17,7 @@ module Acton.CodeGen where
 import qualified Data.Set
 import qualified Data.HashSet as HashSet
 import qualified Data.List
+import qualified Data.Map.Strict as Map
 import qualified Acton.Env
 import Utils
 import Pretty
@@ -669,15 +670,10 @@ providerObjects env                 = concat [ providerRoot qn q | (qn, q) <- al
 allClasses env                      = active ++ closed ++ mods
   where active                      = [ (NoQ n, q) | (n, NClass q _ _ _) <- activeNames env ]
         closed                      = [ (NoQ n, q) | (n, NClass q _ _ _) <- closedNames env ]
-        mods                        = moduleClasses [] (modules env)
-        moduleClasses path ((n, NModule _ te _) : xs)
-                                    = moduleClasses (path ++ [n]) te ++ moduleClasses path xs
-        moduleClasses path ((n, NClass q _ _ _) : xs)
-                                    = (qual path n, q) : moduleClasses path xs
-        moduleClasses path (_ : xs) = moduleClasses path xs
-        moduleClasses _ []          = []
-        qual [] n                   = NoQ n
-        qual path n                 = GName (ModName path) n
+        -- modulePublicTEnv resolves through each module's lookup function, so
+        -- entries rewritten by earlier passes are seen in converted form.
+        mods                        = [ (GName m n, q) | (m, mi) <- Map.toList (moduleInfos env),
+                                                         (n, NClass q _ _ _) <- modulePublicTEnv mi ]
 
 nullConArgs env qn                  = case findQName qn env of
                                         NClass _ _ te _ -> case lookup initKW te of
@@ -729,11 +725,9 @@ derivedWitnessQName (QName m owner) field
 classQBinds env (NoQ n)             = case lookupName n env of
                                         Just (HNClass q _ _ _) -> Just q
                                         _                     -> Nothing
-classQBinds env (GName m n)         = case lookupMod m env of
-                                        Just te -> case lookup n te of
-                                                     Just (NClass q _ _ _) -> Just q
-                                                     _                    -> Nothing
-                                        Nothing -> Nothing
+classQBinds env (GName m n)         = case lookupModuleInfo m env >>= \mi -> moduleLookupName mi n of
+                                        Just (NClass q _ _ _) -> Just q
+                                        _                     -> Nothing
 classQBinds env (QName m n)         = classQBinds env (GName m n)
 
 concreteProvider env tc n           = case lookup n (fullAttrEnv env tc) of

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -2572,8 +2572,8 @@ runFrontPasses gopts opts dbpBlocked paths env0 parsed srcContent srcBytes sourc
                                       else joinPath (docDir : init modPathList) </> last modPathList <.> "html"
                             docFileDir = takeDirectory docFile
                             -- Get the type environment for this module
-                            modTypeEnv = case Acton.Env.lookupMod mn typeEnv of
-                              Just te -> te
+                            modTypeEnv = case Acton.Env.lookupModuleInfo mn typeEnv of
+                              Just mi -> Acton.Env.modulePublicTEnv mi
                               Nothing -> publicIface
                             -- Apply the same simplification as --sigs uses
                             env1 = define publicIface $ setMod mn env

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -923,6 +923,12 @@ implHashCache = unsafePerformIO (newMVar M.empty)
 nameHashCache :: MVar (M.Map A.ModName (M.Map A.Name InterfaceFiles.NameHashInfo))
 nameHashCache = unsafePerformIO (newMVar M.empty)
 
+-- | Per-name results of targeted name-hash reads. Kept apart from
+-- nameHashCache, whose per-module maps must stay complete.
+{-# NOINLINE nameHashOneCache #-}
+nameHashOneCache :: MVar (M.Map (A.ModName, A.Name) (Maybe InterfaceFiles.NameHashInfo))
+nameHashOneCache = unsafePerformIO (newMVar M.empty)
+
 -- | Resolve the on-disk .tydb path for a module, using a process-wide cache.
 -- Avoids repeated filesystem walks when many modules share dependencies.
 getTyFileCached :: [FilePath] -> A.ModName -> IO (Maybe FilePath)
@@ -1017,21 +1023,26 @@ getNameHashMapCached paths mn = modifyMVar nameHashCache $ \m -> do
 
 -- | Read one cached name hash without decoding all per-name hash rows.
 getNameHashCached :: Paths -> A.ModName -> A.Name -> IO (Maybe InterfaceFiles.NameHashInfo)
-getNameHashCached paths mn n = modifyMVar nameHashCache $ \m -> do
+getNameHashCached paths mn n = do
+  m <- readMVar nameHashCache
   case M.lookup mn m of
-    Just hm -> return (m, M.lookup n hm)
-    Nothing -> do
-      mty <- getTyFileCached (searchPath paths) mn
-      case mty of
-        Just ty -> do
-          nh <- InterfaceFiles.readNameHashMaybe ty n
-          return (m, nh)
-        Nothing -> return (m, Nothing)
+    Just hm -> return (M.lookup n hm)
+    Nothing -> modifyMVar nameHashOneCache $ \c ->
+      case M.lookup (mn, n) c of
+        Just r -> return (c, r)
+        Nothing -> do
+          mty <- getTyFileCached (searchPath paths) mn
+          r <- case mty of
+                 Just ty -> InterfaceFiles.readNameHashMaybe ty n
+                 Nothing -> return Nothing
+          return (M.insert (mn, n) r c, r)
 
--- | Update the name-hash cache after a successful compile.
+-- | Update the name-hash cache after a successful compile. Cached modules
+-- carry no name hashes; their entries must not shadow targeted reads.
 updateNameHashCache :: A.ModName -> [InterfaceFiles.NameHashInfo] -> IO ()
 updateNameHashCache mn infos =
-  modifyMVar_ nameHashCache $ \m -> return (M.insert mn (nameHashMapFromList infos) m)
+  when (not (null infos)) $
+    modifyMVar_ nameHashCache $ \m -> return (M.insert mn (nameHashMapFromList infos) m)
 
 
 -- Handling Acton files -----------------------------------------------------------------------------

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -1512,7 +1512,6 @@ forceTypeResult nmod tchecked typeEnv tests = do
   evaluate (rnf nmod)
   evaluate (rnf tchecked)
   evaluate (forceHTEnv (Acton.Env.hnames typeEnv))
-  evaluate (forceHTEnv (Acton.Env.hmodules typeEnv))
   evaluate (rnf tests)
 
 data GlobalTask = GlobalTask

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -1205,6 +1205,7 @@ data FrontResult = FrontResult
   { frIfaceTE  :: [(A.Name, I.NameInfo)]
   , frImps     :: [A.ModName]
   , frDoc      :: Maybe String
+  , frModuleInfo :: Maybe Acton.Env.ModuleInfo
   , frPubHash :: B.ByteString
   , frImplHash :: B.ByteString
   , frNameHashes :: [InterfaceFiles.NameHashInfo]
@@ -1216,6 +1217,10 @@ data FrontResult = FrontResult
   , frDeferredBackJob :: Maybe DeferredBackJob
   , frOutputJobs :: [FrontOutputJob]
   }
+
+frontResultModuleInfo :: A.ModName -> FrontResult -> Acton.Env.ModuleInfo
+frontResultModuleInfo mn fr =
+    fromMaybe (Acton.Env.mkModuleInfo mn (frImps fr) (frIfaceTE fr) (frDoc fr)) (frModuleInfo fr)
 
 data DbpRequest = DbpRequest
   { drMod :: A.ModName
@@ -2119,24 +2124,24 @@ readImports sp gopts opts paths tasks = do
 quiet :: C.GlobalOptions -> C.CompileOptions -> Bool
 quiet gopts opts = C.quiet gopts || altOutput opts
 
--- | Read an interface from a .tydb file and return its NameInfo and module hashes.
+-- | Read a reusable interface shell from a .tydb file and return its hashes.
 -- This is used when a module is deemed fresh and we want to avoid reparsing.
-readIfaceFromTy :: Paths -> A.ModName -> String -> Maybe B.ByteString -> IO (Either [Diagnostic String] ([A.ModName], [(A.Name, I.NameInfo)], Maybe String, B.ByteString, B.ByteString))
+readIfaceFromTy :: Paths -> A.ModName -> String -> Maybe B.ByteString -> IO (Either [Diagnostic String] ([A.ModName], [(A.Name, I.NameInfo)], Maybe String, B.ByteString, B.ByteString, Maybe Acton.Env.ModuleInfo))
 readIfaceFromTy paths mn src mHash = do
     mty <- Acton.Env.findTyFile (searchPath paths) mn
     case mty of
       Nothing -> return $ Left (missingIfaceDiagnostics mn src mn)
       Just tyF -> do
-        fileRes <- InterfaceFiles.readFileMaybe tyF
-        case fileRes of
-          Nothing -> return $ Left (missingIfaceDiagnostics mn src mn)
-          Just (_ms, nmod, _tmod, _sourceMeta, _srcH, pubH, implH, _imps, _depModules, _nameHashes, _roots, _tests, _tm) -> do
-            let I.NModule ms teFull mdoc = nmod
-                te = publicIfaceTE teFull
+        hashes <- InterfaceFiles.readModuleHashesMaybe tyF
+        mdb <- InterfaceFiles.openInterfaceDBMaybe tyF
+        case (hashes, mdb) of
+          (Just (_srcH, pubH, implH), Just db) -> do
+            (ms, mdoc) <- InterfaceFiles.readInterfaceDBModuleInfo db
             ih <- case mHash of
                     Just h -> return h
                     Nothing -> return pubH
-            return $ Right (ms, te, mdoc, ih, implH)
+            return $ Right (ms, [], mdoc, ih, implH, Just (Acton.Env.mkTyFileModuleInfo mn ms mdoc db))
+          _ -> return $ Left (missingIfaceDiagnostics mn src mn)
 
 
 -- | Snapshot of expected/recorded impl hashes for generated code.
@@ -2646,6 +2651,7 @@ runFrontPasses gopts opts dbpBlocked paths env0 parsed srcContent srcBytes sourc
                     return $ Right FrontResult { frIfaceTE = publicIface
                                                , frImps = imps
                                                , frDoc = mdoc
+                                               , frModuleInfo = Nothing
                                                , frPubHash = modulePubHash
                                                , frImplHash = moduleImplHash
                                                , frNameHashes = publicNameHashes nameHashes
@@ -3356,6 +3362,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
               { frIfaceTE = ifaceTE
               , frImps = imps
               , frDoc = mdoc
+              , frModuleInfo = Nothing
               , frPubHash = pubHash
               , frImplHash = implHash
               , frNameHashes = nameHashes
@@ -3372,6 +3379,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
               { frIfaceTE = []
               , frImps = []
               , frDoc = Nothing
+              , frModuleInfo = Nothing
               , frPubHash = B.empty
               , frImplHash = B.empty
               , frNameHashes = []
@@ -3745,14 +3753,16 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                             ParseTask{ src = srcContent } -> readIfaceFromTy paths mn srcContent Nothing
                             ActonTask{ src = srcContent } -> readIfaceFromTy paths mn srcContent Nothing
               case ifaceRes of
-                Right (imps, ifaceTE, mdoc, ih, implH) -> do
+                Right (imps, ifaceTE, mdoc, ih, implH, mModuleInfo) -> do
                   let cachedFullNameHashes = case taskCurrent of
                         TyTask{ tyNameHashes = nhs } -> nhs
                         _ -> []
                       cachedNameHashes = publicNameHashes cachedFullNameHashes
                   interestDeps <- cachedInterestDeps
                   let fr = (mkFrontResult imps ifaceTE mdoc ih implH cachedNameHashes cachedFullNameHashes Nothing Nothing)
-                             { frInterestDeps = interestDeps }
+                             { frModuleInfo = mModuleInfo
+                             , frInterestDeps = interestDeps
+                             }
                   cacheFrontResult fr
                 Left _ ->
                   return (key, Right emptyFrontResult)
@@ -4007,14 +4017,16 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                                   _ -> readIfaceFromTy paths mn "" Nothing
                     case ifaceRes of
                       Left diags -> return (key, Left diags)
-                      Right (imps, ifaceTE, mdoc, ih, implH) -> do
+                      Right (imps, ifaceTE, mdoc, ih, implH, mModuleInfo) -> do
                         let cachedFullNameHashes = case taskCurrent of
                               TyTask{ tyNameHashes = nhs } -> nhs
                               _ -> []
                             cachedNameHashes = publicNameHashes cachedFullNameHashes
                         interestDeps <- cachedInterestDeps
                         let fr = (mkFrontResult imps ifaceTE mdoc ih implH cachedNameHashes cachedFullNameHashes Nothing cachedDeferredBackJob)
-                                   { frInterestDeps = interestDeps }
+                                   { frModuleInfo = mModuleInfo
+                                   , frInterestDeps = interestDeps
+                                   }
                         cacheFrontResult fr
               case () of
                 _ | needFront -> runFront
@@ -4187,7 +4199,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                       implRes2 = M.insert keyDone (frImplHash fr) implRes
                       nameRes2 = M.insert keyDone (nameHashMapFromList (frNameHashes fr)) nameRes
                       parsedTasks2 = M.delete keyDone parsedTasks
-                      envAcc' = Acton.Env.addMod (tkMod keyDone) (frImps fr) (frIfaceTE fr) (frDoc fr) envAcc
+                      envAcc' = Acton.Env.addModuleInfo (tkMod keyDone) (frontResultModuleInfo (tkMod keyDone) fr) envAcc
                       interestMap2 = addInterestDeps (frInterestDeps fr) interestMap
                       frontDone2 = Data.Set.insert keyDone frontDone
                       deferredBacks1 =

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -1279,9 +1279,9 @@ dbpDeferredBackJob :: Bool
                    -> Paths
                    -> A.ModName
                    -> B.ByteString
-                   -> [InterfaceFiles.NameHashInfo]
+                   -> Int
                    -> Maybe DeferredBackJob
-dbpDeferredBackJob blocked opts paths mn moduleImplHash nameHashes
+dbpDeferredBackJob blocked opts paths mn moduleImplHash nameCount
   | C.no_dbp opts = Nothing
   | C.only_build opts = Nothing
   | altOutput opts = Nothing
@@ -1300,7 +1300,6 @@ dbpDeferredBackJob blocked opts paths mn moduleImplHash nameHashes
         }
   | otherwise = Nothing
   where
-    nameCount = length nameHashes
     reqs = parseDbpRequests opts
     forced = M.member mn reqs
     seeds = M.findWithDefault Data.Set.empty mn reqs
@@ -1479,6 +1478,7 @@ data CompileTask        = ParseTask { name :: A.ModName, src :: String, srcBytes
                                     , tyImports :: [(A.ModName, B.ByteString)] -- imports with pub hash used
                                     , tyDepModules :: [InterfaceFiles.DepModuleInfo]
                                     , tyNameHashes :: [InterfaceFiles.NameHashInfo]
+                                    , tyNameCount :: Int
                                     , tyRoots :: [A.Name]
                                     , tyTests :: [String]
                                     , tyDoc :: Maybe String
@@ -1710,8 +1710,8 @@ dbpProviderPathClosure rootProj opts globalTasks dbpBlocked depMap revMap affect
       case M.lookup k taskMap of
         Just t ->
           case gtTask t of
-            TyTask{ tyImplHash = implHash, tyNameHashes = nhs } ->
-              isJust (dbpDeferredBackJob (Data.Set.member k dbpBlocked) (optsFor k) (gtPaths t) (tkMod k) implHash nhs)
+            TyTask{ tyImplHash = implHash, tyNameCount = nameCount } ->
+              isJust (dbpDeferredBackJob (Data.Set.member k dbpBlocked) (optsFor k) (gtPaths t) (tkMod k) implHash nameCount)
             _ -> False
         Nothing -> False
 
@@ -1841,6 +1841,7 @@ data ModuleHead
       , mhTyImports  :: [(A.ModName, B.ByteString)]
       , mhDepModules :: [InterfaceFiles.DepModuleInfo]
       , mhNameHashes :: [InterfaceFiles.NameHashInfo]
+      , mhNameCount  :: Int
       , mhRoots      :: [A.Name]
       , mhTests      :: [String]
       , mhDoc        :: Maybe String
@@ -1876,10 +1877,10 @@ readModuleHeader sp gopts opts paths actFile = do
       else do
         -- .tydb exists: read the cached header and validate it against compiler
         -- compatibility plus source metadata/content as needed.
-        hdrE <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readHeader tyFile
+        hdrE <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readHeaderSummary tyFile
         case hdrE of
           Left _ -> readSourceHead mn
-          Right (cachedSourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash, imps, depModules, nameHashes, roots, tests, mdoc) -> do
+          Right (cachedSourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash, imps, depModules, nameCount, roots, tests, mdoc) -> do
             tyMTimeNs <- InterfaceFiles.interfaceModifiedTimeNs tyFile
             newCompiler <- compilerNewerThan tyMTimeNs
             mOverlay <- Source.spReadOverlay sp actFile
@@ -1887,21 +1888,21 @@ readModuleHeader sp gopts opts paths actFile = do
               Just snap ->
                 if newCompiler
                   then sourceHeadFromSnapshot mn snap
-                  else verifyOrParse mn snap moduleSrcBytesHash modulePubHash moduleImplHash cachedSourceMeta Nothing imps depModules nameHashes roots tests mdoc
+                  else verifyOrParse mn snap moduleSrcBytesHash modulePubHash moduleImplHash cachedSourceMeta Nothing imps depModules nameCount roots tests mdoc
               Nothing -> do
                 if newCompiler
                   then readSourceHead mn
                   else do
                     currentSourceMeta <- readSourceFileMeta actFile
                     if canReuseHeader cachedSourceMeta currentSourceMeta tyMTimeNs
-                      then return (mkTyHead mn moduleSrcBytesHash modulePubHash moduleImplHash imps depModules nameHashes roots tests mdoc)
+                      then return (mkTyHead mn moduleSrcBytesHash modulePubHash moduleImplHash imps depModules nameCount roots tests mdoc)
                       else do
                         snap <- Source.spReadFile sp actFile
-                        verifyOrParse mn snap moduleSrcBytesHash modulePubHash moduleImplHash cachedSourceMeta (Just currentSourceMeta) imps depModules nameHashes roots tests mdoc
+                        verifyOrParse mn snap moduleSrcBytesHash modulePubHash moduleImplHash cachedSourceMeta (Just currentSourceMeta) imps depModules nameCount roots tests mdoc
   where
     fileStatusMTimeNs st = floor (toRational (modificationTimeHiRes st) * 1000000000)
 
-    mkTyHead mn moduleSrcBytesHash modulePubHash moduleImplHash imps depModules nameHashes roots tests mdoc =
+    mkTyHead mn moduleSrcBytesHash modulePubHash moduleImplHash imps depModules nameCount roots tests mdoc =
       TyHead
         { mhName       = mn
         , mhSrcHash    = moduleSrcBytesHash
@@ -1909,7 +1910,8 @@ readModuleHeader sp gopts opts paths actFile = do
         , mhImplHash   = moduleImplHash
         , mhTyImports  = imps
         , mhDepModules = depModules
-        , mhNameHashes = nameHashes
+        , mhNameHashes = []
+        , mhNameCount  = nameCount
         , mhRoots      = roots
         , mhTests      = tests
         , mhDoc        = mdoc
@@ -1960,7 +1962,7 @@ readModuleHeader sp gopts opts paths actFile = do
         Right (_ms, nmod, tmod, _oldSourceMeta, srcHash, pubHash, implHash, imps, depModules, nameHashes, roots, tests, mdoc) ->
           InterfaceFiles.writeFile tyFilePath srcHash pubHash implHash currentSourceMeta imps depModules nameHashes roots tests mdoc nmod tmod
 
-    verifyOrParse mn snap moduleSrcBytesHash modulePubHash moduleImplHash cachedSourceMeta currentSourceMeta imps depModules nameHashes roots tests mdoc = do
+    verifyOrParse mn snap moduleSrcBytesHash modulePubHash moduleImplHash cachedSourceMeta currentSourceMeta imps depModules nameCount roots tests mdoc = do
       let curHash = SHA256.hash (Source.ssBytes snap)
           short8 bs = take 8 (B.unpack $ Base16.encode bs)
           same = curHash == moduleSrcBytesHash
@@ -1979,7 +1981,7 @@ readModuleHeader sp gopts opts paths actFile = do
         then do
           when (currentSourceMeta /= Nothing && currentSourceMeta /= cachedSourceMeta) $
             refreshCachedSourceMeta currentSourceMeta
-          return (mkTyHead mn moduleSrcBytesHash modulePubHash moduleImplHash imps depModules nameHashes roots tests mdoc)
+          return (mkTyHead mn moduleSrcBytesHash modulePubHash moduleImplHash imps depModules nameCount roots tests mdoc)
         else sourceHeadFromSnapshot mn snap
 
 -- | Prepare a task for dependency graph construction.
@@ -1996,6 +1998,7 @@ readModuleTask sp gopts opts paths actFile = do
           , mhTyImports = imps
           , mhDepModules = depModules
           , mhNameHashes = nameHashes
+          , mhNameCount = nameCount
           , mhRoots = roots
           , mhTests = tests
           , mhDoc = mdoc
@@ -2009,6 +2012,7 @@ readModuleTask sp gopts opts paths actFile = do
                 , tyImports  = imps
                 , tyDepModules = depModules
                 , tyNameHashes = nameHashes
+                , tyNameCount = nameCount
                 , tyRoots   = roots
                 , tyTests   = tests
                 , tyDoc     = mdoc
@@ -2046,8 +2050,8 @@ readModuleDocIndexEntry :: Source.SourceProvider
 readModuleDocIndexEntry sp gopts opts paths actFile = do
   h <- readModuleHeader sp gopts opts paths actFile
   return $ case h of
-    TyHead{ mhName = mn, mhNameHashes = nameHashes, mhDoc = mdoc } ->
-      Just (mn, mdoc, shouldGenerateDocOutput opts (isTmp paths) (length nameHashes))
+    TyHead{ mhName = mn, mhNameCount = nameCount, mhDoc = mdoc } ->
+      Just (mn, mdoc, shouldGenerateDocOutput opts (isTmp paths) nameCount)
     SrcHead{ mhName = mn, mhDoc = mdoc } -> Just (mn, mdoc, True)
     HeadError{} -> Nothing
 
@@ -2600,7 +2604,7 @@ runFrontPasses gopts opts dbpBlocked paths env0 parsed srcContent srcBytes sourc
                                  , ftTypeStmtTimings = typeStmtTimings
                                  }
                           else Nothing
-                      deferredBackJob = dbpDeferredBackJob dbpBlocked opts paths mn moduleImplHash nameHashes
+                      deferredBackJob = dbpDeferredBackJob dbpBlocked opts paths mn moduleImplHash (length nameHashes)
                       backJob =
                         case deferredBackJob of
                           Just _ -> Nothing
@@ -2672,7 +2676,7 @@ prepareDeferredBackJob sp gopts callbacks envAcc interestMap dbj = do
       mn = dbjMod dbj
       tyFile = tyDbPath paths mn
       actFile = srcFile paths mn
-  (_sourceMeta, _moduleSrcBytesHash, _modulePubHash, _moduleImplHashStored, _imps, _depModules, nameHashes, roots, _tests, _mdoc) <- InterfaceFiles.readHeader tyFile
+  roots <- InterfaceFiles.readRoots tyFile
   let explicitSeeds = dbjSeeds dbj
       interested =
         if Data.Set.null explicitSeeds
@@ -2680,19 +2684,20 @@ prepareDeferredBackJob sp gopts callbacks envAcc interestMap dbj = do
           else explicitSeeds
       rootSeeds = Data.Set.fromList roots
       selectedSeeds = Data.Set.union interested rootSeeds
-  nameSelection <- selectDbpNames mn tyFile selectedSeeds nameHashes
+      totalNames = dbjNameCount dbj
+  nameSelection <- selectDbpNames mn tyFile selectedSeeds
   let codegenHash = dbpCodegenHash (dbjImplHash dbj) (dnsSelectedNames nameSelection)
   codegen <- codegenStatus paths mn codegenHash
   if codegenUpToDate codegen
     then do
-      logDbpSelection gopts callbacks mn dbj (length nameHashes) (Data.Set.size interested) (Data.Set.size rootSeeds) (Data.Set.size (dnsSelectedNames nameSelection)) Nothing "generated code up to date"
+      logDbpSelection gopts callbacks mn dbj totalNames (Data.Set.size interested) (Data.Set.size rootSeeds) (Data.Set.size (dnsSelectedNames nameSelection)) Nothing "generated code up to date"
       return Nothing
     else do
       (_ms, _nmod, tmod, _sourceMetaFull, _moduleSrcBytesHashFull, _modulePubHashFull, _moduleImplHashStoredFull, _impsFull, _depModulesFull, _nameHashesFull, _rootsFull, _testsFull, _mdocFull) <- InterfaceFiles.readFile tyFile
       snap <- Source.readSource sp actFile
       env1 <- Acton.Env.mkEnv (searchPath paths) envAcc tmod
-      let selection = selectDbpModule (length nameHashes) (Data.Set.size interested) nameSelection tmod
-      logDbpSelection gopts callbacks mn dbj (length nameHashes) (Data.Set.size interested) (Data.Set.size rootSeeds) (dbsSelectedCount selection) (dbsFallbackReason selection) "generated code out of date"
+      let selection = selectDbpModule totalNames (Data.Set.size interested) nameSelection tmod
+      logDbpSelection gopts callbacks mn dbj totalNames (Data.Set.size interested) (Data.Set.size rootSeeds) (dbsSelectedCount selection) (dbsFallbackReason selection) "generated code out of date"
       return $ Just BackJob
         { bjPaths = paths
         , bjOpts = dbjOpts dbj
@@ -2739,26 +2744,18 @@ dbpCodegenHash moduleImplHash selected =
 selectDbpNames :: A.ModName
                -> FilePath
                -> Data.Set.Set A.Name
-               -> [InterfaceFiles.NameHashInfo]
                -> IO DbpNameSelection
-selectDbpNames mn tyFile seeds nameHashes
+selectDbpNames mn tyFile seeds
   | Data.Set.null seeds =
       return DbpNameSelection
         { dnsSelectedNames = Data.Set.empty
         }
-  | otherwise =
-      case ( traverse (dbpOwningName topNames) (Data.Set.toList seeds)
-           , dbpLocalDepsFromNameHashes topNames nameHashes
-           ) of
-        (Left reason, _) -> dbpSelectionError mn reason
-        (_, Left reason) -> dbpSelectionError mn reason
-        (Right roots, Right localDeps) -> do
-          selected <- dbpNameClosure (dbpExtensionsForName mn tyFile topNames) localDeps (Data.Set.fromList roots)
-          return DbpNameSelection
-            { dnsSelectedNames = selected
-            }
-  where
-    topNames = dbpTopNamesFromNameHashes nameHashes
+  | otherwise = do
+      roots <- traverse (dbpReadOwningName mn tyFile) (Data.Set.toList seeds)
+      selected <- dbpNameHashClosure mn tyFile Data.Set.empty roots
+      return DbpNameSelection
+        { dnsSelectedNames = selected
+        }
 
 dbpSelectionError :: A.ModName -> String -> IO a
 dbpSelectionError mn reason =
@@ -2789,65 +2786,50 @@ selectDbpModule totalNames interestedCount nameSelection tmod@(A.Module loc imps
         , dbsFallbackReason = Just reason
         }
 
-dbpTopNamesFromNameHashes :: [InterfaceFiles.NameHashInfo] -> Data.Set.Set A.Name
-dbpTopNamesFromNameHashes nameHashes =
-  Data.Set.fromList [ InterfaceFiles.nhName nh | nh <- nameHashes ]
+dbpReadNameHash :: A.ModName -> FilePath -> A.Name -> IO InterfaceFiles.NameHashInfo
+dbpReadNameHash mn tyFile n = do
+  mnh <- InterfaceFiles.readNameHashMaybe tyFile n
+  case mnh of
+    Just nh -> return nh
+    Nothing -> dbpSelectionError mn ("hash info missing for " ++ nameToString n)
 
-dbpOwningName :: Data.Set.Set A.Name -> A.Name -> Either String A.Name
-dbpOwningName topNames n
-  | Data.Set.member n topNames = Right n
-  | otherwise =
+dbpReadOwningName :: A.ModName -> FilePath -> A.Name -> IO A.Name
+dbpReadOwningName mn tyFile n = do
+  mnh <- InterfaceFiles.readNameHashMaybe tyFile n
+  case mnh of
+    Just _ -> return n
+    Nothing ->
       case n of
-        A.Derived base _ -> dbpOwningName topNames base
-        _ | Names.isWitness n -> Left ("unresolved witness owner for " ++ nameToString n)
-        _ -> Left ("no top-level owner for " ++ nameToString n)
+        A.Derived base _ -> dbpReadOwningName mn tyFile base
+        _ | Names.isWitness n -> dbpSelectionError mn ("unresolved witness owner for " ++ nameToString n)
+        _ -> dbpSelectionError mn ("no top-level owner for " ++ nameToString n)
 
-dbpLocalDepsFromNameHashes :: Data.Set.Set A.Name
-                           -> [InterfaceFiles.NameHashInfo]
-                           -> Either String (M.Map A.Name [A.Name])
-dbpLocalDepsFromNameHashes topNames nameHashes =
-  M.fromList <$> traverse depsFor nameHashes
+dbpNameHashClosure :: A.ModName
+                   -> FilePath
+                   -> Data.Set.Set A.Name
+                   -> [A.Name]
+                   -> IO (Data.Set.Set A.Name)
+dbpNameHashClosure _ _ selected [] = return selected
+dbpNameHashClosure mn tyFile selected (n:ns)
+  | Data.Set.member n selected = dbpNameHashClosure mn tyFile selected ns
+  | otherwise = do
+      nh <- dbpReadNameHash mn tyFile n
+      localDeps <- traverse (dbpReadOwningName mn tyFile)
+                     (InterfaceFiles.nhPubLocalDeps nh ++ InterfaceFiles.nhImplLocalDeps nh)
+      exts <- dbpExtensionsForName tyFile n
+      extDeps <- traverse (dbpReadOwningName mn tyFile) exts
+      let deps = unionNames localDeps extDeps
+          selected' = Data.Set.insert n selected
+          new = filter (`Data.Set.notMember` selected') deps
+      dbpNameHashClosure mn tyFile selected' (new ++ ns)
   where
-    depsFor nh = do
-      deps <- traverse
-                (dbpOwningName topNames)
-                (InterfaceFiles.nhPubLocalDeps nh ++ InterfaceFiles.nhImplLocalDeps nh)
-      return
-        ( InterfaceFiles.nhName nh
-        , unionNames deps []
-        )
     unionNames xs ys = Data.List.sortOn Hashing.nameKey (Data.List.nub (xs ++ ys))
 
-dbpExtensionsForName :: A.ModName -> FilePath -> Data.Set.Set A.Name -> A.Name -> IO [A.Name]
-dbpExtensionsForName mn tyFile topNames n = do
+dbpExtensionsForName :: FilePath -> A.Name -> IO [A.Name]
+dbpExtensionsForName tyFile n = do
   byClass <- InterfaceFiles.readExtensionsByClass tyFile n
   byProtocol <- InterfaceFiles.readExtensionsByProtocol tyFile n
-  let exts = unionNames byClass byProtocol
-      missing = [ ext | ext <- exts, Data.Set.notMember ext topNames ]
-  if null missing
-    then return exts
-    else dbpSelectionError mn $
-           "extension index for " ++ nameToString n
-           ++ " points at non-top-level extension(s) "
-           ++ Data.List.intercalate ", " (map nameToString missing)
-  where
-    unionNames xs ys = Data.List.sortOn Hashing.nameKey (Data.List.nub (xs ++ ys))
-
-dbpNameClosure :: (A.Name -> IO [A.Name])
-               -> M.Map A.Name [A.Name]
-               -> Data.Set.Set A.Name
-               -> IO (Data.Set.Set A.Name)
-dbpNameClosure extensionsForName localDeps roots = go roots (Data.Set.toList roots)
-  where
-    go seen [] = return seen
-    go seen (n:ns) = do
-      exts <- extensionsForName n
-      let deps = unionNames (M.findWithDefault [] n localDeps) exts
-          new = filter (`Data.Set.notMember` seen) deps
-          seen' = foldl' (flip Data.Set.insert) seen new
-      go seen' (new ++ ns)
-
-    unionNames xs ys = Data.List.sortOn Hashing.nameKey (Data.List.nub (xs ++ ys))
+  return (Data.List.sortOn Hashing.nameKey (Data.List.nub (byClass ++ byProtocol)))
 
 dbpPruneTopStmt :: Data.Set.Set A.Name -> A.Stmt -> Maybe A.Stmt
 dbpPruneTopStmt selected stmt =
@@ -3435,12 +3417,21 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
             case M.lookup m providers of
               Just depKey ->
                 case M.lookup depKey nameMap of
-                  Just hm -> return (M.lookup n hm)
+                  Just hm ->
+                    case M.lookup n hm of
+                      Just info -> return (Just info)
+                      Nothing
+                        | providerIsCachedTy depKey -> getNameHashCached paths m n
+                        | otherwise -> return Nothing
                   Nothing
                     | isBuiltinKey depKey -> getNameHashCached paths m n
                     | M.member depKey taskMap -> error ("Internal error: missing name hashes for dep " ++ modNameToString m)
                     | otherwise -> getNameHashCached paths m n
               Nothing -> getNameHashCached paths m n
+          providerIsCachedTy depKey =
+            case M.lookup depKey taskMap of
+              Just GlobalTask{ gtTask = TyTask{} } -> True
+              _ -> False
 
           missingNameHashDiagnostics qn =
             errsToDiagnostics "Compilation error" (modNameToFilename mn) ""
@@ -3776,7 +3767,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                     TyTask{ tyImplHash = implHash } -> Just implHash
                     _ -> Nothing
                   cachedDeferredBackJob = case taskCurrent of
-                    TyTask{ tyImplHash = implHash, tyNameHashes = nhs } -> dbpDeferredBackJob (isDbpBlocked key) optsT paths mn implHash nhs
+                    TyTask{ tyImplHash = implHash, tyNameCount = nameCount } -> dbpDeferredBackJob (isDbpBlocked key) optsT paths mn implHash nameCount
                     _ -> Nothing
                   isCachedDbp =
                     case cachedDeferredBackJob of
@@ -3790,7 +3781,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
               let runFront = do
                     prevNameHashes <- if C.verbose gopts
                       then case taskCurrent of
-                        TyTask{ tyNameHashes = nhs } -> return (Just (nameHashMapFromList (publicNameHashes nhs)))
+                        TyTask{ tyNameHashes = nhs } | not (null nhs) -> return (Just (nameHashMapFromList (publicNameHashes nhs)))
                         _ -> getNameHashMapCached paths mn
                       else return Nothing
                     when (C.verbose gopts) $ do
@@ -3949,7 +3940,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                                           rememberFrontOutputJobList frontOutputRef outputJobs
                                           let I.NModule imps ifaceFull _mdoc = nmod
                                               ifaceTE = publicIfaceTE ifaceFull
-                                              deferredBackJob0 = dbpDeferredBackJob (isDbpBlocked key) optsT paths mn moduleImplHash updatedNameHashes
+                                              deferredBackJob0 = dbpDeferredBackJob (isDbpBlocked key) optsT paths mn moduleImplHash (length updatedNameHashes)
                                               deferredBackJob = fmap (\dbj -> dbj{ dbjOutputJobs = [outputJob] }) deferredBackJob0
                                               backJob =
                                                 case deferredBackJob of
@@ -3972,7 +3963,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                         interestDeps <- cachedInterestDeps
                         let I.NModule imps ifaceFull _mdoc = nmod
                             ifaceTE = publicIfaceTE ifaceFull
-                            deferredBackJob = dbpDeferredBackJob (isDbpBlocked key) optsT paths mn moduleImplHashStored nameHashes
+                            deferredBackJob = dbpDeferredBackJob (isDbpBlocked key) optsT paths mn moduleImplHashStored (length nameHashes)
                             backJob =
                               case deferredBackJob of
                                 Just _ -> Nothing

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -2220,7 +2220,7 @@ runFrontPasses :: C.GlobalOptions
                -> Maybe InterfaceFiles.SourceFileMeta
                -> (A.ModName -> IO (Maybe B.ByteString))
                -> (A.ModName -> IO (Maybe B.ByteString))
-               -> (A.ModName -> IO (Maybe (M.Map A.Name InterfaceFiles.NameHashInfo)))
+               -> (A.ModName -> A.Name -> IO (Maybe InterfaceFiles.NameHashInfo))
                -> (FrontPassProgress -> IO ())
                -> (TaskKey -> FrontOutputKind -> IO ())
                -> (TaskKey -> FrontOutputKind -> FrontOutputProgress -> IO ())
@@ -2228,7 +2228,7 @@ runFrontPasses :: C.GlobalOptions
                -> IO Bool
                -> ([FrontOutputJob] -> IO ())
                -> IO (Either [Diagnostic String] FrontResult)
-runFrontPasses gopts opts dbpBlocked paths env0 parsed srcContent srcBytes sourceMeta resolveImportHash resolveImportImplHash resolveNameHashMap onFrontProgress onFrontOutputStart onFrontOutputProgress onFrontOutputDone shouldWriteFrontOutput recordFrontOutputJobs = do
+runFrontPasses gopts opts dbpBlocked paths env0 parsed srcContent srcBytes sourceMeta resolveImportHash resolveImportImplHash resolveNameHash onFrontProgress onFrontOutputStart onFrontOutputProgress onFrontOutputDone shouldWriteFrontOutput recordFrontOutputJobs = do
   createDirectoryIfMissing True (getModPath (projTypes paths) mn)
   core
     `catch` handleGeneral
@@ -2301,47 +2301,34 @@ runFrontPasses gopts opts dbpBlocked paths env0 parsed srcContent srcBytes sourc
       errsToDiagnostics "Compilation error" filename srcContent
         [(loc, label ++ " hash missing for " ++ prstr qn ++ " (used by " ++ A.nstr owner ++ ")")]
 
-    resolveNameHashMaps :: [A.ModName] -> IO (Either [Diagnostic String] (M.Map A.ModName (M.Map A.Name InterfaceFiles.NameHashInfo)))
-    resolveNameHashMaps mrefs = do
-      resolved <- forM mrefs $ \mref -> do
-        mh <- resolveNameHashMap mref
-        case mh of
-          Just hm -> return (Right (mref, hm))
-          Nothing -> return (Left (missingIfaceDiagnostics mn srcContent mref))
-      let (errs, vals) = partitionEithers resolved
-      if null errs
-        then return (Right (M.fromList vals))
-        else return (Left (concat errs))
-
     resolveDepHashes :: String
                      -> (InterfaceFiles.NameHashInfo -> B.ByteString)
                      -> M.Map A.Name [A.QName]
-                     -> M.Map A.ModName (M.Map A.Name InterfaceFiles.NameHashInfo)
                      -> M.Map A.Name SrcLoc
-                     -> Either [Diagnostic String] (M.Map A.Name [(A.QName, B.ByteString)])
-    resolveDepHashes label getHash deps extMaps nameLocs =
-      let resolveQName owner qn = case qn of
-            A.GName m n -> lookupName owner m n
-            A.QName m n -> lookupName owner m n
-            A.NoQ _ -> Left (missingNameHashDiagnostics qn)
-          lookupName owner m n =
-            case M.lookup m extMaps of
-              Nothing -> Left (missingIfaceDiagnostics mn srcContent m)
-              Just hm ->
-                case M.lookup n hm of
-                  Just info ->
-                    let h = getHash info
-                        loc = M.findWithDefault NoLoc owner nameLocs
-                    in if B.null h
-                         then Left (missingDepHashDiagnostics label owner loc (A.GName m n))
-                         else Right (Just (A.GName m n, h))
-                  Nothing -> Left (missingNameHashDiagnostics (A.GName m n))
-          resolveForName (n, qns) =
-            let resolved = map (resolveQName n) qns
-                (errs, vals) = partitionEithers resolved
-            in if null errs then Right (n, catMaybes vals) else Left (concat errs)
-          (errs, vals) = partitionEithers (map resolveForName (M.toList deps))
-      in if null errs then Right (M.fromList vals) else Left (concat errs)
+                     -> IO (Either [Diagnostic String] (M.Map A.Name [(A.QName, B.ByteString)]))
+    resolveDepHashes label getHash deps nameLocs = do
+      resolved <- forM (M.toList deps) $ \(owner, qns) -> do
+        resolvedQns <- forM qns $ \qn -> case qn of
+          A.GName m n -> lookupName owner m n
+          A.QName m n -> lookupName owner m n
+          A.NoQ _ -> return (Left (missingNameHashDiagnostics qn))
+        let (errs, vals) = partitionEithers resolvedQns
+        return $ if null errs
+          then Right (owner, catMaybes vals)
+          else Left (concat errs)
+      let (errs, vals) = partitionEithers resolved
+      return $ if null errs then Right (M.fromList vals) else Left (concat errs)
+      where
+        lookupName owner m n = do
+          mInfo <- resolveNameHash m n
+          return $ case mInfo of
+            Just info ->
+              let h = getHash info
+                  loc = M.findWithDefault NoLoc owner nameLocs
+              in if B.null h
+                   then Left (missingDepHashDiagnostics label owner loc (A.GName m n))
+                   else Right (Just (A.GName m n, h))
+            Nothing -> Left (missingNameHashDiagnostics (A.GName m n))
 
     emitFrontProgress pass completed total current =
       onFrontProgress FrontPassProgress
@@ -2519,19 +2506,16 @@ runFrontPasses gopts opts dbpBlocked paths env0 parsed srcContent srcBytes sourc
           -- a pub hash.
           let (pubLocalDeps, pubExtDeps) =
                 Hashing.mergePubDeps pubSigLocalDeps pubSigExtDeps implLocalDeps implExtDeps
-              -- Load .tydb maps for any external modules referenced by deps.
               extMods = Data.Set.toList (Hashing.externalModules pubExtDeps `Data.Set.union` Hashing.externalModules implExtDeps)
           evaluate (rnf (pubLocalDeps, pubExtDeps, extMods))
-          extMapsRes <- resolveNameHashMaps extMods
           depModulesRes <- resolveDepModuleHashes extMods
-          case (extMapsRes, depModulesRes) of
-            (Left diags, _) -> return (Left diags)
-            (_, Left diags) -> return (Left diags)
-            (Right extMaps, Right depModules) -> do
+          case depModulesRes of
+            Left diags -> return (Left diags)
+            Right depModules -> do
               -- Resolve external deps to their recorded hashes.
-              let pubSigExtRes = resolveDepHashes "pub" InterfaceFiles.nhPubHash pubSigExtDeps extMaps nameLocs
-                  pubExtRes = resolveDepHashes "pub" InterfaceFiles.nhPubHash pubExtDeps extMaps nameLocs
-                  implExtRes = resolveDepHashes "impl" InterfaceFiles.nhImplHash implExtDeps extMaps nameLocs
+              pubSigExtRes <- resolveDepHashes "pub" InterfaceFiles.nhPubHash pubSigExtDeps nameLocs
+              pubExtRes <- resolveDepHashes "pub" InterfaceFiles.nhPubHash pubExtDeps nameLocs
+              implExtRes <- resolveDepHashes "impl" InterfaceFiles.nhImplHash implExtDeps nameLocs
               case (pubSigExtRes, pubExtRes, implExtRes) of
                 (Left diags, _, _) -> return (Left diags)
                 (_, Left diags, _) -> return (Left diags)
@@ -3311,7 +3295,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                 mSourceMeta
                 (getPubHashCached bPaths)
                 (getImplHashCached bPaths)
-                (getNameHashMapCached bPaths)
+                (getNameHashCached bPaths)
                 (\p -> ccOnFrontProgress callbacks t optsBuiltin p)
                 (ccOnFrontOutputStart callbacks)
                 (ccOnFrontOutputProgress callbacks)
@@ -3447,16 +3431,6 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                     | M.member depKey taskMap -> error ("Internal error: missing impl hash for dep " ++ modNameToString m)
                     | otherwise -> getImplHashCached paths m
               Nothing -> getImplHashCached paths m
-          resolveNameHashMap' m =
-            case M.lookup m providers of
-              Just depKey ->
-                case M.lookup depKey nameMap of
-                  Just hm -> return (Just hm)
-                  Nothing
-                    | isBuiltinKey depKey -> getNameHashMapCached paths m
-                    | M.member depKey taskMap -> error ("Internal error: missing name hashes for dep " ++ modNameToString m)
-                    | otherwise -> getNameHashMapCached paths m
-              Nothing -> getNameHashMapCached paths m
           resolveNameHash' m n =
             case M.lookup m providers of
               Just depKey ->
@@ -3631,13 +3605,10 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
             in if null items then Nothing else Just (intercalate ", " items)
 
           resolveNameHashInfo m n = do
-            hm <- resolveNameHashMap' m
-            case hm of
-              Nothing -> return (Left (missingIfaceDiagnostics mn "" m))
-              Just hmap ->
-                case M.lookup n hmap of
-                  Just info -> return (Right info)
-                  Nothing -> return (Left (missingNameHashDiagnostics (A.GName m n)))
+            mInfo <- resolveNameHash' m n
+            return $ case mInfo of
+              Just info -> Right info
+              Nothing -> Left (missingNameHashDiagnostics (A.GName m n))
 
           resolveQNameHash label getHash users qn =
             case qn of
@@ -3862,7 +3833,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                           mSourceMeta
                           resolveImportHash
                           resolveImportImplHash
-                          resolveNameHashMap'
+                          resolveNameHash'
                           (\p -> ccOnFrontProgress callbacks t optsT p)
                           (ccOnFrontOutputStart callbacks)
                           (ccOnFrontOutputProgress callbacks)

--- a/compiler/lib/src/Acton/Completion.hs
+++ b/compiler/lib/src/Acton/Completion.hs
@@ -585,11 +585,7 @@ completionEnv searchPath baseEnv modName imps =
 -- fallback, which is enough for generated base classes and typed constructors.
 shallowCompletionEnv :: [FilePath] -> Env.Env0 -> [S.Import] -> IO Env.Env0
 shallowCompletionEnv searchPath baseEnv imps =
-  refreshHModules <$> foldM (shallowImport searchPath) baseEnv imps
-
-refreshHModules :: Env.Env0 -> Env.Env0
-refreshHModules env =
-  env { Env.hmodules = I.convTEnv2HTEnv (Env.modules env) }
+  foldM (shallowImport searchPath) baseEnv imps
 
 shallowImport :: [FilePath] -> Env.Env0 -> S.Import -> IO Env.Env0
 shallowImport searchPath env imp =

--- a/compiler/lib/src/Acton/Completion.hs
+++ b/compiler/lib/src/Acton/Completion.hs
@@ -598,17 +598,17 @@ shallowImport searchPath env imp =
     S.Import _ items ->
       foldM (shallowModuleItem searchPath) env items
     S.FromImport _ (S.ModRef (0, Just m)) items ->
-      shallowModule searchPath env m $ \te env' ->
-        Env.importSome items m te env'
+      shallowModule searchPath env m $ \mi env' ->
+        Env.importSome items m mi env'
     S.FromImportAll _ (S.ModRef (0, Just m)) ->
-      shallowModule searchPath env m $ \te env' ->
-        Env.importAll m te env'
+      shallowModule searchPath env m $ \mi env' ->
+        Env.importAll m mi env'
     _ ->
       return env
 
 shallowModuleItem :: [FilePath] -> Env.Env0 -> S.ModuleItem -> IO Env.Env0
 shallowModuleItem searchPath env (S.ModuleItem m as) =
-  shallowModule searchPath env m $ \te env' ->
+  shallowModule searchPath env m $ \_ env' ->
     case as of
       Nothing -> Env.addImport m env'
       Just n -> Env.defineClosed [(n, I.NMAlias m)] env'
@@ -617,14 +617,17 @@ shallowModule
   :: [FilePath]
   -> Env.Env0
   -> S.ModName
-  -> (I.TEnv -> Env.Env0 -> Env.Env0)
+  -> (Env.ModuleInfo -> Env.Env0 -> Env.Env0)
   -> IO Env.Env0
 shallowModule searchPath env m applyImport = do
   loaded <- readModuleInterface searchPath m
   case loaded of
     Nothing -> return env
     Just (ms, te, mdoc) ->
-      return $ applyImport te (Env.addMod m ms te mdoc env)
+      let env' = Env.addMod m ms te mdoc env
+      in case Env.lookupModuleInfo m env' of
+           Just mi -> return $ applyImport mi env'
+           Nothing -> return env'
 
 readModuleInterface :: [FilePath] -> S.ModName -> IO (Maybe ([S.ModName], I.TEnv, Maybe String))
 readModuleInterface searchPath m = do

--- a/compiler/lib/src/Acton/Completion.hs
+++ b/compiler/lib/src/Acton/Completion.hs
@@ -29,7 +29,6 @@ import qualified Control.Monad.Trans.State.Strict as St
 import Data.Char (isAlpha, isAlphaNum, isSpace)
 import Data.List (find, findIndex, intercalate, isPrefixOf, nubBy)
 import Data.Maybe (listToMaybe, mapMaybe)
-import qualified Data.HashMap.Strict as HM
 import qualified InterfaceFiles as IF
 import Text.Megaparsec (eof, runParser)
 
@@ -796,22 +795,22 @@ lookupQNameInfo env qn =
     S.NoQ n ->
       lookupNoQ n
     S.QName m n ->
-      lookupModuleItem env (Env.findHMod m env) n
+      lookupModuleItem env (Env.findModuleInfo m env) n
     S.GName m n
       | Just m == Env.thismod env ->
           lookupQNameInfo env (S.NoQ n)
       | otherwise ->
-          lookupModuleItem env (Env.lookupHMod m env) n
+          lookupModuleItem env (Env.lookupModuleInfo m env) n
   where
     lookupNoQ n              = resolve =<< Env.lookupName n env
 
     resolve (I.HNAlias qn')  = lookupQNameInfo env qn'
     resolve info             = Just (I.convHNameInfo2NameInfo info)
 
-lookupModuleItem :: Env.Env0 -> Maybe I.HTEnv -> S.Name -> Maybe I.NameInfo
-lookupModuleItem env mtenv n = do
-  tenv <- mtenv
-  info <- HM.lookup n tenv
+lookupModuleItem :: Env.Env0 -> Maybe Env.ModuleInfo -> S.Name -> Maybe I.NameInfo
+lookupModuleItem env mmi n = do
+  mi <- mmi
+  info <- Env.moduleLookupHName mi n
   case info of
     I.HNAlias qn -> lookupQNameInfo env qn
     _ -> Just (I.convHNameInfo2NameInfo info)

--- a/compiler/lib/src/Acton/Converter.hs
+++ b/compiler/lib/src/Acton/Converter.hs
@@ -238,8 +238,11 @@ fixupSelf s                             = s
 
 -- Convert a TEnv -------------------------------------------------------------------------------------------
 
-convEnvProtos env                       = mapModules conv env
+convEnvProtos env                       = convertModules convSources conv env
   where
+    convSources (Derived _ n)           = [n]
+    convSources _                       = []
+
     conv m (n, NDef sc d doc)           = [(n, NDef (convS sc) d doc)]
     conv m (n, NSig sc d doc)           = [(n, NSig (convS sc) d doc)]
     conv m (n, NAct q p k te doc)       = [(n, NAct (noqual env q) (qualWRow env q p) k (concat $ map (conv m) te) doc)]

--- a/compiler/lib/src/Acton/Deactorizer.hs
+++ b/compiler/lib/src/Acton/Deactorizer.hs
@@ -29,8 +29,11 @@ import Control.Monad.State.Strict
 
 deactorize                          :: Env0 -> Module -> IO (Module, Env0)
 deactorize env0 (Module m imps mdoc b)
-                                    = return (Module m imps mdoc (runDeactM $ deactSuite env b), mapModules conv env0)
+                                    = return (Module m imps mdoc (runDeactM $ deactSuite env b), convertModules deactSources conv env0)
   where env                         = deactEnv env0
+        deactSources (Derived n s)
+          | s == suffixNewact       = [n]
+        deactSources _              = []
 
 
 -- Deactorizing monad

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -443,7 +443,7 @@ initEnv path False         = do (_,nmod,_,_,_,_,_,_,_,_,_,_,_) <- InterfaceFiles
                                                  qlevel = 0,
                                                  gtypes = [],
                                                  envX = () }
-                                    env = importAll mBuiltin envBuiltinPublic env0
+                                    env = importAll mBuiltin (mkModuleInfo mBuiltin [] envBuiltinPublic builtinDocstring) env0
                                 return env
 
 withModulesFrom             :: EnvF x -> EnvF x -> EnvF x
@@ -1350,24 +1350,24 @@ findTyFile spaths mn = go spaths
         else go ps
 
 -- | Import a module, loading its .tydb and extending the environment.
-doImp                        :: [FilePath] -> EnvF x -> ModName -> IO (EnvF x, TEnv)
-doImp spath env m            = do (env', te, _) <- doImpSeen S.empty env m
-                                  return (addImport m env', te)
+doImp                        :: [FilePath] -> EnvF x -> ModName -> IO (EnvF x, ModuleInfo)
+doImp spath env m            = do (env', mi, _) <- doImpSeen S.empty env m
+                                  return (addImport m env', mi)
   where
     -- A cached module still needs its recorded import closure available in the
-    -- environment. If the module is already loaded, NModule carries that
-    -- closure; otherwise we read it from the .tydb.
+    -- environment. If the module is already loaded, its ModuleInfo carries
+    -- that closure; otherwise we read it from the .tydb.
     doImpSeen seen env m
       | S.member m seen      =
-          case lookupMod m env of
-            Just te -> return (env, te, seen)
+          case lookupModuleInfo m env of
+            Just mi -> return (env, mi, seen)
             Nothing -> fileNotFound m
       | otherwise            =
           let seen' = S.insert m seen in
-          case lookupModule m env of
-            Just (imps, te, _) -> do
-              (env', seen'') <- subImpSeen seen' env imps
-              return (env', te, seen'')
+          case lookupModuleInfo m env of
+            Just mi -> do
+              (env', seen'') <- subImpSeen seen' env (moduleImports mi)
+              return (env', mi, seen'')
             Nothing -> do
               ty <- readFoundTy InterfaceFiles.readFileMaybe m
               case ty of
@@ -1375,8 +1375,8 @@ doImp spath env m            = do (env', te, _) <- doImpSeen S.empty env m
                 Just (ms,nmod,_,_,_,_,_,_,_,_,_,_,_) -> do
                   (env', seen'') <- subImpSeen seen' env ms
                   let NModule ms' teFull mdoc = nmod
-                      te = publicTEnv teFull
-                  return (addMod m ms' te mdoc env', te, seen'')
+                      mi = mkModuleInfo m ms' (publicTEnv teFull) mdoc
+                  return (addModuleInfo m mi (addMod m ms' (publicTEnv teFull) mdoc env'), mi, seen'')
 
     readFoundTy readTy m = do
       tyFile <- findTyFile spath m
@@ -1389,28 +1389,31 @@ doImp spath env m            = do (env', te, _) <- doImpSeen S.empty env m
       (env', _, seen') <- doImpSeen seen env m
       subImpSeen seen' env' ms
 
-importSome                  :: [ImportItem] -> ModName -> TEnv -> EnvF x -> EnvF x
-importSome items m te env   = defineClosed (map pick items) env
+importSome                  :: [ImportItem] -> ModName -> ModuleInfo -> EnvF x -> EnvF x
+importSome items m mi env   = defineClosed (map pick items) env
   where
-    te1                     = impNames m te
-    pick (ImportItem n mbn) = case lookup n te1 of
+    pick (ImportItem n mbn) = case impName m mi n of
                                     Just i  -> (maybe n id mbn, i)
                                     Nothing -> noItem m n
 
-importAll                   :: ModName -> TEnv -> EnvF x -> EnvF x
-importAll m te env          = defineClosed (impNames m te) env
+importAll                   :: ModName -> ModuleInfo -> EnvF x -> EnvF x
+importAll m mi env          = defineClosed (impNames m mi) env
 
-impNames                    :: ModName -> TEnv -> TEnv
-impNames m te               = mapMaybe imp (publicTEnv te)
+impName                     :: ModName -> ModuleInfo -> Name -> Maybe NameInfo
+impName m mi n              = case moduleLookupName mi n of
+                                Just NAct{}   -> Just (NAlias (GName m n))
+                                Just NClass{} -> Just (NAlias (GName m n))
+                                Just NProto{} -> Just (NAlias (GName m n))
+                                Just NExt{}   -> Nothing
+                                Just NAlias{} -> Just (NAlias (GName m n))
+                                Just NVar{}   -> Just (NAlias (GName m n))
+                                Just NDef{}   -> Just (NAlias (GName m n))
+                                _             -> Nothing
+
+impNames                    :: ModName -> ModuleInfo -> TEnv
+impNames m mi               = mapMaybe imp (modulePublicNames mi)
   where
-    imp (n, NAct _ _ _ _ _)   = Just (n, NAlias (GName m n))
-    imp (n, NClass _ _ _ _)   = Just (n, NAlias (GName m n))
-    imp (n, NProto _ _ _ _)   = Just (n, NAlias (GName m n))
-    imp (n, NExt _ _ _ _ _ _) = Nothing
-    imp (n, NAlias _)       = Just (n, NAlias (GName m n))
-    imp (n, NVar t)         = Just (n, NAlias (GName m n))
-    imp (n, NDef t d _)       = Just (n, NAlias (GName m n))
-    imp _                   = Nothing                               -- cannot happen
+    imp n                   = fmap (\i -> (n,i)) (impName m mi n)
 
 
 

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -1402,20 +1402,15 @@ doImp spath env m            = do (env', mi, _) <- doImpSeen S.empty env m
               (env', seen'') <- subImpSeen seen' env (moduleImports mi)
               return (env', mi, seen'')
             Nothing -> do
-              ty <- readFoundTy InterfaceFiles.readFileMaybe m
-              case ty of
+              tyFile <- findTyFile spath m
+              mdb <- maybe (return Nothing) InterfaceFiles.openInterfaceDBMaybe tyFile
+              case mdb of
                 Nothing -> fileNotFound m
-                Just (ms,nmod,_,_,_,_,_,_,_,_,_,_,_) -> do
+                Just db -> do
+                  (ms, mdoc) <- InterfaceFiles.readInterfaceDBModuleInfo db
                   (env', seen'') <- subImpSeen seen' env ms
-                  let NModule ms' teFull mdoc = nmod
-                      mi = mkModuleInfo m ms' (publicTEnv teFull) mdoc
-                  return (addModuleInfo m mi (addMod m ms' (publicTEnv teFull) mdoc env'), mi, seen'')
-
-    readFoundTy readTy m = do
-      tyFile <- findTyFile spath m
-      case tyFile of
-        Nothing -> return Nothing
-        Just tyF -> readTy tyF
+                  let mi = mkTyFileModuleInfo m ms mdoc db
+                  return (addModuleInfo m mi env', mi, seen'')
 
     subImpSeen seen env []   = return (env, seen)
     subImpSeen seen env (m:ms) = do

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -113,26 +113,23 @@ inLoop env                  = contextIs env CtxLoop
 
 setGtypes env te             = env{ gtypes = te }
 
-mapModules1                 :: ((Name,NameInfo) -> (Name,NameInfo)) -> Env0 -> Env0
-mapModules1 f env           = mapModules (\_ ni -> [f ni]) env
+-- Back passes rewrite imported interface entries. The conversion wraps each
+-- module's lookup function, so only names that are actually demanded are
+-- converted (and memoized). sources maps a generated name to the source
+-- entries it may be derived from.
+convertModules1             :: ((Name,NameInfo) -> (Name,NameInfo)) -> Env0 -> Env0
+convertModules1 f env       = convertModules (const []) (\_ ni -> [f ni]) env
 
-mapModules                  :: (ModName -> (Name,NameInfo) -> TEnv) -> Env0 -> Env0
-mapModules f env            = env' { hmodules = convTEnv2HTEnv mods', moduleInfos = Map.mapWithKey conv (moduleInfos env) }
- where env'                 = env { modules = mods' }
-       prim : mods          = modules env
-       mods'                = prim : walk [] mods
-
-       walk ns              = concatMap (go ns)
-
-       go ns (n, NModule ms te doc)
-                            = [(n, NModule ms (walk (ns ++ [n]) te) doc)]
-       go ns ni             = f (ModName ns) ni
-
-       conv m mi
-         | m == mPrim       = mi
-         | otherwise        = case lookupMod m env' of
-                                Just te -> mkModuleInfo m (moduleImports mi) te (moduleDoc mi)
-                                Nothing -> mi
+convertModules              :: (Name -> [Name]) -> (ModName -> (Name,NameInfo) -> TEnv) -> Env0 -> Env0
+convertModules sources f env= env{ moduleInfos = Map.mapWithKey convMod (moduleInfos env) }
+  where convMod m mi
+          | m == mPrim      = mi
+          | otherwise       = mi{ moduleLookupHName = memoLookup lookupConverted }
+          where lookupConverted n
+                            = listToMaybe $ mapMaybe (lookupFrom n) (n : sources n)
+                lookupFrom n src
+                            = do i <- moduleLookupName mi src
+                                 lookup n (f m (src,i)) >>= return . convNameInfo2HNameInfo
 
 
 -- Module interfaces -----------------------------------------------------------------------------

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -59,9 +59,7 @@ data EnvF x                 = EnvF {
                                 closedHNames:: HTEnv,
                                 imports    :: [ModName],
                                 improots   :: [Name],
-                                modules    :: TEnv,
-                                hmodules   :: HTEnv,
-                                moduleInfos:: Map ModName ModuleInfo,
+                                modules    :: Map ModName ModuleInfo,
                                 thismod    :: Maybe ModName,
                                 context    :: [EnvCtx],
                                 qlevel     :: Int,
@@ -79,8 +77,7 @@ setX                        :: EnvF y -> x -> EnvF x
 setX env x                  = EnvF { activeNames = activeNames env, closedNames = closedNames env,
                                      hnames = hnames env, closedHNames = closedHNames env,
                                      imports = imports env, improots = improots env,
-                                     modules = modules env, hmodules = hmodules env,
-                                     moduleInfos = moduleInfos env, thismod = thismod env,
+                                     modules = modules env, thismod = thismod env,
                                      context = context env, qlevel = qlevel env, gtypes = gtypes env, envX = x }
 
 modX                        :: EnvF x -> (x -> x) -> EnvF x
@@ -121,7 +118,7 @@ convertModules1             :: ((Name,NameInfo) -> (Name,NameInfo)) -> Env0 -> E
 convertModules1 f env       = convertModules (const []) (\_ ni -> [f ni]) env
 
 convertModules              :: (Name -> [Name]) -> (ModName -> (Name,NameInfo) -> TEnv) -> Env0 -> Env0
-convertModules sources f env= env{ moduleInfos = Map.mapWithKey convMod (moduleInfos env) }
+convertModules sources f env= env{ modules = Map.mapWithKey convMod (modules env) }
   where convMod m mi
           | m == mPrim      = mi
           | otherwise       = mi{ moduleLookupHName = memoLookup lookupConverted }
@@ -294,7 +291,7 @@ memoLookup f                = unsafePerformIO $ do
 
 instance (Pretty x) => Pretty (EnvF x) where
     pretty env                  = text "--- modules:"  $+$
-                                  vcat (map pretty (modules env)) $+$
+                                  vcat (map pretty (Map.keys (modules env))) $+$
                                   text "--- active names" <+> pretty (thismod env) <+> parens (text (show (qlevel env))) <> colon $+$
                                   vcat (map pretty (activeNames env)) $+$
                                   text "--- closed names" <+> pretty (thismod env) <> colon $+$
@@ -414,9 +411,7 @@ initEnv path True          = return $ EnvF{ activeNames = [],
                                             closedHNames = hnamesFrom [(nPrim,NMAlias mPrim)],
                                             imports = [],
                                             improots = [],
-                                            modules = [(nPrim,NModule [] primEnv Nothing)],
-                                            hmodules = M.empty,
-                                            moduleInfos = Map.singleton mPrim (mkModuleInfo mPrim [] primEnv Nothing),
+                                            modules = Map.singleton mPrim (mkModuleInfo mPrim [] primEnv Nothing),
                                             thismod = Nothing,
                                             context = [],
                                             qlevel = 0,
@@ -432,9 +427,7 @@ initEnv path False         = do (_,nmod,_,_,_,_,_,_,_,_,_,_,_) <- InterfaceFiles
                                                  closedHNames = hnamesFrom initialNames,
                                                  imports = [],
                                                  improots = [],
-                                                 modules = [(nPrim,NModule [] primEnv Nothing), (nBuiltin,NModule [] envBuiltin builtinDocstring)],
-                                                 hmodules = M.empty,
-                                                 moduleInfos = Map.fromList [(mPrim, mkModuleInfo mPrim [] primEnv Nothing), (mBuiltin, mkModuleInfo mBuiltin [] envBuiltin builtinDocstring)],
+                                                 modules = Map.fromList [(mPrim, mkModuleInfo mPrim [] primEnv Nothing), (mBuiltin, mkModuleInfo mBuiltin [] envBuiltin builtinDocstring)],
                                                  thismod = Nothing,
                                                  context = [],
                                                  qlevel = 0,
@@ -444,7 +437,7 @@ initEnv path False         = do (_,nmod,_,_,_,_,_,_,_,_,_,_,_) <- InterfaceFiles
                                 return env
 
 withModulesFrom             :: EnvF x -> EnvF x -> EnvF x
-env `withModulesFrom` env'  = env{modules = modules env', moduleInfos = moduleInfos env'}
+env `withModulesFrom` env'  = env{modules = modules env'}
 
 hnamesFrom                  :: TEnv -> HTEnv
 hnamesFrom te               = extendHNames te M.empty
@@ -527,25 +520,16 @@ setMod                      :: ModName -> EnvF x -> EnvF x
 setMod m env                = env{ thismod = Just m }
 
 addMod                      :: ModName -> [ModName] -> TEnv -> Maybe String -> EnvF x -> EnvF x
-addMod m ms newte mdoc env  = addModuleInfo m (mkModuleInfo m ms newte mdoc) env{ modules = addM ns (modules env) }
-  where
-    ModName ns              = m
-    addM [] te              = newte ++ te
-    addM (n:ns) te          = update n ns te
-    update n ns ((x,i):te)
-      | n == x, NModule ms1 te1 doc <- i
-                            = (n, NModule ms1 (addM ns te1) doc) : te
-    update n ns (ni:te)     = ni : update n ns te
-    update n ns []          = (n, NModule ms (addM ns []) mdoc) : []
+addMod m ms newte mdoc env  = addModuleInfo m (mkModuleInfo m ms newte mdoc) env
 
 addModuleInfo               :: ModName -> ModuleInfo -> EnvF x -> EnvF x
-addModuleInfo m mi env      = env{ moduleInfos = Map.insert m mi (moduleInfos env) }
+addModuleInfo m mi env      = env{ modules = Map.insert m mi (modules env) }
 
 
 -- General Env queries -----------------------------------------------------------------------------------------------------------
 
 inBuiltin                   :: EnvF x -> Bool
-inBuiltin env               = length (modules env) == 1     -- mPrim only
+inBuiltin env               = Map.size (modules env) == 1     -- mPrim only
 
 stateScope                  :: EnvF x -> [Name]
 stateScope env              = scopes (activeNames env) ++ scopes (closedNames env)
@@ -612,29 +596,6 @@ lookupVar n env             = case lookupName n env of
                                 Just (HNVar t) -> Just t
                                 _ -> Nothing
 
-findHMod                    :: ModName -> EnvF x -> Maybe HTEnv  -- m is modname part of a QName, so we must check for aliasing
-findHMod m env | inBuiltin env, m==mBuiltin
-                            = Just (hnames env)
-findHMod m@(ModName ns) env = case lookupName (head ns) env of
-                                Just (HNMAlias (ModName m')) -> lookupHMod (ModName $ m'++tail ns) env
-                                Nothing | m `elem` (mPrim:mBuiltin:imports env) -> lookupHMod m env
-                                _ -> Nothing
-
-lookupHMod                      :: ModName -> EnvF x -> Maybe HTEnv -- m is modname part of a GName, so search directly for module
-lookupHMod m env                = case lookupHModule m env of Just (imps, te, doc) -> Just te; _ -> Nothing
-
-
-lookupHModule m env
- | inBuiltin env, m==mBuiltin   = Just ([], hnames env, Nothing)
-lookupHModule (ModName ns) env  = f ns (hmodules env)
-  where f (n:ns) te             = case M.lookup n te of
-                                    Just (HNModule imps te' doc) -> g ns imps te' doc
-                                    Just (HNMAlias (ModName m)) -> lookupHModule (ModName $ m++ns) env
-                                    _ -> Nothing
-        g ns imps te doc
-          | null ns             = Just (imps, te, doc)
-          | otherwise           = f ns te
-
 findModuleInfo              :: ModName -> EnvF x -> Maybe ModuleInfo  -- m is modname part of a QName, so we must check for aliasing
 findModuleInfo m env | inBuiltin env, m==mBuiltin
                             = Just (builtinModuleInfo env)
@@ -648,34 +609,19 @@ lookupModuleInfo            :: ModName -> EnvF x -> Maybe ModuleInfo  -- m is mo
 lookupModuleInfo m env
   | inBuiltin env, m==mBuiltin
                             = Just (builtinModuleInfo env)
-  | otherwise               = Map.lookup m (moduleInfos env)
+  | otherwise               = Map.lookup m (modules env)
 
 -- A parent package of a loaded module is itself a valid module path prefix,
 -- which the old NModule tree represented implicitly.
 modulePrefix                :: ModName -> EnvF x -> Bool
 modulePrefix (ModName ns) env
-                            = any prefix (Map.keys (moduleInfos env))
+                            = any prefix (Map.keys (modules env))
   where prefix (ModName ns')= ns `isPrefixOf` ns'
 
 -- The builtin module is looked up through the active environment while it is
 -- itself being compiled.
 builtinModuleInfo           :: EnvF x -> ModuleInfo
 builtinModuleInfo env       = (mkModuleInfo mBuiltin [] (activeNames env ++ closedNames env) Nothing){ moduleLookupHName = \n -> lookupName n env }
-
-lookupMod                       :: ModName -> EnvF x -> Maybe TEnv
-lookupMod m env                 = case lookupModule m env of Just (imps, te, doc) -> Just te; _ -> Nothing
-
-lookupModule m env
-  | inBuiltin env, m==mBuiltin  = Just ([], activeNames env ++ closedNames env, Nothing)
-lookupModule (ModName ns) env   = f ns (modules env)
-  where f (n:ns) te             = case lookup n te of
-                                    Just (NModule imps te' doc) -> g ns imps te' doc
-                                    Just (NMAlias (ModName m)) -> lookupModule (ModName $ m++ns) env
-                                    _ -> Nothing
-        g ns imps te doc
-          | null ns             = Just (imps, te, doc)
-          | otherwise           = f ns te
-
 
 isMod                       :: EnvF x -> [Name] -> Bool
 isMod env ns@(n:_)          = (maybe False (const True) (findModuleInfo (ModName ns) env) || modulePrefix (ModName ns) env) && rooted
@@ -1345,7 +1291,7 @@ instance Flows Handler where
 -- Import handling (local definitions only) -------------------------------------------------------------------------
 
 --getImps                         :: [FilePath] -> EnvF x -> [Import] -> IO (EnvF x)
-getImps spath env []         = return env { hmodules = convTEnv2HTEnv (modules env) }
+getImps spath env []         = return env
 getImps spath env (i:is)     = do env' <- impModule spath env i
                                   getImps spath env' is
 

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -330,11 +330,11 @@ instance Unalias ModName where
       | inBuiltin env               = m
       | otherwise                   = case lookupName (head ns) env of
                                         Just (HNMAlias m') -> m'
-                                        Nothing | m `elem` (mPrim:mBuiltin:imports env)  -> m
+                                        Nothing | m `elem` (mPrim:mBuiltin:imports env) || modulePrefix m env -> m
                                         _ -> noModule m
 instance Unalias QName where
-    unalias env n0@(QName m n)      = case findHMod m env of
-                                        Just te -> case M.lookup n te of
+    unalias env n0@(QName m n)      = case findModuleInfo m env of
+                                        Just mi -> case moduleLookupHName mi n of
                                                       Just (HNAlias qn) -> setLoc (loc n0) qn
                                                       Just _ -> GName m' n
                                                       _ -> noItem m n
@@ -575,8 +575,8 @@ findQName n env             = case tryQName n env of
                                  Nothing -> nameNotFound (noq n)
 
 tryQName                    :: QName -> EnvF x -> Maybe HNameInfo
-tryQName (QName m n) env    = case findHMod m env of
-                                Just te -> case M.lookup n te of
+tryQName (QName m n) env    = case findModuleInfo m env of
+                                Just mi -> case moduleLookupHName mi n of
                                     Just (HNAlias qn) -> tryQName qn env
                                     Just i -> Just i
                                     _ -> noItem m n
@@ -589,8 +589,8 @@ tryQName (GName m n) env
   | Just m == thismod env   = tryQName (NoQ n) env
   | inBuiltin env,
     m==mBuiltin             = tryQName (NoQ n) env
-  | otherwise               = case lookupHMod m env of
-                                Just te -> case M.lookup n te of
+  | otherwise               = case lookupModuleInfo m env of
+                                Just mi -> case moduleLookupHName mi n of
                                     Just i -> Just i
                                     Nothing -> noItem m n -- error ("## Failed lookup of " ++ prstr n ++ " in module " ++ prstr m)
                                 Nothing -> noModule m -- error ("## Failed lookup of module " ++ prstr m)
@@ -653,6 +653,13 @@ lookupModuleInfo m env
                             = Just (builtinModuleInfo env)
   | otherwise               = Map.lookup m (moduleInfos env)
 
+-- A parent package of a loaded module is itself a valid module path prefix,
+-- which the old NModule tree represented implicitly.
+modulePrefix                :: ModName -> EnvF x -> Bool
+modulePrefix (ModName ns) env
+                            = any prefix (Map.keys (moduleInfos env))
+  where prefix (ModName ns')= ns `isPrefixOf` ns'
+
 -- The builtin module is looked up through the active environment while it is
 -- itself being compiled.
 builtinModuleInfo           :: EnvF x -> ModuleInfo
@@ -674,7 +681,7 @@ lookupModule (ModName ns) env   = f ns (modules env)
 
 
 isMod                       :: EnvF x -> [Name] -> Bool
-isMod env ns@(n:_)          = maybe False (const True) (findHMod (ModName ns) env) && rooted
+isMod env ns@(n:_)          = (maybe False (const True) (findModuleInfo (ModName ns) env) || modulePrefix (ModName ns) env) && rooted
   where rooted              = n `elem` improots env || isMAlias n env
 
 isMAlias                    :: Name -> EnvF x -> Bool
@@ -924,7 +931,7 @@ transitiveImports env       = mBuiltin : reverse (foldl trav [] (getImports env)
   where trav seen m
           | m `elem` seen   = seen
           | otherwise       = m : foldl trav seen ms
-          where ms          = case lookupModule m env of Just (imps,_,_) -> imps
+          where ms          = case lookupModuleInfo m env of Just mi -> moduleImports mi
 
 allTypes                    :: (NameInfo -> Bool) -> EnvF x -> [TCon]
 allTypes select env         = concatMap impcons mods ++ localcons

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -947,6 +947,8 @@ transitiveImports env       = mBuiltin : reverse (foldl trav [] (getImports env)
           | otherwise       = m : foldl trav seen ms
           where ms          = case lookupModuleInfo m env of Just mi -> moduleImports mi
 
+-- Enumerating every imported type forces each module's constructor records;
+-- solver queries go through the narrow per-query indexes instead.
 allTypes                    :: (NameInfo -> Bool) -> EnvF x -> [TCon]
 allTypes select env         = concatMap impcons mods ++ localcons
   where mods                = transitiveImports env
@@ -956,7 +958,7 @@ allTypes select env         = concatMap impcons mods ++ localcons
         localcons
                             = local (reverse (closedNames env)) ++ local (reverse (activeNames env))
         impcons m           = [ TC (GName m n) (wildargs i) | (n,i) <- te, select i ]
-          where Just te     = lookupMod m env
+          where Just te     = moduleConstructors <$> lookupModuleInfo m env
 
 allCons                     :: EnvF x -> [TCon]
 allCons env                 = allTypes isCon env
@@ -965,9 +967,11 @@ allCons env                 = allTypes isCon env
         isCon _             = False
 
 allActors                   :: EnvF x -> [TCon]
-allActors env               = allTypes isActor env
-  where isActor NAct{}      = True
-        isActor _           = False
+allActors env               = concatMap moduleActors (importedModuleInfos env) ++ localactors
+  where local te
+          | inBuiltin env   = [ TC (GName mBuiltin n) (wildargs i) | (n,i@NAct{}) <- te ]
+          | otherwise       = [ TC (NoQ n) (wildargs i) | (n,i@NAct{}) <- te ]
+        localactors         = local (reverse (closedNames env)) ++ local (reverse (activeNames env))
 
 allProtos env               = allTypes isProto env
   where isProto NProto{}    = True

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -22,9 +22,13 @@ import Data.Char
 import System.FilePath.Posix (joinPath,takeDirectory)
 import System.Directory (doesDirectoryExist, doesFileExist)
 import System.Environment (getExecutablePath)
+import System.IO.Unsafe (unsafePerformIO)
 import Control.Monad
 import Control.Monad.Except
+import Data.IORef
 import qualified Data.HashMap.Strict as M
+import qualified Data.Map.Strict as Map
+import Data.Map.Strict (Map)
 import qualified Data.Set as S
 
 import Acton.Syntax
@@ -57,6 +61,7 @@ data EnvF x                 = EnvF {
                                 improots   :: [Name],
                                 modules    :: TEnv,
                                 hmodules   :: HTEnv,
+                                moduleInfos:: Map ModName ModuleInfo,
                                 thismod    :: Maybe ModName,
                                 context    :: [EnvCtx],
                                 qlevel     :: Int,
@@ -74,7 +79,8 @@ setX                        :: EnvF y -> x -> EnvF x
 setX env x                  = EnvF { activeNames = activeNames env, closedNames = closedNames env,
                                      hnames = hnames env, closedHNames = closedHNames env,
                                      imports = imports env, improots = improots env,
-                                     modules = modules env, hmodules = hmodules env, thismod = thismod env,
+                                     modules = modules env, hmodules = hmodules env,
+                                     moduleInfos = moduleInfos env, thismod = thismod env,
                                      context = context env, qlevel = qlevel env, gtypes = gtypes env, envX = x }
 
 modX                        :: EnvF x -> (x -> x) -> EnvF x
@@ -111,7 +117,7 @@ mapModules1                 :: ((Name,NameInfo) -> (Name,NameInfo)) -> Env0 -> E
 mapModules1 f env           = mapModules (\_ ni -> [f ni]) env
 
 mapModules                  :: (ModName -> (Name,NameInfo) -> TEnv) -> Env0 -> Env0
-mapModules f env            = env' { hmodules = convTEnv2HTEnv mods' }
+mapModules f env            = env' { hmodules = convTEnv2HTEnv mods', moduleInfos = Map.mapWithKey conv (moduleInfos env) }
  where env'                 = env { modules = mods' }
        prim : mods          = modules env
        mods'                = prim : walk [] mods
@@ -121,6 +127,173 @@ mapModules f env            = env' { hmodules = convTEnv2HTEnv mods' }
        go ns (n, NModule ms te doc)
                             = [(n, NModule ms (walk (ns ++ [n]) te) doc)]
        go ns ni             = f (ModName ns) ni
+
+       conv m mi
+         | m == mPrim       = mi
+         | otherwise        = case lookupMod m env' of
+                                Just te -> mkModuleInfo m (moduleImports mi) te (moduleDoc mi)
+                                Nothing -> mi
+
+
+-- Module interfaces -----------------------------------------------------------------------------
+
+-- A ModuleInfo is the per-module view used for all lookups into dependency
+-- modules. A locally compiled module backs it with its in-memory interface
+-- TEnv; an imported module can back it with selective .tydb reads instead, so
+-- a dependent module only pays for the names and indexes it actually demands.
+
+data ModuleInfo             = ModuleInfo {
+                                moduleImports     :: [ModName],
+                                moduleDoc         :: Maybe String,
+                                moduleLookupHName :: Name -> Maybe HNameInfo,
+                                modulePublicNames :: [Name],
+                                moduleConstructors:: TEnv,
+                                moduleActors      :: [TCon],
+                                moduleConAttr     :: Name -> [TCon],
+                                moduleProtoAttr   :: Name -> [TCon],
+                                moduleDescendants :: QName -> [TCon],
+                                moduleProtoDescendants :: QName -> [TCon],
+                                moduleWitnessesByProto :: QName -> [Witness],
+                                moduleWitnessesByType  :: QName -> [Witness]
+                              }
+
+instance Show ModuleInfo where
+    show mi                 = "ModuleInfo {imports = " ++ show (moduleImports mi) ++ "}"
+
+moduleLookupName            :: ModuleInfo -> Name -> Maybe NameInfo
+moduleLookupName mi n       = convHNameInfo2NameInfo <$> moduleLookupHName mi n
+
+modulePublicTEnv            :: ModuleInfo -> TEnv
+modulePublicTEnv mi         = mapMaybe entry (modulePublicNames mi)
+  where entry n             = fmap (\i -> (n,i)) (moduleLookupName mi n)
+
+mkModuleInfo                :: ModName -> [ModName] -> TEnv -> Maybe String -> ModuleInfo
+mkModuleInfo m ms te mdoc   = ModuleInfo {
+                                moduleImports = ms,
+                                moduleDoc = mdoc,
+                                moduleLookupHName = \n -> M.lookup n hte,
+                                modulePublicNames = map fst pte,
+                                moduleConstructors = [ ni | ni@(_,i) <- pte, isCons i ],
+                                moduleActors = [ moduleTCon m ni | ni@(_,NAct{}) <- pte ],
+                                moduleConAttr = \n -> Map.findWithDefault [] n conattrs,
+                                moduleProtoAttr = \n -> Map.findWithDefault [] n protoattrs,
+                                moduleDescendants = qkeyed descendants,
+                                moduleProtoDescendants = qkeyed protodescs,
+                                moduleWitnessesByProto = qkeyed witprotos,
+                                moduleWitnessesByType = qkeyed wittypes
+                              }
+  where pte                 = publicTEnv te
+        hte                 = convTEnv2HTEnv pte
+        wits                = extWitnesses m [ ni | ni@(_,NExt{}) <- pte ]
+        witprotos           = indexMap [ (tcname $ proto w, w) | w <- wits ]
+        wittypes            = indexMap [ (qn, w) | w <- wits, Just qn <- [witnessTypeQName w] ]
+        conattrs            = indexMap [ (a, moduleTCon m ni) | ni@(_,i) <- pte, isCon i, a <- dom (conTE i) ]
+        protoattrs          = indexMap [ (a, moduleTCon m ni) | ni@(_,i@NProto{}) <- pte, a <- dom (conTE i) ]
+        descendants         = indexMap [ (tcname c, moduleTCon m ni) | ni@(_,i@NClass{}) <- pte, (_,c) <- ancestry i ]
+        protodescs          = indexMap [ (tcname c, moduleTCon m ni) | ni@(_,i@NProto{}) <- pte, (_,c) <- ancestry i ]
+        qkeyed mp qn        = concat [ Map.findWithDefault [] qn' mp | qn' <- moduleQNameKeys m qn ]
+        indexMap xs         = Map.fromListWith (++) [ (k, [v]) | (k,v) <- reverse xs ]
+        ancestry (NClass _ us _ _) = us
+        ancestry (NProto _ us _ _) = us
+        ancestry _          = []
+        conTE (NClass _ _ te' _) = te'
+        conTE (NProto _ _ te' _) = te'
+        conTE (NAct _ _ _ te' _) = te'
+        conTE _             = []
+        isCons NClass{}     = True
+        isCons NProto{}     = True
+        isCons NAct{}       = True
+        isCons _            = False
+        isCon NClass{}      = True
+        isCon NAct{}        = True
+        isCon _             = False
+
+-- | Build a ModuleInfo backed by selective .tydb reads. Lookups run keyed
+-- LMDB reads on demand (behind pure-looking functions) and memoize results;
+-- a failed or corrupt read aborts compilation like any other interface cache
+-- error.
+mkTyFileModuleInfo          :: ModName -> [ModName] -> Maybe String -> InterfaceFiles.InterfaceDB -> ModuleInfo
+mkTyFileModuleInfo m ms mdoc db
+                            = ModuleInfo {
+                                moduleImports = ms,
+                                moduleDoc = mdoc,
+                                moduleLookupHName = memoLookup lookupName,
+                                modulePublicNames = publicNames,
+                                moduleConstructors = constructors,
+                                moduleActors = actors,
+                                moduleConAttr = memoLookup conAttr,
+                                moduleProtoAttr = memoLookup protoAttr,
+                                moduleDescendants = memoLookup descendants,
+                                moduleProtoDescendants = memoLookup protoDescendants,
+                                moduleWitnessesByProto = memoLookup witsByProto,
+                                moduleWitnessesByType = memoLookup witsByType
+                              }
+  where lookupName n
+          | not (isPublicName n) = Nothing
+          | otherwise        = unsafePerformIO $ do
+                                  mi <- InterfaceFiles.readInterfaceDBNameInfoMaybe db n
+                                  return $ convNameInfo2HNameInfo . snd <$> mi
+        publicNames          = unsafePerformIO $ InterfaceFiles.readInterfaceDBPublicNames db
+        constructors         = unsafePerformIO $ InterfaceFiles.readInterfaceDBConstructors db
+        actors               = map (moduleTCon m) $ unsafePerformIO $ InterfaceFiles.readInterfaceDBActors db
+        conAttr n            = map (moduleTCon m) $ unsafePerformIO $ InterfaceFiles.readInterfaceDBConAttr db n
+        protoAttr n          = map (moduleTCon m) $ unsafePerformIO $ InterfaceFiles.readInterfaceDBProtoAttr db n
+        descendants qn       = [ moduleTCon m ni | qn' <- moduleQNameKeys m qn, ni@(_,NClass{}) <- readDesc qn' ]
+        protoDescendants qn  = [ moduleTCon m ni | qn' <- moduleQNameKeys m qn, ni@(_,NProto{}) <- readDesc qn' ]
+        readDesc qn          = unsafePerformIO $ InterfaceFiles.readInterfaceDBDescendants db qn
+        -- The proto index stores extension records; one extension can carry
+        -- witnesses for several protocols, so keep only the indexed protocol.
+        witsByProto qn       = concat [ filter ((== qn') . tcname . proto) $
+                                          extWitnesses m $
+                                          unsafePerformIO $
+                                          InterfaceFiles.readInterfaceDBExtByProto db qn'
+                                      | qn' <- moduleQNameKeys m qn ]
+        witsByType qn        = concat [ extWitnesses m $ unsafePerformIO $ InterfaceFiles.readInterfaceDBExtByType db qn' | qn' <- moduleQNameKeys m qn ]
+
+moduleTCon                  :: ModName -> (Name, NameInfo) -> TCon
+moduleTCon m (n, i)         = TC (GName m n) (wildargs i)
+
+-- A module's interface records references to its own names unqualified, so
+-- both the queried form and the module-local form must be tried.
+moduleQNameKeys             :: ModName -> QName -> [QName]
+moduleQNameKeys m qn@(NoQ n)= [qn, GName m n]
+moduleQNameKeys m qn@(GName m' n)
+  | m == m'                 = [qn, NoQ n]
+moduleQNameKeys m qn@(QName m' n)
+  | m == m'                 = [qn, NoQ n]
+moduleQNameKeys _ qn        = [qn]
+
+extWitnesses                :: ModName -> TEnv -> [Witness]
+extWitnesses m exts         = foldl' add [] wits
+  where wits                = [ WClass q (tCon c) p (GName m n) ws (length opts) | (n, NExt q c ps _ opts _) <- exts, (ws,p) <- ps ]
+        add ws w
+          | any (same w) ws = ws
+          | otherwise       = w : ws
+        same w w'           = tcname (proto w) == tcname (proto w') && wtype w == wtype w'
+
+witnessTypeQName            :: Witness -> Maybe QName
+witnessTypeQName w          = nameOf (wtype w)
+  where nameOf (TCon _ c)   = Just (tcname c)
+        nameOf (TVar _ v)   = Just (NoQ $ tvname v)
+        nameOf _            = Nothing
+
+-- | Memoize a pure-looking lookup function whose results come from on-demand
+-- .tydb reads, so each key is read at most once per module handle.
+memoLookup                  :: Ord k => (k -> v) -> k -> v
+memoLookup f                = unsafePerformIO $ do
+                                  memo <- newIORef Map.empty
+                                  return $ \n -> unsafePerformIO $ do
+                                      cache <- readIORef memo
+                                      case Map.lookup n cache of
+                                        Just r  -> return r
+                                        Nothing -> do
+                                          let r = f n
+                                          Control.Exception.evaluate r
+                                          atomicModifyIORef' memo $ \cache' ->
+                                            case Map.lookup n cache' of
+                                              Just r' -> (cache', r')
+                                              Nothing -> (Map.insert n r cache', r)
+{-# NOINLINE memoLookup #-}
 
 instance (Pretty x) => Pretty (EnvF x) where
     pretty env                  = text "--- modules:"  $+$
@@ -246,6 +419,7 @@ initEnv path True          = return $ EnvF{ activeNames = [],
                                             improots = [],
                                             modules = [(nPrim,NModule [] primEnv Nothing)],
                                             hmodules = M.empty,
+                                            moduleInfos = Map.singleton mPrim (mkModuleInfo mPrim [] primEnv Nothing),
                                             thismod = Nothing,
                                             context = [],
                                             qlevel = 0,
@@ -263,6 +437,7 @@ initEnv path False         = do (_,nmod,_,_,_,_,_,_,_,_,_,_,_) <- InterfaceFiles
                                                  improots = [],
                                                  modules = [(nPrim,NModule [] primEnv Nothing), (nBuiltin,NModule [] envBuiltin builtinDocstring)],
                                                  hmodules = M.empty,
+                                                 moduleInfos = Map.fromList [(mPrim, mkModuleInfo mPrim [] primEnv Nothing), (mBuiltin, mkModuleInfo mBuiltin [] envBuiltin builtinDocstring)],
                                                  thismod = Nothing,
                                                  context = [],
                                                  qlevel = 0,
@@ -272,7 +447,7 @@ initEnv path False         = do (_,nmod,_,_,_,_,_,_,_,_,_,_,_) <- InterfaceFiles
                                 return env
 
 withModulesFrom             :: EnvF x -> EnvF x -> EnvF x
-env `withModulesFrom` env'  = env{modules = modules env'}
+env `withModulesFrom` env'  = env{modules = modules env', moduleInfos = moduleInfos env'}
 
 hnamesFrom                  :: TEnv -> HTEnv
 hnamesFrom te               = extendHNames te M.empty
@@ -355,7 +530,7 @@ setMod                      :: ModName -> EnvF x -> EnvF x
 setMod m env                = env{ thismod = Just m }
 
 addMod                      :: ModName -> [ModName] -> TEnv -> Maybe String -> EnvF x -> EnvF x
-addMod m ms newte mdoc env  = env{ modules = addM ns (modules env) }
+addMod m ms newte mdoc env  = addModuleInfo m (mkModuleInfo m ms newte mdoc) env{ modules = addM ns (modules env) }
   where
     ModName ns              = m
     addM [] te              = newte ++ te
@@ -365,6 +540,9 @@ addMod m ms newte mdoc env  = env{ modules = addM ns (modules env) }
                             = (n, NModule ms1 (addM ns te1) doc) : te
     update n ns (ni:te)     = ni : update n ns te
     update n ns []          = (n, NModule ms (addM ns []) mdoc) : []
+
+addModuleInfo               :: ModName -> ModuleInfo -> EnvF x -> EnvF x
+addModuleInfo m mi env      = env{ moduleInfos = Map.insert m mi (moduleInfos env) }
 
 
 -- General Env queries -----------------------------------------------------------------------------------------------------------
@@ -459,6 +637,26 @@ lookupHModule (ModName ns) env  = f ns (hmodules env)
         g ns imps te doc
           | null ns             = Just (imps, te, doc)
           | otherwise           = f ns te
+
+findModuleInfo              :: ModName -> EnvF x -> Maybe ModuleInfo  -- m is modname part of a QName, so we must check for aliasing
+findModuleInfo m env | inBuiltin env, m==mBuiltin
+                            = Just (builtinModuleInfo env)
+findModuleInfo m@(ModName ns) env
+                            = case lookupName (head ns) env of
+                                Just (HNMAlias (ModName m')) -> lookupModuleInfo (ModName $ m'++tail ns) env
+                                Nothing | m `elem` (mPrim:mBuiltin:imports env) -> lookupModuleInfo m env
+                                _ -> Nothing
+
+lookupModuleInfo            :: ModName -> EnvF x -> Maybe ModuleInfo  -- m is modname part of a GName, so search directly for module
+lookupModuleInfo m env
+  | inBuiltin env, m==mBuiltin
+                            = Just (builtinModuleInfo env)
+  | otherwise               = Map.lookup m (moduleInfos env)
+
+-- The builtin module is looked up through the active environment while it is
+-- itself being compiled.
+builtinModuleInfo           :: EnvF x -> ModuleInfo
+builtinModuleInfo env       = (mkModuleInfo mBuiltin [] (activeNames env ++ closedNames env) Nothing){ moduleLookupHName = \n -> lookupName n env }
 
 lookupMod                       :: ModName -> EnvF x -> Maybe TEnv
 lookupMod m env                 = case lookupModule m env of Just (imps, te, doc) -> Just te; _ -> Nothing

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -744,7 +744,9 @@ allDescendants env tc       = concatMap imported (importedModuleInfos env) ++ lo
         local               = [ schematic' c | c <- localCons env, hasAncestor' env (tcname c) (tcname tc) ]
 
 importedModuleInfos         :: EnvF x -> [ModuleInfo]
-importedModuleInfos env     = [ mi | m <- transitiveImports env, Just mi <- [lookupModuleInfo m env] ]
+importedModuleInfos env
+  | inBuiltin env           = []
+  | otherwise               = [ mi | m <- transitiveImports env, Just mi <- [lookupModuleInfo m env] ]
 
 localCons                   :: EnvF x -> [TCon]
 localCons env               = local (reverse (closedNames env)) ++ local (reverse (activeNames env))

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -796,7 +796,21 @@ allAncestors env tc         = reverse [ schematic' c | (_, c) <- us ]
   where (us,te)             = findCon env tc
 
 allDescendants              :: EnvF x -> TCon -> [TCon]
-allDescendants env tc       = [ schematic' c | c <- allCons env, hasAncestor' env (tcname c) (tcname tc) ]
+allDescendants env tc       = concatMap imported (importedModuleInfos env) ++ local
+  where imported mi         = moduleDescendants mi (tcname tc)
+        local               = [ schematic' c | c <- localCons env, hasAncestor' env (tcname c) (tcname tc) ]
+
+importedModuleInfos         :: EnvF x -> [ModuleInfo]
+importedModuleInfos env     = [ mi | m <- transitiveImports env, Just mi <- [lookupModuleInfo m env] ]
+
+localCons                   :: EnvF x -> [TCon]
+localCons env               = local (reverse (closedNames env)) ++ local (reverse (activeNames env))
+  where local te
+          | inBuiltin env   = [ TC (GName mBuiltin n) (wildargs i) | (n,i) <- te, isCon i ]
+          | otherwise       = [ TC (NoQ n) (wildargs i) | (n,i) <- te, isCon i ]
+        isCon NClass{}      = True
+        isCon NAct{}        = True
+        isCon _             = False
 
 findCon                     :: EnvF x -> TCon -> ([WTCon],TEnv)
 findCon env (TC n ts)

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -973,8 +973,16 @@ allProtos env               = allTypes isProto env
   where isProto NProto{}    = True
         isProto _           = False
 
+-- The module indexes record attributes where they are declared, so imported
+-- owners are completed with the descendants of every declaring constructor
+-- (inheriting an attribute means having a declaring ancestor).
 allConAttr                  :: EnvF x -> Name -> [TCon]
-allConAttr env n            = [ tc | tc <- allCons env, hasAttr env tc n ]
+allConAttr env n            = imported ++ [ tc | tc <- localCons env, hasAttr env tc n ]
+  where mis                 = importedModuleInfos env
+        conOwners           = concat [ moduleConAttr mi n | mi <- mis ]
+        protoOwners         = concat [ moduleProtoAttr mi n | mi <- mis ]
+        inherited           = concat [ moduleDescendants mi (tcname o) | o <- conOwners ++ protoOwners, mi <- mis ]
+        imported            = nubBy (\c c' -> tcname c == tcname c') (conOwners ++ inherited)
 
 allConAttrUFree             :: EnvF x -> Name -> [TUni]
 allConAttrUFree env n       = concat [ ufree sc | tc <- activeCons env, Just (_,sc,_) <- [findAttr env tc n] ]
@@ -992,7 +1000,17 @@ activeCons env              = [ TC (localQName x) (wildargs i) | (x,i) <- active
           | otherwise       = NoQ x
 
 allPConAttr                 :: EnvF x -> Name -> [PCon]
-allPConAttr env n           = [ p | p <- allProtos env, hasAttr env p n ]
+allPConAttr env n           = imported ++ [ p | p <- localProtos env, hasAttr env p n ]
+  where mis                 = importedModuleInfos env
+        owners              = concat [ moduleProtoAttr mi n | mi <- mis ]
+        inherited           = concat [ moduleProtoDescendants mi (tcname o) | o <- owners, mi <- mis ]
+        imported            = nubBy (\p p' -> tcname p == tcname p') (owners ++ inherited)
+
+localProtos                 :: EnvF x -> [PCon]
+localProtos env             = local (reverse (closedNames env)) ++ local (reverse (activeNames env))
+  where local te
+          | inBuiltin env   = [ TC (GName mBuiltin n) (wildargs i) | (n,i@NProto{}) <- te ]
+          | otherwise       = [ TC (NoQ n) (wildargs i) | (n,i@NProto{}) <- te ]
 
 hasAttr                     :: EnvF x -> TCon -> Name -> Bool
 hasAttr env tc n            = maybe False (const True) (findAttrInfo' env (tcname tc) n)

--- a/compiler/lib/src/Acton/LambdaLifter.hs
+++ b/compiler/lib/src/Acton/LambdaLifter.hs
@@ -28,7 +28,7 @@ import Acton.Subst
 import Pretty
 import Prelude hiding((<>))
 
-liftModule env0 (Module m imp mdoc stmts) = return $ (Module m imp mdoc stmts', mapModules1 conv env0)
+liftModule env0 (Module m imp mdoc stmts) = return $ (Module m imp mdoc stmts', convertModules1 conv env0)
   where stmts' = runL (llSuite (liftEnv env0) stmts)
 
 

--- a/compiler/lib/src/Acton/Normalizer.hs
+++ b/compiler/lib/src/Acton/Normalizer.hs
@@ -30,7 +30,7 @@ import Debug.Trace
 normalize                           :: Env0 -> Module -> IO (Module, Env0)
 normalize env0 m                    = return (evalState (norm env m) (0,[]), env0')
   where env                         = normEnv env0
-        env0'                       = mapModules convEnv env0
+        env0'                       = convertModules (const []) convEnv env0
 
 
 --  Normalization:

--- a/compiler/lib/src/Acton/Syntax.hs
+++ b/compiler/lib/src/Acton/Syntax.hs
@@ -26,7 +26,7 @@ import Control.DeepSeq
 import Prelude hiding((<>))
 
 version :: [Int]
-version = [0,24]
+version = [0,25]
 
 data Module     = Module        { modname::ModName, imps::[Import], mdoc::Maybe String, mbody::Suite } deriving (Eq,Show,Generic,NFData)
 

--- a/compiler/lib/src/Acton/TypeEnv.hs
+++ b/compiler/lib/src/Acton/TypeEnv.hs
@@ -239,8 +239,7 @@ witsByTName env tn              = uniqueWits env $ locals ++ imported
         imported                = concat [ moduleWitnessesByType mi qn | mi <- importedModuleInfos env, qn <- queryQNames env tn ]
 
 -- Witnesses read from interfaces may name the same protocol or type in
--- aliased and unaliased form, so queries try both and results are deduped
--- under unaliasing.
+-- aliased and unaliased form, so queries try both forms.
 queryQNames                     :: Env -> QName -> [QName]
 queryQNames env qn
   | qn' == qn                   = [qn]
@@ -252,8 +251,7 @@ uniqueWits env                  = reverse . foldl' add []
   where add ws w
           | any (same w) ws     = ws
           | otherwise           = w : ws
-        same w w'               = tcname (unalias env $ proto w) == tcname (unalias env $ proto w') &&
-                                  unalias env (wtype w) == unalias env (wtype w')
+        same w w'               = tcname (proto w) == tcname (proto w') && wtype w == wtype w'
 
 limitQuant                      :: TUni -> Env -> Env
 limitQuant (UV _ l _) env

--- a/compiler/lib/src/Acton/TypeEnv.hs
+++ b/compiler/lib/src/Acton/TypeEnv.hs
@@ -69,8 +69,11 @@ data TyInfo                     = TyInfo {
 type Env                        = EnvF TypeX
 type WitMap                     = Map QName [Witness]
 
+-- Imported modules are not preloaded here: witsByPName/witsByTName merge in
+-- imported witnesses per query, and the tyids/tyinfos lattice only covers
+-- local definitions.
 initTypeEnv                     :: Env0 -> Env
-initTypeEnv env0                = setX env0 $ foldl' importInfo x0 imps
+initTypeEnv env0                = setX env0 x0
   where x0                      = TypeX {
                                     activeWits  = [],
                                     closedWits  = primWits,
@@ -84,10 +87,6 @@ initTypeEnv env0                = setX env0 $ foldl' importInfo x0 imps
                                     typrotos    = IntSet.empty,
                                     tyactors    = IntSet.empty
                                   }
-        importInfo x (m,te)     = setupCons f te $ setupWits addClosedWit f te x
-          where f               = GName m
-        imps | inBuiltin env0   = []
-             | otherwise        = [ (m, fromJust $ lookupMod m env0) | m <- mBuiltin : transitiveImports env0 ]
 
 
 tyinfos0                        = IntMap.fromDistinctAscList pairs
@@ -152,8 +151,10 @@ addconinfo f x (n,i)
         addproto x              = x{ typrotos = IntSet.insert tid (typrotos x) }
         addactor x              = x{ tyactors = IntSet.insert tid (tyactors x) }
 
+        -- Imported ancestors are not registered in tyids, so they contribute
+        -- no ids or attrs here. The lattice only feeds the debug printer.
         addcon n q us te x      = x{ tyids = Map.insert (f n) tid (tyids x), tyinfos = IntMap.insert tid info tyinfos' }
-          where ui              = [ tyids x Map.! tcname c | (_,c) <- us ]
+          where ui              = [ u | (_,c) <- us, Just u <- [Map.lookup (tcname c) (tyids x)] ]
                 info            = TyInfo {
                                     tywild = tCon $ TC (NoQ n) [ tWild | _ <- q ],
                                     tyabove = IntSet.fromList ui,
@@ -182,14 +183,14 @@ setupWits add f te x            = foldl' add x wits
 
 addvarinfo x (tv, c, _)         = x{ tyids = Map.insert (NoQ $ tvname tv) tid (tyids x), tyinfos = IntMap.insert tid info tyinfos' }
   where tid                     = nextid x
-        ci                      = tyinfos x IntMap.! (tyids x Map.! tcname c)
+        ci                      = Map.lookup (tcname c) (tyids x) >>= \i -> IntMap.lookup i (tyinfos x)
         info                    = TyInfo {
                                     tywild = tVar tv,
-                                    tyabove = IntSet.insert tid $ tyabove ci,
+                                    tyabove = maybe (IntSet.singleton tid) (IntSet.insert tid . tyabove) ci,
                                     tybelow = IntSet.singleton tid,
-                                    tyattrs = tyattrs ci
+                                    tyattrs = maybe Set.empty tyattrs ci
                                   }
-        tyinfos'                = IntSet.foldr' (IntMap.adjust addbelow) (tyinfos x) (tyabove ci)
+        tyinfos'                = maybe (tyinfos x) (\i -> IntSet.foldr' (IntMap.adjust addbelow) (tyinfos x) (tyabove i)) ci
         addbelow info           = info{ tybelow = IntSet.insert tid (tybelow info) }
 
 tydefineVars                    :: QBinds -> Env -> Env
@@ -224,15 +225,35 @@ witsByPNameX x pn               = Map.findWithDefault [] pn (activeWitMap x) ++
                                   Map.findWithDefault [] pn (closedWitMap x)
 
 witsByPName                     :: Env -> QName -> [Witness]
-witsByPName env pn              = witsByPNameX (envX env) pn
+witsByPName env pn              = uniqueWits env $ witsByPNameX (envX env) pn ++ imported
+  where imported                = concat [ moduleWitnessesByProto mi qn | mi <- importedModuleInfos env, qn <- queryQNames env pn ]
 
 witsByTName                     :: Env -> QName -> [Witness]
-witsByTName env tn              = [ w | w <- activeWits x, eqname (wtype w) ] ++
+witsByTName env tn              = uniqueWits env $ locals ++ imported
+  where locals                  = [ w | w <- activeWits x, eqname (wtype w) ] ++
                                   [ w | w <- closedWits x, eqname (wtype w) ]
-  where eqname (TCon _ c)       = tcname c == tn
+        eqname (TCon _ c)       = tcname c == tn
         eqname (TVar _ v)       = NoQ (tvname v) == tn
         eqname _                = False
         x                       = envX env
+        imported                = concat [ moduleWitnessesByType mi qn | mi <- importedModuleInfos env, qn <- queryQNames env tn ]
+
+-- Witnesses read from interfaces may name the same protocol or type in
+-- aliased and unaliased form, so queries try both and results are deduped
+-- under unaliasing.
+queryQNames                     :: Env -> QName -> [QName]
+queryQNames env qn
+  | qn' == qn                   = [qn]
+  | otherwise                   = [qn, qn']
+  where qn'                     = unalias env qn
+
+uniqueWits                      :: Env -> [Witness] -> [Witness]
+uniqueWits env                  = reverse . foldl' add []
+  where add ws w
+          | any (same w) ws     = ws
+          | otherwise           = w : ws
+        same w w'               = tcname (unalias env $ proto w) == tcname (unalias env $ proto w') &&
+                                  unalias env (wtype w) == unalias env (wtype w')
 
 limitQuant                      :: TUni -> Env -> Env
 limitQuant (UV _ l _) env

--- a/compiler/lib/src/InterfaceFiles.hs
+++ b/compiler/lib/src/InterfaceFiles.hs
@@ -41,6 +41,9 @@
 --     "tests"          :: [String]                    -- discovered test names
 --     "doc"            :: Maybe String                -- module docstring
 --     "name-count"     :: Int                         -- number of NameInfo entries (see name-order)
+--     "public-names"   :: [A.Name]                    -- public top-level names, in TEnv order
+--     "constructors"   :: [A.Name]                    -- public class/protocol/actor names
+--     "actors"         :: [A.Name]                    -- public actor names
 --     "stmt-count"     :: Int                         -- number of typed top-level statements
 --     "module-header"  :: (A.ModName, Imports, Maybe String)
 --                                                     -- typed module name, imports, docstring
@@ -57,6 +60,13 @@
 --   Per-extension keys:
 --     "ext-by-class/<suffix>"       :: (A.Name, [A.Name]) -- class name to extension names
 --     "ext-by-protocol/<suffix>"    :: (A.Name, [A.Name]) -- protocol name to extension names
+--
+--   Per-query index keys:
+--     "con-attr/<suffix>"     :: [A.Name]             -- class/actor names declaring an attribute
+--     "proto-attr/<suffix>"   :: [A.Name]             -- protocol names declaring an attribute
+--     "descendants/<suffix>"  :: [A.Name]             -- class/protocol names below a constructor
+--     "ext-proto/<suffix>"    :: [A.Name]             -- extension names implementing a protocol
+--     "ext-type/<suffix>"     :: [A.Name]             -- extension names for a type/class
 --
 --   Per-statement keys (typed Module body):
 --     "stmt/<NNN>"     :: A.Stmt                      -- one typed top-level statement (NNN = padIndex)
@@ -83,6 +93,7 @@ module InterfaceFiles
   , SourceFileMeta(..)
   , TyFile
   , TyHeader
+  , InterfaceDB
   , interfaceExt
   , interfacePath
   , interfaceExists
@@ -102,6 +113,17 @@ module InterfaceFiles
   , readExtensionsByProtocol
   , readFileMaybe
   , readHeaderMaybe
+  , openInterfaceDB
+  , readInterfaceDBModuleInfo
+  , readInterfaceDBNameInfoMaybe
+  , readInterfaceDBPublicNames
+  , readInterfaceDBConstructors
+  , readInterfaceDBActors
+  , readInterfaceDBConAttr
+  , readInterfaceDBProtoAttr
+  , readInterfaceDBDescendants
+  , readInterfaceDBExtByProto
+  , readInterfaceDBExtByType
   , TyDbWriteProgress(..)
   , writeFile
   , writeFileWithProgress
@@ -130,6 +152,8 @@ import Data.Time.Clock (UTCTime)
 import qualified Database.LMDB.Raw as LMDB
 import qualified Acton.Syntax as A
 import qualified Acton.NameInfo as I
+import Acton.Names (isPublicName)
+import Utils (SrcLoc(NoLoc))
 import Foreign.Ptr (castPtr)
 import Foreign.Storable (peek)
 import GHC.Generics (Generic)
@@ -240,6 +264,14 @@ type TyMeta =
   , BS.ByteString
   , BS.ByteString
   )
+
+-- | A handle for selective per-name and per-index lookups in one module's
+-- .tydb: the version is validated once at open, and each lookup runs a short
+-- read transaction on the shared per-path environment.
+newtype InterfaceDB = InterfaceDB FilePath
+
+instance Show InterfaceDB where
+    show (InterfaceDB path) = "InterfaceDB " ++ path
 
 -- Note: tests are stored in the header to support listing without compiling
 --       or executing test binaries.
@@ -365,7 +397,7 @@ encodeStrict = Persist.encode
 key :: String -> BS.ByteString
 key = B.pack
 
-keyVersion, keyMeta, keyImports, keyDeps, keyRoots, keyTests, keyDoc, keyNameCount, keyStmtCount, keyModuleHeader :: BS.ByteString
+keyVersion, keyMeta, keyImports, keyDeps, keyRoots, keyTests, keyDoc, keyNameCount, keyPublicNames, keyConstructors, keyActors, keyStmtCount, keyModuleHeader :: BS.ByteString
 keyVersion      = key "version"
 keyMeta         = key "meta"
 keyImports      = key "imports"
@@ -374,6 +406,9 @@ keyRoots        = key "roots"
 keyTests        = key "tests"
 keyDoc          = key "doc"
 keyNameCount    = key "name-count"
+keyPublicNames  = key "public-names"
+keyConstructors = key "constructors"
+keyActors       = key "actors"
 keyStmtCount    = key "stmt-count"
 keyModuleHeader = key "module-header"
 
@@ -442,6 +477,39 @@ keyExtByProtocol n = B.concat [keyExtByProtocolPrefix, nameKeySuffix n]
 
 keyStmt :: Int -> BS.ByteString
 keyStmt i = B.pack ("stmt/" ++ padIndex i)
+
+keyConAttr :: A.Name -> BS.ByteString
+keyConAttr n = B.concat [key "con-attr/", nameKeySuffix n]
+
+keyProtoAttr :: A.Name -> BS.ByteString
+keyProtoAttr n = B.concat [key "proto-attr/", nameKeySuffix n]
+
+keyDescendants :: A.QName -> BS.ByteString
+keyDescendants qn = B.concat [key "descendants/", qNameKeySuffix qn]
+
+keyExtProto :: A.QName -> BS.ByteString
+keyExtProto qn = B.concat [key "ext-proto/", qNameKeySuffix qn]
+
+keyExtType :: A.QName -> BS.ByteString
+keyExtType qn = B.concat [key "ext-type/", qNameKeySuffix qn]
+
+-- QName keys hash a location-free encoding so the same semantic name always
+-- maps to the same key regardless of where it occurred in the source.
+qNameKeySuffix :: A.QName -> BS.ByteString
+qNameKeySuffix qn = Base16.encode (SHA256.hash (encodeStrict (stripQNameKeyLocs qn)))
+
+stripQNameKeyLocs :: A.QName -> A.QName
+stripQNameKeyLocs (A.QName m n) = A.QName (stripModNameKeyLocs m) (stripNameKeyLocs n)
+stripQNameKeyLocs (A.NoQ n)     = A.NoQ (stripNameKeyLocs n)
+stripQNameKeyLocs (A.GName m n) = A.GName (stripModNameKeyLocs m) (stripNameKeyLocs n)
+
+stripModNameKeyLocs :: A.ModName -> A.ModName
+stripModNameKeyLocs (A.ModName ns) = A.ModName (map stripNameKeyLocs ns)
+
+stripNameKeyLocs :: A.Name -> A.Name
+stripNameKeyLocs (A.Name _ s)     = A.Name NoLoc s
+stripNameKeyLocs (A.Derived n n') = A.Derived (stripNameKeyLocs n) (stripNameKeyLocs n')
+stripNameKeyLocs n@A.Internal{}   = n
 
 withVal :: BS.ByteString -> (LMDB.MDB_val -> IO a) -> IO a
 withVal bs f =
@@ -665,6 +733,14 @@ withWriteTxn path mapSize action =
           LMDB.mdb_txn_commit txn
           return r
 
+openInterfaceDB :: FilePath -> IO InterfaceDB
+openInterfaceDB path = do
+    withReadTxn path validateVersion
+    return (InterfaceDB path)
+
+withInterfaceDBReadTxn :: InterfaceDB -> (LMDB.MDB_txn -> LMDB.MDB_dbi -> IO a) -> IO a
+withInterfaceDBReadTxn (InterfaceDB path) action = withReadTxn path action
+
 -- The raw LMDB binding requires transaction setup from a bound thread; this
 -- applies to reads too because of its Haskell-side lock guard.
 runInLmdbThread :: IO a -> IO a
@@ -826,6 +902,80 @@ readNameInfoEntries txn dbi = do
     forM [0 .. nameCount - 1] $ \i -> do
       suffix <- getValue ("name-order " ++ show i) txn dbi (keyNameOrder i)
       getValue ("name-info " ++ show i) txn dbi (keyNameInfoSuffix suffix)
+
+readNameInfoEntryMaybe :: LMDB.MDB_txn -> LMDB.MDB_dbi -> A.Name -> IO (Maybe (A.Name, I.NameInfo))
+readNameInfoEntryMaybe txn dbi n =
+    getMaybeValue ("name-info " ++ A.nstr n) txn dbi (keyNameInfo n)
+
+readNameInfoEntriesByNames :: LMDB.MDB_txn -> LMDB.MDB_dbi -> [A.Name] -> IO I.TEnv
+readNameInfoEntriesByNames txn dbi ns =
+    forM ns $ \n ->
+      getValue ("name-info " ++ A.nstr n) txn dbi (keyNameInfo n)
+
+readInterfaceDBModuleInfo :: InterfaceDB -> IO ([A.ModName], Maybe String)
+readInterfaceDBModuleInfo db =
+    withInterfaceDBReadTxn db $ \txn dbi -> do
+      (tmn, timps, tdoc) <- getValue "module-header" txn dbi keyModuleHeader
+      doc <- getValue "doc" txn dbi keyDoc
+      return (A.importsOf (A.Module tmn timps tdoc []), doc)
+
+readInterfaceDBNameInfoMaybe :: InterfaceDB -> A.Name -> IO (Maybe (A.Name, I.NameInfo))
+readInterfaceDBNameInfoMaybe db@(InterfaceDB path) n = do
+    mi <- withInterfaceDBReadTxn db $ \txn dbi ->
+            readNameInfoEntryMaybe txn dbi n
+    traceTydbRead (case mi of Just _ -> "name-hit"; Nothing -> "name-miss") path (A.nstr n)
+    return mi
+
+readInterfaceDBPublicNames :: InterfaceDB -> IO [A.Name]
+readInterfaceDBPublicNames db@(InterfaceDB path) = do
+    ns <- withInterfaceDBReadTxn db $ \txn dbi ->
+            getValue "public-names" txn dbi keyPublicNames
+    traceTydbRead "public-names" path (show (length ns))
+    return ns
+
+readInterfaceDBConstructors :: InterfaceDB -> IO I.TEnv
+readInterfaceDBConstructors db@(InterfaceDB path) = do
+    te <- withInterfaceDBReadTxn db $ \txn dbi -> do
+            ns <- getValue "constructors" txn dbi keyConstructors
+            readNameInfoEntriesByNames txn dbi ns
+    traceTydbRead "constructors" path (show (length te))
+    return te
+
+readInterfaceDBActors :: InterfaceDB -> IO I.TEnv
+readInterfaceDBActors db@(InterfaceDB path) = do
+    te <- withInterfaceDBReadTxn db $ \txn dbi -> do
+            ns <- getValue "actors" txn dbi keyActors
+            readNameInfoEntriesByNames txn dbi ns
+    traceTydbRead "actors" path (show (length te))
+    return te
+
+readInterfaceDBConAttr :: InterfaceDB -> A.Name -> IO I.TEnv
+readInterfaceDBConAttr db n =
+    readTEnvIndex db ("con-attr " ++ A.nstr n) (keyConAttr n)
+
+readInterfaceDBProtoAttr :: InterfaceDB -> A.Name -> IO I.TEnv
+readInterfaceDBProtoAttr db n =
+    readTEnvIndex db ("proto-attr " ++ A.nstr n) (keyProtoAttr n)
+
+readInterfaceDBDescendants :: InterfaceDB -> A.QName -> IO I.TEnv
+readInterfaceDBDescendants db qn =
+    readTEnvIndex db ("descendants " ++ show qn) (keyDescendants qn)
+
+readInterfaceDBExtByProto :: InterfaceDB -> A.QName -> IO I.TEnv
+readInterfaceDBExtByProto db qn =
+    readTEnvIndex db ("ext-proto " ++ show qn) (keyExtProto qn)
+
+readInterfaceDBExtByType :: InterfaceDB -> A.QName -> IO I.TEnv
+readInterfaceDBExtByType db qn =
+    readTEnvIndex db ("ext-type " ++ show qn) (keyExtType qn)
+
+readTEnvIndex :: InterfaceDB -> String -> BS.ByteString -> IO I.TEnv
+readTEnvIndex db@(InterfaceDB path) label k = do
+    te <- withInterfaceDBReadTxn db $ \txn dbi -> do
+            ns <- maybe [] id <$> getMaybeValue label txn dbi k
+            readNameInfoEntriesByNames txn dbi ns
+    traceTydbRead "index" path (label ++ " " ++ show (length te))
+    return te
 
 readNameHashEntries :: LMDB.MDB_txn -> LMDB.MDB_dbi -> IO [NameHashInfo]
 readNameHashEntries txn dbi = do
@@ -993,6 +1143,62 @@ depIndexEntries depModules nameHashes =
         | (key', (_pubH, _implH, pubUsers, implUsers)) <- Map.toList depMap
         ]
 
+-- Narrow per-module query indexes, so dependent modules can answer solver and
+-- environment queries (attribute owners, descendants, extensions) without
+-- enumerating the whole public interface.
+data QueryIndexes = QueryIndexes
+  { qiPublicNames :: [A.Name]
+  , qiConstructors :: [A.Name]
+  , qiActors :: [A.Name]
+  , qiConAttrs :: Map.Map A.Name [A.Name]
+  , qiProtoAttrs :: Map.Map A.Name [A.Name]
+  , qiDescendants :: Map.Map A.QName [A.Name]
+  , qiExtProtos :: Map.Map A.QName [A.Name]
+  , qiExtTypes :: Map.Map A.QName [A.Name]
+  }
+
+queryIndexes :: I.NameInfo -> QueryIndexes
+queryIndexes (I.NModule _ te _) = QueryIndexes (map fst pte) cons actors conattrs protoattrs descendants extprotos exttypes
+  where pte                    = filter (isPublicName . fst) te
+        cons                   = [ n | (n, i) <- pte, isCons i ]
+        actors                 = [ n | (n, I.NAct{}) <- pte ]
+        conattrs               = indexMap [ (a, n) | (n, i) <- pte, isCon i, a <- attrs i ]
+        protoattrs             = indexMap [ (a, n) | (n, i@I.NProto{}) <- pte, a <- attrs i ]
+        descendants            = indexMap [ (A.tcname c, n) | (n, i) <- pte, (_, c) <- ancestry i ]
+        extprotos              = indexMap [ (A.tcname p, n) | (n, I.NExt _ _ ps _ _ _) <- pte, (_, p) <- ps ]
+        exttypes               = indexMap [ (A.tcname c, n) | (n, I.NExt _ c _ _ _ _) <- pte ]
+        isCons I.NClass{}      = True
+        isCons I.NProto{}      = True
+        isCons I.NAct{}        = True
+        isCons _               = False
+        isCon I.NClass{}       = True
+        isCon I.NAct{}         = True
+        isCon _                = False
+        attrs (I.NClass _ _ te' _) = map fst te'
+        attrs (I.NProto _ _ te' _) = map fst te'
+        attrs (I.NAct _ _ _ te' _) = map fst te'
+        attrs _                = []
+        ancestry (I.NClass _ us _ _) = us
+        ancestry (I.NProto _ us _ _) = us
+        ancestry _             = []
+queryIndexes _                  = QueryIndexes [] [] [] Map.empty Map.empty Map.empty Map.empty Map.empty
+
+indexMap :: Ord k => [(k, A.Name)] -> Map.Map k [A.Name]
+indexMap xs = Map.fromListWith (++) [ (k, [v]) | (k, v) <- reverse xs ]
+
+queryIndexEntries :: I.NameInfo -> [(BS.ByteString, BS.ByteString)]
+queryIndexEntries nmod =
+    [ (keyPublicNames, encodeStrict (qiPublicNames ix))
+    , (keyConstructors, encodeStrict (qiConstructors ix))
+    , (keyActors, encodeStrict (qiActors ix))
+    ]
+    ++ [ (keyConAttr n, encodeStrict ns) | (n, ns) <- Map.toList (qiConAttrs ix) ]
+    ++ [ (keyProtoAttr n, encodeStrict ns) | (n, ns) <- Map.toList (qiProtoAttrs ix) ]
+    ++ [ (keyDescendants qn, encodeStrict ns) | (qn, ns) <- Map.toList (qiDescendants ix) ]
+    ++ [ (keyExtProto qn, encodeStrict ns) | (qn, ns) <- Map.toList (qiExtProtos ix) ]
+    ++ [ (keyExtType qn, encodeStrict ns) | (qn, ns) <- Map.toList (qiExtTypes ix) ]
+  where ix = queryIndexes nmod
+
 interfaceEntries :: (String -> Double -> IO ()) -> [Int] -> BS.ByteString -> BS.ByteString -> BS.ByteString -> Maybe SourceFileMeta -> [(A.ModName, BS.ByteString)] -> [DepModuleInfo] -> [NameHashInfo] -> [A.Name] -> [String] -> Maybe String -> I.NameInfo -> A.Module -> IO [(BS.ByteString, BS.ByteString)]
 interfaceEntries onProgress version moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta imps depModules nameHashes roots tests mdoc nmod tchecked = do
     caps <- getNumCapabilities
@@ -1010,7 +1216,7 @@ interfaceEntries onProgress version moduleSrcBytesHash modulePubHash moduleImplH
         nameChunks = entryChunks caps (zip [0..] te)
         nameHashChunks = entryChunks caps nameHashes
         stmtChunks = entryChunks caps (zip [0..] body)
-        totalPrep = 3 + length nameChunks + length nameHashChunks + length stmtChunks
+        totalPrep = 4 + length nameChunks + length nameHashChunks + length stmtChunks
     prepDone <- newIORef (0 :: Int)
     let mark label = do
           done <- atomicModifyIORef' prepDone $ \n ->
@@ -1021,12 +1227,14 @@ interfaceEntries onProgress version moduleSrcBytesHash modulePubHash moduleImplH
     mark "Preparing .tydb header"
     depEntries <- forceEntries (depIndexEntries depModules nameHashes)
     mark "Preparing .tydb deps"
+    queryEntries <- forceEntries (queryIndexEntries nmod)
+    mark "Preparing .tydb query indexes"
     nameEntries <- parallelEntries mark "Preparing .tydb names" nameInfoEntries nameChunks
     nameHashEntries <- parallelEntries mark "Preparing .tydb hashes" nameHashEntry nameHashChunks
     extEntries <- forceEntries (extensionIndexEntries (extensionIndexFromNameInfo tmn nmod))
     mark "Preparing .tydb extensions"
     stmtEntries <- parallelEntries mark "Preparing .tydb statements" stmtEntry stmtChunks
-    return (headerEntries ++ depEntries ++ nameEntries ++ nameHashEntries ++ extEntries ++ stmtEntries)
+    return (headerEntries ++ depEntries ++ queryEntries ++ nameEntries ++ nameHashEntries ++ extEntries ++ stmtEntries)
   where
     I.NModule _ te _ = nmod
     A.Module tmn timps tdoc body = tchecked

--- a/compiler/lib/src/InterfaceFiles.hs
+++ b/compiler/lib/src/InterfaceFiles.hs
@@ -113,7 +113,7 @@ import Control.DeepSeq (NFData, rnf)
 import qualified Control.Exception as E
 import Control.Concurrent (getNumCapabilities, runInBoundThread, threadDelay)
 import Control.Concurrent.Async (mapConcurrently)
-import Control.Concurrent.MVar (MVar, modifyMVar, newMVar, withMVar)
+import Control.Concurrent.MVar (MVar, modifyMVar, modifyMVar_, newMVar, withMVar)
 import Control.Monad (forM, forM_, unless, when)
 import Data.IORef (atomicModifyIORef', newIORef)
 import qualified Crypto.Hash.SHA256 as SHA256
@@ -139,7 +139,7 @@ import System.FilePath ((</>), takeExtension)
 import System.IO (hPutStrLn, stderr)
 import System.IO.Error (isDoesNotExistError)
 import System.IO.Unsafe (unsafePerformIO)
-import System.Posix.Files (fileAccess, getFileStatus, modificationTimeHiRes, setFileMode)
+import System.Posix.Files (deviceID, fileAccess, fileID, getFileStatus, modificationTimeHiRes, setFileMode)
 
 data NameHashInfo = NameHashInfo
   { nhName     :: A.Name
@@ -261,11 +261,37 @@ lmdbOpenLock :: MVar ()
 {-# NOINLINE lmdbOpenLock #-}
 lmdbOpenLock = unsafePerformIO (newMVar ())
 
--- LMDB does not support opening the same environment twice in one process, so
--- keep one in-process lock per .tydb path while an environment handle is open.
+-- LMDB does not support opening the same environment twice in one process.
+-- Exclusive users (writers, env copies) serialize on a per-path lock and own
+-- the only environment while they run. Readers share one cached read-only
+-- environment per path, tracked in sharedEnvs with an active-reader count;
+-- exclusive users retire the cached environment and wait for its readers to
+-- drain before opening their own, so the process never holds two
+-- environments for one path.
 interfaceLocks :: MVar (Map.Map FilePath (MVar ()))
 {-# NOINLINE interfaceLocks #-}
 interfaceLocks = unsafePerformIO (newMVar Map.empty)
+
+data SharedEnv = SharedEnv
+  { seEnv :: LMDB.MDB_env
+  , seIdent :: Maybe (Integer, Integer)
+  , seReaders :: Int
+  , seRetiring :: Bool
+  }
+
+data SharedEnvClaim = Claimed SharedEnv | Retiring | Absent
+
+-- Identify the data file behind a path, so a cached environment whose file
+-- was removed and recreated (a new inode) is not mistaken for current.
+envFileIdent :: FilePath -> IO (Maybe (Integer, Integer))
+envFileIdent path =
+    (do st <- getFileStatus (dataFilePath path)
+        return (Just (fromIntegral (deviceID st), fromIntegral (fileID st))))
+      `E.catch` \e -> if isDoesNotExistError e then return Nothing else E.throwIO e
+
+sharedEnvs :: MVar (Map.Map FilePath SharedEnv)
+{-# NOINLINE sharedEnvs #-}
+sharedEnvs = unsafePerformIO (newMVar Map.empty)
 
 traceTydbReads :: Bool
 traceTydbReads =
@@ -427,11 +453,16 @@ copyVal (LMDB.MDB_val len ptr) =
     BS.packCStringLen (castPtr ptr, fromIntegral len)
 
 withEnv :: FilePath -> Bool -> Int -> (LMDB.MDB_env -> IO a) -> IO a
-withEnv path readOnly mapSize action =
-    withInterfaceLock path $
-      E.bracket open LMDB.mdb_env_close action
+withEnv path readOnly mapSize action = do
+    cpath <- canonicalizePath path
+    withInterfaceLockC cpath $ do
+      evictSharedEnv cpath
+      E.bracket (openEnvWithRetry path readOnly mapSize) LMDB.mdb_env_close action
+
+openEnvWithRetry :: FilePath -> Bool -> Int -> IO LMDB.MDB_env
+openEnvWithRetry path readOnly mapSize =
+    withMVar lmdbOpenLock $ \_ -> openWithRetry lmdbTransientMaxAttempts
   where
-    open = withMVar lmdbOpenLock $ \_ -> openWithRetry lmdbTransientMaxAttempts
     -- Concurrent opens of the same env race on lock.mdb setup, which surfaces as
     -- a transient OS-level mdb_env_open failure (e.g. ENOENT) that resolves on
     -- retry. LMDB-semantic failures (corruption, version mismatch) are not
@@ -504,6 +535,10 @@ lmdbTransientRetryDelayUs = 20000
 withInterfaceLock :: FilePath -> IO a -> IO a
 withInterfaceLock path action = do
     cpath <- canonicalizePath path
+    withInterfaceLockC cpath action
+
+withInterfaceLockC :: FilePath -> IO a -> IO a
+withInterfaceLockC cpath action = do
     lock <- modifyMVar interfaceLocks $ \locks ->
       case Map.lookup cpath locks of
         Just lock -> return (locks, lock)
@@ -512,25 +547,113 @@ withInterfaceLock path action = do
           return (Map.insert cpath lock locks, lock)
     withMVar lock $ \_ -> action
 
+-- Claim the shared read environment for a path, opening it on first use. The
+-- open runs under the per-path lock so it cannot race an exclusive user; a
+-- retiring entry is waited out, since its last reader closes it.
+acquireSharedEnv :: FilePath -> FilePath -> IO LMDB.MDB_env
+acquireSharedEnv cpath path = do
+    ident <- envFileIdent path
+    claim <- claimSharedEnv cpath
+    case claim of
+      Claimed se
+        | seIdent se == ident -> return (seEnv se)
+        | otherwise -> do
+            -- The file behind the cached environment was replaced.
+            retireSharedEnv cpath
+            releaseSharedEnv cpath
+            acquireSharedEnv cpath path
+      Retiring -> threadDelay lmdbTransientRetryDelayUs >> acquireSharedEnv cpath path
+      Absent -> do
+        mopened <- withInterfaceLockC cpath $ do
+          claim' <- claimSharedEnv cpath
+          case claim' of
+            Claimed se -> return (Just (seEnv se))
+            Retiring -> return Nothing
+            Absent -> do
+              -- The binding adds MDB_NOTLS implicitly, so reader slots follow
+              -- transactions rather than the transient bound threads they run
+              -- on.
+              mapSize <- readMapSize path
+              env <- openEnvWithRetry path True mapSize
+              ident' <- envFileIdent path
+              modifyMVar_ sharedEnvs (return . Map.insert cpath (SharedEnv env ident' 1 False))
+              return (Just env)
+        case mopened of
+          Just env -> return env
+          Nothing -> threadDelay lmdbTransientRetryDelayUs >> acquireSharedEnv cpath path
+
+claimSharedEnv :: FilePath -> IO SharedEnvClaim
+claimSharedEnv cpath =
+    modifyMVar sharedEnvs $ \envs ->
+      case Map.lookup cpath envs of
+        Just se | not (seRetiring se) ->
+          return (Map.insert cpath se{ seReaders = seReaders se + 1 } envs, Claimed se)
+        Just _ -> return (envs, Retiring)
+        Nothing -> return (envs, Absent)
+
+releaseSharedEnv :: FilePath -> IO ()
+releaseSharedEnv cpath = do
+    mclose <- modifyMVar sharedEnvs $ \envs ->
+      case Map.lookup cpath envs of
+        Just se
+          | seReaders se <= 1 && seRetiring se -> return (Map.delete cpath envs, Just (seEnv se))
+          | otherwise -> return (Map.insert cpath se{ seReaders = seReaders se - 1 } envs, Nothing)
+        Nothing -> return (envs, Nothing)
+    mapM_ LMDB.mdb_env_close mclose
+
+-- Mark the shared environment stale (e.g. the map was grown by another
+-- process); the last reader closes it and the next acquire reopens.
+retireSharedEnv :: FilePath -> IO ()
+retireSharedEnv cpath = do
+    mclose <- modifyMVar sharedEnvs $ \envs ->
+      case Map.lookup cpath envs of
+        Just se
+          | seReaders se <= 0 -> return (Map.delete cpath envs, Just (seEnv se))
+          | otherwise -> return (Map.insert cpath se{ seRetiring = True } envs, Nothing)
+        Nothing -> return (envs, Nothing)
+    mapM_ LMDB.mdb_env_close mclose
+
+-- Exclusive users call this under the per-path lock: retire the shared
+-- environment and wait until its active readers have drained and closed it.
+evictSharedEnv :: FilePath -> IO ()
+evictSharedEnv cpath = do
+    retireSharedEnv cpath
+    waitGone
+  where
+    waitGone = do
+      gone <- withMVar sharedEnvs (return . Map.notMember cpath)
+      unless gone (threadDelay lmdbTransientRetryDelayUs >> waitGone)
+
 withReadTxn :: FilePath -> (LMDB.MDB_txn -> LMDB.MDB_dbi -> IO a) -> IO a
 withReadTxn path action = do
-    mapSize <- readMapSize path
-    -- mdb_txn_begin can still hit a transient lock-table OS error after a
-    -- successful env open, so retry the read transaction with a fresh env.
-    runInLmdbThread $ readTxnWithRetry lmdbTransientMaxAttempts mapSize
+    cpath <- canonicalizePath path
+    -- mdb_txn_begin can hit a transient lock-table OS error, and another
+    -- process may have grown the map since the shared environment was opened;
+    -- both retire the cached environment and retry with a fresh one.
+    runInLmdbThread $ readTxnWithRetry lmdbTransientMaxAttempts cpath
   where
-    readTxnWithRetry attempt mapSize = do
-      res <- withEnv path True mapSize $ \env ->
-        E.try $
-          E.bracket (LMDB.mdb_txn_begin env Nothing True) LMDB.mdb_txn_abort $ \txn -> do
-            dbi <- LMDB.mdb_dbi_open txn Nothing []
-            action txn dbi
+    readTxnWithRetry attempt cpath = do
+      env <- acquireSharedEnv cpath path
+      res <- (E.try $
+               E.bracket (LMDB.mdb_txn_begin env Nothing True) LMDB.mdb_txn_abort $ \txn -> do
+                 dbi <- LMDB.mdb_dbi_open txn Nothing []
+                 action txn dbi)
+             `E.onException` releaseSharedEnv cpath
       case res of
-        Right x -> return x
+        Right x -> releaseSharedEnv cpath >> return x
         Left (err :: LMDB.LMDB_Error)
-          | attempt > 1 && isTransientLmdbOsError err ->
-              threadDelay lmdbTransientRetryDelayUs >> readTxnWithRetry (attempt - 1) mapSize
-          | otherwise -> E.throwIO err
+          | attempt > 1 && (isTransientLmdbOsError err || isMapResized err) -> do
+              retireSharedEnv cpath
+              releaseSharedEnv cpath
+              threadDelay lmdbTransientRetryDelayUs
+              readTxnWithRetry (attempt - 1) cpath
+          | otherwise -> releaseSharedEnv cpath >> E.throwIO err
+
+isMapResized :: LMDB.LMDB_Error -> Bool
+isMapResized err =
+    case LMDB.e_code err of
+      Right LMDB.MDB_MAP_RESIZED -> True
+      _ -> False
 
 withWriteTxn :: FilePath -> Int -> (LMDB.MDB_txn -> LMDB.MDB_dbi -> IO a) -> IO a
 withWriteTxn path mapSize action =

--- a/compiler/lib/src/InterfaceFiles.hs
+++ b/compiler/lib/src/InterfaceFiles.hs
@@ -93,6 +93,7 @@ module InterfaceFiles
   , SourceFileMeta(..)
   , TyFile
   , TyHeader
+  , TyHeaderSummary
   , InterfaceDB
   , interfaceExt
   , interfacePath
@@ -109,10 +110,13 @@ module InterfaceFiles
   , readModuleHashesMaybe
   , readFile
   , readHeader
+  , readHeaderSummary
+  , readRoots
   , readExtensionsByClass
   , readExtensionsByProtocol
   , readFileMaybe
   , readHeaderMaybe
+  , readHeaderSummaryMaybe
   , openInterfaceDB
   , openInterfaceDBMaybe
   , readInterfaceDBModuleInfo
@@ -254,6 +258,19 @@ type TyHeader =
   , [(A.ModName, BS.ByteString)]
   , [DepModuleInfo]
   , [NameHashInfo]
+  , [A.Name]
+  , [String]
+  , Maybe String
+  )
+
+type TyHeaderSummary =
+  ( Maybe SourceFileMeta
+  , BS.ByteString
+  , BS.ByteString
+  , BS.ByteString
+  , [(A.ModName, BS.ByteString)]
+  , [DepModuleInfo]
+  , Int
   , [A.Name]
   , [String]
   , Maybe String
@@ -1308,6 +1325,27 @@ readHeader f =
       traceTydbRead "name-hash-all" f (show (length nameHashes))
       return (sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash, imps, depModules, nameHashes, roots, tests, doc)
 
+-- Like readHeader, but reads the stored name count instead of decoding every
+-- per-name hash row, so cache checks stay independent of module size.
+readHeaderSummary :: FilePath -> IO TyHeaderSummary
+readHeaderSummary f =
+    withReadTxn f $ \txn dbi -> do
+      (sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash) <- readMeta txn dbi
+      imps <- getValue "imports" txn dbi keyImports
+      depModules <- getValue "deps" txn dbi keyDeps
+      roots <- getValue "roots" txn dbi keyRoots
+      tests <- getValue "tests" txn dbi keyTests
+      doc <- getValue "doc" txn dbi keyDoc
+      nameCount <- getValue "name-count" txn dbi keyNameCount
+      traceTydbRead "header" f "cached"
+      return (sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash, imps, depModules, nameCount, roots, tests, doc)
+
+readRoots :: FilePath -> IO [A.Name]
+readRoots f =
+    withReadTxn f $ \txn dbi -> do
+      validateVersion txn dbi
+      getValue "roots" txn dbi keyRoots
+
 readDepNames :: FilePath -> A.ModName -> IO [DepNameInfo]
 readDepNames f mn =
     withReadTxn f $ \txn dbi -> do
@@ -1367,6 +1405,9 @@ readFileMaybe = readTyMaybe readFile
 
 readHeaderMaybe :: FilePath -> IO (Maybe TyHeader)
 readHeaderMaybe = readTyMaybe readHeader
+
+readHeaderSummaryMaybe :: FilePath -> IO (Maybe TyHeaderSummary)
+readHeaderSummaryMaybe = readTyMaybe readHeaderSummary
 
 readTyMaybe :: (FilePath -> IO a) -> FilePath -> IO (Maybe a)
 readTyMaybe readTy f = (Just <$> readTy f) `E.catch` tyCacheMiss

--- a/compiler/lib/src/InterfaceFiles.hs
+++ b/compiler/lib/src/InterfaceFiles.hs
@@ -114,6 +114,7 @@ module InterfaceFiles
   , readFileMaybe
   , readHeaderMaybe
   , openInterfaceDB
+  , openInterfaceDBMaybe
   , readInterfaceDBModuleInfo
   , readInterfaceDBNameInfoMaybe
   , readInterfaceDBPublicNames
@@ -737,6 +738,11 @@ openInterfaceDB :: FilePath -> IO InterfaceDB
 openInterfaceDB path = do
     withReadTxn path validateVersion
     return (InterfaceDB path)
+
+-- | Like openInterfaceDB, but treats a missing, corrupt, or version-mismatched
+-- cache as a miss, mirroring readFileMaybe.
+openInterfaceDBMaybe :: FilePath -> IO (Maybe InterfaceDB)
+openInterfaceDBMaybe = readTyMaybe openInterfaceDB
 
 withInterfaceDBReadTxn :: InterfaceDB -> (LMDB.MDB_txn -> LMDB.MDB_dbi -> IO a) -> IO a
 withInterfaceDBReadTxn (InterfaceDB path) action = withReadTxn path action

--- a/compiler/lib/src/InterfaceFiles.hs
+++ b/compiler/lib/src/InterfaceFiles.hs
@@ -151,6 +151,7 @@ import qualified Data.List
 import Data.List (foldl')
 import qualified Data.Map.Strict as Map
 import qualified Data.Persist as Persist
+import qualified Data.Set as Set
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import Data.Time.Clock (UTCTime)
@@ -1128,12 +1129,12 @@ depIndexEntries depModules nameHashes =
       where
         addToEntry Nothing =
           if isPub
-            then (Just h, Nothing, [owner], [])
-            else (Nothing, Just h, [], [owner])
+            then (Just h, Nothing, Set.singleton owner, Set.empty)
+            else (Nothing, Just h, Set.empty, Set.singleton owner)
         addToEntry (Just (pubH, implH, pubUsers, implUsers)) =
           if isPub
-            then (Just h, implH, owner : pubUsers, implUsers)
-            else (pubH, Just h, pubUsers, owner : implUsers)
+            then (Just h, implH, Set.insert owner pubUsers, implUsers)
+            else (pubH, Just h, pubUsers, Set.insert owner implUsers)
 
     depMap =
       foldl' addInfo Map.empty nameHashes
@@ -1158,7 +1159,7 @@ depIndexEntries depModules nameHashes =
             ]
       ]
 
-    cleanNames = Data.List.sortOn nameKey . Data.List.nub
+    cleanNames = Data.List.sortOn nameKey . Set.toList
 
     userRows =
       sortUserRows

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -54,6 +54,7 @@ import System.FilePath ((</>), joinPath, takeFileName, takeBaseName, takeDirecto
 import System.Directory (createDirectoryIfMissing, getCurrentDirectory, setCurrentDirectory, listDirectory, doesDirectoryExist, doesFileExist)
 import System.Posix.Files (setFileMode)
 import System.IO.Temp (withSystemTempDirectory)
+import qualified System.IO.Unsafe
 import System.Timeout (timeout)
 import Control.Monad (forM_, when, foldM)
 import qualified Control.Exception as E
@@ -855,8 +856,8 @@ main = do
             mdoc
             nmod
             tmod
-          (_env2, te) <- Acton.Env.doImp [dir] env1 directMod
-          map fst te `shouldBe` [valueName]
+          (_env2, mi) <- Acton.Env.doImp [dir] env1 directMod
+          map fst (Acton.Env.modulePublicTEnv mi) `shouldBe` [valueName]
 
     describe "Pass 1: Parser" $ do
 
@@ -1821,6 +1822,54 @@ main = do
           Right _ -> expectationFailure "Expected multiple type errors but type checking succeeded"
 
     describe "Import Semantics" $ do
+      it "selected imports only look up requested names" $ do
+        lookedUp <- newIORef []
+        let wanted = S.name "wanted"
+            unused = S.name "unused"
+            m = S.modName ["lazy_import"]
+            mi = Acton.Env.ModuleInfo {
+                    Acton.Env.moduleImports = [],
+                    Acton.Env.moduleDoc = Nothing,
+                    Acton.Env.moduleLookupHName = \n -> System.IO.Unsafe.unsafePerformIO $ do
+                      modifyIORef' lookedUp (++ [S.nstr n])
+                      if n == wanted
+                        then return (Just (I.HNVar S.tWild))
+                        else error ("unexpected import lookup: " ++ S.nstr n),
+                    Acton.Env.modulePublicNames = [unused, wanted],
+                    Acton.Env.moduleConstructors = [],
+                    Acton.Env.moduleActors = [],
+                    Acton.Env.moduleConAttr = const [],
+                    Acton.Env.moduleProtoAttr = const [],
+                    Acton.Env.moduleDescendants = const [],
+                    Acton.Env.moduleProtoDescendants = const [],
+                    Acton.Env.moduleWitnessesByProto = const [],
+                    Acton.Env.moduleWitnessesByType = const []
+                  }
+            env = Acton.Env.importSome [S.ImportItem wanted Nothing] m mi env0
+
+        case Acton.Env.lookupName wanted env of
+          Just (I.HNAlias qn) -> qn `shouldBe` S.GName m wanted
+          other -> expectationFailure $ "Expected selected import alias, got " ++ show other
+        readIORef lookedUp `shouldReturn` ["wanted"]
+
+      it "rejects selected imports of private names" $ do
+        (envA, parsedA) <- parseAct env0 "import_private_a"
+        kcheckedA <- liftIO $ Acton.Kinds.check envA parsedA
+        (nmodA, _, _, _) <- liftIO $ Acton.Types.reconstruct Nothing Nothing envA kcheckedA
+        let I.NModule impsA tenvA mdocA = nmodA
+            env1 = Acton.Env.addMod (S.modname parsedA) impsA tenvA mdocA env0
+
+        result <- liftIO $ (E.try (do
+          (envB, _) <- parseAct env1 "import_private_selected"
+          _ <- E.evaluate (Acton.Env.lookupName (S.name "__foo") envB)
+          pure ()
+          ) :: IO (Either CompilationError ()))
+
+        case result of
+          Left NoItem{} -> pure ()
+          Left err -> expectationFailure $ "Expected NoItem error, got " ++ show err
+          Right _ -> expectationFailure "Expected selected private import to fail"
+
       it "omits private names from the public interface" $ do
         (envA, parsedA) <- parseAct env0 "import_private_a"
         kcheckedA <- liftIO $ Acton.Kinds.check envA parsedA

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -208,6 +208,67 @@ main = do
           testsH `shouldBe` tests
           docH `shouldBe` Just "module docs"
 
+      it "reads module query indexes independently" $ do
+        withSystemTempDirectory "acton-iface-indexes" $ \dir -> do
+          let mn = S.modName ["iface_indexes"]
+              tyPath = dir </> "iface_indexes.tydb"
+              clsName = S.name "Cls"
+              parentName = S.name "Parent"
+              childName = S.name "Child"
+              actorName = S.name "Worker"
+              protoName = S.name "Proto"
+              subProtoName = S.name "SubProto"
+              extName = S.name "Ext"
+              classAttr = S.name "class_attr"
+              actorAttr = S.name "actor_attr"
+              protoAttr = S.name "proto_attr"
+              clsTC = S.TC (S.NoQ clsName) []
+              parentTC = S.TC (S.NoQ parentName) []
+              protoTC = S.TC (S.NoQ protoName) []
+              iface =
+                [ (clsName, I.NClass [] [] [(classAttr, I.NVar S.tWild)] Nothing)
+                , (parentName, I.NClass [] [] [] Nothing)
+                , (childName, I.NClass [] [([], parentTC)] [] Nothing)
+                , (actorName, I.NAct [] S.posNil S.kwdNil [(actorAttr, I.NVar S.tWild)] Nothing)
+                , (protoName, I.NProto [] [] [(protoAttr, I.NVar S.tWild)] Nothing)
+                , (subProtoName, I.NProto [] [([], protoTC)] [] Nothing)
+                , (extName, I.NExt [] clsTC [([], protoTC)] [] [] Nothing)
+                ]
+              nmod = I.NModule [] iface Nothing
+              tmod = S.Module mn [] Nothing []
+              names = sort . map fst
+          InterfaceFiles.writeFile tyPath "src" "pub" "impl" Nothing [] [] [] [] [] Nothing nmod tmod
+          db <- InterfaceFiles.openInterfaceDB tyPath
+          (do InterfaceFiles.readInterfaceDBNameInfoMaybe db clsName `shouldReturn` Just (clsName, I.NClass [] [] [(classAttr, I.NVar S.tWild)] Nothing)
+              InterfaceFiles.readInterfaceDBNameInfoMaybe db (S.name "missing") `shouldReturn` Nothing
+              InterfaceFiles.readInterfaceDBPublicNames db `shouldReturn` map fst iface
+              names <$> InterfaceFiles.readInterfaceDBConstructors db `shouldReturn` sort [actorName, childName, clsName, parentName, protoName, subProtoName]
+              names <$> InterfaceFiles.readInterfaceDBActors db `shouldReturn` [actorName]
+              names <$> InterfaceFiles.readInterfaceDBConAttr db classAttr `shouldReturn` [clsName]
+              names <$> InterfaceFiles.readInterfaceDBConAttr db actorAttr `shouldReturn` [actorName]
+              names <$> InterfaceFiles.readInterfaceDBProtoAttr db protoAttr `shouldReturn` [protoName]
+              names <$> InterfaceFiles.readInterfaceDBDescendants db (S.NoQ parentName) `shouldReturn` [childName]
+              names <$> InterfaceFiles.readInterfaceDBDescendants db (S.NoQ protoName) `shouldReturn` [subProtoName]
+              names <$> InterfaceFiles.readInterfaceDBExtByProto db (S.NoQ protoName) `shouldReturn` [extName]
+              names <$> InterfaceFiles.readInterfaceDBExtByType db (S.NoQ clsName) `shouldReturn` [extName]
+              fst <$> InterfaceFiles.readInterfaceDBModuleInfo db `shouldReturn` [])
+
+      it "serves fresh data through a handle across rewrites" $ do
+        withSystemTempDirectory "acton-iface-rewrite" $ \dir -> do
+          let mn = S.modName ["iface_rewrite"]
+              tyPath = dir </> "iface_rewrite.tydb"
+              vName = S.name "v"
+              wName = S.name "w"
+              write iface = InterfaceFiles.writeFile tyPath "src" "pub" "impl" Nothing [] [] [] [] [] Nothing (I.NModule [] iface Nothing) (S.Module mn [] Nothing [])
+          write [(vName, I.NVar S.tWild)]
+          db <- InterfaceFiles.openInterfaceDB tyPath
+          fmap fst <$> InterfaceFiles.readInterfaceDBNameInfoMaybe db vName `shouldReturn` Just vName
+          -- Rewriting the same path retires the shared environment; reads
+          -- through the existing handle must observe the new contents.
+          write [(wName, I.NVar S.tWild)]
+          InterfaceFiles.readInterfaceDBNameInfoMaybe db vName `shouldReturn` Nothing
+          fmap fst <$> InterfaceFiles.readInterfaceDBNameInfoMaybe db wName `shouldReturn` Just wName
+
       it "supports concurrent read-only access to one interface" $ do
         withSystemTempDirectory "acton-iface-concurrent" $ \dir -> do
           let mn = S.modName ["iface"]

--- a/compiler/lib/test/src/import_private_selected.act
+++ b/compiler/lib/test/src/import_private_selected.act
@@ -1,0 +1,4 @@
+from import_private_a import __foo
+
+actor main(env):
+    print(__foo)

--- a/docs/acton-dev-guide/src/compiler/imports_and_envs.md
+++ b/docs/acton-dev-guide/src/compiler/imports_and_envs.md
@@ -32,14 +32,19 @@ finished modules. In `Acton.Compile.compileTasks`, each completed module extends
 that snapshot with:
 
 ```haskell
-Acton.Env.addMod (tkMod keyDone) (frImps fr) (frIfaceTE fr) (frDoc fr) envAcc
+Acton.Env.addModuleInfo (tkMod keyDone) (frontResultModuleInfo (tkMod keyDone) fr) envAcc
 ```
 
-This shared cache stores loaded module interfaces in `modules` as
-`NModule imps te doc`: the module's recorded imports, public interface, and
-optional docstring. It does not store the current module's local names, and it
-should not be thought of as "the current type-checker env". It is a shared cache
-of interfaces that later tasks start from.
+This shared cache stores loaded module interfaces in
+`modules :: Map ModName ModuleInfo`. It does not store the current module's
+local names, and it should not be thought of as "the current type-checker env".
+It is a shared cache of interfaces that later tasks start from.
+
+`ModuleInfo` is the only Env-side representation of dependency modules. A local
+module backs it with an in-memory `TEnv`; an imported module backs it with a
+read-only `.tydb` handle plus compact metadata. Normal compiler code should ask
+`ModuleInfo` for specific names or specific indexes, not for a whole imported
+`TEnv`.
 
 ### Current-module import overlay
 
@@ -80,32 +85,31 @@ available later through `Acton.Env`.
 
 ## When `.tydb` headers are read
 
-The compiler reads `.tydb` data in two different modes.
+The compiler reads `.tydb` data in three different modes.
 
 ### Header-only reads
 
-Header reads are used for cheap decisions:
+Header summary reads are used for cheap decisions:
 
 - module freshness
 - direct import names for graph construction
-- module public and implementation hashes
-- per-name dependency hash snapshots
+- module public and implementation hashes and the stored name count
 - roots, tests, and docstrings
 
 This is the path used by `readModuleTask` and the various cache lookups in
-`Acton.Compile`. It is also the first DBP path: deferred jobs read the header
-to collect per-name dependency edges, root actor seeds, and enough metadata to
-decide whether the selected generated code is already up to date.
+`Acton.Compile`. Per-name dependency hashes are no longer part of the header
+read; stale checks and DBP selection read exact `name-hash` rows on demand.
 
 ### Full `.tydb` reads
 
-Full reads are used when the compiler needs actual interface contents or the
-typed module:
+Full reads are used when the compiler needs the full typed payload, not for
+normal imported-name lookup:
 
-- reusing an interface from a fresh cached module
 - implementation-hash refresh
 - codegen refresh
 - DBP back-pass execution after the selected codegen hash is stale
+- tools that intentionally inspect a whole interface
+- completion fallback when the normal import environment cannot be restored
 
 Reading a full `.tydb` does not by itself reconstruct the import closure in the
 active environment. It only gives the caller the stored interface and typed
@@ -118,6 +122,38 @@ DBP later uses that map to prune a provider's typed module. That does not make
 the selected provider names available to the active type-checker environment;
 imports still become type-checker bindings only through `mkEnv`/`doImp`.
 
+### Selective interface reads
+
+Normal imported-module lookup uses selective reads. `doImp` opens the imported
+module's `.tydb` with `InterfaceFiles.openInterfaceDB`, reads only imports and
+docstring, then installs a `ModuleInfo` shell in `modules`.
+
+The shell has a pure-looking lookup function. `tryQName`, selected imports, and
+generated-name lookup call that function with one `Name`; the implementation
+runs `readInterfaceDBNameInfoMaybe` for that name and memoizes the result.
+Read/decode failure aborts the compilation like any other corrupt interface
+cache error.
+
+Passes that rewrite imported names do not materialize the module either. They
+wrap `moduleLookupHName` with their conversion function (`convertModules`), so
+Normalizer, Converter, Deactorizer, CPS, and LambdaLifter convert only names
+that are actually demanded. Generated names map back to their source name
+before lookup when necessary.
+
+Solver queries go through narrow per-module indexes: attribute owners,
+descendants, and extension witnesses keyed by protocol or by type. The
+attribute indexes record attributes where they are declared; `allConAttr` and
+`allPConAttr` complete inherited owners with the descendants of each declaring
+constructor, which preserves the ancestry-aware semantics of the old full
+scan. All transitive imports are consulted with keyed reads, so query cost is
+proportional to the number of imported modules, never to their size.
+
+Broad enumeration stays explicit. `from module import *` walks
+`modulePublicNames` and forces one lookup per importable public name.
+Completion, documentation, and debug paths may also choose broad reads, but
+those paths are separate from normal qualified-name and selected-import
+lookup.
+
 ## How transitive imports become available
 
 The transitive import closure is reconstructed through `Acton.Env.mkEnv`,
@@ -128,23 +164,22 @@ When a module imports another module:
 1. `mkEnv` walks the AST import list
 2. `impModule` delegates to `doImp`
 3. `doImp` first checks whether the imported module is already in `modules`
-4. if it is loaded, `doImp` follows the in-memory `NModule` import list
-5. otherwise, `doImp` reads the imported module's `.tydb` and follows its stored
-   imports
-6. only then does it return the imported module interface
+4. if it is loaded, `doImp` follows the recorded `moduleImports` list
+5. otherwise, `doImp` opens the imported module's `.tydb`, reads its import
+   metadata, and follows the stored imports
+6. only then does it return the imported module interface shell
 
 This is the mechanism that turns a direct import into a transitive environment
 closure suitable for kinds and type checking.
 
 An important invariant is that a cached direct module must still restore its own
-recorded imports. When the module is already present in the shared scheduler
-env, that closure is in memory: `lookupModule` returns the `NModule` import list
-alongside the public interface. `doImp` should use that in-memory list and avoid
-opening `.tydb` for modules compiled earlier in the same build process.
+recorded imports. `ModuleInfo` stores the imported module's import list, so a
+module already present in `modules` can restore its transitive imports without
+any `.tydb` read.
 
 When the module is not present in `modules`, `doImp` falls back to the `.tydb`
-cache on the search path, reads the stored interface, recursively materializes
-its imports, and then adds the module to the shared cache.
+cache on the search path, opens the module metadata, recursively materializes
+its imports, and then adds the module shell to the shared cache.
 
 The boundary is important: `.tydb` is a persistent cache and cross-process
 interface artifact, not an IPC mechanism between front stages in one compiler
@@ -171,9 +206,9 @@ When debugging import failures, it helps to ask which layer is failing:
   Then look at `mkEnv` and `doImp`.
 - Is a cached module present but its transitives missing? Then the issue is in
   environment materialization, not scheduler ordering.
-- Is a full `.tydb` being read but imports still not appearing? Then check
-  whether the caller is only decoding interface payload rather than invoking the
-  import loader.
+- Is a full `.tydb` being read during normal import lookup? Then look for a
+  caller that asks for broad enumeration instead of `tryQName` or
+  `moduleLookupName`.
 
 ## Related pages
 

--- a/docs/acton-dev-guide/src/compiler/interface_caches.md
+++ b/docs/acton-dev-guide/src/compiler/interface_caches.md
@@ -11,23 +11,34 @@ The compiler code should not construct these paths directly. Use the
 
 ## Compatibility Boundary
 
-`InterfaceFiles` deliberately preserves the old interface-cache API:
+`InterfaceFiles` preserves the full-cache API and also exposes a selective
+read API for imported-module lookup:
 
 - `writeFile` writes the cache for one module.
-- `readHeader` reads only metadata, imports, roots, tests, docstring, and
-  per-name hash records.
+- `readHeaderSummary` reads metadata, imports, the stored name count, roots,
+  tests, and docstring; `readHeader` additionally decodes every per-name hash
+  record.
 - `readExtensionsByClass` and `readExtensionsByProtocol` read exact extension
   index entries without decoding `NameInfo` entries or typed
   statements.
 - `readFile` reconstructs the full cached payload: imports, `NameInfo`, typed
   module, metadata, module hashes, per-name hashes, roots, tests, and docstring.
-- `readHeaderMaybe` and `readFileMaybe` turn missing, corrupt, unreadable, or
-  version-mismatched caches into cache misses.
+- `readHeaderMaybe`, `readHeaderSummaryMaybe`, and `readFileMaybe` turn
+  missing, corrupt, unreadable, or version-mismatched caches into cache misses.
+- `openInterfaceDB` validates a `.tydb` for selective reads on the shared
+  per-path environment; `openInterfaceDBMaybe` is its cache-miss form.
+- `readInterfaceDBModuleInfo` reads only import/doc metadata.
+- `readInterfaceDBNameInfoMaybe` reads exactly one `name-info` entry by `Name`.
+- `readInterfaceDBPublicNames`, `readInterfaceDBConstructors`,
+  `readInterfaceDBActors`, `readInterfaceDBConAttr`,
+  `readInterfaceDBProtoAttr`, `readInterfaceDBDescendants`,
+  `readInterfaceDBExtByProto`, and `readInterfaceDBExtByType` read narrow
+  query indexes.
 
 That boundary lets the rest of the compiler keep treating cache access as a
 plain lookup while the on-disk representation moves from one binary blob to a
-keyed store. Current full reads still rebuild the same payload as before.
-More selective lookup by imported name is future work.
+keyed store. Full reads still rebuild the same payload as before, but normal
+imported-module lookup no longer decodes every `NameInfo` entry.
 
 ## LMDB Key Layout
 
@@ -49,6 +60,9 @@ Metadata and module-level keys:
 | `doc` | `Maybe String` |
 | `module-header` | `(ModName, [Import], Maybe String)` |
 | `name-count` | `Int` |
+| `public-names` | `[Name]` |
+| `constructors` | `[Name]` |
+| `actors` | `[Name]` |
 | `stmt-count` | `Int` |
 
 The three `ByteString` hashes in `meta` are the module source-bytes hash, module
@@ -124,6 +138,23 @@ Typed statements are stored by module order:
 
 Statement order is preserved for full typed-module reconstruction.
 
+Narrow query indexes are stored as separate keys, so solver and environment
+queries do not need to decode one combined module metadata value:
+
+| Key | Value type |
+| --- | --- |
+| `con-attr/<name>` | `[Name]` of public classes/actors declaring that attribute |
+| `proto-attr/<name>` | `[Name]` of public protocols declaring that attribute |
+| `descendants/<hash>` | `[Name]` of public classes/protocols below that constructor |
+| `ext-proto/<hash>` | `[Name]` of public extensions implementing that protocol |
+| `ext-type/<hash>` | `[Name]` of public extensions for that type/class |
+
+The `<hash>` suffix is a SHA-256 key for a source-location-free `QName`.
+Attribute keys reuse the normal name-key suffix scheme. Readers resolve the
+stored names through the matching `name-info/<suffix>` entries, so the query
+index itself stays small. The attribute indexes record attributes where they
+are declared; readers complete inherited owners through the descendants index.
+
 For example, `base/src/base64.act` contains top-level `encode` and `decode`
 definitions. Its `.tydb` uses these keys:
 
@@ -149,12 +180,13 @@ stmt/000000000001                 -> typed Stmt for decode
 
 ## Read And Write Behavior
 
-`readHeader` opens a read-only LMDB transaction and reads the header keys plus
-the `deps` row and `name-hash` entries. It does not decode `NameInfo` entries
-or typed statements. Stale checks first compare the dependency module hashes in
-`deps`; DBP uses the header path to get per-name hashes, local dependency
-edges, and root actor names before deciding whether the full typed module must
-be decoded.
+`readHeaderSummary` opens a read-only LMDB transaction and reads the header
+keys plus the `deps` row and the stored name count. It does not decode
+`NameInfo` entries, per-name hash rows, or typed statements. Stale checks
+first compare the dependency module hashes in `deps`; if that gate changes,
+they use per-name dependency rows to decide which local names are affected.
+DBP reads `roots` and exact `name-hash/<suffix>` entries while expanding the
+selected local dependency closure.
 
 `readExtensionsByClass` and `readExtensionsByProtocol` read one class or
 protocol key directly. DBP uses these exact lookups while expanding the selected
@@ -166,6 +198,24 @@ following the explicit order keys for ordered sections. It does not depend on
 LMDB cursor order for `TEnv` or typed statement reconstruction. DBP calls this
 only when its selection-sensitive codegen hash says the existing `.c`/`.h`
 output is missing or stale.
+
+All readers share one cached read-only LMDB environment per `.tydb` path,
+opened with the normal reader lock table so concurrent writers in other
+processes cannot recycle pages under an active read transaction. Writers keep
+their exclusive per-path lock and retire the cached environment, waiting for
+active readers to drain, before opening their own, so the process never holds
+two environments for one path. `openInterfaceDB` validates the version once
+and hands `Acton.Env` a handle it installs in a `ModuleInfo`; later
+exact-name lookups call `readInterfaceDBNameInfoMaybe`, which runs a short
+read transaction on the shared environment and decodes only the demanded
+`name-info/<suffix>` value. Those reads sit behind Env's pure-looking lookup
+functions and are memoized per module.
+
+The same handle exposes the narrow query readers for non-name solver
+questions: actor lookup reads `actors`; attribute lookup reads
+`con-attr/<name>` or `proto-attr/<name>`; descendant lookup reads one
+`descendants/<hash>` record; and witness lookup reads `ext-proto/<hash>` or
+`ext-type/<hash>`. Plain imports do not read these records.
 
 `writeFile` writes the full environment in one write transaction. The compiler
 has one writer for a module cache, while multiple readers may run in parallel.
@@ -197,8 +247,7 @@ write:             .ty 1.68 s/write, .tydb 1.12 s/write (-33%)
 ```
 
 The current `.tydb` format is larger because LMDB stores page-structured data
-and we keep values uncompressed. Header and full reads are still close to the
-old binary blob path because the compiler still reads all per-name hash records
-for cache decisions. The useful change is the storage boundary: names and typed
-statements now have explicit keys, so future work can load only the imported
-names a dependent module actually needs.
+and we keep values uncompressed. The useful property is the storage boundary:
+normal imported-module lookup loads only the names and index rows a dependent
+module actually uses, while full reconstruction remains available for explicit
+broad paths.

--- a/test/compiler/module_lookup/.gitignore
+++ b/test/compiler/module_lookup/.gitignore
@@ -1,0 +1,3 @@
+.acton.lock
+build.zig*
+out

--- a/test/compiler/module_lookup/Build.act
+++ b/test/compiler/module_lookup/Build.act
@@ -1,0 +1,2 @@
+name = "module_lookup"
+fingerprint = 0x5a1ff12a1d3ae79c

--- a/test/compiler/module_lookup/src/big.act
+++ b/test/compiler/module_lookup/src/big.act
@@ -1,0 +1,28 @@
+class Box:
+    value: int
+    __init__ : (int) -> None
+
+    def __init__(self, value):
+        self.value = value
+
+extension Box (Eq):
+    def __eq__(x, y):
+        return x.value == y.value
+
+class OrderedBox:
+    value: int
+    __init__ : (int) -> None
+
+    def __init__(self, value):
+        self.value = value
+
+extension OrderedBox (Ord):
+    def __eq__(x, y):
+        return x.value == y.value
+
+    def __lt__(x, y):
+        return x.value < y.value
+
+actor Worker():
+    def ping():
+        return 1

--- a/test/compiler/module_lookup/src/main.act
+++ b/test/compiler/module_lookup/src/main.act
@@ -1,0 +1,12 @@
+import big
+
+actor main(env):
+    box = big.Box(1)
+    other = big.Box(1)
+    ordered = big.OrderedBox(1)
+    ordered2 = big.OrderedBox(2)
+    worker = big.Worker()
+    if box == other and ordered == ordered and ordered < ordered2:
+        env.exit(0)
+    else:
+        env.exit(1)


### PR DESCRIPTION
This makes the compiler read imported modules' .tydb interfaces selectively instead of decoding them in full. Until now, compiling a module forced the complete interface of every transitive import: doImp decoded the whole .tydb, initTypeEnv folded every imported constructor and extension witness into the type-check environment, the solver's candidate queries scanned every imported constructor, each back pass rewrote every loaded module's interface, and cache checks decoded whole per-name hash sections. A small module importing a large one therefore paid for the dependency's size on every rebuild.

The series introduces ModuleInfo as the only environment representation of dependency modules: a per-module view that answers questions through lookup functions rather than exposing a materialized TEnv. A locally compiled module backs it with its in-memory interface; an imported module backs it with a long-lived read-only LMDB handle (InterfaceDB) doing keyed reads that are memoized per handle. To support this, the .tydb format gains narrow per-module query indexes written next to the existing keyed name entries: public names, constructors, actors, attribute owners, descendants, and extensions keyed by protocol and by type. The version is bumped to [0,25].

The conversion is staged for review, so the commits are best read in order, oldest first. First the plumbing lands (the indexes and read API, then ModuleInfo alongside the old modules/hmodules storage), then consumers are rerouted one group per commit while the two representations are kept in sync and behavior is preserved: qualified-name lookup, imports, the solver-facing queries, the type-check environment, tools, and the back passes (which now convert imported entries on demand instead of rewriting whole module trees). Only then does the lazy flip happen: doImp and cached-module reuse install .tydb-backed shells, dependency hashes resolve per name, and cache checks read a header summary with a stored name count instead of every hash row. The final step deletes the NModule tree and its hashed mirror, leaving the ModuleInfo map as the only module storage.

A deliberate design constraint throughout: no change to inference behavior, and Solver.hs is untouched. The attribute indexes record attributes where they are declared, and readers complete inherited owners through the descendants of each declaring constructor, preserving the ancestry-aware semantics of the old hasAttr scans. Witness queries merge keyed extension-index reads over all transitive imports, so cross-module extensions keep working and query cost follows the number of imported modules, never their size.

The benchmark this targets is a project with a generated class-heavy module (test/compiler/concurrent_typecheck_class_heavy/generate_heavy.py) and a small module importing it. Rebuilding only the small module takes 0.09s whether the dependency has 3,000, 10,000 or 30,000 classes; on main the same rebuild takes 0.55s, 1.6s and 5.8s respectively. Full builds also got faster, mostly from the dependency-index writer deduplicating user lists with sets instead of quadratic nub: the 30,000-class project drops from 345s to 96s.

New traced regression tests pin the behavior down with ACTON_TYDB_TRACE_READS: a small importer must perform keyed lookups only (exact name reads, attribute-index reads, keyed extension reads) with no whole-section decodes, an unused import must not read names at all, and an unrelated added name in the dependency must keep the importer fresh. A module_lookup compiler test project covers imported classes, extension witnesses and actors end to end. The lib, incremental and compiler test suites all pass.

Known follow-up work, intentionally out of scope here: when DBP has to regenerate a large dependency's code (its selection changed or the module itself changed), prepareDeferredBackJob still does one full typed-module read before pruning; storing per-name statement indexes so only the selected statements are read is the natural next step. Test discovery in acton test still decodes whole name-hash sections, initEnv still reads __builtin__ in full once per process, and InterfaceDB handles rely on a GC finalizer backstop, which is fine for CLI compiles but worth revisiting for the long-lived LSP process.

This PR is arranged as a, rather long, series of commit. Each make sense on its own, introducing one conceptual change. It is expressly written to be simple to review.