### PR TITLE
Index name, solver candidate and witness lookups in the type checker

### DIFF
--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -574,16 +574,6 @@ actorSelf env               = case lookupName selfKW env of
                                 Just (HNVar (TCon _ tc)) | isActor env (tcname tc) -> True
                                 _ -> False
 
-actorMethod env n0          = walk [] (activeNames env) (closedNames env)
-  where
-    walk ns ((n,NDef{}):te) rest
-                            = walk (n:ns) te rest
-    walk ns ((n,NVar (TCon _ tc)):te) rest
-      | n == selfKW         = isActor env (tcname tc) && n0 `elem` ns
-    walk ns (_ : te) rest   = walk ns te rest
-    walk ns [] []           = False
-    walk ns [] rest         = walk ns rest []
-
 isDef                       :: EnvF x -> QName -> Bool
 isDef env n                 = case tryQName n env of
                                 Just HNDef{} -> True

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -53,6 +53,12 @@ data EnvF x                 = EnvF {
                                 closedNames:: TEnv,
                                 hnames     :: HTEnv,
                                 closedHNames:: HTEnv,
+                                sigLocs    :: LocEnv,
+                                closedSigLocs:: LocEnv,
+                                defLocs    :: LocEnv,
+                                closedDefLocs:: LocEnv,
+                                activeStateNames:: [Name],
+                                activeTypeVars:: [(Name, Kind, CCon)],
                                 imports    :: [ModName],
                                 improots   :: [Name],
                                 modules    :: TEnv,
@@ -65,6 +71,7 @@ data EnvF x                 = EnvF {
                               } deriving (Show)
 
 type Env0                   = EnvF ()
+type LocEnv                 = M.HashMap Name SrcLoc
 
 -- activeNames may contain live unification variables; closedNames must not.
 -- hnames is the full active-over-closed lookup index, while closedHNames is
@@ -73,6 +80,10 @@ type Env0                   = EnvF ()
 setX                        :: EnvF y -> x -> EnvF x
 setX env x                  = EnvF { activeNames = activeNames env, closedNames = closedNames env,
                                      hnames = hnames env, closedHNames = closedHNames env,
+                                     sigLocs = sigLocs env, closedSigLocs = closedSigLocs env,
+                                     defLocs = defLocs env, closedDefLocs = closedDefLocs env,
+                                     activeStateNames = activeStateNames env,
+                                     activeTypeVars = activeTypeVars env,
                                      imports = imports env, improots = improots env,
                                      modules = modules env, hmodules = hmodules env, thismod = thismod env,
                                      context = context env, qlevel = qlevel env, gtypes = gtypes env, envX = x }
@@ -242,6 +253,12 @@ initEnv path True          = return $ EnvF{ activeNames = [],
                                             closedNames = [(nPrim,NMAlias mPrim)],
                                             hnames = hnamesFrom [(nPrim,NMAlias mPrim)],
                                             closedHNames = hnamesFrom [(nPrim,NMAlias mPrim)],
+                                            sigLocs = M.empty,
+                                            closedSigLocs = M.empty,
+                                            defLocs = M.empty,
+                                            closedDefLocs = M.empty,
+                                            activeStateNames = [],
+                                            activeTypeVars = [],
                                             imports = [],
                                             improots = [],
                                             modules = [(nPrim,NModule [] primEnv Nothing)],
@@ -259,6 +276,12 @@ initEnv path False         = do (_,nmod,_,_,_,_,_,_,_,_,_,_,_) <- InterfaceFiles
                                                  closedNames = initialNames,
                                                  hnames = hnamesFrom initialNames,
                                                  closedHNames = hnamesFrom initialNames,
+                                                 sigLocs = M.empty,
+                                                 closedSigLocs = M.empty,
+                                                 defLocs = M.empty,
+                                                 closedDefLocs = M.empty,
+                                                 activeStateNames = [],
+                                                 activeTypeVars = [],
                                                  imports = [],
                                                  improots = [],
                                                  modules = [(nPrim,NModule [] primEnv Nothing), (nBuiltin,NModule [] envBuiltin builtinDocstring)],
@@ -281,15 +304,49 @@ extendHNames                :: TEnv -> HTEnv -> HTEnv
 extendHNames te hte         = foldr add hte te
   where add (n,i) hte       = M.insert n (convNameInfo2HNameInfo i) hte
 
+extendSigLocs               :: TEnv -> LocEnv -> LocEnv
+extendSigLocs te locs       = foldr add locs te
+  where add (n, NSig{}) locs = M.insert n (loc n) locs
+        add _ locs          = locs
+
+extendDefLocs               :: TEnv -> LocEnv -> LocEnv
+extendDefLocs te locs       = foldr add locs te
+  where add (n, NDef{}) locs = M.insert n (loc n) locs
+        add _ locs          = locs
+
+stateNamesIn                :: TEnv -> [Name]
+stateNamesIn te             = [ n | (n, NSVar _) <- te ]
+
+typeVarsIn                  :: TEnv -> [(Name, Kind, CCon)]
+typeVarsIn te               = [ (n, k, c) | (n, NTVar k c _) <- te ]
+
 setActiveNames              :: TEnv -> EnvF x -> EnvF x
-setActiveNames te env       = env{ activeNames = te, hnames = extendHNames te (closedHNames env) }
+setActiveNames te env       = env{ activeNames = te,
+                                   hnames = extendHNames te (closedHNames env),
+                                   sigLocs = extendSigLocs te (closedSigLocs env),
+                                   defLocs = extendDefLocs te (closedDefLocs env),
+                                   activeStateNames = stateNamesIn te,
+                                   activeTypeVars = typeVarsIn te }
 
 addActiveNames              :: TEnv -> EnvF x -> EnvF x
-addActiveNames te env       = env{ activeNames = te ++ activeNames env, hnames = extendHNames te (hnames env) }
+addActiveNames te env       = env{ activeNames = te ++ activeNames env,
+                                   hnames = extendHNames te (hnames env),
+                                   sigLocs = extendSigLocs te (sigLocs env),
+                                   defLocs = extendDefLocs te (defLocs env),
+                                   activeStateNames = stateNamesIn te ++ activeStateNames env,
+                                   activeTypeVars = typeVarsIn te ++ activeTypeVars env }
 
 addClosedNames              :: TEnv -> EnvF x -> EnvF x
-addClosedNames te env       = env{ closedNames = te ++ closedNames env, hnames = extendHNames (activeNames env) hte, closedHNames = hte }
+addClosedNames te env       = env{ closedNames = te ++ closedNames env,
+                                   hnames = extendHNames (activeNames env) hte,
+                                   closedHNames = hte,
+                                   sigLocs = extendSigLocs (activeNames env) slocs,
+                                   closedSigLocs = slocs,
+                                   defLocs = extendDefLocs (activeNames env) dlocs,
+                                   closedDefLocs = dlocs }
   where hte                 = extendHNames te (closedHNames env)
+        slocs               = extendSigLocs te (closedSigLocs env)
+        dlocs               = extendDefLocs te (closedDefLocs env)
 
 lookupName                  :: Name -> EnvF x -> Maybe HNameInfo
 lookupName n env            = M.lookup n (hnames env)
@@ -373,8 +430,18 @@ inBuiltin                   :: EnvF x -> Bool
 inBuiltin env               = length (modules env) == 1     -- mPrim only
 
 stateScope                  :: EnvF x -> [Name]
-stateScope env              = scopes (activeNames env) ++ scopes (closedNames env)
-  where scopes te           = [ z | (z, NSVar _) <- te ]
+stateScope env              = activeStateNames env
+
+typeScope                   :: EnvF x -> [TVar]
+typeScope env               = [ TV k n | (n, k, _) <- activeTypeVars env ]
+
+lookupTypeVarKind           :: TVar -> EnvF x -> Maybe Kind
+lookupTypeVarKind (TV _ n) env
+                            = findKind (activeTypeVars env)
+  where findKind []         = Nothing
+        findKind ((n', k, _) : xs)
+          | n == n'         = Just k
+          | otherwise       = findKind xs
 
 quantScope0                 :: EnvF x -> QBinds
 quantScope0 env             = [ QBind (TV k n) (if c==cValue then ps else (c:ps)) | (n, NTVar k c ps) <- activeNames env ]
@@ -383,7 +450,7 @@ quantScope                  :: EnvF x -> QBinds
 quantScope env              = [ q | q@(QBind tv _) <- quantScope0 env, tv /= tvSelf ]
 
 tvarDescendants             :: EnvF x -> [TCon] -> [TVar]
-tvarDescendants env cs      = [ TV k n | (n, NTVar k c _) <- activeNames env, c `elem` cs ]
+tvarDescendants env cs      = [ TV k n | (n, k, c) <- activeTypeVars env, c `elem` cs ]
 
 selfScopeSubst              :: EnvF x -> Substitution
 selfScopeSubst env          = [ (TV k n, tCon c) | (n, NTVar k c ps) <- activeNames env, n == nSelf ]
@@ -417,19 +484,9 @@ tryQName (GName m n) env
                                     Nothing -> noItem m n -- error ("## Failed lookup of " ++ prstr n ++ " in module " ++ prstr m)
                                 Nothing -> noModule m -- error ("## Failed lookup of module " ++ prstr m)
 
-findSigLoc n env            = findSL (activeNames env) (closedNames env)
-    where findSL ((n',t):ps) rest
-             | NSig{} <- t, n==n' = Just (loc n')
-             | otherwise          = findSL ps rest
-          findSL [] []            = Nothing
-          findSL [] rest          = findSL rest []
+findSigLoc n env            = M.lookup n (sigLocs env)
 
-findDefLoc n env            = findSL (activeNames env) (closedNames env)
-    where findSL ((n',t):ps) rest
-             | NDef{} <- t, n==n' = Just (loc n')
-             | otherwise          = findSL ps rest
-          findSL [] []            = Nothing
-          findSL [] rest          = findSL rest []
+findDefLoc n env            = M.lookup n (defLocs env)
 
 findName n env              = findQName (NoQ n) env
 
@@ -1381,10 +1438,18 @@ instance Simp QName where
       | inBuiltin env               = NoQ n                                                     -- Restore builtins
       | Just m == thismod env       = NoQ n                                                     -- Restore locals
     simp env n
+      | Just n1 <- findIndexedAlias n = NoQ n1
       | Just n1 <- findAlias (activeNames env) = NoQ n1                                      -- Restore aliases
       | Just n1 <- findAlias (closedNames env) = NoQ n1                                      -- Restore aliases
       | otherwise                   = n
-      where findAlias ((n1, NAlias n2):te)
+      where findIndexedAlias qn@(GName _ n1) = case lookupName n1 env of
+                                                  Just (HNAlias n2) | n2 == qn -> Just n1
+                                                  _ -> Nothing
+            findIndexedAlias qn@(QName _ n1) = case lookupName n1 env of
+                                                  Just (HNAlias n2) | n2 == qn -> Just n1
+                                                  _ -> Nothing
+            findIndexedAlias _               = Nothing
+            findAlias ((n1, NAlias n2):te)
               | n2 == n             = Just n1
             findAlias (_:te)        = findAlias te
             findAlias []            = Nothing

--- a/compiler/lib/src/Acton/Kinds.hs
+++ b/compiler/lib/src/Acton/Kinds.hs
@@ -75,8 +75,8 @@ type KindEnv                        = EnvF ()
 
 kindEnv env0                        = env0
 
-tvars env                           = tvs (activeNames env) ++ tvs (closedNames env)
-  where tvs te                      = [ TV k n | (n, NTVar k _ _) <- te ]
+tvars                              :: KindEnv -> [TVar]
+tvars                              = typeScope
 
 extcons ke env                      = define ke env
 
@@ -89,9 +89,9 @@ extvars vs env
 
 tcKind qn env                       = tconKind qn env
 
-tvKind v env                        = case filter (==v) (tvars env) of
-                                        [] -> err1 v "Unbound type variable:"
-                                        TV k _ : _ -> k
+tvKind v env                        = case lookupTypeVarKind v env of
+                                        Nothing -> err1 v "Unbound type variable:"
+                                        Just k -> k
 
 instance Pretty (Name,Kind) where
     pretty (n,k)                    = pretty n <+> colon <+> pretty k

--- a/compiler/lib/src/Acton/Names.hs
+++ b/compiler/lib/src/Acton/Names.hs
@@ -18,6 +18,7 @@ import Utils
 import Acton.Syntax
 import Acton.Builtin
 import Debug.Trace
+import qualified Data.Set as Set
 
 
 isWitness (Internal Witness _ _)    = True
@@ -167,9 +168,15 @@ class Vars a where
     freeQ x                         = []
     bound x                         = []
 
-qns `diffQ` ns                      = filter f qns
-  where f (NoQ n)                   = n `notElem` ns
-        f _                         = True
+qns `diffQ` ns
+  | hasMany ns                      = filter fSet qns
+  | otherwise                       = filter fList qns
+  where fList (NoQ n)               = n `notElem` ns
+        fList _                     = True
+        fSet (NoQ n)                = not (Set.member n boundNames)
+        fSet _                      = True
+        boundNames                  = Set.fromList ns
+        hasMany xs                  = length (take 9 xs) > 8
 
 instance Vars a => Vars [a] where
     free                            = concatMap free

--- a/compiler/lib/src/Acton/Solver.hs
+++ b/compiler/lib/src/Acton/Solver.hs
@@ -18,6 +18,7 @@ import Control.Monad
 import Control.Monad.Except
 import qualified Data.Map.Strict as Map
 import Data.Map.Strict (Map)
+import qualified Data.IntSet as IntSet
 import qualified Control.Exception
 import Control.DeepSeq
 
@@ -362,11 +363,11 @@ solve' env select hist te eq cs
           where cond (RRed c : rs)          = RRed c
                 cond (RSealed v : rs)       = RSealed v
                 cond (RTry v as r : rs)     = RTry v (if rev' then subrev ts' else ts') rev'
-                  where ts                  = foldr intersect as $ map alts rs
-                        ts'                 = if v `elem` optvs then ts \\ [tOpt tWild] else ts
+                  where ts                  = foldr (typeIntersect env) as $ map alts rs
+                        ts'                 = if v `elem` optvs then typeDiff env ts [tOpt tWild] else ts
 --                        rev'                = (or $ r : map rev rs) || v `elem` posvs       -- (new, matches new solver but picks bad order for lower None)
                         rev'                = (and $ r : map rev rs) || v `elem` posvs        -- (old, incorrect in general, but avoids the None problem)
-                cond (RVar v as : rs)       = RVar v (foldr union as $ map alts rs)
+                cond (RVar v as : rs)       = RVar v (foldr (typeUnion env) as $ map alts rs)
                 cond (RSkip : rs)           = RSkip
                 cond rs                     = error ("### condense " ++ show rs)
 
@@ -394,12 +395,16 @@ solve' env select hist te eq cs
 
         deco (RRed cs)                      = (0, 0, 0, 0)
         deco (RSealed v)                    = (2, 0, 0, 0)
-        deco (RTry v as r)                  = (w, length as, length $ filter (==v) embvs, length $ filter (==v) univs)
+        deco (RTry v as r)                  = (w, boundedLength 256 as, length $ filter (==v) embvs, length $ filter (==v) univs)
           where w | uvkind v == KFX         =  5    -- effect search, last to be explored
                   | [TTuple{}] <- as        =  4    -- default selection solution, deferred search
                   | otherwise               =  3    -- types and rows, normal search
-        deco (RVar v as)                    = (6, length as, 0, 0)
+        deco (RVar v as)                    = (6, boundedLength 256 as, 0, 0)
         deco (RSkip)                        = (7, 0, 0, 0)
+
+        boundedLength n _ | n <= 0          = n
+        boundedLength _ []                  = 0
+        boundedLength n (_:xs)              = 1 + boundedLength (n-1) xs
 
 
 -- subrev [int,Pt,float,CPt,C3Pt]           = [] ++ int : subrev [Pt,float,CPt,C3Pt]
@@ -430,6 +435,75 @@ rank _ (Seal _ env (TUni _ v))
 rank _ c                                    = RRed c
 
 wildTuple                                   = tTuple tWild tWild
+
+-- The id-keyed paths below pay one QName hash per element, which beats list
+-- scans only once the lists grow. The overwhelmingly common case in condense
+-- is tiny lists, where structural equality (which bails out on the first
+-- differing character) is much cheaper than hashing whole generated names,
+-- so short inputs take the plain Data.List route. Both routes implement the
+-- same (order- and duplicate-preserving) semantics.
+shortList :: [a] -> Bool
+shortList xs                                = null (drop 8 xs)
+
+typeIntersect :: Env -> [Type] -> [Type] -> [Type]
+typeIntersect env xs ys
+  | shortList xs && shortList ys            = xs `intersect` ys
+  | otherwise                               = filter keep xs
+  where (ykeys, yother)                     = typeKeySet env ys
+        keep t
+          | Just k <- typeKey env t         = k `IntSet.member` ykeys
+          | otherwise                       = t `elem` yother
+
+typeUnion :: Env -> [Type] -> [Type] -> [Type]
+typeUnion env xs ys
+  | shortList xs && shortList ys            = xs `union` ys
+  | otherwise                               = xs ++ go IntSet.empty [] ys
+  where (xkeys, xother)                     = typeKeySet env xs
+        go _ _ []                           = []
+        go seenKeys seenOther (y:ys)
+          | Just k <- typeKey env y,
+            k `IntSet.member` xkeys || k `IntSet.member` seenKeys
+                                                = go seenKeys seenOther ys
+          | Just k <- typeKey env y         = y : go (IntSet.insert k seenKeys) seenOther ys
+          | y `elem` xother || y `elem` seenOther
+                                                = go seenKeys seenOther ys
+          | otherwise                       = y : go seenKeys (y:seenOther) ys
+
+-- Unlike intersection and union, a keyed set difference cannot reproduce the
+-- per-element multiplicity of Data.List.(\\): it would drop every occurrence
+-- whose key appears in ys rather than one occurrence per element of ys, which
+-- in condense could remove all copies of a duplicated alternative (e.g.
+-- tOpt tWild for a nested optional) and thus a solver alternative the old code
+-- kept. The only caller subtracts a single element, so plain list difference
+-- is already linear here; keep the exact list semantics.
+typeDiff :: Env -> [Type] -> [Type] -> [Type]
+typeDiff _ xs ys                            = xs \\ ys
+
+typeKeySet :: Env -> [Type] -> (IntSet.IntSet, [Type])
+typeKeySet env                              = foldr add (IntSet.empty, [])
+  where add t (ks, ts)
+          | Just k <- typeKey env t         = (IntSet.insert k ks, ts)
+          | otherwise                       = (ks, t:ts)
+
+typeKey :: Env -> Type -> Maybe Int
+typeKey env (TCon _ c)
+  | all isWild (tcargs c)                   = lookupTypeId (envX env) (tcname c)
+typeKey env (TVar _ tv)                     = lookupTypeId (envX env) (NoQ $ tvname tv)
+typeKey _ TNone{}                           = Just (-1)
+typeKey _ (TOpt _ TWild{})                  = Just (-2)
+typeKey _ (TFun _ TWild{} TWild{} TWild{} TWild{})
+                                                = Just (-3)
+typeKey _ (TTuple _ TWild{} TWild{})        = Just (-4)
+typeKey _ (TFX _ fx)                        = Just $ case fx of
+                                                    FXProc -> -5
+                                                    FXMut -> -6
+                                                    FXPure -> -7
+                                                    FXAction -> -8
+typeKey _ _                                 = Nothing
+
+isWild :: Type -> Bool
+isWild TWild{}                              = True
+isWild _                                    = False
 
 
 -------------------------------------------------------------------------------------------------------------------------
@@ -497,8 +571,12 @@ allAbove env (TFX _ FXMut)          = [fxProc, fxMut]
 allAbove env (TFX _ FXPure)         = [fxProc, fxMut, fxPure]
 allAbove env (TFX _ FXAction)       = [fxProc, fxAction]
 
-allBelow env (TCon _ tc)            = map tCon tcons ++ map tVar tvars
-  where tcons                       = schematic' tc : allDescendants env tc
+allBelow env (TCon _ tc)
+  | Just tids <- tyconBelowTids env tc
+                                    = map tCon (schematic' tc : tyconDescendants env tc) ++
+                                      map tVar (tvarsInTids env tids)
+  | otherwise                       = map tCon tcons ++ map tVar tvars
+  where tcons                       = schematic' tc : tyconDescendants env tc
         tvars                       = tvarDescendants env tcons
 allBelow env (TVar _ tv)            = [tVar tv]
 allBelow env (TOpt _ t)             = tOpt tWild : allBelow env t ++ [tNone]
@@ -513,17 +591,16 @@ allBelow env (TFX _ FXAction)       = [fxAction]
 allBelowProto env (TC n [t@TFX{},_])
   | n == primWrappedP               = reverse [ schematic (wtype w) | w <- witsByPName env n, t == (head $ tcargs $ proto w) ]
 allBelowProto env p
-  | p == pIdentity                  = ts ++ [ schematic $ tCon tc | tc <- allActors env ]
+  | p == pIdentity                  = ts ++ [ schematic $ tCon tc | tc <- tyactorsAll env ]
   | p == pEq                        = ts ++ [tOpt tWild]
   | otherwise                       = ts
   where ts                          = reverse [ schematic (wtype w) | w <- witsByPName env (tcname p) ] -- includes tvars
 
-allClassAttr env n                  = map tCon tcons ++ map tVar tvars
-  where tcons                       = allConAttr env n
-        tvars                       = tvarDescendants env tcons
+allClassAttr env n                  = map tCon (tyconsByAttr env n) ++
+                                      map tVar (tvarsInTids env (tyconAttrTids env n))
 
 allProtoAttr env n                  = map tCon pcons ++ concatMap (allBelowProto env) pcons
-  where pcons                       = allPConAttr env n
+  where pcons                       = typrotosByAttr env n
 
 
 ----------------------------------------------------------------------------------------------------------------------

--- a/compiler/lib/src/Acton/Solver.hs
+++ b/compiler/lib/src/Acton/Solver.hs
@@ -589,12 +589,12 @@ allBelow env (TFX _ FXPure)         = [fxPure]
 allBelow env (TFX _ FXAction)       = [fxAction]
 
 allBelowProto env (TC n [t@TFX{},_])
-  | n == primWrappedP               = reverse [ schematic (wtype w) | w <- witsByPName env n, t == (head $ tcargs $ proto w) ]
+  | n == primWrappedP               = [ schematic (wtype w) | w <- witsByPName env n, t == (head $ tcargs $ proto w) ]
 allBelowProto env p
   | p == pIdentity                  = ts ++ [ schematic $ tCon tc | tc <- tyactorsAll env ]
   | p == pEq                        = ts ++ [tOpt tWild]
   | otherwise                       = ts
-  where ts                          = reverse [ schematic (wtype w) | w <- witsByPName env (tcname p) ] -- includes tvars
+  where ts                          = [ schematic (wtype w) | w <- witsByPName env (tcname p) ] -- includes tvars; oldest first
 
 allClassAttr env n                  = map tCon (tyconsByAttr env n) ++
                                       map tVar (tvarsInTids env (tyconAttrTids env n))
@@ -770,15 +770,19 @@ solveMutAttr (wf,sc,dec) c@(Mut info env t1 n t2)
 ----------------------------------------------------------------------------------------------------------------------
 
 findWitness                 :: Env -> Type -> PCon -> [Witness]
-findWitness env t p         = reverse $ filter (eqhead t . wtype) $ witsByPName env $ tcname p
+findWitness env t p         = filter match $ candidates t
   where eqhead (TCon _ c) (TCon _ c')   = tcname c == tcname c'
         eqhead (TFX _ fx) (TFX _ fx')   = fx == fx'
         eqhead (TVar _ v) (TVar _ v')   = v == v'
         eqhead _          _             = False
+        match w                         = tcname (proto w) == tcname p && eqhead t (wtype w)
+        candidates (TCon _ c)           = witsByTName env (tcname c)
+        candidates (TVar _ v)           = witsByTName env (NoQ $ tvname v)
+        candidates _                    = witsByPName env (tcname p)
 
 findProtoByAttr env cn n    = case filter hasAttr $ witsByTName env cn of
                                 [] -> Nothing
-                                w:_ -> Just $ schematic' $ proto w
+                                ws -> Just $ schematic' $ proto (last ws)   -- newest matching witness, as before
   where hasAttr w           = n `elem` conAttrs env (tcname $ proto w)
 
 hasWitness                  :: Env -> Type -> PCon -> Bool

--- a/compiler/lib/src/Acton/TypeEnv.hs
+++ b/compiler/lib/src/Acton/TypeEnv.hs
@@ -26,6 +26,8 @@ import qualified Data.Map.Strict as Map
 import Data.Map.Strict (Map)
 import qualified Data.HashMap.Strict as HashMap
 import Data.HashMap.Strict (HashMap)
+import qualified Data.Sequence as Seq
+import qualified Data.Foldable
 
 import qualified Data.Set as Set
 import Data.Set (Set)
@@ -52,6 +54,8 @@ data TypeX                      = TypeX {
                                     closedWits  :: [Witness],
                                     activeWitMap :: WitMap,
                                     closedWitMap :: WitMap,
+                                    activeWitTypeMap :: WitMap,
+                                    closedWitTypeMap :: WitMap,
                                     posnames    :: [Name],
                                     indecl      :: Bool,
                                     forced      :: Bool,
@@ -73,7 +77,7 @@ data TyInfo                     = TyInfo {
                                   }
 
 type Env                        = EnvF TypeX
-type WitMap                     = Map QName [Witness]
+type WitMap                     = Map QName (Seq.Seq Witness)
 type TyAttrMap                  = Map Name IntSet
 
 initTypeEnv                     :: Env0 -> Env
@@ -83,6 +87,8 @@ initTypeEnv env0                = setX env0 $ foldl' importInfo x0 imps
                                     closedWits  = primWits,
                                     activeWitMap = Map.empty,
                                     closedWitMap = witMap primWits,
+                                    activeWitTypeMap = Map.empty,
+                                    closedWitTypeMap = witTypeMap primWits,
                                     posnames    = [],
                                     indecl      = False,
                                     forced      = False,
@@ -139,7 +145,9 @@ prinfo x (n, tid)               = pretty (noq n) <+> text "=" <+> pretty tid <> 
 
 instance USubst TypeX where
     usubstWith s x              = let we = usubstWith s (activeWits x)
-                                  in x{ activeWits = we, activeWitMap = witMap we }
+                                  in x{ activeWits = we,
+                                        activeWitMap = witMap we,
+                                        activeWitTypeMap = witTypeMap we }
 
 instance UFree TypeX where
     ufree x                     = ufree (activeWits x)
@@ -149,6 +157,9 @@ witnesses x                     = activeWits x ++ closedWits x
 
 witMap                          :: [Witness] -> WitMap
 witMap                          = foldr addWit Map.empty
+
+witTypeMap                      :: [Witness] -> WitMap
+witTypeMap                      = foldr addWitType Map.empty
 
 
 nextid x                        = 1 + fst (IntMap.findMax $ tyinfos x)
@@ -297,40 +308,60 @@ tydefineInst c ps w env         = modX env (\x -> foldl' addActiveWit x wits)
 
 addActiveWit                    :: TypeX -> Witness -> TypeX
 addActiveWit x wit
-  | null same                   = x{ activeWits = wit : activeWits x,
-                                     activeWitMap = addWit wit (activeWitMap x) }
+  | not $ hasWit x wit          = x{ activeWits = wit : activeWits x,
+                                     activeWitMap = addWit wit (activeWitMap x),
+                                     activeWitTypeMap = addWitType wit (activeWitTypeMap x) }
   | otherwise                   = x
-  where same                    = [ w | w <- witsByPNameX x (tcname $ proto wit), wtype w == wtype wit ]
 
 addClosedWit                    :: TypeX -> Witness -> TypeX
 addClosedWit x wit
-  | null same                   = x{ closedWits = wit : closedWits x,
-                                     closedWitMap = addWit wit (closedWitMap x) }
+  | not $ hasWit x wit          = x{ closedWits = wit : closedWits x,
+                                     closedWitMap = addWit wit (closedWitMap x),
+                                     closedWitTypeMap = addWitType wit (closedWitTypeMap x) }
   | otherwise                   = x
-  where same                    = [ w | w <- witsByPNameX x (tcname $ proto wit), wtype w == wtype wit ]
 
+hasWit                          :: TypeX -> Witness -> Bool
+hasWit x wit                     = any same $ case wtypeKey (wtype wit) of
+                                      Just n  -> witsByTNameX x n
+                                      Nothing -> witsByPNameX x (tcname $ proto wit)
+  where same w                   = tcname (proto w) == tcname (proto wit) && wtype w == wtype wit
+
+-- Witness buckets are kept in insertion (oldest-first) order, the order in
+-- which consumers want to enumerate them, so queries need no reversal of the
+-- ever-growing bucket.
 addWit                          :: Witness -> WitMap -> WitMap
-addWit w                        = Map.insertWith (++) (tcname $ proto w) [w]
+addWit w                        = Map.insertWith (\_ old -> old Seq.|> w) (tcname $ proto w) (Seq.singleton w)
 
-witsByPNameX x pn               = Map.findWithDefault [] pn (activeWitMap x) ++
-                                  Map.findWithDefault [] pn (closedWitMap x)
+addWitType                      :: Witness -> WitMap -> WitMap
+addWitType w m                  = maybe m (\n -> Map.insertWith (\_ old -> old Seq.|> w) n (Seq.singleton w) m) (wtypeKey $ wtype w)
+
+wtypeKey                        :: Type -> Maybe QName
+wtypeKey (TCon _ c)             = Just (tcname c)
+wtypeKey (TVar _ v)             = Just (NoQ $ tvname v)
+wtypeKey _                      = Nothing
+
+-- Closed witnesses precede active ones: combined with oldest-first buckets this
+-- equals the reverse of the old newest-first active++closed enumeration, which
+-- is the order the (previously reversing) consumers rely on.
+witsByPNameX x pn               = Data.Foldable.toList (Map.findWithDefault Seq.empty pn (closedWitMap x)) ++
+                                  Data.Foldable.toList (Map.findWithDefault Seq.empty pn (activeWitMap x))
+
+witsByTNameX x tn               = Data.Foldable.toList (Map.findWithDefault Seq.empty tn (closedWitTypeMap x)) ++
+                                  Data.Foldable.toList (Map.findWithDefault Seq.empty tn (activeWitTypeMap x))
 
 witsByPName                     :: Env -> QName -> [Witness]
 witsByPName env pn              = witsByPNameX (envX env) pn
 
 witsByTName                     :: Env -> QName -> [Witness]
-witsByTName env tn              = [ w | w <- activeWits x, eqname (wtype w) ] ++
-                                  [ w | w <- closedWits x, eqname (wtype w) ]
-  where eqname (TCon _ c)       = tcname c == tn
-        eqname (TVar _ v)       = NoQ (tvname v) == tn
-        eqname _                = False
-        x                       = envX env
+witsByTName env tn              = witsByTNameX (envX env) tn
 
 limitQuant                      :: TUni -> Env -> Env
 limitQuant (UV _ l _) env
   | n <= 0                      = env
   | otherwise                   = modX env1 $ \x -> let we = dropw (activeWits x)
-                                                    in x{ activeWits = we, activeWitMap = witMap we }
+                                                    in x{ activeWits = we,
+                                                          activeWitMap = witMap we,
+                                                          activeWitTypeMap = witTypeMap we }
   where env1                    = setActiveNames (dropv n (activeNames env)) env{ qlevel = qlevel env - n }
         n                       = qlevel env - l
         vs                      = takev n (activeNames env)

--- a/compiler/lib/src/Acton/TypeEnv.hs
+++ b/compiler/lib/src/Acton/TypeEnv.hs
@@ -24,6 +24,8 @@ import Prelude hiding ((<>))
 
 import qualified Data.Map.Strict as Map
 import Data.Map.Strict (Map)
+import qualified Data.HashMap.Strict as HashMap
+import Data.HashMap.Strict (HashMap)
 
 import qualified Data.Set as Set
 import Data.Set (Set)
@@ -54,9 +56,13 @@ data TypeX                      = TypeX {
                                     indecl      :: Bool,
                                     forced      :: Bool,
                                     tyids       :: Map QName Int,
+                                    tyidHash    :: HashMap QName Int,
                                     tyinfos     :: IntMap TyInfo,
+                                    tycons      :: IntSet,
                                     typrotos    :: IntSet,
-                                    tyactors    :: IntSet
+                                    tyactors    :: IntSet,
+                                    tyconAttrs  :: TyAttrMap,
+                                    typrotoAttrs:: TyAttrMap
                                   }
 
 data TyInfo                     = TyInfo {
@@ -68,6 +74,7 @@ data TyInfo                     = TyInfo {
 
 type Env                        = EnvF TypeX
 type WitMap                     = Map QName [Witness]
+type TyAttrMap                  = Map Name IntSet
 
 initTypeEnv                     :: Env0 -> Env
 initTypeEnv env0                = setX env0 $ foldl' importInfo x0 imps
@@ -80,14 +87,18 @@ initTypeEnv env0                = setX env0 $ foldl' importInfo x0 imps
                                     indecl      = False,
                                     forced      = False,
                                     tyids       = Map.empty,
+                                    tyidHash    = HashMap.empty,
                                     tyinfos     = tyinfos0,
+                                    tycons      = IntSet.empty,
                                     typrotos    = IntSet.empty,
-                                    tyactors    = IntSet.empty
+                                    tyactors    = IntSet.empty,
+                                    tyconAttrs  = Map.empty,
+                                    typrotoAttrs= Map.empty
                                   }
         importInfo x (m,te)     = setupCons f te $ setupWits addClosedWit f te x
           where f               = GName m
         imps | inBuiltin env0   = []
-             | otherwise        = [ (m, fromJust $ lookupMod m env0) | m <- mBuiltin : transitiveImports env0 ]
+             | otherwise        = [ (m, fromJust $ lookupMod m env0) | m <- transitiveImports env0 ]
 
 
 tyinfos0                        = IntMap.fromDistinctAscList pairs
@@ -144,18 +155,25 @@ nextid x                        = 1 + fst (IntMap.findMax $ tyinfos x)
 
 addconinfo                      :: (Name -> QName) -> TypeX -> (Name,NameInfo) -> TypeX
 addconinfo f x (n,i)
-  | NClass q us te _ <- i       = addcon n q us te x
-  | NProto q us te _ <- i       = addproto $ addcon n q us te x
-  | NAct q _ _ te _ <- i        = addactor $ addcon n q [] te x
+  | NClass q us te _ <- i       = addcon n q us te addclass x
+  | NProto q us te _ <- i       = addcon n q us te addproto x
+  | NAct q _ _ te _ <- i        = addcon n q [] (notHidden te) addactor x
   | otherwise                   = x
-  where tid                     = nextid x
-        addproto x              = x{ typrotos = IntSet.insert tid (typrotos x) }
-        addactor x              = x{ tyactors = IntSet.insert tid (tyactors x) }
+  where addclass tid info x     = x{ tycons = IntSet.insert tid (tycons x),
+                                     tyconAttrs = addTyAttrs tid (tyattrs info) (tyconAttrs x) }
+        addproto tid info x     = x{ typrotos = IntSet.insert tid (typrotos x),
+                                     typrotoAttrs = addTyAttrs tid (tyattrs info) (typrotoAttrs x) }
+        addactor tid info x     = addclass tid info x{ tyactors = IntSet.insert tid (tyactors x) }
 
-        addcon n q us te x      = x{ tyids = Map.insert (f n) tid (tyids x), tyinfos = IntMap.insert tid info tyinfos' }
-          where ui              = [ tyids x Map.! tcname c | (_,c) <- us ]
+        addcon n q us te index x
+                                  = index tid info x{ tyids = Map.insert qn tid (tyids x),
+                                                      tyidHash = HashMap.insert qn tid (tyidHash x),
+                                                      tyinfos = IntMap.insert tid info tyinfos' }
+          where tid             = nextid x
+                qn              = f n
+                ui              = [ typeId x (tcname c) | (_,c) <- us ]
                 info            = TyInfo {
-                                    tywild = tCon $ TC (NoQ n) [ tWild | _ <- q ],
+                                    tywild = tCon $ TC qn [ tWild | _ <- q ],
                                     tyabove = IntSet.fromList ui,
                                     tybelow = IntSet.singleton tid,
                                     tyattrs = foldr Set.union (Set.fromList $ dom te) [ tyattrs $ fromJust $ IntMap.lookup u $ tyinfos x | u <- ui ]
@@ -163,6 +181,77 @@ addconinfo f x (n,i)
                 tyinfos'        = foldr (IntMap.adjust addbelow) (tyinfos x) ui
                 addbelow info   = info{ tybelow = IntSet.insert tid (tybelow info) }
 
+addTyAttrs                      :: Int -> Set Name -> TyAttrMap -> TyAttrMap
+addTyAttrs tid attrs attrmap     = Set.foldr add attrmap attrs
+  where add n                   = Map.insertWith IntSet.union n (IntSet.singleton tid)
+
+typeById                        :: TypeX -> Int -> Type
+typeById x tid                  = tywild (tyinfos x IntMap.! tid)
+
+conById                         :: TypeX -> Int -> Maybe TCon
+conById x tid                   = case typeById x tid of
+                                    TCon _ c -> Just c
+                                    _ -> Nothing
+
+lookupTypeId                    :: TypeX -> QName -> Maybe Int
+lookupTypeId x n                = HashMap.lookup n (tyidHash x)
+
+typeId                          :: TypeX -> QName -> Int
+typeId x n                      = fromJust $ lookupTypeId x n
+
+tyconDescendants                :: Env -> TCon -> [TCon]
+tyconDescendants env tc
+  | Just tid <- lookupTypeId x (tcname tc),
+    Just info <- IntMap.lookup tid (tyinfos x)
+                                = [ c | tid' <- tids tid info, Just c <- [conById x tid'] ]
+  | otherwise                   = allDescendants env tc
+  where x                       = envX env
+        tids tid info           = IntSet.toAscList $
+                                  IntSet.delete tid $
+                                  IntSet.intersection (tybelow info) (tycons x)
+
+-- Attr-indexed candidate tid sets. IntSet.toAscList is insertion order (ids grow
+-- monotonically) and is produced lazily, so consumers that only inspect a prefix
+-- of the candidate list do not pay for the whole, ever-growing population.
+tyconAttrTids                   :: Env -> Name -> IntSet
+tyconAttrTids env n             = Map.findWithDefault IntSet.empty n (tyconAttrs (envX env))
+
+typrotoAttrTids                 :: Env -> Name -> IntSet
+typrotoAttrTids env n           = Map.findWithDefault IntSet.empty n (typrotoAttrs (envX env))
+
+tyconsByAttr                    :: Env -> Name -> [TCon]
+tyconsByAttr env n              = [ c | tid <- IntSet.toAscList (tyconAttrTids env n), Just c <- [conById x tid] ]
+  where x                       = envX env
+
+typrotosByAttr                  :: Env -> Name -> [PCon]
+typrotosByAttr env n            = [ p | tid <- IntSet.toAscList (typrotoAttrTids env n), Just p <- [conById x tid] ]
+  where x                       = envX env
+
+-- Self-plus-descendants tid set for a class, when indexed.
+tyconBelowTids                  :: Env -> TCon -> Maybe IntSet
+tyconBelowTids env tc
+  | Just tid <- lookupTypeId x (tcname tc),
+    Just info <- IntMap.lookup tid (tyinfos x)
+                                = Just (IntSet.intersection (tybelow info) (IntSet.insert tid (tycons x)))
+  | otherwise                   = Nothing
+  where x                       = envX env
+
+-- Active type variables whose class bound is one of the given indexed types.
+-- Equivalent to tvarDescendants against the corresponding wild-argument TCon
+-- list, but a membership test instead of a scan of that list.
+tvarsInTids                     :: Env -> IntSet -> [TVar]
+tvarsInTids env tids            = [ TV k n | (n, k, c) <- activeTypeVars env,
+                                            Just tid <- [lookupTypeId x (tcname c)],
+                                            tid `IntSet.member` tids,
+                                            Just c' <- [conById x tid],
+                                            c == c' ]
+  where x                       = envX env
+
+-- All actor types in scope, in definition order (imports first). Mirrors what
+-- allTypes/allActors produce, without scanning the name environment.
+tyactorsAll                     :: Env -> [TCon]
+tyactorsAll env                 = [ c | tid <- IntSet.toAscList (tyactors x), Just c <- [conById x tid] ]
+  where x                       = envX env
 
 
 tydefine                        :: TEnv -> Env -> Env
@@ -180,9 +269,12 @@ setupWits                       :: (TypeX -> Witness -> TypeX) -> (Name -> QName
 setupWits add f te x            = foldl' add x wits
   where wits                    = [ WClass q (tCon c) p (f n) ws (length opts) | (n, NExt q c ps te' opts _) <- te, (ws,p) <- ps ]
 
-addvarinfo x (tv, c, _)         = x{ tyids = Map.insert (NoQ $ tvname tv) tid (tyids x), tyinfos = IntMap.insert tid info tyinfos' }
+addvarinfo x (tv, c, _)         = x{ tyids = Map.insert qn tid (tyids x),
+                                     tyidHash = HashMap.insert qn tid (tyidHash x),
+                                     tyinfos = IntMap.insert tid info tyinfos' }
   where tid                     = nextid x
-        ci                      = tyinfos x IntMap.! (tyids x Map.! tcname c)
+        qn                      = NoQ $ tvname tv
+        ci                      = tyinfos x IntMap.! typeId x (tcname c)
         info                    = TyInfo {
                                     tywild = tVar tv,
                                     tyabove = IntSet.insert tid $ tyabove ci,
@@ -825,6 +917,15 @@ instance USubst Witness where
 
 
 instance USubst Env where
+    -- A fully closed env (no active names, no active witnesses) cannot contain
+    -- unification variables, so substitution is the identity. This is the common
+    -- case for top-level statements.
+    usubstWith s env
+      | null (activeNames env) && null (activeWits (envX env))
+                                      = env
+    -- The attribute environment cache only holds closed definitions (imports and
+    -- defineClosed entries), which cannot contain unification variables, so it
+    -- survives substitution unchanged.
     usubstWith s env                  = let ne = usubstWith s (activeNames env)
                                             ex = usubstWith s (envX env)
                                         in setActiveNames ne env{ envX = ex }


### PR DESCRIPTION
Type checking very large generated modules slowed down dramatically as the checker progressed through the file. A 288k statement module generated from the juniper_crpd YANG models took around two and a half hours, with the cost of each statement growing the further into the module the checker got. The cause was a handful of linear scans over data structures that grow with every statement processed, which makes each scan quadratic when summed over a whole module. This branch removes three such scans, as three independent commits, each with a detailed commit message describing the scan it eliminates and why the replacement preserves behaviour.

The first commit mirrors the name environment association lists with purpose built indexes. Several lookups scanned activeNames and closedNames linearly, and since every top level statement adds a name, each lookup cost time proportional to the number of names already defined. The worst offender ran for every call expression, just to recover a source location for a potential error message. The new indexes cover signature and definition locations, state variable names and type variables, and are maintained at exactly the same points as the existing hnames hash index, so the invariant that they mirror the name lists stays local to a few functions. State variables and type variables only ever exist inside actor, class and def bodies and never among the closed top level names, so those two keep no closed side structure at all, which the commit notes is a consequence of Acton semantics rather than an omission.

The second commit makes the previously debug only type id graph the source of the solver's candidate sets. When the solver ranks alternatives for an unresolved goal it needs candidate types, for example all classes or protocols carrying a given attribute, or all descendants of an upper bound. These were produced by scanning every type in scope and walking the ancestry of each, so candidate generation grew with every class and extension the module defines. The graph already recorded the necessary relationships but was only used for debug output. Candidate enumeration now becomes a set lookup, with the ascending traversal of integer id sets reproducing the previous definition order exactly. The commit also fixes a latent double indexing of the builtin module that would otherwise feed duplicated candidates to the solver and change which solutions it commits, so inference results now match the previous compiler exactly. For the common case where candidate lists are tiny, the set operations fall back to plain list operations, because hashing the long qualified names of generated types is more expensive than a structural comparison that stops at the first difference.

The third commit adds a second witness map keyed by the implementing type. Witness lookup by type and the duplicate check performed on every witness insertion both scanned the witness bucket of a protocol, and popular protocols such as Iterable and Indexed gain one witness per implementing type, so the bucket grows with every extension in the module. Keyed by the implementing type instead, both become proportional to the few protocols a single type implements. Buckets are kept in insertion order and closed witnesses are enumerated before active ones, which reproduces exactly the order the previously reversing consumers produced, so the order in which the solver considers witnesses is unchanged.

Candidate and witness enumeration order is preserved throughout, since that order determines which alternative the backtracking solver commits to first. On the full juniper_crpd module the type reconstruction phase now finishes in well under twenty minutes where it previously ran for hours.