### PR TITLE
Selective .tydb reads and deferred back-pass codegen

### DIFF
--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -2368,9 +2368,9 @@ writeRootC env gopts opts paths tasks binTask = do
         rootsHeader <- case tyPath of
                          Just ty -> do (_sourceMeta, _, _, _implH, _imps, _depModules, _nameHashes, roots, _tests, _) <- InterfaceFiles.readHeader ty; return roots
                          Nothing -> throwProjectError ("Root module " ++ prstr mn' ++ " not found")
-        let rootsEnv = case Acton.Env.lookupMod mn env of
+        let rootsEnv = case Acton.Env.lookupModuleInfo mn env of
                          Nothing -> []
-                         Just te -> [ n' | (n', i) <- te, rootEligible i ]
+                         Just mi -> [ n' | (n', i) <- Acton.Env.modulePublicTEnv mi, rootEligible i ]
             shouldGen = n `elem` rootsHeader || n `elem` rootsEnv
         if shouldGen
           then do
@@ -2973,10 +2973,10 @@ normalizeZigDep b dep =
 filterMainActor :: Acton.Env.Env0 -> Paths -> BinTask -> IO (Maybe BinTask)
 filterMainActor env paths binTask = do
     let qn@(A.GName m n) = rootActor binTask
-    let checkEnv = case Acton.Env.lookupMod m env of
+    let checkEnv = case Acton.Env.lookupModuleInfo m env of
                      Nothing -> return Nothing
-                     Just te -> do
-                       let rootsEnv = [ n' | (n', i) <- te, rootEligible i ]
+                     Just mi -> do
+                       let rootsEnv = [ n' | (n', i) <- Acton.Env.modulePublicTEnv mi, rootEligible i ]
                        if n `elem` rootsEnv then return (Just binTask) else return Nothing
     mty <- Acton.Env.findTyFile (searchPath paths) m
     case mty of

--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -692,10 +692,10 @@ readModuleImports paths mn = do
     if not exists
       then return []
       else do
-        hdrE <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readHeader tyFile
+        hdrE <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readHeaderSummary tyFile
         case hdrE of
           Left _ -> return []
-          Right (_sourceMeta, _hash, _ih, _implH, imps, _depModules, _nameHashes, _roots, _tests, _doc) -> return (map fst imps)
+          Right (_sourceMeta, _hash, _ih, _implH, imps, _depModules, _nameCount, _roots, _tests, _doc) -> return (map fst imps)
 
 dependentTestModulesFromHeaders :: Paths -> [FilePath] -> [String] -> IO [String]
 dependentTestModulesFromHeaders paths srcFiles changedModules = do
@@ -2217,9 +2217,9 @@ expectedRootStubs paths tasks = do
             mn'     = dropProjPrefix paths mn
             outbase = outBase paths mn'
             tyPath  = tyDbPath paths mn
-        hdrE <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readHeader tyPath
+        hdrE <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readHeaderSummary tyPath
         case hdrE of
-          Right (_sourceMeta, _, _, _implH, _imps, _depModules, _nameHashes, rs, _tests, _) -> return (map (mkStub outbase) rs)
+          Right (_sourceMeta, _, _, _implH, _imps, _depModules, _nameCount, rs, _tests, _) -> return (map (mkStub outbase) rs)
           _ -> return []
     return (concat roots)
   where
@@ -2366,7 +2366,7 @@ writeRootC env gopts opts paths tasks binTask = do
         -- was rebuilt during this run.
         tyPath <- Acton.Env.findTyFile (searchPath paths) mn
         rootsHeader <- case tyPath of
-                         Just ty -> do (_sourceMeta, _, _, _implH, _imps, _depModules, _nameHashes, roots, _tests, _) <- InterfaceFiles.readHeader ty; return roots
+                         Just ty -> do (_sourceMeta, _, _, _implH, _imps, _depModules, _nameCount, roots, _tests, _) <- InterfaceFiles.readHeaderSummary ty; return roots
                          Nothing -> throwProjectError ("Root module " ++ prstr mn' ++ " not found")
         let rootsEnv = case Acton.Env.lookupModuleInfo mn env of
                          Nothing -> []
@@ -2981,9 +2981,9 @@ filterMainActor env paths binTask = do
     mty <- Acton.Env.findTyFile (searchPath paths) m
     case mty of
       Just ty -> do
-        hdrE <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readHeader ty
+        hdrE <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readHeaderSummary ty
         case hdrE of
-          Right (_sourceMeta, _, _, _implH, _imps, _depModules, _nameHashes, roots, _tests, _) | n `elem` roots -> return (Just binTask)
+          Right (_sourceMeta, _, _, _implH, _imps, _depModules, _nameCount, roots, _tests, _) | n `elem` roots -> return (Just binTask)
           _ -> checkEnv
       Nothing -> checkEnv
 

--- a/compiler/acton/TestRunner.hs
+++ b/compiler/acton/TestRunner.hs
@@ -574,10 +574,10 @@ readModuleTests paths mn = do
     if not exists
       then return []
       else do
-        hdrE <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readHeader tyFile
+        hdrE <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readHeaderSummary tyFile
         case hdrE of
           Left _ -> return []
-          Right (_sourceMeta, _srcH, _ih, _implH, _imps, _depModules, _nameHashes, _roots, tests, _doc) ->
+          Right (_sourceMeta, _srcH, _ih, _implH, _imps, _depModules, _nameCount, _roots, tests, _doc) ->
             return tests
 
 modNameFromString :: String -> A.ModName

--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -104,6 +104,9 @@ compilerTests =
         (returnCode, cmdOut, cmdErr) <- readCreateProcessWithExitCode (shell $ "rm -rf ../../test/compiler/subdash/out") ""
         testBuild "" ExitSuccess False "../../test/compiler/subdash/"
         testBuild "" ExitSuccess False "../../test/compiler/subdash/"
+  , testCase "module lookup exact imports" $ do
+        (returnCode, cmdOut, cmdErr) <- readCreateProcessWithExitCode (shell $ "rm -rf ../../test/compiler/module_lookup/out") ""
+        testBuild "--skip-build" ExitSuccess False "../../test/compiler/module_lookup/"
   , testCase "dynamic module library build" $ do
         withSystemTempDirectory "acton-dynamic-module-build" $ \proj -> do
           actonExe <- canonicalizePath "../../dist/bin/acton"

--- a/compiler/acton/test_incremental.hs
+++ b/compiler/acton/test_incremental.hs
@@ -7,11 +7,12 @@ import qualified Data.ByteString as B
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import qualified Data.Text.Encoding as TE
+import           Data.Char (isHexDigit, isSpace, toLower)
 import           Data.Bits (shiftL, (.|.))
 import           Data.Word (Word64)
 import qualified Acton.Fingerprint as Fingerprint
 import qualified Crypto.Hash.SHA256 as SHA256
-import           Data.List (find, sort)
+import           Data.List (elemIndex, find, isPrefixOf, partition, sort, sortOn)
 import qualified Data.Map.Strict as M
 import           Data.Maybe (isJust)
 import           System.Directory
@@ -414,6 +415,88 @@ readTyLocalDeps tyPath nameLabel = do
       let pubDeps = sort (map prstr (InterfaceFiles.nhPubLocalDeps nh))
           implDeps = sort (map prstr (InterfaceFiles.nhImplLocalDeps nh))
       pure (pubDeps, implDeps)
+
+-- | Generate a class-heavy module with the same shape as the
+-- test/compiler/concurrent_typecheck_class_heavy fixture generator. Ported
+-- here rather than invoking generate_heavy.py so the tests do not depend on
+-- python3 being installed.
+writeHeavyClassModule :: FilePath -> Int -> IO ()
+writeHeavyClassModule outPath trees =
+  writeFileUtf8 outPath (T.pack (heavyClassModule trees))
+
+heavyClassModule :: Int -> String
+heavyClassModule trees =
+    unlines (header ++ concat (zipWith emitClass [1 ..] classSites))
+  where
+    header =
+      [ "# Generated class-heavy fixture (Haskell port of generate_heavy.py)."
+      , ""
+      ]
+    classSites = [ (tree, shape) | tree <- [0 .. trees - 1], shape <- shapes ]
+    roots = "ABCDEFGH"
+    shapes =
+      [ ("", Nothing), ("1", Just ""), ("2", Just ""), ("2A", Just "2")
+      , ("2A1", Just "2A"), ("2A2", Just "2A"), ("2B", Just "2")
+      , ("3", Just ""), ("3A", Just "3"), ("3A1", Just "3A")
+      ]
+    pad w n = let str = show (n :: Int) in replicate (w - length str) '0' ++ str
+    className tree suffix =
+      "Node" ++ pad 3 (tree `div` length roots) ++ [roots !! (tree `mod` length roots)] ++ suffix
+    emitClass n (tree, (suffix, parentSuffix)) =
+      [ "class " ++ name ++ "(" ++ parent ++ "):" ]
+      ++ (if rootClass then [ "    seed: int", "    total: int", "    weight: int" ] else [])
+      ++
+      [ "    " ++ branch ++ ": int"
+      , "    " ++ extra ++ ": int"
+      , "    __init__ : (int) -> None"
+      , "    fold_" ++ method ++ " : (int, int, int) -> int"
+      , "    score_" ++ method ++ " : (int) -> int"
+      , ""
+      , "    def __init__(self, seed):"
+      ]
+      ++ (if rootClass
+            then [ "        self.seed = seed + " ++ show n
+                 , "        self.total = self.seed + seed + " ++ show (n + 1)
+                 , "        self.weight = self.total + self.seed + " ++ show (n + 2)
+                 , "        self." ++ branch ++ " = seed + self.seed + self.total + " ++ show (n + 3)
+                 , "        self." ++ extra ++ " = self." ++ branch ++ " + self.weight + " ++ show (n + 4)
+                 ]
+            else [ "        self." ++ branch ++ " = seed + " ++ show (n + 4)
+                 , "        self." ++ extra ++ " = self." ++ branch ++ " + seed + " ++ show (n + 5)
+                 , "        " ++ parent ++ ".__init__(self, seed + " ++ show (n + 1) ++ ")"
+                 ])
+      ++
+      [ ""
+      , "    def fold_" ++ method ++ "(self, x, y, z):"
+      , "        v0: int = x + y + z + self.seed + " ++ show n
+      ]
+      ++ [ "        v" ++ show i ++ ": int = v" ++ show (i - 1) ++ " + self."
+             ++ (if odd i then branch else extra) ++ " + self.total + " ++ show (n + i)
+         | i <- [1 .. 14 :: Int]
+         ]
+      ++
+      [ "        return v14"
+      , ""
+      , "    def score_" ++ method ++ "(self, bonus):"
+      , "        r0: int = self.fold_" ++ method ++ "(self.seed, self.total, self.weight) + bonus"
+      ]
+      ++ [ "        r" ++ show i ++ ": int = r" ++ show (i - 1) ++ " + self."
+             ++ (if odd i then extra else branch) ++ " + self.weight + " ++ show (n + i)
+         | i <- [1 .. 10 :: Int]
+         ]
+      ++
+      [ "        return r10"
+      , ""
+      , "_sep_" ++ pad 5 n ++ ": int = " ++ show n
+      , ""
+      ]
+      where
+        name = className tree suffix
+        parent = maybe "object" (className tree) parentSuffix
+        rootClass = parentSuffix == Nothing
+        method = map toLower name
+        branch = "branch_" ++ pad 5 n
+        extra = "extra_" ++ pad 5 n
 
 -- | Rewrite source hash and name-hash section of a .tydb file.
 rewriteTySrcHashAndNameHashes :: FilePath -> B.ByteString -> ([InterfaceFiles.NameHashInfo] -> [InterfaceFiles.NameHashInfo]) -> IO ()
@@ -2410,6 +2493,264 @@ buildHashTraceDep depDir = do
 hashTraceBuildArgs :: [String]
 hashTraceBuildArgs = ["--skip-build", "--searchpath", "deps/big/out/types"]
 
+-- Broad .tydb reads decode whole sections (every name, every constructor);
+-- these tests pin down that dependent-module compiles stay on keyed reads.
+broadReadMarkers :: [T.Text]
+broadReadMarkers =
+  [ "tydb-read all"
+  , "tydb-read public-names"
+  , "tydb-read constructors"
+  , "tydb-read name-hash-all"
+  ]
+
+p50_big_dep_added_name_keeps_small_fresh :: TestTree
+p50_big_dep_added_name_keeps_small_fresh =
+  testCase "50-added name in big dependency keeps small fresh" $ do
+    let proj = casesProjDir
+        src = casesSrcDir
+        modSmall = modLabel proj "small"
+        tySmall = proj </> "out" </> "types" </> "small.tydb"
+    ensureCasesProjectWithDeps [("big", "deps/big")]
+    depDir <- ensureDepProject proj "big"
+    let bigSrc = depDir </> "src" </> "big.act"
+    writeHeavyClassModule bigSrc 20
+    writeFileUtf8 (src </> "small.act") $ T.unlines
+      [ "import big"
+      , ""
+      , "def use_one() -> int:"
+      , "    return big.Node000A(1).score_node000a(2)"
+      , ""
+      , "actor main(env: Env):"
+      , "    print(use_one())"
+      , "    env.exit(0)"
+      ]
+    _ <- buildOutInArgs proj ["--skip-build"]
+    (pubDeps, implDeps) <- readTyDeps tySmall "use_one"
+    let bigPubDeps = sort [ dep | dep <- pubDeps, "big." `isPrefixOf` dep ]
+        bigImplDeps = sort [ dep | dep <- implDeps, "big." `isPrefixOf` dep ]
+    assertEqual "small pub deps into big" ["big.Node000A"] bigPubDeps
+    assertEqual "small impl deps into big" ["big.Node000A"] bigImplDeps
+    bigV1 <- T.readFile bigSrc
+    writeFileUtf8 bigSrc $ bigV1 <> T.unlines
+      [ ""
+      , "def unrelated_added_name() -> int:"
+      , "    return 123"
+      ]
+    res@(_ec, out) <- runActonInEnv [("ACTON_TYDB_TRACE_READS", "1")] proj ["build", "--color", "never", "--verbose", "--skip-build"]
+    assertExitSuccess "selective unchanged dependency build" res
+    -- big itself recompiles here, and the verbose delta report reads big's
+    -- own previous hashes; only reads serving small's freshness are pinned.
+    let traceLines = filter (T.isPrefixOf "tydb-read ") (T.lines out)
+        bigLines = filter (T.isInfixOf "big.tydb") traceLines
+        bigForbiddenLines = filter (\line -> any (`T.isInfixOf` line) (filter (/= "tydb-read name-hash-all") broadReadMarkers)) bigLines
+    assertBool ("expected small.act to stay fresh\n" ++ T.unpack out)
+      (T.isInfixOf "Fresh small: using cached .tydb" out)
+    assertBool "did not expect small.act to type check" (not (typechecked out modSmall))
+    assertEqual ("did not expect broad big.tydb reads\ntrace:\n" ++ T.unpack (T.unlines traceLines))
+      [] bigForbiddenLines
+
+p51_imported_lookup_stays_selective :: TestTree
+p51_imported_lookup_stays_selective =
+  testCase "51-imported .tydb lookup stays selective" $ do
+    let proj = casesProjDir
+        src = casesSrcDir
+        modSmall = modLabel proj "small"
+        writeSmall offset = writeFileUtf8 (src </> "small.act") $ T.unlines
+          [ "import big"
+          , ""
+          , "def use_one() -> int:"
+          , T.pack ("    return big.used_value() + " ++ show (offset :: Int))
+          , ""
+          , "actor main(env: Env):"
+          , "    print(use_one())"
+          , "    env.exit(0)"
+          ]
+    ensureCasesProjectWithDeps [("big", "deps/big")]
+    depDir <- ensureDepProject proj "big"
+    let bigSrc = depDir </> "src" </> "big.act"
+    writeHeavyClassModule bigSrc 20
+    bigV1 <- T.readFile bigSrc
+    writeFileUtf8 bigSrc $ bigV1 <> T.unlines
+      [ ""
+      , "def used_value() -> int:"
+      , "    return Node000A(1).score_node000a(2)"
+      ]
+    writeSmall 1
+    _ <- buildOutInArgs proj ["--skip-build"]
+    writeSmall 2
+    res@(_ec, out) <- runActonInEnv [("ACTON_TYDB_TRACE_READS", "1")] proj ["build", "--color", "never", "--verbose", "--skip-build"]
+    assertExitSuccess "selective .tydb trace build" res
+    let traceLines = filter (T.isPrefixOf "tydb-read ") (T.lines out)
+        bigLines = filter (T.isInfixOf "big.tydb") traceLines
+        bigForbiddenLines = filter (\line -> any (`T.isInfixOf` line) broadReadMarkers) bigLines
+        bigUsedValueLines = filter (\line -> T.isInfixOf "name-hit" line && T.isInfixOf "used_value" line) bigLines
+    assertBool ("expected small.act to type check\n" ++ T.unpack out) (typechecked out modSmall)
+    assertBool ("expected exact used_value lookup in big.tydb\ntrace:\n" ++ T.unpack (T.unlines traceLines))
+      (not (null bigUsedValueLines))
+    assertEqual ("did not expect broad big.tydb reads\ntrace:\n" ++ T.unpack (T.unlines traceLines))
+      [] bigForbiddenLines
+
+p52_imported_witness_lookup_stays_selective :: TestTree
+p52_imported_witness_lookup_stays_selective =
+  testCase "52-imported .tydb witness lookup stays selective" $ do
+    let proj = casesProjDir
+        src = casesSrcDir
+        modSmall = modLabel proj "small"
+        writeSmall offset = writeFileUtf8 (src </> "small.act") $ T.unlines
+          [ "import big"
+          , ""
+          , "actor main(env: Env):"
+          , "    box = big.Box(1)"
+          , "    other = big.Box(1)"
+          , "    ordered = big.OrderedBox(1)"
+          , T.pack ("    ordered2 = big.OrderedBox(" ++ show (offset :: Int) ++ ")")
+          , "    worker = big.Worker()"
+          , "    direct = big.Box(1).value"
+          , "    if box == other and ordered == ordered and ordered < ordered2 and direct == 1:"
+          , "        env.exit(0)"
+          , "    else:"
+          , "        env.exit(1)"
+          ]
+    ensureCasesProjectWithDeps [("big", "deps/big")]
+    depDir <- ensureDepProject proj "big"
+    let bigSrc = depDir </> "src" </> "big.act"
+    writeHeavyClassModule bigSrc 20
+    bigV1 <- T.readFile bigSrc
+    writeFileUtf8 bigSrc $ bigV1 <> T.unlines
+      [ ""
+      , "class Box:"
+      , "    value: int"
+      , "    __init__ : (int) -> None"
+      , ""
+      , "    def __init__(self, value):"
+      , "        self.value = value"
+      , ""
+      , "extension Box (Eq):"
+      , "    def __eq__(x, y):"
+      , "        return x.value == y.value"
+      , ""
+      , "class OrderedBox:"
+      , "    value: int"
+      , "    __init__ : (int) -> None"
+      , ""
+      , "    def __init__(self, value):"
+      , "        self.value = value"
+      , ""
+      , "extension OrderedBox (Ord):"
+      , "    def __eq__(x, y):"
+      , "        return x.value == y.value"
+      , ""
+      , "    def __lt__(x, y):"
+      , "        return x.value < y.value"
+      , ""
+      , "actor Worker():"
+      , "    def ping():"
+      , "        return 1"
+      ]
+    writeSmall 2
+    _ <- buildOutInArgs proj ["--skip-build"]
+    writeSmall 3
+    res@(_ec, out) <- runActonInEnv [("ACTON_TYDB_TRACE_READS", "1")] proj ["build", "--color", "never", "--verbose", "--skip-build"]
+    assertExitSuccess "selective .tydb witness trace build" res
+    let traceLines = filter (T.isPrefixOf "tydb-read ") (T.lines out)
+        bigLines = filter (T.isInfixOf "big.tydb") traceLines
+        bigForbiddenLines = filter (\line -> any (`T.isInfixOf` line) broadReadMarkers) bigLines
+        bigBoxLines = filter (\line -> T.isInfixOf "name-hit" line && T.isInfixOf "Box" line) bigLines
+        bigWorkerLines = filter (\line -> T.isInfixOf "name-hit" line && T.isInfixOf "Worker" line) bigLines
+        bigWitnessLines = filter (\line -> T.isInfixOf "ext-" line) bigLines
+    assertBool ("expected small.act to type check\n" ++ T.unpack out) (typechecked out modSmall)
+    assertBool ("expected exact Box lookup in big.tydb\ntrace:\n" ++ T.unpack (T.unlines traceLines))
+      (not (null bigBoxLines))
+    assertBool ("expected exact Worker lookup in big.tydb\ntrace:\n" ++ T.unpack (T.unlines traceLines))
+      (not (null bigWorkerLines))
+    assertBool ("expected keyed extension index lookups in big.tydb\ntrace:\n" ++ T.unpack (T.unlines traceLines))
+      (not (null bigWitnessLines))
+    assertEqual ("did not expect broad big.tydb reads\ntrace:\n" ++ T.unpack (T.unlines traceLines))
+      [] bigForbiddenLines
+
+p53_imported_attr_inference_stays_selective :: TestTree
+p53_imported_attr_inference_stays_selective =
+  testCase "53-imported .tydb attr inference stays selective" $ do
+    let proj = casesProjDir
+        src = casesSrcDir
+        modSmall = modLabel proj "small"
+        writeSmall offset = writeFileUtf8 (src </> "small.act") $ T.unlines
+          [ "import big"
+          , ""
+          , "def read_flag(args):"
+          , "    return args.get_bool(\"flag\")"
+          , ""
+          , "actor main(env: Env):"
+          , T.pack ("    if read_flag(big.Args()) and " ++ show (offset :: Int) ++ " > 0:")
+          , "        env.exit(0)"
+          , "    else:"
+          , "        env.exit(1)"
+          ]
+    ensureCasesProjectWithDeps [("big", "deps/big")]
+    depDir <- ensureDepProject proj "big"
+    let bigSrc = depDir </> "src" </> "big.act"
+    writeHeavyClassModule bigSrc 20
+    bigV1 <- T.readFile bigSrc
+    writeFileUtf8 bigSrc $ bigV1 <> T.unlines
+      [ ""
+      , "class Args:"
+      , "    def __init__(self):"
+      , "        pass"
+      , ""
+      , "    def get_bool(self, name: str) -> bool:"
+      , "        return True"
+      ]
+    writeSmall 1
+    _ <- buildOutInArgs proj ["--skip-build"]
+    writeSmall 2
+    res@(_ec, out) <- runActonInEnv [("ACTON_TYDB_TRACE_READS", "1")] proj ["build", "--color", "never", "--verbose", "--skip-build"]
+    assertExitSuccess "selective .tydb attr inference trace build" res
+    let traceLines = filter (T.isPrefixOf "tydb-read ") (T.lines out)
+        bigLines = filter (T.isInfixOf "big.tydb") traceLines
+        bigForbiddenLines = filter (\line -> any (`T.isInfixOf` line) broadReadMarkers) bigLines
+        bigArgsLines = filter (\line -> T.isInfixOf "name-hit" line && T.isInfixOf "Args" line) bigLines
+        bigAttrLines = filter (\line -> T.isInfixOf "con-attr" line && T.isInfixOf "get_bool" line) bigLines
+    assertBool ("expected small.act to type check\n" ++ T.unpack out) (typechecked out modSmall)
+    assertBool ("expected attr-index get_bool lookup in big.tydb\ntrace:\n" ++ T.unpack (T.unlines traceLines))
+      (not (null bigAttrLines))
+    assertBool ("expected exact Args lookup in big.tydb\ntrace:\n" ++ T.unpack (T.unlines traceLines))
+      (not (null bigArgsLines))
+    assertEqual ("did not expect broad big.tydb reads\ntrace:\n" ++ T.unpack (T.unlines traceLines))
+      [] bigForbiddenLines
+
+p54_unused_import_reads_no_names :: TestTree
+p54_unused_import_reads_no_names =
+  testCase "54-unused import full build reads no .tydb names" $ do
+    let proj = casesProjDir
+        src = casesSrcDir
+        modSmall = modLabel proj "small"
+    ensureCasesProject
+    let bigSrc = src </> "big.act"
+    writeHeavyClassModule bigSrc 10
+    bigRes <- runActonIn proj ["build", "--color", "never", "--skip-build", "src/big.act"]
+    assertExitSuccess "build cached big dependency" bigRes
+    writeFileUtf8 (src </> "small.act") $ T.unlines
+      [ "import big"
+      , ""
+      , "def use_none() -> int:"
+      , "    return 42"
+      ]
+    res@(_ec, out) <- runActonInEnv [("ACTON_TYDB_TRACE_READS", "1")] proj ["build", "--color", "never", "--verbose", "--skip-build", "src/small.act"]
+    assertExitSuccess "unused import .tydb trace build" res
+    let traceLines = filter (T.isPrefixOf "tydb-read ") (T.lines out)
+        bigLines = filter (T.isInfixOf "big.tydb") traceLines
+        -- Solver witness queries may still probe each import's keyed
+        -- extension indexes; those reads are per-module, not per-size.
+        bigForbiddenLines = filter (\line -> any (`T.isInfixOf` line)
+                                     (broadReadMarkers ++
+                                      [ "tydb-read name-hit"
+                                      , "tydb-read name-miss"
+                                      , "tydb-read name-hash"
+                                      ])) bigLines
+    assertBool ("expected small.act to type check\n" ++ T.unpack out) (typechecked out modSmall)
+    assertEqual ("did not expect any broad or name reads from unused big.tydb\ntrace:\n" ++ T.unpack (T.unlines traceLines))
+      [] bigForbiddenLines
+
 -- Main -----------------------------------------------------------------------
 
 -- | Tasty entry point for incremental tests.
@@ -2483,5 +2824,10 @@ main = defaultMain $ localOption (NumThreads 1) $ testGroup "incremental"
       , p47_unchanged_dep_reads_module_hashes_only
       , p48_unrelated_dep_addition_reads_used_name_only
       , p49_changed_dep_name_reads_users
+      , p50_big_dep_added_name_keeps_small_fresh
+      , p51_imported_lookup_stays_selective
+      , p52_imported_witness_lookup_stays_selective
+      , p53_imported_attr_inference_stays_selective
+      , p54_unused_import_reads_no_names
       ]
   ]

--- a/compiler/acton/test_incremental.hs
+++ b/compiler/acton/test_incremental.hs
@@ -2718,6 +2718,43 @@ p53_imported_attr_inference_stays_selective =
     assertEqual ("did not expect broad big.tydb reads\ntrace:\n" ++ T.unpack (T.unlines traceLines))
       [] bigForbiddenLines
 
+p55_dbp_reads_selected_statements :: TestTree
+p55_dbp_reads_selected_statements =
+  testCase "55-cached DBP reads selected .tydb statements" $ do
+    let proj = casesProjDir
+        src = casesSrcDir
+        modSmall = modLabel proj "small"
+    ensureCasesProjectWithDeps [("big", "deps/big")]
+    depDir <- ensureDepProject proj "big"
+    let bigSrc = depDir </> "src" </> "big.act"
+    writeHeavyClassModule bigSrc 40
+    bigRes <- runActonIn depDir ["build", "--color", "never", "--skip-build"]
+    assertExitSuccess "build cached big dependency" bigRes
+    writeFileUtf8 (src </> "small.act") $ T.unlines
+      [ "import big"
+      , ""
+      , "def use_one() -> int:"
+      , "    return big.Node000A(1).score_node000a(2)"
+      , ""
+      , "actor main(env: Env):"
+      , "    print(use_one())"
+      , "    env.exit(0)"
+      ]
+    res@(_ec, out) <- runActonInEnv [("ACTON_TYDB_TRACE_READS", "1")] proj ["build", "--color", "never", "--verbose", "--skip-build", "--dbp", "big:Node000A"]
+    assertExitSuccess "selective DBP .tydb trace build" res
+    let traceLines = filter (T.isPrefixOf "tydb-read ") (T.lines out)
+        bigLines = filter (T.isInfixOf "big.tydb") traceLines
+        bigForbiddenLines = filter (\line -> any (`T.isInfixOf` line) broadReadMarkers) bigLines
+        bigNodeLines = filter (\line -> T.isInfixOf "name-hash" line && T.isInfixOf "Node000A" line) bigLines
+        bigStmtLines = filter (\line -> T.isInfixOf "tydb-read stmts" line && T.isInfixOf "selected 1 -> 1" line) bigLines
+    assertBool ("expected small.act to type check\n" ++ T.unpack out) (typechecked out modSmall)
+    assertBool ("expected exact Node000A hash lookup in big.tydb\ntrace:\n" ++ T.unpack (T.unlines traceLines))
+      (not (null bigNodeLines))
+    assertBool ("expected selected statement read in big.tydb\ntrace:\n" ++ T.unpack (T.unlines traceLines))
+      (not (null bigStmtLines))
+    assertEqual ("did not expect broad big.tydb reads\ntrace:\n" ++ T.unpack (T.unlines traceLines))
+      [] bigForbiddenLines
+
 p54_unused_import_reads_no_names :: TestTree
 p54_unused_import_reads_no_names =
   testCase "54-unused import full build reads no .tydb names" $ do
@@ -2829,5 +2866,6 @@ main = defaultMain $ localOption (NumThreads 1) $ testGroup "incremental"
       , p52_imported_witness_lookup_stays_selective
       , p53_imported_attr_inference_stays_selective
       , p54_unused_import_reads_no_names
+      , p55_dbp_reads_selected_statements
       ]
   ]

--- a/compiler/acton/test_incremental.hs
+++ b/compiler/acton/test_incremental.hs
@@ -2503,50 +2503,63 @@ broadReadMarkers =
   , "tydb-read name-hash-all"
   ]
 
+-- | Create and build a heavy-class dependency project "big_dep" under deps/big
+-- with `trees` classes. Importers find it via "--searchpath deps/big/out/types"
+-- (hashTraceBuildArgs / buildHashTraceRoot) and import it as "big_dep.big",
+-- matching the project-prefixed layout out/types/big_dep/big.tydb.
+ensureHeavyDep :: Int -> IO FilePath
+ensureHeavyDep trees = do
+  ensureCasesProject
+  let depDir = casesProjDir </> "deps" </> "big"
+  createDirectoryIfMissing True (depDir </> "src")
+  writeBuildAct depDir "big_dep" []
+  writeHeavyClassModule (depDir </> "src" </> "big.act") trees
+  buildHashTraceDep depDir
+  pure depDir
+
 p50_big_dep_added_name_keeps_small_fresh :: TestTree
 p50_big_dep_added_name_keeps_small_fresh =
   testCase "50-added name in big dependency keeps small fresh" $ do
     let proj = casesProjDir
         src = casesSrcDir
         modSmall = modLabel proj "small"
-        tySmall = proj </> "out" </> "types" </> "small.tydb"
-    ensureCasesProjectWithDeps [("big", "deps/big")]
-    depDir <- ensureDepProject proj "big"
+        tySmall = proj </> "out" </> "types" </> casesProjName </> "small.tydb"
+    depDir <- ensureHeavyDep 20
     let bigSrc = depDir </> "src" </> "big.act"
-    writeHeavyClassModule bigSrc 20
     writeFileUtf8 (src </> "small.act") $ T.unlines
-      [ "import big"
+      [ "import big_dep.big"
       , ""
       , "def use_one() -> int:"
-      , "    return big.Node000A(1).score_node000a(2)"
+      , "    return big_dep.big.Node000A(1).score_node000a(2)"
       , ""
       , "actor main(env: Env):"
       , "    print(use_one())"
       , "    env.exit(0)"
       ]
-    _ <- buildOutInArgs proj ["--skip-build"]
+    buildHashTraceRoot
     (pubDeps, implDeps) <- readTyDeps tySmall "use_one"
-    let bigPubDeps = sort [ dep | dep <- pubDeps, "big." `isPrefixOf` dep ]
-        bigImplDeps = sort [ dep | dep <- implDeps, "big." `isPrefixOf` dep ]
-    assertEqual "small pub deps into big" ["big.Node000A"] bigPubDeps
-    assertEqual "small impl deps into big" ["big.Node000A"] bigImplDeps
+    let bigPubDeps = sort [ dep | dep <- pubDeps, "big_dep.big." `isPrefixOf` dep ]
+        bigImplDeps = sort [ dep | dep <- implDeps, "big_dep.big." `isPrefixOf` dep ]
+    assertEqual "small pub deps into big" ["big_dep.big.Node000A"] bigPubDeps
+    assertEqual "small impl deps into big" ["big_dep.big.Node000A"] bigImplDeps
     bigV1 <- T.readFile bigSrc
     writeFileUtf8 bigSrc $ bigV1 <> T.unlines
       [ ""
       , "def unrelated_added_name() -> int:"
       , "    return 123"
       ]
-    res@(_ec, out) <- runActonInEnv [("ACTON_TYDB_TRACE_READS", "1")] proj ["build", "--color", "never", "--verbose", "--skip-build"]
+    buildHashTraceDep depDir
+    res@(_ec, out) <- runActonInEnv [("ACTON_TYDB_TRACE_READS", "1")] proj (["build", "--color", "never", "--verbose"] ++ hashTraceBuildArgs)
     assertExitSuccess "selective unchanged dependency build" res
     -- big itself recompiles here, and the verbose delta report reads big's
     -- own previous hashes; only reads serving small's freshness are pinned.
-    let traceLines = filter (T.isPrefixOf "tydb-read ") (T.lines out)
-        bigLines = filter (T.isInfixOf "big.tydb") traceLines
+    let traceLines = tydbTraceLines out
+        bigLines = traceLinesForTydb "big_dep/big" out
         bigForbiddenLines = filter (\line -> any (`T.isInfixOf` line) (filter (/= "tydb-read name-hash-all") broadReadMarkers)) bigLines
     assertBool ("expected small.act to stay fresh\n" ++ T.unpack out)
-      (T.isInfixOf "Fresh small: using cached .tydb" out)
+      (T.isInfixOf (T.pack "Fresh small: using cached .tydb") out)
     assertBool "did not expect small.act to type check" (not (typechecked out modSmall))
-    assertEqual ("did not expect broad big.tydb reads\ntrace:\n" ++ T.unpack (T.unlines traceLines))
+    assertEqual ("did not expect broad big_dep.big.tydb reads\ntrace:\n" ++ T.unpack (T.unlines traceLines))
       [] bigForbiddenLines
 
 p51_imported_lookup_stays_selective :: TestTree
@@ -2556,38 +2569,37 @@ p51_imported_lookup_stays_selective =
         src = casesSrcDir
         modSmall = modLabel proj "small"
         writeSmall offset = writeFileUtf8 (src </> "small.act") $ T.unlines
-          [ "import big"
+          [ "import big_dep.big"
           , ""
           , "def use_one() -> int:"
-          , T.pack ("    return big.used_value() + " ++ show (offset :: Int))
+          , T.pack ("    return big_dep.big.used_value() + " ++ show (offset :: Int))
           , ""
           , "actor main(env: Env):"
           , "    print(use_one())"
           , "    env.exit(0)"
           ]
-    ensureCasesProjectWithDeps [("big", "deps/big")]
-    depDir <- ensureDepProject proj "big"
+    depDir <- ensureHeavyDep 20
     let bigSrc = depDir </> "src" </> "big.act"
-    writeHeavyClassModule bigSrc 20
     bigV1 <- T.readFile bigSrc
     writeFileUtf8 bigSrc $ bigV1 <> T.unlines
       [ ""
       , "def used_value() -> int:"
       , "    return Node000A(1).score_node000a(2)"
       ]
+    buildHashTraceDep depDir
     writeSmall 1
-    _ <- buildOutInArgs proj ["--skip-build"]
+    buildHashTraceRoot
     writeSmall 2
-    res@(_ec, out) <- runActonInEnv [("ACTON_TYDB_TRACE_READS", "1")] proj ["build", "--color", "never", "--verbose", "--skip-build"]
+    res@(_ec, out) <- runActonInEnv [("ACTON_TYDB_TRACE_READS", "1")] proj (["build", "--color", "never", "--verbose"] ++ hashTraceBuildArgs)
     assertExitSuccess "selective .tydb trace build" res
-    let traceLines = filter (T.isPrefixOf "tydb-read ") (T.lines out)
-        bigLines = filter (T.isInfixOf "big.tydb") traceLines
+    let traceLines = tydbTraceLines out
+        bigLines = traceLinesForTydb "big_dep/big" out
         bigForbiddenLines = filter (\line -> any (`T.isInfixOf` line) broadReadMarkers) bigLines
         bigUsedValueLines = filter (\line -> T.isInfixOf "name-hit" line && T.isInfixOf "used_value" line) bigLines
     assertBool ("expected small.act to type check\n" ++ T.unpack out) (typechecked out modSmall)
-    assertBool ("expected exact used_value lookup in big.tydb\ntrace:\n" ++ T.unpack (T.unlines traceLines))
+    assertBool ("expected exact used_value lookup in big_dep.big.tydb\ntrace:\n" ++ T.unpack (T.unlines traceLines))
       (not (null bigUsedValueLines))
-    assertEqual ("did not expect broad big.tydb reads\ntrace:\n" ++ T.unpack (T.unlines traceLines))
+    assertEqual ("did not expect broad big_dep.big.tydb reads\ntrace:\n" ++ T.unpack (T.unlines traceLines))
       [] bigForbiddenLines
 
 p52_imported_witness_lookup_stays_selective :: TestTree
@@ -2597,24 +2609,22 @@ p52_imported_witness_lookup_stays_selective =
         src = casesSrcDir
         modSmall = modLabel proj "small"
         writeSmall offset = writeFileUtf8 (src </> "small.act") $ T.unlines
-          [ "import big"
+          [ "import big_dep.big"
           , ""
           , "actor main(env: Env):"
-          , "    box = big.Box(1)"
-          , "    other = big.Box(1)"
-          , "    ordered = big.OrderedBox(1)"
-          , T.pack ("    ordered2 = big.OrderedBox(" ++ show (offset :: Int) ++ ")")
-          , "    worker = big.Worker()"
-          , "    direct = big.Box(1).value"
+          , "    box = big_dep.big.Box(1)"
+          , "    other = big_dep.big.Box(1)"
+          , "    ordered = big_dep.big.OrderedBox(1)"
+          , T.pack ("    ordered2 = big_dep.big.OrderedBox(" ++ show (offset :: Int) ++ ")")
+          , "    worker = big_dep.big.Worker()"
+          , "    direct = big_dep.big.Box(1).value"
           , "    if box == other and ordered == ordered and ordered < ordered2 and direct == 1:"
           , "        env.exit(0)"
           , "    else:"
           , "        env.exit(1)"
           ]
-    ensureCasesProjectWithDeps [("big", "deps/big")]
-    depDir <- ensureDepProject proj "big"
+    depDir <- ensureHeavyDep 20
     let bigSrc = depDir </> "src" </> "big.act"
-    writeHeavyClassModule bigSrc 20
     bigV1 <- T.readFile bigSrc
     writeFileUtf8 bigSrc $ bigV1 <> T.unlines
       [ ""
@@ -2647,25 +2657,26 @@ p52_imported_witness_lookup_stays_selective =
       , "    def ping():"
       , "        return 1"
       ]
+    buildHashTraceDep depDir
     writeSmall 2
-    _ <- buildOutInArgs proj ["--skip-build"]
+    buildHashTraceRoot
     writeSmall 3
-    res@(_ec, out) <- runActonInEnv [("ACTON_TYDB_TRACE_READS", "1")] proj ["build", "--color", "never", "--verbose", "--skip-build"]
+    res@(_ec, out) <- runActonInEnv [("ACTON_TYDB_TRACE_READS", "1")] proj (["build", "--color", "never", "--verbose"] ++ hashTraceBuildArgs)
     assertExitSuccess "selective .tydb witness trace build" res
-    let traceLines = filter (T.isPrefixOf "tydb-read ") (T.lines out)
-        bigLines = filter (T.isInfixOf "big.tydb") traceLines
+    let traceLines = tydbTraceLines out
+        bigLines = traceLinesForTydb "big_dep/big" out
         bigForbiddenLines = filter (\line -> any (`T.isInfixOf` line) broadReadMarkers) bigLines
         bigBoxLines = filter (\line -> T.isInfixOf "name-hit" line && T.isInfixOf "Box" line) bigLines
         bigWorkerLines = filter (\line -> T.isInfixOf "name-hit" line && T.isInfixOf "Worker" line) bigLines
         bigWitnessLines = filter (\line -> T.isInfixOf "ext-" line) bigLines
     assertBool ("expected small.act to type check\n" ++ T.unpack out) (typechecked out modSmall)
-    assertBool ("expected exact Box lookup in big.tydb\ntrace:\n" ++ T.unpack (T.unlines traceLines))
+    assertBool ("expected exact Box lookup in big_dep.big.tydb\ntrace:\n" ++ T.unpack (T.unlines traceLines))
       (not (null bigBoxLines))
-    assertBool ("expected exact Worker lookup in big.tydb\ntrace:\n" ++ T.unpack (T.unlines traceLines))
+    assertBool ("expected exact Worker lookup in big_dep.big.tydb\ntrace:\n" ++ T.unpack (T.unlines traceLines))
       (not (null bigWorkerLines))
-    assertBool ("expected keyed extension index lookups in big.tydb\ntrace:\n" ++ T.unpack (T.unlines traceLines))
+    assertBool ("expected keyed extension index lookups in big_dep.big.tydb\ntrace:\n" ++ T.unpack (T.unlines traceLines))
       (not (null bigWitnessLines))
-    assertEqual ("did not expect broad big.tydb reads\ntrace:\n" ++ T.unpack (T.unlines traceLines))
+    assertEqual ("did not expect broad big_dep.big.tydb reads\ntrace:\n" ++ T.unpack (T.unlines traceLines))
       [] bigForbiddenLines
 
 p53_imported_attr_inference_stays_selective :: TestTree
@@ -2675,21 +2686,19 @@ p53_imported_attr_inference_stays_selective =
         src = casesSrcDir
         modSmall = modLabel proj "small"
         writeSmall offset = writeFileUtf8 (src </> "small.act") $ T.unlines
-          [ "import big"
+          [ "import big_dep.big"
           , ""
           , "def read_flag(args):"
           , "    return args.get_bool(\"flag\")"
           , ""
           , "actor main(env: Env):"
-          , T.pack ("    if read_flag(big.Args()) and " ++ show (offset :: Int) ++ " > 0:")
+          , T.pack ("    if read_flag(big_dep.big.Args()) and " ++ show (offset :: Int) ++ " > 0:")
           , "        env.exit(0)"
           , "    else:"
           , "        env.exit(1)"
           ]
-    ensureCasesProjectWithDeps [("big", "deps/big")]
-    depDir <- ensureDepProject proj "big"
+    depDir <- ensureHeavyDep 20
     let bigSrc = depDir </> "src" </> "big.act"
-    writeHeavyClassModule bigSrc 20
     bigV1 <- T.readFile bigSrc
     writeFileUtf8 bigSrc $ bigV1 <> T.unlines
       [ ""
@@ -2700,22 +2709,23 @@ p53_imported_attr_inference_stays_selective =
       , "    def get_bool(self, name: str) -> bool:"
       , "        return True"
       ]
+    buildHashTraceDep depDir
     writeSmall 1
-    _ <- buildOutInArgs proj ["--skip-build"]
+    buildHashTraceRoot
     writeSmall 2
-    res@(_ec, out) <- runActonInEnv [("ACTON_TYDB_TRACE_READS", "1")] proj ["build", "--color", "never", "--verbose", "--skip-build"]
+    res@(_ec, out) <- runActonInEnv [("ACTON_TYDB_TRACE_READS", "1")] proj (["build", "--color", "never", "--verbose"] ++ hashTraceBuildArgs)
     assertExitSuccess "selective .tydb attr inference trace build" res
-    let traceLines = filter (T.isPrefixOf "tydb-read ") (T.lines out)
-        bigLines = filter (T.isInfixOf "big.tydb") traceLines
+    let traceLines = tydbTraceLines out
+        bigLines = traceLinesForTydb "big_dep/big" out
         bigForbiddenLines = filter (\line -> any (`T.isInfixOf` line) broadReadMarkers) bigLines
         bigArgsLines = filter (\line -> T.isInfixOf "name-hit" line && T.isInfixOf "Args" line) bigLines
         bigAttrLines = filter (\line -> T.isInfixOf "con-attr" line && T.isInfixOf "get_bool" line) bigLines
     assertBool ("expected small.act to type check\n" ++ T.unpack out) (typechecked out modSmall)
-    assertBool ("expected attr-index get_bool lookup in big.tydb\ntrace:\n" ++ T.unpack (T.unlines traceLines))
+    assertBool ("expected attr-index get_bool lookup in big_dep.big.tydb\ntrace:\n" ++ T.unpack (T.unlines traceLines))
       (not (null bigAttrLines))
-    assertBool ("expected exact Args lookup in big.tydb\ntrace:\n" ++ T.unpack (T.unlines traceLines))
+    assertBool ("expected exact Args lookup in big_dep.big.tydb\ntrace:\n" ++ T.unpack (T.unlines traceLines))
       (not (null bigArgsLines))
-    assertEqual ("did not expect broad big.tydb reads\ntrace:\n" ++ T.unpack (T.unlines traceLines))
+    assertEqual ("did not expect broad big_dep.big.tydb reads\ntrace:\n" ++ T.unpack (T.unlines traceLines))
       [] bigForbiddenLines
 
 p55_dbp_reads_selected_statements :: TestTree
@@ -2724,12 +2734,13 @@ p55_dbp_reads_selected_statements =
     let proj = casesProjDir
         src = casesSrcDir
         modSmall = modLabel proj "small"
-    ensureCasesProjectWithDeps [("big", "deps/big")]
-    depDir <- ensureDepProject proj "big"
-    let bigSrc = depDir </> "src" </> "big.act"
+    -- --dbp targets root-project modules (parseDbpSpec prefixes the project
+    -- name), so big must be a local module here, not a searchpath dependency.
+    ensureCasesProject
+    let bigSrc = src </> "big.act"
     writeHeavyClassModule bigSrc 40
-    bigRes <- runActonIn depDir ["build", "--color", "never", "--skip-build"]
-    assertExitSuccess "build cached big dependency" bigRes
+    bigRes <- runActonIn proj ["build", "--color", "never", "--skip-build", "src/big.act"]
+    assertExitSuccess "build cached big module" bigRes
     writeFileUtf8 (src </> "small.act") $ T.unlines
       [ "import big"
       , ""
@@ -2742,17 +2753,17 @@ p55_dbp_reads_selected_statements =
       ]
     res@(_ec, out) <- runActonInEnv [("ACTON_TYDB_TRACE_READS", "1")] proj ["build", "--color", "never", "--verbose", "--skip-build", "--dbp", "big:Node000A"]
     assertExitSuccess "selective DBP .tydb trace build" res
-    let traceLines = filter (T.isPrefixOf "tydb-read ") (T.lines out)
-        bigLines = filter (T.isInfixOf "big.tydb") traceLines
+    let traceLines = tydbTraceLines out
+        bigLines = traceLinesForTydb "incremental_cases/big" out
         bigForbiddenLines = filter (\line -> any (`T.isInfixOf` line) broadReadMarkers) bigLines
         bigNodeLines = filter (\line -> T.isInfixOf "name-hash" line && T.isInfixOf "Node000A" line) bigLines
         bigStmtLines = filter (\line -> T.isInfixOf "tydb-read stmts" line && T.isInfixOf "selected 1 -> 1" line) bigLines
     assertBool ("expected small.act to type check\n" ++ T.unpack out) (typechecked out modSmall)
-    assertBool ("expected exact Node000A hash lookup in big.tydb\ntrace:\n" ++ T.unpack (T.unlines traceLines))
+    assertBool ("expected exact Node000A hash lookup in incremental_cases/big.tydb\ntrace:\n" ++ T.unpack (T.unlines traceLines))
       (not (null bigNodeLines))
-    assertBool ("expected selected statement read in big.tydb\ntrace:\n" ++ T.unpack (T.unlines traceLines))
+    assertBool ("expected selected statement read in incremental_cases/big.tydb\ntrace:\n" ++ T.unpack (T.unlines traceLines))
       (not (null bigStmtLines))
-    assertEqual ("did not expect broad big.tydb reads\ntrace:\n" ++ T.unpack (T.unlines traceLines))
+    assertEqual ("did not expect broad incremental_cases/big.tydb reads\ntrace:\n" ++ T.unpack (T.unlines traceLines))
       [] bigForbiddenLines
 
 p54_unused_import_reads_no_names :: TestTree
@@ -2774,8 +2785,8 @@ p54_unused_import_reads_no_names =
       ]
     res@(_ec, out) <- runActonInEnv [("ACTON_TYDB_TRACE_READS", "1")] proj ["build", "--color", "never", "--verbose", "--skip-build", "src/small.act"]
     assertExitSuccess "unused import .tydb trace build" res
-    let traceLines = filter (T.isPrefixOf "tydb-read ") (T.lines out)
-        bigLines = filter (T.isInfixOf "big.tydb") traceLines
+    let traceLines = tydbTraceLines out
+        bigLines = traceLinesForTydb "incremental_cases/big" out
         -- Solver witness queries may still probe each import's keyed
         -- extension indexes; those reads are per-module, not per-size.
         bigForbiddenLines = filter (\line -> any (`T.isInfixOf` line)
@@ -2785,7 +2796,7 @@ p54_unused_import_reads_no_names =
                                       , "tydb-read name-hash"
                                       ])) bigLines
     assertBool ("expected small.act to type check\n" ++ T.unpack out) (typechecked out modSmall)
-    assertEqual ("did not expect any broad or name reads from unused big.tydb\ntrace:\n" ++ T.unpack (T.unlines traceLines))
+    assertEqual ("did not expect any broad or name reads from unused incremental_cases/big.tydb\ntrace:\n" ++ T.unpack (T.unlines traceLines))
       [] bigForbiddenLines
 
 -- Main -----------------------------------------------------------------------

--- a/compiler/lib/bench/CompilerBench.hs
+++ b/compiler/lib/bench/CompilerBench.hs
@@ -168,6 +168,13 @@ resolveNameHashMap paths mn = do
           Just (_, _, _, _, _, _, nameHashes, _, _, _) -> Just (nameHashMapFromHeader nameHashes)
           Nothing -> Nothing
 
+resolveNameHash :: Compile.Paths -> Syntax.ModName -> Syntax.Name -> IO (Maybe InterfaceFiles.NameHashInfo)
+resolveNameHash paths mn n = do
+    mty <- Env.findTyFile (Compile.searchPath paths) mn
+    case mty of
+      Nothing -> return Nothing
+      Just ty -> InterfaceFiles.readNameHashMaybe ty n
+
 resolveDepHashMap :: String
                   -> (InterfaceFiles.NameHashInfo -> B.ByteString)
                   -> Map.Map Syntax.ModName (Map.Map Syntax.Name InterfaceFiles.NameHashInfo)
@@ -764,7 +771,7 @@ runCompilerFront buildFront runBack typesPath sourcePath = do
       Nothing
       (Compile.getPubHashCached paths)
       (Compile.getImplHashCached paths)
-      (resolveNameHashMap paths)
+      (resolveNameHash paths)
       (\_ -> return ())
       (\_ _ -> return ())
       (\_ _ _ -> return ())

--- a/compiler/lib/bench/CompilerBench.hs
+++ b/compiler/lib/bench/CompilerBench.hs
@@ -101,8 +101,8 @@ measureRepeated statsEnabled label reps action = do
       let total' = total + count
       total' `seq` loop (n - 1) total'
 
-forceHTEnv = HashMap.foldl' forceHNameInfo () where
-    forceHNameInfo () hni                        = hni `seq` ()
+forceHTEnv = HashMap.foldl' forceNameInfo () where
+    forceNameInfo () ni                          = ni `seq` ()
 
 forceModuleInfos = Map.foldl' forceModuleInfo () where
     forceModuleInfo () mi = rnf (Env.modulePublicTEnv mi)

--- a/compiler/lib/bench/CompilerBench.hs
+++ b/compiler/lib/bench/CompilerBench.hs
@@ -102,7 +102,6 @@ measureRepeated statsEnabled label reps action = do
       total' `seq` loop (n - 1) total'
 
 forceHTEnv = HashMap.foldl' forceHNameInfo () where
-    forceHNameInfo () (NameInfo.HNModule _ te _) = forceHTEnv te
     forceHNameInfo () hni                        = hni `seq` ()
 
 forceModuleInfos = Map.foldl' forceModuleInfo () where
@@ -202,7 +201,7 @@ data HashBenchState = HashBenchState
     , hbsEnv      :: Env.Env0
     , hbsParsed   :: Syntax.Module
     , hbsTChecked :: Syntax.Module
-    , hbsNMod     :: NameInfo.NameInfo
+    , hbsNMod     :: NameInfo.NModule
     , hbsExtMaps  :: Map.Map Syntax.ModName (Map.Map Syntax.Name InterfaceFiles.NameHashInfo)
     }
 
@@ -262,7 +261,7 @@ prepareHashBench typesPath sourcePath = do
 
 hashBenchFromHashes :: Syntax.ModName
                     -> Env.Env0
-                    -> NameInfo.NameInfo
+                    -> NameInfo.NModule
                     -> Map.Map Syntax.ModName (Map.Map Syntax.Name InterfaceFiles.NameHashInfo)
                     -> [Hashing.TopLevelItem]
                     -> Map.Map Syntax.Name B.ByteString
@@ -303,7 +302,7 @@ hashBenchOnce :: Syntax.ModName
               -> Env.Env0
               -> Syntax.Module
               -> Syntax.Module
-              -> NameInfo.NameInfo
+              -> NameInfo.NModule
               -> Map.Map Syntax.ModName (Map.Map Syntax.Name InterfaceFiles.NameHashInfo)
               -> (B.ByteString, B.ByteString, [InterfaceFiles.NameHashInfo])
 hashBenchOnce mn env parsed tchecked nmod extMaps =

--- a/compiler/lib/bench/CompilerBench.hs
+++ b/compiler/lib/bench/CompilerBench.hs
@@ -105,6 +105,9 @@ forceHTEnv = HashMap.foldl' forceHNameInfo () where
     forceHNameInfo () (NameInfo.HNModule _ te _) = forceHTEnv te
     forceHNameInfo () hni                        = hni `seq` ()
 
+forceModuleInfos = Map.foldl' forceModuleInfo () where
+    forceModuleInfo () mi = rnf (Env.modulePublicTEnv mi)
+
 fmtTime :: TimeSpec -> String
 fmtTime t = show seconds ++ "s"
   where seconds = (fromIntegral (toNanoSecs t) / 1000000000.0 :: Double)
@@ -221,14 +224,14 @@ prepareHashBench typesPath sourcePath = do
     E.evaluate (rnf parsed)
     env <- Env.mkEnv (Compile.searchPath paths) env0 parsed
     E.evaluate (forceHTEnv (Env.hnames env))
-    E.evaluate (forceHTEnv (Env.hmodules env))
+    E.evaluate (forceModuleInfos (Env.modules env))
     kchecked <- Kinds.check env parsed
     E.evaluate (rnf kchecked)
     (nmod, tchecked, typeEnv, tests) <- Types.reconstruct Nothing Nothing env kchecked Nothing
     E.evaluate (rnf nmod)
     E.evaluate (rnf tchecked)
     E.evaluate (forceHTEnv (Env.hnames typeEnv))
-    E.evaluate (forceHTEnv (Env.hmodules typeEnv))
+    E.evaluate (forceModuleInfos (Env.modules typeEnv))
     E.evaluate (length tests)
 
     let NameInfo.NModule _ fullIface _ = nmod
@@ -713,7 +716,7 @@ runDirect mode typesPath sourcePath = do
       _ -> do
         env <- Env.mkEnv [typesPath] env0 parsed
         E.evaluate (forceHTEnv (Env.hnames env))
-        E.evaluate (forceHTEnv (Env.hmodules env))
+        E.evaluate (forceModuleInfos (Env.modules env))
         t2 <- getCurrentTime
         s2 <- getStats statsEnabled
         elapsed "env" t1 t2
@@ -733,7 +736,7 @@ runDirect mode typesPath sourcePath = do
             E.evaluate (rnf nmod)
             E.evaluate (rnf tchecked)
             E.evaluate (forceHTEnv (Env.hnames typeEnv))
-            E.evaluate (forceHTEnv (Env.hmodules typeEnv))
+            E.evaluate (forceModuleInfos (Env.modules typeEnv))
             E.evaluate (length tests)
             t4 <- getCurrentTime
             s4 <- getStats statsEnabled

--- a/compiler/lib/bench/KindsBench.hs
+++ b/compiler/lib/bench/KindsBench.hs
@@ -60,7 +60,6 @@ main = do
 
         env <- Env.mkEnv [typesPath] env0 parsed
         E.evaluate (forceHTEnv (Env.hnames env))
-        E.evaluate (forceHTEnv (Env.hmodules env))
         t2 <- getCurrentTime
         s2 <- getStats statsEnabled
         elapsed "env" t1 t2

--- a/compiler/lib/bench/KindsBench.hs
+++ b/compiler/lib/bench/KindsBench.hs
@@ -36,7 +36,6 @@ printStatsMaybe label (Just before) (Just after) = printStats label before after
 printStatsMaybe _ _ _                            = return ()
 
 forceHTEnv = HashMap.foldl' forceHNameInfo () where
-    forceHNameInfo () (NameInfo.HNModule _ te _) = forceHTEnv te
     forceHNameInfo () hni                        = hni `seq` ()
 
 main = do

--- a/compiler/lib/bench/KindsBench.hs
+++ b/compiler/lib/bench/KindsBench.hs
@@ -35,8 +35,8 @@ getStats enabled =
 printStatsMaybe label (Just before) (Just after) = printStats label before after
 printStatsMaybe _ _ _                            = return ()
 
-forceHTEnv = HashMap.foldl' forceHNameInfo () where
-    forceHNameInfo () hni                        = hni `seq` ()
+forceHTEnv = HashMap.foldl' forceNameInfo () where
+    forceNameInfo () ni                          = ni `seq` ()
 
 main = do
     hSetBuffering stdout LineBuffering

--- a/compiler/lib/bench/TypesBench.hs
+++ b/compiler/lib/bench/TypesBench.hs
@@ -61,7 +61,6 @@ main = do
 
         env <- Env.mkEnv [typesPath] env0 parsed
         E.evaluate (forceHTEnv (Env.hnames env))
-        E.evaluate (forceHTEnv (Env.hmodules env))
         t2 <- getCurrentTime
         s2 <- getStats statsEnabled
         elapsed "env" t1 t2
@@ -78,7 +77,6 @@ main = do
         E.evaluate (rnf nmod)
         E.evaluate (rnf tchecked)
         E.evaluate (forceHTEnv (Env.hnames typeEnv))
-        E.evaluate (forceHTEnv (Env.hmodules typeEnv))
         E.evaluate (length tests)
         t4 <- getCurrentTime
         s4 <- getStats statsEnabled

--- a/compiler/lib/bench/TypesBench.hs
+++ b/compiler/lib/bench/TypesBench.hs
@@ -36,8 +36,8 @@ getStats enabled =
 printStatsMaybe label (Just before) (Just after) = printStats label before after
 printStatsMaybe _ _ _                            = return ()
 
-forceHTEnv = HashMap.foldl' forceHNameInfo () where
-    forceHNameInfo () hni                        = hni `seq` ()
+forceHTEnv = HashMap.foldl' forceNameInfo () where
+    forceNameInfo () ni                          = ni `seq` ()
 
 main = do
     hSetBuffering stdout LineBuffering

--- a/compiler/lib/bench/TypesBench.hs
+++ b/compiler/lib/bench/TypesBench.hs
@@ -37,7 +37,6 @@ printStatsMaybe label (Just before) (Just after) = printStats label before after
 printStatsMaybe _ _ _                            = return ()
 
 forceHTEnv = HashMap.foldl' forceHNameInfo () where
-    forceHNameInfo () (NameInfo.HNModule _ te _) = forceHTEnv te
     forceHNameInfo () hni                        = hni `seq` ()
 
 main = do

--- a/compiler/lib/package.yaml.in
+++ b/compiler/lib/package.yaml.in
@@ -64,6 +64,7 @@ library:
   source-dirs: src
   exposed-modules:
     - Acton.ArchiveDownload
+    - Acton.Analytics
     - Acton.Boxing
     - Acton.BuildSpec
     - Acton.Builtin

--- a/compiler/lib/src/Acton/Analytics.hs
+++ b/compiler/lib/src/Acton/Analytics.hs
@@ -1,0 +1,162 @@
+{-# LANGUAGE BangPatterns #-}
+-- | Lightweight, generic build-progress analytics for long performance runs.
+--
+-- A background sampler thread snapshots cumulative compiler progress and RTS
+-- memory at a fixed time cadence and writes one machine-readable line per tick.
+-- It is pass-agnostic: any compiler pass that reports through the progress
+-- callbacks feeds the same counters, so the same log covers parse, type check
+-- and the back passes. Unlike the human progress UI (which shows an instant),
+-- this is an append-only event log meant to be plotted or diffed after the run.
+--
+-- Enabled by the @ACTON_ANALYTICS@ env var (sample interval in milliseconds);
+-- disabled and zero-overhead otherwise. Output goes to stderr, or to the file
+-- named by @ACTON_ANALYTICS_FILE@. Memory columns require the process to run
+-- with @+RTS -T@ (otherwise reported as @na@).
+--
+-- One line per tick:
+--   ACTON-ANALYTICS t=<s> parse=<n> type=<done>/<total> type_rate=<units/s>
+--                   back=<n> mem_mb=<m> live_mb=<m> gc=<n> act=<label>
+-- where @type_rate@ is the instantaneous type-check throughput since the
+-- previous tick -- the signal that reveals pace cliffs on large modules --
+-- @mem_mb@ is the RTS memory footprint (what counts against @-M@), and
+-- @live_mb@ is the live data after the most recent GC.
+module Acton.Analytics
+  ( Analytics
+  , withAnalytics
+  , recordParseDone
+  , recordType
+  , recordBackPass
+  ) where
+
+import Control.Concurrent (forkIO, killThread, threadDelay)
+import Control.Exception (bracket)
+import Control.Monad (when)
+import Data.IORef
+import qualified Data.Map.Strict as Map
+import GHC.Stats
+import Numeric (showFFloat)
+import System.Clock
+import System.Environment (lookupEnv)
+import System.IO
+import Text.Read (readMaybe)
+
+data Analytics
+  = AnalyticsOff
+  | AnalyticsOn AState
+
+data AState = AState
+  { asStart     :: TimeSpec
+  , asSink      :: Handle
+  , asParseDone :: IORef Int
+  , asType      :: IORef (Map.Map String (Int, Int)) -- per-module (completed,total), summed at sample time
+  , asBackDone  :: IORef Int
+  , asLabel     :: IORef String
+  , asLast      :: IORef (Double, Int)               -- previous (elapsed seconds, cumulative type units)
+  }
+
+-- | Run an action with analytics sampling active iff @ACTON_ANALYTICS@ is set to
+-- a positive integer (the sample interval in milliseconds). The sampler thread
+-- is started before the action and torn down -- with one final sample -- after,
+-- even on exception.
+withAnalytics :: (Analytics -> IO a) -> IO a
+withAnalytics action = do
+  mInterval <- (>>= readMaybe) <$> lookupEnv "ACTON_ANALYTICS"
+  case mInterval of
+    Just ms | ms > 0 -> do
+      sink <- analyticsSink
+      start <- getTime Monotonic
+      st <- AState start sink
+              <$> newIORef 0
+              <*> newIORef Map.empty
+              <*> newIORef 0
+              <*> newIORef "init"
+              <*> newIORef (0, 0)
+      hPutStrLn sink ("ACTON-ANALYTICS-START interval_ms=" ++ show ms
+                      ++ " columns: t parse type type_rate back mem_mb live_mb gc act")
+      bracket (forkIO (sampleLoop st (ms * 1000)))
+              (\tid -> killThread tid >> emitSample st >> closeSink sink)
+              (\_   -> action (AnalyticsOn st))
+    _ -> action AnalyticsOff
+
+analyticsSink :: IO Handle
+analyticsSink = do
+  mpath <- lookupEnv "ACTON_ANALYTICS_FILE"
+  h <- case mpath of
+         Just p | not (null p) -> openFile p WriteMode
+         _                     -> return stderr
+  hSetBuffering h LineBuffering
+  return h
+
+closeSink :: Handle -> IO ()
+closeSink h = when (h /= stderr) (hClose h)
+
+sampleLoop :: AState -> Int -> IO ()
+sampleLoop st delayUs = go
+  where go = threadDelay delayUs >> emitSample st >> go
+
+emitSample :: AState -> IO ()
+emitSample st = do
+  now <- getTime Monotonic
+  let elapsed = fromIntegral (toNanoSecs (diffTimeSpec now (asStart st))) / 1e9 :: Double
+  pd  <- readIORef (asParseDone st)
+  tm  <- readIORef (asType st)
+  bd  <- readIORef (asBackDone st)
+  lbl <- readIORef (asLabel st)
+  (lastT, lastDone) <- readIORef (asLast st)
+  let (tdone, ttot) = Map.foldl' (\(!a, !b) (c, d) -> (a + c, b + d)) (0, 0) tm
+      dt   = elapsed - lastT
+      rate = if dt > 0 then fromIntegral (tdone - lastDone) / dt else 0 :: Double
+  writeIORef (asLast st) (elapsed, tdone)
+  (mem, live, ngc) <- readMem
+  hPutStrLn (asSink st) $ unwords
+    [ "ACTON-ANALYTICS"
+    , "t="         ++ showF 3 elapsed
+    , "parse="     ++ show pd
+    , "type="      ++ show tdone ++ "/" ++ show ttot
+    , "type_rate=" ++ showF 0 rate
+    , "back="      ++ show bd
+    , "mem_mb="    ++ mem
+    , "live_mb="   ++ live
+    , "gc="        ++ ngc
+    , "act="       ++ lbl
+    ]
+
+-- | RTS memory footprint and live data (MiB) after the most recent GC, plus the
+-- total GC count -- or @na@ when the RTS was not started with @-T@. @mem_mb@ is
+-- the memory the RTS holds (the figure that counts against @-M@); @live_mb@ is
+-- the live data the GC retains.
+readMem :: IO (String, String, String)
+readMem = do
+  enabled <- getRTSStatsEnabled
+  if not enabled
+    then return ("na", "na", "na")
+    else do
+      s <- getRTSStats
+      return ( mb (gcdetails_mem_in_use_bytes (gc s))
+             , mb (gcdetails_live_bytes (gc s))
+             , show (gcs s) )
+  where mb b = show (b `div` (1024 * 1024))
+
+showF :: Int -> Double -> String
+showF prec x = showFFloat (Just prec) x ""
+
+-- Record helpers. Cheap no-ops when analytics is off, so the instrumented
+-- callbacks add nothing measurable to a normal build.
+
+recordParseDone :: Analytics -> String -> IO ()
+recordParseDone AnalyticsOff      _ = return ()
+recordParseDone (AnalyticsOn st)  m = do
+  atomicModifyIORef' (asParseDone st) (\n -> (n + 1, ()))
+  writeIORef (asLabel st) (m ++ ":parsed")
+
+recordType :: Analytics -> String -> Int -> Int -> IO ()
+recordType AnalyticsOff     _ _    _     = return ()
+recordType (AnalyticsOn st) m done total = do
+  atomicModifyIORef' (asType st) (\mp -> (Map.insert m (done, total) mp, ()))
+  writeIORef (asLabel st) (m ++ ":types")
+
+recordBackPass :: Analytics -> String -> String -> IO ()
+recordBackPass AnalyticsOff     _ _    = return ()
+recordBackPass (AnalyticsOn st) m pass = do
+  atomicModifyIORef' (asBackDone st) (\n -> (n + 1, ()))
+  writeIORef (asLabel st) (m ++ ":" ++ pass)

--- a/compiler/lib/src/Acton/Boxing.hs
+++ b/compiler/lib/src/Acton/Boxing.hs
@@ -355,7 +355,7 @@ varType (NVar t)                    = Just t
 varType (NSVar t)                   = Just t
 varType _                           = Nothing
 
-qvarType env n                      = tryQName n env >>= varType . convHNameInfo2NameInfo
+qvarType env n                      = tryQName n env >>= varType
 
 envVarType n te                     = case lookup n te of
                                         Just (NVar t)  -> Just t

--- a/compiler/lib/src/Acton/CPS.hs
+++ b/compiler/lib/src/Acton/CPS.hs
@@ -29,7 +29,7 @@ import Acton.Env
 import Acton.QuickType
 
 convert                                 :: Env0 -> Module -> IO (Module, Env0)
-convert env0 m                          = return (runCpsM (convMod m), mapModules1 (conv env) env0)
+convert env0 m                          = return (runCpsM (convMod m), convertModules1 (conv env) env0)
   where env                             = cpsEnv env0
         convMod (Module m imps mdoc ss) = do ss' <- preSuite env ss
                                              --traceM ("######## preCPS:\n" ++ render (vcat $ map pretty ss') ++ "\n########")

--- a/compiler/lib/src/Acton/CodeGen.hs
+++ b/compiler/lib/src/Acton/CodeGen.hs
@@ -732,7 +732,7 @@ allClasses env                      = active ++ closed ++ mods
         closed                      = [ (NoQ n, q) | (n, NClass q _ _ _) <- closedNames env ]
         -- modulePublicTEnv resolves through each module's lookup function, so
         -- entries rewritten by earlier passes are seen in converted form.
-        mods                        = [ (GName m n, q) | (m, mi) <- Map.toList (moduleInfos env),
+        mods                        = [ (GName m n, q) | (m, mi) <- Map.toList (modules env),
                                                          (n, NClass q _ _ _) <- modulePublicTEnv mi ]
 
 nullConArgs env qn                  = case findQName qn env of

--- a/compiler/lib/src/Acton/CodeGen.hs
+++ b/compiler/lib/src/Acton/CodeGen.hs
@@ -164,10 +164,8 @@ include                             :: GenEnv -> String -> ModName -> Doc
 include env dir m                   = text "#include" <+> doubleQuotes (text (joinPath $ dir : modPath m) <> text ".h")
 
 modNames (Import _ ms : is)         = [ m | ModuleItem m _ <- ms ] ++ modNames is
-modNames (FromImport _ (ModRef (0,Just m)) _ : is)
-                                    = m : modNames is
-modNames (FromImportAll _ (ModRef (0,Just m)) : is)
-                                    = m : modNames is
+modNames (FromImport _ m _ : is)    = m : modNames is
+modNames (FromImportAll _ m : is)   = m : modNames is
 modNames []                         = []
 
 tnm env (Derived _ (Derived _ n))           

--- a/compiler/lib/src/Acton/CodeGen.hs
+++ b/compiler/lib/src/Acton/CodeGen.hs
@@ -783,7 +783,7 @@ derivedWitnessQName (QName m owner) field
                                     = GName m (Derived (noq field) owner)
 
 classQBinds env (NoQ n)             = case lookupName n env of
-                                        Just (HNClass q _ _ _) -> Just q
+                                        Just (NClass q _ _ _) -> Just q
                                         _                     -> Nothing
 classQBinds env (GName m n)         = case lookupModuleInfo m env >>= \mi -> moduleLookupName mi n of
                                         Just (NClass q _ _ _) -> Just q

--- a/compiler/lib/src/Acton/CodeGen.hs
+++ b/compiler/lib/src/Acton/CodeGen.hs
@@ -17,6 +17,7 @@ module Acton.CodeGen where
 import qualified Data.Set
 import qualified Data.HashSet as HashSet
 import qualified Data.List
+import qualified Data.Map.Strict as Map
 import qualified Acton.Env
 import Utils
 import Pretty
@@ -729,15 +730,10 @@ providerObjects env                 = concat [ providerRoot qn q | (qn, q) <- al
 allClasses env                      = active ++ closed ++ mods
   where active                      = [ (NoQ n, q) | (n, NClass q _ _ _) <- activeNames env ]
         closed                      = [ (NoQ n, q) | (n, NClass q _ _ _) <- closedNames env ]
-        mods                        = moduleClasses [] (modules env)
-        moduleClasses path ((n, NModule _ te _) : xs)
-                                    = moduleClasses (path ++ [n]) te ++ moduleClasses path xs
-        moduleClasses path ((n, NClass q _ _ _) : xs)
-                                    = (qual path n, q) : moduleClasses path xs
-        moduleClasses path (_ : xs) = moduleClasses path xs
-        moduleClasses _ []          = []
-        qual [] n                   = NoQ n
-        qual path n                 = GName (ModName path) n
+        -- modulePublicTEnv resolves through each module's lookup function, so
+        -- entries rewritten by earlier passes are seen in converted form.
+        mods                        = [ (GName m n, q) | (m, mi) <- Map.toList (moduleInfos env),
+                                                         (n, NClass q _ _ _) <- modulePublicTEnv mi ]
 
 nullConArgs env qn                  = case findQName qn env of
                                         NClass _ _ te _ -> case lookup initKW te of
@@ -789,11 +785,9 @@ derivedWitnessQName (QName m owner) field
 classQBinds env (NoQ n)             = case lookupName n env of
                                         Just (HNClass q _ _ _) -> Just q
                                         _                     -> Nothing
-classQBinds env (GName m n)         = case lookupMod m env of
-                                        Just te -> case lookup n te of
-                                                     Just (NClass q _ _ _) -> Just q
-                                                     _                    -> Nothing
-                                        Nothing -> Nothing
+classQBinds env (GName m n)         = case lookupModuleInfo m env >>= \mi -> moduleLookupName mi n of
+                                        Just (NClass q _ _ _) -> Just q
+                                        _                     -> Nothing
 classQBinds env (QName m n)         = classQBinds env (GName m n)
 
 concreteProvider env tc n           = case lookup n (fullAttrEnv env tc) of

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -2194,10 +2194,9 @@ adjustImports providers m = --trace ("#### adjust for " ++ prstr (A.modname m) +
         adjust (A.FromImport l m i)  = A.FromImport l (adj' m) i
         adjust (A.FromImportAll l m) = A.FromImportAll l (adj' m)
         adj mi@(A.ModuleItem m mbn)
-          | Just m' <- adjusted m   = case (m, mbn) of
-                                         (A.ModName [n], Nothing) -> A.ModuleItem m' (Just n)
-                                         (_,             Just n)  -> A.ModuleItem m' (Just n)
-                                         _                        -> error ("Local multi-level import without alias not yet supported: " ++ prstr mi)
+          | Just m' <- adjusted m   = case mbn of
+                                         Nothing -> A.ModuleItem m' (Just m)
+                                         Just n  -> A.ModuleItem m' (Just n)
           | otherwise               = mi
         adj' mr@(A.ModRef (0, Just m))
           | Just m' <- adjusted m   = (A.ModRef (0, Just m'))

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -1516,7 +1516,6 @@ forceTypeResult nmod tchecked typeEnv tests = do
   evaluate (rnf nmod)
   evaluate (rnf tchecked)
   evaluate (forceHTEnv (Acton.Env.hnames typeEnv))
-  evaluate (forceHTEnv (Acton.Env.hmodules typeEnv))
   evaluate (rnf tests)
 
 data GlobalTask = GlobalTask

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -2757,6 +2757,7 @@ data DbpSelection = DbpSelection
 
 data DbpNameSelection = DbpNameSelection
   { dnsSelectedNames :: Data.Set.Set A.Name
+  , dnsNameHashes :: [InterfaceFiles.NameHashInfo]
   }
 
 prepareDeferredBackJob :: Source.SourceProvider
@@ -2789,10 +2790,14 @@ prepareDeferredBackJob sp gopts callbacks envAcc interestMap dbj = do
       logDbpSelection gopts callbacks mn dbj totalNames (Data.Set.size interested) (Data.Set.size rootSeeds) (Data.Set.size (dnsSelectedNames nameSelection)) Nothing "generated code up to date"
       return Nothing
     else do
-      (_ms, _nmod, tmod, _sourceMetaFull, _moduleSrcBytesHashFull, _modulePubHashFull, _moduleImplHashStoredFull, _impsFull, _depModulesFull, _nameHashesFull, _rootsFull, _testsFull, _mdocFull) <- InterfaceFiles.readFile tyFile
+      selectedTmod <- InterfaceFiles.readSelectedModule tyFile (dnsNameHashes nameSelection) (dnsSelectedNames nameSelection)
+      selection <- case selectedTmod of
+        Just tmod -> return $ selectDbpModule totalNames (Data.Set.size interested) nameSelection tmod
+        Nothing -> do
+          (_ms, _nmod, tmod, _sourceMetaFull, _moduleSrcBytesHashFull, _modulePubHashFull, _moduleImplHashStoredFull, _impsFull, _depModulesFull, _nameHashesFull, _rootsFull, _testsFull, _mdocFull) <- InterfaceFiles.readFile tyFile
+          return $ selectDbpModule totalNames (Data.Set.size interested) nameSelection tmod
       snap <- Source.readSource sp actFile
-      env1 <- Acton.Env.mkEnv (searchPath paths) envAcc tmod
-      let selection = selectDbpModule totalNames (Data.Set.size interested) nameSelection tmod
+      env1 <- Acton.Env.mkEnv (searchPath paths) envAcc (dbsModule selection)
       logDbpSelection gopts callbacks mn dbj totalNames (Data.Set.size interested) (Data.Set.size rootSeeds) (dbsSelectedCount selection) (dbsFallbackReason selection) "generated code out of date"
       return $ Just BackJob
         { bjPaths = paths
@@ -2845,12 +2850,14 @@ selectDbpNames mn tyFile seeds
   | Data.Set.null seeds =
       return DbpNameSelection
         { dnsSelectedNames = Data.Set.empty
+        , dnsNameHashes = []
         }
   | otherwise = do
       roots <- traverse (dbpReadOwningName mn tyFile) (Data.Set.toList seeds)
-      selected <- dbpNameHashClosure mn tyFile Data.Set.empty roots
+      selected <- dbpNameHashClosure mn tyFile M.empty roots
       return DbpNameSelection
-        { dnsSelectedNames = selected
+        { dnsSelectedNames = Data.Set.fromList (M.keys selected)
+        , dnsNameHashes = M.elems selected
         }
 
 dbpSelectionError :: A.ModName -> String -> IO a
@@ -2902,12 +2909,12 @@ dbpReadOwningName mn tyFile n = do
 
 dbpNameHashClosure :: A.ModName
                    -> FilePath
-                   -> Data.Set.Set A.Name
+                   -> M.Map A.Name InterfaceFiles.NameHashInfo
                    -> [A.Name]
-                   -> IO (Data.Set.Set A.Name)
+                   -> IO (M.Map A.Name InterfaceFiles.NameHashInfo)
 dbpNameHashClosure _ _ selected [] = return selected
 dbpNameHashClosure mn tyFile selected (n:ns)
-  | Data.Set.member n selected = dbpNameHashClosure mn tyFile selected ns
+  | M.member n selected = dbpNameHashClosure mn tyFile selected ns
   | otherwise = do
       nh <- dbpReadNameHash mn tyFile n
       localDeps <- traverse (dbpReadOwningName mn tyFile)
@@ -2915,8 +2922,8 @@ dbpNameHashClosure mn tyFile selected (n:ns)
       exts <- dbpExtensionsForName tyFile n
       extDeps <- traverse (dbpReadOwningName mn tyFile) exts
       let deps = unionNames localDeps extDeps
-          selected' = Data.Set.insert n selected
-          new = filter (`Data.Set.notMember` selected') deps
+          selected' = M.insert n nh selected
+          new = filter (`M.notMember` selected') deps
       dbpNameHashClosure mn tyFile selected' (new ++ ns)
   where
     unionNames xs ys = Data.List.sortOn Hashing.nameKey (Data.List.nub (xs ++ ys))

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -2656,8 +2656,8 @@ runFrontPasses gopts opts dbpBlocked paths env0 parsed srcContent srcBytes sourc
                                       else joinPath (docDir : init modPathList) </> last modPathList <.> "html"
                             docFileDir = takeDirectory docFile
                             -- Get the type environment for this module
-                            modTypeEnv = case Acton.Env.lookupMod mn typeEnv of
-                              Just te -> te
+                            modTypeEnv = case Acton.Env.lookupModuleInfo mn typeEnv of
+                              Just mi -> Acton.Env.modulePublicTEnv mi
                               Nothing -> publicIface
                             -- Apply the same simplification as --sigs uses
                             env1 = define publicIface $ setMod mn env

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -2198,9 +2198,9 @@ adjustImports providers m = --trace ("#### adjust for " ++ prstr (A.modname m) +
                                          Nothing -> A.ModuleItem m' (Just m)
                                          Just n  -> A.ModuleItem m' (Just n)
           | otherwise               = mi
-        adj' mr@(A.ModRef (0, Just m))
-          | Just m' <- adjusted m   = (A.ModRef (0, Just m'))
-          | otherwise               = mr
+        adj' m
+          | Just m' <- adjusted m   = m'
+          | otherwise               = m
         adjusted m = case M.lookup m providers of
                         Just tk | tkMod tk /= m -> Just (tkMod tk)
                         _                       -> Nothing

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -1315,7 +1315,6 @@ dbpDeferredBackJob blocked opts paths mn moduleImplHash nameCount
         }
   | otherwise = Nothing
   where
-    nameCount = length nameHashes
     reqs = parseDbpRequests (projName paths) opts
     forced = M.member mn reqs
     seeds = M.findWithDefault Data.Set.empty mn reqs

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -1208,6 +1208,7 @@ data FrontResult = FrontResult
   { frIfaceTE  :: [(A.Name, I.NameInfo)]
   , frImps     :: [A.ModName]
   , frDoc      :: Maybe String
+  , frModuleInfo :: Maybe Acton.Env.ModuleInfo
   , frPubHash :: B.ByteString
   , frImplHash :: B.ByteString
   , frNameHashes :: [InterfaceFiles.NameHashInfo]
@@ -1219,6 +1220,10 @@ data FrontResult = FrontResult
   , frDeferredBackJob :: Maybe DeferredBackJob
   , frOutputJobs :: [FrontOutputJob]
   }
+
+frontResultModuleInfo :: A.ModName -> FrontResult -> Acton.Env.ModuleInfo
+frontResultModuleInfo mn fr =
+    fromMaybe (Acton.Env.mkModuleInfo mn (frImps fr) (frIfaceTE fr) (frDoc fr)) (frModuleInfo fr)
 
 data DbpRequest = DbpRequest
   { drMod :: A.ModName
@@ -2203,24 +2208,24 @@ readImports sp gopts opts paths tasks = do
 quiet :: C.GlobalOptions -> C.CompileOptions -> Bool
 quiet gopts opts = C.quiet gopts || altOutput opts
 
--- | Read an interface from a .tydb file and return its NameInfo and module hashes.
+-- | Read a reusable interface shell from a .tydb file and return its hashes.
 -- This is used when a module is deemed fresh and we want to avoid reparsing.
-readIfaceFromTy :: Paths -> A.ModName -> String -> Maybe B.ByteString -> IO (Either [Diagnostic String] ([A.ModName], [(A.Name, I.NameInfo)], Maybe String, B.ByteString, B.ByteString))
+readIfaceFromTy :: Paths -> A.ModName -> String -> Maybe B.ByteString -> IO (Either [Diagnostic String] ([A.ModName], [(A.Name, I.NameInfo)], Maybe String, B.ByteString, B.ByteString, Maybe Acton.Env.ModuleInfo))
 readIfaceFromTy paths mn src mHash = do
     mty <- Acton.Env.findTyFile (searchPath paths) mn
     case mty of
       Nothing -> return $ Left (missingIfaceDiagnostics mn src mn)
       Just tyF -> do
-        fileRes <- InterfaceFiles.readFileMaybe tyF
-        case fileRes of
-          Nothing -> return $ Left (missingIfaceDiagnostics mn src mn)
-          Just (_ms, nmod, _tmod, _sourceMeta, _srcH, pubH, implH, _imps, _depModules, _nameHashes, _roots, _tests, _tm) -> do
-            let I.NModule ms teFull mdoc = nmod
-                te = publicIfaceTE teFull
+        hashes <- InterfaceFiles.readModuleHashesMaybe tyF
+        mdb <- InterfaceFiles.openInterfaceDBMaybe tyF
+        case (hashes, mdb) of
+          (Just (_srcH, pubH, implH), Just db) -> do
+            (ms, mdoc) <- InterfaceFiles.readInterfaceDBModuleInfo db
             ih <- case mHash of
                     Just h -> return h
                     Nothing -> return pubH
-            return $ Right (ms, te, mdoc, ih, implH)
+            return $ Right (ms, [], mdoc, ih, implH, Just (Acton.Env.mkTyFileModuleInfo mn ms mdoc db))
+          _ -> return $ Left (missingIfaceDiagnostics mn src mn)
 
 
 -- | Snapshot of expected/recorded impl hashes for generated code.
@@ -2730,6 +2735,7 @@ runFrontPasses gopts opts dbpBlocked paths env0 parsed srcContent srcBytes sourc
                     return $ Right FrontResult { frIfaceTE = publicIface
                                                , frImps = imps
                                                , frDoc = mdoc
+                                               , frModuleInfo = Nothing
                                                , frPubHash = modulePubHash
                                                , frImplHash = moduleImplHash
                                                , frNameHashes = publicNameHashes nameHashes
@@ -3441,6 +3447,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
               { frIfaceTE = ifaceTE
               , frImps = imps
               , frDoc = mdoc
+              , frModuleInfo = Nothing
               , frPubHash = pubHash
               , frImplHash = implHash
               , frNameHashes = nameHashes
@@ -3457,6 +3464,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
               { frIfaceTE = []
               , frImps = []
               , frDoc = Nothing
+              , frModuleInfo = Nothing
               , frPubHash = B.empty
               , frImplHash = B.empty
               , frNameHashes = []
@@ -3830,14 +3838,16 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                             ParseTask{ src = srcContent } -> readIfaceFromTy paths mn srcContent Nothing
                             ActonTask{ src = srcContent } -> readIfaceFromTy paths mn srcContent Nothing
               case ifaceRes of
-                Right (imps, ifaceTE, mdoc, ih, implH) -> do
+                Right (imps, ifaceTE, mdoc, ih, implH, mModuleInfo) -> do
                   let cachedFullNameHashes = case taskCurrent of
                         TyTask{ tyNameHashes = nhs } -> nhs
                         _ -> []
                       cachedNameHashes = publicNameHashes cachedFullNameHashes
                   interestDeps <- cachedInterestDeps
                   let fr = (mkFrontResult imps ifaceTE mdoc ih implH cachedNameHashes cachedFullNameHashes Nothing Nothing)
-                             { frInterestDeps = interestDeps }
+                             { frModuleInfo = mModuleInfo
+                             , frInterestDeps = interestDeps
+                             }
                   cacheFrontResult fr
                 Left _ ->
                   return (key, Right emptyFrontResult)
@@ -4096,14 +4106,16 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                                   _ -> readIfaceFromTy paths mn "" Nothing
                     case ifaceRes of
                       Left diags -> return (key, Left diags)
-                      Right (imps, ifaceTE, mdoc, ih, implH) -> do
+                      Right (imps, ifaceTE, mdoc, ih, implH, mModuleInfo) -> do
                         let cachedFullNameHashes = case taskCurrent of
                               TyTask{ tyNameHashes = nhs } -> nhs
                               _ -> []
                             cachedNameHashes = publicNameHashes cachedFullNameHashes
                         interestDeps <- cachedInterestDeps
                         let fr = (mkFrontResult imps ifaceTE mdoc ih implH cachedNameHashes cachedFullNameHashes Nothing cachedDeferredBackJob)
-                                   { frInterestDeps = interestDeps }
+                                   { frModuleInfo = mModuleInfo
+                                   , frInterestDeps = interestDeps
+                                   }
                         cacheFrontResult fr
               case () of
                 _ | needFront -> runFront
@@ -4277,7 +4289,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                       implRes2 = M.insert keyDone (frImplHash fr) implRes
                       nameRes2 = M.insert keyDone (nameHashMapFromList (frNameHashes fr)) nameRes
                       parsedTasks2 = M.delete keyDone parsedTasks
-                      envAcc' = Acton.Env.addMod (tkMod keyDone) (frImps fr) (frIfaceTE fr) (frDoc fr) envAcc
+                      envAcc' = Acton.Env.addModuleInfo (tkMod keyDone) (frontResultModuleInfo (tkMod keyDone) fr) envAcc
                       interestMap2 = addInterestDeps (frInterestDeps fr) interestMap
                       frontDone2 = Data.Set.insert keyDone frontDone
                       deferredBacks1 =

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -1283,9 +1283,9 @@ dbpDeferredBackJob :: Bool
                    -> Paths
                    -> A.ModName
                    -> B.ByteString
-                   -> [InterfaceFiles.NameHashInfo]
+                   -> Int
                    -> Maybe DeferredBackJob
-dbpDeferredBackJob blocked opts paths mn moduleImplHash nameHashes
+dbpDeferredBackJob blocked opts paths mn moduleImplHash nameCount
   | C.no_dbp opts = Nothing
   | C.only_build opts = Nothing
   | altOutput opts = Nothing
@@ -1483,6 +1483,7 @@ data CompileTask        = ParseTask { name :: A.ModName, src :: String, srcBytes
                                     , tyImports :: [(A.ModName, B.ByteString)] -- imports with pub hash used
                                     , tyDepModules :: [InterfaceFiles.DepModuleInfo]
                                     , tyNameHashes :: [InterfaceFiles.NameHashInfo]
+                                    , tyNameCount :: Int
                                     , tyRoots :: [A.Name]
                                     , tyTests :: [String]
                                     , tyDoc :: Maybe String
@@ -1763,8 +1764,8 @@ dbpProviderPathClosure rootProj opts globalTasks dbpBlocked depMap revMap affect
       case M.lookup k taskMap of
         Just t ->
           case gtTask t of
-            TyTask{ tyImplHash = implHash, tyNameHashes = nhs } ->
-              isJust (dbpDeferredBackJob (Data.Set.member k dbpBlocked) (optsFor k) (gtPaths t) (tkMod k) implHash nhs)
+            TyTask{ tyImplHash = implHash, tyNameCount = nameCount } ->
+              isJust (dbpDeferredBackJob (Data.Set.member k dbpBlocked) (optsFor k) (gtPaths t) (tkMod k) implHash nameCount)
             _ -> False
         Nothing -> False
 
@@ -1895,6 +1896,7 @@ data ModuleHead
       , mhTyImports  :: [(A.ModName, B.ByteString)]
       , mhDepModules :: [InterfaceFiles.DepModuleInfo]
       , mhNameHashes :: [InterfaceFiles.NameHashInfo]
+      , mhNameCount  :: Int
       , mhRoots      :: [A.Name]
       , mhTests      :: [String]
       , mhDoc        :: Maybe String
@@ -1930,10 +1932,10 @@ readModuleHeader sp gopts opts paths actFile = do
       else do
         -- .tydb exists: read the cached header and validate it against compiler
         -- compatibility plus source metadata/content as needed.
-        hdrE <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readHeader tyFile
+        hdrE <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readHeaderSummary tyFile
         case hdrE of
           Left _ -> readSourceHead mn
-          Right (cachedSourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash, imps, depModules, nameHashes, roots, tests, mdoc) -> do
+          Right (cachedSourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash, imps, depModules, nameCount, roots, tests, mdoc) -> do
             tyMTimeNs <- InterfaceFiles.interfaceModifiedTimeNs tyFile
             newCompiler <- compilerNewerThan tyMTimeNs
             mOverlay <- Source.spReadOverlay sp actFile
@@ -1941,21 +1943,21 @@ readModuleHeader sp gopts opts paths actFile = do
               Just snap ->
                 if newCompiler
                   then sourceHeadFromSnapshot mn snap
-                  else verifyOrParse mn snap moduleSrcBytesHash modulePubHash moduleImplHash cachedSourceMeta Nothing imps depModules nameHashes roots tests mdoc
+                  else verifyOrParse mn snap moduleSrcBytesHash modulePubHash moduleImplHash cachedSourceMeta Nothing imps depModules nameCount roots tests mdoc
               Nothing -> do
                 if newCompiler
                   then readSourceHead mn
                   else do
                     currentSourceMeta <- readSourceFileMeta actFile
                     if canReuseHeader cachedSourceMeta currentSourceMeta tyMTimeNs
-                      then return (mkTyHead mn moduleSrcBytesHash modulePubHash moduleImplHash imps depModules nameHashes roots tests mdoc)
+                      then return (mkTyHead mn moduleSrcBytesHash modulePubHash moduleImplHash imps depModules nameCount roots tests mdoc)
                       else do
                         snap <- Source.spReadFile sp actFile
-                        verifyOrParse mn snap moduleSrcBytesHash modulePubHash moduleImplHash cachedSourceMeta (Just currentSourceMeta) imps depModules nameHashes roots tests mdoc
+                        verifyOrParse mn snap moduleSrcBytesHash modulePubHash moduleImplHash cachedSourceMeta (Just currentSourceMeta) imps depModules nameCount roots tests mdoc
   where
     fileStatusMTimeNs st = floor (toRational (modificationTimeHiRes st) * 1000000000)
 
-    mkTyHead mn moduleSrcBytesHash modulePubHash moduleImplHash imps depModules nameHashes roots tests mdoc =
+    mkTyHead mn moduleSrcBytesHash modulePubHash moduleImplHash imps depModules nameCount roots tests mdoc =
       TyHead
         { mhName       = mn
         , mhSrcHash    = moduleSrcBytesHash
@@ -1963,7 +1965,8 @@ readModuleHeader sp gopts opts paths actFile = do
         , mhImplHash   = moduleImplHash
         , mhTyImports  = imps
         , mhDepModules = depModules
-        , mhNameHashes = nameHashes
+        , mhNameHashes = []
+        , mhNameCount  = nameCount
         , mhRoots      = roots
         , mhTests      = tests
         , mhDoc        = mdoc
@@ -2014,7 +2017,7 @@ readModuleHeader sp gopts opts paths actFile = do
         Right (_ms, nmod, tmod, _oldSourceMeta, srcHash, pubHash, implHash, imps, depModules, nameHashes, roots, tests, mdoc) ->
           InterfaceFiles.writeFile tyFilePath srcHash pubHash implHash currentSourceMeta imps depModules nameHashes roots tests mdoc nmod tmod
 
-    verifyOrParse mn snap moduleSrcBytesHash modulePubHash moduleImplHash cachedSourceMeta currentSourceMeta imps depModules nameHashes roots tests mdoc = do
+    verifyOrParse mn snap moduleSrcBytesHash modulePubHash moduleImplHash cachedSourceMeta currentSourceMeta imps depModules nameCount roots tests mdoc = do
       let curHash = SHA256.hash (Source.ssBytes snap)
           short8 bs = take 8 (B.unpack $ Base16.encode bs)
           same = curHash == moduleSrcBytesHash
@@ -2033,7 +2036,7 @@ readModuleHeader sp gopts opts paths actFile = do
         then do
           when (currentSourceMeta /= Nothing && currentSourceMeta /= cachedSourceMeta) $
             refreshCachedSourceMeta currentSourceMeta
-          return (mkTyHead mn moduleSrcBytesHash modulePubHash moduleImplHash imps depModules nameHashes roots tests mdoc)
+          return (mkTyHead mn moduleSrcBytesHash modulePubHash moduleImplHash imps depModules nameCount roots tests mdoc)
         else sourceHeadFromSnapshot mn snap
 
 -- | Prepare a task for dependency graph construction.
@@ -2050,6 +2053,7 @@ readModuleTask sp gopts opts paths actFile = do
           , mhTyImports = imps
           , mhDepModules = depModules
           , mhNameHashes = nameHashes
+          , mhNameCount = nameCount
           , mhRoots = roots
           , mhTests = tests
           , mhDoc = mdoc
@@ -2063,6 +2067,7 @@ readModuleTask sp gopts opts paths actFile = do
                 , tyImports  = imps
                 , tyDepModules = depModules
                 , tyNameHashes = nameHashes
+                , tyNameCount = nameCount
                 , tyRoots   = roots
                 , tyTests   = tests
                 , tyDoc     = mdoc
@@ -2100,8 +2105,8 @@ readModuleDocIndexEntry :: Source.SourceProvider
 readModuleDocIndexEntry sp gopts opts paths actFile = do
   h <- readModuleHeader sp gopts opts paths actFile
   return $ case h of
-    TyHead{ mhName = mn, mhNameHashes = nameHashes, mhDoc = mdoc } ->
-      Just (mn, mdoc, shouldGenerateDocOutput opts (isTmp paths) (length nameHashes))
+    TyHead{ mhName = mn, mhNameCount = nameCount, mhDoc = mdoc } ->
+      Just (mn, mdoc, shouldGenerateDocOutput opts (isTmp paths) nameCount)
     SrcHead{ mhName = mn, mhDoc = mdoc } -> Just (mn, mdoc, True)
     HeadError{} -> Nothing
 
@@ -2684,7 +2689,7 @@ runFrontPasses gopts opts dbpBlocked paths env0 parsed srcContent srcBytes sourc
                                  , ftTypeStmtTimings = typeStmtTimings
                                  }
                           else Nothing
-                      deferredBackJob = dbpDeferredBackJob dbpBlocked opts paths mn moduleImplHash nameHashes
+                      deferredBackJob = dbpDeferredBackJob dbpBlocked opts paths mn moduleImplHash (length nameHashes)
                       backJob =
                         case deferredBackJob of
                           Just _ -> Nothing
@@ -2756,7 +2761,7 @@ prepareDeferredBackJob sp gopts callbacks envAcc interestMap dbj = do
       mn = dbjMod dbj
       tyFile = tyDbPath paths mn
       actFile = srcFile paths mn
-  (_sourceMeta, _moduleSrcBytesHash, _modulePubHash, _moduleImplHashStored, _imps, _depModules, nameHashes, roots, _tests, _mdoc) <- InterfaceFiles.readHeader tyFile
+  roots <- InterfaceFiles.readRoots tyFile
   let explicitSeeds = dbjSeeds dbj
       interested =
         if Data.Set.null explicitSeeds
@@ -2764,19 +2769,20 @@ prepareDeferredBackJob sp gopts callbacks envAcc interestMap dbj = do
           else explicitSeeds
       rootSeeds = Data.Set.fromList roots
       selectedSeeds = Data.Set.union interested rootSeeds
-  nameSelection <- selectDbpNames paths mn tyFile selectedSeeds nameHashes
+      totalNames = dbjNameCount dbj
+  nameSelection <- selectDbpNames mn tyFile selectedSeeds
   let codegenHash = dbpCodegenHash (dbjImplHash dbj) (dnsSelectedNames nameSelection)
   codegen <- codegenStatus paths mn codegenHash
   if codegenUpToDate codegen
     then do
-      logDbpSelection gopts callbacks mn dbj (length nameHashes) (Data.Set.size interested) (Data.Set.size rootSeeds) (Data.Set.size (dnsSelectedNames nameSelection)) Nothing "generated code up to date"
+      logDbpSelection gopts callbacks mn dbj totalNames (Data.Set.size interested) (Data.Set.size rootSeeds) (Data.Set.size (dnsSelectedNames nameSelection)) Nothing "generated code up to date"
       return Nothing
     else do
       (_ms, _nmod, tmod, _sourceMetaFull, _moduleSrcBytesHashFull, _modulePubHashFull, _moduleImplHashStoredFull, _impsFull, _depModulesFull, _nameHashesFull, _rootsFull, _testsFull, _mdocFull) <- InterfaceFiles.readFile tyFile
       snap <- Source.readSource sp actFile
       env1 <- Acton.Env.mkEnv (searchPath paths) envAcc tmod
-      let selection = selectDbpModule (length nameHashes) (Data.Set.size interested) nameSelection tmod
-      logDbpSelection gopts callbacks mn dbj (length nameHashes) (Data.Set.size interested) (Data.Set.size rootSeeds) (dbsSelectedCount selection) (dbsFallbackReason selection) "generated code out of date"
+      let selection = selectDbpModule totalNames (Data.Set.size interested) nameSelection tmod
+      logDbpSelection gopts callbacks mn dbj totalNames (Data.Set.size interested) (Data.Set.size rootSeeds) (dbsSelectedCount selection) (dbsFallbackReason selection) "generated code out of date"
       return $ Just BackJob
         { bjPaths = paths
         , bjOpts = dbjOpts dbj
@@ -2820,34 +2826,25 @@ dbpCodegenHash moduleImplHash selected =
       | n <- Data.List.sortOn Hashing.nameKey (Data.Set.toList selected)
       ]
 
-selectDbpNames :: Paths
-               -> A.ModName
+selectDbpNames :: A.ModName
                -> FilePath
                -> Data.Set.Set A.Name
-               -> [InterfaceFiles.NameHashInfo]
                -> IO DbpNameSelection
-selectDbpNames paths mn tyFile seeds nameHashes
+selectDbpNames mn tyFile seeds
   | Data.Set.null seeds =
       return DbpNameSelection
         { dnsSelectedNames = Data.Set.empty
         }
-  | otherwise =
-      case ( traverse (dbpOwningName topNames) (Data.Set.toList seeds)
-           , dbpLocalDepsFromNameHashes topNames nameHashes
-           ) of
-        (Left reason, _) -> dbpSelectionError paths mn reason
-        (_, Left reason) -> dbpSelectionError paths mn reason
-        (Right roots, Right localDeps) -> do
-          selected <- dbpNameClosure (dbpExtensionsForName paths mn tyFile topNames) localDeps (Data.Set.fromList roots)
-          return DbpNameSelection
-            { dnsSelectedNames = selected
-            }
-  where
-    topNames = dbpTopNamesFromNameHashes nameHashes
+  | otherwise = do
+      roots <- traverse (dbpReadOwningName mn tyFile) (Data.Set.toList seeds)
+      selected <- dbpNameHashClosure mn tyFile Data.Set.empty roots
+      return DbpNameSelection
+        { dnsSelectedNames = selected
+        }
 
-dbpSelectionError :: Paths -> A.ModName -> String -> IO a
-dbpSelectionError paths mn reason =
-  throwIO (DbpSelectionError ("DBP selection failed for " ++ modNameToString (dropProjPrefix paths mn) ++ ": " ++ reason))
+dbpSelectionError :: A.ModName -> String -> IO a
+dbpSelectionError mn reason =
+  throwIO (DbpSelectionError ("DBP selection failed for " ++ modNameToString mn ++ ": " ++ reason))
 
 selectDbpModule :: Int
                 -> Int
@@ -2874,65 +2871,50 @@ selectDbpModule totalNames interestedCount nameSelection tmod@(A.Module loc imps
         , dbsFallbackReason = Just reason
         }
 
-dbpTopNamesFromNameHashes :: [InterfaceFiles.NameHashInfo] -> Data.Set.Set A.Name
-dbpTopNamesFromNameHashes nameHashes =
-  Data.Set.fromList [ InterfaceFiles.nhName nh | nh <- nameHashes ]
+dbpReadNameHash :: A.ModName -> FilePath -> A.Name -> IO InterfaceFiles.NameHashInfo
+dbpReadNameHash mn tyFile n = do
+  mnh <- InterfaceFiles.readNameHashMaybe tyFile n
+  case mnh of
+    Just nh -> return nh
+    Nothing -> dbpSelectionError mn ("hash info missing for " ++ nameToString n)
 
-dbpOwningName :: Data.Set.Set A.Name -> A.Name -> Either String A.Name
-dbpOwningName topNames n
-  | Data.Set.member n topNames = Right n
-  | otherwise =
+dbpReadOwningName :: A.ModName -> FilePath -> A.Name -> IO A.Name
+dbpReadOwningName mn tyFile n = do
+  mnh <- InterfaceFiles.readNameHashMaybe tyFile n
+  case mnh of
+    Just _ -> return n
+    Nothing ->
       case n of
-        A.Derived base _ -> dbpOwningName topNames base
-        _ | Names.isWitness n -> Left ("unresolved witness owner for " ++ nameToString n)
-        _ -> Left ("no top-level owner for " ++ nameToString n)
+        A.Derived base _ -> dbpReadOwningName mn tyFile base
+        _ | Names.isWitness n -> dbpSelectionError mn ("unresolved witness owner for " ++ nameToString n)
+        _ -> dbpSelectionError mn ("no top-level owner for " ++ nameToString n)
 
-dbpLocalDepsFromNameHashes :: Data.Set.Set A.Name
-                           -> [InterfaceFiles.NameHashInfo]
-                           -> Either String (M.Map A.Name [A.Name])
-dbpLocalDepsFromNameHashes topNames nameHashes =
-  M.fromList <$> traverse depsFor nameHashes
+dbpNameHashClosure :: A.ModName
+                   -> FilePath
+                   -> Data.Set.Set A.Name
+                   -> [A.Name]
+                   -> IO (Data.Set.Set A.Name)
+dbpNameHashClosure _ _ selected [] = return selected
+dbpNameHashClosure mn tyFile selected (n:ns)
+  | Data.Set.member n selected = dbpNameHashClosure mn tyFile selected ns
+  | otherwise = do
+      nh <- dbpReadNameHash mn tyFile n
+      localDeps <- traverse (dbpReadOwningName mn tyFile)
+                     (InterfaceFiles.nhPubLocalDeps nh ++ InterfaceFiles.nhImplLocalDeps nh)
+      exts <- dbpExtensionsForName tyFile n
+      extDeps <- traverse (dbpReadOwningName mn tyFile) exts
+      let deps = unionNames localDeps extDeps
+          selected' = Data.Set.insert n selected
+          new = filter (`Data.Set.notMember` selected') deps
+      dbpNameHashClosure mn tyFile selected' (new ++ ns)
   where
-    depsFor nh = do
-      deps <- traverse
-                (dbpOwningName topNames)
-                (InterfaceFiles.nhPubLocalDeps nh ++ InterfaceFiles.nhImplLocalDeps nh)
-      return
-        ( InterfaceFiles.nhName nh
-        , unionNames deps []
-        )
     unionNames xs ys = Data.List.sortOn Hashing.nameKey (Data.List.nub (xs ++ ys))
 
-dbpExtensionsForName :: Paths -> A.ModName -> FilePath -> Data.Set.Set A.Name -> A.Name -> IO [A.Name]
-dbpExtensionsForName paths mn tyFile topNames n = do
+dbpExtensionsForName :: FilePath -> A.Name -> IO [A.Name]
+dbpExtensionsForName tyFile n = do
   byClass <- InterfaceFiles.readExtensionsByClass tyFile n
   byProtocol <- InterfaceFiles.readExtensionsByProtocol tyFile n
-  let exts = unionNames byClass byProtocol
-      missing = [ ext | ext <- exts, Data.Set.notMember ext topNames ]
-  if null missing
-    then return exts
-    else dbpSelectionError paths mn $
-           "extension index for " ++ nameToString n
-           ++ " points at non-top-level extension(s) "
-           ++ Data.List.intercalate ", " (map nameToString missing)
-  where
-    unionNames xs ys = Data.List.sortOn Hashing.nameKey (Data.List.nub (xs ++ ys))
-
-dbpNameClosure :: (A.Name -> IO [A.Name])
-               -> M.Map A.Name [A.Name]
-               -> Data.Set.Set A.Name
-               -> IO (Data.Set.Set A.Name)
-dbpNameClosure extensionsForName localDeps roots = go roots (Data.Set.toList roots)
-  where
-    go seen [] = return seen
-    go seen (n:ns) = do
-      exts <- extensionsForName n
-      let deps = unionNames (M.findWithDefault [] n localDeps) exts
-          new = filter (`Data.Set.notMember` seen) deps
-          seen' = foldl' (flip Data.Set.insert) seen new
-      go seen' (new ++ ns)
-
-    unionNames xs ys = Data.List.sortOn Hashing.nameKey (Data.List.nub (xs ++ ys))
+  return (Data.List.sortOn Hashing.nameKey (Data.List.nub (byClass ++ byProtocol)))
 
 dbpPruneTopStmt :: Data.Set.Set A.Name -> A.Stmt -> Maybe A.Stmt
 dbpPruneTopStmt selected stmt =
@@ -3520,12 +3502,21 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
             case M.lookup m providers of
               Just depKey ->
                 case M.lookup depKey nameMap of
-                  Just hm -> return (M.lookup n hm)
+                  Just hm ->
+                    case M.lookup n hm of
+                      Just info -> return (Just info)
+                      Nothing
+                        | providerIsCachedTy depKey -> getNameHashCached paths m n
+                        | otherwise -> return Nothing
                   Nothing
                     | isBuiltinKey depKey -> getNameHashCached paths m n
                     | M.member depKey taskMap -> error ("Internal error: missing name hashes for dep " ++ modNameToString m)
                     | otherwise -> getNameHashCached paths m n
               Nothing -> getNameHashCached paths m n
+          providerIsCachedTy depKey =
+            case M.lookup depKey taskMap of
+              Just GlobalTask{ gtTask = TyTask{} } -> True
+              _ -> False
 
           missingNameHashDiagnostics qn =
             errsToDiagnostics "Compilation error" (modNameToFilename (dropProjPrefix paths mn)) ""
@@ -3861,7 +3852,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                     TyTask{ tyImplHash = implHash } -> Just implHash
                     _ -> Nothing
                   cachedDeferredBackJob = case taskCurrent of
-                    TyTask{ tyImplHash = implHash, tyNameHashes = nhs } -> dbpDeferredBackJob (isDbpBlocked key) optsT paths mn implHash nhs
+                    TyTask{ tyImplHash = implHash, tyNameCount = nameCount } -> dbpDeferredBackJob (isDbpBlocked key) optsT paths mn implHash nameCount
                     _ -> Nothing
                   isCachedDbp =
                     case cachedDeferredBackJob of
@@ -3876,7 +3867,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                     --traceM ("\n## runFront " ++ prstr mn ++ "\n")
                     prevNameHashes <- if C.verbose gopts
                       then case taskCurrent of
-                        TyTask{ tyNameHashes = nhs } -> return (Just (nameHashMapFromList (publicNameHashes nhs)))
+                        TyTask{ tyNameHashes = nhs } | not (null nhs) -> return (Just (nameHashMapFromList (publicNameHashes nhs)))
                         _ -> getNameHashMapCached paths mn
                       else return Nothing
                     when (C.verbose gopts) $ do
@@ -4036,7 +4027,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                                           rememberFrontOutputJobList frontOutputRef outputJobs
                                           let I.NModule imps ifaceFull _mdoc = nmod
                                               ifaceTE = publicIfaceTE ifaceFull
-                                              deferredBackJob0 = dbpDeferredBackJob (isDbpBlocked key) optsT paths mn moduleImplHash updatedNameHashes
+                                              deferredBackJob0 = dbpDeferredBackJob (isDbpBlocked key) optsT paths mn moduleImplHash (length updatedNameHashes)
                                               deferredBackJob = fmap (\dbj -> dbj{ dbjOutputJobs = [outputJob] }) deferredBackJob0
                                               backJob =
                                                 case deferredBackJob of
@@ -4060,7 +4051,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                         interestDeps <- cachedInterestDeps
                         let I.NModule imps ifaceFull _mdoc = nmod
                             ifaceTE = publicIfaceTE ifaceFull
-                            deferredBackJob = dbpDeferredBackJob (isDbpBlocked key) optsT paths mn moduleImplHashStored nameHashes
+                            deferredBackJob = dbpDeferredBackJob (isDbpBlocked key) optsT paths mn moduleImplHashStored (length nameHashes)
                             backJob =
                               case deferredBackJob of
                                 Just _ -> Nothing

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -926,6 +926,12 @@ implHashCache = unsafePerformIO (newMVar M.empty)
 nameHashCache :: MVar (M.Map A.ModName (M.Map A.Name InterfaceFiles.NameHashInfo))
 nameHashCache = unsafePerformIO (newMVar M.empty)
 
+-- | Per-name results of targeted name-hash reads. Kept apart from
+-- nameHashCache, whose per-module maps must stay complete.
+{-# NOINLINE nameHashOneCache #-}
+nameHashOneCache :: MVar (M.Map (A.ModName, A.Name) (Maybe InterfaceFiles.NameHashInfo))
+nameHashOneCache = unsafePerformIO (newMVar M.empty)
+
 -- | Resolve the on-disk .tydb path for a module, using a process-wide cache.
 -- Avoids repeated filesystem walks when many modules share dependencies.
 getTyFileCached :: [FilePath] -> A.ModName -> IO (Maybe FilePath)
@@ -1020,21 +1026,26 @@ getNameHashMapCached paths mn = modifyMVar nameHashCache $ \m -> do
 
 -- | Read one cached name hash without decoding all per-name hash rows.
 getNameHashCached :: Paths -> A.ModName -> A.Name -> IO (Maybe InterfaceFiles.NameHashInfo)
-getNameHashCached paths mn n = modifyMVar nameHashCache $ \m -> do
+getNameHashCached paths mn n = do
+  m <- readMVar nameHashCache
   case M.lookup mn m of
-    Just hm -> return (m, M.lookup n hm)
-    Nothing -> do
-      mty <- getTyFileCached (searchPath paths) mn
-      case mty of
-        Just ty -> do
-          nh <- InterfaceFiles.readNameHashMaybe ty n
-          return (m, nh)
-        Nothing -> return (m, Nothing)
+    Just hm -> return (M.lookup n hm)
+    Nothing -> modifyMVar nameHashOneCache $ \c ->
+      case M.lookup (mn, n) c of
+        Just r -> return (c, r)
+        Nothing -> do
+          mty <- getTyFileCached (searchPath paths) mn
+          r <- case mty of
+                 Just ty -> InterfaceFiles.readNameHashMaybe ty n
+                 Nothing -> return Nothing
+          return (M.insert (mn, n) r c, r)
 
--- | Update the name-hash cache after a successful compile.
+-- | Update the name-hash cache after a successful compile. Cached modules
+-- carry no name hashes; their entries must not shadow targeted reads.
 updateNameHashCache :: A.ModName -> [InterfaceFiles.NameHashInfo] -> IO ()
 updateNameHashCache mn infos =
-  modifyMVar_ nameHashCache $ \m -> return (M.insert mn (nameHashMapFromList infos) m)
+  when (not (null infos)) $
+    modifyMVar_ nameHashCache $ \m -> return (M.insert mn (nameHashMapFromList infos) m)
 
 
 -- Handling Acton files -----------------------------------------------------------------------------

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -222,6 +222,7 @@ import qualified Acton.Normalizer
 import qualified Acton.CPS
 import qualified Acton.Deactorizer
 import qualified Acton.LambdaLifter
+import Acton.Analytics
 import qualified Acton.Boxing
 import qualified Acton.CodeGen
 import Acton.Builtin (mBuiltin)
@@ -802,8 +803,9 @@ runCompilePlan :: Source.SourceProvider
                -> Int
                -> CompileHooks
                -> IO (Either CompileFailure (Acton.Env.Env0, Bool))
-runCompilePlan sp gopts plan sched gen hooks = do
-  let ctx = cpContext plan
+runCompilePlan sp gopts plan sched gen hooks0 = withAnalytics $ \ana -> do
+  let hooks = instrumentHooksForAnalytics ana hooks0
+      ctx = cpContext plan
       opts' = ccOpts ctx
       pathsRoot = ccPathsRoot ctx
       rootProj = ccRootProj ctx
@@ -836,6 +838,28 @@ runCompilePlan sp gopts plan sched gen hooks = do
         , ccOnInfo = chOnInfo hooks
         }
   compileTasks sp gopts opts' pathsRoot rootProj (cpNeededTasks plan) (cpDbpBlocked plan) callbacks
+
+-- | Tap the generic progress hooks to feed the analytics sampler. Each pass
+-- already reports through these callbacks, so a single wrapper covers parse,
+-- type check and the back passes without touching any individual pass.
+instrumentHooksForAnalytics :: Analytics -> CompileHooks -> CompileHooks
+instrumentHooksForAnalytics ana hooks = hooks
+  { chOnParseDone = \t mtime -> do
+      recordParseDone ana (taskMod t)
+      chOnParseDone hooks t mtime
+  , chOnFrontProgress = \t p -> do
+      when (fppPass p == FrontPassTypes) $
+        recordType ana (taskMod t) (fppCompleted p) (fppTotal p)
+      chOnFrontProgress hooks t p
+  , chOnBackProgress = \job bp -> do
+      case bp of
+        BackPassFinished pass _ _ _ -> recordBackPass ana (backMod job) (backPassName pass)
+        _                           -> return ()
+      chOnBackProgress hooks job bp
+  }
+  where taskMod t   = modNameToString (tkMod (gtKey t))
+        backMod job = modNameToString (A.modname (biTypedMod (bjInput job)))
+
 -- | Baseline compile options for internal helpers and tests.
 -- This mirrors CLI defaults so path discovery and parsing behave predictably
 -- when no command-line flags are present.

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -2805,7 +2805,7 @@ prepareDeferredBackJob sp gopts callbacks envAcc interestMap dbj = do
       rootSeeds = Data.Set.fromList roots
       selectedSeeds = Data.Set.union interested rootSeeds
       totalNames = dbjNameCount dbj
-  nameSelection <- selectDbpNames mn tyFile selectedSeeds
+  nameSelection <- selectDbpNames paths mn tyFile selectedSeeds
   let codegenHash = dbpCodegenHash (dbjImplHash dbj) (dnsSelectedNames nameSelection)
   codegen <- codegenStatus paths mn codegenHash
   if codegenUpToDate codegen
@@ -2865,27 +2865,28 @@ dbpCodegenHash moduleImplHash selected =
       | n <- Data.List.sortOn Hashing.nameKey (Data.Set.toList selected)
       ]
 
-selectDbpNames :: A.ModName
+selectDbpNames :: Paths
+               -> A.ModName
                -> FilePath
                -> Data.Set.Set A.Name
                -> IO DbpNameSelection
-selectDbpNames mn tyFile seeds
+selectDbpNames paths mn tyFile seeds
   | Data.Set.null seeds =
       return DbpNameSelection
         { dnsSelectedNames = Data.Set.empty
         , dnsNameHashes = []
         }
   | otherwise = do
-      roots <- traverse (dbpReadOwningName mn tyFile) (Data.Set.toList seeds)
-      selected <- dbpNameHashClosure mn tyFile M.empty roots
+      roots <- traverse (dbpReadOwningName paths mn tyFile) (Data.Set.toList seeds)
+      selected <- dbpNameHashClosure paths mn tyFile M.empty roots
       return DbpNameSelection
         { dnsSelectedNames = Data.Set.fromList (M.keys selected)
         , dnsNameHashes = M.elems selected
         }
 
-dbpSelectionError :: A.ModName -> String -> IO a
-dbpSelectionError mn reason =
-  throwIO (DbpSelectionError ("DBP selection failed for " ++ modNameToString mn ++ ": " ++ reason))
+dbpSelectionError :: Paths -> A.ModName -> String -> IO a
+dbpSelectionError paths mn reason =
+  throwIO (DbpSelectionError ("DBP selection failed for " ++ modNameToString (dropProjPrefix paths mn) ++ ": " ++ reason))
 
 selectDbpModule :: Int
                 -> Int
@@ -2912,42 +2913,43 @@ selectDbpModule totalNames interestedCount nameSelection tmod@(A.Module loc imps
         , dbsFallbackReason = Just reason
         }
 
-dbpReadNameHash :: A.ModName -> FilePath -> A.Name -> IO InterfaceFiles.NameHashInfo
-dbpReadNameHash mn tyFile n = do
+dbpReadNameHash :: Paths -> A.ModName -> FilePath -> A.Name -> IO InterfaceFiles.NameHashInfo
+dbpReadNameHash paths mn tyFile n = do
   mnh <- InterfaceFiles.readNameHashMaybe tyFile n
   case mnh of
     Just nh -> return nh
-    Nothing -> dbpSelectionError mn ("hash info missing for " ++ nameToString n)
+    Nothing -> dbpSelectionError paths mn ("hash info missing for " ++ nameToString n)
 
-dbpReadOwningName :: A.ModName -> FilePath -> A.Name -> IO A.Name
-dbpReadOwningName mn tyFile n = do
+dbpReadOwningName :: Paths -> A.ModName -> FilePath -> A.Name -> IO A.Name
+dbpReadOwningName paths mn tyFile n = do
   mnh <- InterfaceFiles.readNameHashMaybe tyFile n
   case mnh of
     Just _ -> return n
     Nothing ->
       case n of
-        A.Derived base _ -> dbpReadOwningName mn tyFile base
-        _ | Names.isWitness n -> dbpSelectionError mn ("unresolved witness owner for " ++ nameToString n)
-        _ -> dbpSelectionError mn ("no top-level owner for " ++ nameToString n)
+        A.Derived base _ -> dbpReadOwningName paths mn tyFile base
+        _ | Names.isWitness n -> dbpSelectionError paths mn ("unresolved witness owner for " ++ nameToString n)
+        _ -> dbpSelectionError paths mn ("no top-level owner for " ++ nameToString n)
 
-dbpNameHashClosure :: A.ModName
+dbpNameHashClosure :: Paths
+                   -> A.ModName
                    -> FilePath
                    -> M.Map A.Name InterfaceFiles.NameHashInfo
                    -> [A.Name]
                    -> IO (M.Map A.Name InterfaceFiles.NameHashInfo)
-dbpNameHashClosure _ _ selected [] = return selected
-dbpNameHashClosure mn tyFile selected (n:ns)
-  | M.member n selected = dbpNameHashClosure mn tyFile selected ns
+dbpNameHashClosure _ _ _ selected [] = return selected
+dbpNameHashClosure paths mn tyFile selected (n:ns)
+  | M.member n selected = dbpNameHashClosure paths mn tyFile selected ns
   | otherwise = do
-      nh <- dbpReadNameHash mn tyFile n
-      localDeps <- traverse (dbpReadOwningName mn tyFile)
+      nh <- dbpReadNameHash paths mn tyFile n
+      localDeps <- traverse (dbpReadOwningName paths mn tyFile)
                      (InterfaceFiles.nhPubLocalDeps nh ++ InterfaceFiles.nhImplLocalDeps nh)
       exts <- dbpExtensionsForName tyFile n
-      extDeps <- traverse (dbpReadOwningName mn tyFile) exts
+      extDeps <- traverse (dbpReadOwningName paths mn tyFile) exts
       let deps = unionNames localDeps extDeps
           selected' = M.insert n nh selected
           new = filter (`M.notMember` selected') deps
-      dbpNameHashClosure mn tyFile selected' (new ++ ns)
+      dbpNameHashClosure paths mn tyFile selected' (new ++ ns)
   where
     unionNames xs ys = Data.List.sortOn Hashing.nameKey (Data.List.nub (xs ++ ys))
 

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -1547,8 +1547,8 @@ data StageKey = ParseStage TaskKey | FrontStage TaskKey deriving (Eq, Ord, Show)
 data StageSuccess = StageParsed CompileTask (Maybe TimeSpec) | StageFronted FrontResult
 
 forceHTEnv :: I.HTEnv -> ()
-forceHTEnv hte                  = HM.foldl' forceHNameInfo () hte
-  where forceHNameInfo () hni  = hni `seq` ()
+forceHTEnv hte                  = HM.foldl' forceNameInfo () hte
+  where forceNameInfo () ni    = ni `seq` ()
 
 forceTypeResult :: I.NModule -> A.Module -> Acton.Env.EnvF x -> [String] -> IO ()
 forceTypeResult nmod tchecked typeEnv tests = do

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -1521,7 +1521,7 @@ data CompileTask        = ParseTask { name :: A.ModName, src :: String, srcBytes
                                     , tyRoots :: [A.Name]
                                     , tyTests :: [String]
                                     , tyDoc :: Maybe String
-                                    , iface :: I.NameInfo
+                                    , iface :: I.NModule
                                     , typed :: A.Module
                                     }
                         | ParseErrorTask { name :: A.ModName, parseDiagnostics :: [Diagnostic String] }
@@ -1548,10 +1548,9 @@ data StageSuccess = StageParsed CompileTask (Maybe TimeSpec) | StageFronted Fron
 
 forceHTEnv :: I.HTEnv -> ()
 forceHTEnv hte                  = HM.foldl' forceHNameInfo () hte
-  where forceHNameInfo () (I.HNModule _ te _) = forceHTEnv te
-        forceHNameInfo () hni  = hni `seq` ()
+  where forceHNameInfo () hni  = hni `seq` ()
 
-forceTypeResult :: I.NameInfo -> A.Module -> Acton.Env.EnvF x -> [String] -> IO ()
+forceTypeResult :: I.NModule -> A.Module -> Acton.Env.EnvF x -> [String] -> IO ()
 forceTypeResult nmod tchecked typeEnv tests = do
   evaluate (rnf nmod)
   evaluate (rnf tchecked)

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -2304,7 +2304,7 @@ runFrontPasses :: C.GlobalOptions
                -> Maybe InterfaceFiles.SourceFileMeta
                -> (A.ModName -> IO (Maybe B.ByteString))
                -> (A.ModName -> IO (Maybe B.ByteString))
-               -> (A.ModName -> IO (Maybe (M.Map A.Name InterfaceFiles.NameHashInfo)))
+               -> (A.ModName -> A.Name -> IO (Maybe InterfaceFiles.NameHashInfo))
                -> (FrontPassProgress -> IO ())
                -> (TaskKey -> FrontOutputKind -> IO ())
                -> (TaskKey -> FrontOutputKind -> FrontOutputProgress -> IO ())
@@ -2312,7 +2312,7 @@ runFrontPasses :: C.GlobalOptions
                -> IO Bool
                -> ([FrontOutputJob] -> IO ())
                -> IO (Either [Diagnostic String] FrontResult)
-runFrontPasses gopts opts dbpBlocked paths env0 parsed srcContent srcBytes sourceMeta resolveImportHash resolveImportImplHash resolveNameHashMap onFrontProgress onFrontOutputStart onFrontOutputProgress onFrontOutputDone shouldWriteFrontOutput recordFrontOutputJobs = do
+runFrontPasses gopts opts dbpBlocked paths env0 parsed srcContent srcBytes sourceMeta resolveImportHash resolveImportImplHash resolveNameHash onFrontProgress onFrontOutputStart onFrontOutputProgress onFrontOutputDone shouldWriteFrontOutput recordFrontOutputJobs = do
   createDirectoryIfMissing True (getModPath (projTypes paths) mn)
   core
     `catch` handleGeneral
@@ -2385,47 +2385,34 @@ runFrontPasses gopts opts dbpBlocked paths env0 parsed srcContent srcBytes sourc
       errsToDiagnostics "Compilation error" filename srcContent
         [(loc, label ++ " hash missing for " ++ prstr qn ++ " (used by " ++ A.nstr owner ++ ")")]
 
-    resolveNameHashMaps :: [A.ModName] -> IO (Either [Diagnostic String] (M.Map A.ModName (M.Map A.Name InterfaceFiles.NameHashInfo)))
-    resolveNameHashMaps mrefs = do
-      resolved <- forM mrefs $ \mref -> do
-        mh <- resolveNameHashMap mref
-        case mh of
-          Just hm -> return (Right (mref, hm))
-          Nothing -> return (Left (missingIfaceDiagnostics mn srcContent mref))
-      let (errs, vals) = partitionEithers resolved
-      if null errs
-        then return (Right (M.fromList vals))
-        else return (Left (concat errs))
-
     resolveDepHashes :: String
                      -> (InterfaceFiles.NameHashInfo -> B.ByteString)
                      -> M.Map A.Name [A.QName]
-                     -> M.Map A.ModName (M.Map A.Name InterfaceFiles.NameHashInfo)
                      -> M.Map A.Name SrcLoc
-                     -> Either [Diagnostic String] (M.Map A.Name [(A.QName, B.ByteString)])
-    resolveDepHashes label getHash deps extMaps nameLocs =
-      let resolveQName owner qn = case qn of
-            A.GName m n -> lookupName owner m n
-            A.QName m n -> lookupName owner m n
-            A.NoQ _ -> Left (missingNameHashDiagnostics qn)
-          lookupName owner m n =
-            case M.lookup m extMaps of
-              Nothing -> Left (missingIfaceDiagnostics mn srcContent m)
-              Just hm ->
-                case M.lookup n hm of
-                  Just info ->
-                    let h = getHash info
-                        loc = M.findWithDefault NoLoc owner nameLocs
-                    in if B.null h
-                         then Left (missingDepHashDiagnostics label owner loc (A.GName m n))
-                         else Right (Just (A.GName m n, h))
-                  Nothing -> Left (missingNameHashDiagnostics (A.GName m n))
-          resolveForName (n, qns) =
-            let resolved = map (resolveQName n) qns
-                (errs, vals) = partitionEithers resolved
-            in if null errs then Right (n, catMaybes vals) else Left (concat errs)
-          (errs, vals) = partitionEithers (map resolveForName (M.toList deps))
-      in if null errs then Right (M.fromList vals) else Left (concat errs)
+                     -> IO (Either [Diagnostic String] (M.Map A.Name [(A.QName, B.ByteString)]))
+    resolveDepHashes label getHash deps nameLocs = do
+      resolved <- forM (M.toList deps) $ \(owner, qns) -> do
+        resolvedQns <- forM qns $ \qn -> case qn of
+          A.GName m n -> lookupName owner m n
+          A.QName m n -> lookupName owner m n
+          A.NoQ _ -> return (Left (missingNameHashDiagnostics qn))
+        let (errs, vals) = partitionEithers resolvedQns
+        return $ if null errs
+          then Right (owner, catMaybes vals)
+          else Left (concat errs)
+      let (errs, vals) = partitionEithers resolved
+      return $ if null errs then Right (M.fromList vals) else Left (concat errs)
+      where
+        lookupName owner m n = do
+          mInfo <- resolveNameHash m n
+          return $ case mInfo of
+            Just info ->
+              let h = getHash info
+                  loc = M.findWithDefault NoLoc owner nameLocs
+              in if B.null h
+                   then Left (missingDepHashDiagnostics label owner loc (A.GName m n))
+                   else Right (Just (A.GName m n, h))
+            Nothing -> Left (missingNameHashDiagnostics (A.GName m n))
 
     emitFrontProgress pass completed total current =
       onFrontProgress FrontPassProgress
@@ -2603,19 +2590,16 @@ runFrontPasses gopts opts dbpBlocked paths env0 parsed srcContent srcBytes sourc
           -- a pub hash.
           let (pubLocalDeps, pubExtDeps) =
                 Hashing.mergePubDeps pubSigLocalDeps pubSigExtDeps implLocalDeps implExtDeps
-              -- Load .tydb maps for any external modules referenced by deps.
               extMods = Data.Set.toList (Hashing.externalModules pubExtDeps `Data.Set.union` Hashing.externalModules implExtDeps)
           evaluate (rnf (pubLocalDeps, pubExtDeps, extMods))
-          extMapsRes <- resolveNameHashMaps extMods
           depModulesRes <- resolveDepModuleHashes extMods
-          case (extMapsRes, depModulesRes) of
-            (Left diags, _) -> return (Left diags)
-            (_, Left diags) -> return (Left diags)
-            (Right extMaps, Right depModules) -> do
+          case depModulesRes of
+            Left diags -> return (Left diags)
+            Right depModules -> do
               -- Resolve external deps to their recorded hashes.
-              let pubSigExtRes = resolveDepHashes "pub" InterfaceFiles.nhPubHash pubSigExtDeps extMaps nameLocs
-                  pubExtRes = resolveDepHashes "pub" InterfaceFiles.nhPubHash pubExtDeps extMaps nameLocs
-                  implExtRes = resolveDepHashes "impl" InterfaceFiles.nhImplHash implExtDeps extMaps nameLocs
+              pubSigExtRes <- resolveDepHashes "pub" InterfaceFiles.nhPubHash pubSigExtDeps nameLocs
+              pubExtRes <- resolveDepHashes "pub" InterfaceFiles.nhPubHash pubExtDeps nameLocs
+              implExtRes <- resolveDepHashes "impl" InterfaceFiles.nhImplHash implExtDeps nameLocs
               case (pubSigExtRes, pubExtRes, implExtRes) of
                 (Left diags, _, _) -> return (Left diags)
                 (_, Left diags, _) -> return (Left diags)
@@ -3396,7 +3380,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                 mSourceMeta
                 (getPubHashCached bPaths)
                 (getImplHashCached bPaths)
-                (getNameHashMapCached bPaths)
+                (getNameHashCached bPaths)
                 (\p -> ccOnFrontProgress callbacks t optsBuiltin p)
                 (ccOnFrontOutputStart callbacks)
                 (ccOnFrontOutputProgress callbacks)
@@ -3532,16 +3516,6 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                     | M.member depKey taskMap -> error ("Internal error: missing impl hash for dep " ++ modNameToString m)
                     | otherwise -> getImplHashCached paths m
               Nothing -> getImplHashCached paths m
-          resolveNameHashMap' m =
-            case M.lookup m providers of
-              Just depKey ->
-                case M.lookup depKey nameMap of
-                  Just hm -> return (Just hm)
-                  Nothing
-                    | isBuiltinKey depKey -> getNameHashMapCached paths m
-                    | M.member depKey taskMap -> error ("Internal error: missing name hashes for dep " ++ modNameToString m)
-                    | otherwise -> getNameHashMapCached paths m
-              Nothing -> getNameHashMapCached paths m
           resolveNameHash' m n =
             case M.lookup m providers of
               Just depKey ->
@@ -3716,13 +3690,10 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
             in if null items then Nothing else Just (intercalate ", " items)
 
           resolveNameHashInfo m n = do
-            hm <- resolveNameHashMap' m
-            case hm of
-              Nothing -> return (Left (missingIfaceDiagnostics mn "" m))
-              Just hmap ->
-                case M.lookup n hmap of
-                  Just info -> return (Right info)
-                  Nothing -> return (Left (missingNameHashDiagnostics (A.GName m n)))
+            mInfo <- resolveNameHash' m n
+            return $ case mInfo of
+              Just info -> Right info
+              Nothing -> Left (missingNameHashDiagnostics (A.GName m n))
 
           resolveQNameHash label getHash users qn =
             case qn of
@@ -3948,7 +3919,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                           mSourceMeta
                           resolveImportHash
                           resolveImportImplHash
-                          resolveNameHashMap'
+                          resolveNameHash'
                           (\p -> ccOnFrontProgress callbacks t optsT p)
                           (ccOnFrontOutputStart callbacks)
                           (ccOnFrontOutputProgress callbacks)

--- a/compiler/lib/src/Acton/Completion.hs
+++ b/compiler/lib/src/Acton/Completion.hs
@@ -603,10 +603,12 @@ shallowImport searchPath env imp =
 
 shallowModuleItem :: [FilePath] -> Env.Env0 -> S.ModuleItem -> IO Env.Env0
 shallowModuleItem searchPath env (S.ModuleItem m as) =
-  shallowModule searchPath env m $ \_ env' ->
+  shallowModule searchPath env m $ \mi env' ->
     case as of
-      Nothing -> Env.addImport m env'
-      Just n -> Env.defineClosed [(n, I.NMAlias m)] env'
+      Nothing -> Env.addVisibleModule m (Env.addImport m env')
+      Just n ->
+        let a = S.ModName [n]
+        in Env.addVisibleModule a (Env.addModuleAlias a mi (Env.addImport m env'))
 
 shallowModule
   :: [FilePath]
@@ -791,7 +793,7 @@ lookupQNameInfo env qn =
     S.NoQ n ->
       lookupNoQ n
     S.QName m n ->
-      lookupModuleItem env (Env.findModuleInfo m env) n
+      lookupModuleItem env (Env.lookupModuleInfo m env) n
     S.GName m n
       | Just m == Env.thismod env ->
           lookupQNameInfo env (S.NoQ n)

--- a/compiler/lib/src/Acton/Completion.hs
+++ b/compiler/lib/src/Acton/Completion.hs
@@ -806,7 +806,7 @@ lookupQNameInfo env qn =
 lookupModuleItem :: Env.Env0 -> Maybe Env.ModuleInfo -> S.Name -> Maybe I.NameInfo
 lookupModuleItem env mmi n = do
   mi <- mmi
-  info <- Env.moduleLookupHName mi n
+  info <- Env.moduleLookupName mi n
   case info of
     I.NAlias qn -> lookupQNameInfo env qn
     _ -> Just info

--- a/compiler/lib/src/Acton/Completion.hs
+++ b/compiler/lib/src/Acton/Completion.hs
@@ -585,11 +585,7 @@ completionEnv searchPath baseEnv modName imps =
 -- fallback, which is enough for generated base classes and typed constructors.
 shallowCompletionEnv :: [FilePath] -> Env.Env0 -> [S.Import] -> IO Env.Env0
 shallowCompletionEnv searchPath baseEnv imps =
-  refreshHModules <$> foldM (shallowImport searchPath) baseEnv imps
-
-refreshHModules :: Env.Env0 -> Env.Env0
-refreshHModules env =
-  env { Env.hmodules = I.convTEnv2HTEnv (Env.modules env) }
+  foldM (shallowImport searchPath) baseEnv imps
 
 shallowImport :: [FilePath] -> Env.Env0 -> S.Import -> IO Env.Env0
 shallowImport searchPath env imp =

--- a/compiler/lib/src/Acton/Completion.hs
+++ b/compiler/lib/src/Acton/Completion.hs
@@ -598,17 +598,17 @@ shallowImport searchPath env imp =
     S.Import _ items ->
       foldM (shallowModuleItem searchPath) env items
     S.FromImport _ (S.ModRef (0, Just m)) items ->
-      shallowModule searchPath env m $ \te env' ->
-        Env.importSome items m te env'
+      shallowModule searchPath env m $ \mi env' ->
+        Env.importSome items m mi env'
     S.FromImportAll _ (S.ModRef (0, Just m)) ->
-      shallowModule searchPath env m $ \te env' ->
-        Env.importAll m te env'
+      shallowModule searchPath env m $ \mi env' ->
+        Env.importAll m mi env'
     _ ->
       return env
 
 shallowModuleItem :: [FilePath] -> Env.Env0 -> S.ModuleItem -> IO Env.Env0
 shallowModuleItem searchPath env (S.ModuleItem m as) =
-  shallowModule searchPath env m $ \te env' ->
+  shallowModule searchPath env m $ \_ env' ->
     case as of
       Nothing -> Env.addImport m env'
       Just n -> Env.defineClosed [(n, I.NMAlias m)] env'
@@ -617,14 +617,17 @@ shallowModule
   :: [FilePath]
   -> Env.Env0
   -> S.ModName
-  -> (I.TEnv -> Env.Env0 -> Env.Env0)
+  -> (Env.ModuleInfo -> Env.Env0 -> Env.Env0)
   -> IO Env.Env0
 shallowModule searchPath env m applyImport = do
   loaded <- readModuleInterface searchPath m
   case loaded of
     Nothing -> return env
     Just (ms, te, mdoc) ->
-      return $ applyImport te (Env.addMod m ms te mdoc env)
+      let env' = Env.addMod m ms te mdoc env
+      in case Env.lookupModuleInfo m env' of
+           Just mi -> return $ applyImport mi env'
+           Nothing -> return env'
 
 readModuleInterface :: [FilePath] -> S.ModName -> IO (Maybe ([S.ModName], I.TEnv, Maybe String))
 readModuleInterface searchPath m = do

--- a/compiler/lib/src/Acton/Completion.hs
+++ b/compiler/lib/src/Acton/Completion.hs
@@ -592,14 +592,12 @@ shallowImport searchPath env imp =
   case imp of
     S.Import _ items ->
       foldM (shallowModuleItem searchPath) env items
-    S.FromImport _ (S.ModRef (0, Just m)) items ->
+    S.FromImport _ m items ->
       shallowModule searchPath env m $ \mi env' ->
         Env.importSome items m mi env'
-    S.FromImportAll _ (S.ModRef (0, Just m)) ->
+    S.FromImportAll _ m ->
       shallowModule searchPath env m $ \mi env' ->
         Env.importAll m mi env'
-    _ ->
-      return env
 
 shallowModuleItem :: [FilePath] -> Env.Env0 -> S.ModuleItem -> IO Env.Env0
 shallowModuleItem searchPath env (S.ModuleItem m as) =

--- a/compiler/lib/src/Acton/Completion.hs
+++ b/compiler/lib/src/Acton/Completion.hs
@@ -850,7 +850,6 @@ docOfInfo info =
       I.NClass _ _ _ doc -> doc
       I.NProto _ _ _ doc -> doc
       I.NExt _ _ _ _ _ doc -> doc
-      I.NModule _ _ doc -> doc
       _ -> Nothing
 
 typeDoc :: Env.Env0 -> S.Type -> Maybe String

--- a/compiler/lib/src/Acton/Completion.hs
+++ b/compiler/lib/src/Acton/Completion.hs
@@ -800,16 +800,16 @@ lookupQNameInfo env qn =
   where
     lookupNoQ n              = resolve =<< Env.lookupName n env
 
-    resolve (I.HNAlias qn')  = lookupQNameInfo env qn'
-    resolve info             = Just (I.convHNameInfo2NameInfo info)
+    resolve (I.NAlias qn')  = lookupQNameInfo env qn'
+    resolve info             = Just info
 
 lookupModuleItem :: Env.Env0 -> Maybe Env.ModuleInfo -> S.Name -> Maybe I.NameInfo
 lookupModuleItem env mmi n = do
   mi <- mmi
   info <- Env.moduleLookupHName mi n
   case info of
-    I.HNAlias qn -> lookupQNameInfo env qn
-    _ -> Just (I.convHNameInfo2NameInfo info)
+    I.NAlias qn -> lookupQNameInfo env qn
+    _ -> Just info
 
 functionReturnType :: Env.Env0 -> I.NameInfo -> Maybe S.Type
 functionReturnType env info = do

--- a/compiler/lib/src/Acton/Completion.hs
+++ b/compiler/lib/src/Acton/Completion.hs
@@ -29,7 +29,6 @@ import qualified Control.Monad.Trans.State.Strict as St
 import Data.Char (isAlpha, isAlphaNum, isSpace)
 import Data.List (find, findIndex, intercalate, isPrefixOf, nubBy)
 import Data.Maybe (listToMaybe, mapMaybe)
-import qualified Data.HashMap.Strict as HM
 import qualified InterfaceFiles as IF
 import Text.Megaparsec (eof, runParser)
 
@@ -796,22 +795,22 @@ lookupQNameInfo env qn =
     S.NoQ n ->
       lookupNoQ n
     S.QName m n ->
-      lookupModuleItem env (Env.findHMod m env) n
+      lookupModuleItem env (Env.findModuleInfo m env) n
     S.GName m n
       | Just m == Env.thismod env ->
           lookupQNameInfo env (S.NoQ n)
       | otherwise ->
-          lookupModuleItem env (Env.lookupHMod m env) n
+          lookupModuleItem env (Env.lookupModuleInfo m env) n
   where
     lookupNoQ n              = resolve =<< Env.lookupName n env
 
     resolve (I.HNAlias qn')  = lookupQNameInfo env qn'
     resolve info             = Just (I.convHNameInfo2NameInfo info)
 
-lookupModuleItem :: Env.Env0 -> Maybe I.HTEnv -> S.Name -> Maybe I.NameInfo
-lookupModuleItem env mtenv n = do
-  tenv <- mtenv
-  info <- HM.lookup n tenv
+lookupModuleItem :: Env.Env0 -> Maybe Env.ModuleInfo -> S.Name -> Maybe I.NameInfo
+lookupModuleItem env mmi n = do
+  mi <- mmi
+  info <- Env.moduleLookupHName mi n
   case info of
     I.HNAlias qn -> lookupQNameInfo env qn
     _ -> Just (I.convHNameInfo2NameInfo info)

--- a/compiler/lib/src/Acton/Completion.hs
+++ b/compiler/lib/src/Acton/Completion.hs
@@ -604,11 +604,7 @@ shallowImport searchPath env imp =
 shallowModuleItem :: [FilePath] -> Env.Env0 -> S.ModuleItem -> IO Env.Env0
 shallowModuleItem searchPath env (S.ModuleItem m as) =
   shallowModule searchPath env m $ \mi env' ->
-    case as of
-      Nothing -> Env.addVisibleModule m (Env.addImport m env')
-      Just n ->
-        let a = S.ModName [n]
-        in Env.addVisibleModule a (Env.addModuleAlias a mi (Env.addImport m env'))
+    Env.addQualifier m mi as (Env.addImport m env')
 
 shallowModule
   :: [FilePath]

--- a/compiler/lib/src/Acton/Converter.hs
+++ b/compiler/lib/src/Acton/Converter.hs
@@ -238,8 +238,11 @@ fixupSelf s                             = s
 
 -- Convert a TEnv -------------------------------------------------------------------------------------------
 
-convEnvProtos env                       = mapModules conv env
+convEnvProtos env                       = convertModules convSources conv env
   where
+    convSources (Derived _ n)           = [n]
+    convSources _                       = []
+
     conv m (n, NDef sc d doc)           = [(n, NDef (convS sc) d doc)]
     conv m (n, NSig sc d doc)           = [(n, NSig (convS sc) d doc)]
     conv m (n, NAct q p k te doc)       = [(n, NAct (noqual env q) (qualWRow env q p) k (concat $ map (conv m) te) doc)]

--- a/compiler/lib/src/Acton/Deactorizer.hs
+++ b/compiler/lib/src/Acton/Deactorizer.hs
@@ -29,8 +29,11 @@ import Control.Monad.State.Strict
 
 deactorize                          :: Env0 -> Module -> IO (Module, Env0)
 deactorize env0 (Module m imps mdoc b)
-                                    = return (Module m imps mdoc (runDeactM $ deactSuite env b), mapModules conv env0)
+                                    = return (Module m imps mdoc (runDeactM $ deactSuite env b), convertModules deactSources conv env0)
   where env                         = deactEnv env0
+        deactSources (Derived n s)
+          | s == suffixNewact       = [n]
+        deactSources _              = []
 
 
 -- Deactorizing monad

--- a/compiler/lib/src/Acton/DocPrinter.hs
+++ b/compiler/lib/src/Acton/DocPrinter.hs
@@ -45,7 +45,7 @@ docTEnv = foldr (uncurry Map.insert) Map.empty
 
 
 -- | Generate documentation from a module in Markdown format with types
-docModuleWithTypes :: NameInfo -> Module -> Doc
+docModuleWithTypes :: NModule -> Module -> Doc
 docModuleWithTypes (NModule _ tenv mdocstring) (Module qn _ _ stmts) =
     -- Use module docstring from NModule
     let moduleDocstring = mdocstring
@@ -99,7 +99,6 @@ extractNameDocstring (NAct _ _ _ _ mdoc) = mdoc
 extractNameDocstring (NClass _ _ _ mdoc) = mdoc
 extractNameDocstring (NProto _ _ _ mdoc) = mdoc
 extractNameDocstring (NExt _ _ _ _ _ mdoc) = mdoc
-extractNameDocstring (NModule _ _ mdoc) = mdoc
 extractNameDocstring _ = Nothing
 
 -- | Document a declaration in Markdown format with types
@@ -453,7 +452,7 @@ docMethodWithTypes tenv (Def _ n q p k a b _ _ ddoc) =
 docMethodWithTypes _ _ = empty
 
 -- | Print documentation as Markdown with type information
-printMdDoc :: NameInfo -> Module -> String
+printMdDoc :: NModule -> Module -> String
 printMdDoc nmod m = render (docModuleWithTypes nmod m)
 
 -- | Print documentation as ASCII with optional styling and type information
@@ -461,7 +460,7 @@ printMdDoc nmod m = render (docModuleWithTypes nmod m)
 --   useStyle: Enable ANSI control codes (bold + color)
 --   tenv: Type environment for enhanced type information
 --   module: The module to document
-printAsciiDoc :: Bool -> NameInfo -> Module -> String
+printAsciiDoc :: Bool -> NModule -> Module -> String
 printAsciiDoc useStyle nmod m =
     render (docModuleAsciiUnified useStyle nmod m) ++ "\n"
 
@@ -487,7 +486,7 @@ dim True = "\ESC[2m"
 dim False = ""
 
 -- | Generate ASCII documentation from a module with unified style and type handling
-docModuleAsciiUnified :: Bool -> NameInfo -> Module -> Doc
+docModuleAsciiUnified :: Bool -> NModule -> Module -> Doc
 docModuleAsciiUnified useStyle (NModule _ tenv mdocstring) (Module qn _ _ stmts) =
     -- Use module docstring from NModule
     let moduleDocstring = mdocstring
@@ -1171,7 +1170,7 @@ docRetTypeAscii (Just t) = text " -> " <> pretty (SimplifiedType t)
 
 
 -- | Print documentation as HTML with type information
-printHtmlDoc :: NameInfo -> Module -> String
+printHtmlDoc :: NModule -> Module -> String
 printHtmlDoc nmod m = unlines
         [ "<!DOCTYPE html>"
         , "<html lang=\"en\">"
@@ -1566,7 +1565,7 @@ htmlScript = unlines
 
 
 -- | Generate HTML documentation from a module with type information
-docModuleHtmlWithTypes :: NameInfo -> Module -> Doc
+docModuleHtmlWithTypes :: NModule -> Module -> Doc
 docModuleHtmlWithTypes (NModule _ tenv mdocstring) (Module modName _ _ stmts) =
     -- Use module docstring from NModule
     let tenvMap = docTEnv tenv

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -1332,13 +1332,12 @@ impModule spath env (Import _ ms)
 --                                                  Just n  -> let a = ModName [n]
 --                                                             in addVisibleImport a (addImportAlias a mi env1)
                                      imp (addQualifier m mi as env1) is
-impModule spath env (FromImport _ (ModRef (0,Just m)) items)
+impModule spath env (FromImport _ m items)
                                 = do (env1,mi) <- doImp spath env m
                                      return $ importSome items m mi env1
-impModule spath env (FromImportAll _ (ModRef (0,Just m)))
+impModule spath env (FromImportAll _ m)
                                 = do (env1,mi) <- doImp spath env m
                                      return $ importAll m mi env1
-impModule _ _ i                 = illegalImport (loc i)
 
 
 findTyFile spaths mn = go spaths
@@ -1434,7 +1433,6 @@ data CompilationError               = KindError SrcLoc Kind Kind
                                     | IllegalSigOverride Name
                                     | IllegalExtension QName
                                     | MissingSelf Name
-                                    | IllegalImport SrcLoc
                                     | DuplicateAlias ModName
                                     | IllegalAlias ModName
                                     | IllegalAlias2 ModName
@@ -1463,7 +1461,6 @@ instance HasLoc CompilationError where
     loc (IllegalSigOverride n)      = loc n
     loc (IllegalExtension n)        = loc n
     loc (MissingSelf n)             = loc n
-    loc (IllegalImport l)           = l
     loc (DuplicateAlias m)          = loc m
     loc (IllegalAlias m)            = loc m
     loc (IllegalAlias2 m)           = loc m
@@ -1492,7 +1489,6 @@ compilationError err                = [(loc err, render (expl err))]
     expl (IllegalSigOverride n)     = text "Illegal signature override:" <+> pretty n
     expl (IllegalExtension n)       = text "Illegal extension of" <+> pretty n
     expl (MissingSelf n)            = text "Missing 'self' parameter in definition of"
-    expl (IllegalImport l)          = text "Relative import not yet supported"
     expl (DuplicateAlias m)         = text "Duplicate import alias" <+> pretty m
     expl (IllegalAlias m)           = text "Module alias clashes with an already imported module" <+> pretty m
     expl (IllegalAlias2 m)          = text "Module name is an already declared alias" <+> pretty m
@@ -1518,7 +1514,6 @@ illegalSigOverride n                = Control.Exception.throw $ IllegalSigOverri
 illegalExtension n                  = Control.Exception.throw $ IllegalExtension n
 missingSelf n                       = Control.Exception.throw $ MissingSelf n
 fileNotFound n                      = Control.Exception.throw $ FileNotFound n
-illegalImport l                     = Control.Exception.throw $ IllegalImport l
 duplicateAlias m                    = Control.Exception.throw $ DuplicateAlias m
 illegalAlias m                      = Control.Exception.throw $ IllegalAlias m
 illegalAlias2 m                     = Control.Exception.throw $ IllegalAlias2 m

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -134,7 +134,7 @@ convertModules sources f env= env{ modules = Map.mapWithKey convMod (modules env
                             = listToMaybe $ mapMaybe (lookupFrom n) (n : sources n)
                 lookupFrom n src
                             = do i <- moduleLookupName mi src
-                                 lookup n (f m (src,i)) >>= return . convNameInfo2HNameInfo
+                                 lookup n (f m (src,i))
 
 
 -- Module interfaces -----------------------------------------------------------------------------
@@ -147,7 +147,7 @@ convertModules sources f env= env{ modules = Map.mapWithKey convMod (modules env
 data ModuleInfo             = ModuleInfo {
                                 moduleImports     :: [ModName],
                                 moduleDoc         :: Maybe String,
-                                moduleLookupHName :: Name -> Maybe HNameInfo,
+                                moduleLookupHName :: Name -> Maybe NameInfo,
                                 modulePublicNames :: [Name],
                                 moduleConstructors:: TEnv,
                                 moduleActors      :: [TCon],
@@ -163,7 +163,7 @@ instance Show ModuleInfo where
     show mi                 = "ModuleInfo {imports = " ++ show (moduleImports mi) ++ "}"
 
 moduleLookupName            :: ModuleInfo -> Name -> Maybe NameInfo
-moduleLookupName mi n       = convHNameInfo2NameInfo <$> moduleLookupHName mi n
+moduleLookupName mi n       = moduleLookupHName mi n
 
 modulePublicTEnv            :: ModuleInfo -> TEnv
 modulePublicTEnv mi         = mapMaybe entry (modulePublicNames mi)
@@ -234,7 +234,7 @@ mkTyFileModuleInfo m ms mdoc db
           | not (isPublicName n) = Nothing
           | otherwise        = unsafePerformIO $ do
                                   mi <- InterfaceFiles.readInterfaceDBNameInfoMaybe db n
-                                  return $ convNameInfo2HNameInfo . snd <$> mi
+                                  return $ snd <$> mi
         publicNames          = unsafePerformIO $ InterfaceFiles.readInterfaceDBPublicNames db
         constructors         = unsafePerformIO $ InterfaceFiles.readInterfaceDBConstructors db
         actors               = map (moduleTCon m) $ unsafePerformIO $ InterfaceFiles.readInterfaceDBActors db
@@ -331,13 +331,13 @@ instance Unalias ModName where
     unalias env m@(ModName ns)
       | inBuiltin env               = m
       | otherwise                   = case lookupName (head ns) env of
-                                        Just (HNMAlias m') -> m'
+                                        Just (NMAlias m') -> m'
                                         Nothing | m `elem` (mPrim:mBuiltin:imports env) || modulePrefix m env -> m
                                         _ -> noModule m
 instance Unalias QName where
     unalias env n0@(QName m n)      = case findModuleInfo m env of
                                         Just mi -> case moduleLookupHName mi n of
-                                                      Just (HNAlias qn) -> setLoc (loc n0) qn
+                                                      Just (NAlias qn) -> setLoc (loc n0) qn
                                                       Just _ -> GName m' n
                                                       _ -> noItem m n
                                         Nothing -> error ("#### unalias fails for " ++ prstr (QName m n))
@@ -345,7 +345,7 @@ instance Unalias QName where
     unalias env (NoQ n)
       | inBuiltin env               = GName mBuiltin n
       | otherwise                   = case lookupName n env of
-                                        Just (HNAlias qn) -> setLoc (loc n) qn
+                                        Just (NAlias qn) -> setLoc (loc n) qn
                                         _ -> case thismod env of Just m -> GName m n; _ -> NoQ n
     unalias env (GName m n)
 --      | inBuiltin env, m==mBuiltin  = NoQ n
@@ -464,7 +464,7 @@ hnamesFrom te               = extendHNames te M.empty
 
 extendHNames                :: TEnv -> HTEnv -> HTEnv
 extendHNames te hte         = foldr add hte te
-  where add (n,i) hte       = M.insert n (convNameInfo2HNameInfo i) hte
+  where add (n,i) hte       = M.insert n i hte
 
 extendSigLocs               :: TEnv -> LocEnv -> LocEnv
 extendSigLocs te locs       = foldr add locs te
@@ -510,7 +510,7 @@ addClosedNames te env       = env{ closedNames = te ++ closedNames env,
         slocs               = extendSigLocs te (closedSigLocs env)
         dlocs               = extendDefLocs te (closedDefLocs env)
 
-lookupName                  :: Name -> EnvF x -> Maybe HNameInfo
+lookupName                  :: Name -> EnvF x -> Maybe NameInfo
 lookupName n env            = M.lookup n (hnames env)
 
 reserve                     :: [Name] -> EnvF x -> EnvF x
@@ -616,18 +616,18 @@ selfScopeSubst env          = [ (TV k n, tCon c) | (n, NTVar k c ps) <- activeNa
 
 findQName                   :: QName -> EnvF x -> NameInfo
 findQName n env             = case tryQName n env of
-                                 Just i -> convHNameInfo2NameInfo i
+                                 Just i -> i
                                  Nothing -> nameNotFound (noq n)
 
-tryQName                    :: QName -> EnvF x -> Maybe HNameInfo
+tryQName                    :: QName -> EnvF x -> Maybe NameInfo
 tryQName (QName m n) env    = case findModuleInfo m env of
                                 Just mi -> case moduleLookupHName mi n of
-                                    Just (HNAlias qn) -> tryQName qn env
+                                    Just (NAlias qn) -> tryQName qn env
                                     Just i -> Just i
                                     _ -> noItem m n
                                 _ -> noModule m
 tryQName (NoQ n) env        = case lookupName n env of
-                                Just (HNAlias qn) -> tryQName qn env
+                                Just (NAlias qn) -> tryQName qn env
                                 Just ni -> Just ni
                                 Nothing -> Nothing
 tryQName (GName m n) env
@@ -647,7 +647,7 @@ findDefLoc n env            = M.lookup n (defLocs env)
 findName n env              = findQName (NoQ n) env
 
 lookupVar n env             = case lookupName n env of
-                                Just (HNVar t) -> Just t
+                                Just (NVar t) -> Just t
                                 _ -> Nothing
 
 findModuleInfo              :: ModName -> EnvF x -> Maybe ModuleInfo  -- m is modname part of a QName, so we must check for aliasing
@@ -655,7 +655,7 @@ findModuleInfo m env | inBuiltin env, m==mBuiltin
                             = Just (builtinModuleInfo env)
 findModuleInfo m@(ModName ns) env
                             = case lookupName (head ns) env of
-                                Just (HNMAlias (ModName m')) -> lookupModuleInfo (ModName $ m'++tail ns) env
+                                Just (NMAlias (ModName m')) -> lookupModuleInfo (ModName $ m'++tail ns) env
                                 Nothing | m `elem` (mPrim:mBuiltin:imports env) -> lookupModuleInfo m env
                                 _ -> Nothing
 
@@ -683,12 +683,12 @@ isMod env ns@(n:_)          = (maybe False (const True) (findModuleInfo (ModName
 
 isMAlias                    :: Name -> EnvF x -> Bool
 isMAlias n env              = case lookupName n env of
-                                Just HNMAlias{} -> True
+                                Just NMAlias{} -> True
                                 _ -> False
 
 isAlias                     :: Name -> EnvF x -> Bool
 isAlias n env               = case lookupName n env of
-                                Just HNAlias{} -> True
+                                Just NAlias{} -> True
                                 _ -> False
 
 kindOf env (TVar _ tv)      = tvkind tv
@@ -716,33 +716,33 @@ tconKind n env              = case findQName n env of
         kind k q            = KFun [ tvkind v | QBind v _ <- q ] k
 
 actorSelf env               = case lookupName selfKW env of
-                                Just (HNVar (TCon _ tc)) | isActor env (tcname tc) -> True
+                                Just (NVar (TCon _ tc)) | isActor env (tcname tc) -> True
                                 _ -> False
 
 isDef                       :: EnvF x -> QName -> Bool
 isDef env n                 = case tryQName n env of
-                                Just HNDef{} -> True
+                                Just NDef{} -> True
                                 _ -> False
 
 isActor                     :: EnvF x -> QName -> Bool
 isActor env n               = case tryQName n env of
-                                Just HNAct{} -> True
+                                Just NAct{} -> True
                                 _ -> False
 
 isClass                     :: EnvF x -> QName -> Bool
 isClass env n               = case tryQName n env of
-                                Just HNClass{} -> True
+                                Just NClass{} -> True
                                 _ -> False
 
 isProto                     :: EnvF x -> QName -> Bool
 isProto env n               = case tryQName n env of
-                                Just HNProto{} -> True
+                                Just NProto{} -> True
                                 _ -> False
 
 isDefOrClass                :: EnvF x -> QName -> Bool
 isDefOrClass env n          = case tryQName n env of
-                                Just HNDef{} -> True
-                                Just HNClass{} -> True
+                                Just NDef{} -> True
+                                Just NClass{} -> True
                                 _ -> False
 
 
@@ -1626,10 +1626,10 @@ instance Simp QName where
       | Just n1 <- findAlias (closedNames env) = NoQ n1                                      -- Restore aliases
       | otherwise                   = n
       where findIndexedAlias qn@(GName _ n1) = case lookupName n1 env of
-                                                  Just (HNAlias n2) | n2 == qn -> Just n1
+                                                  Just (NAlias n2) | n2 == qn -> Just n1
                                                   _ -> Nothing
             findIndexedAlias qn@(QName _ n1) = case lookupName n1 env of
-                                                  Just (HNAlias n2) | n2 == qn -> Just n1
+                                                  Just (NAlias n2) | n2 == qn -> Just n1
                                                   _ -> Nothing
             findIndexedAlias _               = Nothing
             findAlias ((n1, NAlias n2):te)

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -390,9 +390,6 @@ instance Unalias NameInfo where
     unalias env (NMAlias m)         = NMAlias (unalias env m)
     unalias env NReserved           = NReserved
 
-instance Unalias NModule where
-    unalias env (NModule ms te doc) = NModule (unalias env ms) (unalias env te) doc
-
 instance Unalias (Name,NameInfo) where
     unalias env (n,i)               = (n, unalias env i)
 

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -391,8 +391,10 @@ instance Unalias NameInfo where
     unalias env (NTVar k c ps)      = NTVar k (unalias env c) (unalias env ps)
     unalias env (NAlias qn)         = NAlias (unalias env qn)
     unalias env (NMAlias m)         = NMAlias (unalias env m)
-    unalias env (NModule ms te doc) = NModule (unalias env ms) (unalias env te) doc
     unalias env NReserved           = NReserved
+
+instance Unalias NModule where
+    unalias env (NModule ms te doc) = NModule (unalias env ms) (unalias env te) doc
 
 instance Unalias (Name,NameInfo) where
     unalias env (n,i)               = (n, unalias env i)

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -338,11 +338,11 @@ instance Unalias ModName where
       | inBuiltin env               = m
       | otherwise                   = case lookupName (head ns) env of
                                         Just (HNMAlias m') -> m'
-                                        Nothing | m `elem` (mPrim:mBuiltin:imports env)  -> m
+                                        Nothing | m `elem` (mPrim:mBuiltin:imports env) || modulePrefix m env -> m
                                         _ -> noModule m
 instance Unalias QName where
-    unalias env n0@(QName m n)      = case findHMod m env of
-                                        Just te -> case M.lookup n te of
+    unalias env n0@(QName m n)      = case findModuleInfo m env of
+                                        Just mi -> case moduleLookupHName mi n of
                                                       Just (HNAlias qn) -> setLoc (loc n0) qn
                                                       Just _ -> GName m' n
                                                       _ -> noItem m n
@@ -637,8 +637,8 @@ findQName n env             = case tryQName n env of
                                  Nothing -> nameNotFound (noq n)
 
 tryQName                    :: QName -> EnvF x -> Maybe HNameInfo
-tryQName (QName m n) env    = case findHMod m env of
-                                Just te -> case M.lookup n te of
+tryQName (QName m n) env    = case findModuleInfo m env of
+                                Just mi -> case moduleLookupHName mi n of
                                     Just (HNAlias qn) -> tryQName qn env
                                     Just i -> Just i
                                     _ -> noItem m n
@@ -651,8 +651,8 @@ tryQName (GName m n) env
   | Just m == thismod env   = tryQName (NoQ n) env
   | inBuiltin env,
     m==mBuiltin             = tryQName (NoQ n) env
-  | otherwise               = case lookupHMod m env of
-                                Just te -> case M.lookup n te of
+  | otherwise               = case lookupModuleInfo m env of
+                                Just mi -> case moduleLookupHName mi n of
                                     Just i -> Just i
                                     Nothing -> noItem m n -- error ("## Failed lookup of " ++ prstr n ++ " in module " ++ prstr m)
                                 Nothing -> noModule m -- error ("## Failed lookup of module " ++ prstr m)
@@ -705,6 +705,13 @@ lookupModuleInfo m env
                             = Just (builtinModuleInfo env)
   | otherwise               = Map.lookup m (moduleInfos env)
 
+-- A parent package of a loaded module is itself a valid module path prefix,
+-- which the old NModule tree represented implicitly.
+modulePrefix                :: ModName -> EnvF x -> Bool
+modulePrefix (ModName ns) env
+                            = any prefix (Map.keys (moduleInfos env))
+  where prefix (ModName ns')= ns `isPrefixOf` ns'
+
 -- The builtin module is looked up through the active environment while it is
 -- itself being compiled.
 builtinModuleInfo           :: EnvF x -> ModuleInfo
@@ -726,7 +733,7 @@ lookupModule (ModName ns) env   = f ns (modules env)
 
 
 isMod                       :: EnvF x -> [Name] -> Bool
-isMod env ns@(n:_)          = maybe False (const True) (findHMod (ModName ns) env) && rooted
+isMod env ns@(n:_)          = (maybe False (const True) (findModuleInfo (ModName ns) env) || modulePrefix (ModName ns) env) && rooted
   where rooted              = n `elem` improots env || isMAlias n env
 
 isMAlias                    :: Name -> EnvF x -> Bool
@@ -966,7 +973,7 @@ transitiveImports env       = mBuiltin : reverse (foldl trav [] (getImports env)
   where trav seen m
           | m `elem` seen   = seen
           | otherwise       = m : foldl trav seen ms
-          where ms          = case lookupModule m env of Just (imps,_,_) -> imps
+          where ms          = case lookupModuleInfo m env of Just mi -> moduleImports mi
 
 allTypes                    :: (NameInfo -> Bool) -> EnvF x -> [TCon]
 allTypes select env         = concatMap impcons mods ++ localcons

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -838,7 +838,21 @@ allAncestors env tc         = reverse [ schematic' c | (_, c) <- us ]
   where (us,te)             = findCon env tc
 
 allDescendants              :: EnvF x -> TCon -> [TCon]
-allDescendants env tc       = [ schematic' c | c <- allCons env, hasAncestor' env (tcname c) (tcname tc) ]
+allDescendants env tc       = concatMap imported (importedModuleInfos env) ++ local
+  where imported mi         = moduleDescendants mi (tcname tc)
+        local               = [ schematic' c | c <- localCons env, hasAncestor' env (tcname c) (tcname tc) ]
+
+importedModuleInfos         :: EnvF x -> [ModuleInfo]
+importedModuleInfos env     = [ mi | m <- transitiveImports env, Just mi <- [lookupModuleInfo m env] ]
+
+localCons                   :: EnvF x -> [TCon]
+localCons env               = local (reverse (closedNames env)) ++ local (reverse (activeNames env))
+  where local te
+          | inBuiltin env   = [ TC (GName mBuiltin n) (wildargs i) | (n,i) <- te, isCon i ]
+          | otherwise       = [ TC (NoQ n) (wildargs i) | (n,i) <- te, isCon i ]
+        isCon NClass{}      = True
+        isCon NAct{}        = True
+        isCon _             = False
 
 findCon                     :: EnvF x -> TCon -> ([WTCon],TEnv)
 findCon env (TC n ts)

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -22,9 +22,13 @@ import Data.Char
 import System.FilePath.Posix (joinPath,takeDirectory)
 import System.Directory (doesDirectoryExist, doesFileExist)
 import System.Environment (getExecutablePath)
+import System.IO.Unsafe (unsafePerformIO)
 import Control.Monad
 import Control.Monad.Except
+import Data.IORef
 import qualified Data.HashMap.Strict as M
+import qualified Data.Map.Strict as Map
+import Data.Map.Strict (Map)
 import qualified Data.Set as S
 
 import Acton.Syntax
@@ -63,6 +67,7 @@ data EnvF x                 = EnvF {
                                 improots   :: [Name],
                                 modules    :: TEnv,
                                 hmodules   :: HTEnv,
+                                moduleInfos:: Map ModName ModuleInfo,
                                 thismod    :: Maybe ModName,
                                 context    :: [EnvCtx],
                                 qlevel     :: Int,
@@ -84,7 +89,8 @@ setX env x                  = EnvF { activeNames = activeNames env, closedNames 
                                      activeStateNames = activeStateNames env,
                                      activeTypeVars = activeTypeVars env,
                                      imports = imports env, improots = improots env,
-                                     modules = modules env, hmodules = hmodules env, thismod = thismod env,
+                                     modules = modules env, hmodules = hmodules env,
+                                     moduleInfos = moduleInfos env, thismod = thismod env,
                                      context = context env, qlevel = qlevel env, envX = x }
 
 modX                        :: EnvF x -> (x -> x) -> EnvF x
@@ -119,7 +125,7 @@ mapModules1                 :: ((Name,NameInfo) -> (Name,NameInfo)) -> Env0 -> E
 mapModules1 f env           = mapModules (\_ ni -> [f ni]) env
 
 mapModules                  :: (ModName -> (Name,NameInfo) -> TEnv) -> Env0 -> Env0
-mapModules f env            = env' { hmodules = convTEnv2HTEnv mods' }
+mapModules f env            = env' { hmodules = convTEnv2HTEnv mods', moduleInfos = Map.mapWithKey conv (moduleInfos env) }
  where env'                 = env { modules = mods' }
        prim : mods          = modules env
        mods'                = prim : walk [] mods
@@ -129,6 +135,173 @@ mapModules f env            = env' { hmodules = convTEnv2HTEnv mods' }
        go ns (n, NModule ms te doc)
                             = [(n, NModule ms (walk (ns ++ [n]) te) doc)]
        go ns ni             = f (ModName ns) ni
+
+       conv m mi
+         | m == mPrim       = mi
+         | otherwise        = case lookupMod m env' of
+                                Just te -> mkModuleInfo m (moduleImports mi) te (moduleDoc mi)
+                                Nothing -> mi
+
+
+-- Module interfaces -----------------------------------------------------------------------------
+
+-- A ModuleInfo is the per-module view used for all lookups into dependency
+-- modules. A locally compiled module backs it with its in-memory interface
+-- TEnv; an imported module can back it with selective .tydb reads instead, so
+-- a dependent module only pays for the names and indexes it actually demands.
+
+data ModuleInfo             = ModuleInfo {
+                                moduleImports     :: [ModName],
+                                moduleDoc         :: Maybe String,
+                                moduleLookupHName :: Name -> Maybe HNameInfo,
+                                modulePublicNames :: [Name],
+                                moduleConstructors:: TEnv,
+                                moduleActors      :: [TCon],
+                                moduleConAttr     :: Name -> [TCon],
+                                moduleProtoAttr   :: Name -> [TCon],
+                                moduleDescendants :: QName -> [TCon],
+                                moduleProtoDescendants :: QName -> [TCon],
+                                moduleWitnessesByProto :: QName -> [Witness],
+                                moduleWitnessesByType  :: QName -> [Witness]
+                              }
+
+instance Show ModuleInfo where
+    show mi                 = "ModuleInfo {imports = " ++ show (moduleImports mi) ++ "}"
+
+moduleLookupName            :: ModuleInfo -> Name -> Maybe NameInfo
+moduleLookupName mi n       = convHNameInfo2NameInfo <$> moduleLookupHName mi n
+
+modulePublicTEnv            :: ModuleInfo -> TEnv
+modulePublicTEnv mi         = mapMaybe entry (modulePublicNames mi)
+  where entry n             = fmap (\i -> (n,i)) (moduleLookupName mi n)
+
+mkModuleInfo                :: ModName -> [ModName] -> TEnv -> Maybe String -> ModuleInfo
+mkModuleInfo m ms te mdoc   = ModuleInfo {
+                                moduleImports = ms,
+                                moduleDoc = mdoc,
+                                moduleLookupHName = \n -> M.lookup n hte,
+                                modulePublicNames = map fst pte,
+                                moduleConstructors = [ ni | ni@(_,i) <- pte, isCons i ],
+                                moduleActors = [ moduleTCon m ni | ni@(_,NAct{}) <- pte ],
+                                moduleConAttr = \n -> Map.findWithDefault [] n conattrs,
+                                moduleProtoAttr = \n -> Map.findWithDefault [] n protoattrs,
+                                moduleDescendants = qkeyed descendants,
+                                moduleProtoDescendants = qkeyed protodescs,
+                                moduleWitnessesByProto = qkeyed witprotos,
+                                moduleWitnessesByType = qkeyed wittypes
+                              }
+  where pte                 = publicTEnv te
+        hte                 = convTEnv2HTEnv pte
+        wits                = extWitnesses m [ ni | ni@(_,NExt{}) <- pte ]
+        witprotos           = indexMap [ (tcname $ proto w, w) | w <- wits ]
+        wittypes            = indexMap [ (qn, w) | w <- wits, Just qn <- [witnessTypeQName w] ]
+        conattrs            = indexMap [ (a, moduleTCon m ni) | ni@(_,i) <- pte, isCon i, a <- dom (conTE i) ]
+        protoattrs          = indexMap [ (a, moduleTCon m ni) | ni@(_,i@NProto{}) <- pte, a <- dom (conTE i) ]
+        descendants         = indexMap [ (tcname c, moduleTCon m ni) | ni@(_,i@NClass{}) <- pte, (_,c) <- ancestry i ]
+        protodescs          = indexMap [ (tcname c, moduleTCon m ni) | ni@(_,i@NProto{}) <- pte, (_,c) <- ancestry i ]
+        qkeyed mp qn        = concat [ Map.findWithDefault [] qn' mp | qn' <- moduleQNameKeys m qn ]
+        indexMap xs         = Map.fromListWith (++) [ (k, [v]) | (k,v) <- reverse xs ]
+        ancestry (NClass _ us _ _) = us
+        ancestry (NProto _ us _ _) = us
+        ancestry _          = []
+        conTE (NClass _ _ te' _) = te'
+        conTE (NProto _ _ te' _) = te'
+        conTE (NAct _ _ _ te' _) = te'
+        conTE _             = []
+        isCons NClass{}     = True
+        isCons NProto{}     = True
+        isCons NAct{}       = True
+        isCons _            = False
+        isCon NClass{}      = True
+        isCon NAct{}        = True
+        isCon _             = False
+
+-- | Build a ModuleInfo backed by selective .tydb reads. Lookups run keyed
+-- LMDB reads on demand (behind pure-looking functions) and memoize results;
+-- a failed or corrupt read aborts compilation like any other interface cache
+-- error.
+mkTyFileModuleInfo          :: ModName -> [ModName] -> Maybe String -> InterfaceFiles.InterfaceDB -> ModuleInfo
+mkTyFileModuleInfo m ms mdoc db
+                            = ModuleInfo {
+                                moduleImports = ms,
+                                moduleDoc = mdoc,
+                                moduleLookupHName = memoLookup lookupName,
+                                modulePublicNames = publicNames,
+                                moduleConstructors = constructors,
+                                moduleActors = actors,
+                                moduleConAttr = memoLookup conAttr,
+                                moduleProtoAttr = memoLookup protoAttr,
+                                moduleDescendants = memoLookup descendants,
+                                moduleProtoDescendants = memoLookup protoDescendants,
+                                moduleWitnessesByProto = memoLookup witsByProto,
+                                moduleWitnessesByType = memoLookup witsByType
+                              }
+  where lookupName n
+          | not (isPublicName n) = Nothing
+          | otherwise        = unsafePerformIO $ do
+                                  mi <- InterfaceFiles.readInterfaceDBNameInfoMaybe db n
+                                  return $ convNameInfo2HNameInfo . snd <$> mi
+        publicNames          = unsafePerformIO $ InterfaceFiles.readInterfaceDBPublicNames db
+        constructors         = unsafePerformIO $ InterfaceFiles.readInterfaceDBConstructors db
+        actors               = map (moduleTCon m) $ unsafePerformIO $ InterfaceFiles.readInterfaceDBActors db
+        conAttr n            = map (moduleTCon m) $ unsafePerformIO $ InterfaceFiles.readInterfaceDBConAttr db n
+        protoAttr n          = map (moduleTCon m) $ unsafePerformIO $ InterfaceFiles.readInterfaceDBProtoAttr db n
+        descendants qn       = [ moduleTCon m ni | qn' <- moduleQNameKeys m qn, ni@(_,NClass{}) <- readDesc qn' ]
+        protoDescendants qn  = [ moduleTCon m ni | qn' <- moduleQNameKeys m qn, ni@(_,NProto{}) <- readDesc qn' ]
+        readDesc qn          = unsafePerformIO $ InterfaceFiles.readInterfaceDBDescendants db qn
+        -- The proto index stores extension records; one extension can carry
+        -- witnesses for several protocols, so keep only the indexed protocol.
+        witsByProto qn       = concat [ filter ((== qn') . tcname . proto) $
+                                          extWitnesses m $
+                                          unsafePerformIO $
+                                          InterfaceFiles.readInterfaceDBExtByProto db qn'
+                                      | qn' <- moduleQNameKeys m qn ]
+        witsByType qn        = concat [ extWitnesses m $ unsafePerformIO $ InterfaceFiles.readInterfaceDBExtByType db qn' | qn' <- moduleQNameKeys m qn ]
+
+moduleTCon                  :: ModName -> (Name, NameInfo) -> TCon
+moduleTCon m (n, i)         = TC (GName m n) (wildargs i)
+
+-- A module's interface records references to its own names unqualified, so
+-- both the queried form and the module-local form must be tried.
+moduleQNameKeys             :: ModName -> QName -> [QName]
+moduleQNameKeys m qn@(NoQ n)= [qn, GName m n]
+moduleQNameKeys m qn@(GName m' n)
+  | m == m'                 = [qn, NoQ n]
+moduleQNameKeys m qn@(QName m' n)
+  | m == m'                 = [qn, NoQ n]
+moduleQNameKeys _ qn        = [qn]
+
+extWitnesses                :: ModName -> TEnv -> [Witness]
+extWitnesses m exts         = foldl' add [] wits
+  where wits                = [ WClass q (tCon c) p (GName m n) ws (length opts) | (n, NExt q c ps _ opts _) <- exts, (ws,p) <- ps ]
+        add ws w
+          | any (same w) ws = ws
+          | otherwise       = w : ws
+        same w w'           = tcname (proto w) == tcname (proto w') && wtype w == wtype w'
+
+witnessTypeQName            :: Witness -> Maybe QName
+witnessTypeQName w          = nameOf (wtype w)
+  where nameOf (TCon _ c)   = Just (tcname c)
+        nameOf (TVar _ v)   = Just (NoQ $ tvname v)
+        nameOf _            = Nothing
+
+-- | Memoize a pure-looking lookup function whose results come from on-demand
+-- .tydb reads, so each key is read at most once per module handle.
+memoLookup                  :: Ord k => (k -> v) -> k -> v
+memoLookup f                = unsafePerformIO $ do
+                                  memo <- newIORef Map.empty
+                                  return $ \n -> unsafePerformIO $ do
+                                      cache <- readIORef memo
+                                      case Map.lookup n cache of
+                                        Just r  -> return r
+                                        Nothing -> do
+                                          let r = f n
+                                          Control.Exception.evaluate r
+                                          atomicModifyIORef' memo $ \cache' ->
+                                            case Map.lookup n cache' of
+                                              Just r' -> (cache', r')
+                                              Nothing -> (Map.insert n r cache', r)
+{-# NOINLINE memoLookup #-}
 
 instance (Pretty x) => Pretty (EnvF x) where
     pretty env                  = text "--- modules:"  $+$
@@ -260,6 +433,7 @@ initEnv path True          = return $ EnvF{ activeNames = [],
                                             improots = [],
                                             modules = [(nPrim,NModule [] primEnv Nothing)],
                                             hmodules = M.empty,
+                                            moduleInfos = Map.singleton mPrim (mkModuleInfo mPrim [] primEnv Nothing),
                                             thismod = Nothing,
                                             context = [],
                                             qlevel = 0,
@@ -282,6 +456,7 @@ initEnv path False         = do (_,nmod,_,_,_,_,_,_,_,_,_,_,_) <- InterfaceFiles
                                                  improots = [],
                                                  modules = [(nPrim,NModule [] primEnv Nothing), (nBuiltin,NModule [] envBuiltin builtinDocstring)],
                                                  hmodules = M.empty,
+                                                 moduleInfos = Map.fromList [(mPrim, mkModuleInfo mPrim [] primEnv Nothing), (mBuiltin, mkModuleInfo mBuiltin [] envBuiltin builtinDocstring)],
                                                  thismod = Nothing,
                                                  context = [],
                                                  qlevel = 0,
@@ -290,7 +465,7 @@ initEnv path False         = do (_,nmod,_,_,_,_,_,_,_,_,_,_,_) <- InterfaceFiles
                                 return env
 
 withModulesFrom             :: EnvF x -> EnvF x -> EnvF x
-env `withModulesFrom` env'  = env{modules = modules env'}
+env `withModulesFrom` env'  = env{modules = modules env', moduleInfos = moduleInfos env'}
 
 hnamesFrom                  :: TEnv -> HTEnv
 hnamesFrom te               = extendHNames te M.empty
@@ -407,7 +582,7 @@ setMod                      :: ModName -> EnvF x -> EnvF x
 setMod m env                = env{ thismod = Just m }
 
 addMod                      :: ModName -> [ModName] -> TEnv -> Maybe String -> EnvF x -> EnvF x
-addMod m ms newte mdoc env  = env{ modules = addM ns (modules env) }
+addMod m ms newte mdoc env  = addModuleInfo m (mkModuleInfo m ms newte mdoc) env{ modules = addM ns (modules env) }
   where
     ModName ns              = m
     addM [] te              = newte ++ te
@@ -417,6 +592,9 @@ addMod m ms newte mdoc env  = env{ modules = addM ns (modules env) }
                             = (n, NModule ms1 (addM ns te1) doc) : te
     update n ns (ni:te)     = ni : update n ns te
     update n ns []          = (n, NModule ms (addM ns []) mdoc) : []
+
+addModuleInfo               :: ModName -> ModuleInfo -> EnvF x -> EnvF x
+addModuleInfo m mi env      = env{ moduleInfos = Map.insert m mi (moduleInfos env) }
 
 
 -- General Env queries -----------------------------------------------------------------------------------------------------------
@@ -511,6 +689,26 @@ lookupHModule (ModName ns) env  = f ns (hmodules env)
         g ns imps te doc
           | null ns             = Just (imps, te, doc)
           | otherwise           = f ns te
+
+findModuleInfo              :: ModName -> EnvF x -> Maybe ModuleInfo  -- m is modname part of a QName, so we must check for aliasing
+findModuleInfo m env | inBuiltin env, m==mBuiltin
+                            = Just (builtinModuleInfo env)
+findModuleInfo m@(ModName ns) env
+                            = case lookupName (head ns) env of
+                                Just (HNMAlias (ModName m')) -> lookupModuleInfo (ModName $ m'++tail ns) env
+                                Nothing | m `elem` (mPrim:mBuiltin:imports env) -> lookupModuleInfo m env
+                                _ -> Nothing
+
+lookupModuleInfo            :: ModName -> EnvF x -> Maybe ModuleInfo  -- m is modname part of a GName, so search directly for module
+lookupModuleInfo m env
+  | inBuiltin env, m==mBuiltin
+                            = Just (builtinModuleInfo env)
+  | otherwise               = Map.lookup m (moduleInfos env)
+
+-- The builtin module is looked up through the active environment while it is
+-- itself being compiled.
+builtinModuleInfo           :: EnvF x -> ModuleInfo
+builtinModuleInfo env       = (mkModuleInfo mBuiltin [] (activeNames env ++ closedNames env) Nothing){ moduleLookupHName = \n -> lookupName n env }
 
 lookupMod                       :: ModName -> EnvF x -> Maybe TEnv
 lookupMod m env                 = case lookupModule m env of Just (imps, te, doc) -> Just te; _ -> Nothing

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -65,9 +65,7 @@ data EnvF x                 = EnvF {
                                 activeTypeVars:: [(Name, Kind, CCon)],
                                 imports    :: [ModName],
                                 improots   :: [Name],
-                                modules    :: TEnv,
-                                hmodules   :: HTEnv,
-                                moduleInfos:: Map ModName ModuleInfo,
+                                modules    :: Map ModName ModuleInfo,
                                 thismod    :: Maybe ModName,
                                 context    :: [EnvCtx],
                                 qlevel     :: Int,
@@ -89,8 +87,7 @@ setX env x                  = EnvF { activeNames = activeNames env, closedNames 
                                      activeStateNames = activeStateNames env,
                                      activeTypeVars = activeTypeVars env,
                                      imports = imports env, improots = improots env,
-                                     modules = modules env, hmodules = hmodules env,
-                                     moduleInfos = moduleInfos env, thismod = thismod env,
+                                     modules = modules env, thismod = thismod env,
                                      context = context env, qlevel = qlevel env, envX = x }
 
 modX                        :: EnvF x -> (x -> x) -> EnvF x
@@ -129,7 +126,7 @@ convertModules1             :: ((Name,NameInfo) -> (Name,NameInfo)) -> Env0 -> E
 convertModules1 f env       = convertModules (const []) (\_ ni -> [f ni]) env
 
 convertModules              :: (Name -> [Name]) -> (ModName -> (Name,NameInfo) -> TEnv) -> Env0 -> Env0
-convertModules sources f env= env{ moduleInfos = Map.mapWithKey convMod (moduleInfos env) }
+convertModules sources f env= env{ modules = Map.mapWithKey convMod (modules env) }
   where convMod m mi
           | m == mPrim      = mi
           | otherwise       = mi{ moduleLookupHName = memoLookup lookupConverted }
@@ -302,7 +299,7 @@ memoLookup f                = unsafePerformIO $ do
 
 instance (Pretty x) => Pretty (EnvF x) where
     pretty env                  = text "--- modules:"  $+$
-                                  vcat (map pretty (modules env)) $+$
+                                  vcat (map pretty (Map.keys (modules env))) $+$
                                   text "--- active names" <+> pretty (thismod env) <+> parens (text (show (qlevel env))) <> colon $+$
                                   vcat (map pretty (activeNames env)) $+$
                                   text "--- closed names" <+> pretty (thismod env) <> colon $+$
@@ -428,9 +425,7 @@ initEnv path True          = return $ EnvF{ activeNames = [],
                                             activeTypeVars = [],
                                             imports = [],
                                             improots = [],
-                                            modules = [(nPrim,NModule [] primEnv Nothing)],
-                                            hmodules = M.empty,
-                                            moduleInfos = Map.singleton mPrim (mkModuleInfo mPrim [] primEnv Nothing),
+                                            modules = Map.singleton mPrim (mkModuleInfo mPrim [] primEnv Nothing),
                                             thismod = Nothing,
                                             context = [],
                                             qlevel = 0,
@@ -451,9 +446,7 @@ initEnv path False         = do (_,nmod,_,_,_,_,_,_,_,_,_,_,_) <- InterfaceFiles
                                                  activeTypeVars = [],
                                                  imports = [],
                                                  improots = [],
-                                                 modules = [(nPrim,NModule [] primEnv Nothing), (nBuiltin,NModule [] envBuiltin builtinDocstring)],
-                                                 hmodules = M.empty,
-                                                 moduleInfos = Map.fromList [(mPrim, mkModuleInfo mPrim [] primEnv Nothing), (mBuiltin, mkModuleInfo mBuiltin [] envBuiltin builtinDocstring)],
+                                                 modules = Map.fromList [(mPrim, mkModuleInfo mPrim [] primEnv Nothing), (mBuiltin, mkModuleInfo mBuiltin [] envBuiltin builtinDocstring)],
                                                  thismod = Nothing,
                                                  context = [],
                                                  qlevel = 0,
@@ -462,7 +455,7 @@ initEnv path False         = do (_,nmod,_,_,_,_,_,_,_,_,_,_,_) <- InterfaceFiles
                                 return env
 
 withModulesFrom             :: EnvF x -> EnvF x -> EnvF x
-env `withModulesFrom` env'  = env{modules = modules env', moduleInfos = moduleInfos env'}
+env `withModulesFrom` env'  = env{modules = modules env'}
 
 hnamesFrom                  :: TEnv -> HTEnv
 hnamesFrom te               = extendHNames te M.empty
@@ -579,25 +572,16 @@ setMod                      :: ModName -> EnvF x -> EnvF x
 setMod m env                = env{ thismod = Just m }
 
 addMod                      :: ModName -> [ModName] -> TEnv -> Maybe String -> EnvF x -> EnvF x
-addMod m ms newte mdoc env  = addModuleInfo m (mkModuleInfo m ms newte mdoc) env{ modules = addM ns (modules env) }
-  where
-    ModName ns              = m
-    addM [] te              = newte ++ te
-    addM (n:ns) te          = update n ns te
-    update n ns ((x,i):te)
-      | n == x, NModule ms1 te1 doc <- i
-                            = (n, NModule ms1 (addM ns te1) doc) : te
-    update n ns (ni:te)     = ni : update n ns te
-    update n ns []          = (n, NModule ms (addM ns []) mdoc) : []
+addMod m ms newte mdoc env  = addModuleInfo m (mkModuleInfo m ms newte mdoc) env
 
 addModuleInfo               :: ModName -> ModuleInfo -> EnvF x -> EnvF x
-addModuleInfo m mi env      = env{ moduleInfos = Map.insert m mi (moduleInfos env) }
+addModuleInfo m mi env      = env{ modules = Map.insert m mi (modules env) }
 
 
 -- General Env queries -----------------------------------------------------------------------------------------------------------
 
 inBuiltin                   :: EnvF x -> Bool
-inBuiltin env               = length (modules env) == 1     -- mPrim only
+inBuiltin env               = Map.size (modules env) == 1     -- mPrim only
 
 stateScope                  :: EnvF x -> [Name]
 stateScope env              = activeStateNames env
@@ -664,29 +648,6 @@ lookupVar n env             = case lookupName n env of
                                 Just (HNVar t) -> Just t
                                 _ -> Nothing
 
-findHMod                    :: ModName -> EnvF x -> Maybe HTEnv  -- m is modname part of a QName, so we must check for aliasing
-findHMod m env | inBuiltin env, m==mBuiltin
-                            = Just (hnames env)
-findHMod m@(ModName ns) env = case lookupName (head ns) env of
-                                Just (HNMAlias (ModName m')) -> lookupHMod (ModName $ m'++tail ns) env
-                                Nothing | m `elem` (mPrim:mBuiltin:imports env) -> lookupHMod m env
-                                _ -> Nothing
-
-lookupHMod                      :: ModName -> EnvF x -> Maybe HTEnv -- m is modname part of a GName, so search directly for module
-lookupHMod m env                = case lookupHModule m env of Just (imps, te, doc) -> Just te; _ -> Nothing
-
-
-lookupHModule m env
- | inBuiltin env, m==mBuiltin   = Just ([], hnames env, Nothing)
-lookupHModule (ModName ns) env  = f ns (hmodules env)
-  where f (n:ns) te             = case M.lookup n te of
-                                    Just (HNModule imps te' doc) -> g ns imps te' doc
-                                    Just (HNMAlias (ModName m)) -> lookupHModule (ModName $ m++ns) env
-                                    _ -> Nothing
-        g ns imps te doc
-          | null ns             = Just (imps, te, doc)
-          | otherwise           = f ns te
-
 findModuleInfo              :: ModName -> EnvF x -> Maybe ModuleInfo  -- m is modname part of a QName, so we must check for aliasing
 findModuleInfo m env | inBuiltin env, m==mBuiltin
                             = Just (builtinModuleInfo env)
@@ -700,34 +661,19 @@ lookupModuleInfo            :: ModName -> EnvF x -> Maybe ModuleInfo  -- m is mo
 lookupModuleInfo m env
   | inBuiltin env, m==mBuiltin
                             = Just (builtinModuleInfo env)
-  | otherwise               = Map.lookup m (moduleInfos env)
+  | otherwise               = Map.lookup m (modules env)
 
 -- A parent package of a loaded module is itself a valid module path prefix,
 -- which the old NModule tree represented implicitly.
 modulePrefix                :: ModName -> EnvF x -> Bool
 modulePrefix (ModName ns) env
-                            = any prefix (Map.keys (moduleInfos env))
+                            = any prefix (Map.keys (modules env))
   where prefix (ModName ns')= ns `isPrefixOf` ns'
 
 -- The builtin module is looked up through the active environment while it is
 -- itself being compiled.
 builtinModuleInfo           :: EnvF x -> ModuleInfo
 builtinModuleInfo env       = (mkModuleInfo mBuiltin [] (activeNames env ++ closedNames env) Nothing){ moduleLookupHName = \n -> lookupName n env }
-
-lookupMod                       :: ModName -> EnvF x -> Maybe TEnv
-lookupMod m env                 = case lookupModule m env of Just (imps, te, doc) -> Just te; _ -> Nothing
-
-lookupModule m env
-  | inBuiltin env, m==mBuiltin  = Just ([], activeNames env ++ closedNames env, Nothing)
-lookupModule (ModName ns) env   = f ns (modules env)
-  where f (n:ns) te             = case lookup n te of
-                                    Just (NModule imps te' doc) -> g ns imps te' doc
-                                    Just (NMAlias (ModName m)) -> lookupModule (ModName $ m++ns) env
-                                    _ -> Nothing
-        g ns imps te doc
-          | null ns             = Just (imps, te, doc)
-          | otherwise           = f ns te
-
 
 isMod                       :: EnvF x -> [Name] -> Bool
 isMod env ns@(n:_)          = (maybe False (const True) (findModuleInfo (ModName ns) env) || modulePrefix (ModName ns) env) && rooted
@@ -1387,7 +1333,7 @@ instance Flows Handler where
 -- Import handling (local definitions only) -------------------------------------------------------------------------
 
 --getImps                         :: [FilePath] -> EnvF x -> [Import] -> IO (EnvF x)
-getImps spath env []         = return env { hmodules = convTEnv2HTEnv (modules env) }
+getImps spath env []         = return env
 getImps spath env (i:is)     = do env' <- impModule spath env i
                                   getImps spath env' is
 

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -989,6 +989,8 @@ transitiveImports env       = mBuiltin : reverse (foldl trav [] (getImports env)
           | otherwise       = m : foldl trav seen ms
           where ms          = case lookupModuleInfo m env of Just mi -> moduleImports mi
 
+-- Enumerating every imported type forces each module's constructor records;
+-- solver queries go through the narrow per-query indexes instead.
 allTypes                    :: (NameInfo -> Bool) -> EnvF x -> [TCon]
 allTypes select env         = concatMap impcons mods ++ localcons
   where mods                = transitiveImports env
@@ -998,7 +1000,7 @@ allTypes select env         = concatMap impcons mods ++ localcons
         localcons
                             = local (reverse (closedNames env)) ++ local (reverse (activeNames env))
         impcons m           = [ TC (GName m n) (wildargs i) | (n,i) <- te, select i ]
-          where Just te     = lookupMod m env
+          where Just te     = moduleConstructors <$> lookupModuleInfo m env
 
 allCons                     :: EnvF x -> [TCon]
 allCons env                 = allTypes isCon env
@@ -1007,9 +1009,11 @@ allCons env                 = allTypes isCon env
         isCon _             = False
 
 allActors                   :: EnvF x -> [TCon]
-allActors env               = allTypes isActor env
-  where isActor NAct{}      = True
-        isActor _           = False
+allActors env               = concatMap moduleActors (importedModuleInfos env) ++ localactors
+  where local te
+          | inBuiltin env   = [ TC (GName mBuiltin n) (wildargs i) | (n,i@NAct{}) <- te ]
+          | otherwise       = [ TC (NoQ n) (wildargs i) | (n,i@NAct{}) <- te ]
+        localactors         = local (reverse (closedNames env)) ++ local (reverse (activeNames env))
 
 allProtos env               = allTypes isProto env
   where isProto NProto{}    = True

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -545,15 +545,15 @@ addImport m env
   | m `elem` imports env    = env
   | otherwise               = env{ imports = m : imports env }
 
-addQualifier                :: ModName -> ModuleInfo -> Maybe Name -> EnvF x -> EnvF x
+addQualifier                :: ModName -> ModuleInfo -> Maybe ModName -> EnvF x -> EnvF x
 addQualifier m _ Nothing env
   | m `elem` qualifiers env = env
   | otherwise               = env{ qualifiers = m : qualifiers env }
-addQualifier _ mi (Just n) env
-  | a `elem` qualifiers env = duplicateAlias n
+addQualifier _ mi (Just a) env
+  | a `elem` qualifiers env = duplicateAlias a
+  | a `elem` imports env    = illegalAlias a
   | otherwise               = env'{ qualifiers = a : qualifiers env }
   where env'                = env{ modules = Map.insert a mi (modules env) }
-        a                   = ModName [n]
 
 addImportAlias              :: ModName -> ModuleInfo -> EnvF x -> EnvF x
 addImportAlias m mi env     = env{ modules = Map.insert m mi (modules env) }
@@ -588,6 +588,11 @@ getImports env              = reverse (imports env)
 
 isQualifier                 :: EnvF x -> ModName -> Bool
 isQualifier env m           = m `elem` mBuiltin : qualifiers env
+
+isModuleAlias               :: EnvF x -> ModName -> Bool
+isModuleAlias env m         = case lookupModuleInfo m env of
+                                Just mi -> m /= moduleName mi
+                                Nothing -> isQualifier env m
 
 inBuiltin                   :: EnvF x -> Bool
 inBuiltin env               = Map.size (modules env) == 1     -- mPrim only
@@ -1336,10 +1341,6 @@ impModule spath env (FromImportAll _ (ModRef (0,Just m)))
 impModule _ _ i                 = illegalImport (loc i)
 
 
-subImp spath env []          = return env
-subImp spath env (m:ms)      = do (env',_) <- doImp spath env m
-                                  subImp spath env' ms
-
 findTyFile spaths mn = go spaths
   where
     go []     = return Nothing
@@ -1352,9 +1353,11 @@ findTyFile spaths mn = go spaths
         else go ps
 
 -- | Import a module, loading its .tydb and extending the environment.
-doImp                        :: [FilePath] -> EnvF x -> ModName -> IO (EnvF x, ModuleInfo)
-doImp spath env m            = do (env', mi, _) <- doImpSeen S.empty env m
-                                  return (addImport m env', mi)
+doImp                       :: [FilePath] -> EnvF x -> ModName -> IO (EnvF x, ModuleInfo)
+doImp spath env m
+  | isModuleAlias env m     = illegalAlias2 m
+  | otherwise               = do (env', mi, _) <- doImpSeen S.empty env m
+                                 return (addImport m env', mi)
   where
     -- A cached module still needs its recorded import closure available in the
     -- environment. If the module is already loaded, its ModuleInfo carries
@@ -1432,7 +1435,9 @@ data CompilationError               = KindError SrcLoc Kind Kind
                                     | IllegalExtension QName
                                     | MissingSelf Name
                                     | IllegalImport SrcLoc
-                                    | DuplicateAlias Name
+                                    | DuplicateAlias ModName
+                                    | IllegalAlias ModName
+                                    | IllegalAlias2 ModName
                                     | NoItem ModName Name
                                     | NoModule ModName
                                     | NoClassOrProto QName
@@ -1459,7 +1464,9 @@ instance HasLoc CompilationError where
     loc (IllegalExtension n)        = loc n
     loc (MissingSelf n)             = loc n
     loc (IllegalImport l)           = l
-    loc (DuplicateAlias n)          = loc n
+    loc (DuplicateAlias m)          = loc m
+    loc (IllegalAlias m)            = loc m
+    loc (IllegalAlias2 m)           = loc m
     loc (NoModule m)                = loc m
     loc (NoItem m n)                = loc n
     loc (NoClassOrProto n)          = loc n
@@ -1486,7 +1493,9 @@ compilationError err                = [(loc err, render (expl err))]
     expl (IllegalExtension n)       = text "Illegal extension of" <+> pretty n
     expl (MissingSelf n)            = text "Missing 'self' parameter in definition of"
     expl (IllegalImport l)          = text "Relative import not yet supported"
-    expl (DuplicateAlias n)         = text "Duplicate import alias" <+> pretty n
+    expl (DuplicateAlias m)         = text "Duplicate import alias" <+> pretty m
+    expl (IllegalAlias m)           = text "Module alias clashes with an already imported module" <+> pretty m
+    expl (IllegalAlias2 m)          = text "Module name is an already declared alias" <+> pretty m
     expl (NoModule m)               = text "Module" <+> pretty m <+> text "does not exist"
     expl (NoItem m n)               = text "Module" <+> pretty m <+> text "does not export" <+> pretty n
     expl (NoClassOrProto n)         = text "Class or protocol name expected, got" <+> pretty n
@@ -1510,7 +1519,9 @@ illegalExtension n                  = Control.Exception.throw $ IllegalExtension
 missingSelf n                       = Control.Exception.throw $ MissingSelf n
 fileNotFound n                      = Control.Exception.throw $ FileNotFound n
 illegalImport l                     = Control.Exception.throw $ IllegalImport l
-duplicateAlias n                    = Control.Exception.throw $ DuplicateAlias n
+duplicateAlias m                    = Control.Exception.throw $ DuplicateAlias m
+illegalAlias m                      = Control.Exception.throw $ IllegalAlias m
+illegalAlias2 m                     = Control.Exception.throw $ IllegalAlias2 m
 noItem m n                          = Control.Exception.throw $ NoItem m n
 noModule m                          = Control.Exception.throw $ NoModule m
 notClassOrProto n                   = Control.Exception.throw $ NoClassOrProto n

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -53,23 +53,23 @@ mkEnv spath env m           = getImps spath env (imps m)
 -- Full environment -------------------------------------------------------------------------------
 
 data EnvF x                 = EnvF {
-                                activeNames:: TEnv,
-                                closedNames:: TEnv,
-                                hnames     :: HTEnv,
-                                closedHNames:: HTEnv,
-                                sigLocs    :: LocEnv,
-                                closedSigLocs:: LocEnv,
-                                defLocs    :: LocEnv,
-                                closedDefLocs:: LocEnv,
-                                activeStateNames:: [Name],
-                                activeTypeVars:: [(Name, Kind, CCon)],
-                                imports    :: [ModName],
-                                visibleModules :: [ModName],
-                                modules    :: Map ModName ModuleInfo,
-                                thismod    :: Maybe ModName,
-                                context    :: [EnvCtx],
-                                qlevel     :: Int,
-                                envX       :: x
+                                activeNames         :: TEnv,
+                                closedNames         :: TEnv,
+                                hnames              :: HTEnv,
+                                closedHNames        :: HTEnv,
+                                sigLocs             :: LocEnv,
+                                closedSigLocs       :: LocEnv,
+                                defLocs             :: LocEnv,
+                                closedDefLocs       :: LocEnv,
+                                activeStateNames    :: [Name],
+                                activeTypeVars      :: [(Name, Kind, CCon)],
+                                imports             :: [ModName],               -- The canoncal names m in 'import m', 'import m as _' or 'from m import _'
+                                qualifiers          :: [ModName],               -- The actual names m in 'import m' or 'import _ as m'
+                                modules             :: Map ModName ModuleInfo,
+                                thismod             :: Maybe ModName,
+                                context             :: [EnvCtx],
+                                qlevel              :: Int,
+                                envX                :: x
                               } deriving (Show)
 
 type Env0                   = EnvF ()
@@ -86,7 +86,7 @@ setX env x                  = EnvF { activeNames = activeNames env, closedNames 
                                      defLocs = defLocs env, closedDefLocs = closedDefLocs env,
                                      activeStateNames = activeStateNames env,
                                      activeTypeVars = activeTypeVars env,
-                                     imports = imports env, visibleModules = visibleModules env,
+                                     imports = imports env, qualifiers = qualifiers env,
                                      modules = modules env, thismod = thismod env,
                                      context = context env, qlevel = qlevel env, envX = x }
 
@@ -419,7 +419,7 @@ initEnv path True          = return $ EnvF{ activeNames = [],
                                             activeStateNames = [],
                                             activeTypeVars = [],
                                             imports = [],
-                                            visibleModules = [],
+                                            qualifiers = [],
                                             modules = Map.singleton mPrim (mkModuleInfo mPrim [] primEnv Nothing),
                                             thismod = Nothing,
                                             context = [],
@@ -440,7 +440,7 @@ initEnv path False         = do (_,nmod,_,_,_,_,_,_,_,_,_,_,_) <- InterfaceFiles
                                                  activeStateNames = [],
                                                  activeTypeVars = [],
                                                  imports = [],
-                                                 visibleModules = [],
+                                                 qualifiers = [],
                                                  modules = Map.fromList [(mPrim, mkModuleInfo mPrim [] primEnv Nothing), (mBuiltin, mkModuleInfo mBuiltin [] envBuiltin builtinDocstring)],
                                                  thismod = Nothing,
                                                  context = [],
@@ -540,22 +540,24 @@ defineClosed te env
   where badSelf             = if inAct env then dom te `intersect` [selfKW] else []
         te'                 = reverse te
 
-
 addImport                   :: ModName -> EnvF x -> EnvF x
 addImport m env
   | m `elem` imports env    = env
   | otherwise               = env{ imports = m : imports env }
 
-addVisibleModule            :: ModName -> EnvF x -> EnvF x
-addVisibleModule m env
-  | m `elem` visibleModules env
-                            = env
-  | otherwise               = env{ visibleModules = m : visibleModules env }
+addQualifier                :: ModName -> ModuleInfo -> Maybe Name -> EnvF x -> EnvF x
+addQualifier m _ Nothing env
+  | m `elem` qualifiers env = env
+  | otherwise               = env{ qualifiers = m : qualifiers env }
+addQualifier _ mi (Just n) env
+  | a `elem` qualifiers env = duplicateAlias n
+  | otherwise               = env'{ qualifiers = a : qualifiers env }
+  where env'                = env{ modules = Map.insert a mi (modules env) }
+        a                   = ModName [n]
 
-addModuleAlias              :: ModName -> ModuleInfo -> EnvF x -> EnvF x
-addModuleAlias m mi env     = env{ modules = Map.insert m mi (modules env) }
+addImportAlias              :: ModName -> ModuleInfo -> EnvF x -> EnvF x
+addImportAlias m mi env     = env{ modules = Map.insert m mi (modules env) }
 
-getImports env              = reverse (imports env)
 
 defineTVars                 :: QBinds -> EnvF x -> EnvF x
 defineTVars q env           = foldr f env (unalias env q)
@@ -580,6 +582,12 @@ addModuleInfo m mi env      = env{ modules = Map.insert m mi (modules env) }
 
 
 -- General Env queries -----------------------------------------------------------------------------------------------------------
+
+getImports                  :: EnvF x -> [ModName]
+getImports env              = reverse (imports env)
+
+isQualifier                 :: EnvF x -> ModName -> Bool
+isQualifier env m           = m `elem` mBuiltin : qualifiers env
 
 inBuiltin                   :: EnvF x -> Bool
 inBuiltin env               = Map.size (modules env) == 1     -- mPrim only
@@ -660,15 +668,14 @@ lookupModuleInfo m env
 builtinModuleInfo           :: EnvF x -> ModuleInfo
 builtinModuleInfo env       = (mkModuleInfo mBuiltin [] (activeNames env ++ closedNames env) Nothing){ moduleLookupName = \n -> lookupName n env }
 
-isMod                       :: EnvF x -> [Name] -> Bool
-isMod env ns                = isVisibleModule env m && maybe False (const True) (lookupModuleInfo m env)
-  where m                   = ModName ns
-
-isVisibleModule             :: EnvF x -> ModName -> Bool
-isVisibleModule env m
-  | m == mPrim || m == mBuiltin
-                            = True
-  | otherwise               = m `elem` visibleModules env
+isModName                   :: EnvF x -> Expr -> Maybe ModName
+isModName env e             = do ns@(n:_) <- fmap reverse (dotChain e)
+                                 let m = ModName ns
+                                 guard (lookupName n env == Nothing && isQualifier env m)
+                                 return m
+  where dotChain (Var _ (NoQ n)) = Just [n]
+        dotChain (Dot _ e n)     = fmap (n:) (dotChain e)
+        dotChain _               = Nothing
 
 isAlias                     :: Name -> EnvF x -> Bool
 isAlias n env               = case lookupName n env of
@@ -1315,11 +1322,11 @@ impModule spath env (Import _ ms)
   where imp env []              = return env
         imp env (ModuleItem m as : is)
                                 = do (env1,mi) <- doImp spath env m
-                                     let env2 = case as of
-                                                  Nothing -> addVisibleModule m env1
-                                                  Just n  -> let a = ModName [n]
-                                                             in addVisibleModule a (addModuleAlias a mi env1)
-                                     imp env2 is
+--                                     let env2 = case as of
+--                                                  Nothing -> addVisibleImport m env1
+--                                                  Just n  -> let a = ModName [n]
+--                                                             in addVisibleImport a (addImportAlias a mi env1)
+                                     imp (addQualifier m mi as env1) is
 impModule spath env (FromImport _ (ModRef (0,Just m)) items)
                                 = do (env1,mi) <- doImp spath env m
                                      return $ importSome items m mi env1
@@ -1425,7 +1432,7 @@ data CompilationError               = KindError SrcLoc Kind Kind
                                     | IllegalExtension QName
                                     | MissingSelf Name
                                     | IllegalImport SrcLoc
-                                    | DuplicateImport Name
+                                    | DuplicateAlias Name
                                     | NoItem ModName Name
                                     | NoModule ModName
                                     | NoClassOrProto QName
@@ -1452,7 +1459,7 @@ instance HasLoc CompilationError where
     loc (IllegalExtension n)        = loc n
     loc (MissingSelf n)             = loc n
     loc (IllegalImport l)           = l
-    loc (DuplicateImport n)         = loc n
+    loc (DuplicateAlias n)          = loc n
     loc (NoModule m)                = loc m
     loc (NoItem m n)                = loc n
     loc (NoClassOrProto n)          = loc n
@@ -1479,7 +1486,7 @@ compilationError err                = [(loc err, render (expl err))]
     expl (IllegalExtension n)       = text "Illegal extension of" <+> pretty n
     expl (MissingSelf n)            = text "Missing 'self' parameter in definition of"
     expl (IllegalImport l)          = text "Relative import not yet supported"
-    expl (DuplicateImport n)        = text "Duplicate import of name" <+> pretty n
+    expl (DuplicateAlias n)         = text "Duplicate import alias" <+> pretty n
     expl (NoModule m)               = text "Module" <+> pretty m <+> text "does not exist"
     expl (NoItem m n)               = text "Module" <+> pretty m <+> text "does not export" <+> pretty n
     expl (NoClassOrProto n)         = text "Class or protocol name expected, got" <+> pretty n
@@ -1503,7 +1510,7 @@ illegalExtension n                  = Control.Exception.throw $ IllegalExtension
 missingSelf n                       = Control.Exception.throw $ MissingSelf n
 fileNotFound n                      = Control.Exception.throw $ FileNotFound n
 illegalImport l                     = Control.Exception.throw $ IllegalImport l
-duplicateImport n                   = Control.Exception.throw $ DuplicateImport n
+duplicateAlias n                    = Control.Exception.throw $ DuplicateAlias n
 noItem m n                          = Control.Exception.throw $ NoItem m n
 noModule m                          = Control.Exception.throw $ NoModule m
 notClassOrProto n                   = Control.Exception.throw $ NoClassOrProto n

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -930,39 +930,9 @@ transitiveImports env       = mBuiltin : reverse (foldl trav [] (getImports env)
           | otherwise       = m : foldl trav seen ms
           where ms          = case lookupModuleInfo m env of Just mi -> moduleImports mi
 
--- Enumerating every imported type forces each module's constructor records;
--- solver queries go through the narrow per-query indexes instead.
-allTypes                    :: (NameInfo -> Bool) -> EnvF x -> [TCon]
-allTypes select env         = concatMap impcons mods ++ localcons
-  where mods                = transitiveImports env
-        local te
-          | inBuiltin env   = [ TC (GName mBuiltin n) (wildargs i) | (n,i) <- te, select i ]
-          | otherwise       = [ TC (NoQ n) (wildargs i) | (n,i) <- te, select i ]
-        localcons
-                            = local (reverse (closedNames env)) ++ local (reverse (activeNames env))
-        impcons m           = [ TC (GName m n) (wildargs i) | (n,i) <- te, select i ]
-          where Just te     = moduleConstructors <$> lookupModuleInfo m env
-
-allCons                     :: EnvF x -> [TCon]
-allCons env                 = allTypes isCon env
-  where isCon NClass{}      = True
-        isCon NAct{}        = True
-        isCon _             = False
-
 -- Actors declared in imported modules, from the per-module actor index.
 importedActors              :: EnvF x -> [TCon]
 importedActors env          = concatMap moduleActors (importedModuleInfos env)
-
-allActors                   :: EnvF x -> [TCon]
-allActors env               = importedActors env ++ localactors
-  where local te
-          | inBuiltin env   = [ TC (GName mBuiltin n) (wildargs i) | (n,i@NAct{}) <- te ]
-          | otherwise       = [ TC (NoQ n) (wildargs i) | (n,i@NAct{}) <- te ]
-        localactors         = local (reverse (closedNames env)) ++ local (reverse (activeNames env))
-
-allProtos env               = allTypes isProto env
-  where isProto NProto{}    = True
-        isProto _           = False
 
 -- The module indexes record attributes where they are declared, so imported
 -- owners are completed with the descendants of every declaring constructor

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -461,7 +461,7 @@ initEnv path False         = do (_,nmod,_,_,_,_,_,_,_,_,_,_,_) <- InterfaceFiles
                                                  context = [],
                                                  qlevel = 0,
                                                  envX = () }
-                                    env = importAll mBuiltin envBuiltinPublic env0
+                                    env = importAll mBuiltin (mkModuleInfo mBuiltin [] envBuiltinPublic builtinDocstring) env0
                                 return env
 
 withModulesFrom             :: EnvF x -> EnvF x -> EnvF x
@@ -1392,25 +1392,24 @@ findTyFile spaths mn = go spaths
         else go ps
 
 -- | Import a module, loading its .tydb and extending the environment.
-doImp                        :: [FilePath] -> EnvF x -> ModName -> IO (EnvF x, TEnv)
-doImp spath env m            = do --traceM ("#### doImp " ++ prstr m)
-                                  (env', te, _) <- doImpSeen S.empty env m
-                                  return (addImport m env', te)
+doImp                        :: [FilePath] -> EnvF x -> ModName -> IO (EnvF x, ModuleInfo)
+doImp spath env m            = do (env', mi, _) <- doImpSeen S.empty env m
+                                  return (addImport m env', mi)
   where
     -- A cached module still needs its recorded import closure available in the
-    -- environment. If the module is already loaded, NModule carries that
-    -- closure; otherwise we read it from the .tydb.
+    -- environment. If the module is already loaded, its ModuleInfo carries
+    -- that closure; otherwise we read it from the .tydb.
     doImpSeen seen env m
       | S.member m seen      =
-          case lookupMod m env of
-            Just te -> return (env, te, seen)
+          case lookupModuleInfo m env of
+            Just mi -> return (env, mi, seen)
             Nothing -> fileNotFound m
       | otherwise            =
           let seen' = S.insert m seen in
-          case lookupModule m env of
-            Just (imps, te, _) -> do
-              (env', seen'') <- subImpSeen seen' env imps
-              return (env', te, seen'')
+          case lookupModuleInfo m env of
+            Just mi -> do
+              (env', seen'') <- subImpSeen seen' env (moduleImports mi)
+              return (env', mi, seen'')
             Nothing -> do
               ty <- readFoundTy InterfaceFiles.readFileMaybe m
               case ty of
@@ -1418,8 +1417,8 @@ doImp spath env m            = do --traceM ("#### doImp " ++ prstr m)
                 Just (ms,nmod,_,_,_,_,_,_,_,_,_,_,_) -> do
                   (env', seen'') <- subImpSeen seen' env ms
                   let NModule ms' teFull mdoc = nmod
-                      te = publicTEnv teFull
-                  return (addMod m ms' te mdoc env', te, seen'')
+                      mi = mkModuleInfo m ms' (publicTEnv teFull) mdoc
+                  return (addModuleInfo m mi (addMod m ms' (publicTEnv teFull) mdoc env'), mi, seen'')
 
     readFoundTy readTy m = do
       tyFile <- findTyFile spath m
@@ -1432,28 +1431,31 @@ doImp spath env m            = do --traceM ("#### doImp " ++ prstr m)
       (env', _, seen') <- doImpSeen seen env m
       subImpSeen seen' env' ms
 
-importSome                  :: [ImportItem] -> ModName -> TEnv -> EnvF x -> EnvF x
-importSome items m te env   = defineClosed (map pick items) env
+importSome                  :: [ImportItem] -> ModName -> ModuleInfo -> EnvF x -> EnvF x
+importSome items m mi env   = defineClosed (map pick items) env
   where
-    te1                     = impNames m te
-    pick (ImportItem n mbn) = case lookup n te1 of
+    pick (ImportItem n mbn) = case impName m mi n of
                                     Just i  -> (maybe n id mbn, i)
                                     Nothing -> noItem m n
 
-importAll                   :: ModName -> TEnv -> EnvF x -> EnvF x
-importAll m te env          = defineClosed (impNames m te) env
+importAll                   :: ModName -> ModuleInfo -> EnvF x -> EnvF x
+importAll m mi env          = defineClosed (impNames m mi) env
 
-impNames                    :: ModName -> TEnv -> TEnv
-impNames m te               = mapMaybe imp (publicTEnv te)
+impName                     :: ModName -> ModuleInfo -> Name -> Maybe NameInfo
+impName m mi n              = case moduleLookupName mi n of
+                                Just NAct{}   -> Just (NAlias (GName m n))
+                                Just NClass{} -> Just (NAlias (GName m n))
+                                Just NProto{} -> Just (NAlias (GName m n))
+                                Just NExt{}   -> Nothing
+                                Just NAlias{} -> Just (NAlias (GName m n))
+                                Just NVar{}   -> Just (NAlias (GName m n))
+                                Just NDef{}   -> Just (NAlias (GName m n))
+                                _             -> Nothing
+
+impNames                    :: ModName -> ModuleInfo -> TEnv
+impNames m mi               = mapMaybe imp (modulePublicNames mi)
   where
-    imp (n, NAct _ _ _ _ _)   = Just (n, NAlias (GName m n))
-    imp (n, NClass _ _ _ _)   = Just (n, NAlias (GName m n))
-    imp (n, NProto _ _ _ _)   = Just (n, NAlias (GName m n))
-    imp (n, NExt _ _ _ _ _ _) = Nothing
-    imp (n, NAlias _)       = Just (n, NAlias (GName m n))
-    imp (n, NVar t)         = Just (n, NAlias (GName m n))
-    imp (n, NDef t d _)       = Just (n, NAlias (GName m n))
-    imp _                   = Nothing                               -- cannot happen
+    imp n                   = fmap (\i -> (n,i)) (impName m mi n)
 
 
 

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -121,26 +121,23 @@ inClass env                 = contextIs env CtxClass
 
 inLoop env                  = contextIs env CtxLoop
 
-mapModules1                 :: ((Name,NameInfo) -> (Name,NameInfo)) -> Env0 -> Env0
-mapModules1 f env           = mapModules (\_ ni -> [f ni]) env
+-- Back passes rewrite imported interface entries. The conversion wraps each
+-- module's lookup function, so only names that are actually demanded are
+-- converted (and memoized). sources maps a generated name to the source
+-- entries it may be derived from.
+convertModules1             :: ((Name,NameInfo) -> (Name,NameInfo)) -> Env0 -> Env0
+convertModules1 f env       = convertModules (const []) (\_ ni -> [f ni]) env
 
-mapModules                  :: (ModName -> (Name,NameInfo) -> TEnv) -> Env0 -> Env0
-mapModules f env            = env' { hmodules = convTEnv2HTEnv mods', moduleInfos = Map.mapWithKey conv (moduleInfos env) }
- where env'                 = env { modules = mods' }
-       prim : mods          = modules env
-       mods'                = prim : walk [] mods
-
-       walk ns              = concatMap (go ns)
-
-       go ns (n, NModule ms te doc)
-                            = [(n, NModule ms (walk (ns ++ [n]) te) doc)]
-       go ns ni             = f (ModName ns) ni
-
-       conv m mi
-         | m == mPrim       = mi
-         | otherwise        = case lookupMod m env' of
-                                Just te -> mkModuleInfo m (moduleImports mi) te (moduleDoc mi)
-                                Nothing -> mi
+convertModules              :: (Name -> [Name]) -> (ModName -> (Name,NameInfo) -> TEnv) -> Env0 -> Env0
+convertModules sources f env= env{ moduleInfos = Map.mapWithKey convMod (moduleInfos env) }
+  where convMod m mi
+          | m == mPrim      = mi
+          | otherwise       = mi{ moduleLookupHName = memoLookup lookupConverted }
+          where lookupConverted n
+                            = listToMaybe $ mapMaybe (lookupFrom n) (n : sources n)
+                lookupFrom n src
+                            = do i <- moduleLookupName mi src
+                                 lookup n (f m (src,i)) >>= return . convNameInfo2HNameInfo
 
 
 -- Module interfaces -----------------------------------------------------------------------------

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -64,7 +64,7 @@ data EnvF x                 = EnvF {
                                 activeStateNames:: [Name],
                                 activeTypeVars:: [(Name, Kind, CCon)],
                                 imports    :: [ModName],
-                                improots   :: [Name],
+                                visibleModules :: [ModName],
                                 modules    :: Map ModName ModuleInfo,
                                 thismod    :: Maybe ModName,
                                 context    :: [EnvCtx],
@@ -86,7 +86,7 @@ setX env x                  = EnvF { activeNames = activeNames env, closedNames 
                                      defLocs = defLocs env, closedDefLocs = closedDefLocs env,
                                      activeStateNames = activeStateNames env,
                                      activeTypeVars = activeTypeVars env,
-                                     imports = imports env, improots = improots env,
+                                     imports = imports env, visibleModules = visibleModules env,
                                      modules = modules env, thismod = thismod env,
                                      context = context env, qlevel = qlevel env, envX = x }
 
@@ -127,14 +127,15 @@ convertModules1 f env       = convertModules (const []) (\_ ni -> [f ni]) env
 
 convertModules              :: (Name -> [Name]) -> (ModName -> (Name,NameInfo) -> TEnv) -> Env0 -> Env0
 convertModules sources f env= env{ modules = Map.mapWithKey convMod (modules env) }
-  where convMod m mi
-          | m == mPrim      = mi
+  where convMod _ mi
+          | moduleName mi == mPrim
+                            = mi
           | otherwise       = mi{ moduleLookupName = memoLookup lookupConverted }
           where lookupConverted n
                             = listToMaybe $ mapMaybe (lookupFrom n) (n : sources n)
                 lookupFrom n src
                             = do i <- moduleLookupName mi src
-                                 lookup n (f m (src,i))
+                                 lookup n (f (moduleName mi) (src,i))
 
 
 -- Module interfaces -----------------------------------------------------------------------------
@@ -145,6 +146,7 @@ convertModules sources f env= env{ modules = Map.mapWithKey convMod (modules env
 -- a dependent module only pays for the names and indexes it actually demands.
 
 data ModuleInfo             = ModuleInfo {
+                                moduleName        :: ModName,
                                 moduleImports     :: [ModName],
                                 moduleDoc         :: Maybe String,
                                 moduleLookupName :: Name -> Maybe NameInfo,
@@ -160,7 +162,7 @@ data ModuleInfo             = ModuleInfo {
                               }
 
 instance Show ModuleInfo where
-    show mi                 = "ModuleInfo {imports = " ++ show (moduleImports mi) ++ "}"
+    show mi                 = "ModuleInfo {moduleName = " ++ show (moduleName mi) ++ ", imports = " ++ show (moduleImports mi) ++ "}"
 
 modulePublicTEnv            :: ModuleInfo -> TEnv
 modulePublicTEnv mi         = mapMaybe entry (modulePublicNames mi)
@@ -168,6 +170,7 @@ modulePublicTEnv mi         = mapMaybe entry (modulePublicNames mi)
 
 mkModuleInfo                :: ModName -> [ModName] -> TEnv -> Maybe String -> ModuleInfo
 mkModuleInfo m ms te mdoc   = ModuleInfo {
+                                moduleName = m,
                                 moduleImports = ms,
                                 moduleDoc = mdoc,
                                 moduleLookupName = \n -> M.lookup n hte,
@@ -214,6 +217,7 @@ mkModuleInfo m ms te mdoc   = ModuleInfo {
 mkTyFileModuleInfo          :: ModName -> [ModName] -> Maybe String -> InterfaceFiles.InterfaceDB -> ModuleInfo
 mkTyFileModuleInfo m ms mdoc db
                             = ModuleInfo {
+                                moduleName = m,
                                 moduleImports = ms,
                                 moduleDoc = mdoc,
                                 moduleLookupName = memoLookup lookupName,
@@ -325,20 +329,16 @@ instance (Unalias a) => Unalias (Maybe a) where
     unalias env                     = fmap (unalias env)
 
 instance Unalias ModName where
-    unalias env m@(ModName ns)
+    unalias env m
       | inBuiltin env               = m
-      | otherwise                   = case lookupName (head ns) env of
-                                        Just (NMAlias m') -> m'
-                                        Nothing | m `elem` (mPrim:mBuiltin:imports env) || modulePrefix m env -> m
-                                        _ -> noModule m
+      | otherwise                   = maybe (noModule m) moduleName (lookupModuleInfo m env)
 instance Unalias QName where
-    unalias env n0@(QName m n)      = case findModuleInfo m env of
+    unalias env n0@(QName m n)      = case lookupModuleInfo m env of
                                         Just mi -> case moduleLookupName mi n of
                                                       Just (NAlias qn) -> setLoc (loc n0) qn
-                                                      Just _ -> GName m' n
+                                                      Just _ -> GName (moduleName mi) n
                                                       _ -> noItem m n
                                         Nothing -> error ("#### unalias fails for " ++ prstr (QName m n))
-      where m'                      = unalias env m
     unalias env (NoQ n)
       | inBuiltin env               = GName mBuiltin n
       | otherwise                   = case lookupName n env of
@@ -387,7 +387,6 @@ instance Unalias NameInfo where
     unalias env (NExt q c ps te opts doc)= NExt (unalias env q) (unalias env c) (unalias env ps) (unalias env te) opts doc
     unalias env (NTVar k c ps)      = NTVar k (unalias env c) (unalias env ps)
     unalias env (NAlias qn)         = NAlias (unalias env qn)
-    unalias env (NMAlias m)         = NMAlias (unalias env m)
     unalias env NReserved           = NReserved
 
 instance Unalias (Name,NameInfo) where
@@ -410,9 +409,9 @@ publicTEnv                 = filter (isPublicName . fst)
 
 initEnv                    :: FilePath -> Bool -> IO Env0
 initEnv path True          = return $ EnvF{ activeNames = [],
-                                            closedNames = [(nPrim,NMAlias mPrim)],
-                                            hnames = hnamesFrom [(nPrim,NMAlias mPrim)],
-                                            closedHNames = hnamesFrom [(nPrim,NMAlias mPrim)],
+                                            closedNames = [],
+                                            hnames = hnamesFrom [],
+                                            closedHNames = hnamesFrom [],
                                             sigLocs = M.empty,
                                             closedSigLocs = M.empty,
                                             defLocs = M.empty,
@@ -420,7 +419,7 @@ initEnv path True          = return $ EnvF{ activeNames = [],
                                             activeStateNames = [],
                                             activeTypeVars = [],
                                             imports = [],
-                                            improots = [],
+                                            visibleModules = [],
                                             modules = Map.singleton mPrim (mkModuleInfo mPrim [] primEnv Nothing),
                                             thismod = Nothing,
                                             context = [],
@@ -429,7 +428,7 @@ initEnv path True          = return $ EnvF{ activeNames = [],
 initEnv path False         = do (_,nmod,_,_,_,_,_,_,_,_,_,_,_) <- InterfaceFiles.readFile (InterfaceFiles.interfacePath path (modName ["__builtin__"]))
                                 let NModule _ envBuiltin builtinDocstring = nmod
                                     envBuiltinPublic = publicTEnv envBuiltin
-                                    initialNames = [(nPrim,NMAlias mPrim), (nBuiltin,NMAlias mBuiltin)]
+                                    initialNames = []
                                     env0 = EnvF{ activeNames = [],
                                                  closedNames = initialNames,
                                                  hnames = hnamesFrom initialNames,
@@ -441,7 +440,7 @@ initEnv path False         = do (_,nmod,_,_,_,_,_,_,_,_,_,_,_) <- InterfaceFiles
                                                  activeStateNames = [],
                                                  activeTypeVars = [],
                                                  imports = [],
-                                                 improots = [],
+                                                 visibleModules = [],
                                                  modules = Map.fromList [(mPrim, mkModuleInfo mPrim [] primEnv Nothing), (mBuiltin, mkModuleInfo mBuiltin [] envBuiltin builtinDocstring)],
                                                  thismod = Nothing,
                                                  context = [],
@@ -547,8 +546,14 @@ addImport m env
   | m `elem` imports env    = env
   | otherwise               = env{ imports = m : imports env }
 
-addImpRoot m env            = env{ improots = n : improots env }
-  where ModName (n:_)       = m
+addVisibleModule            :: ModName -> EnvF x -> EnvF x
+addVisibleModule m env
+  | m `elem` visibleModules env
+                            = env
+  | otherwise               = env{ visibleModules = m : visibleModules env }
+
+addModuleAlias              :: ModName -> ModuleInfo -> EnvF x -> EnvF x
+addModuleAlias m mi env     = env{ modules = Map.insert m mi (modules env) }
 
 getImports env              = reverse (imports env)
 
@@ -614,7 +619,7 @@ findQName n env             = case tryQName n env of
                                  Nothing -> nameNotFound (noq n)
 
 tryQName                    :: QName -> EnvF x -> Maybe NameInfo
-tryQName (QName m n) env    = case findModuleInfo m env of
+tryQName (QName m n) env    = case lookupModuleInfo m env of
                                 Just mi -> case moduleLookupName mi n of
                                     Just (NAlias qn) -> tryQName qn env
                                     Just i -> Just i
@@ -644,27 +649,11 @@ lookupVar n env             = case lookupName n env of
                                 Just (NVar t) -> Just t
                                 _ -> Nothing
 
-findModuleInfo              :: ModName -> EnvF x -> Maybe ModuleInfo  -- m is modname part of a QName, so we must check for aliasing
-findModuleInfo m env | inBuiltin env, m==mBuiltin
-                            = Just (builtinModuleInfo env)
-findModuleInfo m@(ModName ns) env
-                            = case lookupName (head ns) env of
-                                Just (NMAlias (ModName m')) -> lookupModuleInfo (ModName $ m'++tail ns) env
-                                Nothing | m `elem` (mPrim:mBuiltin:imports env) -> lookupModuleInfo m env
-                                _ -> Nothing
-
 lookupModuleInfo            :: ModName -> EnvF x -> Maybe ModuleInfo  -- m is modname part of a GName, so search directly for module
 lookupModuleInfo m env
   | inBuiltin env, m==mBuiltin
                             = Just (builtinModuleInfo env)
   | otherwise               = Map.lookup m (modules env)
-
--- A parent package of a loaded module is itself a valid module path prefix,
--- which the old NModule tree represented implicitly.
-modulePrefix                :: ModName -> EnvF x -> Bool
-modulePrefix (ModName ns) env
-                            = any prefix (Map.keys (modules env))
-  where prefix (ModName ns')= ns `isPrefixOf` ns'
 
 -- The builtin module is looked up through the active environment while it is
 -- itself being compiled.
@@ -672,13 +661,14 @@ builtinModuleInfo           :: EnvF x -> ModuleInfo
 builtinModuleInfo env       = (mkModuleInfo mBuiltin [] (activeNames env ++ closedNames env) Nothing){ moduleLookupName = \n -> lookupName n env }
 
 isMod                       :: EnvF x -> [Name] -> Bool
-isMod env ns@(n:_)          = (maybe False (const True) (findModuleInfo (ModName ns) env) || modulePrefix (ModName ns) env) && rooted
-  where rooted              = n `elem` improots env || isMAlias n env
+isMod env ns                = isVisibleModule env m && maybe False (const True) (lookupModuleInfo m env)
+  where m                   = ModName ns
 
-isMAlias                    :: Name -> EnvF x -> Bool
-isMAlias n env              = case lookupName n env of
-                                Just NMAlias{} -> True
-                                _ -> False
+isVisibleModule             :: EnvF x -> ModName -> Bool
+isVisibleModule env m
+  | m == mPrim || m == mBuiltin
+                            = True
+  | otherwise               = m `elem` visibleModules env
 
 isAlias                     :: Name -> EnvF x -> Bool
 isAlias n env               = case lookupName n env of
@@ -1324,15 +1314,18 @@ impModule spath env (Import _ ms)
                                 = imp env ms
   where imp env []              = return env
         imp env (ModuleItem m as : is)
-                                = do (env1,te) <- doImp spath env m
-                                     let env2 = maybe (addImpRoot m) (\n->defineClosed [(n, NMAlias m)]) as env1
+                                = do (env1,mi) <- doImp spath env m
+                                     let env2 = case as of
+                                                  Nothing -> addVisibleModule m env1
+                                                  Just n  -> let a = ModName [n]
+                                                             in addVisibleModule a (addModuleAlias a mi env1)
                                      imp env2 is
 impModule spath env (FromImport _ (ModRef (0,Just m)) items)
-                                = do (env1,te) <- doImp spath env m
-                                     return $ importSome items m te env1
+                                = do (env1,mi) <- doImp spath env m
+                                     return $ importSome items m mi env1
 impModule spath env (FromImportAll _ (ModRef (0,Just m)))
-                                = do (env1,te) <- doImp spath env m
-                                     return $ importAll m te env1
+                                = do (env1,mi) <- doImp spath env m
+                                     return $ importAll m mi env1
 impModule _ _ i                 = illegalImport (loc i)
 
 
@@ -1360,11 +1353,11 @@ doImp spath env m            = do (env', mi, _) <- doImpSeen S.empty env m
     -- environment. If the module is already loaded, its ModuleInfo carries
     -- that closure; otherwise we read it from the .tydb.
     doImpSeen seen env m
-      | S.member m seen      =
+      | S.member m seen =
           case lookupModuleInfo m env of
             Just mi -> return (env, mi, seen)
             Nothing -> fileNotFound m
-      | otherwise            =
+      | otherwise =
           let seen' = S.insert m seen in
           case lookupModuleInfo m env of
             Just mi -> do
@@ -1397,15 +1390,16 @@ importAll                   :: ModName -> ModuleInfo -> EnvF x -> EnvF x
 importAll m mi env          = defineClosed (impNames m mi) env
 
 impName                     :: ModName -> ModuleInfo -> Name -> Maybe NameInfo
-impName m mi n              = case moduleLookupName mi n of
-                                Just NAct{}   -> Just (NAlias (GName m n))
-                                Just NClass{} -> Just (NAlias (GName m n))
-                                Just NProto{} -> Just (NAlias (GName m n))
+impName _ mi n              = case moduleLookupName mi n of
+                                Just NAct{}   -> imported
+                                Just NClass{} -> imported
+                                Just NProto{} -> imported
                                 Just NExt{}   -> Nothing
-                                Just NAlias{} -> Just (NAlias (GName m n))
-                                Just NVar{}   -> Just (NAlias (GName m n))
-                                Just NDef{}   -> Just (NAlias (GName m n))
+                                Just NAlias{} -> imported
+                                Just NVar{}   -> imported
+                                Just NDef{}   -> imported
                                 _             -> Nothing
+  where imported             = Just (NAlias (GName (moduleName mi) n))
 
 impNames                    :: ModName -> ModuleInfo -> TEnv
 impNames m mi               = mapMaybe imp (modulePublicNames mi)

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -1444,20 +1444,15 @@ doImp spath env m            = do (env', mi, _) <- doImpSeen S.empty env m
               (env', seen'') <- subImpSeen seen' env (moduleImports mi)
               return (env', mi, seen'')
             Nothing -> do
-              ty <- readFoundTy InterfaceFiles.readFileMaybe m
-              case ty of
+              tyFile <- findTyFile spath m
+              mdb <- maybe (return Nothing) InterfaceFiles.openInterfaceDBMaybe tyFile
+              case mdb of
                 Nothing -> fileNotFound m
-                Just (ms,nmod,_,_,_,_,_,_,_,_,_,_,_) -> do
+                Just db -> do
+                  (ms, mdoc) <- InterfaceFiles.readInterfaceDBModuleInfo db
                   (env', seen'') <- subImpSeen seen' env ms
-                  let NModule ms' teFull mdoc = nmod
-                      mi = mkModuleInfo m ms' (publicTEnv teFull) mdoc
-                  return (addModuleInfo m mi (addMod m ms' (publicTEnv teFull) mdoc env'), mi, seen'')
-
-    readFoundTy readTy m = do
-      tyFile <- findTyFile spath m
-      case tyFile of
-        Nothing -> return Nothing
-        Just tyF -> readTy tyF
+                  let mi = mkTyFileModuleInfo m ms mdoc db
+                  return (addModuleInfo m mi env', mi, seen'')
 
     subImpSeen seen env []   = return (env, seen)
     subImpSeen seen env (m:ms) = do

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -129,7 +129,7 @@ convertModules              :: (Name -> [Name]) -> (ModName -> (Name,NameInfo) -
 convertModules sources f env= env{ modules = Map.mapWithKey convMod (modules env) }
   where convMod m mi
           | m == mPrim      = mi
-          | otherwise       = mi{ moduleLookupHName = memoLookup lookupConverted }
+          | otherwise       = mi{ moduleLookupName = memoLookup lookupConverted }
           where lookupConverted n
                             = listToMaybe $ mapMaybe (lookupFrom n) (n : sources n)
                 lookupFrom n src
@@ -147,7 +147,7 @@ convertModules sources f env= env{ modules = Map.mapWithKey convMod (modules env
 data ModuleInfo             = ModuleInfo {
                                 moduleImports     :: [ModName],
                                 moduleDoc         :: Maybe String,
-                                moduleLookupHName :: Name -> Maybe NameInfo,
+                                moduleLookupName :: Name -> Maybe NameInfo,
                                 modulePublicNames :: [Name],
                                 moduleConstructors:: TEnv,
                                 moduleActors      :: [TCon],
@@ -162,9 +162,6 @@ data ModuleInfo             = ModuleInfo {
 instance Show ModuleInfo where
     show mi                 = "ModuleInfo {imports = " ++ show (moduleImports mi) ++ "}"
 
-moduleLookupName            :: ModuleInfo -> Name -> Maybe NameInfo
-moduleLookupName mi n       = moduleLookupHName mi n
-
 modulePublicTEnv            :: ModuleInfo -> TEnv
 modulePublicTEnv mi         = mapMaybe entry (modulePublicNames mi)
   where entry n             = fmap (\i -> (n,i)) (moduleLookupName mi n)
@@ -173,7 +170,7 @@ mkModuleInfo                :: ModName -> [ModName] -> TEnv -> Maybe String -> M
 mkModuleInfo m ms te mdoc   = ModuleInfo {
                                 moduleImports = ms,
                                 moduleDoc = mdoc,
-                                moduleLookupHName = \n -> M.lookup n hte,
+                                moduleLookupName = \n -> M.lookup n hte,
                                 modulePublicNames = map fst pte,
                                 moduleConstructors = [ ni | ni@(_,i) <- pte, isCons i ],
                                 moduleActors = [ moduleTCon m ni | ni@(_,NAct{}) <- pte ],
@@ -219,7 +216,7 @@ mkTyFileModuleInfo m ms mdoc db
                             = ModuleInfo {
                                 moduleImports = ms,
                                 moduleDoc = mdoc,
-                                moduleLookupHName = memoLookup lookupName,
+                                moduleLookupName = memoLookup lookupName,
                                 modulePublicNames = publicNames,
                                 moduleConstructors = constructors,
                                 moduleActors = actors,
@@ -336,7 +333,7 @@ instance Unalias ModName where
                                         _ -> noModule m
 instance Unalias QName where
     unalias env n0@(QName m n)      = case findModuleInfo m env of
-                                        Just mi -> case moduleLookupHName mi n of
+                                        Just mi -> case moduleLookupName mi n of
                                                       Just (NAlias qn) -> setLoc (loc n0) qn
                                                       Just _ -> GName m' n
                                                       _ -> noItem m n
@@ -460,10 +457,10 @@ withModulesFrom             :: EnvF x -> EnvF x -> EnvF x
 env `withModulesFrom` env'  = env{modules = modules env'}
 
 hnamesFrom                  :: TEnv -> HTEnv
-hnamesFrom te               = extendHNames te M.empty
+hnamesFrom te               = extendNames te M.empty
 
-extendHNames                :: TEnv -> HTEnv -> HTEnv
-extendHNames te hte         = foldr add hte te
+extendNames                :: TEnv -> HTEnv -> HTEnv
+extendNames te hte         = foldr add hte te
   where add (n,i) hte       = M.insert n i hte
 
 extendSigLocs               :: TEnv -> LocEnv -> LocEnv
@@ -484,7 +481,7 @@ typeVarsIn te               = [ (n, k, c) | (n, NTVar k c _) <- te ]
 
 setActiveNames              :: TEnv -> EnvF x -> EnvF x
 setActiveNames te env       = env{ activeNames = te,
-                                   hnames = extendHNames te (closedHNames env),
+                                   hnames = extendNames te (closedHNames env),
                                    sigLocs = extendSigLocs te (closedSigLocs env),
                                    defLocs = extendDefLocs te (closedDefLocs env),
                                    activeStateNames = stateNamesIn te,
@@ -492,7 +489,7 @@ setActiveNames te env       = env{ activeNames = te,
 
 addActiveNames              :: TEnv -> EnvF x -> EnvF x
 addActiveNames te env       = env{ activeNames = te ++ activeNames env,
-                                   hnames = extendHNames te (hnames env),
+                                   hnames = extendNames te (hnames env),
                                    sigLocs = extendSigLocs te (sigLocs env),
                                    defLocs = extendDefLocs te (defLocs env),
                                    activeStateNames = stateNamesIn te ++ activeStateNames env,
@@ -500,13 +497,13 @@ addActiveNames te env       = env{ activeNames = te ++ activeNames env,
 
 addClosedNames              :: TEnv -> EnvF x -> EnvF x
 addClosedNames te env       = env{ closedNames = te ++ closedNames env,
-                                   hnames = extendHNames (activeNames env) hte,
+                                   hnames = extendNames (activeNames env) hte,
                                    closedHNames = hte,
                                    sigLocs = extendSigLocs (activeNames env) slocs,
                                    closedSigLocs = slocs,
                                    defLocs = extendDefLocs (activeNames env) dlocs,
                                    closedDefLocs = dlocs }
-  where hte                 = extendHNames te (closedHNames env)
+  where hte                 = extendNames te (closedHNames env)
         slocs               = extendSigLocs te (closedSigLocs env)
         dlocs               = extendDefLocs te (closedDefLocs env)
 
@@ -621,7 +618,7 @@ findQName n env             = case tryQName n env of
 
 tryQName                    :: QName -> EnvF x -> Maybe NameInfo
 tryQName (QName m n) env    = case findModuleInfo m env of
-                                Just mi -> case moduleLookupHName mi n of
+                                Just mi -> case moduleLookupName mi n of
                                     Just (NAlias qn) -> tryQName qn env
                                     Just i -> Just i
                                     _ -> noItem m n
@@ -635,7 +632,7 @@ tryQName (GName m n) env
   | inBuiltin env,
     m==mBuiltin             = tryQName (NoQ n) env
   | otherwise               = case lookupModuleInfo m env of
-                                Just mi -> case moduleLookupHName mi n of
+                                Just mi -> case moduleLookupName mi n of
                                     Just i -> Just i
                                     Nothing -> noItem m n -- error ("## Failed lookup of " ++ prstr n ++ " in module " ++ prstr m)
                                 Nothing -> noModule m -- error ("## Failed lookup of module " ++ prstr m)
@@ -675,7 +672,7 @@ modulePrefix (ModName ns) env
 -- The builtin module is looked up through the active environment while it is
 -- itself being compiled.
 builtinModuleInfo           :: EnvF x -> ModuleInfo
-builtinModuleInfo env       = (mkModuleInfo mBuiltin [] (activeNames env ++ closedNames env) Nothing){ moduleLookupHName = \n -> lookupName n env }
+builtinModuleInfo env       = (mkModuleInfo mBuiltin [] (activeNames env ++ closedNames env) Nothing){ moduleLookupName = \n -> lookupName n env }
 
 isMod                       :: EnvF x -> [Name] -> Bool
 isMod env ns@(n:_)          = (maybe False (const True) (findModuleInfo (ModName ns) env) || modulePrefix (ModName ns) env) && rooted

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -182,7 +182,7 @@ mkModuleInfo m ms te mdoc   = ModuleInfo {
                                 moduleWitnessesByType = qkeyed wittypes
                               }
   where pte                 = publicTEnv te
-        hte                 = convTEnv2HTEnv pte
+        hte                 = M.fromList pte
         wits                = extWitnesses m [ ni | ni@(_,NExt{}) <- pte ]
         witprotos           = indexMap [ (tcname $ proto w, w) | w <- wits ]
         wittypes            = indexMap [ (qn, w) | w <- wits, Just qn <- [witnessTypeQName w] ]

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -786,7 +786,9 @@ allDescendants env tc       = concatMap imported (importedModuleInfos env) ++ lo
         local               = [ schematic' c | c <- localCons env, hasAncestor' env (tcname c) (tcname tc) ]
 
 importedModuleInfos         :: EnvF x -> [ModuleInfo]
-importedModuleInfos env     = [ mi | m <- transitiveImports env, Just mi <- [lookupModuleInfo m env] ]
+importedModuleInfos env
+  | inBuiltin env           = []
+  | otherwise               = [ mi | m <- transitiveImports env, Just mi <- [lookupModuleInfo m env] ]
 
 localCons                   :: EnvF x -> [TCon]
 localCons env               = local (reverse (closedNames env)) ++ local (reverse (activeNames env))

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -1015,8 +1015,16 @@ allProtos env               = allTypes isProto env
   where isProto NProto{}    = True
         isProto _           = False
 
+-- The module indexes record attributes where they are declared, so imported
+-- owners are completed with the descendants of every declaring constructor
+-- (inheriting an attribute means having a declaring ancestor).
 allConAttr                  :: EnvF x -> Name -> [TCon]
-allConAttr env n            = [ tc | tc <- allCons env, hasAttr env tc n ]
+allConAttr env n            = imported ++ [ tc | tc <- localCons env, hasAttr env tc n ]
+  where mis                 = importedModuleInfos env
+        conOwners           = concat [ moduleConAttr mi n | mi <- mis ]
+        protoOwners         = concat [ moduleProtoAttr mi n | mi <- mis ]
+        inherited           = concat [ moduleDescendants mi (tcname o) | o <- conOwners ++ protoOwners, mi <- mis ]
+        imported            = nubBy (\c c' -> tcname c == tcname c') (conOwners ++ inherited)
 
 allConAttrUFree             :: EnvF x -> Name -> [TUni]
 allConAttrUFree env n       = concat [ ufree sc | tc <- activeCons env, Just (_,sc,_) <- [findAttr env tc n] ]
@@ -1034,7 +1042,17 @@ activeCons env              = [ TC (localQName x) (wildargs i) | (x,i) <- active
           | otherwise       = NoQ x
 
 allPConAttr                 :: EnvF x -> Name -> [PCon]
-allPConAttr env n           = [ p | p <- allProtos env, hasAttr env p n ]
+allPConAttr env n           = imported ++ [ p | p <- localProtos env, hasAttr env p n ]
+  where mis                 = importedModuleInfos env
+        owners              = concat [ moduleProtoAttr mi n | mi <- mis ]
+        inherited           = concat [ moduleProtoDescendants mi (tcname o) | o <- owners, mi <- mis ]
+        imported            = nubBy (\p p' -> tcname p == tcname p') (owners ++ inherited)
+
+localProtos                 :: EnvF x -> [PCon]
+localProtos env             = local (reverse (closedNames env)) ++ local (reverse (activeNames env))
+  where local te
+          | inBuiltin env   = [ TC (GName mBuiltin n) (wildargs i) | (n,i@NProto{}) <- te ]
+          | otherwise       = [ TC (NoQ n) (wildargs i) | (n,i@NProto{}) <- te ]
 
 hasAttr                     :: EnvF x -> TCon -> Name -> Bool
 hasAttr env tc n            = maybe False (const True) (findAttrInfo' env (tcname tc) n)

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -953,8 +953,12 @@ allCons env                 = allTypes isCon env
         isCon NAct{}        = True
         isCon _             = False
 
+-- Actors declared in imported modules, from the per-module actor index.
+importedActors              :: EnvF x -> [TCon]
+importedActors env          = concatMap moduleActors (importedModuleInfos env)
+
 allActors                   :: EnvF x -> [TCon]
-allActors env               = concatMap moduleActors (importedModuleInfos env) ++ localactors
+allActors env               = importedActors env ++ localactors
   where local te
           | inBuiltin env   = [ TC (GName mBuiltin n) (wildargs i) | (n,i@NAct{}) <- te ]
           | otherwise       = [ TC (NoQ n) (wildargs i) | (n,i@NAct{}) <- te ]
@@ -967,13 +971,19 @@ allProtos env               = allTypes isProto env
 -- The module indexes record attributes where they are declared, so imported
 -- owners are completed with the descendants of every declaring constructor
 -- (inheriting an attribute means having a declaring ancestor).
-allConAttr                  :: EnvF x -> Name -> [TCon]
-allConAttr env n            = imported ++ [ tc | tc <- localCons env, hasAttr env tc n ]
+-- Constructors carrying an attribute, declared in imported modules. The
+-- indexes record attributes where they are declared, so imported owners are
+-- completed with the descendants of every declaring constructor (inheriting an
+-- attribute means having a declaring ancestor).
+importedConAttr             :: EnvF x -> Name -> [TCon]
+importedConAttr env n       = nubBy (\c c' -> tcname c == tcname c') (conOwners ++ inherited)
   where mis                 = importedModuleInfos env
         conOwners           = concat [ moduleConAttr mi n | mi <- mis ]
         protoOwners         = concat [ moduleProtoAttr mi n | mi <- mis ]
         inherited           = concat [ moduleDescendants mi (tcname o) | o <- conOwners ++ protoOwners, mi <- mis ]
-        imported            = nubBy (\c c' -> tcname c == tcname c') (conOwners ++ inherited)
+
+allConAttr                  :: EnvF x -> Name -> [TCon]
+allConAttr env n            = importedConAttr env n ++ [ tc | tc <- localCons env, hasAttr env tc n ]
 
 allConAttrUFree             :: EnvF x -> Name -> [TUni]
 allConAttrUFree env n       = concat [ ufree sc | tc <- activeCons env, Just (_,sc,_) <- [findAttr env tc n] ]
@@ -990,12 +1000,15 @@ activeCons env              = [ TC (localQName x) (wildargs i) | (x,i) <- active
           | inBuiltin env   = GName mBuiltin x
           | otherwise       = NoQ x
 
-allPConAttr                 :: EnvF x -> Name -> [PCon]
-allPConAttr env n           = imported ++ [ p | p <- localProtos env, hasAttr env p n ]
+-- Protocols carrying an attribute, declared in imported modules.
+importedProtoAttr           :: EnvF x -> Name -> [PCon]
+importedProtoAttr env n     = nubBy (\p p' -> tcname p == tcname p') (owners ++ inherited)
   where mis                 = importedModuleInfos env
         owners              = concat [ moduleProtoAttr mi n | mi <- mis ]
         inherited           = concat [ moduleProtoDescendants mi (tcname o) | o <- owners, mi <- mis ]
-        imported            = nubBy (\p p' -> tcname p == tcname p') (owners ++ inherited)
+
+allPConAttr                 :: EnvF x -> Name -> [PCon]
+allPConAttr env n           = importedProtoAttr env n ++ [ p | p <- localProtos env, hasAttr env p n ]
 
 localProtos                 :: EnvF x -> [PCon]
 localProtos env             = local (reverse (closedNames env)) ++ local (reverse (activeNames env))

--- a/compiler/lib/src/Acton/Hashing.hs
+++ b/compiler/lib/src/Acton/Hashing.hs
@@ -709,7 +709,6 @@ feedNameInfo info sink = feedTag 249 sink >> case info of
     feedTEnv te sink >> feedList feedName o sink
   I.NTVar k c ps     -> feedTag 8 sink >> feedKind k sink >> feedTCon c sink >> feedList feedTCon ps sink
   I.NAlias qn        -> feedTag 9 sink >> feedQName qn sink
-  I.NMAlias mn       -> feedTag 10 sink >> feedModName mn sink
   I.NReserved        -> feedTag 12 sink
 
 feedTEnv :: I.TEnv -> HashFeed
@@ -872,7 +871,6 @@ foldNameInfoDeps add info acc = case info of
   I.NExt q c ws te _ _ -> foldDepsTEnv add te (foldDepsList (foldDepsWTCon add) ws (foldDepsTCon add c (foldDepsList (foldDepsQBind add) q acc)))
   I.NTVar _ c ps       -> foldDepsList (foldDepsTCon add) ps (foldDepsTCon add c acc)
   I.NAlias qn          -> add qn acc
-  I.NMAlias _          -> acc
   I.NReserved          -> acc
 
 foldDepsTEnv :: (A.QName -> acc -> acc) -> I.TEnv -> acc -> acc

--- a/compiler/lib/src/Acton/Hashing.hs
+++ b/compiler/lib/src/Acton/Hashing.hs
@@ -1580,6 +1580,7 @@ assembleNameHashes nameKeys nameSrcHashes pubHashes implHashes pubLocalDeps impl
         , InterfaceFiles.nhImplLocalDeps = localDeps implLocalDeps n
         , InterfaceFiles.nhPubDeps = M.findWithDefault [] n pubExtHashes
         , InterfaceFiles.nhImplDeps = M.findWithDefault [] n implExtHashes
+        , InterfaceFiles.nhStmtIndices = []
         }
     | n <- namesSorted
     ]

--- a/compiler/lib/src/Acton/Hashing.hs
+++ b/compiler/lib/src/Acton/Hashing.hs
@@ -710,7 +710,6 @@ feedNameInfo info sink = feedTag 249 sink >> case info of
   I.NTVar k c ps     -> feedTag 8 sink >> feedKind k sink >> feedTCon c sink >> feedList feedTCon ps sink
   I.NAlias qn        -> feedTag 9 sink >> feedQName qn sink
   I.NMAlias mn       -> feedTag 10 sink >> feedModName mn sink
-  I.NModule ms te _  -> feedTag 11 sink >> feedList feedModName ms sink >> feedTEnv te sink
   I.NReserved        -> feedTag 12 sink
 
 feedTEnv :: I.TEnv -> HashFeed
@@ -874,7 +873,6 @@ foldNameInfoDeps add info acc = case info of
   I.NTVar _ c ps       -> foldDepsList (foldDepsTCon add) ps (foldDepsTCon add c acc)
   I.NAlias qn          -> add qn acc
   I.NMAlias _          -> acc
-  I.NModule _ te _     -> foldDepsTEnv add te acc
   I.NReserved          -> acc
 
 foldDepsTEnv :: (A.QName -> acc -> acc) -> I.TEnv -> acc -> acc
@@ -1623,7 +1621,7 @@ refreshImplHashes nameHashes nameImplHashes implLocalDeps implExtHashes =
     ]
 
 -- | Hash module-level pub/impl summaries from the final per-name hash maps.
-moduleHashesFromHashMaps :: I.NameInfo
+moduleHashesFromHashMaps :: I.NModule
                          -> Data.Set.Set A.Name
                          -> M.Map A.Name B.ByteString
                          -> M.Map A.Name B.ByteString
@@ -1632,7 +1630,7 @@ moduleHashesFromHashMaps nmod nameKeys pubHashes implHashes =
   (modulePubHashFromHashMap nmod pubHashes, moduleImplHashFromHashMap nameKeys implHashes)
 
 -- | Hash the module public interface entries.
-modulePubHashFromIface :: I.NameInfo -> [InterfaceFiles.NameHashInfo] -> B.ByteString
+modulePubHashFromIface :: I.NModule -> [InterfaceFiles.NameHashInfo] -> B.ByteString
 modulePubHashFromIface nmod nameHashes =
   modulePubHashFromHashMap nmod $
     M.fromList
@@ -1640,7 +1638,7 @@ modulePubHashFromIface nmod nameHashes =
         | nh <- nameHashes
         ]
 
-modulePubHashFromHashMap :: I.NameInfo -> M.Map A.Name B.ByteString -> B.ByteString
+modulePubHashFromHashMap :: I.NModule -> M.Map A.Name B.ByteString -> B.ByteString
 modulePubHashFromHashMap nmod pubHashes =
   let I.NModule _ iface _ = nmod
       pubNamesSorted =

--- a/compiler/lib/src/Acton/Kinds.hs
+++ b/compiler/lib/src/Acton/Kinds.hs
@@ -393,10 +393,13 @@ instance KCheck Expr where
     kchk env (SetComp l e c)        = SetComp l <$> kchk env e <*> kchk env c
     kchk env (Paren l e)            = Paren l <$> kchk env e
 
-isModule env e                          = fmap ModName $ mfilter (isMod env) $ fmap reverse $ dotChain e
-  where dotChain (Var _ (NoQ n))        = Just [n]
-        dotChain (Dot _ e n)            = fmap (n:) (dotChain e)
-        dotChain _                      = Nothing
+isModule env e                      = do ns@(n:_) <- fmap reverse (dotChain e)
+                                         let m = ModName ns
+                                         guard (lookupName n env == Nothing && isMod env ns)
+                                         return m
+  where dotChain (Var _ (NoQ n))    = Just [n]
+        dotChain (Dot _ e n)        = fmap (n:) (dotChain e)
+        dotChain _                  = Nothing
 
 instance KCheck Pattern where
     kchk env (PWild l t)            = PWild l <$> (kexp KType env =<< maybeConvTWild env t)

--- a/compiler/lib/src/Acton/Kinds.hs
+++ b/compiler/lib/src/Acton/Kinds.hs
@@ -373,7 +373,7 @@ instance KCheck Expr where
     kchk env (CompOp l e ops)       = CompOp l <$> kchk env e <*> kchk env ops
     kchk env (UnOp l op e)          = UnOp l op <$> kchk env e
     kchk env (Dot l e n)
-      | Just m <- isModule env e    = return $ Var l (QName m n)
+      | Just m <- isModName env e   = return $ Var l (QName m n)
       | otherwise                   = Dot l <$> kchk env e <*> return n
     kchk env (Rest l e n)           = Rest l <$> kchk env e <*> return n
     kchk env (DotI l e i)           = DotI l <$> kchk env e <*> return i
@@ -392,14 +392,6 @@ instance KCheck Expr where
     kchk env (Set l es)             = Set l <$> kchk env es
     kchk env (SetComp l e c)        = SetComp l <$> kchk env e <*> kchk env c
     kchk env (Paren l e)            = Paren l <$> kchk env e
-
-isModule env e                      = do ns@(n:_) <- fmap reverse (dotChain e)
-                                         let m = ModName ns
-                                         guard (lookupName n env == Nothing && isMod env ns)
-                                         return m
-  where dotChain (Var _ (NoQ n))    = Just [n]
-        dotChain (Dot _ e n)        = fmap (n:) (dotChain e)
-        dotChain _                  = Nothing
 
 instance KCheck Pattern where
     kchk env (PWild l t)            = PWild l <$> (kexp KType env =<< maybeConvTWild env t)

--- a/compiler/lib/src/Acton/LambdaLifter.hs
+++ b/compiler/lib/src/Acton/LambdaLifter.hs
@@ -28,7 +28,7 @@ import Acton.Subst
 import Pretty
 import Prelude hiding((<>))
 
-liftModule env0 (Module m imp mdoc stmts) = return $ (Module m imp mdoc stmts', mapModules1 conv env0)
+liftModule env0 (Module m imp mdoc stmts) = return $ (Module m imp mdoc stmts', convertModules1 conv env0)
   where stmts' = runL (llSuite (liftEnv env0) stmts)
 
 

--- a/compiler/lib/src/Acton/NameInfo.hs
+++ b/compiler/lib/src/Acton/NameInfo.hs
@@ -60,8 +60,10 @@ data NameInfo           = NVar      Type
                         | NTVar     Kind CCon [PCon]
                         | NAlias    QName
                         | NMAlias   ModName
-                        | NModule   [ModName] TEnv (Maybe String)
                         | NReserved
+                        deriving (Eq,Show,Read,Generic,NFData)
+
+data NModule            = NModule [ModName] TEnv (Maybe String)
                         deriving (Eq,Show,Read,Generic,NFData)
 
 typeDecl (_,NDef{})     = False
@@ -80,15 +82,18 @@ data HNameInfo          = HNVar      Type
                         | HNTVar     Kind CCon [PCon]
                         | HNAlias    QName
                         | HNMAlias   ModName
-                        | HNModule   [ModName] HTEnv (Maybe String)
                         | HNReserved
                         deriving (Eq, Show, Read, Generic)
 
+data HNModule           = HNModule [ModName] HTEnv (Maybe String)
+                        deriving (Eq, Show, Read, Generic)
+
 instance Data.Binary.Binary NameInfo
+instance Data.Binary.Binary NModule
 instance Persist NameInfo
+instance Persist NModule
 
 convNameInfo2HNameInfo               :: NameInfo -> HNameInfo
-convNameInfo2HNameInfo (NModule ms te mdoc)   = HNModule ms (convTEnv2HTEnv te) mdoc
 convNameInfo2HNameInfo (NVar t)               = HNVar t
 convNameInfo2HNameInfo (NSVar t)              = HNSVar t
 convNameInfo2HNameInfo (NDef sc dec mdoc)     = HNDef sc dec mdoc
@@ -103,7 +108,6 @@ convNameInfo2HNameInfo (NMAlias mn)           = HNMAlias mn
 convNameInfo2HNameInfo (NReserved)            = HNReserved
 
 convHNameInfo2NameInfo               :: HNameInfo -> NameInfo
-convHNameInfo2NameInfo (HNModule ms te mdoc)   = NModule ms (convHTEnv2TEnv te) mdoc
 convHNameInfo2NameInfo (HNVar t)               = NVar t
 convHNameInfo2NameInfo (HNSVar t)              = NSVar t
 convHNameInfo2NameInfo (HNDef sc dec mdoc)     = NDef sc dec mdoc
@@ -116,6 +120,12 @@ convHNameInfo2NameInfo (HNTVar k c ps)         = NTVar k c ps
 convHNameInfo2NameInfo (HNAlias qn)            = NAlias qn
 convHNameInfo2NameInfo (HNMAlias mn)           = NMAlias mn
 convHNameInfo2NameInfo (HNReserved)            = NReserved
+
+convNModule2HNModule                 :: NModule -> HNModule
+convNModule2HNModule (NModule ms te mdoc) = HNModule ms (convTEnv2HTEnv te) mdoc
+
+convHNModule2NModule                 :: HNModule -> NModule
+convHNModule2NModule (HNModule ms te mdoc) = NModule ms (convHTEnv2TEnv te) mdoc
 
 convTEnv2HTEnv                       :: TEnv -> HTEnv
 convTEnv2HTEnv te                     = M.fromList (map convPair te)
@@ -132,7 +142,6 @@ convHTEnv2TEnv te                     = map convPair (M.toList te)
 -- documentation-only edits do not cause dependents to rebuild.
 stripDocsNI :: NameInfo -> NameInfo
 stripDocsNI ni = case ni of
-  NModule ms te _     -> NModule ms (map stripBind te) Nothing
   NAct q p k te _     -> NAct q p k (map stripBind te) Nothing
   NClass q cs te _    -> NClass q cs (map stripBind te) Nothing
   NProto q ps te _    -> NProto q ps (map stripBind te) Nothing
@@ -140,6 +149,11 @@ stripDocsNI ni = case ni of
   NDef sc dec _       -> NDef sc dec Nothing
   NSig sc dec _       -> NSig sc dec Nothing
   other               -> other
+  where
+    stripBind (n, info) = (n, stripDocsNI info)
+
+stripDocsNModule :: NModule -> NModule
+stripDocsNModule (NModule ms te _) = NModule ms (map stripBind te) Nothing
   where
     stripBind (n, info) = (n, stripDocsNI info)
 
@@ -160,7 +174,6 @@ stripLocsNI ni = case ni of
   NTVar k c ps       -> NTVar k (stripLocsTCon c) (map stripLocsTCon ps)
   NAlias qn          -> NAlias (stripLocsQName qn)
   NMAlias mn         -> NMAlias (stripLocsModName mn)
-  NModule ms te doc  -> NModule ms (stripLocsTEnv te) doc
   NReserved          -> NReserved
   where
     stripLocsTEnv :: TEnv -> TEnv
@@ -218,6 +231,18 @@ stripLocsNI ni = case ni of
       Derived n1 n2  -> Derived (stripLocsName n1) (stripLocsName n2)
       Internal{}     -> n
 
+stripLocsNModule :: NModule -> NModule
+stripLocsNModule (NModule ms te doc) = NModule ms (stripLocsTEnv te) doc
+  where
+    stripLocsTEnv :: TEnv -> TEnv
+    stripLocsTEnv = map $ \(n, info) -> (stripLocsName n, stripLocsNI info)
+
+    stripLocsName :: Name -> Name
+    stripLocsName n = case n of
+      Name _ s       -> Name NoLoc s
+      Derived n1 n2  -> Derived (stripLocsName n1) (stripLocsName n2)
+      Internal{}     -> n
+
 instance Leaves NameInfo where
     leaves (NClass q cs te _) = leaves q ++ leaves cs ++ leaves te
     leaves (NProto q ps te _) = leaves q ++ leaves ps ++ leaves te
@@ -225,6 +250,9 @@ instance Leaves NameInfo where
     leaves (NExt q c ps te _ _) = leaves q ++ leaves c ++ leaves ps ++ leaves te
     leaves (NDef sc dec _)    = leaves sc
     leaves _                  = []
+
+instance Leaves NModule where
+    leaves (NModule _ te _)    = leaves te
 
 instance Pretty TEnv where
     pretty tenv               = vcat (map pretty $ normTEnv tenv)
@@ -261,12 +289,14 @@ instance Pretty (Name,NameInfo) where
     pretty (n, NTVar k c ps)    = pretty n <> parens (commaList (c:ps))
     pretty (n, NAlias qn)       = text "alias" <+> pretty n <+> equals <+> pretty qn
     pretty (n, NMAlias m)       = text "module" <+> pretty n <+> equals <+> pretty m
+    pretty (n, NReserved)       = pretty n <+> text "(reserved)"
+
+instance Pretty (Name,NModule) where
     pretty (n, NModule ms te doc)
-                                = text "module" <+> pretty n <> colon $+$ 
+                                = text "module" <+> pretty n <> colon $+$
                                   nest 4 (vcat [ text "import" <+> pretty m | m <- ms ]) $+$
                                   nest 4 (prettyDocstring doc) $+$
                                   nest 4 (pretty te)
-    pretty (n, NReserved)       = pretty n <+> text "(reserved)"
 
 prettyOrPass te
   | isEmpty doc                 = text "pass"
@@ -289,8 +319,10 @@ instance VFree NameInfo where
     vfree (NTVar k c ps)        = vfree c ++ vfree ps
     vfree (NAlias qn)           = []
     vfree (NMAlias qn)          = []
-    vfree (NModule ms te doc)   = []        -- actually vfree te, but a module has no free variables on the top level
     vfree NReserved             = []
+
+instance VFree NModule where
+    vfree (NModule ms te doc)   = []        -- actually vfree te, but a module has no free variables on the top level
 
 instance VSubst NameInfo where
     vsubst s (NVar t)           = NVar (vsubst s t)
@@ -304,8 +336,10 @@ instance VSubst NameInfo where
     vsubst s (NTVar k c ps)        = NTVar k (vsubst s c) (vsubst s ps)
     vsubst s (NAlias qn)        = NAlias qn
     vsubst s (NMAlias m)        = NMAlias m
-    vsubst s (NModule ms te x)  = NModule ms te x        -- actually vsubst s te, but te has no free variables (top-level)
     vsubst s NReserved          = NReserved
+
+instance VSubst NModule where
+    vsubst s (NModule ms te x)  = NModule ms te x        -- actually vsubst s te, but te has no free variables (top-level)
 
 instance UFree NameInfo where
     ufree (NVar t)              = ufree t
@@ -319,8 +353,10 @@ instance UFree NameInfo where
     ufree (NTVar k c ps)        = ufree c ++ ufree ps
     ufree (NAlias qn)           = []
     ufree (NMAlias qn)          = []
-    ufree (NModule ms te doc)   = []        -- actually ufree te, but a module has no free variables on the top level
     ufree NReserved             = []
+
+instance UFree NModule where
+    ufree (NModule ms te doc)   = []        -- actually ufree te, but a module has no free variables on the top level
 
 instance Polarity (Name,NameInfo) where
     polvars (n, i)              = polvars i
@@ -455,7 +491,6 @@ instance Vars NameInfo where
       NTVar _ c ps -> freeQ c ++ freeQ ps
       NAlias qn -> freeQ qn
       NMAlias _ -> []
-      NModule ms te _ -> freeQTEnv te
       NReserved -> []
       where
         freeQTEnv :: TEnv -> [QName]
@@ -472,6 +507,9 @@ instance Vars NameInfo where
           where
             step (Left qn) = freeQ qn
             step (Right qn) = freeQ qn
+
+instance Vars NModule where
+    freeQ (NModule _ te _) = concatMap (freeQ . snd) te
 
 instance UWild WTCon where
     uwild (wpath, p)    = (wpath, uwild p)

--- a/compiler/lib/src/Acton/NameInfo.hs
+++ b/compiler/lib/src/Acton/NameInfo.hs
@@ -72,9 +72,7 @@ typeDecl _              = True
 type HTEnv            =  M.HashMap Name NameInfo
 
 instance Data.Binary.Binary NameInfo
-instance Data.Binary.Binary NModule
 instance Persist NameInfo
-instance Persist NModule
 
 -- | Strip all docstrings from NameInfo (and nested environments).
 -- This is used when computing a public-interface hash so that
@@ -182,17 +180,6 @@ stripLocsNModule (NModule ms te doc) = NModule ms (stripLocsTEnv te) doc
       Derived n1 n2  -> Derived (stripLocsName n1) (stripLocsName n2)
       Internal{}     -> n
 
-instance Leaves NameInfo where
-    leaves (NClass q cs te _) = leaves q ++ leaves cs ++ leaves te
-    leaves (NProto q ps te _) = leaves q ++ leaves ps ++ leaves te
-    leaves (NAct q p k te _)  = leaves q ++ leaves [p,k] ++ leaves te
-    leaves (NExt q c ps te _ _) = leaves q ++ leaves c ++ leaves ps ++ leaves te
-    leaves (NDef sc dec _)    = leaves sc
-    leaves _                  = []
-
-instance Leaves NModule where
-    leaves (NModule _ te _)    = leaves te
-
 instance Pretty TEnv where
     pretty tenv               = vcat (map pretty $ normTEnv tenv)
       where normTEnv te       = f [] te
@@ -230,13 +217,6 @@ instance Pretty (Name,NameInfo) where
     pretty (n, NMAlias m)       = text "module" <+> pretty n <+> equals <+> pretty m
     pretty (n, NReserved)       = pretty n <+> text "(reserved)"
 
-instance Pretty (Name,NModule) where
-    pretty (n, NModule ms te doc)
-                                = text "module" <+> pretty n <> colon $+$
-                                  nest 4 (vcat [ text "import" <+> pretty m | m <- ms ]) $+$
-                                  nest 4 (prettyDocstring doc) $+$
-                                  nest 4 (pretty te)
-
 prettyOrPass te
   | isEmpty doc                 = text "pass"
   | otherwise                   = doc
@@ -260,9 +240,6 @@ instance VFree NameInfo where
     vfree (NMAlias qn)          = []
     vfree NReserved             = []
 
-instance VFree NModule where
-    vfree (NModule ms te doc)   = []        -- actually vfree te, but a module has no free variables on the top level
-
 instance VSubst NameInfo where
     vsubst s (NVar t)           = NVar (vsubst s t)
     vsubst s (NSVar t)          = NSVar (vsubst s t)
@@ -277,9 +254,6 @@ instance VSubst NameInfo where
     vsubst s (NMAlias m)        = NMAlias m
     vsubst s NReserved          = NReserved
 
-instance VSubst NModule where
-    vsubst s (NModule ms te x)  = NModule ms te x        -- actually vsubst s te, but te has no free variables (top-level)
-
 instance UFree NameInfo where
     ufree (NVar t)              = ufree t
     ufree (NSVar t)             = ufree t
@@ -293,9 +267,6 @@ instance UFree NameInfo where
     ufree (NAlias qn)           = []
     ufree (NMAlias qn)          = []
     ufree NReserved             = []
-
-instance UFree NModule where
-    ufree (NModule ms te doc)   = []        -- actually ufree te, but a module has no free variables on the top level
 
 instance Polarity (Name,NameInfo) where
     polvars (n, i)              = polvars i
@@ -399,23 +370,14 @@ instance UFree Witness where
     ufree w@WInst{}     = ufree (wtype w) ++ ufree (proto w)
 
 
-instance Leaves WTCon where
-    leaves (wp,p)       = leaves p
-
 instance VFree WTCon where
     vfree (wpath, p)    = vfree p
 
 instance UFree WTCon where
     ufree (wpath, p)    = ufree p
 
-instance Tailvars WTCon where
-    tailvars (wpath, p) = tailvars p
-
 instance VSubst WTCon where
     vsubst s (w,u)      = (w, vsubst s u)
-
-instance Vars WTCon where
-    freeQ (wpath, p)    = freeQ p
 
 instance Vars NameInfo where
     freeQ ni = case ni of
@@ -446,12 +408,6 @@ instance Vars NameInfo where
           where
             step (Left qn) = freeQ qn
             step (Right qn) = freeQ qn
-
-instance Vars NModule where
-    freeQ (NModule _ te _) = concatMap (freeQ . snd) te
-
-instance UWild WTCon where
-    uwild (wpath, p)    = (wpath, uwild p)
 
 instance Pretty WTCon where
     pretty (wpath, p)   = pretty p

--- a/compiler/lib/src/Acton/NameInfo.hs
+++ b/compiler/lib/src/Acton/NameInfo.hs
@@ -69,73 +69,18 @@ data NModule            = NModule [ModName] TEnv (Maybe String)
 typeDecl (_,NDef{})     = False
 typeDecl _              = True
 
-type HTEnv            =  M.HashMap Name HNameInfo
-
-data HNameInfo          = HNVar      Type
-                        | HNSVar     Type
-                        | HNDef      TSchema Deco (Maybe String)
-                        | HNSig      TSchema Deco (Maybe String)
-                        | HNAct      QBinds PosRow KwdRow TEnv (Maybe String)
-                        | HNClass    QBinds [WTCon] TEnv (Maybe String)
-                        | HNProto    QBinds [WTCon] TEnv (Maybe String)
-                        | HNExt      QBinds TCon [WTCon] TEnv [Name] (Maybe String)
-                        | HNTVar     Kind CCon [PCon]
-                        | HNAlias    QName
-                        | HNMAlias   ModName
-                        | HNReserved
-                        deriving (Eq, Show, Read, Generic)
-
-data HNModule           = HNModule [ModName] HTEnv (Maybe String)
-                        deriving (Eq, Show, Read, Generic)
+type HTEnv            =  M.HashMap Name NameInfo
 
 instance Data.Binary.Binary NameInfo
 instance Data.Binary.Binary NModule
 instance Persist NameInfo
 instance Persist NModule
 
-convNameInfo2HNameInfo               :: NameInfo -> HNameInfo
-convNameInfo2HNameInfo (NVar t)               = HNVar t
-convNameInfo2HNameInfo (NSVar t)              = HNSVar t
-convNameInfo2HNameInfo (NDef sc dec mdoc)     = HNDef sc dec mdoc
-convNameInfo2HNameInfo (NSig sc dec mdoc)     = HNSig sc dec mdoc
-convNameInfo2HNameInfo (NAct q p k te mdoc)   = HNAct q p k te mdoc
-convNameInfo2HNameInfo (NClass q ws te mdoc)  = HNClass q ws te mdoc
-convNameInfo2HNameInfo (NProto q ws te mdoc)  = HNProto q ws te mdoc
-convNameInfo2HNameInfo (NExt q tc ws te ns mdoc) = HNExt q tc ws te ns mdoc
-convNameInfo2HNameInfo (NTVar k c ps)         = HNTVar k c ps
-convNameInfo2HNameInfo (NAlias qn)            = HNAlias qn
-convNameInfo2HNameInfo (NMAlias mn)           = HNMAlias mn
-convNameInfo2HNameInfo (NReserved)            = HNReserved
-
-convHNameInfo2NameInfo               :: HNameInfo -> NameInfo
-convHNameInfo2NameInfo (HNVar t)               = NVar t
-convHNameInfo2NameInfo (HNSVar t)              = NSVar t
-convHNameInfo2NameInfo (HNDef sc dec mdoc)     = NDef sc dec mdoc
-convHNameInfo2NameInfo (HNSig sc dec mdoc)     = NSig sc dec mdoc
-convHNameInfo2NameInfo (HNAct q p k te mdoc)   = NAct q p k te mdoc
-convHNameInfo2NameInfo (HNClass q ws te mdoc)  = NClass q ws te mdoc
-convHNameInfo2NameInfo (HNProto q ws te mdoc)  = NProto q ws te mdoc
-convHNameInfo2NameInfo (HNExt q tc ws te ns mdoc) = NExt q tc ws te ns mdoc
-convHNameInfo2NameInfo (HNTVar k c ps)         = NTVar k c ps
-convHNameInfo2NameInfo (HNAlias qn)            = NAlias qn
-convHNameInfo2NameInfo (HNMAlias mn)           = NMAlias mn
-convHNameInfo2NameInfo (HNReserved)            = NReserved
-
-convNModule2HNModule                 :: NModule -> HNModule
-convNModule2HNModule (NModule ms te mdoc) = HNModule ms (convTEnv2HTEnv te) mdoc
-
-convHNModule2NModule                 :: HNModule -> NModule
-convHNModule2NModule (HNModule ms te mdoc) = NModule ms (convHTEnv2TEnv te) mdoc
-
 convTEnv2HTEnv                       :: TEnv -> HTEnv
-convTEnv2HTEnv te                     = M.fromList (map convPair te)
-  where
-     convPair (n, ni)      = (n, convNameInfo2HNameInfo ni)
+convTEnv2HTEnv te                     = M.fromList te
 
 convHTEnv2TEnv                       :: HTEnv -> TEnv
-convHTEnv2TEnv te                     = map convPair (M.toList te)
-  where
-     convPair (n, hni)      = (n, convHNameInfo2NameInfo hni)
+convHTEnv2TEnv te                     = M.toList te
 
 -- | Strip all docstrings from NameInfo (and nested environments).
 -- This is used when computing a public-interface hash so that

--- a/compiler/lib/src/Acton/NameInfo.hs
+++ b/compiler/lib/src/Acton/NameInfo.hs
@@ -76,12 +76,6 @@ instance Data.Binary.Binary NModule
 instance Persist NameInfo
 instance Persist NModule
 
-convTEnv2HTEnv                       :: TEnv -> HTEnv
-convTEnv2HTEnv te                     = M.fromList te
-
-convHTEnv2TEnv                       :: HTEnv -> TEnv
-convHTEnv2TEnv te                     = M.toList te
-
 -- | Strip all docstrings from NameInfo (and nested environments).
 -- This is used when computing a public-interface hash so that
 -- documentation-only edits do not cause dependents to rebuild.

--- a/compiler/lib/src/Acton/NameInfo.hs
+++ b/compiler/lib/src/Acton/NameInfo.hs
@@ -59,7 +59,6 @@ data NameInfo           = NVar      Type
                         | NExt      QBinds TCon [WTCon] TEnv [Name] (Maybe String)
                         | NTVar     Kind CCon [PCon]
                         | NAlias    QName
-                        | NMAlias   ModName
                         | NReserved
                         deriving (Eq,Show,Read,Generic,NFData)
 
@@ -110,7 +109,6 @@ stripLocsNI ni = case ni of
     NExt (stripLocsQBinds q) (stripLocsTCon c) (map stripLocsWTCon ps) (stripLocsTEnv te) (map stripLocsName o) doc
   NTVar k c ps       -> NTVar k (stripLocsTCon c) (map stripLocsTCon ps)
   NAlias qn          -> NAlias (stripLocsQName qn)
-  NMAlias mn         -> NMAlias (stripLocsModName mn)
   NReserved          -> NReserved
   where
     stripLocsTEnv :: TEnv -> TEnv
@@ -214,7 +212,6 @@ instance Pretty (Name,NameInfo) where
                                   colon $+$ nest 4 (prettyDocstring doc) $+$ (nest 4 $ prettyOrPass te)
     pretty (n, NTVar k c ps)    = pretty n <> parens (commaList (c:ps))
     pretty (n, NAlias qn)       = text "alias" <+> pretty n <+> equals <+> pretty qn
-    pretty (n, NMAlias m)       = text "module" <+> pretty n <+> equals <+> pretty m
     pretty (n, NReserved)       = pretty n <+> text "(reserved)"
 
 prettyOrPass te
@@ -237,7 +234,6 @@ instance VFree NameInfo where
     vfree (NExt q c ps te _ _)  = (vfree q ++ vfree c ++ vfree ps ++ vfree te) \\ (tvSelf : qbound q)
     vfree (NTVar k c ps)        = vfree c ++ vfree ps
     vfree (NAlias qn)           = []
-    vfree (NMAlias qn)          = []
     vfree NReserved             = []
 
 instance VSubst NameInfo where
@@ -251,7 +247,6 @@ instance VSubst NameInfo where
     vsubst s (NExt q c ps te opts x) = NExt (vsubst s q) (vsubst s c) (vsubst s ps) (vsubst s te) opts x
     vsubst s (NTVar k c ps)        = NTVar k (vsubst s c) (vsubst s ps)
     vsubst s (NAlias qn)        = NAlias qn
-    vsubst s (NMAlias m)        = NMAlias m
     vsubst s NReserved          = NReserved
 
 instance UFree NameInfo where
@@ -265,7 +260,6 @@ instance UFree NameInfo where
     ufree (NExt q c ps te _ _)  = ufree q ++ ufree c ++ ufree ps ++ ufree te
     ufree (NTVar k c ps)        = ufree c ++ ufree ps
     ufree (NAlias qn)           = []
-    ufree (NMAlias qn)          = []
     ufree NReserved             = []
 
 instance Polarity (Name,NameInfo) where
@@ -391,7 +385,6 @@ instance Vars NameInfo where
       NExt q c ws te _ _ -> freeQ q ++ freeQ c ++ freeQWTCons ws ++ freeQTEnv te
       NTVar _ c ps -> freeQ c ++ freeQ ps
       NAlias qn -> freeQ qn
-      NMAlias _ -> []
       NReserved -> []
       where
         freeQTEnv :: TEnv -> [QName]

--- a/compiler/lib/src/Acton/Names.hs
+++ b/compiler/lib/src/Acton/Names.hs
@@ -427,10 +427,6 @@ instance Vars ImportItem where
     bound (ImportItem n Nothing)    = free n
     bound (ImportItem n (Just as))  = free as
 
-instance Vars ModRef where
-    bound (ModRef (0, n))           = free n
-    bound _                         = []
-
 instance Vars TSchema where
     freeQ (TSchema _ q t)           = freeQ q ++ freeQ t
 

--- a/compiler/lib/src/Acton/Normalizer.hs
+++ b/compiler/lib/src/Acton/Normalizer.hs
@@ -30,7 +30,7 @@ import Debug.Trace
 normalize                           :: Env0 -> Module -> IO (Module, Env0)
 normalize env0 m                    = return (evalState (norm env m) (0,[]), env0')
   where env                         = normEnv env0
-        env0'                       = mapModules convEnv env0
+        env0'                       = convertModules (const []) convEnv env0
 
 
 --  Normalization:

--- a/compiler/lib/src/Acton/Parser.hs
+++ b/compiler/lib/src/Acton/Parser.hs
@@ -1854,17 +1854,13 @@ import_stmt = import_name <|> import_from <?> "import statement"
 
          import_from = addLoc $ do
                 rword "from"
-                mr <- import_module
+                mn <- module_name
                 rword "import"
                 is <- import_items
                 case is of
-                   [] -> return $ S.FromImportAll NoLoc mr
-                   _  -> return $ S.FromImport NoLoc mr is
+                   [] -> return $ S.FromImportAll NoLoc mn
+                   _  -> return $ S.FromImport NoLoc mn is
 
-         import_module = do
-                ds <- many dot
-                mbn <- optional module_name
-                return $ S.ModRef (length ds, mbn)
          import_items = ([] <$ star)   -- Note: [] means all...
                      <|> parens import_as_names
                      <|> import_as_names

--- a/compiler/lib/src/Acton/Parser.hs
+++ b/compiler/lib/src/Acton/Parser.hs
@@ -1850,7 +1850,7 @@ import_stmt = import_name <|> import_from <?> "import statement"
 
          module_item = do
                 dn <- module_name
-                S.ModuleItem dn <$> optional (rword "as" *> name)
+                S.ModuleItem dn <$> optional (rword "as" *> module_name)
 
          import_from = addLoc $ do
                 rword "from"

--- a/compiler/lib/src/Acton/Printer.hs
+++ b/compiler/lib/src/Acton/Printer.hs
@@ -283,9 +283,6 @@ instance Pretty QName where
       | ModName [Name _ "$"] <- m   = text ("$" ++ rawstr n)
       | otherwise                   = pretty m <> dot <> pretty n
 
-instance Pretty ModRef where
-    pretty (ModRef (i,n))           = hcat (replicate i dot) <> pretty n
-
 instance Pretty Handler where
     pretty (Handler ex b)           = pretty ex <> colon $+$ prettySuite b
 

--- a/compiler/lib/src/Acton/Solver.hs
+++ b/compiler/lib/src/Acton/Solver.hs
@@ -591,16 +591,19 @@ allBelow env (TFX _ FXAction)       = [fxAction]
 allBelowProto env (TC n [t@TFX{},_])
   | n == primWrappedP               = [ schematic (wtype w) | w <- witsByPName env n, t == (head $ tcargs $ proto w) ]
 allBelowProto env p
-  | p == pIdentity                  = ts ++ [ schematic $ tCon tc | tc <- tyactorsAll env ]
+  | p == pIdentity                  = ts ++ [ schematic $ tCon tc | tc <- tyactorsAll env ++ importedActors env ]
   | p == pEq                        = ts ++ [tOpt tWild]
   | otherwise                       = ts
-  where ts                          = [ schematic (wtype w) | w <- witsByPName env (tcname p) ] -- includes tvars; oldest first
+  where ts                          = [ schematic (wtype w) | w <- witsByPName env (tcname p) ] -- includes tvars; oldest first, lazy
 
-allClassAttr env n                  = map tCon (tyconsByAttr env n) ++
+-- Local candidate classes come from the in-memory type-id lattice (lazy, O(1)
+-- attribute lookup, preserving the speedup on large local modules); imported
+-- candidate classes come from the per-module indexes.
+allClassAttr env n                  = map tCon (tyconsByAttr env n ++ importedConAttr env n) ++
                                       map tVar (tvarsInTids env (tyconAttrTids env n))
 
 allProtoAttr env n                  = map tCon pcons ++ concatMap (allBelowProto env) pcons
-  where pcons                       = typrotosByAttr env n
+  where pcons                       = typrotosByAttr env n ++ importedProtoAttr env n
 
 
 ----------------------------------------------------------------------------------------------------------------------
@@ -769,6 +772,10 @@ solveMutAttr (wf,sc,dec) c@(Mut info env t1 n t2)
 -- witness lookup
 ----------------------------------------------------------------------------------------------------------------------
 
+-- Search the type-keyed bucket (witsByTName) for concrete goals: those buckets
+-- are small and enumerated lazily, so we never force the whole, ever-growing
+-- proto-keyed list. Only the rare TFX goal falls back to the proto-keyed bucket.
+-- Imported witnesses are merged in lazily by witsByTName/witsByPName.
 findWitness                 :: Env -> Type -> PCon -> [Witness]
 findWitness env t p         = filter match $ candidates t
   where eqhead (TCon _ c) (TCon _ c')   = tcname c == tcname c'
@@ -782,7 +789,7 @@ findWitness env t p         = filter match $ candidates t
 
 findProtoByAttr env cn n    = case filter hasAttr $ witsByTName env cn of
                                 [] -> Nothing
-                                ws -> Just $ schematic' $ proto (last ws)   -- newest matching witness, as before
+                                ws -> Just $ schematic' $ proto (last ws)   -- newest matching witness
   where hasAttr w           = n `elem` conAttrs env (tcname $ proto w)
 
 hasWitness                  :: Env -> Type -> PCon -> Bool

--- a/compiler/lib/src/Acton/Syntax.hs
+++ b/compiler/lib/src/Acton/Syntax.hs
@@ -187,7 +187,7 @@ qName ss s      = QName (modName ss) (name s)
 noQ s           = NoQ (name s)
 
 
-data ModuleItem = ModuleItem ModName (Maybe Name) deriving (Show,Eq,Read,NFData,Generic)
+data ModuleItem = ModuleItem ModName (Maybe ModName) deriving (Show,Eq,Read,NFData,Generic)
 data ModRef     = ModRef (Int, Maybe ModName) deriving (Show,Eq,Read,NFData,Generic)
 data ImportItem = ImportItem Name (Maybe Name) deriving (Show,Eq,Read,NFData,Generic)
 data Branch     = Branch Expr Suite deriving (Show,Eq,Read,NFData,Generic)

--- a/compiler/lib/src/Acton/Syntax.hs
+++ b/compiler/lib/src/Acton/Syntax.hs
@@ -26,7 +26,7 @@ import Control.DeepSeq
 import Prelude hiding((<>))
 
 version :: [Int]
-version = [0,28]
+version = [0,29]
 
 data Module     = Module        { modname::ModName, imps::[Import], mdoc::Maybe String, mbody::Suite } deriving (Eq,Show,Generic,NFData)
 

--- a/compiler/lib/src/Acton/Syntax.hs
+++ b/compiler/lib/src/Acton/Syntax.hs
@@ -26,13 +26,13 @@ import Control.DeepSeq
 import Prelude hiding((<>))
 
 version :: [Int]
-version = [0,29]
+version = [0,30]
 
 data Module     = Module        { modname::ModName, imps::[Import], mdoc::Maybe String, mbody::Suite } deriving (Eq,Show,Generic,NFData)
 
 data Import     = Import        { iloc::SrcLoc, moduls::[ModuleItem] }
-                | FromImport    { iloc::SrcLoc, modul::ModRef, items::[ImportItem] }
-                | FromImportAll { iloc::SrcLoc, modul::ModRef }
+                | FromImport    { iloc::SrcLoc, modul::ModName, items::[ImportItem] }
+                | FromImportAll { iloc::SrcLoc, modul::ModName }
                 deriving (Show,Read,NFData,Generic)
 
 type Suite      = [Stmt]
@@ -188,7 +188,6 @@ noQ s           = NoQ (name s)
 
 
 data ModuleItem = ModuleItem ModName (Maybe ModName) deriving (Show,Eq,Read,NFData,Generic)
-data ModRef     = ModRef (Int, Maybe ModName) deriving (Show,Eq,Read,NFData,Generic)
 data ImportItem = ImportItem Name (Maybe Name) deriving (Show,Eq,Read,NFData,Generic)
 data Branch     = Branch Expr Suite deriving (Show,Eq,Read,NFData,Generic)
 data Handler    = Handler Except Suite deriving (Show,Eq,Read,NFData,Generic)
@@ -566,8 +565,6 @@ instance Data.Binary.Binary ModuleItem
 instance Persist ModuleItem
 instance Data.Binary.Binary ImportItem
 instance Persist ImportItem
-instance Data.Binary.Binary ModRef
-instance Persist ModRef
 
 
 -- Locations ----------------
@@ -814,13 +811,10 @@ importsOf (Module _ imps _ _)       = impsOf imps
   where
     impsOf []                       = []
     impsOf (Import _ mis : i)       = map mName mis ++ impsOf i
-    impsOf (FromImport _ mr _ : i)  = mRef mr : impsOf i
-    impsOf (FromImportAll _ mr : i) = mRef mr : impsOf i
+    impsOf (FromImport _ mn _ : i)  = mn : impsOf i
+    impsOf (FromImportAll _ mn : i) = mn : impsOf i
 
     mName (ModuleItem qn _)         = qn
-
-    mRef (ModRef (0,Just qn))       = qn
-    mRef _                          = error "dot prefix in name of import modules not supported"
 
 unop op e                           = UnOp l0 op e
 binop e1 op e2                      = BinOp l0 e1 op e2

--- a/compiler/lib/src/Acton/TypeEnv.hs
+++ b/compiler/lib/src/Acton/TypeEnv.hs
@@ -270,19 +270,19 @@ tyactorsAll env                 = [ c | tid <- IntSet.toAscList (tyactors x), Ju
 
 
 tydefine                        :: TEnv -> Env -> Env
-tydefine te env                 = modX (define te env) (setupCons f te . setupWits addActiveWit NoQ te)
+tydefine te env                 = modX (define te env) (setupCons f te . setupWits addActiveWit te)
   where f                       = if inBuiltin env then GName mBuiltin else NoQ
 
 tydefineClosed                  :: TEnv -> Env -> Env
-tydefineClosed te env           = modX (defineClosed te env) (setupCons f te . setupWits addClosedWit NoQ te)
+tydefineClosed te env           = modX (defineClosed te env) (setupCons f te . setupWits addClosedWit te)
   where f                       = if inBuiltin env then GName mBuiltin else NoQ
 
 setupCons                       :: (Name -> QName) -> TEnv -> TypeX -> TypeX
 setupCons f te x                = foldl' (addconinfo f) x te
  
-setupWits                       :: (TypeX -> Witness -> TypeX) -> (Name -> QName) -> TEnv -> TypeX -> TypeX
-setupWits add f te x            = foldl' add x wits
-  where wits                    = [ WClass q (tCon c) p (f n) ws (length opts) | (n, NExt q c ps te' opts _) <- te, (ws,p) <- ps ]
+setupWits                       :: (TypeX -> Witness -> TypeX) -> TEnv -> TypeX -> TypeX
+setupWits add te x              = foldl' add x wits
+  where wits                    = [ WClass q (tCon c) p (NoQ n) ws (length opts) | (n, NExt q c ps _ opts _) <- te, (ws,p) <- ps ]
 
 addvarinfo x (tv, c, _)         = x{ tyids = Map.insert qn tid (tyids x),
                                      tyidHash = HashMap.insert qn tid (tyidHash x),

--- a/compiler/lib/src/Acton/TypeEnv.hs
+++ b/compiler/lib/src/Acton/TypeEnv.hs
@@ -374,8 +374,7 @@ importedUnique                  :: Env -> [Witness] -> [Witness]
 importedUnique env              = reverse . uniqueWits env
 
 -- Witnesses read from interfaces may name the same protocol or type in
--- aliased and unaliased form, so queries try both and results are deduped
--- under unaliasing.
+-- aliased and unaliased form, so queries try both forms.
 queryQNames                     :: Env -> QName -> [QName]
 queryQNames env qn
   | qn' == qn                   = [qn]
@@ -387,8 +386,7 @@ uniqueWits env                  = reverse . foldl' add []
   where add ws w
           | any (same w) ws     = ws
           | otherwise           = w : ws
-        same w w'               = tcname (unalias env $ proto w) == tcname (unalias env $ proto w') &&
-                                  unalias env (wtype w) == unalias env (wtype w')
+        same w w'               = tcname (proto w) == tcname (proto w') && wtype w == wtype w'
 
 limitQuant                      :: TUni -> Env -> Env
 limitQuant (UV _ l _) env

--- a/compiler/lib/src/Acton/TypeEnv.hs
+++ b/compiler/lib/src/Acton/TypeEnv.hs
@@ -971,7 +971,6 @@ instance USubst NameInfo where
     usubstWith s (NExt q c ps te opts doc) = NExt (usubstWith s q) (usubstWith s c) (usubstWith s ps) (usubstWith s te) opts doc
     usubstWith s (NTVar k c ps)       = NTVar k (usubstWith s c) (usubstWith s ps)
     usubstWith s (NAlias qn)          = NAlias qn
-    usubstWith s (NMAlias m)          = NMAlias m
     usubstWith s NReserved            = NReserved
 
 instance USubst Witness where

--- a/compiler/lib/src/Acton/TypeEnv.hs
+++ b/compiler/lib/src/Acton/TypeEnv.hs
@@ -972,8 +972,10 @@ instance USubst NameInfo where
     usubstWith s (NTVar k c ps)       = NTVar k (usubstWith s c) (usubstWith s ps)
     usubstWith s (NAlias qn)          = NAlias qn
     usubstWith s (NMAlias m)          = NMAlias m
-    usubstWith s (NModule ms te doc)  = NModule ms te doc       -- actually usubstWith s te, but te has no free variables (top-level)
     usubstWith s NReserved            = NReserved
+
+instance USubst NModule where
+    usubstWith s (NModule ms te doc)  = NModule ms te doc       -- actually usubstWith s te, but te has no free variables (top-level)
 
 instance USubst Witness where
     usubstWith s w@WClass{}           = w                               -- A WClass (i.e., an extension) can't have any free type variables

--- a/compiler/lib/src/Acton/TypeEnv.hs
+++ b/compiler/lib/src/Acton/TypeEnv.hs
@@ -80,8 +80,11 @@ type Env                        = EnvF TypeX
 type WitMap                     = Map QName (Seq.Seq Witness)
 type TyAttrMap                  = Map Name IntSet
 
+-- Imported modules are not preloaded here: witsByPName/witsByTName merge in
+-- imported witnesses per query, and the tyids/tyinfos lattice only covers
+-- local definitions.
 initTypeEnv                     :: Env0 -> Env
-initTypeEnv env0                = setX env0 $ foldl' importInfo x0 imps
+initTypeEnv env0                = setX env0 x0
   where x0                      = TypeX {
                                     activeWits  = [],
                                     closedWits  = primWits,
@@ -101,10 +104,6 @@ initTypeEnv env0                = setX env0 $ foldl' importInfo x0 imps
                                     tyconAttrs  = Map.empty,
                                     typrotoAttrs= Map.empty
                                   }
-        importInfo x (m,te)     = setupCons f te $ setupWits addClosedWit f te x
-          where f               = GName m
-        imps | inBuiltin env0   = []
-             | otherwise        = [ (m, fromJust $ lookupMod m env0) | m <- transitiveImports env0 ]
 
 
 tyinfos0                        = IntMap.fromDistinctAscList pairs
@@ -176,13 +175,18 @@ addconinfo f x (n,i)
                                      typrotoAttrs = addTyAttrs tid (tyattrs info) (typrotoAttrs x) }
         addactor tid info x     = addclass tid info x{ tyactors = IntSet.insert tid (tyactors x) }
 
+        -- Local definitions populate the type-id lattice (used for solver
+        -- candidate enumeration of local types). Imported ancestors are not
+        -- registered in tyids, so the ancestor lookup is guarded and they
+        -- contribute no ids or attrs here; imported candidates come from the
+        -- per-module indexes instead.
         addcon n q us te index x
                                   = index tid info x{ tyids = Map.insert qn tid (tyids x),
                                                       tyidHash = HashMap.insert qn tid (tyidHash x),
                                                       tyinfos = IntMap.insert tid info tyinfos' }
           where tid             = nextid x
                 qn              = f n
-                ui              = [ typeId x (tcname c) | (_,c) <- us ]
+                ui              = [ u | (_,c) <- us, Just u <- [Map.lookup (tcname c) (tyids x)] ]
                 info            = TyInfo {
                                     tywild = tCon $ TC qn [ tWild | _ <- q ],
                                     tyabove = IntSet.fromList ui,
@@ -285,14 +289,14 @@ addvarinfo x (tv, c, _)         = x{ tyids = Map.insert qn tid (tyids x),
                                      tyinfos = IntMap.insert tid info tyinfos' }
   where tid                     = nextid x
         qn                      = NoQ $ tvname tv
-        ci                      = tyinfos x IntMap.! typeId x (tcname c)
+        ci                      = Map.lookup (tcname c) (tyids x) >>= \i -> IntMap.lookup i (tyinfos x)
         info                    = TyInfo {
                                     tywild = tVar tv,
-                                    tyabove = IntSet.insert tid $ tyabove ci,
+                                    tyabove = maybe (IntSet.singleton tid) (IntSet.insert tid . tyabove) ci,
                                     tybelow = IntSet.singleton tid,
-                                    tyattrs = tyattrs ci
+                                    tyattrs = maybe Set.empty tyattrs ci
                                   }
-        tyinfos'                = IntSet.foldr' (IntMap.adjust addbelow) (tyinfos x) (tyabove ci)
+        tyinfos'                = maybe (tyinfos x) (\i -> IntSet.foldr' (IntMap.adjust addbelow) (tyinfos x) (tyabove i)) ci
         addbelow info           = info{ tybelow = IntSet.insert tid (tybelow info) }
 
 tydefineVars                    :: QBinds -> Env -> Env
@@ -340,20 +344,51 @@ wtypeKey (TCon _ c)             = Just (tcname c)
 wtypeKey (TVar _ v)             = Just (NoQ $ tvname v)
 wtypeKey _                      = Nothing
 
--- Closed witnesses precede active ones: combined with oldest-first buckets this
--- equals the reverse of the old newest-first active++closed enumeration, which
--- is the order the (previously reversing) consumers rely on.
+-- Buckets are stored oldest-first (Seq append) and enumerated lazily,
+-- closed-then-active, so consumers can stop early without forcing the whole
+-- ever-growing bucket. This is exactly the order the old code produced by
+-- storing newest-first and reversing both halves, but without the forcing.
 witsByPNameX x pn               = Data.Foldable.toList (Map.findWithDefault Seq.empty pn (closedWitMap x)) ++
                                   Data.Foldable.toList (Map.findWithDefault Seq.empty pn (activeWitMap x))
 
 witsByTNameX x tn               = Data.Foldable.toList (Map.findWithDefault Seq.empty tn (closedWitTypeMap x)) ++
                                   Data.Foldable.toList (Map.findWithDefault Seq.empty tn (activeWitTypeMap x))
 
+-- Local witnesses are already unique (deduped on insertion via hasWit), so they
+-- are presented as-is and kept lazy -- re-deduping the ever-growing local bucket
+-- with uniqueWits is the O(n^2) cost that previously stalled large modules. Only
+-- the small imported set, possibly read via aliased and unaliased queries, needs
+-- deduping. Imported witnesses take the leading (closed) position the preloaded
+-- environment used to give them, so enumeration order matches the in-memory case.
 witsByPName                     :: Env -> QName -> [Witness]
-witsByPName env pn              = witsByPNameX (envX env) pn
+witsByPName env pn              = importedUnique env imported ++ witsByPNameX (envX env) pn
+  where imported                = concat [ moduleWitnessesByProto mi qn | mi <- importedModuleInfos env, qn <- queryQNames env pn ]
 
 witsByTName                     :: Env -> QName -> [Witness]
-witsByTName env tn              = witsByTNameX (envX env) tn
+witsByTName env tn              = importedUnique env imported ++ witsByTNameX (envX env) tn
+  where imported                = concat [ moduleWitnessesByType mi qn | mi <- importedModuleInfos env, qn <- queryQNames env tn ]
+
+-- Deduplicate the imported witnesses, preserving the leading position the legacy
+-- (newest-first, reversed) enumeration gave them.
+importedUnique                  :: Env -> [Witness] -> [Witness]
+importedUnique env              = reverse . uniqueWits env
+
+-- Witnesses read from interfaces may name the same protocol or type in
+-- aliased and unaliased form, so queries try both and results are deduped
+-- under unaliasing.
+queryQNames                     :: Env -> QName -> [QName]
+queryQNames env qn
+  | qn' == qn                   = [qn]
+  | otherwise                   = [qn, qn']
+  where qn'                     = unalias env qn
+
+uniqueWits                      :: Env -> [Witness] -> [Witness]
+uniqueWits env                  = reverse . foldl' add []
+  where add ws w
+          | any (same w) ws     = ws
+          | otherwise           = w : ws
+        same w w'               = tcname (unalias env $ proto w) == tcname (unalias env $ proto w') &&
+                                  unalias env (wtype w) == unalias env (wtype w')
 
 limitQuant                      :: TUni -> Env -> Env
 limitQuant (UV _ l _) env

--- a/compiler/lib/src/Acton/TypeEnv.hs
+++ b/compiler/lib/src/Acton/TypeEnv.hs
@@ -974,9 +974,6 @@ instance USubst NameInfo where
     usubstWith s (NMAlias m)          = NMAlias m
     usubstWith s NReserved            = NReserved
 
-instance USubst NModule where
-    usubstWith s (NModule ms te doc)  = NModule ms te doc       -- actually usubstWith s te, but te has no free variables (top-level)
-
 instance USubst Witness where
     usubstWith s w@WClass{}           = w                               -- A WClass (i.e., an extension) can't have any free type variables
     usubstWith s w@WInst{}            = w{ wtype  = usubstWith s (wtype w), proto = usubstWith s (proto w) }

--- a/compiler/lib/src/Acton/TypeEnv.hs
+++ b/compiler/lib/src/Acton/TypeEnv.hs
@@ -262,8 +262,8 @@ tvarsInTids env tids            = [ TV k n | (n, k, c) <- activeTypeVars env,
                                             c == c' ]
   where x                       = envX env
 
--- All actor types in scope, in definition order (imports first). Mirrors what
--- allTypes/allActors produce, without scanning the name environment.
+-- All actor types in scope, in definition order (imports first), without
+-- scanning the name environment.
 tyactorsAll                     :: Env -> [TCon]
 tyactorsAll env                 = [ c | tid <- IntSet.toAscList (tyactors x), Just c <- [conById x tid] ]
   where x                       = envX env

--- a/compiler/lib/src/Acton/Types.hs
+++ b/compiler/lib/src/Acton/Types.hs
@@ -64,8 +64,8 @@ data TypeErrors = TypeErrors [TypeError]
 
 instance Control.Exception.Exception TypeErrors
 
--- | Type-check a module and return its NameInfo, typed module, env, and discovered tests.
-reconstruct                             :: Maybe TypeProgressCallback -> Maybe TypeInferredCallback -> Env0 -> Module -> Maybe String -> IO (NameInfo, Module, Env0, [String])
+-- | Type-check a module and return its module NameInfo, typed module, env, and discovered tests.
+reconstruct                             :: Maybe TypeProgressCallback -> Maybe TypeInferredCallback -> Env0 -> Module -> Maybe String -> IO (NModule, Module, Env0, [String])
 reconstruct progressCb inferredCb env0 (Module m i mdoc ss) bareMod = do --traceM ("#################### original env0 for " ++ prstr m ++ ":")
                                              --traceM (render (pretty env0))
                                              (te,ss1) <- infTop progressCb inferredCb env1 ss

--- a/compiler/lib/src/InterfaceFiles.hs
+++ b/compiler/lib/src/InterfaceFiles.hs
@@ -93,6 +93,7 @@ module InterfaceFiles
   , SourceFileMeta(..)
   , TyFile
   , TyHeader
+  , TyHeaderSummary
   , InterfaceDB
   , interfaceExt
   , interfacePath
@@ -110,10 +111,13 @@ module InterfaceFiles
   , readModuleHashesMaybe
   , readFile
   , readHeader
+  , readHeaderSummary
+  , readRoots
   , readExtensionsByClass
   , readExtensionsByProtocol
   , readFileMaybe
   , readHeaderMaybe
+  , readHeaderSummaryMaybe
   , openInterfaceDB
   , openInterfaceDBMaybe
   , readInterfaceDBModuleInfo
@@ -256,6 +260,19 @@ type TyHeader =
   , [(A.ModName, BS.ByteString)]
   , [DepModuleInfo]
   , [NameHashInfo]
+  , [A.Name]
+  , [String]
+  , Maybe String
+  )
+
+type TyHeaderSummary =
+  ( Maybe SourceFileMeta
+  , BS.ByteString
+  , BS.ByteString
+  , BS.ByteString
+  , [(A.ModName, BS.ByteString)]
+  , [DepModuleInfo]
+  , Int
   , [A.Name]
   , [String]
   , Maybe String
@@ -1325,6 +1342,27 @@ readHeader f =
       traceTydbRead "name-hash-all" f (show (length nameHashes))
       return (sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash, imps, depModules, nameHashes, roots, tests, doc)
 
+-- Like readHeader, but reads the stored name count instead of decoding every
+-- per-name hash row, so cache checks stay independent of module size.
+readHeaderSummary :: FilePath -> IO TyHeaderSummary
+readHeaderSummary f =
+    withReadTxn f $ \txn dbi -> do
+      (sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash) <- readMeta txn dbi
+      imps <- getValue "imports" txn dbi keyImports
+      depModules <- getValue "deps" txn dbi keyDeps
+      roots <- getValue "roots" txn dbi keyRoots
+      tests <- getValue "tests" txn dbi keyTests
+      doc <- getValue "doc" txn dbi keyDoc
+      nameCount <- getValue "name-count" txn dbi keyNameCount
+      traceTydbRead "header" f "cached"
+      return (sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash, imps, depModules, nameCount, roots, tests, doc)
+
+readRoots :: FilePath -> IO [A.Name]
+readRoots f =
+    withReadTxn f $ \txn dbi -> do
+      validateVersion txn dbi
+      getValue "roots" txn dbi keyRoots
+
 readDepNames :: FilePath -> A.ModName -> IO [DepNameInfo]
 readDepNames f mn =
     withReadTxn f $ \txn dbi -> do
@@ -1384,6 +1422,9 @@ readFileMaybe = readTyMaybe readFile
 
 readHeaderMaybe :: FilePath -> IO (Maybe TyHeader)
 readHeaderMaybe = readTyMaybe readHeader
+
+readHeaderSummaryMaybe :: FilePath -> IO (Maybe TyHeaderSummary)
+readHeaderSummaryMaybe = readTyMaybe readHeaderSummary
 
 readTyMaybe :: (FilePath -> IO a) -> FilePath -> IO (Maybe a)
 readTyMaybe readTy f = (Just <$> readTy f) `E.catch` tyCacheMiss

--- a/compiler/lib/src/InterfaceFiles.hs
+++ b/compiler/lib/src/InterfaceFiles.hs
@@ -115,6 +115,7 @@ module InterfaceFiles
   , readFileMaybe
   , readHeaderMaybe
   , openInterfaceDB
+  , openInterfaceDBMaybe
   , readInterfaceDBModuleInfo
   , readInterfaceDBNameInfoMaybe
   , readInterfaceDBPublicNames
@@ -754,6 +755,11 @@ openInterfaceDB :: FilePath -> IO InterfaceDB
 openInterfaceDB path = do
     withReadTxn path validateVersion
     return (InterfaceDB path)
+
+-- | Like openInterfaceDB, but treats a missing, corrupt, or version-mismatched
+-- cache as a miss, mirroring readFileMaybe.
+openInterfaceDBMaybe :: FilePath -> IO (Maybe InterfaceDB)
+openInterfaceDBMaybe = readTyMaybe openInterfaceDB
 
 withInterfaceDBReadTxn :: InterfaceDB -> (LMDB.MDB_txn -> LMDB.MDB_dbi -> IO a) -> IO a
 withInterfaceDBReadTxn (InterfaceDB path) action = withReadTxn path action

--- a/compiler/lib/src/InterfaceFiles.hs
+++ b/compiler/lib/src/InterfaceFiles.hs
@@ -41,6 +41,9 @@
 --     "tests"          :: [String]                    -- discovered test names
 --     "doc"            :: Maybe String                -- module docstring
 --     "name-count"     :: Int                         -- number of NameInfo entries (see name-order)
+--     "public-names"   :: [A.Name]                    -- public top-level names, in TEnv order
+--     "constructors"   :: [A.Name]                    -- public class/protocol/actor names
+--     "actors"         :: [A.Name]                    -- public actor names
 --     "stmt-count"     :: Int                         -- number of typed top-level statements
 --     "module-header"  :: (A.ModName, Imports, Maybe String)
 --                                                     -- typed module name, imports, docstring
@@ -57,6 +60,13 @@
 --   Per-extension keys:
 --     "ext-by-class/<suffix>"       :: (A.Name, [A.Name]) -- class name to extension names
 --     "ext-by-protocol/<suffix>"    :: (A.Name, [A.Name]) -- protocol name to extension names
+--
+--   Per-query index keys:
+--     "con-attr/<suffix>"     :: [A.Name]             -- class/actor names declaring an attribute
+--     "proto-attr/<suffix>"   :: [A.Name]             -- protocol names declaring an attribute
+--     "descendants/<suffix>"  :: [A.Name]             -- class/protocol names below a constructor
+--     "ext-proto/<suffix>"    :: [A.Name]             -- extension names implementing a protocol
+--     "ext-type/<suffix>"     :: [A.Name]             -- extension names for a type/class
 --
 --   Per-statement keys (typed Module body):
 --     "stmt/<NNN>"     :: A.Stmt                      -- one typed top-level statement (NNN = padIndex)
@@ -83,6 +93,7 @@ module InterfaceFiles
   , SourceFileMeta(..)
   , TyFile
   , TyHeader
+  , InterfaceDB
   , interfaceExt
   , interfacePath
   , interfaceExists
@@ -103,6 +114,17 @@ module InterfaceFiles
   , readExtensionsByProtocol
   , readFileMaybe
   , readHeaderMaybe
+  , openInterfaceDB
+  , readInterfaceDBModuleInfo
+  , readInterfaceDBNameInfoMaybe
+  , readInterfaceDBPublicNames
+  , readInterfaceDBConstructors
+  , readInterfaceDBActors
+  , readInterfaceDBConAttr
+  , readInterfaceDBProtoAttr
+  , readInterfaceDBDescendants
+  , readInterfaceDBExtByProto
+  , readInterfaceDBExtByType
   , TyDbWriteProgress(..)
   , writeFile
   , writeFileWithProgress
@@ -132,6 +154,8 @@ import Data.Time.Clock (UTCTime)
 import qualified Database.LMDB.Raw as LMDB
 import qualified Acton.Syntax as A
 import qualified Acton.NameInfo as I
+import Acton.Names (isPublicName)
+import Utils (SrcLoc(NoLoc))
 import Foreign.Ptr (castPtr)
 import Foreign.Storable (peek)
 import GHC.Generics (Generic)
@@ -242,6 +266,14 @@ type TyMeta =
   , BS.ByteString
   , BS.ByteString
   )
+
+-- | A handle for selective per-name and per-index lookups in one module's
+-- .tydb: the version is validated once at open, and each lookup runs a short
+-- read transaction on the shared per-path environment.
+newtype InterfaceDB = InterfaceDB FilePath
+
+instance Show InterfaceDB where
+    show (InterfaceDB path) = "InterfaceDB " ++ path
 
 -- Note: tests are stored in the header to support listing without compiling
 --       or executing test binaries.
@@ -380,7 +412,7 @@ encodeStrict = Persist.encode
 key :: String -> BS.ByteString
 key = B.pack
 
-keyVersion, keyMeta, keyImports, keyDeps, keyRoots, keyTests, keyDoc, keyNameCount, keyStmtCount, keyModuleHeader :: BS.ByteString
+keyVersion, keyMeta, keyImports, keyDeps, keyRoots, keyTests, keyDoc, keyNameCount, keyPublicNames, keyConstructors, keyActors, keyStmtCount, keyModuleHeader :: BS.ByteString
 keyVersion      = key "version"
 keyMeta         = key "meta"
 keyImports      = key "imports"
@@ -389,6 +421,9 @@ keyRoots        = key "roots"
 keyTests        = key "tests"
 keyDoc          = key "doc"
 keyNameCount    = key "name-count"
+keyPublicNames  = key "public-names"
+keyConstructors = key "constructors"
+keyActors       = key "actors"
 keyStmtCount    = key "stmt-count"
 keyModuleHeader = key "module-header"
 
@@ -457,6 +492,39 @@ keyExtByProtocol n = B.concat [keyExtByProtocolPrefix, nameKeySuffix n]
 
 keyStmt :: Int -> BS.ByteString
 keyStmt i = B.pack ("stmt/" ++ padIndex i)
+
+keyConAttr :: A.Name -> BS.ByteString
+keyConAttr n = B.concat [key "con-attr/", nameKeySuffix n]
+
+keyProtoAttr :: A.Name -> BS.ByteString
+keyProtoAttr n = B.concat [key "proto-attr/", nameKeySuffix n]
+
+keyDescendants :: A.QName -> BS.ByteString
+keyDescendants qn = B.concat [key "descendants/", qNameKeySuffix qn]
+
+keyExtProto :: A.QName -> BS.ByteString
+keyExtProto qn = B.concat [key "ext-proto/", qNameKeySuffix qn]
+
+keyExtType :: A.QName -> BS.ByteString
+keyExtType qn = B.concat [key "ext-type/", qNameKeySuffix qn]
+
+-- QName keys hash a location-free encoding so the same semantic name always
+-- maps to the same key regardless of where it occurred in the source.
+qNameKeySuffix :: A.QName -> BS.ByteString
+qNameKeySuffix qn = Base16.encode (SHA256.hash (encodeStrict (stripQNameKeyLocs qn)))
+
+stripQNameKeyLocs :: A.QName -> A.QName
+stripQNameKeyLocs (A.QName m n) = A.QName (stripModNameKeyLocs m) (stripNameKeyLocs n)
+stripQNameKeyLocs (A.NoQ n)     = A.NoQ (stripNameKeyLocs n)
+stripQNameKeyLocs (A.GName m n) = A.GName (stripModNameKeyLocs m) (stripNameKeyLocs n)
+
+stripModNameKeyLocs :: A.ModName -> A.ModName
+stripModNameKeyLocs (A.ModName ns) = A.ModName (map stripNameKeyLocs ns)
+
+stripNameKeyLocs :: A.Name -> A.Name
+stripNameKeyLocs (A.Name _ s)     = A.Name NoLoc s
+stripNameKeyLocs (A.Derived n n') = A.Derived (stripNameKeyLocs n) (stripNameKeyLocs n')
+stripNameKeyLocs n@A.Internal{}   = n
 
 withVal :: BS.ByteString -> (LMDB.MDB_val -> IO a) -> IO a
 withVal bs f =
@@ -682,6 +750,14 @@ withWriteTxn path mapSize action =
           LMDB.mdb_txn_commit txn
           return r
 
+openInterfaceDB :: FilePath -> IO InterfaceDB
+openInterfaceDB path = do
+    withReadTxn path validateVersion
+    return (InterfaceDB path)
+
+withInterfaceDBReadTxn :: InterfaceDB -> (LMDB.MDB_txn -> LMDB.MDB_dbi -> IO a) -> IO a
+withInterfaceDBReadTxn (InterfaceDB path) action = withReadTxn path action
+
 -- The raw LMDB binding requires transaction setup from a bound thread; this
 -- applies to reads too because of its Haskell-side lock guard.
 runInLmdbThread :: IO a -> IO a
@@ -843,6 +919,80 @@ readNameInfoEntries txn dbi = do
     forM [0 .. nameCount - 1] $ \i -> do
       suffix <- getValue ("name-order " ++ show i) txn dbi (keyNameOrder i)
       getValue ("name-info " ++ show i) txn dbi (keyNameInfoSuffix suffix)
+
+readNameInfoEntryMaybe :: LMDB.MDB_txn -> LMDB.MDB_dbi -> A.Name -> IO (Maybe (A.Name, I.NameInfo))
+readNameInfoEntryMaybe txn dbi n =
+    getMaybeValue ("name-info " ++ A.nstr n) txn dbi (keyNameInfo n)
+
+readNameInfoEntriesByNames :: LMDB.MDB_txn -> LMDB.MDB_dbi -> [A.Name] -> IO I.TEnv
+readNameInfoEntriesByNames txn dbi ns =
+    forM ns $ \n ->
+      getValue ("name-info " ++ A.nstr n) txn dbi (keyNameInfo n)
+
+readInterfaceDBModuleInfo :: InterfaceDB -> IO ([A.ModName], Maybe String)
+readInterfaceDBModuleInfo db =
+    withInterfaceDBReadTxn db $ \txn dbi -> do
+      (tmn, timps, tdoc) <- getValue "module-header" txn dbi keyModuleHeader
+      doc <- getValue "doc" txn dbi keyDoc
+      return (A.importsOf (A.Module tmn timps tdoc []), doc)
+
+readInterfaceDBNameInfoMaybe :: InterfaceDB -> A.Name -> IO (Maybe (A.Name, I.NameInfo))
+readInterfaceDBNameInfoMaybe db@(InterfaceDB path) n = do
+    mi <- withInterfaceDBReadTxn db $ \txn dbi ->
+            readNameInfoEntryMaybe txn dbi n
+    traceTydbRead (case mi of Just _ -> "name-hit"; Nothing -> "name-miss") path (A.nstr n)
+    return mi
+
+readInterfaceDBPublicNames :: InterfaceDB -> IO [A.Name]
+readInterfaceDBPublicNames db@(InterfaceDB path) = do
+    ns <- withInterfaceDBReadTxn db $ \txn dbi ->
+            getValue "public-names" txn dbi keyPublicNames
+    traceTydbRead "public-names" path (show (length ns))
+    return ns
+
+readInterfaceDBConstructors :: InterfaceDB -> IO I.TEnv
+readInterfaceDBConstructors db@(InterfaceDB path) = do
+    te <- withInterfaceDBReadTxn db $ \txn dbi -> do
+            ns <- getValue "constructors" txn dbi keyConstructors
+            readNameInfoEntriesByNames txn dbi ns
+    traceTydbRead "constructors" path (show (length te))
+    return te
+
+readInterfaceDBActors :: InterfaceDB -> IO I.TEnv
+readInterfaceDBActors db@(InterfaceDB path) = do
+    te <- withInterfaceDBReadTxn db $ \txn dbi -> do
+            ns <- getValue "actors" txn dbi keyActors
+            readNameInfoEntriesByNames txn dbi ns
+    traceTydbRead "actors" path (show (length te))
+    return te
+
+readInterfaceDBConAttr :: InterfaceDB -> A.Name -> IO I.TEnv
+readInterfaceDBConAttr db n =
+    readTEnvIndex db ("con-attr " ++ A.nstr n) (keyConAttr n)
+
+readInterfaceDBProtoAttr :: InterfaceDB -> A.Name -> IO I.TEnv
+readInterfaceDBProtoAttr db n =
+    readTEnvIndex db ("proto-attr " ++ A.nstr n) (keyProtoAttr n)
+
+readInterfaceDBDescendants :: InterfaceDB -> A.QName -> IO I.TEnv
+readInterfaceDBDescendants db qn =
+    readTEnvIndex db ("descendants " ++ show qn) (keyDescendants qn)
+
+readInterfaceDBExtByProto :: InterfaceDB -> A.QName -> IO I.TEnv
+readInterfaceDBExtByProto db qn =
+    readTEnvIndex db ("ext-proto " ++ show qn) (keyExtProto qn)
+
+readInterfaceDBExtByType :: InterfaceDB -> A.QName -> IO I.TEnv
+readInterfaceDBExtByType db qn =
+    readTEnvIndex db ("ext-type " ++ show qn) (keyExtType qn)
+
+readTEnvIndex :: InterfaceDB -> String -> BS.ByteString -> IO I.TEnv
+readTEnvIndex db@(InterfaceDB path) label k = do
+    te <- withInterfaceDBReadTxn db $ \txn dbi -> do
+            ns <- maybe [] id <$> getMaybeValue label txn dbi k
+            readNameInfoEntriesByNames txn dbi ns
+    traceTydbRead "index" path (label ++ " " ++ show (length te))
+    return te
 
 readNameHashEntries :: LMDB.MDB_txn -> LMDB.MDB_dbi -> IO [NameHashInfo]
 readNameHashEntries txn dbi = do
@@ -1010,6 +1160,62 @@ depIndexEntries depModules nameHashes =
         | (key', (_pubH, _implH, pubUsers, implUsers)) <- Map.toList depMap
         ]
 
+-- Narrow per-module query indexes, so dependent modules can answer solver and
+-- environment queries (attribute owners, descendants, extensions) without
+-- enumerating the whole public interface.
+data QueryIndexes = QueryIndexes
+  { qiPublicNames :: [A.Name]
+  , qiConstructors :: [A.Name]
+  , qiActors :: [A.Name]
+  , qiConAttrs :: Map.Map A.Name [A.Name]
+  , qiProtoAttrs :: Map.Map A.Name [A.Name]
+  , qiDescendants :: Map.Map A.QName [A.Name]
+  , qiExtProtos :: Map.Map A.QName [A.Name]
+  , qiExtTypes :: Map.Map A.QName [A.Name]
+  }
+
+queryIndexes :: I.NameInfo -> QueryIndexes
+queryIndexes (I.NModule _ te _) = QueryIndexes (map fst pte) cons actors conattrs protoattrs descendants extprotos exttypes
+  where pte                    = filter (isPublicName . fst) te
+        cons                   = [ n | (n, i) <- pte, isCons i ]
+        actors                 = [ n | (n, I.NAct{}) <- pte ]
+        conattrs               = indexMap [ (a, n) | (n, i) <- pte, isCon i, a <- attrs i ]
+        protoattrs             = indexMap [ (a, n) | (n, i@I.NProto{}) <- pte, a <- attrs i ]
+        descendants            = indexMap [ (A.tcname c, n) | (n, i) <- pte, (_, c) <- ancestry i ]
+        extprotos              = indexMap [ (A.tcname p, n) | (n, I.NExt _ _ ps _ _ _) <- pte, (_, p) <- ps ]
+        exttypes               = indexMap [ (A.tcname c, n) | (n, I.NExt _ c _ _ _ _) <- pte ]
+        isCons I.NClass{}      = True
+        isCons I.NProto{}      = True
+        isCons I.NAct{}        = True
+        isCons _               = False
+        isCon I.NClass{}       = True
+        isCon I.NAct{}         = True
+        isCon _                = False
+        attrs (I.NClass _ _ te' _) = map fst te'
+        attrs (I.NProto _ _ te' _) = map fst te'
+        attrs (I.NAct _ _ _ te' _) = map fst te'
+        attrs _                = []
+        ancestry (I.NClass _ us _ _) = us
+        ancestry (I.NProto _ us _ _) = us
+        ancestry _             = []
+queryIndexes _                  = QueryIndexes [] [] [] Map.empty Map.empty Map.empty Map.empty Map.empty
+
+indexMap :: Ord k => [(k, A.Name)] -> Map.Map k [A.Name]
+indexMap xs = Map.fromListWith (++) [ (k, [v]) | (k, v) <- reverse xs ]
+
+queryIndexEntries :: I.NameInfo -> [(BS.ByteString, BS.ByteString)]
+queryIndexEntries nmod =
+    [ (keyPublicNames, encodeStrict (qiPublicNames ix))
+    , (keyConstructors, encodeStrict (qiConstructors ix))
+    , (keyActors, encodeStrict (qiActors ix))
+    ]
+    ++ [ (keyConAttr n, encodeStrict ns) | (n, ns) <- Map.toList (qiConAttrs ix) ]
+    ++ [ (keyProtoAttr n, encodeStrict ns) | (n, ns) <- Map.toList (qiProtoAttrs ix) ]
+    ++ [ (keyDescendants qn, encodeStrict ns) | (qn, ns) <- Map.toList (qiDescendants ix) ]
+    ++ [ (keyExtProto qn, encodeStrict ns) | (qn, ns) <- Map.toList (qiExtProtos ix) ]
+    ++ [ (keyExtType qn, encodeStrict ns) | (qn, ns) <- Map.toList (qiExtTypes ix) ]
+  where ix = queryIndexes nmod
+
 interfaceEntries :: (String -> Double -> IO ()) -> [Int] -> BS.ByteString -> BS.ByteString -> BS.ByteString -> Maybe SourceFileMeta -> [(A.ModName, BS.ByteString)] -> [DepModuleInfo] -> [NameHashInfo] -> [A.Name] -> [String] -> Maybe String -> I.NameInfo -> A.Module -> IO [(BS.ByteString, BS.ByteString)]
 interfaceEntries onProgress version moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta imps depModules nameHashes roots tests mdoc nmod tchecked = do
     caps <- getNumCapabilities
@@ -1027,7 +1233,7 @@ interfaceEntries onProgress version moduleSrcBytesHash modulePubHash moduleImplH
         nameChunks = entryChunks caps (zip [0..] te)
         nameHashChunks = entryChunks caps nameHashes
         stmtChunks = entryChunks caps (zip [0..] body)
-        totalPrep = 3 + length nameChunks + length nameHashChunks + length stmtChunks
+        totalPrep = 4 + length nameChunks + length nameHashChunks + length stmtChunks
     prepDone <- newIORef (0 :: Int)
     let mark label = do
           done <- atomicModifyIORef' prepDone $ \n ->
@@ -1038,12 +1244,14 @@ interfaceEntries onProgress version moduleSrcBytesHash modulePubHash moduleImplH
     mark "Preparing .tydb header"
     depEntries <- forceEntries (depIndexEntries depModules nameHashes)
     mark "Preparing .tydb deps"
+    queryEntries <- forceEntries (queryIndexEntries nmod)
+    mark "Preparing .tydb query indexes"
     nameEntries <- parallelEntries mark "Preparing .tydb names" nameInfoEntries nameChunks
     nameHashEntries <- parallelEntries mark "Preparing .tydb hashes" nameHashEntry nameHashChunks
     extEntries <- forceEntries (extensionIndexEntries (extensionIndexFromNameInfo tmn nmod))
     mark "Preparing .tydb extensions"
     stmtEntries <- parallelEntries mark "Preparing .tydb statements" stmtEntry stmtChunks
-    return (headerEntries ++ depEntries ++ nameEntries ++ nameHashEntries ++ extEntries ++ stmtEntries)
+    return (headerEntries ++ depEntries ++ queryEntries ++ nameEntries ++ nameHashEntries ++ extEntries ++ stmtEntries)
   where
     I.NModule _ te _ = nmod
     A.Module tmn timps tdoc body = tchecked

--- a/compiler/lib/src/InterfaceFiles.hs
+++ b/compiler/lib/src/InterfaceFiles.hs
@@ -114,7 +114,7 @@ import Control.DeepSeq (NFData, rnf)
 import qualified Control.Exception as E
 import Control.Concurrent (getNumCapabilities, runInBoundThread, threadDelay)
 import Control.Concurrent.Async (mapConcurrently)
-import Control.Concurrent.MVar (MVar, modifyMVar, newMVar, withMVar)
+import Control.Concurrent.MVar (MVar, modifyMVar, modifyMVar_, newMVar, withMVar)
 import Control.Monad (forM, forM_, unless, when)
 import Data.IORef (atomicModifyIORef', newIORef)
 import qualified Crypto.Hash.SHA256 as SHA256
@@ -141,7 +141,7 @@ import System.FilePath ((</>), addTrailingPathSeparator, normalise, takeDirector
 import System.IO (hPutStrLn, stderr)
 import System.IO.Error (isDoesNotExistError)
 import System.IO.Unsafe (unsafePerformIO)
-import System.Posix.Files (getFileStatus, modificationTimeHiRes, setFileMode)
+import System.Posix.Files (deviceID, fileAccess, fileID, getFileStatus, modificationTimeHiRes, setFileMode)
 
 data NameHashInfo = NameHashInfo
   { nhName     :: A.Name
@@ -263,8 +263,13 @@ lmdbOpenLock :: MVar ()
 {-# NOINLINE lmdbOpenLock #-}
 lmdbOpenLock = unsafePerformIO (newMVar ())
 
--- LMDB does not support opening the same environment twice in one process, so
--- keep one in-process lock per .tydb path while an environment handle is open.
+-- LMDB does not support opening the same environment twice in one process.
+-- Exclusive users (writers, env copies) serialize on a per-path lock and own
+-- the only environment while they run. Readers share one cached read-only
+-- environment per path, tracked in sharedEnvs with an active-reader count;
+-- exclusive users retire the cached environment and wait for its readers to
+-- drain before opening their own, so the process never holds two
+-- environments for one path.
 interfaceLocks :: MVar (Map.Map FilePath (MVar ()))
 {-# NOINLINE interfaceLocks #-}
 interfaceLocks = unsafePerformIO (newMVar Map.empty)
@@ -281,6 +286,27 @@ registerSystemTypeRoots roots =
     addRoot acc root
       | root `elem` acc = acc
       | otherwise       = root : acc
+
+data SharedEnv = SharedEnv
+  { seEnv :: LMDB.MDB_env
+  , seIdent :: Maybe (Integer, Integer)
+  , seReaders :: Int
+  , seRetiring :: Bool
+  }
+
+data SharedEnvClaim = Claimed SharedEnv | Retiring | Absent
+
+-- Identify the data file behind a path, so a cached environment whose file
+-- was removed and recreated (a new inode) is not mistaken for current.
+envFileIdent :: FilePath -> IO (Maybe (Integer, Integer))
+envFileIdent path =
+    (do st <- getFileStatus (dataFilePath path)
+        return (Just (fromIntegral (deviceID st), fromIntegral (fileID st))))
+      `E.catch` \e -> if isDoesNotExistError e then return Nothing else E.throwIO e
+
+sharedEnvs :: MVar (Map.Map FilePath SharedEnv)
+{-# NOINLINE sharedEnvs #-}
+sharedEnvs = unsafePerformIO (newMVar Map.empty)
 
 traceTydbReads :: Bool
 traceTydbReads =
@@ -442,11 +468,16 @@ copyVal (LMDB.MDB_val len ptr) =
     BS.packCStringLen (castPtr ptr, fromIntegral len)
 
 withEnv :: FilePath -> Bool -> Int -> (LMDB.MDB_env -> IO a) -> IO a
-withEnv path readOnly mapSize action =
-    withInterfaceLock path $
-      E.bracket open LMDB.mdb_env_close action
+withEnv path readOnly mapSize action = do
+    cpath <- canonicalizePath path
+    withInterfaceLockC cpath $ do
+      evictSharedEnv cpath
+      E.bracket (openEnvWithRetry path readOnly mapSize) LMDB.mdb_env_close action
+
+openEnvWithRetry :: FilePath -> Bool -> Int -> IO LMDB.MDB_env
+openEnvWithRetry path readOnly mapSize =
+    withMVar lmdbOpenLock $ \_ -> openWithRetry lmdbTransientMaxAttempts
   where
-    open = withMVar lmdbOpenLock $ \_ -> openWithRetry lmdbTransientMaxAttempts
     -- Concurrent opens of the same env race on lock.mdb setup, which surfaces as
     -- a transient OS-level mdb_env_open failure (e.g. ENOENT) that resolves on
     -- retry. LMDB-semantic failures (corruption, version mismatch) are not
@@ -515,6 +546,10 @@ lmdbTransientRetryDelayUs = 20000
 withInterfaceLock :: FilePath -> IO a -> IO a
 withInterfaceLock path action = do
     cpath <- canonicalizePath path
+    withInterfaceLockC cpath action
+
+withInterfaceLockC :: FilePath -> IO a -> IO a
+withInterfaceLockC cpath action = do
     lock <- modifyMVar interfaceLocks $ \locks ->
       case Map.lookup cpath locks of
         Just lock -> return (locks, lock)
@@ -523,28 +558,119 @@ withInterfaceLock path action = do
           return (Map.insert cpath lock locks, lock)
     withMVar lock $ \_ -> action
 
+-- Claim the shared read environment for a path, opening it on first use. The
+-- open runs under the per-path lock so it cannot race an exclusive user; a
+-- retiring entry is waited out, since its last reader closes it.
+acquireSharedEnv :: FilePath -> FilePath -> IO LMDB.MDB_env
+acquireSharedEnv cpath path = do
+    ident <- envFileIdent path
+    claim <- claimSharedEnv cpath
+    case claim of
+      Claimed se
+        | seIdent se == ident -> return (seEnv se)
+        | otherwise -> do
+            -- The file behind the cached environment was replaced.
+            retireSharedEnv cpath
+            releaseSharedEnv cpath
+            acquireSharedEnv cpath path
+      Retiring -> threadDelay lmdbTransientRetryDelayUs >> acquireSharedEnv cpath path
+      Absent -> do
+        mopened <- withInterfaceLockC cpath $ do
+          claim' <- claimSharedEnv cpath
+          case claim' of
+            Claimed se -> return (Just (seEnv se))
+            Retiring -> return Nothing
+            Absent -> do
+              -- The binding adds MDB_NOTLS implicitly, so reader slots follow
+              -- transactions rather than the transient bound threads they run
+              -- on.
+              mapSize <- readMapSize path
+              env <- openEnvWithRetry path True mapSize
+              ident' <- envFileIdent path
+              modifyMVar_ sharedEnvs (return . Map.insert cpath (SharedEnv env ident' 1 False))
+              return (Just env)
+        case mopened of
+          Just env -> return env
+          Nothing -> threadDelay lmdbTransientRetryDelayUs >> acquireSharedEnv cpath path
+
+claimSharedEnv :: FilePath -> IO SharedEnvClaim
+claimSharedEnv cpath =
+    modifyMVar sharedEnvs $ \envs ->
+      case Map.lookup cpath envs of
+        Just se | not (seRetiring se) ->
+          return (Map.insert cpath se{ seReaders = seReaders se + 1 } envs, Claimed se)
+        Just _ -> return (envs, Retiring)
+        Nothing -> return (envs, Absent)
+
+releaseSharedEnv :: FilePath -> IO ()
+releaseSharedEnv cpath = do
+    mclose <- modifyMVar sharedEnvs $ \envs ->
+      case Map.lookup cpath envs of
+        Just se
+          | seReaders se <= 1 && seRetiring se -> return (Map.delete cpath envs, Just (seEnv se))
+          | otherwise -> return (Map.insert cpath se{ seReaders = seReaders se - 1 } envs, Nothing)
+        Nothing -> return (envs, Nothing)
+    mapM_ LMDB.mdb_env_close mclose
+
+-- Mark the shared environment stale (e.g. the map was grown by another
+-- process); the last reader closes it and the next acquire reopens.
+retireSharedEnv :: FilePath -> IO ()
+retireSharedEnv cpath = do
+    mclose <- modifyMVar sharedEnvs $ \envs ->
+      case Map.lookup cpath envs of
+        Just se
+          | seReaders se <= 0 -> return (Map.delete cpath envs, Just (seEnv se))
+          | otherwise -> return (Map.insert cpath se{ seRetiring = True } envs, Nothing)
+        Nothing -> return (envs, Nothing)
+    mapM_ LMDB.mdb_env_close mclose
+
+-- Exclusive users call this under the per-path lock: retire the shared
+-- environment and wait until its active readers have drained and closed it.
+evictSharedEnv :: FilePath -> IO ()
+evictSharedEnv cpath = do
+    retireSharedEnv cpath
+    waitGone
+  where
+    waitGone = do
+      gone <- withMVar sharedEnvs (return . Map.notMember cpath)
+      unless gone (threadDelay lmdbTransientRetryDelayUs >> waitGone)
+
 withReadTxn :: FilePath -> (LMDB.MDB_txn -> LMDB.MDB_dbi -> IO a) -> IO a
 withReadTxn path action = do
+    -- A genuinely absent data file is a cache miss, not an environmental error:
+    -- surface it as TyCacheInvalid so readFileMaybe/readHeaderMaybe report a miss
+    -- instead of letting mdb_env_open raise a raw "No such file or directory".
     exists <- doesFileExist (dataFilePath path)
     unless exists $
       E.throwIO (TyCacheInvalid ("Missing .tydb data file: " ++ dataFilePath path))
-    mapSize <- readMapSize path
-    -- mdb_txn_begin can still hit a transient lock-table OS error after a
-    -- successful env open, so retry the read transaction with a fresh env.
-    runInLmdbThread $ readTxnWithRetry lmdbTransientMaxAttempts mapSize
+    cpath <- canonicalizePath path
+    -- mdb_txn_begin can hit a transient lock-table OS error, and another
+    -- process may have grown the map since the shared environment was opened;
+    -- both retire the cached environment and retry with a fresh one.
+    runInLmdbThread $ readTxnWithRetry lmdbTransientMaxAttempts cpath
   where
-    readTxnWithRetry attempt mapSize = do
-      res <- withEnv path True mapSize $ \env ->
-        E.try $
-          E.bracket (LMDB.mdb_txn_begin env Nothing True) LMDB.mdb_txn_abort $ \txn -> do
-            dbi <- LMDB.mdb_dbi_open txn Nothing []
-            action txn dbi
+    readTxnWithRetry attempt cpath = do
+      env <- acquireSharedEnv cpath path
+      res <- (E.try $
+               E.bracket (LMDB.mdb_txn_begin env Nothing True) LMDB.mdb_txn_abort $ \txn -> do
+                 dbi <- LMDB.mdb_dbi_open txn Nothing []
+                 action txn dbi)
+             `E.onException` releaseSharedEnv cpath
       case res of
-        Right x -> return x
+        Right x -> releaseSharedEnv cpath >> return x
         Left (err :: LMDB.LMDB_Error)
-          | attempt > 1 && isTransientLmdbOsError err ->
-              threadDelay lmdbTransientRetryDelayUs >> readTxnWithRetry (attempt - 1) mapSize
-          | otherwise -> E.throwIO err
+          | attempt > 1 && (isTransientLmdbOsError err || isMapResized err) -> do
+              retireSharedEnv cpath
+              releaseSharedEnv cpath
+              threadDelay lmdbTransientRetryDelayUs
+              readTxnWithRetry (attempt - 1) cpath
+          | otherwise -> releaseSharedEnv cpath >> E.throwIO err
+
+isMapResized :: LMDB.LMDB_Error -> Bool
+isMapResized err =
+    case LMDB.e_code err of
+      Right LMDB.MDB_MAP_RESIZED -> True
+      _ -> False
 
 withWriteTxn :: FilePath -> Int -> (LMDB.MDB_txn -> LMDB.MDB_dbi -> IO a) -> IO a
 withWriteTxn path mapSize action =

--- a/compiler/lib/src/InterfaceFiles.hs
+++ b/compiler/lib/src/InterfaceFiles.hs
@@ -153,6 +153,7 @@ import qualified Data.Set
 import Data.List (foldl')
 import qualified Data.Map.Strict as Map
 import qualified Data.Persist as Persist
+import qualified Data.Set as Set
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import Data.Time.Clock (UTCTime)
@@ -1145,12 +1146,12 @@ depIndexEntries depModules nameHashes =
       where
         addToEntry Nothing =
           if isPub
-            then (Just h, Nothing, [owner], [])
-            else (Nothing, Just h, [], [owner])
+            then (Just h, Nothing, Set.singleton owner, Set.empty)
+            else (Nothing, Just h, Set.empty, Set.singleton owner)
         addToEntry (Just (pubH, implH, pubUsers, implUsers)) =
           if isPub
-            then (Just h, implH, owner : pubUsers, implUsers)
-            else (pubH, Just h, pubUsers, owner : implUsers)
+            then (Just h, implH, Set.insert owner pubUsers, implUsers)
+            else (pubH, Just h, pubUsers, Set.insert owner implUsers)
 
     depMap =
       foldl' addInfo Map.empty nameHashes
@@ -1175,7 +1176,7 @@ depIndexEntries depModules nameHashes =
             ]
       ]
 
-    cleanNames = Data.List.sortOn nameKey . Data.Set.toList . Data.Set.fromList
+    cleanNames = Data.List.sortOn nameKey . Set.toList
 
     userRows =
       sortUserRows

--- a/compiler/lib/src/InterfaceFiles.hs
+++ b/compiler/lib/src/InterfaceFiles.hs
@@ -154,6 +154,7 @@ import qualified Data.ByteString.Char8 as B
 import qualified Data.List
 import qualified Data.Set
 import Data.List (foldl')
+import qualified Data.IntSet as IntSet
 import qualified Data.Map.Strict as Map
 import qualified Data.Persist as Persist
 import qualified Data.Set as Set
@@ -1065,7 +1066,10 @@ readSelectedModule f nameHashes selected =
               traceTydbRead "stmt-index-miss" f (Data.List.intercalate "," (map A.nstr unusable))
               return Nothing
             else do
-              let indices = Data.List.sort $ Data.List.nub $ concat [ is | (_, Just is) <- owners ]
+              -- Selected names can cover most of a large module; dedup the
+              -- pooled statement indices with an IntSet (O(n log n)) rather than
+              -- Data.List.nub (O(n^2)). toAscList also yields them sorted.
+              let indices = IntSet.toAscList $ IntSet.fromList $ concat [ is | (_, Just is) <- owners ]
               stmts <- forM indices $ \i ->
                 getValue ("stmt " ++ show i) txn dbi (keyStmt i)
               traceTydbRead "stmts" f ("selected " ++ show (length names) ++ " -> " ++ show (length stmts))

--- a/compiler/lib/src/InterfaceFiles.hs
+++ b/compiler/lib/src/InterfaceFiles.hs
@@ -45,6 +45,7 @@
 --     "constructors"   :: [A.Name]                    -- public class/protocol/actor names
 --     "actors"         :: [A.Name]                    -- public actor names
 --     "stmt-count"     :: Int                         -- number of typed top-level statements
+--     "stmt-has-not-impl" :: Bool                     -- any statement contains NotImplemented
 --     "module-header"  :: (A.ModName, Imports, Maybe String)
 --                                                     -- typed module name, imports, docstring
 --
@@ -52,6 +53,7 @@
 --     "name-order/<NNN>"   :: ByteString              -- name-key suffix, in TEnv order (NNN = padIndex)
 --     "name-info/<suffix>" :: (A.Name, I.NameInfo)    -- the name and its type/name environment entry
 --     "name-hash/<suffix>" :: NameHashInfo            -- per-name src/pub/impl hashes + local deps
+--                                                     -- + owned statement indexes
 --
 --   Per-dependency keys:
 --     "deps/<module>"          :: [DepNameInfo]        -- dependency names with pub/impl hashes
@@ -130,6 +132,7 @@ module InterfaceFiles
   , readInterfaceDBDescendants
   , readInterfaceDBExtByProto
   , readInterfaceDBExtByType
+  , readSelectedModule
   , TyDbWriteProgress(..)
   , writeFile
   , writeFileWithProgress
@@ -161,6 +164,7 @@ import qualified Database.LMDB.Raw as LMDB
 import qualified Acton.Syntax as A
 import qualified Acton.NameInfo as I
 import Acton.Names (isPublicName)
+import qualified Acton.Names as Names
 import Utils (SrcLoc(NoLoc))
 import Foreign.Ptr (castPtr)
 import Foreign.Storable (peek)
@@ -182,6 +186,7 @@ data NameHashInfo = NameHashInfo
   , nhImplLocalDeps :: [A.Name]
   , nhPubDeps  :: [(A.QName, BS.ByteString)]
   , nhImplDeps :: [(A.QName, BS.ByteString)]
+  , nhStmtIndices :: [Int]
   } deriving (Show, Eq, Generic)
 
 instance Persist.Persist NameHashInfo
@@ -431,7 +436,7 @@ encodeStrict = Persist.encode
 key :: String -> BS.ByteString
 key = B.pack
 
-keyVersion, keyMeta, keyImports, keyDeps, keyRoots, keyTests, keyDoc, keyNameCount, keyPublicNames, keyConstructors, keyActors, keyStmtCount, keyModuleHeader :: BS.ByteString
+keyVersion, keyMeta, keyImports, keyDeps, keyRoots, keyTests, keyDoc, keyNameCount, keyPublicNames, keyConstructors, keyActors, keyStmtCount, keyStmtHasNotImpl, keyModuleHeader :: BS.ByteString
 keyVersion      = key "version"
 keyMeta         = key "meta"
 keyImports      = key "imports"
@@ -444,6 +449,7 @@ keyPublicNames  = key "public-names"
 keyConstructors = key "constructors"
 keyActors       = key "actors"
 keyStmtCount    = key "stmt-count"
+keyStmtHasNotImpl = key "stmt-has-not-impl"
 keyModuleHeader = key "module-header"
 
 padIndex :: Int -> String
@@ -1031,6 +1037,40 @@ readStmtEntries txn dbi = do
     forM [0 .. count - 1] $ \i ->
       getValue ("stmt " ++ show i) txn dbi (keyStmt i)
 
+-- | Reconstruct a typed module containing only the statements owned by the
+-- selected names. Returns Nothing when the cache predates statement
+-- ownership, when ownership is missing for a selected name, or when the
+-- module contains NotImplemented hooks (whose native-extension pairing needs
+-- the whole module); callers then fall back to a full read.
+readSelectedModule :: FilePath -> [NameHashInfo] -> Set.Set A.Name -> IO (Maybe A.Module)
+readSelectedModule f nameHashes selected =
+    withReadTxn f $ \txn dbi -> do
+      validateVersion txn dbi
+      (tmn, timps, tdoc) <- getValue "module-header" txn dbi keyModuleHeader
+      mHasNotImpl <- getMaybeValue "stmt-has-not-impl" txn dbi keyStmtHasNotImpl
+      case mHasNotImpl of
+        Nothing -> do
+          traceTydbRead "stmt-index-miss" f "stmt-has-not-impl"
+          return Nothing
+        Just True -> do
+          traceTydbRead "stmt-fallback" f "not-impl"
+          return Nothing
+        Just False -> do
+          let names = Set.toList selected
+              stmtMap = Map.fromList [ (nhName nh, nhStmtIndices nh) | nh <- nameHashes ]
+              owners = [ (n, Map.lookup n stmtMap) | n <- names ]
+              unusable = [ n | (n, mis) <- owners, maybe True null mis ]
+          if not (null unusable)
+            then do
+              traceTydbRead "stmt-index-miss" f (Data.List.intercalate "," (map A.nstr unusable))
+              return Nothing
+            else do
+              let indices = Data.List.sort $ Data.List.nub $ concat [ is | (_, Just is) <- owners ]
+              stmts <- forM indices $ \i ->
+                getValue ("stmt " ++ show i) txn dbi (keyStmt i)
+              traceTydbRead "stmts" f ("selected " ++ show (length names) ++ " -> " ++ show (length stmts))
+              return $ Just (A.Module tmn timps tdoc stmts)
+
 emptyExtensionIndex :: ExtensionIndex
 emptyExtensionIndex =
     ExtensionIndex
@@ -1240,6 +1280,28 @@ queryIndexEntries nmod =
     ++ [ (keyExtType qn, encodeStrict ns) | (qn, ns) <- Map.toList (qiExtTypes ix) ]
   where ix = queryIndexes nmod
 
+-- Statement ownership: each top-level name records the indexes of the typed
+-- statements that declare it, so a statement-selective reader can fetch just
+-- the stmt/<NNN> rows for a selected name set.
+addStmtIndices :: [A.Stmt] -> [NameHashInfo] -> [NameHashInfo]
+addStmtIndices body nameHashes =
+    [ nh { nhStmtIndices = Map.findWithDefault [] (nhName nh) owners }
+    | nh <- nameHashes
+    ]
+  where
+    owners = Map.map (Data.List.sort . Data.List.nub) $
+             foldl' addStmt Map.empty (zip [0..] body)
+    addStmt acc (i, stmt) = foldl' (\m n -> Map.insertWith (++) n [i] m) acc (stmtTopNames stmt)
+
+stmtTopNames :: A.Stmt -> [A.Name]
+stmtTopNames stmt =
+    case stmt of
+      A.Decl _ ds          -> [ Names.dname' d | d <- ds ]
+      A.Signature _ ns _ _ -> ns
+      A.Assign _ ps _      -> Data.List.nub (Names.bound ps)
+      A.VarAssign _ ps _   -> Data.List.nub (Names.bound ps)
+      _                    -> []
+
 interfaceEntries :: (String -> Double -> IO ()) -> [Int] -> BS.ByteString -> BS.ByteString -> BS.ByteString -> Maybe SourceFileMeta -> [(A.ModName, BS.ByteString)] -> [DepModuleInfo] -> [NameHashInfo] -> [A.Name] -> [String] -> Maybe String -> I.NameInfo -> A.Module -> IO [(BS.ByteString, BS.ByteString)]
 interfaceEntries onProgress version moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta imps depModules nameHashes roots tests mdoc nmod tchecked = do
     caps <- getNumCapabilities
@@ -1252,10 +1314,11 @@ interfaceEntries onProgress version moduleSrcBytesHash modulePubHash moduleImplH
           , (keyDoc, encodeStrict mdoc)
           , (keyNameCount, encodeStrict (length te))
           , (keyStmtCount, encodeStrict (length body))
+          , (keyStmtHasNotImpl, encodeStrict (A.hasNotImpl body))
           , (keyModuleHeader, encodeStrict (tmn, timps, tdoc))
           ]
         nameChunks = entryChunks caps (zip [0..] te)
-        nameHashChunks = entryChunks caps nameHashes
+        nameHashChunks = entryChunks caps (addStmtIndices body nameHashes)
         stmtChunks = entryChunks caps (zip [0..] body)
         totalPrep = 4 + length nameChunks + length nameHashChunks + length stmtChunks
     prepDone <- newIORef (0 :: Int)

--- a/compiler/lib/src/InterfaceFiles.hs
+++ b/compiler/lib/src/InterfaceFiles.hs
@@ -245,7 +245,7 @@ data TyDbWriteProgress = TyDbWriteProgress
 
 type TyFile =
   ( [A.ModName]
-  , I.NameInfo
+  , I.NModule
   , A.Module
   , Maybe SourceFileMeta
   , BS.ByteString
@@ -1082,11 +1082,9 @@ emptyExtensionIndex =
       , extByProtocol = Map.empty
       }
 
-extensionIndexFromNameInfo :: A.ModName -> I.NameInfo -> ExtensionIndex
-extensionIndexFromNameInfo mn nmod =
-    case nmod of
-      I.NModule _ te _ -> foldl addExt emptyExtensionIndex te
-      _ -> emptyExtensionIndex
+extensionIndexFromNameInfo :: A.ModName -> I.NModule -> ExtensionIndex
+extensionIndexFromNameInfo mn (I.NModule _ te _) =
+    foldl addExt emptyExtensionIndex te
   where
     addExt acc (ext, I.NExt _ c ps _ _ _) =
       let cls = localQName (A.tcname c)
@@ -1242,7 +1240,7 @@ data QueryIndexes = QueryIndexes
   , qiExtTypes :: Map.Map A.QName [A.Name]
   }
 
-queryIndexes :: I.NameInfo -> QueryIndexes
+queryIndexes :: I.NModule -> QueryIndexes
 queryIndexes (I.NModule _ te _) = QueryIndexes (map fst pte) cons actors conattrs protoattrs descendants extprotos exttypes
   where pte                    = filter (isPublicName . fst) te
         cons                   = [ n | (n, i) <- pte, isCons i ]
@@ -1266,12 +1264,11 @@ queryIndexes (I.NModule _ te _) = QueryIndexes (map fst pte) cons actors conattr
         ancestry (I.NClass _ us _ _) = us
         ancestry (I.NProto _ us _ _) = us
         ancestry _             = []
-queryIndexes _                  = QueryIndexes [] [] [] Map.empty Map.empty Map.empty Map.empty Map.empty
 
 indexMap :: Ord k => [(k, A.Name)] -> Map.Map k [A.Name]
 indexMap xs = Map.fromListWith (++) [ (k, [v]) | (k, v) <- reverse xs ]
 
-queryIndexEntries :: I.NameInfo -> [(BS.ByteString, BS.ByteString)]
+queryIndexEntries :: I.NModule -> [(BS.ByteString, BS.ByteString)]
 queryIndexEntries nmod =
     [ (keyPublicNames, encodeStrict (qiPublicNames ix))
     , (keyConstructors, encodeStrict (qiConstructors ix))
@@ -1306,7 +1303,7 @@ stmtTopNames stmt =
       A.VarAssign _ ps _   -> Data.List.nub (Names.bound ps)
       _                    -> []
 
-interfaceEntries :: (String -> Double -> IO ()) -> [Int] -> BS.ByteString -> BS.ByteString -> BS.ByteString -> Maybe SourceFileMeta -> [(A.ModName, BS.ByteString)] -> [DepModuleInfo] -> [NameHashInfo] -> [A.Name] -> [String] -> Maybe String -> I.NameInfo -> A.Module -> IO [(BS.ByteString, BS.ByteString)]
+interfaceEntries :: (String -> Double -> IO ()) -> [Int] -> BS.ByteString -> BS.ByteString -> BS.ByteString -> Maybe SourceFileMeta -> [(A.ModName, BS.ByteString)] -> [DepModuleInfo] -> [NameHashInfo] -> [A.Name] -> [String] -> Maybe String -> I.NModule -> A.Module -> IO [(BS.ByteString, BS.ByteString)]
 interfaceEntries onProgress version moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta imps depModules nameHashes roots tests mdoc nmod tchecked = do
     caps <- getNumCapabilities
     let header =
@@ -1355,14 +1352,14 @@ interfaceEntries onProgress version moduleSrcBytesHash modulePubHash moduleImplH
     nameHashEntry nh = [(keyNameHash (nhName nh), encodeStrict (stripExternalDeps nh))]
     stmtEntry (i, stmt) = [(keyStmt i, encodeStrict stmt)]
 
-writeFile :: FilePath -> BS.ByteString -> BS.ByteString -> BS.ByteString -> Maybe SourceFileMeta -> [(A.ModName, BS.ByteString)] -> [DepModuleInfo] -> [NameHashInfo] -> [A.Name] -> [String] -> Maybe String -> I.NameInfo -> A.Module -> IO ()
+writeFile :: FilePath -> BS.ByteString -> BS.ByteString -> BS.ByteString -> Maybe SourceFileMeta -> [(A.ModName, BS.ByteString)] -> [DepModuleInfo] -> [NameHashInfo] -> [A.Name] -> [String] -> Maybe String -> I.NModule -> A.Module -> IO ()
 writeFile = writeFileWithVersion A.version
 
-writeFileWithVersion :: [Int] -> FilePath -> BS.ByteString -> BS.ByteString -> BS.ByteString -> Maybe SourceFileMeta -> [(A.ModName, BS.ByteString)] -> [DepModuleInfo] -> [NameHashInfo] -> [A.Name] -> [String] -> Maybe String -> I.NameInfo -> A.Module -> IO ()
+writeFileWithVersion :: [Int] -> FilePath -> BS.ByteString -> BS.ByteString -> BS.ByteString -> Maybe SourceFileMeta -> [(A.ModName, BS.ByteString)] -> [DepModuleInfo] -> [NameHashInfo] -> [A.Name] -> [String] -> Maybe String -> I.NModule -> A.Module -> IO ()
 writeFileWithVersion version f moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta imps depModules nameHashes roots tests mdoc nmod tchecked =
     writeFileWithProgress (\_ -> return ()) version f moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta imps depModules nameHashes roots tests mdoc nmod tchecked
 
-writeFileWithProgress :: (TyDbWriteProgress -> IO ()) -> [Int] -> FilePath -> BS.ByteString -> BS.ByteString -> BS.ByteString -> Maybe SourceFileMeta -> [(A.ModName, BS.ByteString)] -> [DepModuleInfo] -> [NameHashInfo] -> [A.Name] -> [String] -> Maybe String -> I.NameInfo -> A.Module -> IO ()
+writeFileWithProgress :: (TyDbWriteProgress -> IO ()) -> [Int] -> FilePath -> BS.ByteString -> BS.ByteString -> BS.ByteString -> Maybe SourceFileMeta -> [(A.ModName, BS.ByteString)] -> [DepModuleInfo] -> [NameHashInfo] -> [A.Name] -> [String] -> Maybe String -> I.NModule -> A.Module -> IO ()
 writeFileWithProgress onProgress version f moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta imps depModules nameHashes roots tests mdoc nmod tchecked = do
     entries <- interfaceEntries prepProgress version moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta imps depModules nameHashes roots tests mdoc nmod tchecked
     writeProgress 0

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -1924,7 +1924,7 @@ main = do
                     Acton.Env.moduleLookupHName = \n -> System.IO.Unsafe.unsafePerformIO $ do
                       modifyIORef' lookedUp (++ [S.nstr n])
                       if n == wanted
-                        then return (Just (I.HNVar S.tWild))
+                        then return (Just (I.NVar S.tWild))
                         else error ("unexpected import lookup: " ++ S.nstr n),
                     Acton.Env.modulePublicNames = [unused, wanted],
                     Acton.Env.moduleConstructors = [],
@@ -1939,7 +1939,7 @@ main = do
             env = Acton.Env.importSome [S.ImportItem wanted Nothing] m mi env0
 
         case Acton.Env.lookupName wanted env of
-          Just (I.HNAlias qn) -> qn `shouldBe` S.GName m wanted
+          Just (I.NAlias qn) -> qn `shouldBe` S.GName m wanted
           other -> expectationFailure $ "Expected selected import alias, got " ++ show other
         readIORef lookedUp `shouldReturn` ["wanted"]
 
@@ -1974,7 +1974,7 @@ main = do
           Just _ -> expectationFailure "from import * should skip __foo"
 
         case Acton.Env.lookupName (S.name "public_value") envB of
-          Just (I.HNAlias _) -> pure ()
+          Just (I.NAlias _) -> pure ()
           _ -> expectationFailure "from import * should include public_value"
 
       it "blocks qualified access to private names" $ do

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -1960,35 +1960,35 @@ main = do
             canonical = S.modName ["dep", "lib"]
             wanted = S.name "wanted"
             mi = Acton.Env.mkModuleInfo canonical [] [(wanted, I.NVar S.tWild)] Nothing
-            env = Acton.Env.addVisibleModule imported (Acton.Env.addImport imported (Acton.Env.addModuleInfo imported mi env0))
+            env = Acton.Env.addQualifier imported mi Nothing (Acton.Env.addImport imported (Acton.Env.addModuleInfo imported mi env0))
 
         (Acton.Env.unalias env imported :: S.ModName) `shouldBe` canonical
         Acton.Env.unalias env (S.QName imported wanted) `shouldBe` S.GName canonical wanted
 
       it "does not expand module aliases as prefixes" $ do
-        let alias = S.modName ["c"]
+        let qual = S.modName ["c"]
             canonical = S.modName ["a", "b"]
+            alias = Just c
             c = S.name "c"
             d = S.name "d"
             x = S.name "X"
             mi = Acton.Env.mkModuleInfo canonical [] [(d, I.NVar S.tWild), (x, I.NVar S.tWild)] Nothing
-            env = Acton.Env.addVisibleModule alias (Acton.Env.addModuleAlias alias mi env0)
+            env = Acton.Env.addQualifier canonical mi alias env0
             expr = S.Dot NoLoc (S.Dot NoLoc (S.Var NoLoc (S.NoQ c)) d) x
             parsed = S.Module (S.modName ["alias_prefix"]) [] Nothing [S.Expr NoLoc expr]
         checked <- liftIO $ Acton.Kinds.check env parsed
         S.mbody checked `shouldBe`
-          [S.Expr NoLoc (S.Dot NoLoc (S.Var NoLoc (S.QName alias d)) x)]
+          [S.Expr NoLoc (S.Dot NoLoc (S.Var NoLoc (S.QName qual d)) x)]
 
       it "lets local bindings shadow module aliases in dotted expressions" $ do
-        let alias = S.modName ["c"]
-            canonical = S.modName ["a", "b"]
+        let canonical = S.modName ["a", "b"]
+            alias = Just c
             c = S.name "c"
             x = S.name "X"
             mi = Acton.Env.mkModuleInfo canonical [] [(x, I.NVar S.tWild)] Nothing
             env =
               Acton.Env.addActiveNames [(c, I.NVar S.tWild)] $
-              Acton.Env.addVisibleModule alias $
-              Acton.Env.addModuleAlias alias mi env0
+              Acton.Env.addQualifier canonical mi alias env0
             expr = S.Dot NoLoc (S.Var NoLoc (S.NoQ c)) x
             parsed = S.Module (S.modName ["alias_shadow"]) [] Nothing [S.Expr NoLoc expr]
         checked <- liftIO $ Acton.Kinds.check env parsed

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -78,6 +78,7 @@ nameHash n src pub impl =
     , InterfaceFiles.nhImplLocalDeps = []
     , InterfaceFiles.nhPubDeps = []
     , InterfaceFiles.nhImplDeps = []
+    , InterfaceFiles.nhStmtIndices = []
     }
 
 hashTestName :: S.Name
@@ -340,6 +341,31 @@ main = do
           write [(wName, I.NVar S.tWild)]
           InterfaceFiles.readInterfaceDBNameInfoMaybe db vName `shouldReturn` Nothing
           fmap fst <$> InterfaceFiles.readInterfaceDBNameInfoMaybe db wName `shouldReturn` Just wName
+
+      it "reads selected statements by ownership" $ do
+        withSystemTempDirectory "acton-iface-stmts" $ \dir -> do
+          let mn = S.modName ["iface_stmts"]
+              tyPath = dir </> "iface_stmts.tydb"
+              aName = S.name "a"
+              bName = S.name "b"
+              cName = S.name "c"
+              stmtFor n v = S.Assign NoLoc [S.pVar' n] (S.eInt v)
+              body = [stmtFor aName 1, stmtFor bName 2, stmtFor cName 3]
+              iface = [ (n, I.NVar S.tWild) | n <- [aName, bName, cName] ]
+              nameHashes0 = [ nameHash n "s" "p" "i" | n <- [aName, bName, cName] ]
+              nmod = I.NModule [] iface Nothing
+              tmod = S.Module mn [] Nothing body
+          InterfaceFiles.writeFile tyPath "src" "pub" "impl" Nothing [] [] nameHashes0 [] [] Nothing nmod tmod
+          (_sourceMetaH, _srcH, _pubH, _implH, _impsH, _depModulesH, nameHashesH, _rootsH, _testsH, _docH) <-
+            InterfaceFiles.readHeader tyPath
+          [ InterfaceFiles.nhStmtIndices nh | nh <- nameHashesH, InterfaceFiles.nhName nh == bName ]
+            `shouldBe` [[1]]
+          selected <- InterfaceFiles.readSelectedModule tyPath nameHashesH (Set.fromList [aName, cName])
+          case selected of
+            Just (S.Module _ _ _ stmts) -> stmts `shouldBe` [stmtFor aName 1, stmtFor cName 3]
+            Nothing -> expectationFailure "expected selected statements"
+          missing <- InterfaceFiles.readSelectedModule tyPath nameHashesH (Set.fromList [S.name "nope"])
+          missing `shouldBe` Nothing
 
       it "supports concurrent read-only access to one interface" $ do
         withSystemTempDirectory "acton-iface-concurrent" $ \dir -> do

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -552,22 +552,15 @@ main = do
             depCType = S.tCon (S.TC depC [S.tCon (S.TC localDep [])])
             depDType = S.TUnboxed NoLoc (S.tCon (S.TC depD []))
             info =
-              I.NModule
-                []
-                [ ( hashTestName
-                  , I.NExt
-                      [qbind]
-                      (S.TC depA [depBType])
-                      [([Left depB, Right depC], S.TC depC [depAType])]
-                      [ (S.name "alias", I.NAlias depB)
-                      , (S.name "field", I.NSig (S.tSchema [] depCType) S.NoDec Nothing)
-                      , (S.name "unboxed_field", I.NSig (S.tSchema [] depDType) S.NoDec Nothing)
-                      ]
-                      []
-                      Nothing
-                  )
-                , (S.name "derived_alias", I.NAlias derived)
+              I.NExt
+                [qbind]
+                (S.TC depA [depBType])
+                [([Left depB, Right depC], S.TC depC [depAType])]
+                [ (S.name "alias", I.NAlias depB)
+                , (S.name "field", I.NSig (S.tSchema [] depCType) S.NoDec Nothing)
+                , (S.name "unboxed_field", I.NSig (S.tSchema [] depDType) S.NoDec Nothing)
                 ]
+                []
                 Nothing
             infos = M.singleton hashTestName info
             expectedDeps = M.singleton hashTestName (Set.fromList [depA, depB, depC, depD, localDep])

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -54,6 +54,7 @@ import Prettyprinter.Render.Text (renderStrict)
 import System.FilePath ((</>), joinPath, takeFileName, takeBaseName, takeDirectory, splitDirectories, takeExtension)
 import System.Directory (createDirectoryIfMissing, getCurrentDirectory, setCurrentDirectory, listDirectory, doesDirectoryExist, doesFileExist, removeFile)
 import System.IO.Temp (withSystemTempDirectory)
+import qualified System.IO.Unsafe
 import System.Timeout (timeout)
 import Control.Monad (forM_, when, foldM)
 import qualified Control.Exception as E
@@ -927,8 +928,8 @@ main = do
             mdoc
             nmod
             tmod
-          (_env2, te) <- Acton.Env.doImp [dir] env1 directMod
-          map fst te `shouldBe` [valueName]
+          (_env2, mi) <- Acton.Env.doImp [dir] env1 directMod
+          map fst (Acton.Env.modulePublicTEnv mi) `shouldBe` [valueName]
 
     describe "Pass 1: Parser" $ do
 
@@ -1893,6 +1894,54 @@ main = do
           Right _ -> expectationFailure "Expected multiple type errors but type checking succeeded"
 
     describe "Import Semantics" $ do
+      it "selected imports only look up requested names" $ do
+        lookedUp <- newIORef []
+        let wanted = S.name "wanted"
+            unused = S.name "unused"
+            m = S.modName ["lazy_import"]
+            mi = Acton.Env.ModuleInfo {
+                    Acton.Env.moduleImports = [],
+                    Acton.Env.moduleDoc = Nothing,
+                    Acton.Env.moduleLookupHName = \n -> System.IO.Unsafe.unsafePerformIO $ do
+                      modifyIORef' lookedUp (++ [S.nstr n])
+                      if n == wanted
+                        then return (Just (I.HNVar S.tWild))
+                        else error ("unexpected import lookup: " ++ S.nstr n),
+                    Acton.Env.modulePublicNames = [unused, wanted],
+                    Acton.Env.moduleConstructors = [],
+                    Acton.Env.moduleActors = [],
+                    Acton.Env.moduleConAttr = const [],
+                    Acton.Env.moduleProtoAttr = const [],
+                    Acton.Env.moduleDescendants = const [],
+                    Acton.Env.moduleProtoDescendants = const [],
+                    Acton.Env.moduleWitnessesByProto = const [],
+                    Acton.Env.moduleWitnessesByType = const []
+                  }
+            env = Acton.Env.importSome [S.ImportItem wanted Nothing] m mi env0
+
+        case Acton.Env.lookupName wanted env of
+          Just (I.HNAlias qn) -> qn `shouldBe` S.GName m wanted
+          other -> expectationFailure $ "Expected selected import alias, got " ++ show other
+        readIORef lookedUp `shouldReturn` ["wanted"]
+
+      it "rejects selected imports of private names" $ do
+        (envA, parsedA) <- parseAct env0 "import_private_a"
+        kcheckedA <- liftIO $ Acton.Kinds.check envA parsedA
+        (nmodA, _, _, _) <- liftIO $ Acton.Types.reconstruct Nothing Nothing envA kcheckedA Nothing
+        let I.NModule impsA tenvA mdocA = nmodA
+            env1 = Acton.Env.addMod (S.modname parsedA) impsA tenvA mdocA env0
+
+        result <- liftIO $ (E.try (do
+          (envB, _) <- parseAct env1 "import_private_selected"
+          _ <- E.evaluate (Acton.Env.lookupName (S.name "__foo") envB)
+          pure ()
+          ) :: IO (Either CompilationError ()))
+
+        case result of
+          Left NoItem{} -> pure ()
+          Left err -> expectationFailure $ "Expected NoItem error, got " ++ show err
+          Right _ -> expectationFailure "Expected selected private import to fail"
+
       it "omits private names from the public interface" $ do
         (envA, parsedA) <- parseAct env0 "import_private_a"
         kcheckedA <- liftIO $ Acton.Kinds.check envA parsedA

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -1966,29 +1966,42 @@ main = do
         Acton.Env.unalias env (S.QName imported wanted) `shouldBe` S.GName canonical wanted
 
       it "does not expand module aliases as prefixes" $ do
-        let qual = S.modName ["c"]
+        let alias = S.modName ["c"]
             canonical = S.modName ["a", "b"]
-            alias = Just c
             c = S.name "c"
             d = S.name "d"
             x = S.name "X"
             mi = Acton.Env.mkModuleInfo canonical [] [(d, I.NVar S.tWild), (x, I.NVar S.tWild)] Nothing
-            env = Acton.Env.addQualifier canonical mi alias env0
+            env = Acton.Env.addQualifier canonical mi (Just alias) env0
             expr = S.Dot NoLoc (S.Dot NoLoc (S.Var NoLoc (S.NoQ c)) d) x
             parsed = S.Module (S.modName ["alias_prefix"]) [] Nothing [S.Expr NoLoc expr]
         checked <- liftIO $ Acton.Kinds.check env parsed
         S.mbody checked `shouldBe`
-          [S.Expr NoLoc (S.Dot NoLoc (S.Var NoLoc (S.QName qual d)) x)]
+          [S.Expr NoLoc (S.Dot NoLoc (S.Var NoLoc (S.QName alias d)) x)]
+
+      it "accepts nested module aliases" $ do
+        let alias = S.modName ["c","b"]
+            canonical = S.modName ["a", "b"]
+            c = S.name "c"
+            b = S.name "b"
+            x = S.name "X"
+            mi = Acton.Env.mkModuleInfo canonical [] [(x, I.NVar S.tWild)] Nothing
+            env = Acton.Env.addQualifier canonical mi (Just alias) env0
+            expr = S.Dot NoLoc (S.Dot NoLoc (S.Var NoLoc (S.NoQ c)) b) x
+            parsed = S.Module (S.modName ["alias_nested"]) [] Nothing [S.Expr NoLoc expr]
+        checked <- liftIO $ Acton.Kinds.check env parsed
+        S.mbody checked `shouldBe`
+          [S.Expr NoLoc (S.Var NoLoc (S.QName alias x))]
 
       it "lets local bindings shadow module aliases in dotted expressions" $ do
-        let canonical = S.modName ["a", "b"]
-            alias = Just c
+        let alias = S.modName ["c"]
+            canonical = S.modName ["a", "b"]
             c = S.name "c"
             x = S.name "X"
             mi = Acton.Env.mkModuleInfo canonical [] [(x, I.NVar S.tWild)] Nothing
             env =
               Acton.Env.addActiveNames [(c, I.NVar S.tWild)] $
-              Acton.Env.addQualifier canonical mi alias env0
+              Acton.Env.addQualifier canonical mi (Just alias) env0
             expr = S.Dot NoLoc (S.Var NoLoc (S.NoQ c)) x
             parsed = S.Module (S.modName ["alias_shadow"]) [] Nothing [S.Expr NoLoc expr]
         checked <- liftIO $ Acton.Kinds.check env parsed

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -1919,6 +1919,7 @@ main = do
             unused = S.name "unused"
             m = S.modName ["lazy_import"]
             mi = Acton.Env.ModuleInfo {
+                    Acton.Env.moduleName = m,
                     Acton.Env.moduleImports = [],
                     Acton.Env.moduleDoc = Nothing,
                     Acton.Env.moduleLookupName = \n -> System.IO.Unsafe.unsafePerformIO $ do
@@ -1942,6 +1943,56 @@ main = do
           Just (I.NAlias qn) -> qn `shouldBe` S.GName m wanted
           other -> expectationFailure $ "Expected selected import alias, got " ++ show other
         readIORef lookedUp `shouldReturn` ["wanted"]
+
+      it "qualifies selected imports with the module's canonical identity" $ do
+        let imported = S.modName ["dep"]
+            canonical = S.modName ["dep", "lib"]
+            wanted = S.name "wanted"
+            mi = Acton.Env.mkModuleInfo canonical [] [(wanted, I.NVar S.tWild)] Nothing
+            env = Acton.Env.importSome [S.ImportItem wanted Nothing] imported mi env0
+
+        case Acton.Env.lookupName wanted env of
+          Just (I.NAlias qn) -> qn `shouldBe` S.GName canonical wanted
+          other -> expectationFailure $ "Expected canonical selected import alias, got " ++ show other
+
+      it "unaliases qualified names with the module's canonical identity" $ do
+        let imported = S.modName ["dep"]
+            canonical = S.modName ["dep", "lib"]
+            wanted = S.name "wanted"
+            mi = Acton.Env.mkModuleInfo canonical [] [(wanted, I.NVar S.tWild)] Nothing
+            env = Acton.Env.addVisibleModule imported (Acton.Env.addImport imported (Acton.Env.addModuleInfo imported mi env0))
+
+        (Acton.Env.unalias env imported :: S.ModName) `shouldBe` canonical
+        Acton.Env.unalias env (S.QName imported wanted) `shouldBe` S.GName canonical wanted
+
+      it "does not expand module aliases as prefixes" $ do
+        let alias = S.modName ["c"]
+            canonical = S.modName ["a", "b"]
+            c = S.name "c"
+            d = S.name "d"
+            x = S.name "X"
+            mi = Acton.Env.mkModuleInfo canonical [] [(d, I.NVar S.tWild), (x, I.NVar S.tWild)] Nothing
+            env = Acton.Env.addVisibleModule alias (Acton.Env.addModuleAlias alias mi env0)
+            expr = S.Dot NoLoc (S.Dot NoLoc (S.Var NoLoc (S.NoQ c)) d) x
+            parsed = S.Module (S.modName ["alias_prefix"]) [] Nothing [S.Expr NoLoc expr]
+        checked <- liftIO $ Acton.Kinds.check env parsed
+        S.mbody checked `shouldBe`
+          [S.Expr NoLoc (S.Dot NoLoc (S.Var NoLoc (S.QName alias d)) x)]
+
+      it "lets local bindings shadow module aliases in dotted expressions" $ do
+        let alias = S.modName ["c"]
+            canonical = S.modName ["a", "b"]
+            c = S.name "c"
+            x = S.name "X"
+            mi = Acton.Env.mkModuleInfo canonical [] [(x, I.NVar S.tWild)] Nothing
+            env =
+              Acton.Env.addActiveNames [(c, I.NVar S.tWild)] $
+              Acton.Env.addVisibleModule alias $
+              Acton.Env.addModuleAlias alias mi env0
+            expr = S.Dot NoLoc (S.Var NoLoc (S.NoQ c)) x
+            parsed = S.Module (S.modName ["alias_shadow"]) [] Nothing [S.Expr NoLoc expr]
+        checked <- liftIO $ Acton.Kinds.check env parsed
+        S.mbody checked `shouldBe` [S.Expr NoLoc expr]
 
       it "rejects selected imports of private names" $ do
         (envA, parsedA) <- parseAct env0 "import_private_a"

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -1921,7 +1921,7 @@ main = do
             mi = Acton.Env.ModuleInfo {
                     Acton.Env.moduleImports = [],
                     Acton.Env.moduleDoc = Nothing,
-                    Acton.Env.moduleLookupHName = \n -> System.IO.Unsafe.unsafePerformIO $ do
+                    Acton.Env.moduleLookupName = \n -> System.IO.Unsafe.unsafePerformIO $ do
                       modifyIORef' lookedUp (++ [S.nstr n])
                       if n == wanted
                         then return (Just (I.NVar S.tWild))

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -279,6 +279,67 @@ main = do
           testsH `shouldBe` tests
           docH `shouldBe` Just "module docs"
 
+      it "reads module query indexes independently" $ do
+        withSystemTempDirectory "acton-iface-indexes" $ \dir -> do
+          let mn = S.modName ["iface_indexes"]
+              tyPath = dir </> "iface_indexes.tydb"
+              clsName = S.name "Cls"
+              parentName = S.name "Parent"
+              childName = S.name "Child"
+              actorName = S.name "Worker"
+              protoName = S.name "Proto"
+              subProtoName = S.name "SubProto"
+              extName = S.name "Ext"
+              classAttr = S.name "class_attr"
+              actorAttr = S.name "actor_attr"
+              protoAttr = S.name "proto_attr"
+              clsTC = S.TC (S.NoQ clsName) []
+              parentTC = S.TC (S.NoQ parentName) []
+              protoTC = S.TC (S.NoQ protoName) []
+              iface =
+                [ (clsName, I.NClass [] [] [(classAttr, I.NVar S.tWild)] Nothing)
+                , (parentName, I.NClass [] [] [] Nothing)
+                , (childName, I.NClass [] [([], parentTC)] [] Nothing)
+                , (actorName, I.NAct [] S.posNil S.kwdNil [(actorAttr, I.NVar S.tWild)] Nothing)
+                , (protoName, I.NProto [] [] [(protoAttr, I.NVar S.tWild)] Nothing)
+                , (subProtoName, I.NProto [] [([], protoTC)] [] Nothing)
+                , (extName, I.NExt [] clsTC [([], protoTC)] [] [] Nothing)
+                ]
+              nmod = I.NModule [] iface Nothing
+              tmod = S.Module mn [] Nothing []
+              names = sort . map fst
+          InterfaceFiles.writeFile tyPath "src" "pub" "impl" Nothing [] [] [] [] [] Nothing nmod tmod
+          db <- InterfaceFiles.openInterfaceDB tyPath
+          (do InterfaceFiles.readInterfaceDBNameInfoMaybe db clsName `shouldReturn` Just (clsName, I.NClass [] [] [(classAttr, I.NVar S.tWild)] Nothing)
+              InterfaceFiles.readInterfaceDBNameInfoMaybe db (S.name "missing") `shouldReturn` Nothing
+              InterfaceFiles.readInterfaceDBPublicNames db `shouldReturn` map fst iface
+              names <$> InterfaceFiles.readInterfaceDBConstructors db `shouldReturn` sort [actorName, childName, clsName, parentName, protoName, subProtoName]
+              names <$> InterfaceFiles.readInterfaceDBActors db `shouldReturn` [actorName]
+              names <$> InterfaceFiles.readInterfaceDBConAttr db classAttr `shouldReturn` [clsName]
+              names <$> InterfaceFiles.readInterfaceDBConAttr db actorAttr `shouldReturn` [actorName]
+              names <$> InterfaceFiles.readInterfaceDBProtoAttr db protoAttr `shouldReturn` [protoName]
+              names <$> InterfaceFiles.readInterfaceDBDescendants db (S.NoQ parentName) `shouldReturn` [childName]
+              names <$> InterfaceFiles.readInterfaceDBDescendants db (S.NoQ protoName) `shouldReturn` [subProtoName]
+              names <$> InterfaceFiles.readInterfaceDBExtByProto db (S.NoQ protoName) `shouldReturn` [extName]
+              names <$> InterfaceFiles.readInterfaceDBExtByType db (S.NoQ clsName) `shouldReturn` [extName]
+              fst <$> InterfaceFiles.readInterfaceDBModuleInfo db `shouldReturn` [])
+
+      it "serves fresh data through a handle across rewrites" $ do
+        withSystemTempDirectory "acton-iface-rewrite" $ \dir -> do
+          let mn = S.modName ["iface_rewrite"]
+              tyPath = dir </> "iface_rewrite.tydb"
+              vName = S.name "v"
+              wName = S.name "w"
+              write iface = InterfaceFiles.writeFile tyPath "src" "pub" "impl" Nothing [] [] [] [] [] Nothing (I.NModule [] iface Nothing) (S.Module mn [] Nothing [])
+          write [(vName, I.NVar S.tWild)]
+          db <- InterfaceFiles.openInterfaceDB tyPath
+          fmap fst <$> InterfaceFiles.readInterfaceDBNameInfoMaybe db vName `shouldReturn` Just vName
+          -- Rewriting the same path retires the shared environment; reads
+          -- through the existing handle must observe the new contents.
+          write [(wName, I.NVar S.tWild)]
+          InterfaceFiles.readInterfaceDBNameInfoMaybe db vName `shouldReturn` Nothing
+          fmap fst <$> InterfaceFiles.readInterfaceDBNameInfoMaybe db wName `shouldReturn` Just wName
+
       it "supports concurrent read-only access to one interface" $ do
         withSystemTempDirectory "acton-iface-concurrent" $ \dir -> do
           let mn = S.modName ["iface"]

--- a/compiler/lib/test/src/import_private_selected.act
+++ b/compiler/lib/test/src/import_private_selected.act
@@ -1,0 +1,4 @@
+from import_private_a import __foo
+
+actor main(env):
+    print(__foo)

--- a/docs/acton-dev-guide/src/compiler/imports_and_envs.md
+++ b/docs/acton-dev-guide/src/compiler/imports_and_envs.md
@@ -32,14 +32,19 @@ finished modules. In `Acton.Compile.compileTasks`, each completed module extends
 that snapshot with:
 
 ```haskell
-Acton.Env.addMod (tkMod keyDone) (frImps fr) (frIfaceTE fr) (frDoc fr) envAcc
+Acton.Env.addModuleInfo (tkMod keyDone) (frontResultModuleInfo (tkMod keyDone) fr) envAcc
 ```
 
-This shared cache stores loaded module interfaces in `modules` as
-`NModule imps te doc`: the module's recorded imports, public interface, and
-optional docstring. It does not store the current module's local names, and it
-should not be thought of as "the current type-checker env". It is a shared cache
-of interfaces that later tasks start from.
+This shared cache stores loaded module interfaces in
+`modules :: Map ModName ModuleInfo`. It does not store the current module's
+local names, and it should not be thought of as "the current type-checker env".
+It is a shared cache of interfaces that later tasks start from.
+
+`ModuleInfo` is the only Env-side representation of dependency modules. A local
+module backs it with an in-memory `TEnv`; an imported module backs it with a
+read-only `.tydb` handle plus compact metadata. Normal compiler code should ask
+`ModuleInfo` for specific names or specific indexes, not for a whole imported
+`TEnv`.
 
 ### Current-module import overlay
 
@@ -80,32 +85,31 @@ available later through `Acton.Env`.
 
 ## When `.tydb` headers are read
 
-The compiler reads `.tydb` data in two different modes.
+The compiler reads `.tydb` data in three different modes.
 
 ### Header-only reads
 
-Header reads are used for cheap decisions:
+Header summary reads are used for cheap decisions:
 
 - module freshness
 - direct import names for graph construction
-- module public and implementation hashes
-- per-name dependency hash snapshots
+- module public and implementation hashes and the stored name count
 - roots, tests, and docstrings
 
 This is the path used by `readModuleTask` and the various cache lookups in
-`Acton.Compile`. It is also the first DBP path: deferred jobs read the header
-to collect per-name dependency edges, root actor seeds, and enough metadata to
-decide whether the selected generated code is already up to date.
+`Acton.Compile`. Per-name dependency hashes are no longer part of the header
+read; stale checks and DBP selection read exact `name-hash` rows on demand.
 
 ### Full `.tydb` reads
 
-Full reads are used when the compiler needs actual interface contents or the
-typed module:
+Full reads are used when the compiler needs the full typed payload, not for
+normal imported-name lookup:
 
-- reusing an interface from a fresh cached module
 - implementation-hash refresh
 - codegen refresh
 - DBP back-pass execution after the selected codegen hash is stale
+- tools that intentionally inspect a whole interface
+- completion fallback when the normal import environment cannot be restored
 
 Reading a full `.tydb` does not by itself reconstruct the import closure in the
 active environment. It only gives the caller the stored interface and typed
@@ -118,6 +122,38 @@ DBP later uses that map to prune a provider's typed module. That does not make
 the selected provider names available to the active type-checker environment;
 imports still become type-checker bindings only through `mkEnv`/`doImp`.
 
+### Selective interface reads
+
+Normal imported-module lookup uses selective reads. `doImp` opens the imported
+module's `.tydb` with `InterfaceFiles.openInterfaceDB`, reads only imports and
+docstring, then installs a `ModuleInfo` shell in `modules`.
+
+The shell has a pure-looking lookup function. `tryQName`, selected imports, and
+generated-name lookup call that function with one `Name`; the implementation
+runs `readInterfaceDBNameInfoMaybe` for that name and memoizes the result.
+Read/decode failure aborts the compilation like any other corrupt interface
+cache error.
+
+Passes that rewrite imported names do not materialize the module either. They
+wrap `moduleLookupHName` with their conversion function (`convertModules`), so
+Normalizer, Converter, Deactorizer, CPS, and LambdaLifter convert only names
+that are actually demanded. Generated names map back to their source name
+before lookup when necessary.
+
+Solver queries go through narrow per-module indexes: attribute owners,
+descendants, and extension witnesses keyed by protocol or by type. The
+attribute indexes record attributes where they are declared; `allConAttr` and
+`allPConAttr` complete inherited owners with the descendants of each declaring
+constructor, which preserves the ancestry-aware semantics of the old full
+scan. All transitive imports are consulted with keyed reads, so query cost is
+proportional to the number of imported modules, never to their size.
+
+Broad enumeration stays explicit. `from module import *` walks
+`modulePublicNames` and forces one lookup per importable public name.
+Completion, documentation, and debug paths may also choose broad reads, but
+those paths are separate from normal qualified-name and selected-import
+lookup.
+
 ## How transitive imports become available
 
 The transitive import closure is reconstructed through `Acton.Env.mkEnv`,
@@ -128,23 +164,22 @@ When a module imports another module:
 1. `mkEnv` walks the AST import list
 2. `impModule` delegates to `doImp`
 3. `doImp` first checks whether the imported module is already in `modules`
-4. if it is loaded, `doImp` follows the in-memory `NModule` import list
-5. otherwise, `doImp` reads the imported module's `.tydb` and follows its stored
-   imports
-6. only then does it return the imported module interface
+4. if it is loaded, `doImp` follows the recorded `moduleImports` list
+5. otherwise, `doImp` opens the imported module's `.tydb`, reads its import
+   metadata, and follows the stored imports
+6. only then does it return the imported module interface shell
 
 This is the mechanism that turns a direct import into a transitive environment
 closure suitable for kinds and type checking.
 
 An important invariant is that a cached direct module must still restore its own
-recorded imports. When the module is already present in the shared scheduler
-env, that closure is in memory: `lookupModule` returns the `NModule` import list
-alongside the public interface. `doImp` should use that in-memory list and avoid
-opening `.tydb` for modules compiled earlier in the same build process.
+recorded imports. `ModuleInfo` stores the imported module's import list, so a
+module already present in `modules` can restore its transitive imports without
+any `.tydb` read.
 
 When the module is not present in `modules`, `doImp` falls back to the `.tydb`
-cache on the search path, reads the stored interface, recursively materializes
-its imports, and then adds the module to the shared cache.
+cache on the search path, opens the module metadata, recursively materializes
+its imports, and then adds the module shell to the shared cache.
 
 The boundary is important: `.tydb` is a persistent cache and cross-process
 interface artifact, not an IPC mechanism between front stages in one compiler
@@ -171,9 +206,9 @@ When debugging import failures, it helps to ask which layer is failing:
   Then look at `mkEnv` and `doImp`.
 - Is a cached module present but its transitives missing? Then the issue is in
   environment materialization, not scheduler ordering.
-- Is a full `.tydb` being read but imports still not appearing? Then check
-  whether the caller is only decoding interface payload rather than invoking the
-  import loader.
+- Is a full `.tydb` being read during normal import lookup? Then look for a
+  caller that asks for broad enumeration instead of `tryQName` or
+  `moduleLookupName`.
 
 ## Related pages
 

--- a/docs/acton-dev-guide/src/compiler/imports_and_envs.md
+++ b/docs/acton-dev-guide/src/compiler/imports_and_envs.md
@@ -107,7 +107,7 @@ normal imported-name lookup:
 
 - implementation-hash refresh
 - codegen refresh
-- DBP back-pass execution after the selected codegen hash is stale
+- DBP back-pass fallback when selected statements cannot be reconstructed
 - tools that intentionally inspect a whole interface
 - completion fallback when the normal import environment cannot be restored
 

--- a/docs/acton-dev-guide/src/compiler/interface_caches.md
+++ b/docs/acton-dev-guide/src/compiler/interface_caches.md
@@ -64,6 +64,7 @@ Metadata and module-level keys:
 | `constructors` | `[Name]` |
 | `actors` | `[Name]` |
 | `stmt-count` | `Int` |
+| `stmt-has-not-impl` | `Bool` |
 
 The three `ByteString` hashes in `meta` are the module source-bytes hash, module
 public hash, and module implementation hash. The `ByteString` stored with each
@@ -105,7 +106,8 @@ Per-name keys:
 
 Each `NameHashInfo` value contains the local name, `srcHash`, `pubHash`,
 `implHash`, local public/implementation dependency names
-(`pubLocalDeps` / `implLocalDeps`). External dependency snapshots are stored in
+(`pubLocalDeps` / `implLocalDeps`), and the indexes of the typed top-level
+statements owned by that name. External dependency snapshots are stored in
 dependency rows instead of being repeated inside every `NameHashInfo`.
 
 Dependency rows:
@@ -186,7 +188,11 @@ keys plus the `deps` row and the stored name count. It does not decode
 first compare the dependency module hashes in `deps`; if that gate changes,
 they use per-name dependency rows to decide which local names are affected.
 DBP reads `roots` and exact `name-hash/<suffix>` entries while expanding the
-selected local dependency closure.
+selected local dependency closure. When the selected codegen hash is stale,
+`readSelectedModule` reconstructs a pruned typed module from only the selected
+`stmt/<index>` records; it falls back to `readFile` when statement ownership
+is missing or the module contains NotImplemented hooks, whose
+native-extension pairing needs the whole module.
 
 `readExtensionsByClass` and `readExtensionsByProtocol` read one class or
 protocol key directly. DBP uses these exact lookups while expanding the selected
@@ -196,8 +202,8 @@ extension names that the typed module can actually retain.
 `readFile` opens a read-only transaction and reconstructs the full payload by
 following the explicit order keys for ordered sections. It does not depend on
 LMDB cursor order for `TEnv` or typed statement reconstruction. DBP calls this
-only when its selection-sensitive codegen hash says the existing `.c`/`.h`
-output is missing or stale.
+only when selected statement reconstruction cannot serve a stale
+selection-sensitive codegen output.
 
 All readers share one cached read-only LMDB environment per `.tydb` path,
 opened with the normal reader lock table so concurrent writers in other

--- a/docs/acton-dev-guide/src/compiler/interface_caches.md
+++ b/docs/acton-dev-guide/src/compiler/interface_caches.md
@@ -11,23 +11,34 @@ The compiler code should not construct these paths directly. Use the
 
 ## Compatibility Boundary
 
-`InterfaceFiles` deliberately preserves the old interface-cache API:
+`InterfaceFiles` preserves the full-cache API and also exposes a selective
+read API for imported-module lookup:
 
 - `writeFile` writes the cache for one module.
-- `readHeader` reads only metadata, imports, roots, tests, docstring, and
-  per-name hash records.
+- `readHeaderSummary` reads metadata, imports, the stored name count, roots,
+  tests, and docstring; `readHeader` additionally decodes every per-name hash
+  record.
 - `readExtensionsByClass` and `readExtensionsByProtocol` read exact extension
   index entries without decoding `NameInfo` entries or typed
   statements.
 - `readFile` reconstructs the full cached payload: imports, `NameInfo`, typed
   module, metadata, module hashes, per-name hashes, roots, tests, and docstring.
-- `readHeaderMaybe` and `readFileMaybe` turn missing, corrupt, unreadable, or
-  version-mismatched caches into cache misses.
+- `readHeaderMaybe`, `readHeaderSummaryMaybe`, and `readFileMaybe` turn
+  missing, corrupt, unreadable, or version-mismatched caches into cache misses.
+- `openInterfaceDB` validates a `.tydb` for selective reads on the shared
+  per-path environment; `openInterfaceDBMaybe` is its cache-miss form.
+- `readInterfaceDBModuleInfo` reads only import/doc metadata.
+- `readInterfaceDBNameInfoMaybe` reads exactly one `name-info` entry by `Name`.
+- `readInterfaceDBPublicNames`, `readInterfaceDBConstructors`,
+  `readInterfaceDBActors`, `readInterfaceDBConAttr`,
+  `readInterfaceDBProtoAttr`, `readInterfaceDBDescendants`,
+  `readInterfaceDBExtByProto`, and `readInterfaceDBExtByType` read narrow
+  query indexes.
 
 That boundary lets the rest of the compiler keep treating cache access as a
 plain lookup while the on-disk representation moves from one binary blob to a
-keyed store. Current full reads still rebuild the same payload as before.
-More selective lookup by imported name is future work.
+keyed store. Full reads still rebuild the same payload as before, but normal
+imported-module lookup no longer decodes every `NameInfo` entry.
 
 ## LMDB Key Layout
 
@@ -49,6 +60,9 @@ Metadata and module-level keys:
 | `doc` | `Maybe String` |
 | `module-header` | `(ModName, [Import], Maybe String)` |
 | `name-count` | `Int` |
+| `public-names` | `[Name]` |
+| `constructors` | `[Name]` |
+| `actors` | `[Name]` |
 | `stmt-count` | `Int` |
 
 The three `ByteString` hashes in `meta` are the module source-bytes hash, module
@@ -124,6 +138,23 @@ Typed statements are stored by module order:
 
 Statement order is preserved for full typed-module reconstruction.
 
+Narrow query indexes are stored as separate keys, so solver and environment
+queries do not need to decode one combined module metadata value:
+
+| Key | Value type |
+| --- | --- |
+| `con-attr/<name>` | `[Name]` of public classes/actors declaring that attribute |
+| `proto-attr/<name>` | `[Name]` of public protocols declaring that attribute |
+| `descendants/<hash>` | `[Name]` of public classes/protocols below that constructor |
+| `ext-proto/<hash>` | `[Name]` of public extensions implementing that protocol |
+| `ext-type/<hash>` | `[Name]` of public extensions for that type/class |
+
+The `<hash>` suffix is a SHA-256 key for a source-location-free `QName`.
+Attribute keys reuse the normal name-key suffix scheme. Readers resolve the
+stored names through the matching `name-info/<suffix>` entries, so the query
+index itself stays small. The attribute indexes record attributes where they
+are declared; readers complete inherited owners through the descendants index.
+
 For example, `base/src/base64.act` contains top-level `encode` and `decode`
 definitions. Its `.tydb` uses these keys:
 
@@ -149,12 +180,13 @@ stmt/000000000001                 -> typed Stmt for decode
 
 ## Read And Write Behavior
 
-`readHeader` opens a read-only LMDB transaction and reads the header keys plus
-the `deps` row and `name-hash` entries. It does not decode `NameInfo` entries
-or typed statements. Stale checks first compare the dependency module hashes in
-`deps`; DBP uses the header path to get per-name hashes, local dependency
-edges, and root actor names before deciding whether the full typed module must
-be decoded.
+`readHeaderSummary` opens a read-only LMDB transaction and reads the header
+keys plus the `deps` row and the stored name count. It does not decode
+`NameInfo` entries, per-name hash rows, or typed statements. Stale checks
+first compare the dependency module hashes in `deps`; if that gate changes,
+they use per-name dependency rows to decide which local names are affected.
+DBP reads `roots` and exact `name-hash/<suffix>` entries while expanding the
+selected local dependency closure.
 
 `readExtensionsByClass` and `readExtensionsByProtocol` read one class or
 protocol key directly. DBP uses these exact lookups while expanding the selected
@@ -166,6 +198,24 @@ following the explicit order keys for ordered sections. It does not depend on
 LMDB cursor order for `TEnv` or typed statement reconstruction. DBP calls this
 only when its selection-sensitive codegen hash says the existing `.c`/`.h`
 output is missing or stale.
+
+All readers share one cached read-only LMDB environment per `.tydb` path,
+opened with the normal reader lock table so concurrent writers in other
+processes cannot recycle pages under an active read transaction. Writers keep
+their exclusive per-path lock and retire the cached environment, waiting for
+active readers to drain, before opening their own, so the process never holds
+two environments for one path. `openInterfaceDB` validates the version once
+and hands `Acton.Env` a handle it installs in a `ModuleInfo`; later
+exact-name lookups call `readInterfaceDBNameInfoMaybe`, which runs a short
+read transaction on the shared environment and decodes only the demanded
+`name-info/<suffix>` value. Those reads sit behind Env's pure-looking lookup
+functions and are memoized per module.
+
+The same handle exposes the narrow query readers for non-name solver
+questions: actor lookup reads `actors`; attribute lookup reads
+`con-attr/<name>` or `proto-attr/<name>`; descendant lookup reads one
+`descendants/<hash>` record; and witness lookup reads `ext-proto/<hash>` or
+`ext-type/<hash>`. Plain imports do not read these records.
 
 `writeFile` writes the full environment in one write transaction. The compiler
 has one writer for a module cache, while multiple readers may run in parallel.
@@ -197,8 +247,7 @@ write:             .ty 1.68 s/write, .tydb 1.12 s/write (-33%)
 ```
 
 The current `.tydb` format is larger because LMDB stores page-structured data
-and we keep values uncompressed. Header and full reads are still close to the
-old binary blob path because the compiler still reads all per-name hash records
-for cache decisions. The useful change is the storage boundary: names and typed
-statements now have explicit keys, so future work can load only the imported
-names a dependent module actually needs.
+and we keep values uncompressed. The useful property is the storage boundary:
+normal imported-module lookup loads only the names and index rows a dependent
+module actually uses, while full reconstruction remains available for explicit
+broad paths.

--- a/test/compiler/module_lookup/.gitignore
+++ b/test/compiler/module_lookup/.gitignore
@@ -1,0 +1,3 @@
+.acton.lock
+build.zig*
+out

--- a/test/compiler/module_lookup/Build.act
+++ b/test/compiler/module_lookup/Build.act
@@ -1,0 +1,2 @@
+name = "module_lookup"
+fingerprint = 0x5a1ff12a1d3ae79c

--- a/test/compiler/module_lookup/src/big.act
+++ b/test/compiler/module_lookup/src/big.act
@@ -1,0 +1,28 @@
+class Box:
+    value: int
+    __init__ : (int) -> None
+
+    def __init__(self, value):
+        self.value = value
+
+extension Box (Eq):
+    def __eq__(x, y):
+        return x.value == y.value
+
+class OrderedBox:
+    value: int
+    __init__ : (int) -> None
+
+    def __init__(self, value):
+        self.value = value
+
+extension OrderedBox (Ord):
+    def __eq__(x, y):
+        return x.value == y.value
+
+    def __lt__(x, y):
+        return x.value < y.value
+
+actor Worker():
+    def ping():
+        return 1

--- a/test/compiler/module_lookup/src/main.act
+++ b/test/compiler/module_lookup/src/main.act
@@ -1,0 +1,12 @@
+import big
+
+actor main(env):
+    box = big.Box(1)
+    other = big.Box(1)
+    ordered = big.OrderedBox(1)
+    ordered2 = big.OrderedBox(2)
+    worker = big.Worker()
+    if box == other and ordered == ordered and ordered < ordered2:
+        env.exit(0)
+    else:
+        env.exit(1)


### PR DESCRIPTION
Rebases the selective-tydb-read series onto current main and appends the cleaned-up deferred-back-pass commits. Incremental builds now read only the interface names actually needed from each dependency's .tydb rather than whole interfaces, route imported interfaces through ModuleInfo and on-demand indexes, and use deferred back passes so a changed module regenerates only the code a change actually reaches. A time-sampled build progress diagnostic is included for long compiler runs. The individual commits cover the specifics.