### PR TITLE
Run nightly workflow at 02:00

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ on:
       - v*
   schedule:
     # Schedule to run daily
-    - cron: '4 0 * * *'
+    - cron: '0 2 * * *'
   # Manual trigger that behaves exactly like the nightly run: rebuilds the Acton
   # compile cache cold and saves a fresh snapshot. Use it to populate caches
   # immediately (e.g. right after merging) instead of waiting for the next nightly.


### PR DESCRIPTION
Set the scheduled workflow to minute zero of hour two so the nightly
producer runs at 02:00 UTC.