### PR TITLE
Suppres project prefix from local module names

### DIFF
--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -1472,6 +1472,7 @@ initCliCompileHooks :: ProgressUI
 initCliCompileHooks progressUI progressState gopts sched gen plan = do
     let neededTasks = cpNeededTasks plan
         rootProj = ccRootProj (cpContext plan)
+        rootPaths = ccPathsRoot (cpContext plan)
         optsPlan = ccOpts (cpContext plan)
         isBuiltinTask t = tkMod (gtKey t) == A.modName ["__builtin__"]
         parseNeeded t =
@@ -1539,7 +1540,7 @@ initCliCompileHooks progressUI progressState gopts sched gen plan = do
           gate (progressWithLog progressUI (printDiagnostics gopts optsT diags))
         termProgress = puTermProgress progressUI
         termEnabled = termProgressEnabled termProgress
-        modLabel mn = modNameToString mn
+        modLabel mn = modNameToString (dropProjPrefix rootPaths mn)
         timeSep = "    "
         parseDoneStatus = "Parse done"
         frontDoneStatus = "Type check done"

--- a/compiler/acton/TestRunner.hs
+++ b/compiler/acton/TestRunner.hs
@@ -87,11 +87,6 @@ printErrorAndExit msg = do
     errorWithoutStackTrace msg
     exitFailure
 
-moduleHeaderLine :: String -> String
-moduleHeaderLine modName
-  | null modName = "Tests"
-  | otherwise = "Tests - module " ++ modName ++ ":"
-
 -- | List test modules by reading discovered tests from .tydb headers.
 listTestModules :: C.CompileOptions -> Paths -> IO [String]
 listTestModules _opts paths = do
@@ -141,7 +136,7 @@ listProjectTests opts paths topts modules = do
                    ]
             moduleObj (modName, names) =
               Aeson.object
-                [ AesonKey.fromString "name" Aeson..= modName
+                [ AesonKey.fromString "name" Aeson..= displayModName paths modName
                 , AesonKey.fromString "tests" Aeson..= map testObj names
                 ]
             report = Aeson.object
@@ -155,7 +150,7 @@ listProjectTests opts paths topts modules = do
           exitSuccess
         else do
           forM_ (Data.List.sortOn fst nonEmpty) $ \(modName, names) -> do
-            putStrLn ("Module " ++ modName ++ ":")
+            putStrLn ("Module " ++ displayModName paths modName ++ ":")
             forM_ names $ \name -> do
               let display = displayTestName name
               if display /= name
@@ -186,7 +181,7 @@ runProjectTests useColorOut gopts opts paths topts mode modules maxParallel = do
         if emitJson
           then do
             timeEnd <- getTime Monotonic
-            outputJsonReport (timeEnd - timeStart) []
+            outputJsonReport paths (timeEnd - timeStart) []
             return 0
           else do
             putStrLn "Nothing to test"
@@ -260,6 +255,7 @@ runProjectTests useColorOut gopts opts paths topts mode modules maxParallel = do
             startSpec spec running results = do
               let key = TestKey (tsModule spec) (tsName spec)
                   display = tsDisplay spec
+                  modDisplay = displayModName paths (tsModule spec)
                   useColorLine = tpuUseColor ui
                   showLog = tpuShowLog ui
               case M.lookup key cachedMap of
@@ -268,7 +264,7 @@ runProjectTests useColorOut gopts opts paths topts mode modules maxParallel = do
                       details = formatTestDetailLines useColorLine showLog cachedRes
                   if shouldShowCached cachedRes
                     then do
-                      ok <- testUiAppendFinal ui key (tsModule spec) line
+                      ok <- testUiAppendFinal ui key modDisplay line
                       if not ok
                         then return Nothing
                         else do
@@ -305,7 +301,7 @@ runProjectTests useColorOut gopts opts paths topts mode modules maxParallel = do
                             , trCached = False
                             }
                           initLine = formatTestLiveLineRenderer useColorLine expectedDurationMs nameWidth display initRes
-                      started <- testUiStart ui key (tsModule spec) initLine
+                      started <- testUiStart ui key modDisplay initLine
                       if not started
                         then return Nothing
                         else do
@@ -360,12 +356,12 @@ runProjectTests useColorOut gopts opts paths topts mode modules maxParallel = do
           writeTestCache (testCachePath paths) newCache
         if emitJson
           then do
-            outputJsonReport (timeEnd - timeStart) results
+            outputJsonReport paths (timeEnd - timeStart) results
             testUiProgressClear ui
             return (testExitCode results)
           else do
             when (not (tpuEnabled ui)) $
-              printTestResultsOrdered (tpuUseColor ui) (tpuShowLog ui) showCached nameWidth specs results
+              printTestResultsOrdered paths (tpuUseColor ui) (tpuShowLog ui) showCached nameWidth specs results
             _ <- printTestSummary (tpuUseColor ui) (timeEnd - timeStart) showCached results
             testUiProgressClear ui
             return (testExitCode results)
@@ -384,8 +380,8 @@ testExitCode results =
         errors = length [ r | r <- results, trSuccess r == Nothing ]
     in if errors > 0 then 2 else if failures > 0 then 1 else 0
 
-outputJsonReport :: TimeSpec -> [TestResult] -> IO ()
-outputJsonReport elapsed results = do
+outputJsonReport :: Paths -> TimeSpec -> [TestResult] -> IO ()
+outputJsonReport paths elapsed results = do
     let total = length results
         failures = length [ r | r <- results, trSuccess r == Just False ]
         errors = length [ r | r <- results, trSuccess r == Nothing ]
@@ -414,7 +410,7 @@ outputJsonReport elapsed results = do
               name = displayTestName (trName res)
               combinedOutput = if includeOutput then formatCombinedOutput (trStdOut res) (trStdErr res) else Nothing
           in Aeson.object
-               [ AesonKey.fromString "module" Aeson..= trModule res
+               [ AesonKey.fromString "module" Aeson..= displayModName paths (trModule res)
                , AesonKey.fromString "name" Aeson..= name
                , AesonKey.fromString "raw_name" Aeson..= trName res
                , AesonKey.fromString "status" Aeson..= status
@@ -569,6 +565,12 @@ readModuleTests paths mn = do
 
 modNameFromString :: String -> A.ModName
 modNameFromString s = A.modName (splitOnChar '.' s)
+
+-- | Render a module name for user-facing output, dropping the project-name
+-- prefix so consumers (the VS Code extension, the --module flag, the on-disk
+-- src/ layout) see the bare module name instead of e.g. "proj.mod".
+displayModName :: Paths -> String -> String
+displayModName paths = modNameToString . dropProjPrefix paths . modNameFromString
 
 splitOnChar :: Char -> String -> [String]
 splitOnChar ch input = case break (== ch) input of
@@ -1155,8 +1157,8 @@ printTestSummary useColor elapsed showCached results = do
             then return 1
             else return 0
 
-printTestResultsOrdered :: Bool -> Bool -> Bool -> Int -> [TestSpec] -> [TestResult] -> IO ()
-printTestResultsOrdered useColor showLog showCached nameWidth specs results = do
+printTestResultsOrdered :: Paths -> Bool -> Bool -> Bool -> Int -> [TestSpec] -> [TestResult] -> IO ()
+printTestResultsOrdered paths useColor showLog showCached nameWidth specs results = do
     let resMap = M.fromList [ (TestKey (trModule res) (trName res), res) | res <- results ]
         isOk res = trSuccess res == Just True && trException res == Nothing && not (trSkipped res)
         shouldShow res = not (trCached res) || showCached || not (isOk res) || trSnapshotUpdated res
@@ -1176,7 +1178,7 @@ printTestResultsOrdered useColor showLog showCached nameWidth specs results = do
                       then return printedMods
                       else do
                         when printedAny $ putStrLn ""
-                        putStrLn (moduleHeaderLine modName)
+                        putStrLn (moduleHeaderLine (displayModName paths modName))
                         return (Set.insert modName printedMods)
                   putStrLn (formatLine spec res)
                   mapM_ putStrLn (formatTestDetailLines useColor showLog res)

--- a/compiler/acton/TestRunner.hs
+++ b/compiler/acton/TestRunner.hs
@@ -44,7 +44,6 @@ import TerminalSize (termFitAnsiRight)
 import qualified Text.Regex.TDFA as TDFA
 import Data.Version (showVersion)
 import qualified Paths_acton
-import Debug.Trace
 
 data TestMode = TestModeRun | TestModeList | TestModePerf | TestModeStress deriving (Eq, Show)
 
@@ -172,9 +171,6 @@ runProjectTests useColorOut gopts opts paths topts mode modules maxParallel = do
     let emitJson = C.testJson topts
     nameRegexes <- compileTestNameRegexes (C.testNames topts)
     let wantedModules = Data.List.sort (filterModules (modulesOpt paths topts) modules)
-    traceM ("## modules: " ++ show modules)
-    traceM ("## --modules: " ++ show (C.testModules topts))
-    traceM ("## wanted: " ++ show wantedModules)
     testsByModule <- forM wantedModules $ \modName -> do
       names <- listModuleTests opts paths modName
       let wantedNames = Data.List.sort (filterTests nameRegexes names)

--- a/compiler/acton/TestUI.hs
+++ b/compiler/acton/TestUI.hs
@@ -12,6 +12,7 @@ module TestUI
   , testUiProgressClear
   , queuePendingDetails
   , flushPendingDetails
+  , moduleHeaderLine
   ) where
 
 import qualified Acton.CommandLineParser as C

--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -437,7 +437,7 @@ compilerTests =
             ]
           firstLog <- assertOk "initial dbp build" =<<
             runBuild ["build", "--skip-build", "--verbose", "--dbp", "provider:make_box", "--color", "never"]
-          assertBool "initial build should report DBP selection" ("DBP dbp_fixture.provider: forced by --dbp" `isInfixOf` firstLog)
+          assertBool "initial build should report DBP selection" ("DBP provider: forced by --dbp" `isInfixOf` firstLog)
           assertBool "initial build should select a subset" ("selected closure" `isInfixOf` firstLog)
           providerC <- readFile (typesDir </> "provider.c")
           assertBool "selected provider C should include selected root" ("make_box" `isInfixOf` providerC)
@@ -445,7 +445,7 @@ compilerTests =
           badSeedLog <- assertFails "bad dbp seed reports selection failure" =<<
             runBuild ["build", "--skip-build", "--dbp", "provider:not_a_name", "--color", "never"]
           assertBool "bad dbp seed should report selection failure"
-            ("DBP selection failed for dbp_fixture.provider" `isInfixOf` badSeedLog)
+            ("DBP selection failed for provider" `isInfixOf` badSeedLog)
           writeFile (srcDir </> "main.act") $ unlines
             [ "import provider"
             , ""
@@ -455,20 +455,20 @@ compilerTests =
             ]
           changedConsumerLog <- assertOk "changed consumer updates dbp selection" =<<
             runBuild ["build", "--skip-build", "--verbose", "--dbp", "provider", "--color", "never"]
-          assertBool "changed consumer should rerun provider DBP" ("DBP dbp_fixture.provider: forced by --dbp" `isInfixOf` changedConsumerLog)
+          assertBool "changed consumer should rerun provider DBP" ("DBP provider: forced by --dbp" `isInfixOf` changedConsumerLog)
           assertBool "changed consumer should make DBP codegen stale" ("generated code out of date" `isInfixOf` changedConsumerLog)
           providerC1b <- readFile (typesDir </> "provider.c")
           assertBool "changed consumer C should include newly interested root" ("unused_0" `isInfixOf` providerC1b)
           assertBool "changed consumer C should omit previously selected root" (not ("make_box" `isInfixOf` providerC1b))
           sameSelectionLog <- assertOk "cached dbp selection is up to date" =<<
             runBuild ["build", "--skip-build", "--verbose", "--dbp", "provider", "--color", "never"]
-          assertBool "same selection should reuse cached consumer" ("Fresh dbp_fixture.main: using cached .tydb" `isInfixOf` sameSelectionLog)
+          assertBool "same selection should reuse cached consumer" ("Fresh main: using cached .tydb" `isInfixOf` sameSelectionLog)
           assertBool "same selection should skip provider back passes" ("generated code up to date" `isInfixOf` sameSelectionLog)
           removeFile (typesDir </> "provider.c")
           removeFile (typesDir </> "provider.h")
           secondLog <- assertOk "cached dbp build" =<<
             runBuild ["build", "--skip-build", "--verbose", "--dbp", "provider", "--color", "never"]
-          assertBool "cached consumer should be reused" ("Fresh dbp_fixture.main: using cached .tydb" `isInfixOf` secondLog)
+          assertBool "cached consumer should be reused" ("Fresh main: using cached .tydb" `isInfixOf` secondLog)
           assertBool "cached build should collect provider interest from headers" ("interested names 1" `isInfixOf` secondLog)
           assertBool "cached build should still select the dependency closure" ("selected closure" `isInfixOf` secondLog)
           removeFile (typesDir </> "provider.c")
@@ -504,13 +504,13 @@ compilerTests =
           removeIfExists (typesDir </> "main.root.c")
           sixthLog <- assertOk "dbp keeps executable root actor" =<<
             runBuild ["build", "--verbose", "--dbp", "main", "--dbp", "provider", "--color", "never"]
-          assertBool "root module should report root seed" ("DBP dbp_fixture.main: forced by --dbp" `isInfixOf` sixthLog)
+          assertBool "root module should report root seed" ("DBP main: forced by --dbp" `isInfixOf` sixthLog)
           assertBool "root module should count root name" ("root names 1" `isInfixOf` sixthLog)
           mainC <- readFile (typesDir </> "main.c")
           assertBool "selected main C should keep root actor" ("mainQ_main" `isInfixOf` mainC)
           seventhLog <- assertOk "no-dbp disables forced dbp" =<<
             runBuild ["build", "--skip-build", "--verbose", "--dbp", "provider", "--no-dbp", "--color", "never"]
-          assertBool "no-dbp should suppress provider DBP" (not ("DBP dbp_fixture.provider" `isInfixOf` seventhLog))
+          assertBool "no-dbp should suppress provider DBP" (not ("DBP provider:" `isInfixOf` seventhLog))
           providerC5 <- readFile (typesDir </> "provider.c")
           assertBool "no-dbp provider C should include full module definitions" ("unused_1" `isInfixOf` providerC5)
 
@@ -568,9 +568,9 @@ compilerTests =
             putStrLn ("\nDBP library boundary log:\n" ++ logTxt)
           assertBool "library boundary should explain forced DBP exclusion" hasBoundaryInfo
           assertBool "internal library module should still run DBP"
-            ("DBP dbp_library_boundary.a: forced by --dbp" `isInfixOf` logTxt)
+            ("DBP a: forced by --dbp" `isInfixOf` logTxt)
           assertBool "boundary library module should not run DBP"
-            (not ("DBP dbp_library_boundary.b:" `isInfixOf` logTxt))
+            (not ("DBP b:" `isInfixOf` logTxt))
           aC <- readFile (typesDir </> "a.c")
           bC <- readFile (typesDir </> "b.c")
           assertBool "internal DBP module should keep used name" ("used" `isInfixOf` aC)

--- a/compiler/acton/test_incremental.hs
+++ b/compiler/acton/test_incremental.hs
@@ -178,16 +178,26 @@ stale = statusReported "Stale"
 -- different module's line) cannot cause a cross-module false match.
 statusReported :: T.Text -> T.Text -> T.Text -> Bool
 statusReported keyword out modName =
-  any (T.isInfixOf prefix) (T.lines out)
-  where prefix = keyword <> " " <> T.replace "/" "." modName <> ":"
+  any matches (T.lines out)
+  where
+    dotName = T.replace "/" "." modName
+    matches line =
+      case T.stripPrefix (keyword <> " ") (T.dropWhile (== ' ') line) of
+        Just afterKw ->
+          let tok = T.takeWhile (/= ':') afterKw
+          in tok == dotName || ("." <> tok) `T.isSuffixOf` dotName
+        Nothing -> False
 
--- | Match module labels across legacy "proj/mod" and new "proj.mod" formats.
+-- | Match module labels across "proj/mod", "proj.mod", and bare de-prefixed
+-- formats. A token matches when it equals the (dotted) module name or is a
+-- dot-boundary suffix of it, so bare "main" matches "proj.main" and "sub.bar"
+-- matches "proj.sub.bar" without falsely matching unrelated modules.
 matchesModule :: T.Text -> T.Text -> Bool
 matchesModule line modName =
   let dotName = T.replace "/" "." modName
-      leafName = T.takeWhileEnd (/= '/') modName
       tokens = T.words line
-  in any (`elem` tokens) [modName, dotName, leafName]
+      matchesTok tok = tok == modName || tok == dotName || ("." <> tok) `T.isSuffixOf` dotName
+  in any matchesTok tokens
 
 -- | Remove a file if it exists.
 removeIfExists :: FilePath -> IO ()

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -2305,7 +2305,7 @@ runFrontPasses gopts opts dbpBlocked paths env0 parsed srcContent srcBytes sourc
     `catch` handleTypeError
   where
     mn = A.modname parsed
-    filename = modNameToFilename mn
+    filename = modNameToFilename (dropProjPrefix paths mn)
     outbase = outBase paths mn
     absSrcBase = srcBase paths mn
     actFile = absSrcBase ++ ".act"
@@ -2763,7 +2763,7 @@ prepareDeferredBackJob sp gopts callbacks envAcc interestMap dbj = do
           else explicitSeeds
       rootSeeds = Data.Set.fromList roots
       selectedSeeds = Data.Set.union interested rootSeeds
-  nameSelection <- selectDbpNames mn tyFile selectedSeeds nameHashes
+  nameSelection <- selectDbpNames paths mn tyFile selectedSeeds nameHashes
   let codegenHash = dbpCodegenHash (dbjImplHash dbj) (dnsSelectedNames nameSelection)
   codegen <- codegenStatus paths mn codegenHash
   if codegenUpToDate codegen
@@ -2801,7 +2801,7 @@ logDbpSelection :: C.GlobalOptions
 logDbpSelection gopts callbacks mn dbj totalNames interestedCount rootCount selectedCount fallbackReason codegenReason =
   when (C.verbose gopts) $
     ccOnInfo callbacks $
-      "  DBP " ++ modNameToString mn
+      "  DBP " ++ modNameToString (dropProjPrefix (dbjPaths dbj) mn)
       ++ ": " ++ dbjReason dbj
       ++ ", total names " ++ show totalNames
       ++ ", interested names " ++ show interestedCount
@@ -2819,12 +2819,13 @@ dbpCodegenHash moduleImplHash selected =
       | n <- Data.List.sortOn Hashing.nameKey (Data.Set.toList selected)
       ]
 
-selectDbpNames :: A.ModName
+selectDbpNames :: Paths
+               -> A.ModName
                -> FilePath
                -> Data.Set.Set A.Name
                -> [InterfaceFiles.NameHashInfo]
                -> IO DbpNameSelection
-selectDbpNames mn tyFile seeds nameHashes
+selectDbpNames paths mn tyFile seeds nameHashes
   | Data.Set.null seeds =
       return DbpNameSelection
         { dnsSelectedNames = Data.Set.empty
@@ -2833,19 +2834,19 @@ selectDbpNames mn tyFile seeds nameHashes
       case ( traverse (dbpOwningName topNames) (Data.Set.toList seeds)
            , dbpLocalDepsFromNameHashes topNames nameHashes
            ) of
-        (Left reason, _) -> dbpSelectionError mn reason
-        (_, Left reason) -> dbpSelectionError mn reason
+        (Left reason, _) -> dbpSelectionError paths mn reason
+        (_, Left reason) -> dbpSelectionError paths mn reason
         (Right roots, Right localDeps) -> do
-          selected <- dbpNameClosure (dbpExtensionsForName mn tyFile topNames) localDeps (Data.Set.fromList roots)
+          selected <- dbpNameClosure (dbpExtensionsForName paths mn tyFile topNames) localDeps (Data.Set.fromList roots)
           return DbpNameSelection
             { dnsSelectedNames = selected
             }
   where
     topNames = dbpTopNamesFromNameHashes nameHashes
 
-dbpSelectionError :: A.ModName -> String -> IO a
-dbpSelectionError mn reason =
-  throwIO (DbpSelectionError ("DBP selection failed for " ++ modNameToString mn ++ ": " ++ reason))
+dbpSelectionError :: Paths -> A.ModName -> String -> IO a
+dbpSelectionError paths mn reason =
+  throwIO (DbpSelectionError ("DBP selection failed for " ++ modNameToString (dropProjPrefix paths mn) ++ ": " ++ reason))
 
 selectDbpModule :: Int
                 -> Int
@@ -2901,15 +2902,15 @@ dbpLocalDepsFromNameHashes topNames nameHashes =
         )
     unionNames xs ys = Data.List.sortOn Hashing.nameKey (Data.List.nub (xs ++ ys))
 
-dbpExtensionsForName :: A.ModName -> FilePath -> Data.Set.Set A.Name -> A.Name -> IO [A.Name]
-dbpExtensionsForName mn tyFile topNames n = do
+dbpExtensionsForName :: Paths -> A.ModName -> FilePath -> Data.Set.Set A.Name -> A.Name -> IO [A.Name]
+dbpExtensionsForName paths mn tyFile topNames n = do
   byClass <- InterfaceFiles.readExtensionsByClass tyFile n
   byProtocol <- InterfaceFiles.readExtensionsByProtocol tyFile n
   let exts = unionNames byClass byProtocol
       missing = [ ext | ext <- exts, Data.Set.notMember ext topNames ]
   if null missing
     then return exts
-    else dbpSelectionError mn $
+    else dbpSelectionError paths mn $
            "extension index for " ++ nameToString n
            ++ " points at non-top-level extension(s) "
            ++ Data.List.intercalate ", " (map nameToString missing)
@@ -3231,7 +3232,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
 
     forcedDbpMods = M.keysSet (parseDbpRequests (projName rootPaths) opts)
 
-    formatTaskKey k = modNameToString (tkMod k)
+    formatTaskKey k = modNameToString (dropProjPrefix rootPaths (tkMod k))
 
     logForcedDbpBoundaryExclusions =
       unless (C.no_dbp opts) $
@@ -3534,11 +3535,11 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
               Nothing -> getNameHashCached paths m n
 
           missingNameHashDiagnostics qn =
-            errsToDiagnostics "Compilation error" (modNameToFilename mn) ""
+            errsToDiagnostics "Compilation error" (modNameToFilename (dropProjPrefix paths mn)) ""
               [(NoLoc, "Hash info missing for " ++ prstr qn)]
 
           missingDepHashDiagnostics label qn users =
-            errsToDiagnostics "Compilation error" (modNameToFilename mn) ""
+            errsToDiagnostics "Compilation error" (modNameToFilename (dropProjPrefix paths mn)) ""
               [(NoLoc, label ++ " hash missing for " ++ prstr qn ++ users)]
 
           checkImportHashes imps = do
@@ -3888,11 +3889,11 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                       else return Nothing
                     when (C.verbose gopts) $ do
                       if needBySource
-                        then ccOnInfo callbacks ("  Stale " ++ modNameToString mn ++ ": source changed")
+                        then ccOnInfo callbacks ("  Stale " ++ modNameToString (dropProjPrefix paths mn) ++ ": source changed")
                         else do
                           when needByPub $ do
                             let fmtDelta (qn, old, new) = prstr qn ++ " " ++ short8 old ++ " → " ++ short8 new ++ fmtUsers pubUsers qn
-                            ccOnInfo callbacks ("  Stale " ++ modNameToString mn ++ ": pub changes in " ++ Data.List.intercalate ", " (map fmtDelta pubDeltas))
+                            ccOnInfo callbacks ("  Stale " ++ modNameToString (dropProjPrefix paths mn) ++ ": pub changes in " ++ Data.List.intercalate ", " (map fmtDelta pubDeltas))
                           when needByMissing $ do
                             let fmtMissing users qn = prstr qn ++ fmtUsers users qn
                                 pubMissingItems =
@@ -3907,7 +3908,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                                   [ "rows " ++ modNameToString depMn
                                   | depMn <- Data.List.sortOn modNameToString (Data.Set.toList rowMissingMods)
                                   ]
-                            ccOnInfo callbacks ("  Stale " ++ modNameToString mn ++ ": missing dep hashes in " ++ Data.List.intercalate ", " (pubMissingItems ++ implMissingItems ++ rowMissingItems))
+                            ccOnInfo callbacks ("  Stale " ++ modNameToString (dropProjPrefix paths mn) ++ ": missing dep hashes in " ++ Data.List.intercalate ", " (pubMissingItems ++ implMissingItems ++ rowMissingItems))
                     t' <- case taskCurrent of
                             ActonTask{} -> return taskCurrent
                             _ -> materializeTask optsT sp mn actFile providers Nothing taskCurrent
@@ -3939,7 +3940,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                             when (C.verbose gopts) $
                               forM_ prevNameHashes $ \prevMap ->
                                 forM_ (nameHashSummary prevMap (frNameHashes fr)) $ \summary ->
-                                  ccOnInfo callbacks ("  Hash deltas " ++ modNameToString mn ++ ": " ++ summary)
+                                  ccOnInfo callbacks ("  Hash deltas " ++ modNameToString (dropProjPrefix paths mn) ++ ": " ++ summary)
                             cacheFrontResult fr
                       ParseTask{} -> error ("Internal error: unmaterialized ParseTask " ++ modNameToString mn)
                       _ -> error ("Internal error: unexpected task " ++ show t')
@@ -3947,7 +3948,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                     --traceM ("\n## runImplRefresh " ++ prstr mn ++ "\n")
                     let rerunFront = do
                           when (C.verbose gopts) $
-                            ccOnInfo callbacks ("  Stale " ++ modNameToString mn ++ ": impl refresh encountered unresolved dep hashes; rerunning front passes")
+                            ccOnInfo callbacks ("  Stale " ++ modNameToString (dropProjPrefix paths mn) ++ ": impl refresh encountered unresolved dep hashes; rerunning front passes")
                           runFront
                         handleSyncFailure :: SomeException -> IO (TaskKey, Either [Diagnostic String] FrontResult)
                         handleSyncFailure err =
@@ -3959,7 +3960,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                     (do
                       when (C.verbose gopts) $ do
                         let fmtDelta (qn, old, new) = prstr qn ++ " " ++ short8 old ++ " → " ++ short8 new ++ fmtUsers implUsers qn
-                        ccOnInfo callbacks ("  Stale " ++ modNameToString mn ++ ": impl changes in " ++ Data.List.intercalate ", " (map fmtDelta implDeltas))
+                        ccOnInfo callbacks ("  Stale " ++ modNameToString (dropProjPrefix paths mn) ++ ": impl changes in " ++ Data.List.intercalate ", " (map fmtDelta implDeltas))
                       tyRes <- readTyFile
                       case tyRes of
                         Left diags -> return (key, Left diags)
@@ -4057,7 +4058,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                     --traceM ("\n## runCodegenRefresh " ++ prstr mn ++ "\n")
                     when (C.verbose gopts) $ do
                       let suffix = maybe "" formatCodegenDelta mCodegenStatus
-                      ccOnInfo callbacks ("  Stale " ++ modNameToString mn ++ ": generated code out of date" ++ suffix)
+                      ccOnInfo callbacks ("  Stale " ++ modNameToString (dropProjPrefix paths mn) ++ ": generated code out of date" ++ suffix)
                     tyRes <- readTyFile
                     case tyRes of
                       Left diags -> return (key, Left diags)
@@ -4078,7 +4079,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                   runReuse = do
                     --traceM ("\n## runReuse " ++ prstr mn ++ "\n")
                     when (C.verbose gopts) $
-                      ccOnInfo callbacks ("  Fresh " ++ modNameToString mn ++ ": using cached .tydb")
+                      ccOnInfo callbacks ("  Fresh " ++ modNameToString (dropProjPrefix paths mn) ++ ": using cached .tydb")
                     ifaceRes <- case taskCurrent of
                                   TyTask{ tyPubHash = h } -> readIfaceFromTy paths mn "" (Just h)
                                   _ -> readIfaceFromTy paths mn "" Nothing


### PR DESCRIPTION
This aligns the compiler output to consistently print local project names without the project prefix:
- acton build
- acton test list
- acton test --module <local-name>
- paths in error messages 

I didn't do `snapshots/expected` paths, but I guess that should be updated too?