### PR TITLE
Fix macOS Zig SDK fallback for Homebrew

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -641,7 +641,7 @@ ifeq ($(OS),macos)
 # /dev/null to prevent Zig from trying to use them and instead falling back to
 # its own implementation.
 # See https://codeberg.org/ziglang/zig/issues/31658.
-dist/bin/actondb: export DEVELOPER_DIR := $(or $(DEVELOPER_DIR),/dev/null)
+dist/bin/actondb: export DEVELOPER_DIR := /dev/null
 endif
 dist/bin/actondb: $(DIST_ZIG) $(DEPS)
 	@mkdir -p $(dir $@)

--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -2457,8 +2457,8 @@ runZig gopts opts zigExe zigArgs paths wd mProgressUI = do
               closeFd readFd `catch` ignoreIO
               takeMVar doneVar
         return (Just ("ZIG_PROGRESS", envVal), onStart', onStop', False)
-    let env1 = if System.Info.os == "darwin" && not (any ((== "DEVELOPER_DIR") . fst) env0)
-               then ("DEVELOPER_DIR", "/dev/null") : env0
+    let env1 = if System.Info.os == "darwin"
+               then ("DEVELOPER_DIR", "/dev/null") : filter ((/= "DEVELOPER_DIR") . fst) env0
                else env0
     homeDir <- getHomeDirectory
     let zigEnv = [ ("ZIG_LOCAL_CACHE_DIR", joinPath [homeDir, ".cache", "acton", "zig-local-cache"])

--- a/homebrew/Formula/acton.rb
+++ b/homebrew/Formula/acton.rb
@@ -26,7 +26,8 @@ class Acton < Formula
     bin.install_symlink "acton" => "actonc"
     bin.install "dist/bin/actondb"
     bin.install "dist/bin/runacton"
-    prefix.install Dir["dist/*"]
+    bin.install "dist/bin/lsp-server-acton"
+    prefix.install Dir["dist/*"] - ["dist/bin"]
     bash_completion.install "completion/acton.bash-completion"
   end
 


### PR DESCRIPTION
The v0.28.0 Homebrew source build can still let Zig see the macOS 26 Command Line Tools SDK when the runner already provides DEVELOPER_DIR. That bypasses the existing fallback and makes the Formula test fail while compiling C++ dependencies through bundled Zig.

This forces the fallback for spawned Zig builds on macOS and applies the same rule to the direct actondb build. It also keeps the in-repo Homebrew Formula aligned with the tap by installing lsp-server-acton explicitly and keeping dist/bin out of prefix.install.