### PR TITLE
Box unboxed-rep values reaching `value` targets at more use-sites

### DIFF
--- a/compiler/lib/src/Acton/Boxing.hs
+++ b/compiler/lib/src/Acton/Boxing.hs
@@ -242,6 +242,11 @@ literalUnboxedRep _              = Nothing
 exprUnboxedRep env e@Int{}       = literalUnboxedRep e
 exprUnboxedRep env e@Float{}     = literalUnboxedRep e
 exprUnboxedRep env e@DotI{}      = Nothing
+-- After boxing, an And/Or expression has boxed operands and yields a boxed
+-- value (its result IS one of the operands), so it must not be re-boxed by a
+-- use-site fallback, even though its static type is unboxable.
+exprUnboxedRep env (BinOp _ _ op _)
+  | op `elem` [And, Or]           = Nothing
 exprUnboxedRep env c@(Call _ f _ KwdNil)
   | callReturnsMsg env f          = Nothing
   | rawClassConstructor env c f    = unboxedRepType (typeOf env c)
@@ -266,6 +271,8 @@ fixassign env (TOpt _ t) e
     exprUnboxedRep env e == Just t = Box t e
 fixassign env t e
   | Just t' <- unboxedRepType t    = forceUnbox env t' e
+  | Box{} <- e                     = e
+  | Just rt <- exprUnboxedRep env e = Box rt e
   | otherwise                      = e
 
 fixarg env (TUnboxed _ t) e     = forceUnbox env t e
@@ -460,9 +467,9 @@ instance Boxing Expr where
                                          (ws3,e3') <- boxing env e3
                                          case unboxedRepType (typeOf env e) of
                                              Just t -> return (HashSet.unions [ws1, ws2, ws3], Box t $ Cond l (forceUnbox env t e1') e2' (forceUnbox env t e3'))
-                                             Nothing -> return (HashSet.unions [ws1, ws2, ws3], Cond l e1' e2' e3')
+                                             Nothing -> return (HashSet.unions [ws1, ws2, ws3], Cond l (boxValueExpr env e1 e1') e2' (boxValueExpr env e3 e3'))
     boxing env (IsInstance l e qn)  = do (ws1,e1) <- boxing env e
-                                         return (ws1, IsInstance l e1 qn)
+                                         return (ws1, IsInstance l (boxValueExpr env e e1) qn)
     boxing env e@(BinOp l e1 op e2)
       | op `notElem` [And, Or],
         Just rt <- unboxedRepType t
@@ -471,6 +478,10 @@ instance Boxing Expr where
                                          return (HashSet.union ws1 ws2, Box rt $ Paren NoLoc $ BinOp l (unboxArg e1 e1') op (unboxArg e2 e2'))
       where t                       = typeOf env e
             unboxArg e0 e'          = maybe e' (\t -> forceUnbox env t e') (unboxedRepType (typeOf env e0))
+    boxing env e@(BinOp l e1 op e2)
+      | op `elem` [And, Or]         = do (ws1,e1') <- boxing env e1
+                                         (ws2,e2') <- boxing env e2
+                                         return (HashSet.union ws1 ws2, BinOp l (boxValueExpr env e1 e1') op (boxValueExpr env e2 e2'))
     boxing env e@(BinOp l e1 op e2) = do (ws1,e1') <- boxing env e1
                                          (ws2,e2') <- boxing env e2
                                          return (HashSet.union ws1 ws2, BinOp l e1' op e2')

--- a/test/regression_auto/179-unbox-value-field-assign.act
+++ b/test/regression_auto/179-unbox-value-field-assign.act
@@ -1,0 +1,24 @@
+# Regression: assigning an unboxed primitive (u64) to a `value`/`?value` field
+# or variable must box it. Otherwise the raw integer is stored where a heap
+# pointer is expected and the first virtual access (isinstance) dereferences it,
+# crashing with "member access within misaligned address".
+PORT: u64 = u64(2001)
+
+class Cell(object):
+    v: ?value
+    def __init__(self):
+        self.v = None
+
+def build() -> Cell:
+    c = Cell()
+    n: u64 = u64(1000)
+    c.v = n              # bare local u64 -> ?value field
+    return c
+
+actor main(env):
+    c1 = Cell()
+    c1.v = PORT          # module global u64 -> ?value field
+    c2 = build()
+    if isinstance(c1.v, atom) and isinstance(c2.v, atom):
+        env.exit(0)
+    env.exit(1)

--- a/test/regression_auto/180-unbox-value-conditional.act
+++ b/test/regression_auto/180-unbox-value-conditional.act
@@ -1,0 +1,13 @@
+# Regression: a conditional expression (a if c else b) whose join type is not
+# unboxable (here `value`/`atom`) must box an unboxed-primitive branch. The raw
+# integer would otherwise be dereferenced by the following isinstance.
+PORT: u64 = u64(2001)
+
+def pick(b: bool) -> value:
+    n: u64 = u64(1000)
+    return n if b else "x"       # unboxed-rep then-branch into a `value` result
+
+actor main(env):
+    if isinstance(pick(True), atom) and isinstance(pick(False), atom):
+        env.exit(0)
+    env.exit(1)

--- a/test/regression_auto/181-unbox-value-and-or.act
+++ b/test/regression_auto/181-unbox-value-and-or.act
@@ -1,0 +1,19 @@
+# Regression: the runtime $AND/$OR macros call __bool__ on their operands via
+# the object's class pointer, so an unboxed-primitive operand must be boxed.
+# Also guards the use-site: an and/or of unboxable type passed where a `value`
+# is expected must not be double-boxed (which would emit toB_u64(B_u64), a
+# compile error), while staying unboxed in arithmetic.
+PORT: u64 = u64(2001)
+
+def take(v: value) -> bool:
+    return isinstance(v, atom)
+
+actor main(env):
+    a: u64 = u64(5)
+    b: u64 = u64(6)
+    ok_isinstance = isinstance(a or b, atom)     # and/or operand via $ISINSTANCE
+    ok_value_arg = take(a or PORT)               # and/or -> `value` argument (fixarg)
+    ok_unboxed = (a or b) + u64(1) == u64(6)     # and/or stays unboxed in arithmetic
+    if ok_isinstance and ok_value_arg and ok_unboxed:
+        env.exit(0)
+    env.exit(1)

--- a/test/regression_auto/182-unbox-value-isinstance.act
+++ b/test/regression_auto/182-unbox-value-isinstance.act
@@ -1,0 +1,10 @@
+# Regression: isinstance(x, T) lowers to $ISINSTANCE, which reads x->$class.
+# An unboxed-primitive operand (a module global or a bare local) must be boxed
+# first, otherwise the raw integer is dereferenced as a pointer.
+PORT: u64 = u64(2001)
+
+actor main(env):
+    n: u64 = u64(1000)
+    if isinstance(PORT, atom) and isinstance(n, atom):
+        env.exit(0)
+    env.exit(1)


### PR DESCRIPTION
This closes #2942. The initial fix was only limited to the crash I found in one of the applications:

```diff
 fixassign env t e
   | Just t' <- unboxedRepType t    = forceUnbox env t' e
+  | Box{} <- e                     = e
+  | Just rt <- exprUnboxedRep env e = Box rt e
   | otherwise                      = e
```

But then my robot continued the search and came up with more edge cases

> Unboxable primitives (u64/int/float) are now carried unboxed; each use-site that needs a boxed `value` must insert the `Box`. That insertion existed for fixarg/fixreturn/boxValueExpr but was missing elsewhere, so a raw int reached a boxed slot and the first virtual access dereferenced it, causing a runtime crash.
> 
> - fixassign: box a raw unboxed-rep RHS into a value/?value target. #2942 
> - Cond: box then/else branches when the join type is not unboxable.
> - IsInstance: box the operand ($ISINSTANCE derefs $class).
> - BinOp And/Or: box both operands ($AND/$OR call __bool__ on them).
> - exprUnboxedRep: treat a processed And/Or as already boxed, else a fallback re-boxes it (toB_u64(B_u64), a compile error).




