### PR TITLE
Treat system tydb files as immutable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -623,6 +623,8 @@ dist/base: base base/.build base/__root.zig base/acton.zig base/build.zig base/b
 	rm -rf "$@/src" "$@/out/types/std"
 	cp -a base/__root.zig base/Build.act base/acton.zig base/build.zig base/build.zig.zon base/builtin base/rts base/src dist/base/
 	cd dist/base && ../bin/acton build --skip-build && rm -rf .build
+	find "$@/out/types" -name lock.mdb -type f -delete
+	find "$@/out/types" -name data.mdb -type f -exec chmod 0644 {} +
 
 .PHONY: dist/std
 dist/std: std std/Build.act std/build.zig std/build.zig.zon dist/base dist/bin/acton $(DEPS)
@@ -630,6 +632,8 @@ dist/std: std std/Build.act std/build.zig std/build.zig.zon dist/base dist/bin/a
 	rm -rf "$@/src" "$@/out/types"
 	cp -a std/Build.act std/build.zig std/build.zig.zon std/src dist/std/
 	cd dist/std && ../bin/acton build --skip-build && rm -rf .build
+	find "$@/out/types" -name lock.mdb -type f -delete
+	find "$@/out/types" -name data.mdb -type f -exec chmod 0644 {} +
 
 # This does a little hack, first copying and then moving the file in place. This
 # is to avoid an error if the executable is currently running. cp tries to open

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -4611,6 +4611,7 @@ findPaths actFile opts  = do execDir <- takeDirectory <$> getExecutablePath
                              (projName,depTypePaths) <- if isTmp then return ("",[]) else collectDepTypePaths projPath depOverrides
                              let sPaths = [projTypes] ++ depTypePaths ++ (C.searchpath opts) ++ systemTypePaths sysPath sysTypes
                                  modName = A.modName $ (if isTmp then dirInSrc else projName:dirInSrc) ++ [fileBody]
+                             InterfaceFiles.registerSystemTypeRoots (systemTypePaths sysPath sysTypes)
                              createDirectoryIfMissing True binDir
                              createDirectoryIfMissing True projOut
                              createDirectoryIfMissing True projTypes
@@ -4760,6 +4761,7 @@ pathsForModule opts projMap ctx mn = do
         src = projSrcDir ctx
         proj = BuildSpec.specName $ projBuildSpec ctx
         p = Paths sPaths (projSysPath ctx) (projSysTypes ctx) (projRoot ctx) (projOutDir ctx) (projTypesDir ctx) bin src False ".act" mn proj
+    InterfaceFiles.registerSystemTypeRoots (systemTypePaths (projSysPath ctx) (projSysTypes ctx))
     createDirectoryIfMissing True bin
     createDirectoryIfMissing True (projOutDir ctx)
     createDirectoryIfMissing True (projTypesDir ctx)

--- a/compiler/lib/src/InterfaceFiles.hs
+++ b/compiler/lib/src/InterfaceFiles.hs
@@ -90,6 +90,7 @@ module InterfaceFiles
   , interfaceModifiedTimeNs
   , copyInterface
   , listInterfaceDirsRecursive
+  , registerSystemTypeRoots
   , keyNameInfo
   , keyNameHash
   , readDepNames
@@ -135,12 +136,12 @@ import Foreign.Ptr (castPtr)
 import Foreign.Storable (peek)
 import GHC.Generics (Generic)
 import System.Directory (canonicalizePath, createDirectoryIfMissing, doesDirectoryExist, doesFileExist, getFileSize, getModificationTime, listDirectory, removeFile, removePathForcibly)
-import System.Environment (lookupEnv)
-import System.FilePath ((</>), takeExtension)
+import System.Environment (getExecutablePath, lookupEnv)
+import System.FilePath ((</>), addTrailingPathSeparator, normalise, takeDirectory, takeExtension)
 import System.IO (hPutStrLn, stderr)
 import System.IO.Error (isDoesNotExistError)
 import System.IO.Unsafe (unsafePerformIO)
-import System.Posix.Files (fileAccess, getFileStatus, modificationTimeHiRes, setFileMode)
+import System.Posix.Files (getFileStatus, modificationTimeHiRes, setFileMode)
 
 data NameHashInfo = NameHashInfo
   { nhName     :: A.Name
@@ -267,6 +268,19 @@ lmdbOpenLock = unsafePerformIO (newMVar ())
 interfaceLocks :: MVar (Map.Map FilePath (MVar ()))
 {-# NOINLINE interfaceLocks #-}
 interfaceLocks = unsafePerformIO (newMVar Map.empty)
+
+systemTypeRoots :: MVar [FilePath]
+{-# NOINLINE systemTypeRoots #-}
+systemTypeRoots = unsafePerformIO (newMVar [])
+
+registerSystemTypeRoots :: [FilePath] -> IO ()
+registerSystemTypeRoots roots =
+    modifyMVar systemTypeRoots $ \old ->
+      return (foldl' addRoot old (map normalise roots), ())
+  where
+    addRoot acc root
+      | root `elem` acc = acc
+      | otherwise       = root : acc
 
 traceTydbReads :: Bool
 traceTydbReads =
@@ -463,38 +477,34 @@ isTransientLmdbOsError err =
       Left _  -> True
       Right _ -> False
 
--- Choose read-only open flags. A writable cache may be rewritten by a
--- concurrent acton process, so it MUST keep LMDB's lock table for reader/writer
--- safety (the lock.mdb open race there is handled by retrying the open). Only an
--- installed cache the user cannot write -- where no writer can exist -- uses
--- MDB_NOLOCK, so it stays readable even when lock.mdb cannot be created in a
--- read-only directory.
+-- Choose read-only open flags. Project and dependency caches may be rewritten
+-- by a concurrent acton process, so they MUST keep LMDB's lock table for
+-- reader/writer safety (the lock.mdb open race there is handled by retrying the
+-- open). Selected Acton system type roots are immutable runtime input, so
+-- bundled base/std interfaces are read without lock-table state.
 readOnlyOpenFlags :: FilePath -> IO [LMDB.MDB_EnvFlag]
 readOnlyOpenFlags path = do
-    useLock <- canUseLockFile path
-    noLock <- canReadWithoutLock path
-    return $ if useLock || not noLock
-               then [LMDB.MDB_RDONLY]
-               else [LMDB.MDB_RDONLY, LMDB.MDB_NOLOCK]
+    noLock <- isUnderImmutableInterfaceRoot path
+    return $ if noLock
+               then [LMDB.MDB_RDONLY, LMDB.MDB_NOLOCK]
+               else [LMDB.MDB_RDONLY]
 
-canUseLockFile :: FilePath -> IO Bool
-canUseLockFile path = do
-    let lockPath = lockFilePath path
-    exists <- doesFileExist lockPath
-    if exists
-      then fileAccess lockPath False True False
-      else fileAccess path False True True
+actonDistributionRoot :: FilePath
+{-# NOINLINE actonDistributionRoot #-}
+actonDistributionRoot =
+    unsafePerformIO $ do
+      exe <- getExecutablePath
+      canonicalizePath (takeDirectory exe </> "..")
 
-canReadWithoutLock :: FilePath -> IO Bool
-canReadWithoutLock path = do
-    let dataPath = dataFilePath path
-    exists <- doesFileExist dataPath
-    if not exists
-      then return False
-      else do
-        dataWritable <- fileAccess dataPath False True False
-        dirWritable <- fileAccess path False True True
-        return (not dataWritable && not dirWritable)
+isUnderImmutableInterfaceRoot :: FilePath -> IO Bool
+isUnderImmutableInterfaceRoot path = do
+    cpath <- canonicalizePath path
+    roots <- withMVar systemTypeRoots return
+    return (any (`containsPath` cpath) (actonDistributionRoot : roots))
+  where
+    containsPath root child =
+      let rootDir = addTrailingPathSeparator root
+      in child == root || rootDir `Data.List.isPrefixOf` child
 
 lmdbTransientMaxAttempts :: Int
 lmdbTransientMaxAttempts = 10
@@ -515,6 +525,9 @@ withInterfaceLock path action = do
 
 withReadTxn :: FilePath -> (LMDB.MDB_txn -> LMDB.MDB_dbi -> IO a) -> IO a
 withReadTxn path action = do
+    exists <- doesFileExist (dataFilePath path)
+    unless exists $
+      E.throwIO (TyCacheInvalid ("Missing .tydb data file: " ++ dataFilePath path))
     mapSize <- readMapSize path
     -- mdb_txn_begin can still hit a transient lock-table OS error after a
     -- successful env open, so retry the read transaction with a fresh env.

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -51,8 +51,7 @@ import Error.Diagnose.Report (Report(..))
 import Prettyprinter (unAnnotate, layoutPretty, defaultLayoutOptions)
 import Prettyprinter.Render.Text (renderStrict)
 import System.FilePath ((</>), joinPath, takeFileName, takeBaseName, takeDirectory, splitDirectories, takeExtension)
-import System.Directory (createDirectoryIfMissing, getCurrentDirectory, setCurrentDirectory, listDirectory, doesDirectoryExist, doesFileExist)
-import System.Posix.Files (setFileMode)
+import System.Directory (createDirectoryIfMissing, getCurrentDirectory, setCurrentDirectory, listDirectory, doesDirectoryExist, doesFileExist, removeFile)
 import System.IO.Temp (withSystemTempDirectory)
 import System.Timeout (timeout)
 import Control.Monad (forM_, when, foldM)
@@ -245,11 +244,11 @@ main = do
           (srcHashH, pubHashH, implHashH) `shouldBe` ("src", "pub", "impl")
           nameHashesH `shouldBe` nameHashes
 
-      it "reads interfaces from read-only installed directories" $ do
-        withSystemTempDirectory "acton-iface-readonly" $ \dir -> do
+      it "does not create lock files when reading registered system roots" $ do
+        withSystemTempDirectory "acton-iface-syspath" $ \dir -> do
           let mn = S.modName ["iface"]
-              tyPath = dir </> "iface.tydb"
-              dataPath = tyPath </> "data.mdb"
+              typesRoot = dir </> "sys" </> "base" </> "out" </> "types"
+              tyPath = typesRoot </> "iface.tydb"
               lockPath = tyPath </> "lock.mdb"
               firstName = S.name "first"
               iface = [(firstName, I.NVar S.tWild)]
@@ -257,18 +256,19 @@ main = do
               nmod = I.NModule [] iface Nothing
               tmod = S.Module mn [] Nothing []
           InterfaceFiles.writeFile tyPath "src" "pub" "impl" Nothing [] [] nameHashes [] [] Nothing nmod tmod
-          let restore = do
-                setFileMode tyPath 0o755
-                setFileMode dataPath 0o644
-                setFileMode lockPath 0o644
-          (do setFileMode tyPath 0o555
-              setFileMode dataPath 0o444
-              setFileMode lockPath 0o444
-              (_sourceMetaH, srcHashH, pubHashH, implHashH, _impsH, _depModulesH, nameHashesH, _rootsH, _testsH, _docH) <-
-                InterfaceFiles.readHeader tyPath
-              (srcHashH, pubHashH, implHashH) `shouldBe` ("src", "pub", "impl")
-              nameHashesH `shouldBe` nameHashes)
-            `E.finally` restore
+          removeFile lockPath
+          InterfaceFiles.registerSystemTypeRoots [typesRoot]
+          (_sourceMetaH, srcHashH, pubHashH, implHashH, _impsH, _depModulesH, nameHashesH, _rootsH, _testsH, _docH) <-
+            InterfaceFiles.readHeader tyPath
+          (srcHashH, pubHashH, implHashH) `shouldBe` ("src", "pub", "impl")
+          nameHashesH `shouldBe` nameHashes
+          doesFileExist lockPath `shouldReturn` False
+
+      it "treats missing .tydb directories as cache misses" $ do
+        withSystemTempDirectory "acton-iface-missing" $ \dir -> do
+          let tyPath = dir </> "missing.tydb"
+          InterfaceFiles.readHeaderMaybe tyPath `shouldReturn` Nothing
+          InterfaceFiles.readFileMaybe tyPath `shouldReturn` Nothing
 
       it "treats corrupt .tydb directories as cache misses" $ do
         withSystemTempDirectory "acton-iface-corrupt" $ \dir -> do


### PR DESCRIPTION
Bundled base and std interface databases are read-only runtime inputs from the selected Acton system root. The compiler now opens those .tydb files with MDB_RDONLY and MDB_NOLOCK whether the root is next to the executable or supplied with --syspath. Project and dependency interface caches keep normal LMDB read locking because they can still be rewritten by concurrent builds.

The dist/base and dist/std build targets remove generated LMDB lock files and normalize data.mdb permissions before packaging, so release tarballs do not ship lock files and their interface databases remain world-readable.