### PR TITLE
Add RPM packaging

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -535,6 +535,144 @@ jobs:
           if-no-files-found: error
 
 
+  build-rpms:
+    needs: [build-version, test-linux]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - rpm_arch: x86_64
+            tar_arch: x86_64
+            artifact: acton-debian-11-x86_64
+            runner: ubuntu-24.04
+          - rpm_arch: aarch64
+            tar_arch: aarch64
+            artifact: acton-ubuntu-24.04-arm64v8
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    container:
+      image: fedora:latest
+    env:
+      BUILD_TIME: ${{ needs.build-version.outputs.build_time }}
+    steps:
+      - name: "Show platform and environment"
+        run: |
+          uname -a
+          cat /etc/os-release
+          rpm --version
+      - name: "Set BUILD_RELEASE when we are building for a version tag"
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          echo "BUILD_RELEASE=1" >> $GITHUB_ENV
+      - name: "Install RPM build prerequisites"
+        run: |
+          dnf install -y findutils make rpm-build tar xz
+          dnf clean all || true
+      - name: "Check out repository code"
+        uses: actions/checkout@v6
+      - name: "Download Linux release artifact"
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ matrix.artifact }}
+      - name: "Build RPM from release artifact"
+        run: |
+          set -euo pipefail
+          tarball="$(ls acton-linux-${{ matrix.tar_arch }}-*.tar.xz | tail -n1)"
+          rm -rf dist acton
+          rm -f rpm/*.rpm
+          tar -xJf "$tarball"
+          mv acton dist
+          make -C "${GITHUB_WORKSPACE}" rpms BUILD_RELEASE=${{ env.BUILD_RELEASE }} BUILD_TIME=${BUILD_TIME}
+          mkdir -p rpm
+          find rpmbuild/RPMS -name 'acton-*.rpm' -exec cp -v {} rpm/ \;
+      - name: "Show RPM package metadata"
+        run: |
+          rpm -qip rpm/acton-*.rpm
+          rpm -qlp rpm/acton-*.rpm | sed -n '1,120p'
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@v7
+        with:
+          name: acton-rpms-${{ matrix.rpm_arch }}
+          path: rpm/*.rpm
+          if-no-files-found: error
+
+
+  test-rpms:
+    needs: build-rpms
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - rpm_arch: x86_64
+            runner: ubuntu-24.04
+          - rpm_arch: aarch64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    container:
+      image: fedora:latest
+      options: --privileged --ulimit core=-1 --security-opt seccomp=unconfined
+    steps:
+      - name: "Show platform and environment"
+        run: |
+          uname -a
+          cat /etc/os-release
+          rpm --version
+      - name: "Download RPM artifact"
+        uses: actions/download-artifact@v8
+        with:
+          name: acton-rpms-${{ matrix.rpm_arch }}
+          path: rpm
+      - name: "Install Acton from RPM"
+        run: |
+          set -euo pipefail
+          rpm -qip rpm/acton-*.rpm
+          dnf install -y rpm/acton-*.rpm
+          rpm -q acton
+          acton version
+          acton --help >/dev/null
+          test -x /usr/lib/acton/bin/acton
+          test -L /usr/bin/acton
+          test -L /usr/bin/actonc
+          test -L /usr/bin/actondb
+          test -L /usr/bin/runacton
+          test -L /usr/bin/lsp-server-acton
+      - name: "Enable dumping core files to /tmp/core..."
+        run: |
+          dnf install -y procps-ng
+          cat /proc/sys/kernel/core_pattern
+          sysctl kernel.core_pattern='/tmp/core.%h.%e.%t' || true
+          cat /proc/sys/kernel/core_pattern
+          ulimit -c unlimited
+      - name: "Compile acton program"
+        run: |
+          echo '#!/usr/bin/env runacton'   > acton-test.act
+          echo 'actor main(env):'          >> acton-test.act
+          echo '    print("Hello, world")' >> acton-test.act
+          echo '    env.exit(0)'           >> acton-test.act
+          chmod a+x acton-test.act
+          ./acton-test.act
+          ./acton-test.act | grep "Hello, world"
+          acton build acton-test.act
+          ./acton-test
+          ./acton-test | grep "Hello, world"
+      - name: "ls core"
+        if: failure()
+        run: |
+          pwd
+          ls
+          find /tmp
+          mv /tmp/core* .
+      - name: "Upload core file & binaries as artifacts on test failure"
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpm-coredumps-${{ matrix.rpm_arch }}-${{ github.run_id }}.zip
+          path: |
+            ${{ github.workspace }}/core*
+            ${{ github.workspace }}/acton-test
+            ${{ github.workspace }}/out/**
+
+
   run-macos:
     needs: test-macos
     strategy:
@@ -1018,7 +1156,7 @@ jobs:
     # Only run on the main branch
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    needs: [test-macos, test-linux, test-cross-compile, test-windows, build-debs, build-container-image]
+    needs: [test-macos, test-linux, test-cross-compile, test-windows, build-debs, test-rpms, build-container-image]
     steps:
       - name: "Delete current tip release & tag"
         uses: dev-drprasad/delete-tag-and-release@v1.1
@@ -1050,10 +1188,17 @@ jobs:
         with:
           pattern: acton-debs-*
           merge-multiple: true
+      - name: "Download RPM artifacts for Linux x86_64 & aarch64"
+        uses: actions/download-artifact@v8
+        with:
+          pattern: acton-rpms-*
+          path: rpm
+          merge-multiple: true
       - name: "List downloaded artifacts"
         run: |
           ls
           ls deb
+          ls rpm
       - name: "Workaround for changelog extractor that looks for number versions in headlines, which won't work for 'Unreleased'"
         run: sed -i -e 's/^## Unreleased/## [999.9] Unreleased\nThis is an unreleased snapshot built from the main branch. Like a nightly but more up to date./' CHANGELOG.md
       - name: "Extract release notes"
@@ -1063,7 +1208,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           allowUpdates: true
-          artifacts: "acton*.tar*,deb/*deb"
+          artifacts: "acton*.tar*,deb/*deb,rpm/*rpm"
           body: ${{ steps.extract-release-notes.outputs.release_notes }}
           draft: false
           prerelease: true
@@ -1083,15 +1228,20 @@ jobs:
         run: mv $(ls deb/acton_*amd64.deb | tail -n1) deb/acton_tip_amd64.deb
       - name: "Remove version number from debian arm64 package"
         run: mv $(ls deb/acton_*arm64.deb | tail -n1) deb/acton_tip_arm64.deb
+      - name: "Remove version number from RPM x86_64 package"
+        run: mv $(ls rpm/acton-*x86_64.rpm | tail -n1) rpm/acton-tip-x86_64.rpm
+      - name: "Remove version number from RPM aarch64 package"
+        run: mv $(ls rpm/acton-*aarch64.rpm | tail -n1) rpm/acton-tip-aarch64.rpm
       - name: "List files for debug"
         run: |
           ls
           ls deb
+          ls rpm
       - name: "Upload artifacts without version number for stable links"
         uses: ncipollo/release-action@v1
         with:
           allowUpdates: true
-          artifacts: "acton*.tar*,deb/acton_*.deb"
+          artifacts: "acton*.tar*,deb/acton_*.deb,rpm/acton-*.rpm"
           body: ${{ steps.extract-release-notes.outputs.release_notes }}
           draft: false
           prerelease: true
@@ -1105,7 +1255,7 @@ jobs:
   release:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
-    needs: [test-macos, test-linux, test-cross-compile, test-windows, build-debs, build-container-image]
+    needs: [test-macos, test-linux, test-cross-compile, test-windows, build-debs, test-rpms, build-container-image]
     steps:
       - name: "Check out repository code"
         uses: actions/checkout@v6
@@ -1130,8 +1280,16 @@ jobs:
         with:
           pattern: acton-debs-*
           merge-multiple: true
+      - name: "Download RPM artifacts for Linux"
+        uses: actions/download-artifact@v8
+        with:
+          pattern: acton-rpms-*
+          path: rpm
+          merge-multiple: true
       - name: "List downloaded artifacts"
-        run: ls
+        run: |
+          ls
+          ls rpm
       - name: "Extract release notes"
         id: extract-release-notes
         uses: ffurrer2/extract-release-notes@v3
@@ -1139,7 +1297,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           allowUpdates: true
-          artifacts: "acton*.tar*,deb/*deb"
+          artifacts: "acton*.tar*,deb/*deb,rpm/*rpm"
           body: ${{ steps.extract-release-notes.outputs.release_notes }}
           draft: false
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/trigger-web-update.yml
+++ b/.github/workflows/trigger-web-update.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: "Trigger build of www.acton-lang.org"
+      - name: "Trigger build of acton.now"
         uses: benc-uk/workflow-dispatch@v1
         with:
           repo: actonlang/www.acton-lang.org

--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ bdeps/**/zig-out
 bdeps/**/zig-pkg
 
 dist/*
+rpmbuild/
 
 builder/deps/*
 

--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,7 @@ help:
 	@echo "  all     - build everything"
 	@echo "  test    - run the test suite"
 	@echo "  make PROFILE=1 dist/bin/acton - build profiled acton binary"
+	@echo "  rpms    - build RPM package from existing dist/"
 	@echo ""
 	@echo "  clean   - /normal/ clean repo"
 	@echo "  clean-all - thorough cleaning"
@@ -359,6 +360,7 @@ dist/deps/libbsdnt: deps-download/$(LIBBSDNT_REF).tar.gz $(LIBBSDNT_BUILD_ZIG)
 	mkdir -p "$@"
 	cd "$@" && tar zx --strip-components=1 -f "$(TD)/$<"
 	cp "$(TD)/$(LIBBSDNT_BUILD_ZIG)" "$@/build.zig"
+	rm -rf "$@/.github" "$@/configure" "$@/test"
 	touch "$(TD)/$@"
 
 # /deps/libgc --------------------------------------------
@@ -373,7 +375,7 @@ dist/deps/libgc: deps-download/$(LIBGC_REF).tar.gz $(LIBGC_BUILD_ZIG)
 	mkdir -p "$@"
 	cd "$@" && tar zx --strip-components=1 -f "$(TD)/$<"
 	cp "$(TD)/$(LIBGC_BUILD_ZIG)" "$@/build.zig"
-	rm -rf "$@/tests" "$@/tools"
+	rm -rf "$@/.github" "$@/autogen.sh" "$@/cord/tests" "$@/docs" "$@/tests" "$@/tools"
 	touch "$(TD)/$@"
 
 # /deps/libmbedtls --------------------------------------------
@@ -388,6 +390,10 @@ dist/deps/mbedtls: deps-download/$(LIBMBEDTLS_REF).tar.gz $(LIBMBEDTLS_BUILD_ZIG
 	mkdir -p "$@"
 	cd "$@" && tar zx --strip-components=1 -f "$(TD)/$<"
 	cp "$(TD)/$(LIBMBEDTLS_BUILD_ZIG)" "$@/build.zig"
+	rm -rf "$@/.github" "$@/cmake" "$@/docs" "$@/doxygen" "$@/programs" "$@/scripts" "$@/visualc"
+	# The TLS test server builds against mbed TLS' certificate fixtures.
+	find "$@/tests" -mindepth 1 -maxdepth 1 ! -name include ! -name src -exec rm -rf {} +
+	find "$@/tests/src" -mindepth 1 ! -name certs.c ! -name test_certs.h -exec rm -rf {} +
 	touch "$(TD)/$@"
 
 # /deps/libprotobuf_c --------------------------------------------
@@ -402,6 +408,9 @@ dist/deps/libprotobuf_c: deps-download/$(LIBPROTOBUF_C_REF).tar.gz $(LIBPROTOBUF
 	mkdir -p "$@"
 	cd "$@" && tar zx --strip-components=1 -f "$(TD)/$<"
 	cp "$(TD)/$(LIBPROTOBUF_C_BUILD_ZIG)" "$@/build.zig"
+	rm -rf "$@/.github" "$@/autogen.sh" "$@/build-cmake" "$@/protoc-c" "$@/t"
+	rm -f "$@/.commit_docs.sh"
+	chmod a-x "$@/protobuf-c/protobuf-c.h"
 	touch "$(TD)/$@"
 
 # /deps/tlsuv ---------------------------------------------
@@ -418,6 +427,7 @@ dist/deps/tlsuv: deps-download/$(TLSUV_REF).tar.gz dist/deps/libuv dist/deps/mbe
 	cd "$@" && tar zx --strip-components=1 -f "$(TD)/$<"
 	cp "$(TD)/$(TLSUV_BUILD_ZIG)" "$@/build.zig"
 	cp "$(TD)/$(TLSUV_BUILD_ZON)" "$@/build.zig.zon"
+	rm -rf "$@/.github" "$@/.idea" "$@/cmake" "$@/deps/uv_link_t/docs" "$@/deps/uv_link_t/example" "$@/deps/uv_link_t/test" "$@/sample" "$@/tests"
 	touch "$(TD)/$@"
 
 # /deps/libutf8proc --------------------------------------
@@ -432,6 +442,7 @@ dist/deps/libutf8proc: deps-download/$(LIBUTF8PROC_REF).tar.gz $(LIBUTF8PROC_BUI
 	mkdir -p "$@"
 	cd "$@" && tar zx --strip-components=1 -f "$(TD)/$<"
 	cp "$(TD)/$(LIBUTF8PROC_BUILD_ZIG)" "$@/build.zig"
+	rm -rf "$@/.github" "$@/bench" "$@/data" "$@/test"
 	touch "$(TD)/$@"
 
 # /deps/libuuid ------------------------------------------
@@ -465,7 +476,8 @@ dist/deps/libxml2: deps-download/$(LIBXML2_REF).tar.gz $(LIBXML2_BUILD_ZIG)
 	mkdir -p "$@"
 	cd "$@" && tar zx --strip-components=1 -f "$(TD)/$<"
 	cp "$(TD)/$(LIBXML2_BUILD_ZIG)" "$@/build.zig"
-	rm -rf "$@/doc" "$@/example" "$@/fuzz" "$@/os400" "$@/python" $@/test*
+	rm -rf "$@/.gitlab-ci" "$@/autogen.sh" "$@/doc" "$@/example" "$@/fuzz" "$@/os400" "$@/python" "$@/result" "$@/vms" "$@/win32" "$@/xstc" $@/test*
+	rm -f "$@"/check-*.py "$@"/dbgen*.pl "$@"/gen*.py "$@"/gentest.py "$@"/build_glob.py "$@"/xml2-config.in
 	touch "$(TD)/$@"
 
 # /deps/pcre2 --------------------------------------------
@@ -480,6 +492,8 @@ dist/deps/pcre2: deps-download/$(LIBPCRE2_REF).tar.gz $(LIBPCRE2_BUILD_ZIG)
 	mkdir -p "$@"
 	cd "$@" && tar zx --strip-components=1 -f "$(TD)/$<"
 	cp "$(TD)/$(LIBPCRE2_BUILD_ZIG)" "$@/build.zig"
+	rm -rf "$@/.github" "$@/autogen.sh" "$@/doc" "$@/maint" "$@/testdata" "$@/vms"
+	rm -f "$@"/132html "$@"/CheckMan "$@"/CleanTxt "$@"/Detrail "$@"/PrepareRelease "$@"/RunGrepTest "$@"/RunTest "$@"/pcre2-config.in "$@"/perltest.sh
 	touch "$(TD)/$@"
 
 # /deps/libsnappy_c --------------------------------------------
@@ -494,6 +508,7 @@ dist/deps/libsnappy_c: deps-download/$(LIBSNAPPY_C_REF).tar.gz $(LIBSNAPPY_C_BUI
 	mkdir -p "$@"
 	cd "$@" && tar zx --strip-components=1 -f "$(TD)/$<"
 	cp "$(TD)/$(LIBSNAPPY_C_BUILD_ZIG)" "$@/build.zig"
+	rm -rf "$@/.github" "$@/cmake" "$@/docs" "$@/testdata" "$@/third_party"
 	touch "$(TD)/$@"
 
 dist/deps/libnetstring: deps/libnetstring $(DIST_ZIG)
@@ -593,8 +608,8 @@ online-tests: dist/bin/acton
 	cd compiler && stack test acton:test_acton_online
 
 
-.PHONY: clean clean-all clean-base clean-std clean-bdeps
-clean: clean-distribution clean-base clean-std clean-bdeps
+.PHONY: clean clean-all clean-base clean-std clean-bdeps clean-rpm
+clean: clean-distribution clean-base clean-std clean-bdeps clean-rpm
 
 clean-all: clean clean-compiler
 	rm -rf $(ZIG_LOCAL_CACHE_DIR)
@@ -607,6 +622,9 @@ clean-std:
 
 clean-bdeps:
 	rm -rf bdeps/out bdeps/*/zig-out bdeps/*/zig-pkg bdeps/*/.zig-cache
+
+clean-rpm:
+	rm -rf rpmbuild
 
 # == DIST ==
 #
@@ -738,6 +756,57 @@ debian/changelog: debian/changelog.in CHANGELOG.md
 .PHONY: debs
 debs: debian/changelog
 	debuild --preserve-envvar VERSION_INFO --preserve-envvar PATH --preserve-envvar STACK_ROOT --preserve-envvar ZIG_DOWNLOAD_BASE_URL --preserve-envvar ACTON_ZIG_GLIBC_VERSION -i -us -uc -nc -b
+
+RPM_RELEASE ?= 1
+.PHONY: rpms rpm-validate
+
+rpms: rpm/acton.spec.in LICENSE README.md
+	command -v rpmbuild >/dev/null 2>&1 || { echo "ERROR: rpmbuild is required to build RPM packages"; exit 1; }
+	test -x dist/bin/acton || { echo "ERROR: dist/ is not built; run make first"; exit 1; }
+	rm -rf rpmbuild/payload
+	mkdir -p rpmbuild/payload rpmbuild/SOURCES
+	$(MAKE) install DESTDIR="$(TD)/rpmbuild/payload"
+	install -D -m 0644 completion/acton.bash-completion "rpmbuild/payload/usr/share/bash-completion/completions/acton"
+	tar -C rpmbuild/payload -cJf "rpmbuild/SOURCES/acton-rpm-payload-$(VERSION_INFO).tar.xz" .
+	mkdir -p rpmbuild/SPECS rpmbuild/SOURCES
+	sed -e 's,@VERSION@,$(VERSION_INFO),g' -e 's,@RELEASE@,$(RPM_RELEASE),g' "rpm/acton.spec.in" > rpmbuild/SPECS/acton.spec
+	cp LICENSE README.md rpmbuild/SOURCES/
+	mkdir -p rpmbuild/BUILD rpmbuild/BUILDROOT rpmbuild/RPMS rpmbuild/SRPMS
+	rpmbuild --define "_topdir $(TD)/rpmbuild" -bb rpmbuild/SPECS/acton.spec
+	@find rpmbuild/RPMS -name '*.rpm' -print
+
+rpm-validate:
+	@command -v docker >/dev/null 2>&1 || { echo "ERROR: docker is required to validate RPM packages"; exit 1; }
+	@rpm_file="$$(find "$(TD)/rpmbuild/RPMS" -name 'acton-[0-9]*.rpm' 2>/dev/null | sort | tail -n1)"; \
+	if [ -z "$$rpm_file" ]; then \
+		echo "ERROR: no Acton RPM found under rpmbuild/RPMS; run 'make rpms' first"; \
+		exit 1; \
+	fi; \
+	rpm_dir="$$(dirname "$$rpm_file")"; \
+	rpm_base="$$(basename "$$rpm_file")"; \
+	echo "Validating $$rpm_base in fedora:latest"; \
+	docker run --rm -v "$$rpm_dir:/rpms:ro" -e ACTON_RPM="/rpms/$$rpm_base" fedora:latest sh -lc '\
+		set -eu; \
+		rpm -qip "$$ACTON_RPM"; \
+		dnf install -y "$$ACTON_RPM"; \
+		rpm -q acton; \
+		acton version; \
+		acton --help >/dev/null; \
+		test -x /usr/lib/acton/bin/acton; \
+		test -L /usr/bin/acton; \
+		test -L /usr/bin/actonc; \
+		test -L /usr/bin/actondb; \
+		test -L /usr/bin/runacton; \
+		test -L /usr/bin/lsp-server-acton; \
+		work="$$(mktemp -d)"; \
+		cd "$$work"; \
+		printf "%s\n" "#!/usr/bin/env runacton" "actor main(env):" "    print(\"Hello, world\")" "    env.exit(0)" > acton-test.act; \
+		chmod a+x acton-test.act; \
+		./acton-test.act; \
+		./acton-test.act | grep "Hello, world"; \
+		acton build acton-test.act; \
+		./acton-test; \
+		./acton-test | grep "Hello, world"'
 
 .PHONY: container-image image image-deb push-image
 container-image: all

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ worked out, there may be changes.
 
 ## Install Acton
 
-Check out the [installation guide](https://www.acton-lang.org/install) for more details.
+Check out the [installation guide](https://acton.now/install) for more details.
 
 ### Debian / Ubuntu
 ```sh
@@ -82,11 +82,11 @@ Hello, world!
 ```
 
 ## And then...?
-Check out our [learning resources](https://www.acton-lang.org/learn).
+Check out our [learning resources](https://acton.now/learn).
 
 
 # Building Acton from source
-See [building Acton from source](https://www.acton-lang.org/install/from-source).
+See [building Acton from source](https://acton.now/install/from-source).
 
 # Developing Acton
 See [dev info](docs/dev.md).

--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Build-Depends:
  make,
  zlib1g-dev
 Standards-Version: 4.6.0
-Homepage: http://www.acton-lang.org
+Homepage: https://acton.now/
 Rules-Requires-Root: no
 
 Package: acton

--- a/homebrew/Formula/acton.rb
+++ b/homebrew/Formula/acton.rb
@@ -1,6 +1,6 @@
 class Acton < Formula
   desc "Delightful distributed programming language"
-  homepage "https://www.acton-lang.org"
+  homepage "https://acton.now/"
   url "https://github.com/actonlang/acton/archive/refs/tags/v0.0.0.tar.gz"
   sha256 "0000000000000000000000000000000000000000000000000000000000000000"
   license "BSD-3-Clause"

--- a/rpm/acton.spec.in
+++ b/rpm/acton.spec.in
@@ -1,0 +1,55 @@
+%global debug_package %{nil}
+%global _build_id_links none
+%global _missing_build_ids_terminate_build 0
+%global __provides_exclude_from ^/usr/lib/acton/.*$
+%global __brp_strip %{nil}
+%global __brp_strip_static_archive %{nil}
+%global __brp_strip_comment_note %{nil}
+
+Name:           acton
+Version:        @VERSION@
+Release:        @RELEASE@%{?dist}
+Summary:        Acton programming language
+License:        BSD-3-Clause
+URL:            https://acton.now/
+Source0:        acton-rpm-payload-%{version}.tar.xz
+Source1:        LICENSE
+Source2:        README.md
+
+BuildRequires:  tar
+BuildRequires:  xz
+
+%description
+Acton is a general purpose programming language designed for desktop,
+embedded, and distributed systems.
+
+%prep
+# The top-level Makefile builds and stages the release payload before rpmbuild
+# runs. Source0 is that staged install tree.
+
+%build
+# Nothing to build here.
+
+%install
+rm -rf %{buildroot}
+mkdir -p %{buildroot}
+tar -xJf %{SOURCE0} -C %{buildroot}
+install -D -m 0644 %{SOURCE1} %{buildroot}%{_licensedir}/%{name}/LICENSE
+install -D -m 0644 %{SOURCE2} %{buildroot}%{_docdir}/%{name}/README.md
+
+%check
+test -x %{buildroot}%{_bindir}/acton
+test -x %{buildroot}/usr/lib/acton/bin/acton
+test -x %{buildroot}/usr/lib/acton/bin/actondb
+test -x %{buildroot}/usr/lib/acton/bin/lsp-server-acton
+
+%files
+%license %{_licensedir}/%{name}/LICENSE
+%doc %{_docdir}/%{name}/README.md
+%{_bindir}/acton
+%{_bindir}/actonc
+%{_bindir}/actondb
+%{_bindir}/runacton
+%{_bindir}/lsp-server-acton
+%{_datadir}/bash-completion/completions/acton
+/usr/lib/acton


### PR DESCRIPTION
Teach make rpms to package an existing dist/ tree into an RPM using a small spec template, and add Fedora-based CI jobs that build, install, and compile-test those packages.

Prune upstream dependency test, script, maint, and documentation cruft during dist/deps extraction so RPM dependency scanning only sees runtime files.

Update package metadata and public docs links to use https://acton.now/.