### PR TITLE
Add ca-certificates dependency

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,6 +1,11 @@
 FROM debian:13
 MAINTAINER Kristian Larsson <kristian@spritelink.net>
 
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
 COPY dist/ /usr/lib/acton/
 
 RUN cd /usr/bin \

--- a/debian/control
+++ b/debian/control
@@ -19,6 +19,7 @@ Package: acton
 Architecture: any
 Depends:
  libc6 (>= 2.27),
+ ca-certificates,
  ${shlibs:Depends},
  ${misc:Depends}
 Description: Acton Programming Language


### PR DESCRIPTION
Declare ca-certificates as a runtime dependency of the .deb. Acton package manager uses TLS to fetch packages, so valid CAs must be present in the system.

On an end-user system ca-certificates is likely already installed (it is a dep of curl, wget, ... probably many other packages). But of course it was missing in a stripped down container image.