### PR TITLE
Repair environ for zig-cc-linked binaries

### DIFF
--- a/compiler/acton/cbits/environ_fix.c
+++ b/compiler/acton/cbits/environ_fix.c
@@ -1,0 +1,30 @@
+/*
+ * environ_fix.c -- repair getEnvironment() on Linux binaries linked by `zig cc`.
+ *
+ * The compiler is linked as a -no-pie executable by zig cc (to target an older
+ * glibc for portability). Under that link lld emits a copy relocation for the
+ * glibc `environ` symbol but does not redirect glibc's `__environ` alias to the
+ * copied storage. __libc_start_main() initialises `__environ` (so getenv() and
+ * base's lookupEnv keep working), while the executable's copied `environ` -- the
+ * one GHC's RTS reads for System.Environment.getEnvironment -- stays NULL. So
+ * getEnvironment() returns [], and e.g. http-client's proxyEnvironment never
+ * sees HTTP(S)_PROXY.
+ *
+ * Defining `environ` here (a strong definition in the executable) means no copy
+ * relocation is generated for it, and a startup constructor points it at glibc's
+ * live `__environ`, so getEnvironment() sees the real environment.
+ *
+ * The snapshot is taken at startup; the compiler never calls setenv()/putenv()
+ * (which could reallocate the block), so it stays valid, and getenv()/lookupEnv
+ * read glibc's live `__environ` regardless.
+ *
+ * Linux/glibc only -- gated to os(linux) in package.yaml.in (macOS builds are
+ * PIE and expose no `__environ`).
+ */
+extern char **__environ;
+char **environ;
+
+__attribute__((constructor))
+static void acton_fix_environ(void) {
+    environ = __environ;
+}

--- a/compiler/acton/package.yaml.in
+++ b/compiler/acton/package.yaml.in
@@ -93,6 +93,10 @@ executables:
         - -no-pie
         - -optl-no-pie
         - -pgml=../tools/ld-wrapper.sh
+      # zig cc's -no-pie link leaves `environ` unpopulated, which breaks GHC's
+      # getEnvironment(); this shim repairs it. See cbits/environ_fix.c.
+      c-sources:
+        - cbits/environ_fix.c
     - condition: os(darwin)
       ghc-options:
         - -pgml=../tools/ld-wrapper.sh

--- a/compiler/lsp-server/package.yaml.in
+++ b/compiler/lsp-server/package.yaml.in
@@ -48,3 +48,7 @@ executables:
           - -no-pie
           - -optl-no-pie
           - -pgml=../tools/ld-wrapper.sh
+        # zig cc's -no-pie link leaves `environ` unpopulated, which breaks GHC's
+        # getEnvironment(); this shim repairs it. Shared with the acton exe.
+        c-sources:
+          - ../acton/cbits/environ_fix.c


### PR DESCRIPTION
acton and lsp-server-acton are linked as -no-pie executables by zig cc (to target an older glibc). Under that link lld emits a copy relocation for glibc's `environ` but does not redirect the `__environ` alias to it, so __libc_start_main populates __environ (getenv/lookupEnv keep working) while the executable's `environ` copy -- which GHC's RTS reads for getEnvironment -- stays NULL. getEnvironment then returns [], so e.g. http-client's proxyEnvironment never sees HTTP(S)_PROXY and dependency fetches ignore the proxy.

Link a small C shim (cbits/environ_fix.c) into both executables: it defines `environ` in the executable (so no copy relocation is generated) and points it at glibc's live __environ in a startup constructor. Linux only.