### PR TITLE
Fix dependency fetching behind an HTTP proxy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -897,6 +897,37 @@ jobs:
         if: always()
         run: df -h || true
 
+  # Verify acton fetches dependencies through an HTTP proxy from a network with
+  # no direct egress. Runs on the host runner (not a container) so Docker is
+  # available for the two-container (acton + tinyproxy) compose topology. Both
+  # arches matter: the x86_64 -no-pie `environ`/getEnvironment bug only shows up
+  # on amd64, while arm64 is the unaffected control. See test/proxy/README.md.
+  test-proxy:
+    needs: [build-debs]
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [amd64, arm64]
+    runs-on: ${{ matrix.arch == 'amd64' && 'ubuntu-latest' || 'ubuntu-24.04-arm' }}
+    steps:
+      - name: "Show platform and environment"
+        run: |
+          uname -a
+          docker version
+          docker compose version
+      - name: "Check out repository code"
+        uses: actions/checkout@v6
+      - name: "Download .deb files"
+        uses: actions/download-artifact@v8
+        with:
+          name: acton-debs-${{ matrix.arch }}
+      - name: "Install acton from .deb"
+        run: |
+          sudo dpkg -i ./deb/acton_*.deb
+          acton version
+      - name: "Proxy dependency-fetch test"
+        run: make test-proxy ACTON_DIST=/usr/lib/acton
+
   test-windows:
     needs: test-cross-compile
     strategy:
@@ -1156,7 +1187,7 @@ jobs:
     # Only run on the main branch
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    needs: [test-macos, test-linux, test-cross-compile, test-windows, build-debs, test-rpms, build-container-image]
+    needs: [test-macos, test-linux, test-cross-compile, test-windows, test-proxy, build-debs, test-rpms, build-container-image]
     steps:
       - name: "Delete current tip release & tag"
         uses: dev-drprasad/delete-tag-and-release@v1.1
@@ -1255,7 +1286,7 @@ jobs:
   release:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
-    needs: [test-macos, test-linux, test-cross-compile, test-windows, build-debs, test-rpms, build-container-image]
+    needs: [test-macos, test-linux, test-cross-compile, test-windows, test-proxy, build-debs, test-rpms, build-container-image]
     steps:
       - name: "Check out repository code"
         uses: actions/checkout@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1090,7 +1090,7 @@ jobs:
       repo_url: "actonlang/acton-http2"
 
   build-container-image:
-    needs: [test-macos, test-linux, test-cross-compile, test-windows, build-debs]
+    needs: [test-macos, test-linux, test-cross-compile, test-windows, test-proxy, build-debs]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1341,7 +1341,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: debian:experimental
-    needs: [test-macos, test-linux, test-cross-compile, test-windows, build-debs]
+    needs: [test-macos, test-linux, test-cross-compile, test-windows, test-proxy, build-debs]
     steps:
       - name: Install build prerequisites
         run: |
@@ -1395,7 +1395,7 @@ jobs:
       image: debian:experimental
     permissions:
       contents: write
-    needs: [test-macos, test-linux, test-cross-compile, test-windows, build-debs]
+    needs: [test-macos, test-linux, test-cross-compile, test-windows, test-proxy, build-debs]
     steps:
       - name: Install build prerequisites
         run: |
@@ -1441,7 +1441,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     # Depend on all test jobs so we don't update brew repo in case anything fails
-    needs: [test-macos, test-linux, test-cross-compile, test-windows, build-debs]
+    needs: [test-macos, test-linux, test-cross-compile, test-windows, test-proxy, build-debs]
     steps:
       - name: "Check out code of main acton repo"
         uses: actions/checkout@v6

--- a/Makefile
+++ b/Makefile
@@ -557,6 +557,13 @@ test-goldens-accept: test-compiler-accept test-incremental-accept test-syntaxerr
 test-cross-compile:
 	cd compiler && stack test acton --ta '-p "/cross-compilation/"'
 
+# Docker-based reproduction: acton must fetch a dependency through an HTTP proxy
+# from a network with no direct egress. Defaults to ./dist; override ACTON_DIST
+# (e.g. CI points it at the installed release). See test/proxy/README.md.
+.PHONY: test-proxy
+test-proxy:
+	ACTON_DIST="$(or $(ACTON_DIST),$(CURDIR)/dist)" bash test/proxy/run.sh
+
 test-incremental: dist/bin/acton
 	cd compiler && stack test acton:incremental
 

--- a/compiler/acton/cbits/environ_fix.c
+++ b/compiler/acton/cbits/environ_fix.c
@@ -1,0 +1,30 @@
+/*
+ * environ_fix.c -- repair getEnvironment() on Linux binaries linked by `zig cc`.
+ *
+ * The compiler is linked as a -no-pie executable by zig cc (to target an older
+ * glibc for portability). Under that link lld emits a copy relocation for the
+ * glibc `environ` symbol but does not redirect glibc's `__environ` alias to the
+ * copied storage. __libc_start_main() initialises `__environ` (so getenv() and
+ * base's lookupEnv keep working), while the executable's copied `environ` -- the
+ * one GHC's RTS reads for System.Environment.getEnvironment -- stays NULL. So
+ * getEnvironment() returns [], and e.g. http-client's proxyEnvironment never
+ * sees HTTP(S)_PROXY.
+ *
+ * Defining `environ` here (a strong definition in the executable) means no copy
+ * relocation is generated for it, and a startup constructor points it at glibc's
+ * live `__environ`, so getEnvironment() sees the real environment.
+ *
+ * The snapshot is taken at startup; the compiler never calls setenv()/putenv()
+ * (which could reallocate the block), so it stays valid, and getenv()/lookupEnv
+ * read glibc's live `__environ` regardless.
+ *
+ * Linux/glibc only -- gated to os(linux) in package.yaml.in (macOS builds are
+ * PIE and expose no `__environ`).
+ */
+extern char **__environ;
+char **environ;
+
+__attribute__((constructor))
+static void acton_fix_environ(void) {
+    environ = __environ;
+}

--- a/compiler/acton/package.yaml.in
+++ b/compiler/acton/package.yaml.in
@@ -93,6 +93,10 @@ executables:
         - -no-pie
         - -optl-no-pie
         - -pgml=../tools/ld-wrapper.sh
+      # zig cc's -no-pie link leaves `environ` unpopulated, which breaks GHC's
+      # getEnvironment(); this shim repairs it. See cbits/environ_fix.c.
+      c-sources:
+        - cbits/environ_fix.c
     - condition: os(darwin)
       ghc-options:
         - -pgml=../tools/ld-wrapper.sh

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -267,7 +267,7 @@ import Network.HTTP.Types.Status (statusCode)
 import System.Clock
 import System.Directory
 import System.Directory.Recursive (getFilesRecursive)
-import System.Environment (getExecutablePath, lookupEnv)
+import System.Environment (getEnvironment, getExecutablePath, lookupEnv)
 import System.FileLock (FileLock, SharedExclusive(Exclusive), tryLockFile, unlockFile, withFileLock)
 import System.FilePath ((</>))
 import System.FilePath.Posix
@@ -4971,6 +4971,132 @@ validateDepOverridePath depName depPath = do
                          ++ "Hint: Local dependency paths must point to an Acton project root\n"
                          ++ "(directory with src/ and Build.act).")
 
+-- Proxy diagnostics -----------------------------------------------------------
+-- Dependency archives are fetched over HTTPS with http-client, whose proxy
+-- selection (proxyEnvironment) is protocol-specific: an https URL is proxied
+-- only via https_proxy/HTTPS_PROXY, never via http_proxy. When a fetch fails we
+-- report which proxy variable applies to the request and the proxy environment
+-- acton actually saw, so a missing/unexported https_proxy (e.g. under sudo or a
+-- non-interactive make/CI shell, where the interactive shell's proxy vars are
+-- not inherited) is obvious instead of hidden behind a raw "proxy = Nothing"
+-- request-record dump.
+
+-- | Proxy-related environment variables, in the order we report them.
+proxyEnvVarNames :: [String]
+proxyEnvVarNames =
+  [ "http_proxy", "HTTP_PROXY"
+  , "https_proxy", "HTTPS_PROXY"
+  , "all_proxy", "ALL_PROXY"
+  , "no_proxy", "NO_PROXY"
+  ]
+
+-- | Snapshot the proxy environment acton actually sees. Reads via
+--   getEnvironment (the `environ` array), the SAME source http-client's
+--   proxyEnvironment consults -- NOT lookupEnv/getenv. The two can disagree on
+--   Linux binaries hit by the `environ` copy-relocation bug (getEnvironment
+--   returns [] while getenv works); reading getEnvironment keeps this diagnostic
+--   honest about what proxy selection actually saw.
+readProxyEnv :: IO [(String, Maybe String)]
+readProxyEnv = do
+  env <- getEnvironment
+  return [ (n, lookup n env) | n <- proxyEnvVarNames ]
+
+-- | Render one proxy env var for display, masking any embedded credentials.
+formatProxyEnvVar :: (String, Maybe String) -> String
+formatProxyEnvVar (n, v) =
+  n ++ "=" ++ maybe "(unset)" (\x -> if null x then "(empty)" else maskProxyUrl x) v
+
+-- | Indented "proxy environment acton sees" block for use in messages.
+proxyEnvReportLines :: String -> [(String, Maybe String)] -> [String]
+proxyEnvReportLines indent env =
+  (indent ++ "proxy environment acton sees:")
+  : [ indent ++ "  " ++ formatProxyEnvVar kv | kv <- env ]
+
+-- | Mask user:password@ credentials embedded in a proxy URL.
+maskProxyUrl :: String -> String
+maskProxyUrl url =
+  let (scheme, afterScheme) = case findSubstring "://" url of
+                                Just i  -> (take (i + 3) url, drop (i + 3) url)
+                                Nothing -> ("", url)
+      (authority, rest)     = break (== '/') afterScheme
+  in case break (== '@') authority of
+       (_, '@':hostPort) -> scheme ++ "***@" ++ hostPort ++ rest
+       _                 -> url
+
+findSubstring :: String -> String -> Maybe Int
+findSubstring needle = go 0
+  where go _ []              = Nothing
+        go i hay@(_:t)
+          | needle `isPrefixOf` hay = Just i
+          | otherwise               = go (i + 1) t
+
+-- | The proxy variable http-client consults for a request of this scheme, and
+--   its value if set. Selection is protocol-specific (https_proxy for https,
+--   http_proxy for http); ALL_PROXY is intentionally excluded because
+--   http-client does not honor it. NB: we report from the environment rather
+--   than the failed request's `proxy` field, which http-client leaves unset for
+--   https CONNECT tunnels even when a proxy is used.
+applicableProxy :: Bool -> [(String, Maybe String)] -> Maybe (String, String)
+applicableProxy secure env =
+  listToMaybe [ (n, v) | n <- names, Just (Just v) <- [lookup n env], not (null v) ]
+  where names = if secure then ["https_proxy", "HTTPS_PROXY"] else ["http_proxy", "HTTP_PROXY"]
+
+-- | Turn an http-client fetch exception into a clean, actionable message: the
+--   underlying cause, the proxy variable that applies to the request, the proxy
+--   environment acton saw, and a hint when no proxy is configured for the URL.
+describeFetchException :: [(String, Maybe String)] -> SomeException -> String
+describeFetchException env ex =
+  case fromException ex :: Maybe HTTP.HttpException of
+    Just (HTTP.HttpExceptionRequest req content) ->
+      let secure  = HTTP.secure req
+          scheme  = if secure then "https" else "http"
+          target  = B.unpack (HTTP.host req) ++ ":" ++ show (HTTP.port req)
+          vars    = if secure then "https_proxy/HTTPS_PROXY" else "http_proxy/HTTP_PROXY"
+          proxyLn = case applicableProxy secure env of
+                      Just (n, v) -> "  proxy for this " ++ scheme ++ " request: "
+                                     ++ maskProxyUrl v ++ " (from " ++ n ++ ")"
+                      Nothing     -> "  proxy for this " ++ scheme ++ " request: none ("
+                                     ++ vars ++ " unset)"
+      in intercalate "\n"
+           ( [ describeFetchContent content
+             , "  request: " ++ scheme ++ " to " ++ target
+             , proxyLn
+             ]
+             ++ proxyEnvReportLines "  " env
+             ++ proxyFailureHint secure env )
+    Just other -> displayException other
+    Nothing    -> displayException ex
+
+-- | One-line summary of an http-client failure cause (no Request record dump).
+describeFetchContent :: HTTP.HttpExceptionContent -> String
+describeFetchContent c = case c of
+  HTTP.ConnectionTimeout            -> "connection timed out"
+  HTTP.ConnectionFailure e          -> "connection failed: " ++ show e
+  HTTP.ResponseTimeout              -> "response timed out"
+  HTTP.ProxyConnectException h p st -> "proxy CONNECT to " ++ B.unpack h ++ ":" ++ show p
+                                       ++ " failed (status " ++ show (statusCode st) ++ ")"
+  HTTP.StatusCodeException res _    -> "unexpected HTTP status "
+                                       ++ show (statusCode (HTTP.responseStatus res))
+  HTTP.InternalException e          -> "connection failed: " ++ show e
+  other                             -> show other
+
+-- | Hint shown when a fetch failed and no proxy variable applies to its scheme:
+--   the common real-world trap where proxy vars live in an interactive shell but
+--   are absent from the build's environment (sudo/root, make, CI).
+proxyFailureHint :: Bool -> [(String, Maybe String)] -> [String]
+proxyFailureHint secure env
+  | isJust (applicableProxy secure env) = []
+  | otherwise =
+      [ "  hint: no " ++ vars ++ " is set in acton's environment, so this " ++ scheme
+      , "        download was attempted directly. If you use a proxy, make sure "
+        ++ varLower ++ " is"
+      , "        exported in the environment that runs the build. sudo/root shells and"
+      , "        many make/CI setups do not inherit the proxy variables from your"
+      , "        interactive shell." ]
+  where scheme   = if secure then "https" else "http"
+        vars     = if secure then "https_proxy/HTTPS_PROXY" else "http_proxy/HTTP_PROXY"
+        varLower = if secure then "https_proxy" else "http_proxy"
+
 fetchDependencies :: C.GlobalOptions -> Paths -> [(String, FilePath)] -> IO ()
 fetchDependencies gopts paths depOverrides = do
     if isTmp paths
@@ -4980,6 +5106,9 @@ fetchDependencies gopts paths depOverrides = do
         rootSpec <- applyDepOverrides (projPath paths) depOverrides rootSpec0
         unless (C.quiet gopts) $
           putStrLn "Resolving dependencies (fetching if missing)..."
+        when (C.verbose gopts) $ do
+          env <- readProxyEnv
+          putStr (unlines (proxyEnvReportLines "" env))
         home <- getHomeDirectory
         let zigExe      = joinPath [sysPath paths, "zig", "zig"]
             globalCache = joinPath [home, ".cache", "acton", "zig-global-cache"]
@@ -5197,7 +5326,9 @@ fetchDependencies gopts paths depOverrides = do
           manager <- HTTP.newManager settings
           opened <- try (HTTP.responseOpen req manager) :: IO (Either SomeException (HTTP.Response HTTP.BodyReader))
           case opened of
-            Left ex -> return (Left (displayException ex))
+            Left ex -> do
+              env <- readProxyEnv
+              return (Left (describeFetchException env ex))
             Right response -> do
               let code = statusCode (HTTP.responseStatus response)
               if code < 200 || code >= 300

--- a/compiler/lsp-server/package.yaml.in
+++ b/compiler/lsp-server/package.yaml.in
@@ -48,3 +48,7 @@ executables:
           - -no-pie
           - -optl-no-pie
           - -pgml=../tools/ld-wrapper.sh
+        # zig cc's -no-pie link leaves `environ` unpopulated, which breaks GHC's
+        # getEnvironment(); this shim repairs it. Shared with the acton exe.
+        c-sources:
+          - ../acton/cbits/environ_fix.c

--- a/test/proxy/.gitignore
+++ b/test/proxy/.gitignore
@@ -1,0 +1,4 @@
+# The release tarball is large and machine-specific; never commit it.
+acton-dist.tar.xz
+.tar.err
+.tar.rc

--- a/test/proxy/README.md
+++ b/test/proxy/README.md
@@ -1,0 +1,63 @@
+# Proxy dependency-fetch test
+
+Reproduces (and guards against) the report: *Acton can't fetch dependencies from
+behind an HTTP proxy* — even with `http_proxy`/`https_proxy` exported.
+
+## Run
+
+```bash
+make test-proxy
+```
+
+or directly:
+
+```bash
+ACTON_DIST=/path/to/dist bash test/proxy/run.sh        # test a specific dist
+DOCKER_DEFAULT_PLATFORM=linux/amd64 bash test/proxy/run.sh   # cross-arch (emulated)
+```
+
+Requires Docker with the `compose` plugin, plus internet (to pull base images and
+let the proxy reach GitHub). `make test-proxy` defaults to the repo's `dist/`.
+
+## What it does
+
+Two containers (`docker-compose.yml`):
+
+- **acton** — Oracle Linux 9, Acton installed from the release tarball, attached
+  **only** to an `internal: true` docker network, so it has **no direct route to
+  the internet**. Its only way out is the proxy.
+- **proxy** — [tinyproxy](https://tinyproxy.github.io/), on both the internal
+  network and an `egress` network with real internet. It logs every `CONNECT`.
+
+`run.sh` then:
+
+1. packs `dist/` into the release tarball the acton container installs from;
+2. starts the containers;
+3. **control** — runs `curl` on the same internal-only network through the same
+   proxy; it must reach GitHub (so a later failure is acton's fault, not the
+   network/proxy);
+4. runs `acton fetch` (the project has one remote HTTPS `zig_dependency`) with
+   the proxy variables set.
+
+Because the acton box has no direct egress, a successful fetch is only possible
+if acton routed through the proxy:
+
+| result | meaning |
+|--------|---------|
+| **exit 0** | acton honoured `http(s)_proxy` — **PASS** |
+| **exit ≠ 0** | acton ignored the proxy and went direct — **FAIL** |
+
+## The bug this guards against
+
+On Linux **x86_64** binaries linked `-no-pie` by `zig cc` (to target an older
+glibc), GHC's `getEnvironment` returns an empty list: an lld copy-relocation
+issue with the glibc `environ`/`__environ` alias. `http-client`'s
+`proxyEnvironment` reads `getEnvironment`, so it never sees the proxy variables
+and connects directly — which fails on a proxy-only network. (`getenv`/`lookupEnv`
+still work, so `curl` and `$HOME` are fine — which is exactly why this is so
+confusing in the field.) **aarch64 is unaffected**, so this test passes there
+regardless; on x86_64 it fails before the fix and passes after.
+
+The fixture uses a `zig_dependency` (zlib v1.3.1) because `acton fetch` downloads
+and hashes it through the same HTTP path as a package dependency, without needing
+it to be a full Acton package.

--- a/test/proxy/acton/Dockerfile
+++ b/test/proxy/acton/Dockerfile
@@ -1,0 +1,25 @@
+# Oracle Linux 9 (glibc 2.34) matches the user's environment. The locally built
+# acton binary requires at most GLIBC_2.29, so the release tarball runs as-is.
+FROM oraclelinux:9
+
+# Runtime prerequisites:
+#   ca-certificates - TLS trust store so HTTPS to GitHub validates through the tunnel
+#   tar, xz         - unpack the Acton release tarball (acton-*.tar.xz)
+#   git             - used by some `acton pkg` operations
+RUN dnf -y install ca-certificates tar xz git \
+ && dnf clean all \
+ && update-ca-trust
+
+# The tarball extracts to /opt/acton (dist/ is renamed to acton/ at release time).
+ENV PATH=/opt/acton/bin:$PATH
+ENV HOME=/root
+
+# A minimal Acton project whose only dependency is a remote GitHub archive,
+# which forces the network fetch path that carries the proxy diagnostics.
+COPY project /work/proxytest
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+WORKDIR /work/proxytest
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/test/proxy/acton/entrypoint.sh
+++ b/test/proxy/acton/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Install Acton "from a tarball" (the same artifact `make release` produces) and
+# then idle so the demo can exec scenarios into this container.
+set -e
+
+TARBALL="${ACTON_TARBALL:-/acton-dist.tar.xz}"
+
+if [ ! -x /opt/acton/bin/acton ]; then
+    if [ ! -f "$TARBALL" ]; then
+        echo "[entrypoint] ERROR: tarball $TARBALL not mounted." >&2
+        echo "[entrypoint] Build it first: see proxy-repro/run-demo.sh" >&2
+        exit 1
+    fi
+    echo "[entrypoint] Installing Acton from tarball $TARBALL -> /opt/acton ..."
+    mkdir -p /opt
+    tar -C /opt -xf "$TARBALL"
+    echo "[entrypoint] Installed. acton binary: $(ls -l /opt/acton/bin/acton)"
+fi
+
+exec "$@"

--- a/test/proxy/acton/project/Build.act
+++ b/test/proxy/acton/project/Build.act
@@ -1,0 +1,13 @@
+name = "proxytest"
+fingerprint = 0x6fa9d198b98853f8
+
+# A single remote dependency, declared as a zig_dependency so that `acton fetch`
+# downloads + hashes it but does NOT require it to be a full Acton package.
+# The download goes through Acton's HTTP fetch path (the one with the proxy
+# diagnostics). The URL is HTTPS, exactly like real GitHub package fetches.
+zig_dependencies = {
+    "zlib": (
+        url="https://github.com/madler/zlib/archive/refs/tags/v1.3.1.tar.gz",
+        hash="N-V-__8AAB0eQwD-0MdOEBmz7intriBReIsIDNlukNVoNu6o"
+    )
+}

--- a/test/proxy/acton/project/src/main.act
+++ b/test/proxy/acton/project/src/main.act
@@ -1,0 +1,3 @@
+actor main(env):
+    print("hello")
+    env.exit(0)

--- a/test/proxy/docker-compose.yml
+++ b/test/proxy/docker-compose.yml
@@ -1,0 +1,36 @@
+# Two-container proxy reproduction for Acton dependency fetching.
+#
+#   acton  - Oracle Linux 9, Acton installed from the release tarball. Attached
+#            ONLY to the `internal` network, so it has NO direct route to the
+#            internet. Its only way out is the proxy.
+#   proxy  - tinyproxy. Attached to both `internal` (to receive requests from
+#            acton) and `egress` (which has real internet via NAT).
+#
+# This mirrors a locked-down corporate / Oracle Linux host where direct egress
+# is blocked and all traffic must go through an HTTP proxy.
+
+services:
+  proxy:
+    build: ./proxy
+    container_name: acton-proxy
+    networks:
+      - internal
+      - egress
+
+  acton:
+    build:
+      context: ./acton
+    container_name: acton-client
+    depends_on:
+      - proxy
+    networks:
+      - internal          # internal only => no direct internet
+    volumes:
+      - ./acton-dist.tar.xz:/acton-dist.tar.xz:ro
+    command: ["sleep", "infinity"]
+
+networks:
+  internal:
+    internal: true         # no gateway to host/internet
+  egress:
+    driver: bridge         # normal outbound internet

--- a/test/proxy/proxy/Dockerfile
+++ b/test/proxy/proxy/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:24.04
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends tinyproxy ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY tinyproxy.conf /etc/tinyproxy/tinyproxy.conf
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+EXPOSE 8888
+CMD ["/usr/local/bin/entrypoint.sh"]

--- a/test/proxy/proxy/entrypoint.sh
+++ b/test/proxy/proxy/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Start tinyproxy (it daemonizes) and stream its log to container stdout so
+# `docker compose logs proxy` shows every CONNECT.
+set -e
+mkdir -p /var/log/tinyproxy
+: > /var/log/tinyproxy/tinyproxy.log
+tinyproxy -c /etc/tinyproxy/tinyproxy.conf
+echo "[proxy] tinyproxy started on :8888"
+exec tail -F /var/log/tinyproxy/tinyproxy.log

--- a/test/proxy/proxy/tinyproxy.conf
+++ b/test/proxy/proxy/tinyproxy.conf
@@ -1,0 +1,21 @@
+# Minimal forward proxy for the Acton proxy reproduction.
+# Logs every connection so we can see (or not see) Acton's egress.
+
+Port 8888
+Listen 0.0.0.0
+Timeout 600
+
+# Log to a real file; the container entrypoint tails it to stdout. (tinyproxy
+# refuses to open /dev/stdout directly due to its symlink-safety check.)
+LogFile "/var/log/tinyproxy/tinyproxy.log"
+LogLevel Connect
+
+MaxClients 100
+
+# No `Allow` lines => allow every client. The proxy is only reachable on the
+# isolated internal docker network, so this is safe for the test.
+
+# Permit HTTPS tunnelling via CONNECT to the standard TLS ports. GitHub
+# dependency archives are HTTPS, so this is what actually carries the traffic.
+ConnectPort 443
+ConnectPort 563

--- a/test/proxy/run.sh
+++ b/test/proxy/run.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# Deterministic proxy test.
+#
+# Brings up two containers via docker compose:
+#   acton  - Oracle Linux 9, Acton installed from the release tarball, attached
+#            ONLY to an internal docker network => NO direct internet egress.
+#   proxy  - tinyproxy, bridging the internal network to real egress.
+# The ONLY way out of the acton box is the proxy (a locked-down corporate host).
+#
+# It then runs `acton fetch` (one remote https zig dependency) with the proxy
+# env vars set. Because the acton box has no direct egress, a SUCCESSFUL fetch is
+# possible only if acton's HTTP client actually routed through the proxy. So:
+#
+#   exit 0  => acton honoured http(s)_proxy  (PASS)
+#   exit !0 => acton ignored the proxy and went direct  (FAIL / reproduces the
+#              x86_64 -no-pie `environ` bug: getEnvironment() returns [] so
+#              http-client's proxyEnvironment never sees the proxy vars)
+#
+# Usage:
+#   make test-proxy
+#   ACTON_DIST=/path/to/dist bash test/proxy/run.sh         # test a specific dist
+#   DOCKER_DEFAULT_PLATFORM=linux/amd64 bash test/proxy/run.sh   # cross-arch (emulated)
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+ACTON_DIST="${ACTON_DIST:-$ROOT/dist}"
+PROJECT="acton-proxy-test"
+PROXY_URL="http://proxy:8888"
+INTERNAL_NET="${PROJECT}_internal"
+ZLIB_URL="https://github.com/madler/zlib/archive/refs/tags/v1.3.1.tar.gz"
+COMPOSE=(docker compose -p "$PROJECT" -f "$HERE/docker-compose.yml")
+
+note() { printf '\n>>> %s\n' "$*"; }
+
+cleanup() { "${COMPOSE[@]}" down -v --remove-orphans >/dev/null 2>&1 || true; rm -f "$HERE/acton-dist.tar.xz"; }
+trap cleanup EXIT INT TERM
+
+command -v docker >/dev/null 2>&1 || { echo "ERROR: docker not found" >&2; exit 2; }
+docker compose version >/dev/null 2>&1 || { echo "ERROR: docker compose plugin not found" >&2; exit 2; }
+
+# 1. Pack the dist into the release tarball the acton container installs from.
+#    Use a symlink + `tar -h` so the tree is archived under acton/ regardless of
+#    the source dir's name, portably across GNU tar (Linux) and bsdtar (macOS).
+[ -x "$ACTON_DIST/bin/acton" ] || { echo "ERROR: no acton at $ACTON_DIST/bin/acton (run 'make dist/bin/acton', or set ACTON_DIST)" >&2; exit 2; }
+note "Packing $ACTON_DIST -> acton-dist.tar.xz"
+stage="$(mktemp -d)"
+ln -s "$(cd "$ACTON_DIST" && pwd)" "$stage/acton"
+tar -C "$stage" -ch acton | xz -z -0 --threads=0 > "$HERE/acton-dist.tar.xz"
+rm -rf "$stage"
+ls -lh "$HERE/acton-dist.tar.xz" | awk '{print "    tarball: " $5}'
+
+# 2. Build & start the two containers.
+note "docker compose up --build"
+"${COMPOSE[@]}" up -d --build
+
+note "Waiting for acton to install from the tarball"
+installed=
+for _ in $(seq 1 150); do
+    if "${COMPOSE[@]}" exec -T acton test -x /opt/acton/bin/acton >/dev/null 2>&1; then installed=1; break; fi
+    sleep 2
+done
+[ -n "$installed" ] || { echo "ERROR: acton did not install" >&2; "${COMPOSE[@]}" logs acton >&2 || true; exit 2; }
+
+# 3. Control: prove the proxy path itself works (so a later failure is acton's,
+#    not the test infrastructure). curl on the SAME internal-only network, using
+#    the SAME proxy, must reach GitHub.
+note "Control: curl reaches GitHub through the proxy (same isolated network)"
+if ! docker run --rm --network "$INTERNAL_NET" \
+        -e http_proxy="$PROXY_URL" -e https_proxy="$PROXY_URL" \
+        curlimages/curl:latest -fsS -o /dev/null --max-time 30 "$ZLIB_URL"; then
+    echo "ERROR: proxy control failed -- the proxy/egress is broken, not acton" >&2
+    "${COMPOSE[@]}" logs proxy >&2 || true
+    exit 2
+fi
+echo "    [ok] proxy reaches GitHub"
+
+# 4. The actual test: acton fetch on the proxy-only network.
+note "acton fetch through the proxy (http_proxy + https_proxy set)"
+set +e
+out="$("${COMPOSE[@]}" exec -T \
+        -e http_proxy="$PROXY_URL"  -e https_proxy="$PROXY_URL" \
+        -e HTTP_PROXY="$PROXY_URL"  -e HTTPS_PROXY="$PROXY_URL" \
+        -e HOME=/root \
+        acton sh -c 'rm -rf /root/.cache/acton; cd /work/proxytest && exec /opt/acton/bin/acton fetch' 2>&1)"
+code=$?
+set -e
+echo "$out" | sed 's/^/    acton| /'
+
+connects="$("${COMPOSE[@]}" logs --no-color proxy 2>/dev/null | grep -c -i 'CONNECT' || true)"
+
+# 5. Verdict.
+echo
+if [ "$code" -eq 0 ]; then
+    note "PASS: acton fetched the dependency through the proxy (proxy CONNECTs: $connects)"
+    exit 0
+fi
+
+note "FAIL: acton fetch failed (exit $code) on a proxy-only network"
+echo "    proxy CONNECT log:" >&2
+"${COMPOSE[@]}" logs --no-color proxy 2>/dev/null | grep -i 'CONNECT' | sed 's/^/      /' >&2 || true
+cat >&2 <<'EOF'
+    With no direct egress, this means acton's HTTP client did not route through
+    the proxy. The usual cause is GHC's getEnvironment() returning an empty
+    environment on x86_64 -no-pie binaries (the `environ` copy-relocation bug),
+    so http-client's proxyEnvironment never saw http(s)_proxy.
+EOF
+exit 1


### PR DESCRIPTION
Acton could not fetch dependencies from GitHub when run behind an HTTP proxy, even with http_proxy and https_proxy exported. The proxy, the network, and the user's configuration were all fine. The real cause is a link-time issue: the Linux compiler binary is linked with zig cc as a no-pie executable to target an older glibc, and under that link GHC's getEnvironment returns an empty environment. This is an lld copy-relocation difference for the glibc environ symbol and its __environ alias. libc's getenv still works, so lookupEnv and things like HOME resolve, but http-client's proxyEnvironment reads the whole environment via getEnvironment, so it never saw the proxy variables and always connected directly. On a proxy-only network that fails and nothing is fetched. This only manifests on x86_64; aarch64 binaries are unaffected, which is part of why it was so hard to pin down. In the field this looked baffling because curl on the same host and shell reached GitHub through the proxy while acton did not.

There are three commits. The first improves the diagnostics. When a dependency download fails, acton now prints the proxy variable that applies to the request, the proxy environment it actually saw, and an actionable hint, instead of dumping the raw http-client request record. It reads the environment through getEnvironment, the same source proxyEnvironment uses, so the diagnostic agrees with the proxy that was actually selected rather than with getenv.

The second commit adds a reproduction and regression test, runnable with make test-proxy. It uses docker compose to bring up an Oracle Linux 9 container with acton installed from the release tarball, attached only to an internal network with no direct egress, plus a tinyproxy that is its only route out. acton fetch must then pull a remote dependency through the proxy, and because there is no direct egress a successful fetch is only possible if acton honoured the proxy variables. A control step proves the proxy path itself works first, so a failure is acton's and not the test infrastructure. A CI job runs this on both amd64 and arm64 host runners and gates the release and pre-release jobs. Before the fix the amd64 job fails, reproducing the report, while arm64 passes as the unaffected control.

The third commit is the fix itself, repairing getEnvironment under the zig cc link by defining environ in the executable, which removes the copy relocation, and pointing it at glibc's live __environ in a startup constructor. It is gated to Linux.