### PR TITLE
Lower Linux glibc target floor to 2.28

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -372,18 +372,15 @@ jobs:
           install -m 0755 "/tmp/stack-${STACK_VERSION}-linux-${STACK_ARCH}/stack" "${HOME}/.local/bin/stack"
           echo "${HOME}/.local/bin" >> "$GITHUB_PATH"
           "${HOME}/.local/bin/stack" --version
-      - name: "Use container glibc target for source build"
-        run: |
-          GLIBC_VERSION="$(getconf GNU_LIBC_VERSION | awk '{print $2}')"
-          echo "ACTON_ZIG_GLIBC_VERSION=${GLIBC_VERSION}" >> "$GITHUB_ENV"
-          echo "Using Zig glibc target ${GLIBC_VERSION}"
       - name: "Build Acton"
         id: build_acton
         run: |
           make -j2 -C ${GITHUB_WORKSPACE} BUILD_RELEASE=${{ env.BUILD_RELEASE }} BUILD_TIME=${BUILD_TIME}
       - name: "Build a release"
         id: build_release
-        run: make -C ${GITHUB_WORKSPACE} release BUILD_TIME=${BUILD_TIME}
+        run: |
+          make -C ${GITHUB_WORKSPACE} release BUILD_TIME=${BUILD_TIME}
+          make -C ${GITHUB_WORKSPACE} ldd
       - name: "Upload artifact"
         uses: actions/upload-artifact@v7
         with:

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ endif
 # -- Linux ---------------------------------------------------------------------
 ifeq ($(shell uname -s),Linux)
 OS:=linux
-ACTON_ZIG_GLIBC_VERSION ?= 2.31
+ACTON_ZIG_GLIBC_VERSION ?= 2.28
 export ACTON_ZIG_GLIBC_VERSION
 ACTON_STACK_NEEDS_ZIG=1
 STACK=CC="$(ACTON_STACK_CC)" CXX="$(ACTON_STACK_CXX)" CFLAGS= CPPFLAGS= LDFLAGS= ACTON_REAL_LD="$(ACTON_STACK_CC)" stack --with-gcc="$(ACTON_STACK_CC)"
@@ -142,13 +142,11 @@ endif
 # and needs a fixed location independent of the directory the link runs from.
 ACTON_BDEPS_DIR := $(TD)/bdeps/out
 export ACTON_BDEPS_DIR
-# libz is the one bdeps lib that GHC actually links into acton on every platform,
-# so we build and statically link it everywhere. The ld-wrapper rewrites -lz to
-# this archive's full path; dropping any future lib's .a into bdeps/out/lib (e.g.
-# liblmdb.a) makes it link statically the same way, with no per-lib wiring.
+# zlib is pulled in by the Haskell zlib package on every platform, so we build
+# and statically link it everywhere.
 BDEPS += bdeps/out/lib/libz.a
 # liblmdb backs the compiler's .tydb interface cache; GHC links it into acton on
-# every platform, so -- unlike gmp/tinfo below -- it is an unconditional bdep.
+# every platform, so it is also an unconditional bdep.
 BDEPS += bdeps/out/lib/liblmdb.a
 ifeq ($(OS),linux)
 # gmp and tinfo are only pulled in by GHC on Linux (macOS GHC uses the native
@@ -260,8 +258,8 @@ clean-downloads:
 
 # /bdeps -------------------------------------------------
 # Build-time dependencies of the acton compiler executable itself. These are
-# libraries that GHC statically links into `acton` and which we otherwise would
-# pull as host .a files via `gcc -print-file-name` (see compiler/tools/*.sh).
+# libraries that GHC statically links into `acton`; compiler/tools/*.sh now
+# requires these archives under bdeps/out instead of falling back to host .a files.
 # Building them ourselves with zig lets us target an older/chosen libc instead of
 # inheriting whatever the build machine has installed. Each bdeps/<name> is a
 # standalone zig project that fetches its upstream source via build.zig.zon and
@@ -276,11 +274,10 @@ clean-downloads:
 # wrapper instead rewrites each -lfoo to the full path of bdeps/out/lib/libfoo.a
 # (a positional arg ld64 links statically) and execs the system clang/ld64 GHC is
 # configured for; zig only builds the archive, since its bundled linker rejects
-# the ld64 flags GHC emits. gmp and tinfo are not linked into a macOS acton
-# (native bignum backend; libncurses comes from the SDK), so only the zlib rule
-# below runs there. The mechanism generalises: any .a placed in bdeps/out/lib
-# links statically on either platform, which is how future compiler libs (e.g.
-# LMDB) will be linked.
+# the ld64 flags GHC emits. zlib and LMDB are linked on every platform; gmp and
+# tinfo are Linux-only because macOS GHC uses the native bignum backend and the
+# SDK's libncurses. The mechanism generalises: any .a placed in bdeps/out/lib
+# links statically on either platform.
 #
 # The BDEPS list and ACTON_BDEPS_DIR are defined earlier (near
 # ACTON_STACK_PREREQS) so they're in scope when the dist/bin/acton rule is read;
@@ -474,7 +471,7 @@ deps-download/$(LIBXML2_REF).tar.gz:
 dist/deps/libxml2: deps-download/$(LIBXML2_REF).tar.gz $(LIBXML2_BUILD_ZIG)
 	rm -rf "$@"
 	mkdir -p "$@"
-	cd "$@" && tar zx --strip-components=1 -f "$(TD)/$<"
+	cd "$@" && tar zx --exclude='libxml2-$(LIBXML2_REF)/test*' --strip-components=1 -f "$(TD)/$<"
 	cp "$(TD)/$(LIBXML2_BUILD_ZIG)" "$@/build.zig"
 	rm -rf "$@/.gitlab-ci" "$@/autogen.sh" "$@/doc" "$@/example" "$@/fuzz" "$@/os400" "$@/python" "$@/result" "$@/vms" "$@/win32" "$@/xstc" $@/test*
 	rm -f "$@"/check-*.py "$@"/dbgen*.pl "$@"/gen*.py "$@"/gentest.py "$@"/build_glob.py "$@"/xml2-config.in

--- a/compiler/acton/package.yaml.in
+++ b/compiler/acton/package.yaml.in
@@ -81,7 +81,7 @@ executables:
       - '"-with-rtsopts=-N -A64M"'
       - -Wno-x-partial
     # Route the link through our wrapper so host libs are replaced with our
-    # self-built static archives under bdeps/out/lib (libz.a, future LMDB, ...).
+    # self-built static archives under bdeps/out/lib (libz.a, liblmdb.a, ...).
     # Gated per-OS rather than applied unconditionally so an unvalidated platform
     # (e.g. Windows, where this bash wrapper would not run) falls back to the
     # default linker instead of breaking. The script branches internally: GNU ld

--- a/compiler/tools/zig-cc.sh
+++ b/compiler/tools/zig-cc.sh
@@ -19,20 +19,9 @@ run_zig_with_lock() {
   flock "$lock_root/acton-zig-cc.lock" "${ZIG}" "$@"
 }
 
-gcc_lib_path() {
-  local lib="$1"
-  local lib_path
-  lib_path="$(gcc -print-file-name="$lib" 2>/dev/null || true)"
-  if [[ -n "$lib_path" && "$lib_path" != "$lib" ]]; then
-    echo "$lib_path"
-    return 0
-  fi
-  return 1
-}
-
-# Static archives we build ourselves under bdeps/out take precedence over the
-# host's apt-installed .a files, so the acton binary links against libs targeting
-# our chosen libc version rather than the build machine's.
+# Static archives we build ourselves under bdeps/out are required so the acton
+# binary links against libs targeting our chosen libc version rather than the
+# build machine's.
 bdeps_lib_path() {
   local archive="$1"
   if [[ -n "${ACTON_BDEPS_DIR:-}" && -f "${ACTON_BDEPS_DIR}/lib/${archive}" ]]; then
@@ -40,6 +29,16 @@ bdeps_lib_path() {
     return 0
   fi
   return 1
+}
+
+require_bdeps_lib_path() {
+  local archive="$1"
+  if bdeps_lib_path "$archive"; then
+    return 0
+  fi
+  echo "required bdeps archive not found: ${ACTON_BDEPS_DIR:-<unset>}/lib/${archive}" >&2
+  echo "run make to build bdeps before invoking the Zig compiler wrapper" >&2
+  exit 1
 }
 
 add_bdeps_include_dirs() {
@@ -67,25 +66,12 @@ add_arch_feature_args() {
 
 rewrite_lib_arg() {
   local arg="$1"
-  local lib_path
   case "$arg" in
     -lgmp|-l:libgmp.a)
-      if lib_path="$(bdeps_lib_path libgmp.a)"; then
-        echo "$lib_path"
-      elif lib_path="$(gcc_lib_path libgmp.a)"; then
-        echo "$lib_path"
-      else
-        echo "$arg"
-      fi
+      require_bdeps_lib_path libgmp.a
       ;;
     -lz|-l:libz.a)
-      if lib_path="$(bdeps_lib_path libz.a)"; then
-        echo "$lib_path"
-      elif lib_path="$(gcc_lib_path libz.a)"; then
-        echo "$lib_path"
-      else
-        echo "$arg"
-      fi
+      require_bdeps_lib_path libz.a
       ;;
     -lstdc++|-l:libstdc++.a)
       # zig's bundled static libc++ replaces the host libstdc++.a.
@@ -96,13 +82,7 @@ rewrite_lib_arg() {
       echo "-lunwind"
       ;;
     -ltinfo|-l:libtinfo.a)
-      if lib_path="$(bdeps_lib_path libtinfo.a)"; then
-        echo "$lib_path"
-      elif lib_path="$(gcc_lib_path libtinfo.a)"; then
-        echo "$lib_path"
-      else
-        echo "$arg"
-      fi
+      require_bdeps_lib_path libtinfo.a
       ;;
     *)
       echo "$arg"
@@ -144,7 +124,7 @@ case "$(uname -s)" in
       aarch64|arm64) ZIG_ARCH=aarch64 ;;
       *) echo "Unsupported architecture for Linux: ${ARCH}" >&2; exit 1 ;;
     esac
-    GLIBC_VERSION="${ACTON_ZIG_GLIBC_VERSION:-2.31}"
+    GLIBC_VERSION="${ACTON_ZIG_GLIBC_VERSION:-2.28}"
     args=()
     add_bdeps_include_dirs
     add_system_include_dirs

--- a/compiler/tools/zig-cxx.sh
+++ b/compiler/tools/zig-cxx.sh
@@ -19,20 +19,9 @@ run_zig_with_lock() {
   flock "$lock_root/acton-zig-cc.lock" "${ZIG}" "$@"
 }
 
-gcc_lib_path() {
-  local lib="$1"
-  local lib_path
-  lib_path="$(gcc -print-file-name="$lib" 2>/dev/null || true)"
-  if [[ -n "$lib_path" && "$lib_path" != "$lib" ]]; then
-    echo "$lib_path"
-    return 0
-  fi
-  return 1
-}
-
-# Static archives we build ourselves under bdeps/out take precedence over the
-# host's apt-installed .a files, so the acton binary links against libs targeting
-# our chosen libc version rather than the build machine's.
+# Static archives we build ourselves under bdeps/out are required so the acton
+# binary links against libs targeting our chosen libc version rather than the
+# build machine's.
 bdeps_lib_path() {
   local archive="$1"
   if [[ -n "${ACTON_BDEPS_DIR:-}" && -f "${ACTON_BDEPS_DIR}/lib/${archive}" ]]; then
@@ -40,6 +29,16 @@ bdeps_lib_path() {
     return 0
   fi
   return 1
+}
+
+require_bdeps_lib_path() {
+  local archive="$1"
+  if bdeps_lib_path "$archive"; then
+    return 0
+  fi
+  echo "required bdeps archive not found: ${ACTON_BDEPS_DIR:-<unset>}/lib/${archive}" >&2
+  echo "run make to build bdeps before invoking the Zig compiler wrapper" >&2
+  exit 1
 }
 
 add_bdeps_include_dirs() {
@@ -67,25 +66,12 @@ add_arch_feature_args() {
 
 rewrite_lib_arg() {
   local arg="$1"
-  local lib_path
   case "$arg" in
     -lgmp|-l:libgmp.a)
-      if lib_path="$(bdeps_lib_path libgmp.a)"; then
-        echo "$lib_path"
-      elif lib_path="$(gcc_lib_path libgmp.a)"; then
-        echo "$lib_path"
-      else
-        echo "$arg"
-      fi
+      require_bdeps_lib_path libgmp.a
       ;;
     -lz|-l:libz.a)
-      if lib_path="$(bdeps_lib_path libz.a)"; then
-        echo "$lib_path"
-      elif lib_path="$(gcc_lib_path libz.a)"; then
-        echo "$lib_path"
-      else
-        echo "$arg"
-      fi
+      require_bdeps_lib_path libz.a
       ;;
     -lstdc++|-l:libstdc++.a)
       # zig's bundled static libc++ replaces the host libstdc++.a.
@@ -96,13 +82,7 @@ rewrite_lib_arg() {
       echo "-lunwind"
       ;;
     -ltinfo|-l:libtinfo.a)
-      if lib_path="$(bdeps_lib_path libtinfo.a)"; then
-        echo "$lib_path"
-      elif lib_path="$(gcc_lib_path libtinfo.a)"; then
-        echo "$lib_path"
-      else
-        echo "$arg"
-      fi
+      require_bdeps_lib_path libtinfo.a
       ;;
     *)
       echo "$arg"
@@ -144,7 +124,7 @@ case "$(uname -s)" in
       aarch64|arm64) ZIG_ARCH=aarch64 ;;
       *) echo "Unsupported architecture for Linux: ${ARCH}" >&2; exit 1 ;;
     esac
-    GLIBC_VERSION="${ACTON_ZIG_GLIBC_VERSION:-2.31}"
+    GLIBC_VERSION="${ACTON_ZIG_GLIBC_VERSION:-2.28}"
     args=()
     add_bdeps_include_dirs
     add_system_include_dirs

--- a/docs/acton-dev-guide/src/getting_started/build.md
+++ b/docs/acton-dev-guide/src/getting_started/build.md
@@ -32,6 +32,6 @@ dist/bin/actonc path/to/file.act   # compatibility alias
 
 - `ZIG_LOCAL_CACHE_DIR` controls Zig's cache location (defaults to `~/.cache/acton/zig-local-cache` when `HOME` is set).
 - `BUILD_RELEASE=1 make` stamps release versions; default builds get a timestamped version suffix.
-- On Linux, the Makefile uses Zig for the Stack/GHC C compiler path and pins the default glibc target to 2.31 for compatibility.
+- On Linux, the Makefile uses Zig for the Stack/GHC C compiler path and pins the default glibc target to 2.28 for compatibility.
 - `ACTON_ZIG_GLIBC_VERSION` overrides the glibc version used for Stack/GHC linking on Linux.
 - Linux release builds should run in a builder with system static libraries no newer than the requested glibc target.


### PR DESCRIPTION
Let Linux CI builds use the Makefile glibc target instead of deriving ACTON_ZIG_GLIBC_VERSION from the build container. Now that we control the compilation of all libraries that we statically link in, this now works. The net effect is that x86_64 remains on glibc 2.28 as minimum (target max was 2.31) whereas for aarch64 we now lower to 2.28 from Ubuntu 24.04's newer glibc. On keeps x86_64 on the existing target and lowers aarch64 builds that previously inherited Ubuntu 24.04's newer glibc.

Require compiler-linked bdeps to resolve from bdeps/out so missing zlib, GMP, or tinfo archives fail the wrapper instead of falling back to host static libraries.