### PR TITLE
Make all compiler HTTP paths proxy-aware

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -936,6 +936,10 @@ jobs:
           sudo dpkg -i ./deb/acton_*.deb
           acton version
       - name: "Proxy dependency-fetch test"
+        env:
+          # Authenticate the pkg-upgrade scenario's GitHub API calls so they
+          # don't hit the 60/hr unauthenticated limit on shared runner IPs.
+          GITHUB_TOKEN: ${{ github.token }}
         run: make test-proxy ACTON_DIST=/usr/lib/acton
 
   test-windows:

--- a/compiler/acton/PkgCommands.hs
+++ b/compiler/acton/PkgCommands.hs
@@ -22,12 +22,13 @@ module PkgCommands
 
 import Prelude hiding (readFile, writeFile)
 
+import Acton.ArchiveDownload (downloadArchive)
+import Acton.HttpFetch (httpGetBytes, isHttpUrl, newProxyManager)
 import qualified Acton.BuildSpec as BuildSpec
 import qualified Acton.CommandLineParser as C
 import Acton.Compile (loadBuildSpec, throwProjectError)
 
 import Control.Exception (IOException, SomeException, try, displayException, evaluate)
-import Control.Concurrent (threadDelay)
 import Control.Monad (filterM, forM, forM_, unless, when)
 import Data.Char (isHexDigit, isSpace)
 import Data.Foldable (toList)
@@ -41,10 +42,7 @@ import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as AesonKey
 import qualified Data.Aeson.KeyMap as AesonKM
 import qualified Data.Text as T
-import Network.HTTP.Client (Manager, Response, httpLbs, parseRequest, requestHeaders, responseBody, responseStatus)
-import Network.HTTP.Client.TLS (newTlsManager)
-import Network.HTTP.Types.Header (Header)
-import Network.HTTP.Types.Status (statusCode)
+import Network.HTTP.Client (Manager)
 import System.Directory (Permissions, canonicalizePath, copyFile, createDirectoryIfMissing, doesDirectoryExist, doesFileExist, doesPathExist, getCurrentDirectory, getHomeDirectory, getPermissions, listDirectory, removeFile, setPermissions)
 import System.Environment (getExecutablePath, lookupEnv)
 import System.Exit (ExitCode(..))
@@ -90,7 +88,7 @@ installCommand gopts opts = do
         repoRefArg = normalizeMaybe (C.installRepoRef opts)
         pkgNameArg = C.installPkgName opts
     validateInstallName appName
-    manager <- newTlsManager
+    manager <- newProxyManager
     token <- resolveGithubToken (normalizeMaybe (C.installGithubToken opts))
     repoUrl <-
       if null repoUrlArg
@@ -158,7 +156,7 @@ pkgAddCommand _ opts = do
     validateDepName depName
     cwd <- getCurrentDirectory
     spec0 <- loadBuildSpec cwd
-    manager <- newTlsManager
+    manager <- newProxyManager
     token <- resolveGithubToken (normalizeMaybe (C.pkgAddGithubToken opts))
     let urlArg = C.pkgAddUrl opts
         repoUrlArg = C.pkgAddRepoUrl opts
@@ -189,7 +187,7 @@ pkgAddCommand _ opts = do
 resolveLibraryDependency :: String -> IO BuildSpec.PkgDep
 resolveLibraryDependency depName = do
     validateDepName depName
-    manager <- newTlsManager
+    manager <- newProxyManager
     token <- resolveGithubToken Nothing
     repoUrl <- lookupRepoUrlFromIndex depName ""
     ensureGithubUrl "repl :dep add" repoUrl
@@ -223,7 +221,7 @@ pkgUpgradeCommand _ opts = do
     cwd <- getCurrentDirectory
     spec <- loadBuildSpec cwd
     let deps = BuildSpec.dependencies spec
-    manager <- newTlsManager
+    manager <- newProxyManager
     token <- resolveGithubToken (normalizeMaybe (C.pkgUpgradeGithubToken opts))
     resolved <- mapM (resolveDep manager token) (M.toList deps)
     let newUrls = M.fromList [ (n,u) | Just (n,u) <- resolved ]
@@ -293,8 +291,8 @@ pkgUpgradeCommand _ opts = do
 pkgUpdateCommand :: C.GlobalOptions -> IO ()
 pkgUpdateCommand _ = do
     let indexUrl = "https://actonlang.github.io/package-index/index.json"
-    manager <- newTlsManager
-    body <- requireRightWith ("ERROR: Failed to download package index from " ++ indexUrl ++ ": ") =<< httpGet manager [] indexUrl
+    manager <- newProxyManager
+    body <- requireRightWith ("ERROR: Failed to download package index from " ++ indexUrl ++ ": ") =<< httpGetBytes manager [] indexUrl
     home <- getHomeDirectory
     let indexDir = home </> ".cache" </> "acton"
         indexPath = indexDir </> "package-index.json"
@@ -837,7 +835,7 @@ fetchGithubObject manager token url = do
             Just t -> [("Authorization", B.pack ("Bearer " ++ t))]
             Nothing -> []
         headers = ("Accept", "application/vnd.github.v3+json") : authHeader
-    body <- httpGet manager headers url
+    body <- httpGetBytes manager headers url
     case body of
       Left err -> return (Left ("Failed to download " ++ url ++ ": " ++ err))
       Right bs ->
@@ -845,43 +843,6 @@ fetchGithubObject manager token url = do
           Left err -> return (Left err)
           Right (Aeson.Object obj) -> return (Right obj)
           Right _ -> return (Left "Invalid JSON response")
-
-httpGet :: Manager -> [Header] -> String -> IO (Either String BL.ByteString)
-httpGet manager extraHeaders url = do
-    req0 <- parseRequest url
-    let headers = ("User-Agent", "acton") : extraHeaders
-        req = req0 { requestHeaders = headers ++ requestHeaders req0 }
-    let maxAttempts = 10
-        baseDelay = 500000
-        maxDelay = 120000000
-    let go attempt delay = do
-          res <- try (httpLbs req manager) :: IO (Either SomeException (Response BL.ByteString))
-          case res of
-            Left err ->
-              retryOrFail attempt delay (displayException err)
-            Right response -> do
-              let status = statusCode (responseStatus response)
-                  body = responseBody response
-              if status >= 200 && status < 300
-                then return (Right body)
-                else
-                  if shouldRetry status
-                    then retryOrFail attempt delay (httpErrorMessage status body)
-                    else return (Left (httpErrorMessage status body))
-        retryOrFail attempt delay errMsg
-          | attempt >= maxAttempts = return (Left errMsg)
-          | otherwise = do
-              threadDelay delay
-              go (attempt + 1) (min maxDelay (delay * 2))
-    go 1 baseDelay
-  where
-    shouldRetry status = status == 403 || status == 429 || status >= 500
-    httpErrorMessage status body =
-      let raw = trim (B.unpack (BL.toStrict body))
-          clipped = take 200 raw
-          suffix = if length raw > length clipped then "..." else ""
-          detail = if null clipped then "" else ": " ++ clipped ++ suffix
-      in "HTTP " ++ show status ++ detail
 
 lookupString :: String -> Aeson.Object -> Maybe String
 lookupString key obj =
@@ -944,32 +905,38 @@ readIndexFile path = do
       Left err -> throwProjectError ("ERROR: Failed to read package index at " ++ path ++ ": " ++ displayException err)
       Right content -> return content
 
+-- | Download an archive and return its zig package hash. For http(s) URLs the
+--   download goes through the proxy-aware http-client (Acton.ArchiveDownload), and
+--   only the resulting LOCAL file is handed to `zig fetch` -- so it works behind an
+--   HTTP CONNECT proxy, which zig's own network stack does not. Non-http targets
+--   (local paths) go straight to zig fetch.
 zigFetchHash :: FilePath -> String -> IO (Either String String)
-zigFetchHash zigExe depUrl = do
+zigFetchHash zigExe depUrl
+  | isHttpUrl depUrl = do
+      dl <- downloadArchive depUrl
+      case dl of
+        Left err -> return (Left ("Error fetching " ++ err))
+        Right localFile -> do
+          res <- zigFetchLocalHash zigExe localFile
+          _ <- try (removeFile localFile) :: IO (Either IOException ())
+          return res
+  | otherwise = zigFetchLocalHash zigExe depUrl
+
+-- | Run `zig fetch` on a local archive (or non-http target) and return its hash.
+zigFetchLocalHash :: FilePath -> String -> IO (Either String String)
+zigFetchLocalHash zigExe target = do
     home <- getHomeDirectory
     let globalCache = home </> ".cache" </> "acton" </> "zig-global-cache"
     createDirectoryIfMissing True globalCache
     createDirectoryIfMissing True (globalCache </> "tmp")
     withSystemTempDirectory "acton-zig-fetch" $ \tmp -> do
       writeFile (tmp </> "build.zig") zigFetchBuildZig
-      let cmd = (proc zigExe ["fetch", "--global-cache-dir", globalCache, depUrl]) { cwd = Just tmp }
-      let maxAttempts = 10
-          baseDelay = 500000
-          maxDelay = 120000000
-      let go attempt delay = do
-            res <- try (readCreateProcessWithExitCode cmd "") :: IO (Either SomeException (ExitCode, String, String))
-            case res of
-              Left err ->
-                retryOrFail attempt delay ("Error fetching " ++ displayException err)
-              Right (ExitSuccess, out, _) -> return (Right (trim out))
-              Right (ExitFailure _, _, err) ->
-                retryOrFail attempt delay ("Error fetching " ++ trim err)
-          retryOrFail attempt delay errMsg
-            | attempt >= maxAttempts = return (Left errMsg)
-            | otherwise = do
-                threadDelay delay
-                go (attempt + 1) (min maxDelay (delay * 2))
-      go 1 baseDelay
+      let cmd = (proc zigExe ["fetch", "--global-cache-dir", globalCache, target]) { cwd = Just tmp }
+      res <- try (readCreateProcessWithExitCode cmd "") :: IO (Either SomeException (ExitCode, String, String))
+      case res of
+        Left err -> return (Left ("Error hashing archive: " ++ displayException err))
+        Right (ExitSuccess, out, _) -> return (Right (trim out))
+        Right (ExitFailure _, _, err) -> return (Left ("Error hashing archive: " ++ trim err))
 
 zigFetchBuildZig :: String
 zigFetchBuildZig = unlines

--- a/compiler/lib/package.yaml.in
+++ b/compiler/lib/package.yaml.in
@@ -63,6 +63,7 @@ dependencies:
 library:
   source-dirs: src
   exposed-modules:
+    - Acton.ArchiveDownload
     - Acton.Boxing
     - Acton.BuildSpec
     - Acton.Builtin
@@ -77,6 +78,7 @@ library:
     - Acton.Env
     - Acton.Fingerprint
     - Acton.Hashing
+    - Acton.HttpFetch
     - Acton.Kinds
     - Acton.LambdaLifter
     - Acton.NameInfo

--- a/compiler/lib/src/Acton/ArchiveDownload.hs
+++ b/compiler/lib/src/Acton/ArchiveDownload.hs
@@ -1,0 +1,127 @@
+-- | Archive download: the archive-specific layer on top of Acton.HttpFetch.
+--   Downloads a URL to a local file (proxy-aware, via HttpFetch.downloadToFile)
+--   and names it with a suffix reflecting the archive type, so `zig fetch` can
+--   identify the format. Shared by dependency fetching (Acton.Compile) and the
+--   package commands (PkgCommands.zigFetchHash).
+module Acton.ArchiveDownload
+  ( downloadArchive
+  ) where
+
+import Acton.HttpFetch (downloadToFile, newProxyManager)
+import Control.Applicative ((<|>))
+import Control.Exception (IOException, displayException, try)
+import Data.Char (isSpace, toLower)
+import Data.List (isSuffixOf)
+import Data.Word (Word8)
+import System.Directory (removeFile, renameFile)
+import Network.HTTP.Types.Header (Header, hContentDisposition, hContentType)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as B
+
+-- | Download an http(s) archive URL to a temporary local file named with a
+--   suffix that reflects its type. Returns the local file path, or a diagnostic.
+downloadArchive :: String -> IO (Either String FilePath)
+downloadArchive url = do
+  manager <- newProxyManager
+  res <- downloadToFile manager url
+  case res of
+    Left err -> return (Left err)
+    Right (tmpPath, headers, sniff) ->
+      case archiveSuffix url headers sniff of
+        Nothing -> do
+          _ <- try (removeFile tmpPath) :: IO (Either IOException ())
+          return (Left "Could not determine archive type from URL path, response headers, or file bytes")
+        Just suffix -> do
+          let finalPath = tmpPath ++ suffix
+          moveRes <- try (renameFile tmpPath finalPath) :: IO (Either IOException ())
+          case moveRes of
+            Left ex -> do
+              _ <- try (removeFile tmpPath) :: IO (Either IOException ())
+              return (Left ("Unable to finalize downloaded archive path: " ++ displayException ex))
+            Right _ -> return (Right finalPath)
+
+-- | Pick an archive suffix from the URL path, then the response headers, then the
+--   leading bytes -- in that order of preference.
+archiveSuffix :: String -> [Header] -> BS.ByteString -> Maybe String
+archiveSuffix url headers sniff =
+      archiveSuffixFromPath (takeWhile (/= '?') url)
+  <|> archiveSuffixFromContentDisposition (lookup hContentDisposition headers)
+  <|> archiveSuffixFromContentType (lookup hContentType headers)
+  <|> detectArchiveSuffixFromBytes sniff
+
+archiveSuffixFromPath :: String -> Maybe String
+archiveSuffixFromPath rawPath =
+  let p = map toLower rawPath
+  in if ".tar.gz" `isSuffixOf` p then Just ".tar.gz"
+     else if ".tgz" `isSuffixOf` p then Just ".tgz"
+     else if ".tar.xz" `isSuffixOf` p then Just ".tar.xz"
+     else if ".txz" `isSuffixOf` p then Just ".txz"
+     else if ".tar.zst" `isSuffixOf` p then Just ".tar.zst"
+     else if ".tzst" `isSuffixOf` p then Just ".tzst"
+     else if ".tar" `isSuffixOf` p then Just ".tar"
+     else if ".zip" `isSuffixOf` p then Just ".zip"
+     else if ".jar" `isSuffixOf` p then Just ".jar"
+     else Nothing
+
+archiveSuffixFromContentType :: Maybe B.ByteString -> Maybe String
+archiveSuffixFromContentType mType =
+  case map toLower . trim . takeWhile (/= ';') . B.unpack <$> mType of
+    Just "application/x-tar" -> Just ".tar"
+    Just "application/gzip" -> Just ".tar.gz"
+    Just "application/x-gzip" -> Just ".tar.gz"
+    Just "application/tar+gzip" -> Just ".tar.gz"
+    Just "application/x-tar-gz" -> Just ".tar.gz"
+    Just "application/x-gtar-compressed" -> Just ".tar.gz"
+    Just "application/x-xz" -> Just ".tar.xz"
+    Just "application/zstd" -> Just ".tar.zst"
+    Just "application/zip" -> Just ".zip"
+    Just "application/x-zip-compressed" -> Just ".zip"
+    Just "application/java-archive" -> Just ".zip"
+    _ -> Nothing
+
+archiveSuffixFromContentDisposition :: Maybe B.ByteString -> Maybe String
+archiveSuffixFromContentDisposition mVal = do
+  headerVal <- mVal
+  filenameVal <- extractField (B.pack "filename*=") headerVal <|> extractField (B.pack "filename=") headerVal
+  archiveSuffixFromPath (B.unpack filenameVal)
+  where
+    extractField key raw =
+      let lowerRaw = B.map toLower raw
+          (prefix, rest) = B.breakSubstring key lowerRaw
+      in if B.null rest
+           then Nothing
+           else
+             let origRest = B.drop (B.length prefix) raw
+                 val0 = B.drop (B.length key) origRest
+                 val1 = B.takeWhile (/= ';') val0
+                 val2 = stripQuotes (B.dropWhile isSpace (trimBS val1))
+                 val3 =
+                   case B.breakSubstring (B.pack "''") val2 of
+                     (_, t) | B.null t -> val2
+                     (_, t) -> B.drop 2 t
+             in if B.null val3 then Nothing else Just val3
+    trimBS = B.dropWhileEnd isSpace . B.dropWhile isSpace
+    stripQuotes s
+      | B.length s >= 2 && B.head s == '"' && B.last s == '"' = B.tail (B.init s)
+      | otherwise = s
+
+detectArchiveSuffixFromBytes :: BS.ByteString -> Maybe String
+detectArchiveSuffixFromBytes bytes
+  | startsWith [0x50, 0x4b, 0x03, 0x04] bytes = Just ".zip"
+  | startsWith [0x50, 0x4b, 0x05, 0x06] bytes = Just ".zip"
+  | startsWith [0x50, 0x4b, 0x07, 0x08] bytes = Just ".zip"
+  | startsWith [0x1f, 0x8b] bytes = Just ".tar.gz"
+  | startsWith [0xfd, 0x37, 0x7a, 0x58, 0x5a, 0x00] bytes = Just ".tar.xz"
+  | startsWith [0x28, 0xb5, 0x2f, 0xfd] bytes = Just ".tar.zst"
+  | hasUstar bytes = Just ".tar"
+  | otherwise = Nothing
+  where
+    startsWith :: [Word8] -> BS.ByteString -> Bool
+    startsWith sig bs =
+      BS.length bs >= length sig && BS.take (length sig) bs == BS.pack sig
+    hasUstar bs =
+      BS.length bs >= 262 && BS.take 5 (BS.drop 257 bs) == BS.pack [0x75, 0x73, 0x74, 0x61, 0x72]
+
+trim :: String -> String
+trim = f . f
+  where f = reverse . dropWhile isSpace

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -236,7 +236,6 @@ import qualified Pretty
 import Pretty hiding ((<>))
 import qualified InterfaceFiles
 
-import Control.Applicative ((<|>))
 import Control.Concurrent.Async
 import Control.Concurrent.MVar
 import Control.Concurrent (forkIO, myThreadId, threadCapability, threadDelay)
@@ -246,7 +245,7 @@ import Control.Exception (Exception, IOException, SomeAsyncException, SomeExcept
 import Control.Monad
 import Data.Binary (encode)
 import Data.Bits (shiftL, shiftR, (.|.))
-import Data.Char (isAlpha, isDigit, isHexDigit, isSpace, toLower)
+import Data.Char (isAlpha, isDigit, isHexDigit, isSpace)
 import Data.Either (partitionEithers)
 import Data.Graph
 import Data.List (find, foldl', intercalate, intersperse, isPrefixOf, isSuffixOf, nub, partition)
@@ -258,17 +257,15 @@ import qualified Data.Map as M
 import Data.Ord (Down(..))
 import qualified Data.Set
 import Data.Time.Clock (UTCTime)
-import Data.Word (Word8, Word32, Word64)
+import Data.Word (Word32, Word64)
 import Error.Diagnose (Diagnostic)
 import GHC.Conc (getNumCapabilities)
-import qualified Network.HTTP.Client as HTTP
-import Network.HTTP.Client.TLS (tlsManagerSettings)
-import Network.HTTP.Types.Header (hContentDisposition, hContentType)
-import Network.HTTP.Types.Status (statusCode)
+import Acton.ArchiveDownload (downloadArchive)
+import Acton.HttpFetch (isHttpUrl, proxyEnvReportLines, readProxyEnv)
 import System.Clock
 import System.Directory
 import System.Directory.Recursive (getFilesRecursive)
-import System.Environment (getEnvironment, getExecutablePath, lookupEnv)
+import System.Environment (getExecutablePath, lookupEnv)
 import System.FileLock (FileLock, SharedExclusive(Exclusive), tryLockFile, unlockFile, withFileLock)
 import System.FilePath ((</>))
 import System.FilePath.Posix
@@ -4985,132 +4982,6 @@ validateDepOverridePath depName depPath = do
                          ++ "Hint: Local dependency paths must point to an Acton project root\n"
                          ++ "(directory with src/ and Build.act).")
 
--- Proxy diagnostics -----------------------------------------------------------
--- Dependency archives are fetched over HTTPS with http-client, whose proxy
--- selection (proxyEnvironment) is protocol-specific: an https URL is proxied
--- only via https_proxy/HTTPS_PROXY, never via http_proxy. When a fetch fails we
--- report which proxy variable applies to the request and the proxy environment
--- acton actually saw, so a missing/unexported https_proxy (e.g. under sudo or a
--- non-interactive make/CI shell, where the interactive shell's proxy vars are
--- not inherited) is obvious instead of hidden behind a raw "proxy = Nothing"
--- request-record dump.
-
--- | Proxy-related environment variables, in the order we report them.
-proxyEnvVarNames :: [String]
-proxyEnvVarNames =
-  [ "http_proxy", "HTTP_PROXY"
-  , "https_proxy", "HTTPS_PROXY"
-  , "all_proxy", "ALL_PROXY"
-  , "no_proxy", "NO_PROXY"
-  ]
-
--- | Snapshot the proxy environment acton actually sees. Reads via
---   getEnvironment (the `environ` array), the SAME source http-client's
---   proxyEnvironment consults -- NOT lookupEnv/getenv. The two can disagree on
---   Linux binaries hit by the `environ` copy-relocation bug (getEnvironment
---   returns [] while getenv works); reading getEnvironment keeps this diagnostic
---   honest about what proxy selection actually saw.
-readProxyEnv :: IO [(String, Maybe String)]
-readProxyEnv = do
-  env <- getEnvironment
-  return [ (n, lookup n env) | n <- proxyEnvVarNames ]
-
--- | Render one proxy env var for display, masking any embedded credentials.
-formatProxyEnvVar :: (String, Maybe String) -> String
-formatProxyEnvVar (n, v) =
-  n ++ "=" ++ maybe "(unset)" (\x -> if null x then "(empty)" else maskProxyUrl x) v
-
--- | Indented "proxy environment acton sees" block for use in messages.
-proxyEnvReportLines :: String -> [(String, Maybe String)] -> [String]
-proxyEnvReportLines indent env =
-  (indent ++ "proxy environment acton sees:")
-  : [ indent ++ "  " ++ formatProxyEnvVar kv | kv <- env ]
-
--- | Mask user:password@ credentials embedded in a proxy URL.
-maskProxyUrl :: String -> String
-maskProxyUrl url =
-  let (scheme, afterScheme) = case findSubstring "://" url of
-                                Just i  -> (take (i + 3) url, drop (i + 3) url)
-                                Nothing -> ("", url)
-      (authority, rest)     = break (== '/') afterScheme
-  in case break (== '@') authority of
-       (_, '@':hostPort) -> scheme ++ "***@" ++ hostPort ++ rest
-       _                 -> url
-
-findSubstring :: String -> String -> Maybe Int
-findSubstring needle = go 0
-  where go _ []              = Nothing
-        go i hay@(_:t)
-          | needle `isPrefixOf` hay = Just i
-          | otherwise               = go (i + 1) t
-
--- | The proxy variable http-client consults for a request of this scheme, and
---   its value if set. Selection is protocol-specific (https_proxy for https,
---   http_proxy for http); ALL_PROXY is intentionally excluded because
---   http-client does not honor it. NB: we report from the environment rather
---   than the failed request's `proxy` field, which http-client leaves unset for
---   https CONNECT tunnels even when a proxy is used.
-applicableProxy :: Bool -> [(String, Maybe String)] -> Maybe (String, String)
-applicableProxy secure env =
-  listToMaybe [ (n, v) | n <- names, Just (Just v) <- [lookup n env], not (null v) ]
-  where names = if secure then ["https_proxy", "HTTPS_PROXY"] else ["http_proxy", "HTTP_PROXY"]
-
--- | Turn an http-client fetch exception into a clean, actionable message: the
---   underlying cause, the proxy variable that applies to the request, the proxy
---   environment acton saw, and a hint when no proxy is configured for the URL.
-describeFetchException :: [(String, Maybe String)] -> SomeException -> String
-describeFetchException env ex =
-  case fromException ex :: Maybe HTTP.HttpException of
-    Just (HTTP.HttpExceptionRequest req content) ->
-      let secure  = HTTP.secure req
-          scheme  = if secure then "https" else "http"
-          target  = B.unpack (HTTP.host req) ++ ":" ++ show (HTTP.port req)
-          vars    = if secure then "https_proxy/HTTPS_PROXY" else "http_proxy/HTTP_PROXY"
-          proxyLn = case applicableProxy secure env of
-                      Just (n, v) -> "  proxy for this " ++ scheme ++ " request: "
-                                     ++ maskProxyUrl v ++ " (from " ++ n ++ ")"
-                      Nothing     -> "  proxy for this " ++ scheme ++ " request: none ("
-                                     ++ vars ++ " unset)"
-      in intercalate "\n"
-           ( [ describeFetchContent content
-             , "  request: " ++ scheme ++ " to " ++ target
-             , proxyLn
-             ]
-             ++ proxyEnvReportLines "  " env
-             ++ proxyFailureHint secure env )
-    Just other -> displayException other
-    Nothing    -> displayException ex
-
--- | One-line summary of an http-client failure cause (no Request record dump).
-describeFetchContent :: HTTP.HttpExceptionContent -> String
-describeFetchContent c = case c of
-  HTTP.ConnectionTimeout            -> "connection timed out"
-  HTTP.ConnectionFailure e          -> "connection failed: " ++ show e
-  HTTP.ResponseTimeout              -> "response timed out"
-  HTTP.ProxyConnectException h p st -> "proxy CONNECT to " ++ B.unpack h ++ ":" ++ show p
-                                       ++ " failed (status " ++ show (statusCode st) ++ ")"
-  HTTP.StatusCodeException res _    -> "unexpected HTTP status "
-                                       ++ show (statusCode (HTTP.responseStatus res))
-  HTTP.InternalException e          -> "connection failed: " ++ show e
-  other                             -> show other
-
--- | Hint shown when a fetch failed and no proxy variable applies to its scheme:
---   the common real-world trap where proxy vars live in an interactive shell but
---   are absent from the build's environment (sudo/root, make, CI).
-proxyFailureHint :: Bool -> [(String, Maybe String)] -> [String]
-proxyFailureHint secure env
-  | isJust (applicableProxy secure env) = []
-  | otherwise =
-      [ "  hint: no " ++ vars ++ " is set in acton's environment, so this " ++ scheme
-      , "        download was attempted directly. If you use a proxy, make sure "
-        ++ varLower ++ " is"
-      , "        exported in the environment that runs the build. sudo/root shells and"
-      , "        many make/CI setups do not inherit the proxy variables from your"
-      , "        interactive shell." ]
-  where scheme   = if secure then "https" else "http"
-        vars     = if secure then "https_proxy/HTTPS_PROXY" else "http_proxy/HTTP_PROXY"
-        varLower = if secure then "https_proxy" else "http_proxy"
-
 fetchDependencies :: C.GlobalOptions -> Paths -> [(String, FilePath)] -> IO ()
 fetchDependencies gopts paths depOverrides = do
     if isTmp paths
@@ -5301,19 +5172,14 @@ fetchDependencies gopts paths depOverrides = do
             throwProjectError ("Failed to extract cached dependency archive " ++ archive ++ ":\n" ++ out ++ err)
 
     fetchViaDownloadedArchive kind name depUrl mh cacheDir zigExe globalCache = do
-      dl <- downloadToLocalArchive kind name depUrl
+      -- depUrl is always http(s) here (runFetch's isHttpUrl guard), so
+      -- downloadArchive (proxy-aware http-client) is the right path. Do NOT fall
+      -- back to `zig fetch <depUrl>`: zig's network stack cannot traverse an HTTP
+      -- CONNECT proxy, so it would hang and bury the actionable proxy diagnostic.
+      dl <- downloadArchive depUrl
       case dl of
-        Left dlErr -> do
-          direct <- runZigFetch zigExe globalCache depUrl
-          case direct of
-            Left ex ->
-              return (Left ("Failed to fetch dependency " ++ name ++ ":\nDownload step failed: " ++ dlErr
-                            ++ "\nDirect zig fetch failed: " ++ displayException ex))
-            Right (ExitSuccess, out, _) ->
-              validateFetchOutput name mh cacheDir out
-            Right (ExitFailure _, _, err) ->
-              return (Left ("Failed to fetch dependency " ++ name ++ ":\nDownload step failed: " ++ dlErr
-                            ++ "\nDirect zig fetch failed:\n" ++ err))
+        Left dlErr ->
+          return (Left ("Failed to fetch dependency " ++ name ++ ":\n" ++ dlErr))
         Right localArchive -> do
           fetched <- runZigFetch zigExe globalCache localArchive
           _ <- try (removeFile localArchive) :: IO (Either IOException ())
@@ -5324,155 +5190,6 @@ fetchDependencies gopts paths depOverrides = do
               validateFetchOutput name mh cacheDir out
             Right (ExitFailure _, _, err) ->
               return (Left ("Failed to fetch dependency " ++ name ++ ":\n" ++ err))
-
-    isHttpUrl :: String -> Bool
-    isHttpUrl depUrl =
-      let u = map toLower depUrl
-      in "http://" `isPrefixOf` u || "https://" `isPrefixOf` u
-
-    downloadToLocalArchive :: String -> String -> String -> IO (Either String FilePath)
-    downloadToLocalArchive _kind _name depUrl = do
-      parsedReq <- try (HTTP.parseRequest depUrl) :: IO (Either SomeException HTTP.Request)
-      case parsedReq of
-        Left ex -> return (Left ("Invalid dependency URL: " ++ displayException ex))
-        Right req -> do
-          let settings = HTTP.managerSetProxy (HTTP.proxyEnvironment Nothing) tlsManagerSettings
-          manager <- HTTP.newManager settings
-          opened <- try (HTTP.responseOpen req manager) :: IO (Either SomeException (HTTP.Response HTTP.BodyReader))
-          case opened of
-            Left ex -> do
-              env <- readProxyEnv
-              return (Left (describeFetchException env ex))
-            Right response -> do
-              let code = statusCode (HTTP.responseStatus response)
-              if code < 200 || code >= 300
-                then do
-                  _ <- try (HTTP.responseClose response) :: IO (Either SomeException ())
-                  return (Left ("HTTP error " ++ show code))
-                else do
-                  tmpDir <- getTemporaryDirectory
-                  (tmpPath, tmpHandle) <- openBinaryTempFile tmpDir "acton-fetch"
-                  let initialSuffix = archiveSuffixForRequestResponse req response
-                  streamRes <- try (streamDownloadToFile (HTTP.responseBody response) tmpHandle) :: IO (Either SomeException BS.ByteString)
-                  _ <- try (hClose tmpHandle) :: IO (Either IOException ())
-                  _ <- try (HTTP.responseClose response) :: IO (Either SomeException ())
-                  case streamRes of
-                    Left ex -> do
-                      _ <- try (removeFile tmpPath) :: IO (Either IOException ())
-                      return (Left ("Unable to save downloaded archive: " ++ displayException ex))
-                    Right sniffBytes ->
-                      case initialSuffix <|> detectArchiveSuffixFromBytes sniffBytes of
-                        Nothing -> do
-                          _ <- try (removeFile tmpPath) :: IO (Either IOException ())
-                          return (Left "Could not determine archive type from URL path, response headers, or file bytes")
-                        Just suffix -> do
-                          let finalPath = tmpPath ++ suffix
-                          moveRes <- try (renameFile tmpPath finalPath) :: IO (Either IOException ())
-                          case moveRes of
-                            Left ex -> do
-                              _ <- try (removeFile tmpPath) :: IO (Either IOException ())
-                              return (Left ("Unable to finalize downloaded archive path: " ++ displayException ex))
-                            Right _ ->
-                              return (Right finalPath)
-
-    streamDownloadToFile :: HTTP.BodyReader -> Handle -> IO BS.ByteString
-    streamDownloadToFile bodyReader outHandle =
-      loop BS.empty
-      where
-        sniffLimit = 600
-        loop sniff = do
-          chunk <- HTTP.brRead bodyReader
-          if BS.null chunk
-            then return sniff
-            else do
-              BS.hPut outHandle chunk
-              let sniff' =
-                    if BS.length sniff >= sniffLimit
-                      then sniff
-                      else BS.take sniffLimit (sniff <> chunk)
-              loop sniff'
-
-    archiveSuffixForRequestResponse :: HTTP.Request -> HTTP.Response HTTP.BodyReader -> Maybe String
-    archiveSuffixForRequestResponse req response =
-      case archiveSuffixFromPath (B.unpack (HTTP.path req)) of
-        Just suffix -> Just suffix
-        Nothing ->
-          case archiveSuffixFromContentDisposition (lookup hContentDisposition (HTTP.responseHeaders response)) of
-            Just suffix -> Just suffix
-            Nothing -> archiveSuffixFromContentType (lookup hContentType (HTTP.responseHeaders response))
-
-    archiveSuffixFromPath :: String -> Maybe String
-    archiveSuffixFromPath rawPath =
-      let p = map toLower rawPath
-      in if ".tar.gz" `isSuffixOf` p then Just ".tar.gz"
-         else if ".tgz" `isSuffixOf` p then Just ".tgz"
-         else if ".tar.xz" `isSuffixOf` p then Just ".tar.xz"
-         else if ".txz" `isSuffixOf` p then Just ".txz"
-         else if ".tar.zst" `isSuffixOf` p then Just ".tar.zst"
-         else if ".tzst" `isSuffixOf` p then Just ".tzst"
-         else if ".tar" `isSuffixOf` p then Just ".tar"
-         else if ".zip" `isSuffixOf` p then Just ".zip"
-         else if ".jar" `isSuffixOf` p then Just ".jar"
-         else Nothing
-
-    archiveSuffixFromContentType :: Maybe B.ByteString -> Maybe String
-    archiveSuffixFromContentType mType =
-      case map toLower . trim . takeWhile (/= ';') . B.unpack <$> mType of
-        Just "application/x-tar" -> Just ".tar"
-        Just "application/gzip" -> Just ".tar.gz"
-        Just "application/x-gzip" -> Just ".tar.gz"
-        Just "application/tar+gzip" -> Just ".tar.gz"
-        Just "application/x-tar-gz" -> Just ".tar.gz"
-        Just "application/x-gtar-compressed" -> Just ".tar.gz"
-        Just "application/x-xz" -> Just ".tar.xz"
-        Just "application/zstd" -> Just ".tar.zst"
-        Just "application/zip" -> Just ".zip"
-        Just "application/x-zip-compressed" -> Just ".zip"
-        Just "application/java-archive" -> Just ".zip"
-        _ -> Nothing
-
-    archiveSuffixFromContentDisposition :: Maybe B.ByteString -> Maybe String
-    archiveSuffixFromContentDisposition mVal = do
-      headerVal <- mVal
-      filenameVal <- extractField (B.pack "filename*=") headerVal <|> extractField (B.pack "filename=") headerVal
-      archiveSuffixFromPath (B.unpack filenameVal)
-      where
-        extractField key raw =
-          let lowerRaw = B.map toLower raw
-              (prefix, rest) = B.breakSubstring key lowerRaw
-          in if B.null rest
-               then Nothing
-               else
-                 let origRest = B.drop (B.length prefix) raw
-                     val0 = B.drop (B.length key) origRest
-                     val1 = B.takeWhile (/= ';') val0
-                     val2 = stripQuotes (B.dropWhile isSpace (trimBS val1))
-                     val3 =
-                       case B.breakSubstring (B.pack "''") val2 of
-                         (_, t) | B.null t -> val2
-                         (_, t) -> B.drop 2 t
-                 in if B.null val3 then Nothing else Just val3
-        trimBS = B.dropWhileEnd isSpace . B.dropWhile isSpace
-        stripQuotes s
-          | B.length s >= 2 && B.head s == '"' && B.last s == '"' = B.tail (B.init s)
-          | otherwise = s
-
-    detectArchiveSuffixFromBytes :: BS.ByteString -> Maybe String
-    detectArchiveSuffixFromBytes bytes
-      | startsWith [0x50, 0x4b, 0x03, 0x04] bytes = Just ".zip"
-      | startsWith [0x50, 0x4b, 0x05, 0x06] bytes = Just ".zip"
-      | startsWith [0x50, 0x4b, 0x07, 0x08] bytes = Just ".zip"
-      | startsWith [0x1f, 0x8b] bytes = Just ".tar.gz"
-      | startsWith [0xfd, 0x37, 0x7a, 0x58, 0x5a, 0x00] bytes = Just ".tar.xz"
-      | startsWith [0x28, 0xb5, 0x2f, 0xfd] bytes = Just ".tar.zst"
-      | hasUstar bytes = Just ".tar"
-      | otherwise = Nothing
-      where
-        startsWith :: [Word8] -> BS.ByteString -> Bool
-        startsWith sig bs =
-          BS.length bs >= length sig && BS.take (length sig) bs == BS.pack sig
-        hasUstar bs =
-          BS.length bs >= 262 && BS.take 5 (BS.drop 257 bs) == BS.pack [0x75, 0x73, 0x74, 0x61, 0x72]
 
     copyTree :: FilePath -> FilePath -> IO ()
     copyTree src dst = do

--- a/compiler/lib/src/Acton/HttpFetch.hs
+++ b/compiler/lib/src/Acton/HttpFetch.hs
@@ -1,0 +1,280 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+-- | Proxy-aware HTTP, shared by every network path in the compiler: dependency
+--   archive downloads (via Acton.ArchiveDownload) and the package-command
+--   metadata calls (the GitHub API and the package index).
+--
+--   It owns the single proxy-aware Manager (http-client's proxyEnvironment honours
+--   http(s)_proxy and tunnels https via CONNECT), the proxy diagnostics, and two
+--   primitives: httpGetBytes (a body into memory, for JSON) and downloadToFile
+--   (stream to a local file, for archives). Centralising this means one proxy
+--   mechanism and one set of diagnostics everywhere, instead of per-call-site
+--   managers and raw http-client error dumps.
+module Acton.HttpFetch
+  ( newProxyManager
+  , httpGetBytes
+  , downloadToFile
+  , isHttpUrl
+  , readProxyEnv
+  , proxyEnvReportLines
+  ) where
+
+import Control.Concurrent (threadDelay)
+import Control.Exception (IOException, SomeAsyncException, SomeException, displayException, fromException, throwIO, try)
+import Data.Char (isSpace, toLower)
+import Data.List (intercalate, isPrefixOf)
+import Data.Maybe (isJust, listToMaybe)
+import System.Directory (getTemporaryDirectory, removeFile)
+import System.Environment (getEnvironment)
+import System.IO (Handle, hClose, openBinaryTempFile)
+import qualified Network.HTTP.Client as HTTP
+import Network.HTTP.Client.TLS (tlsManagerSettings)
+import Network.HTTP.Types.Header (Header)
+import Network.HTTP.Types.Status (statusCode)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as B
+import qualified Data.ByteString.Lazy as BL
+
+-- | The one proxy-aware Manager. http-client's proxyEnvironment reads
+--   http(s)_proxy / no_proxy from the environment and CONNECT-tunnels https.
+newProxyManager :: IO HTTP.Manager
+newProxyManager =
+  HTTP.newManager (HTTP.managerSetProxy (HTTP.proxyEnvironment Nothing) tlsManagerSettings)
+
+-- | Re-throw async exceptions (Ctrl-C, timeout/concurrent-fetch cancellation)
+--   instead of swallowing them into a proxy diagnostic. Matches the rethrow-async
+--   convention used elsewhere (see InterfaceFiles.tyCacheMiss). Call it first in
+--   any handler that catches SomeException from a network call.
+rethrowAsync :: SomeException -> IO ()
+rethrowAsync ex
+  | Just (_ :: SomeAsyncException) <- fromException ex = throwIO ex
+  | otherwise                                          = return ()
+
+-- | Is this an http(s) URL (as opposed to file:// or a local path)?
+isHttpUrl :: String -> Bool
+isHttpUrl url =
+  let u = map toLower url
+  in "http://" `isPrefixOf` u || "https://" `isPrefixOf` u
+
+-- Retry policy for transient server responses (GitHub rate-limit / 5xx), shared by
+-- the metadata and archive-download paths. Connection-level failures are NOT
+-- retried -- they fail fast with a proxy diagnostic instead.
+retryMaxAttempts :: Int
+retryMaxAttempts = 10
+
+retryBaseDelay, retryMaxDelay :: Int
+retryBaseDelay = 500000        -- 0.5s
+retryMaxDelay  = 120000000     -- 120s
+
+retryableStatus :: Int -> Bool
+retryableStatus s = s == 403 || s == 429 || s >= 500
+
+-- | GET a URL into memory, for JSON metadata (GitHub API, package index). Retries
+--   GitHub rate-limit / server statuses (403/429/5xx); on a connection-level
+--   failure it returns immediately with a clean proxy diagnostic rather than
+--   retrying a misconfigured proxy for minutes.
+httpGetBytes :: HTTP.Manager -> [Header] -> String -> IO (Either String BL.ByteString)
+httpGetBytes manager extraHeaders url = do
+    parsed <- try (HTTP.parseRequest url) :: IO (Either SomeException HTTP.Request)
+    case parsed of
+      Left ex -> return (Left ("Invalid URL: " ++ displayException ex))
+      Right req0 -> do
+        let req = req0 { HTTP.requestHeaders =
+                           ("User-Agent", "acton") : extraHeaders ++ HTTP.requestHeaders req0 }
+        go req 1 retryBaseDelay
+  where
+    go req attempt delay = do
+      res <- try (HTTP.httpLbs req manager) :: IO (Either SomeException (HTTP.Response BL.ByteString))
+      case res of
+        Left ex -> do
+          rethrowAsync ex
+          env <- readProxyEnv
+          return (Left (describeFetchException env ex))
+        Right response -> do
+          let status = statusCode (HTTP.responseStatus response)
+              body   = HTTP.responseBody response
+          if status >= 200 && status < 300
+            then return (Right body)
+            else if retryableStatus status && attempt < retryMaxAttempts
+                   then do threadDelay delay
+                           go req (attempt + 1) (min retryMaxDelay (delay * 2))
+                   else return (Left (httpErrorMessage status body))
+    httpErrorMessage status body =
+      let raw     = trim (B.unpack (BL.toStrict body))
+          clipped = take 200 raw
+          suffix  = if length raw > length clipped then "..." else ""
+          detail  = if null clipped then "" else ": " ++ clipped ++ suffix
+      in "HTTP " ++ show status ++ detail
+
+-- | Stream a URL to a fresh temporary file. Returns the temp path, the response
+--   headers, and the first bytes of the body (for callers that sniff content,
+--   e.g. archive-type detection). Proxy-aware; a connection failure yields a
+--   clean proxy diagnostic.
+downloadToFile :: HTTP.Manager -> String -> IO (Either String (FilePath, [Header], BS.ByteString))
+downloadToFile manager url = do
+  parsed <- try (HTTP.parseRequest url) :: IO (Either SomeException HTTP.Request)
+  case parsed of
+    Left ex -> return (Left ("Invalid URL: " ++ displayException ex))
+    Right req -> go req 1 retryBaseDelay
+  where
+    go req attempt delay = do
+      opened <- try (HTTP.responseOpen req manager) :: IO (Either SomeException (HTTP.Response HTTP.BodyReader))
+      case opened of
+        Left ex -> do
+          rethrowAsync ex
+          env <- readProxyEnv
+          return (Left (describeFetchException env ex))
+        Right response -> do
+          let code = statusCode (HTTP.responseStatus response)
+          if code >= 200 && code < 300
+            then do
+              tmpDir <- getTemporaryDirectory
+              (tmpPath, tmpHandle) <- openBinaryTempFile tmpDir "acton-fetch"
+              streamRes <- try (streamBodyToFile (HTTP.responseBody response) tmpHandle) :: IO (Either SomeException BS.ByteString)
+              _ <- try (hClose tmpHandle) :: IO (Either IOException ())
+              _ <- try (HTTP.responseClose response) :: IO (Either SomeException ())
+              case streamRes of
+                Left ex -> do
+                  _ <- try (removeFile tmpPath) :: IO (Either IOException ())
+                  rethrowAsync ex
+                  return (Left ("Unable to save downloaded file: " ++ displayException ex))
+                Right sniffBytes ->
+                  return (Right (tmpPath, HTTP.responseHeaders response, sniffBytes))
+            else do
+              _ <- try (HTTP.responseClose response) :: IO (Either SomeException ())
+              if retryableStatus code && attempt < retryMaxAttempts
+                then do threadDelay delay
+                        go req (attempt + 1) (min retryMaxDelay (delay * 2))
+                else return (Left ("HTTP error " ++ show code))
+
+streamBodyToFile :: HTTP.BodyReader -> Handle -> IO BS.ByteString
+streamBodyToFile bodyReader outHandle =
+  loop BS.empty
+  where
+    sniffLimit = 600
+    loop sniff = do
+      chunk <- HTTP.brRead bodyReader
+      if BS.null chunk
+        then return sniff
+        else do
+          BS.hPut outHandle chunk
+          let sniff' =
+                if BS.length sniff >= sniffLimit
+                  then sniff
+                  else BS.take sniffLimit (sniff <> chunk)
+          loop sniff'
+
+-- Proxy diagnostics -----------------------------------------------------------
+-- Reported when a fetch fails so a missing/unexported https_proxy (e.g. under
+-- sudo or a non-interactive make/CI shell) is obvious rather than hidden behind a
+-- raw http-client request-record dump.
+
+proxyEnvVarNames :: [String]
+proxyEnvVarNames =
+  [ "http_proxy", "HTTP_PROXY"
+  , "https_proxy", "HTTPS_PROXY"
+  , "all_proxy", "ALL_PROXY"
+  , "no_proxy", "NO_PROXY"
+  ]
+
+-- | Snapshot the proxy environment acton actually sees. Reads via getEnvironment
+--   (the `environ` array), the SAME source http-client's proxyEnvironment
+--   consults -- NOT lookupEnv/getenv, which can disagree on Linux binaries hit by
+--   the `environ` copy-relocation bug.
+readProxyEnv :: IO [(String, Maybe String)]
+readProxyEnv = do
+  env <- getEnvironment
+  return [ (n, lookup n env) | n <- proxyEnvVarNames ]
+
+formatProxyEnvVar :: (String, Maybe String) -> String
+formatProxyEnvVar (n, v) =
+  n ++ "=" ++ maybe "(unset)" (\x -> if null x then "(empty)" else maskProxyUrl x) v
+
+-- | Indented "proxy environment acton sees" block for use in messages.
+proxyEnvReportLines :: String -> [(String, Maybe String)] -> [String]
+proxyEnvReportLines indent env =
+  (indent ++ "proxy environment acton sees:")
+  : [ indent ++ "  " ++ formatProxyEnvVar kv | kv <- env ]
+
+-- | Mask user:password@ credentials embedded in a proxy URL.
+maskProxyUrl :: String -> String
+maskProxyUrl url =
+  let (scheme, afterScheme) = case findSubstring "://" url of
+                                Just i  -> (take (i + 3) url, drop (i + 3) url)
+                                Nothing -> ("", url)
+      (authority, rest)     = break (== '/') afterScheme
+  in case break (== '@') authority of
+       (_, '@':hostPort) -> scheme ++ "***@" ++ hostPort ++ rest
+       _                 -> url
+
+findSubstring :: String -> String -> Maybe Int
+findSubstring needle = go 0
+  where go _ []              = Nothing
+        go i hay@(_:t)
+          | needle `isPrefixOf` hay = Just i
+          | otherwise               = go (i + 1) t
+
+-- | The proxy variable http-client consults for a request of this scheme, and its
+--   value if set. Protocol-specific (https_proxy for https); ALL_PROXY excluded
+--   because http-client does not honor it.
+applicableProxy :: Bool -> [(String, Maybe String)] -> Maybe (String, String)
+applicableProxy secure env =
+  listToMaybe [ (n, v) | n <- names, Just (Just v) <- [lookup n env], not (null v) ]
+  where names = if secure then ["https_proxy", "HTTPS_PROXY"] else ["http_proxy", "HTTP_PROXY"]
+
+-- | Turn an http-client fetch exception into a clean, actionable message.
+describeFetchException :: [(String, Maybe String)] -> SomeException -> String
+describeFetchException env ex =
+  case fromException ex :: Maybe HTTP.HttpException of
+    Just (HTTP.HttpExceptionRequest req content) ->
+      let secure  = HTTP.secure req
+          scheme  = if secure then "https" else "http"
+          target  = B.unpack (HTTP.host req) ++ ":" ++ show (HTTP.port req)
+          vars    = if secure then "https_proxy/HTTPS_PROXY" else "http_proxy/HTTP_PROXY"
+          proxyLn = case applicableProxy secure env of
+                      Just (n, v) -> "  proxy for this " ++ scheme ++ " request: "
+                                     ++ maskProxyUrl v ++ " (from " ++ n ++ ")"
+                      Nothing     -> "  proxy for this " ++ scheme ++ " request: none ("
+                                     ++ vars ++ " unset)"
+      in intercalate "\n"
+           ( [ describeFetchContent content
+             , "  request: " ++ scheme ++ " to " ++ target
+             , proxyLn
+             ]
+             ++ proxyEnvReportLines "  " env
+             ++ proxyFailureHint secure env )
+    Just other -> displayException other
+    Nothing    -> displayException ex
+
+-- | One-line summary of an http-client failure cause (no Request record dump).
+describeFetchContent :: HTTP.HttpExceptionContent -> String
+describeFetchContent c = case c of
+  HTTP.ConnectionTimeout            -> "connection timed out"
+  HTTP.ConnectionFailure e          -> "connection failed: " ++ show e
+  HTTP.ResponseTimeout              -> "response timed out"
+  HTTP.ProxyConnectException h p st -> "proxy CONNECT to " ++ B.unpack h ++ ":" ++ show p
+                                       ++ " failed (status " ++ show (statusCode st) ++ ")"
+  HTTP.StatusCodeException res _    -> "unexpected HTTP status "
+                                       ++ show (statusCode (HTTP.responseStatus res))
+  HTTP.InternalException e          -> "connection failed: " ++ show e
+  other                             -> show other
+
+-- | Hint shown when a fetch failed and no proxy variable applies to its scheme.
+proxyFailureHint :: Bool -> [(String, Maybe String)] -> [String]
+proxyFailureHint secure env
+  | isJust (applicableProxy secure env) = []
+  | otherwise =
+      [ "  hint: no " ++ vars ++ " is set in acton's environment, so this " ++ scheme
+      , "        download was attempted directly. If you use a proxy, make sure "
+        ++ varLower ++ " is"
+      , "        exported in the environment that runs the build. sudo/root shells and"
+      , "        many make/CI setups do not inherit the proxy variables from your"
+      , "        interactive shell." ]
+  where scheme   = if secure then "https" else "http"
+        vars     = if secure then "https_proxy/HTTPS_PROXY" else "http_proxy/HTTP_PROXY"
+        varLower = if secure then "https_proxy" else "http_proxy"
+
+-- Local string trim (kept here so the module is self-contained).
+trim :: String -> String
+trim = f . f
+  where f = reverse . dropWhile isSpace

--- a/test/proxy/README.md
+++ b/test/proxy/README.md
@@ -36,11 +36,13 @@ Two containers (`docker-compose.yml`):
 3. **control** — runs `curl` on the same internal-only network through the same
    proxy; it must reach GitHub (so a later failure is acton's fault, not the
    network/proxy);
-4. runs `acton fetch` (the project has one remote HTTPS `zig_dependency`) with
-   the proxy variables set.
+4. runs three scenarios with the proxy variables set, covering every HTTP path:
+   `acton fetch` (dependency archive download), `acton pkg update` (the package
+   index over http-client), and `acton pkg upgrade` (GitHub API ref resolution
+   plus archive re-hash).
 
-Because the acton box has no direct egress, a successful fetch is only possible
-if acton routed through the proxy:
+Because the acton box has no direct egress, a scenario can only succeed if acton
+routed that request through the proxy:
 
 | result | meaning |
 |--------|---------|

--- a/test/proxy/acton/Dockerfile
+++ b/test/proxy/acton/Dockerfile
@@ -17,6 +17,9 @@ ENV HOME=/root
 # A minimal Acton project whose only dependency is a remote GitHub archive,
 # which forces the network fetch path that carries the proxy diagnostics.
 COPY project /work/proxytest
+# A second project with a github 'dependency' (repo_url set) for the `acton pkg`
+# command tests (pkg upgrade resolves a ref + re-hashes through the proxy).
+COPY pkgproject /work/pkgtest
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh

--- a/test/proxy/acton/entrypoint.sh
+++ b/test/proxy/acton/entrypoint.sh
@@ -8,7 +8,7 @@ TARBALL="${ACTON_TARBALL:-/acton-dist.tar.xz}"
 if [ ! -x /opt/acton/bin/acton ]; then
     if [ ! -f "$TARBALL" ]; then
         echo "[entrypoint] ERROR: tarball $TARBALL not mounted." >&2
-        echo "[entrypoint] Build it first: see proxy-repro/run-demo.sh" >&2
+        echo "[entrypoint] Build it first: run 'make test-proxy' (see test/proxy/run.sh)" >&2
         exit 1
     fi
     echo "[entrypoint] Installing Acton from tarball $TARBALL -> /opt/acton ..."

--- a/test/proxy/acton/pkgproject/Build.act
+++ b/test/proxy/acton/pkgproject/Build.act
@@ -1,0 +1,16 @@
+name = "pkgtest"
+fingerprint = 0xc11efa8100000001
+
+# A github dependency (repo_url set) so `acton pkg upgrade` resolves the latest
+# ref via the GitHub API and re-hashes the archive -- both through the proxy.
+# zlib is not an Acton package, but pkg upgrade only resolves + hashes; it does
+# not build the dependency.
+dependencies = {
+    "zlib": (
+        url="https://github.com/madler/zlib/archive/refs/tags/v1.3.1.tar.gz",
+        hash="N-V-__8AAB0eQwD-0MdOEBmz7intriBReIsIDNlukNVoNu6o",
+        repo_url="https://github.com/madler/zlib"
+    )
+}
+
+zig_dependencies = {}

--- a/test/proxy/acton/pkgproject/src/main.act
+++ b/test/proxy/acton/pkgproject/src/main.act
@@ -1,0 +1,2 @@
+actor main(env):
+    env.exit(0)

--- a/test/proxy/run.sh
+++ b/test/proxy/run.sh
@@ -76,34 +76,62 @@ if ! docker run --rm --network "$INTERNAL_NET" \
 fi
 echo "    [ok] proxy reaches GitHub"
 
-# 4. The actual test: acton fetch on the proxy-only network.
-note "acton fetch through the proxy (http_proxy + https_proxy set)"
-set +e
-out="$("${COMPOSE[@]}" exec -T \
+# 4. Scenarios. With no direct egress, a command can only succeed if acton routed
+#    through the proxy. Each scenario asserts the command's positive success
+#    marker, covering both HTTP code paths: the build/fetch archive download and
+#    the `acton pkg` commands (github API ref resolution + archive re-hash).
+run_in_proxy() {  # $1 = workdir, $2 = command -> prints combined stdout+stderr
+    # Forward GITHUB_TOKEN when set so the pkg-upgrade scenario authenticates to
+    # the GitHub API; unauthenticated requests share the runner IP's 60/hr limit
+    # and rate-limit (403) on CI. Optional locally, recommended in CI.
+    local tok=()
+    [ -n "${GITHUB_TOKEN:-}" ] && tok=(-e "GITHUB_TOKEN=$GITHUB_TOKEN")
+    "${COMPOSE[@]}" exec -T \
         -e http_proxy="$PROXY_URL"  -e https_proxy="$PROXY_URL" \
-        -e HTTP_PROXY="$PROXY_URL"  -e HTTPS_PROXY="$PROXY_URL" \
-        -e HOME=/root \
-        acton sh -c 'rm -rf /root/.cache/acton; cd /work/proxytest && exec /opt/acton/bin/acton fetch' 2>&1)"
-code=$?
+        -e HTTP_PROXY="$PROXY_URL"  -e HTTPS_PROXY="$PROXY_URL" -e HOME=/root \
+        "${tok[@]}" \
+        acton sh -c "rm -rf /root/.cache/acton; cd $1 && $2" 2>&1
+}
+
+fails=0
+check() {  # $1 = label, $2 = exit code, $3 = output, $4 = required success marker
+    echo "$3" | sed 's/^/    acton| /'
+    if [ "$2" -eq 0 ] && printf '%s\n' "$3" | grep -qiE "$4"; then
+        echo "  [PASS] $1"
+    else
+        echo "  [FAIL] $1 (exit $2; expected /$4/)"
+        fails=$((fails + 1))
+    fi
+}
+
+set +e
+note "[1/3] acton fetch  (dependency archive download)"
+o="$(run_in_proxy /work/proxytest '/opt/acton/bin/acton fetch')"; c=$?
+check "acton fetch"       "$c" "$o" 'Dependencies fetched'
+
+note "[2/3] acton pkg update  (package index over http-client)"
+o="$(run_in_proxy /work '/opt/acton/bin/acton pkg update')"; c=$?
+check "acton pkg update"  "$c" "$o" 'Updated package index'
+
+note "[3/3] acton pkg upgrade  (github ref resolve + archive re-hash)"
+o="$(run_in_proxy /work/pkgtest '/opt/acton/bin/acton pkg upgrade')"; c=$?
+check "acton pkg upgrade" "$c" "$o" 'Wrote changes to Build.act'
 set -e
-echo "$out" | sed 's/^/    acton| /'
 
-connects="$("${COMPOSE[@]}" logs --no-color proxy 2>/dev/null | grep -c -i 'CONNECT' || true)"
-
-# 5. Verdict.
 echo
-if [ "$code" -eq 0 ]; then
-    note "PASS: acton fetched the dependency through the proxy (proxy CONNECTs: $connects)"
+connects="$("${COMPOSE[@]}" logs --no-color proxy 2>/dev/null | grep -c -i 'CONNECT' || true)"
+if [ "$fails" -eq 0 ]; then
+    note "PASS: acton routed fetch + pkg commands through the proxy ($connects CONNECTs)"
     exit 0
 fi
 
-note "FAIL: acton fetch failed (exit $code) on a proxy-only network"
+note "FAIL: $fails scenario(s) did not complete through the proxy"
 echo "    proxy CONNECT log:" >&2
 "${COMPOSE[@]}" logs --no-color proxy 2>/dev/null | grep -i 'CONNECT' | sed 's/^/      /' >&2 || true
 cat >&2 <<'EOF'
-    With no direct egress, this means acton's HTTP client did not route through
-    the proxy. The usual cause is GHC's getEnvironment() returning an empty
-    environment on x86_64 -no-pie binaries (the `environ` copy-relocation bug),
-    so http-client's proxyEnvironment never saw http(s)_proxy.
+    With no direct egress, a failure means acton did not route a request through
+    the proxy. Causes: GHC getEnvironment() empty on x86_64 -no-pie binaries (the
+    `environ` bug), or a download/hash step using zig's network stack instead of
+    the proxy-aware http-client.
 EOF
 exit 1


### PR DESCRIPTION
This finishes making the compiler's dependency and package handling work behind an HTTP proxy. Earlier work routed the dependency archive download through Haskell's http-client so it honours http_proxy and https_proxy and tunnels https via CONNECT. The package commands were left out: acton install, acton pkg add, acton pkg upgrade and acton zig pkg add re-hash an archive by shelling out to zig fetch on the remote URL, and zig's network stack does not work through an HTTP CONNECT proxy. Separately, the GitHub API and package-index calls used their own http-client manager and printed the raw http-client request record on failure.

This introduces a single proxy-aware HTTP layer, Acton.HttpFetch, that every network path shares: one proxy-aware Manager, the proxy diagnostics, httpGetBytes for fetching JSON metadata into memory, and downloadToFile for streaming a body to a local file. Acton.ArchiveDownload sits on top of it and adds archive-type detection, so downloadArchive names the temporary file for zig fetch. The dependency fetch in Acton.Compile uses ArchiveDownload, and the package commands now resolve GitHub refs and download the index through HttpFetch and re-hash archives through ArchiveDownload. The result is one proxy mechanism everywhere, zig fetch only ever running on already-downloaded local files, and the same clean proxy diagnostic on every HTTP failure instead of a raw record dump.

One behaviour change worth noting: the metadata path now fails fast on a connection-level error and shows the proxy diagnostic, instead of retrying a dead or misconfigured proxy ten times over several minutes. It still retries GitHub's rate-limit and server statuses, which is what that retry loop is for.

The docker proxy test is extended to also run acton pkg update and acton pkg upgrade through the proxy, so it now covers the GitHub API ref resolution and the archive re-hash in addition to the dependency archive download.
