### PR TITLE
Avoid arm64 parser segfaults

### DIFF
--- a/compiler/lib/src/Acton/Parser.hs
+++ b/compiler/lib/src/Acton/Parser.hs
@@ -12,7 +12,9 @@
 --
 
 {-# LANGUAGE FlexibleInstances #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+-- GHC 9.8.4 on arm64 can segfault in RTS apply stubs when full laziness floats
+-- parser subexpressions into shared closures evaluated by concurrent parses.
+{-# OPTIONS_GHC -fno-warn-orphans -fno-full-laziness #-}
 module Acton.Parser
   ( module Acton.Parser
   , CustomParseError(..)


### PR DESCRIPTION
GHC 9.8.4 on arm64 can crash in RTS apply stubs when concurrent parser evaluation touches parser closures that full laziness has floated into shared top-level values. Compile Acton.Parser with -fno-full-laziness so those closures stay local to each parse while preserving normal parser and compiler concurrency.

I don't quite know why this hits us just in the parser (or well, at all, bug I guess), but this fix certainly seems to have a good measurable effect and it improves runtime performance ever so slightly, though memory usage increases somewhat.