### PR TITLE
Unbox bool

### DIFF
--- a/base/builtin/bigint.c
+++ b/base/builtin/bigint.c
@@ -180,8 +180,8 @@ B_bigint B_bigintD___deserialize__(B_bigint res,$Serial$state state) {
     }
 }
 
-B_bool B_bigintD___bool__(B_bigint n) {
-    return toB_bool(zz_cmpi(&n->val,0));
+bool B_bigintD___bool__(B_bigint n) {
+    return zz_cmpi(&n->val,0);
 }
 
 B_str B_bigintD___str__(B_bigint n) {
@@ -633,38 +633,38 @@ B_float B_DivD_bigintD___truediv__ (B_DivD_bigint wit, B_bigint a, B_bigint b) {
 
 // B_OrdD_bigint  ////////////////////////////////////////////////////////////////////////////////////////
 
-B_bool B_OrdD_bigintD___eq__ (B_OrdD_bigint wit, B_bigint a, B_bigint b) {
-    return toB_bool(zz_equal(&a->val,&b->val));
+bool B_OrdD_bigintD___eq__ (B_OrdD_bigint wit, B_bigint a, B_bigint b) {
+    return zz_equal(&a->val,&b->val);
 }
 
-B_bool B_OrdD_bigintD___ne__ (B_OrdD_bigint wit, B_bigint a, B_bigint b) {
-    return toB_bool(1-zz_equal(&a->val,&b->val));
+bool B_OrdD_bigintD___ne__ (B_OrdD_bigint wit, B_bigint a, B_bigint b) {
+    return !zz_equal(&a->val,&b->val);
 }
 
-B_bool B_OrdD_bigintD___lt__ (B_OrdD_bigint wit, B_bigint a, B_bigint b) {
-    return toB_bool(zz_cmp(&a->val,&b->val) < 0);
+bool B_OrdD_bigintD___lt__ (B_OrdD_bigint wit, B_bigint a, B_bigint b) {
+    return zz_cmp(&a->val,&b->val) < 0;
 }
 
-B_bool B_OrdD_bigintD___le__ (B_OrdD_bigint wit, B_bigint a, B_bigint b) {
-    return toB_bool(zz_cmp(&a->val,&b->val) <= 0);
+bool B_OrdD_bigintD___le__ (B_OrdD_bigint wit, B_bigint a, B_bigint b) {
+    return zz_cmp(&a->val,&b->val) <= 0;
 }
 
-B_bool B_OrdD_bigintD___gt__ (B_OrdD_bigint wit, B_bigint a, B_bigint b) {
-    return toB_bool(zz_cmp(&a->val,&b->val) > 0);
+bool B_OrdD_bigintD___gt__ (B_OrdD_bigint wit, B_bigint a, B_bigint b) {
+    return zz_cmp(&a->val,&b->val) > 0;
 }
 
-B_bool B_OrdD_bigintD___ge__ (B_OrdD_bigint wit, B_bigint a, B_bigint b) {
-    return toB_bool(zz_cmp(&a->val,&b->val) >= 0);
+bool B_OrdD_bigintD___ge__ (B_OrdD_bigint wit, B_bigint a, B_bigint b) {
+    return zz_cmp(&a->val,&b->val) >= 0;
 }
 
 // B_HashableD_bigint ///////////////////////////////////////////////////////////////////////////////////////////////////////
 
-B_bool B_HashableD_bigintD___eq__(B_HashableD_bigint wit, B_bigint a, B_bigint b) {
-    return toB_bool(zz_equal(&a->val,&b->val));
+bool B_HashableD_bigintD___eq__(B_HashableD_bigint wit, B_bigint a, B_bigint b) {
+    return zz_equal(&a->val,&b->val);
 }
 
-B_bool B_HashableD_bigintD___ne__(B_HashableD_bigint wit, B_bigint a, B_bigint b) {
-    return toB_bool(1-zz_equal(&a->val,&b->val));
+bool B_HashableD_bigintD___ne__(B_HashableD_bigint wit, B_bigint a, B_bigint b) {
+    return !zz_equal(&a->val,&b->val);
 }
 
 B_NoneType B_HashableD_bigintD_hash(B_HashableD_bigint wit, B_bigint a, B_hasher h) {

--- a/base/builtin/bool.c
+++ b/base/builtin/bool.c
@@ -17,7 +17,7 @@
 // Serialization ///////////////////////////////////////////////////////////////////////
 
 B_NoneType B_boolD___init__(B_bool self, B_value s){
-    self->val = s->$class->__bool__(s);
+    self->val = B_boolG_new(s);
     return B_None;
 }
 
@@ -48,7 +48,7 @@ B_bool B_boolD___deserialize__(B_bool self, $Serial$state state) {
 }
 
 bool B_boolG_new(B_value s) {
-    return $NEW(B_bool, s);
+    return  s->$class->__bool__(s);
 }
 
 B_bool toB_bool(bool b) {
@@ -66,8 +66,8 @@ B_bool B_True = &$t;
 B_bool B_False = &$f;
 
 
-B_bool $default__bool__(B_value self) {
-    return B_True;
+bool $default__bool__(B_value self) {
+    return true;
 }
 
 // B_HashableD_bool ///////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/base/builtin/bool.c
+++ b/base/builtin/bool.c
@@ -17,12 +17,12 @@
 // Serialization ///////////////////////////////////////////////////////////////////////
 
 B_NoneType B_boolD___init__(B_bool self, B_value s){
-    self->val = (s->$class->__bool__(s))->val;
+    self->val = s->$class->__bool__(s);
     return B_None;
 }
 
-B_bool B_boolD___bool__(B_bool self) {
-    return self;
+bool B_boolD___bool__(B_bool self) {
+    return self->val;
 }
 
 B_str B_boolD___str__(B_bool self) {
@@ -47,20 +47,20 @@ B_bool B_boolD___deserialize__(B_bool self, $Serial$state state) {
     return toB_bool((long)$val_deserialize(state));
 }
 
-B_bool B_boolG_new(B_value s) {
+bool B_boolG_new(B_value s) {
     return $NEW(B_bool, s);
 }
 
-B_bool toB_bool(long b) {
+B_bool toB_bool(bool b) {
     return b ? B_True : B_False;
 }
     
-long fromB_bool(B_bool b) {
+bool fromB_bool(B_bool b) {
     return b->val;
 }
 
-struct B_bool $t = {&B_boolG_methods,1L};
-struct B_bool $f = {&B_boolG_methods,0L};
+struct B_bool $t = {&B_boolG_methods,true};
+struct B_bool $f = {&B_boolG_methods,false};
 
 B_bool B_True = &$t;
 B_bool B_False = &$f;
@@ -72,12 +72,12 @@ B_bool $default__bool__(B_value self) {
 
 // B_HashableD_bool ///////////////////////////////////////////////////////////////////////////////////////////////////////
 
-B_bool B_HashableD_boolD___eq__(B_HashableD_bool wit, B_bool a, B_bool b) {
-    return toB_bool(a->val == b->val);
+bool B_HashableD_boolD___eq__(B_HashableD_bool wit, B_bool a, B_bool b) {
+    return a->val == b->val;
 }
 
-B_bool B_HashableD_boolD___ne__(B_HashableD_bool wit, B_bool a, B_bool b) {
-    return toB_bool(a->val != b->val);
+bool B_HashableD_boolD___ne__(B_HashableD_bool wit, B_bool a, B_bool b) {
+    return a->val != b->val;
 }
 
 B_NoneType B_HashableD_boolD_hash(B_HashableD_bool wit, B_bool a, B_hasher h) {

--- a/base/builtin/bool.h
+++ b/base/builtin/bool.h
@@ -8,4 +8,4 @@ bool fromB_bool(B_bool b);
 
 extern B_bool B_True, B_False;
 
-B_bool $default__bool__(B_value);
+bool $default__bool__(B_value);

--- a/base/builtin/bool.h
+++ b/base/builtin/bool.h
@@ -1,10 +1,10 @@
 struct B_bool {
   struct B_boolG_class *$class;
-  long val;
+  bool val;
 };
 
-B_bool toB_bool(long b);
-long fromB_bool(B_bool b);
+B_bool toB_bool(bool b);
+bool fromB_bool(B_bool b);
 
 extern B_bool B_True, B_False;
 

--- a/base/builtin/box.c
+++ b/base/builtin/box.c
@@ -17,7 +17,7 @@ B_NoneType $BoxD___init__($Box self, $WORD val) {
     return B_None;
 }
 
-B_bool $BoxD___bool__($Box self) {
+bool $BoxD___bool__($Box self) {
     B_value it = (B_value)self->val;
     return it->$class->__bool__(it);
 }

--- a/base/builtin/box.h
+++ b/base/builtin/box.h
@@ -14,7 +14,7 @@ struct $BoxG_class {
     B_NoneType (*__init__) ($Box, $WORD);
     void (*__serialize__) ($Box, $Serial$state);
     $Box (*__deserialize__) ($Box, $Serial$state);
-    B_bool (*__bool__) ($Box);
+    bool (*__bool__) ($Box);
     B_str (*__str__) ($Box);
     B_str (*__repr__) ($Box);
 };

--- a/base/builtin/builtin_functions.c
+++ b/base/builtin/builtin_functions.c
@@ -95,8 +95,8 @@ void B_IteratorD_enumerate_init(B_IteratorD_enumerate self, B_Iterator it, B_int
     self->nxt = fromB_int(n);
 }
 
-B_bool B_IteratorD_enumerate_bool(B_IteratorD_enumerate self) {
-    return B_True;
+bool B_IteratorD_enumerate_bool(B_IteratorD_enumerate self) {
+    return true;
 }
 
 B_str B_IteratorD_enumerate_str(B_IteratorD_enumerate self) {
@@ -144,8 +144,8 @@ void B_IteratorD_filter_init(B_IteratorD_filter self, B_Iterator it,  $pure f) {
     self->f = f;
 }
 
-B_bool B_IteratorD_filter_bool(B_IteratorD_filter self) {
-    return B_True;
+bool B_IteratorD_filter_bool(B_IteratorD_filter self) {
+    return true;
 }
 
 B_str B_IteratorD_filter_str(B_IteratorD_filter self) {
@@ -191,8 +191,8 @@ void B_IteratorD_map_init(B_IteratorD_map self, B_Iterator it, $pure f) {
     self->f = f;
 }
 
-B_bool B_IteratorD_map_bool(B_IteratorD_map self) {
-    return B_True;
+bool B_IteratorD_map_bool(B_IteratorD_map self) {
+    return true;
 }
 
 B_str B_IteratorD_map_str(B_IteratorD_map self) {
@@ -237,7 +237,7 @@ $WORD B_max(B_Ord wit, B_Iterable wit2, $WORD iter, $WORD dflt) {
     while(1) {
         if ($PUSH()) {
             $WORD nxt = it->$class->__next__(it);
-            if (!res || fromB_bool(wit->$class->__lt__(wit,res,nxt)))
+            if (!res || wit->$class->__lt__(wit,res,nxt))
                 res = nxt;
             $DROP();
         } else {
@@ -267,7 +267,7 @@ $WORD B_max_def(B_Ord wit, B_Iterable wit2, $WORD iter, $WORD dflt) {
     while(1) {
         if ($PUSH()) {
             $WORD nxt = it->$class->__next__(it);
-            if (fromB_bool(wit->$class->__lt__(wit,res,nxt)))
+            if (wit->$class->__lt__(wit,res,nxt))
                 res = nxt;
             $DROP();
         } else {
@@ -287,7 +287,7 @@ $WORD B_min(B_Ord wit, B_Iterable wit2, $WORD iter, $WORD dflt) {
     while(1) {
         if ($PUSH()) {
             $WORD nxt = it->$class->__next__(it);
-            if (!res || fromB_bool(wit->$class->__gt__(wit,res,nxt)))
+            if (!res || wit->$class->__gt__(wit,res,nxt))
                 res = nxt;
             $DROP();
         } else {
@@ -317,7 +317,7 @@ $WORD B_min_def(B_Ord wit, B_Iterable wit2, $WORD iter, $WORD dflt) {
     while(1) {
         if ($PUSH()) {
             $WORD nxt = it->$class->__next__(it);
-            if (fromB_bool(wit->$class->__gt__(wit,res,nxt)))
+            if (wit->$class->__gt__(wit,res,nxt))
                 res = nxt;
             $DROP();
         } else {
@@ -371,8 +371,8 @@ void B_IteratorD_zip_init(B_IteratorD_zip self, B_Iterator it1, B_Iterator it2) 
     self->it2 = it2;
 }
 
-B_bool B_IteratorD_zip_bool(B_IteratorD_zip self) {
-    return B_True;
+bool B_IteratorD_zip_bool(B_IteratorD_zip self) {
+    return true;
 }
 
 B_str B_IteratorD_zip_str(B_IteratorD_zip self) {
@@ -421,8 +421,8 @@ void $EqOptD___init__($EqOpt wit, B_Eq W_Eq$A) {
     wit->W_Eq$A = W_Eq$A;
 }
 
-B_bool $EqOptD_bool($EqOpt self) {
-    return B_True;
+bool $EqOptD_bool($EqOpt self) {
+    return true;
 }
 
 B_str $EqOptD_str($EqOpt self) {
@@ -440,17 +440,17 @@ $EqOpt $EqOptD_deserialize($EqOpt res, $Serial$state state) {
     return res;
 }
 
-B_bool $EqOptD___eq__($EqOpt wit, $WORD a, $WORD b) {
+bool $EqOptD___eq__($EqOpt wit, $WORD a, $WORD b) {
     if (a && b) {
         return wit->W_Eq$A->$class->__eq__(wit->W_Eq$A, a, b);
     }
-    return (!a && !b) ? B_True : B_False;
+    return (!a && !b) ? true : false;
 }
 
-B_bool $EqOptD___ne__($EqOpt wit, $WORD a, $WORD b) {
+bool $EqOptD___ne__($EqOpt wit, $WORD a, $WORD b) {
     if (a && b)
         return wit->W_Eq$A->$class->__ne__(wit->W_Eq$A, a, b);
-    return (!a && !b) ? B_False : B_True;
+    return (!a && !b) ? false : true;
 }
 
 struct $EqOptG_class $EqOptG_methods = {"$EqOpt", UNASSIGNED, NULL, $EqOptD___init__, $EqOptD_serialize, $EqOptD_deserialize, 
@@ -468,8 +468,8 @@ extern struct $IdentityActorG_class $IdentityActorG_methods;
 
 void $IdentityActorD___init__($IdentityActor wit) { }
 
-B_bool $IdentityActorD_bool($IdentityActor self) {
-    return B_True;
+bool $IdentityActorD_bool($IdentityActor self) {
+    return true;
 }
 
 B_str $IdentityActorD_str($IdentityActor self) {
@@ -484,12 +484,12 @@ $IdentityActor $IdentityActorD_deserialize($IdentityActor res, $Serial$state sta
     return res;
 }
 
-B_bool $IdentityActorD___is__($IdentityActor wit, $WORD a, $WORD b) {
-    return (a == b) ? B_True : B_False;
+bool $IdentityActorD___is__($IdentityActor wit, $WORD a, $WORD b) {
+    return (a == b) ? true : false;
 }
 
-B_bool $IdentityActorD___isnot__($IdentityActor wit, $WORD a, $WORD b) {
-    return (a == b) ? B_False : B_True;
+bool $IdentityActorD___isnot__($IdentityActor wit, $WORD a, $WORD b) {
+    return (a == b) ? false : true;
 }
 
 struct $IdentityActorG_class $IdentityActorG_methods = {"$IdentityActor", UNASSIGNED, NULL, $IdentityActorD___init__, $IdentityActorD_serialize, $IdentityActorD_deserialize, 
@@ -560,8 +560,8 @@ $WORD B_round (B_Real W_395, $WORD x, B_int n) {
 }
 */
 
-$WORD $ASSERT(B_bool test, B_str msg) {
-    if (!test->val) {
+$WORD $ASSERT(bool test, B_str msg) {
+    if (!test) {
         $RAISE((B_BaseException)$NEW(B_AssertionError,msg));
         return NULL; // to avoid compiler warning
     }

--- a/base/builtin/builtin_functions.h
+++ b/base/builtin/builtin_functions.h
@@ -14,7 +14,7 @@ struct B_IteratorD_enumerateG_class {
   void (*__init__)(B_IteratorD_enumerate, B_Iterator,B_int);
   void (*__serialize__)(B_IteratorD_enumerate,$Serial$state);
   B_IteratorD_enumerate (*__deserialize__)(B_IteratorD_enumerate,$Serial$state);
-  B_bool (*__bool__)(B_IteratorD_enumerate);
+  bool (*__bool__)(B_IteratorD_enumerate);
   B_str (*__str__)(B_IteratorD_enumerate);
   B_str (*__repr__)(B_IteratorD_enumerate);
   $WORD(*__next__)(B_IteratorD_enumerate);
@@ -44,7 +44,7 @@ struct B_IteratorD_filterG_class {
   void (*__init__)(B_IteratorD_filter, B_Iterator, $pure);
   void (*__serialize__)(B_IteratorD_filter,$Serial$state);
   B_IteratorD_filter (*__deserialize__)(B_IteratorD_filter,$Serial$state);
-  B_bool (*__bool__)(B_IteratorD_filter);
+  bool (*__bool__)(B_IteratorD_filter);
   B_str (*__str__)(B_IteratorD_filter);
   B_str (*__repr__)(B_IteratorD_filter);
   $WORD(*__next__)(B_IteratorD_filter);
@@ -73,7 +73,7 @@ struct B_IteratorD_mapG_class {
   void (*__init__)(B_IteratorD_map, B_Iterator, $pure);
   void (*__serialize__)(B_IteratorD_map,$Serial$state);
   B_IteratorD_map (*__deserialize__)(B_IteratorD_map,$Serial$state);
-  B_bool (*__bool__)(B_IteratorD_map);
+  bool (*__bool__)(B_IteratorD_map);
   B_str (*__str__)(B_IteratorD_map);
   B_str (*__repr__)(B_IteratorD_map);
   $WORD(*__next__)(B_IteratorD_map);
@@ -100,7 +100,7 @@ struct B_IteratorD_zipG_class {
   void (*__init__)(B_IteratorD_zip, B_Iterator, B_Iterator);
   void (*__serialize__)(B_IteratorD_zip,$Serial$state);
   B_IteratorD_zip (*__deserialize__)(B_IteratorD_zip,$Serial$state);
-  B_bool (*__bool__)(B_IteratorD_zip);
+  bool (*__bool__)(B_IteratorD_zip);
   B_str (*__str__)(B_IteratorD_zip);
   B_str (*__repr__)(B_IteratorD_zip);
   $WORD(*__next__)(B_IteratorD_zip);
@@ -130,11 +130,11 @@ struct $EqOptG_class {
     void (*__init__)($EqOpt, B_Eq);
     void (*__serialize__)($EqOpt,$Serial$state);
     $EqOpt (*__deserialize__)($EqOpt,$Serial$state);
-    B_bool (*__bool__)($EqOpt);
+    bool (*__bool__)($EqOpt);
     B_str (*__str__)($EqOpt);
     B_str (*__repr__)($EqOpt);
-    B_bool (*__eq__)($EqOpt, $WORD, $WORD);
-    B_bool (*__ne__)($EqOpt, $WORD, $WORD);
+    bool (*__eq__)($EqOpt, $WORD, $WORD);
+    bool (*__ne__)($EqOpt, $WORD, $WORD);
 };
 
 struct $EqOpt {
@@ -157,11 +157,11 @@ struct $IdentityActorG_class {
     void (*__init__)($IdentityActor);
     void (*__serialize__)($IdentityActor,$Serial$state);
     $IdentityActor (*__deserialize__)($IdentityActor,$Serial$state);
-    B_bool (*__bool__)($IdentityActor);
+    bool (*__bool__)($IdentityActor);
     B_str (*__str__)($IdentityActor);
     B_str (*__repr__)($IdentityActor);
-    B_bool (*__is__)($IdentityActor, $WORD, $WORD);
-    B_bool (*__isnot__)($IdentityActor, $WORD, $WORD);
+    bool (*__is__)($IdentityActor, $WORD, $WORD);
+    bool (*__isnot__)($IdentityActor, $WORD, $WORD);
 };
 
 struct $IdentityActor {
@@ -196,4 +196,4 @@ $WORD B_round (B_Real, $WORD, B_int);
 $WORD B_sum(B_Plus, B_Iterable, $WORD, $WORD);
 */
 
-$WORD $ASSERT(B_bool, B_str);
+$WORD $ASSERT(bool, B_str);

--- a/base/builtin/class_hierarchy.c
+++ b/base/builtin/class_hierarchy.c
@@ -48,11 +48,11 @@ B_str B_objectD___str__(B_object self) {
     return $FORMAT("<%s object at %p>", unmangle_name(self->$class->$GCINFO), self);
 }
 
-B_bool B_valueD___bool__(B_value self) {
-    return B_True;
+bool B_valueD___bool__(B_value self) {
+    return true;
 }
-B_bool B_objectD___bool__(B_object self) {
-    return B_True;
+bool B_objectD___bool__(B_object self) {
+    return true;
 }
 
 struct $SerializableG_class $SerializableG_methods = {"$Serializable",UNASSIGNED,NULL, $SerializableD___init__,NULL,NULL};

--- a/base/builtin/common.h
+++ b/base/builtin/common.h
@@ -25,11 +25,11 @@ void $default__init__($WORD);
                                B_dictD_setitem($state->done,(B_Hashable)B_HashableD_intG_witness,toB_bigint($state->row_no-1),$t); \
                                $t; })
 
-#define $AND(T, a, b)       ({ T $a = (a); ($a && ((B_value)$a)->$class->__bool__((B_value)$a)->val) ? (b) : $a; })
+#define $AND(T, a, b)       ({ T $a = (a); ($a && ((B_value)$a)->$class->__bool__((B_value)$a)) ? (b) : $a; })
 
-#define $OR(T, a, b)        ({ T $a = (a); ($a && ((B_value)$a)->$class->__bool__((B_value)$a)->val) ? $a : (b); })
+#define $OR(T, a, b)        ({ T $a = (a); ($a && ((B_value)$a)->$class->__bool__((B_value)$a)) ? $a : (b); })
 
-#define $NOT(T, a)          ({ T $a = (a); ($a && ((B_value)$a)->$class->__bool__((B_value)$a)->val) ? B_False : B_True; })
+#define $NOT(T, a)          ({ T $a = (a); ($a && ((B_value)$a)->$class->__bool__((B_value)$a)) ? B_False : B_True; })
 
 #define $ISINSTANCE($x,$T)  ({ \
                                /* If object is NULL (None), return False */ \

--- a/base/builtin/complex.c
+++ b/base/builtin/complex.c
@@ -52,8 +52,8 @@ B_complex B_complexD___deserialize__(B_complex self, $Serial$state state) {
     return toB_complex(re + im * _Complex_I);
 }
 
-B_bool B_complexD___bool__(B_complex n) {
-    return toB_bool(n->val != 0.0);
+bool B_complexD___bool__(B_complex n) {
+    return n->val != 0.0;
 }
 
 B_str B_complexD___str__(B_complex c) {
@@ -131,23 +131,23 @@ B_complex B_MinusD_NumberD_complexD___sub__(B_MinusD_NumberD_complex wit, B_comp
 }  
 // B_EqD_complex  ////////////////////////////////////////////////////////////////////////////////////////
 
-B_bool B_EqD_complexD___eq__ (B_EqD_complex wit, B_complex a, B_complex b) {
-    return toB_bool(creal(a->val) == creal(b->val) && cimag(a->val) == cimag(b->val));
+bool B_EqD_complexD___eq__ (B_EqD_complex wit, B_complex a, B_complex b) {
+    return creal(a->val) == creal(b->val) && cimag(a->val) == cimag(b->val);
 }
 
-B_bool B_EqD_complexD___ne__ (B_EqD_complex wit, B_complex a, B_complex b) {
-    return toB_bool(!fromB_bool(B_EqD_complexD___eq__(wit,a,b)));
+bool B_EqD_complexD___ne__ (B_EqD_complex wit, B_complex a, B_complex b) {
+    return !B_EqD_complexD___eq__(wit,a,b);
 }
 
 
 // B_HashableD_complex  ////////////////////////////////////////////////////////////////////////////////////////
 
-B_bool B_HashableD_complexD___eq__(B_HashableD_complex wit, B_complex a, B_complex b) {
-    return toB_bool(creal(a->val) == creal(b->val) && cimag(a->val) == cimag(b->val));
+bool B_HashableD_complexD___eq__(B_HashableD_complex wit, B_complex a, B_complex b) {
+    return creal(a->val) == creal(b->val) && cimag(a->val) == cimag(b->val);
 }
 
-B_bool B_HashableD_complexD___ne__(B_HashableD_complex wit, B_complex a, B_complex b) {
-    return toB_bool(!fromB_bool(B_HashableD_complexD___eq__(wit,a,b)));
+bool B_HashableD_complexD___ne__(B_HashableD_complex wit, B_complex a, B_complex b) {
+    return !B_HashableD_complexD___eq__(wit,a,b);
 }
 
 B_NoneType B_HashableD_complexD_hash(B_HashableD_complex wit, B_complex a, B_hasher h) {
@@ -155,142 +155,3 @@ B_NoneType B_HashableD_complexD_hash(B_HashableD_complex wit, B_complex a, B_has
     return B_None;
 }
 
-// init methods ////////////////////////////////////////////////////////////////////////////////////////////////
-/*
-B_NoneType B_NumberD_complex_init (B_NumberD_complex wit) {
-    wit-> W_Minus = (B_Minus)$NEW(B_MinusD_NumberD_complex,(B_Number)wit);
-    return B_None;
-}
-
-B_NoneType B_MinusD_NumberD_complex_init(B_MinusD_NumberD_complex wit, B_Number W_Number) {
-    wit->W_Number =  W_Number;
-    return B_None;
-}
-
-B_NoneType B_EqD_complex_init(B_EqD_complex wit) {
-    return B_None;
-}
-
-B_NoneType B_DivD_complex_init(B_DivD_complex wit) {
-    return B_None;
-}
-
-B_NoneType B_HashableD_complex_init(B_HashableD_complex wit) {
-    return B_None;
-}
-
-B_NumberD_complex B_NumberD_complexG_new() {
-    return $NEW(B_NumberD_complex);
-}
-
-B_MinusD_NumberD_complex B_MinusD_NumberD_complexG_new(B_Number wit) {
-    return $NEW(B_MinusD_NumberD_complex,wit);
-}
-  
-B_EqD_complex B_EqD_complexG_new() {
-    return $NEW(B_EqD_complex);
-}
-
-B_HashableD_complex B_HashableD_complexG_new() {
-    return $NEW(B_HashableD_complex);
-}
-
-
-struct B_NumberD_complex B_NumberD_complex_instance;
-struct B_MinusD_NumberD_complex B_MinusD_NumberD_complex_instance;
-struct B_EqD_complex B_EqD_complex_instance;
-struct B_HashableD_complex B_HashableD_complex_instance;
-
-struct B_NumberD_complexG_class B_NumberD_complexG_methods = {
-    "B_NumberD_complex",
-    UNASSIGNED,
-    ($SuperG_class)&B_NumberG_methods,
-    B_NumberD_complex_init,
-    B_NumberD_complexD___serialize__,
-    B_NumberD_complexD___deserialize__,
-    (B_bool (*)(B_NumberD_complex))$default__bool__,
-    (B_str (*)(B_NumberD_complex))$default__str__,
-    (B_str (*)(B_NumberD_complex))$default__str__,
-    B_NumberD_complexD___add__,
-    (B_complex (*)(B_NumberD_complex, B_complex, B_complex))B_PlusD___iadd__,
-    B_NumberD_complexD___mul__,
-    (B_complex (*)(B_NumberD_complex, B_complex, B_complex))B_TimesD___imul__,
-    NULL,        // fromatom
-    B_NumberD_complexD___complx__,
-    B_NumberD_complexD___pow__,
-    (B_complex (*)(B_NumberD_complex, B_complex, B_complex))B_NumberD___ipow__,
-    B_NumberD_complexD___neg__,
-    B_NumberD_complexD___pos__,
-    B_NumberD_complex$real,
-    B_NumberD_complex$imag,
-    B_NumberD_complexD___abs__,
-    B_NumberD_complex$conjugate
-};
-struct B_NumberD_complex B_NumberD_complex_instance = {&B_NumberD_complexG_methods, (B_Minus)&B_MinusD_NumberD_complex_instance};
-B_NumberD_complex B_NumberD_complexG_witness = &B_NumberD_complex_instance;
-
-struct B_DivD_complexG_class B_DivD_complexG_methods = {
-    "B_DivD_complex",
-    UNASSIGNED,
-    ($SuperG_class)&B_DivG_methods,
-    B_DivD_complex_init,
-    B_DivD_complexD___serialize__,
-    B_DivD_complexD___deserialize__,
-    (B_bool (*)(B_DivD_complex))$default__bool__,
-    (B_str (*)(B_DivD_complex))$default__str__,
-    (B_str (*)(B_DivD_complex))$default__str__,
-    B_DivD_complexD___truediv__,
-    (B_complex (*)(B_DivD_complex, B_complex, B_complex))B_DivD___itruediv__,
-};
-
-struct B_DivD_complex B_DivD_complex_instance = {&B_DivD_complexG_methods};
-B_DivD_complex B_DivD_complexG_witness = &B_DivD_complex_instance;
-
-struct B_MinusD_NumberD_complexG_class B_MinusD_NumberD_complexG_methods = {
-    "B_MinusD_NumberD_complex",
-    UNASSIGNED,
-    ($SuperG_class)&B_MinusG_methods,
-    B_MinusD_NumberD_complex_init,
-    B_MinusD_NumberD_complexD___serialize__,
-    B_MinusD_NumberD_complexD___deserialize__,
-    (B_bool (*)(B_MinusD_NumberD_complex))$default__bool__,
-    (B_str (*)(B_MinusD_NumberD_complex))$default__str__,
-    (B_str (*)(B_MinusD_NumberD_complex))$default__str__,
-    B_MinusD_NumberD_complexD___sub__,
-    (B_complex (*)(B_MinusD_NumberD_complex, B_complex, B_complex))B_MinusD___isub__
-};
-struct B_MinusD_NumberD_complex B_MinusD_NumberD_complex_instance = {&B_MinusD_NumberD_complexG_methods, (B_Number)&B_NumberD_complex_instance};
-B_MinusD_NumberD_complex B_MinusD_NumberD_complexG_witness = &B_MinusD_NumberD_complex_instance;
-
-struct B_EqD_complexG_class B_EqD_complexG_methods = {
-    "B_EqD_complex",
-    UNASSIGNED,
-    ($SuperG_class)&B_EqG_methods,
-    B_EqD_complex_init,
-    B_EqD_complexD___serialize__,
-    B_EqD_complexD___deserialize__,
-    (B_bool (*)(B_EqD_complex))$default__bool__,
-    (B_str (*)(B_EqD_complex))$default__str__,
-    (B_str (*)(B_EqD_complex))$default__str__,
-    B_EqD_complexD___eq__,
-    B_EqD_complexD___ne__
-};
-struct B_EqD_complex B_EqD_complex_instance = {&B_EqD_complexG_methods};
-B_EqD_complex B_EqD_complexG_witness = &B_EqD_complex_instance;
-
-struct B_HashableD_complexG_class B_HashableD_complexG_methods = {
-    "B_HashableD_complex",
-    UNASSIGNED,
-    ($SuperG_class)&B_HashableG_methods,
-    B_HashableD_complex_init,
-    B_HashableD_complexD___serialize__,
-    B_HashableD_complexD___deserialize__,
-    (B_bool (*)(B_HashableD_complex))$default__bool__,
-    (B_str (*)(B_HashableD_complex))$default__str__,
-    (B_str (*)(B_HashableD_complex))$default__str__,
-    B_HashableD_complexD___eq__,
-    B_HashableD_complexD___ne__
-};
-struct B_HashableD_complex B_HashableD_complex_instance = {&B_HashableD_complexG_methods};
-B_HashableD_complex B_HashableD_complexG_witness = &B_HashableD_complex_instance;
-*/

--- a/base/builtin/dict.c
+++ b/base/builtin/dict.c
@@ -140,7 +140,7 @@ int $lookdict(B_dict dict, B_Hashable hashwit, uint64_t hash, $WORD key, $WORD *
         // Ignore hash and do linear search
         for (int ix = 0; ix < (int)table->tb_nentries; ix++) {
             $entry_t entry = &TB_ENTRIES(table)[ix];
-            if (entry->value != DELETED && (entry->key == key || (hashwit->$class->__eq__(hashwit,key,entry->key)->val))) {
+            if (entry->value != DELETED && (entry->key == key || (hashwit->$class->__eq__(hashwit,key,entry->key)))) {
                 // found an entry with the same or equal key
                 *res = entry->value; 
                 return ix;
@@ -162,7 +162,7 @@ int $lookdict(B_dict dict, B_Hashable hashwit, uint64_t hash, $WORD key, $WORD *
             }
             if (ix >= 0) {
                 $entry_t entry = &TB_ENTRIES(table)[ix];
-                if (entry->value != DELETED && (entry->key == key || (entry->hash == hash && hashwit->$class->__eq__(hashwit,key,entry->key)->val))) {
+                if (entry->value != DELETED && (entry->key == key || (entry->hash == hash && hashwit->$class->__eq__(hashwit,key,entry->key)))) {
                     // found an entry with the same or equal key
                     *res = entry->value;
                     return ix;
@@ -249,8 +249,8 @@ B_NoneType B_dictD___init__(B_dict dict, B_Hashable hashwit, B_Iterable wit, $WO
     return B_None;
 }
 
-B_bool B_dictD___bool__(B_dict self) {
-    return toB_bool(self->numelements>0);
+bool B_dictD___bool__(B_dict self) {
+    return self->numelements>0;
 }
 
 B_str B_dictD___str__(B_dict self) {
@@ -335,28 +335,28 @@ B_dict B_dictD___deserialize__(B_dict res, $Serial$state state) {
 
 // B_OrdD_dict ////////////////////////////////////////////////////////////////////////
 
-B_bool B_dictrel(bool directfalse,B_OrdD_dict w, B_dict a, B_dict b) {
+bool B_dictrel(bool directfalse,B_OrdD_dict w, B_dict a, B_dict b) {
     if (directfalse) {
-        return B_False;
+        return false;
     };
     if (a->numelements == 0)
-        return B_True;
+        return true;
     B_Hashable wH = w->W_HashableD_AD_OrdD_dict;
     B_Eq wB = w->W_EqD_BD_OrdD_dict;
     B_MappingD_dict m = B_MappingD_dictG_new(wH);
     B_Iterator it = m->$class->keys(m,a);
     $WORD x,resa,resb;
     if ($PUSH()) {
-        while(1) {
+        while(true) {
             x = it->$class->__next__(it);
             long h = 0;
             if (a->table->tb_size > INIT_SIZE)
                 h = B_hash(wH, x);
             int ixa = $lookdict(a, wH, h, x, &resa);
             int ixb = $lookdict(b, wH, h, x ,&resb);
-            if (ixb<0 || wB->$class->__ne__(wB,resa,resb)->val) {
+            if (ixb<0 || wB->$class->__ne__(wB,resa,resb)) {
                 $DROP();
-                return B_False;
+                return false;
             }
         }
         $DROP();
@@ -365,31 +365,31 @@ B_bool B_dictrel(bool directfalse,B_OrdD_dict w, B_dict a, B_dict b) {
         if (! $ISINSTANCE0(ex, B_StopIteration))
            $RAISE(ex);
     }
-    return B_True;
+    return true;
 }
 
-B_bool B_OrdD_dictD___eq__ (B_OrdD_dict w, B_dict a, B_dict b) {
+bool B_OrdD_dictD___eq__ (B_OrdD_dict w, B_dict a, B_dict b) {
     return B_dictrel(a->numelements != b->numelements,w,a,b);
 }
 
-B_bool B_OrdD_dictD___ne__ (B_OrdD_dict w, B_dict a, B_dict b) {
-    return toB_bool(!(w->$class->__eq__(w,a,b)->val));
+bool B_OrdD_dictD___ne__ (B_OrdD_dict w, B_dict a, B_dict b) {
+    return !w->$class->__eq__(w,a,b);
 }
 
-B_bool B_OrdD_dictD___lt__ (B_OrdD_dict w, B_dict a, B_dict b) {
+bool B_OrdD_dictD___lt__ (B_OrdD_dict w, B_dict a, B_dict b) {
     return B_dictrel(a->numelements >= b->numelements,w,a,b);
 }
 
-B_bool B_OrdD_dictD___le__ (B_OrdD_dict w, B_dict a, B_dict b) {
+bool B_OrdD_dictD___le__ (B_OrdD_dict w, B_dict a, B_dict b) {
     return B_dictrel(a->numelements > b->numelements,w,a,b);
 }
 
-B_bool B_OrdD_dictD___gt__ (B_OrdD_dict w, B_dict a, B_dict b) {
-    return toB_bool(!(w->$class->__lt__(w,b,a)->val));
+bool B_OrdD_dictD___gt__ (B_OrdD_dict w, B_dict a, B_dict b) {
+    return !w->$class->__lt__(w,b,a);
 }
 
-B_bool B_OrdD_dictD___ge__ (B_OrdD_dict w, B_dict a, B_dict b) {
-    return toB_bool(!(w->$class->__le__(w,b,a)->val));
+bool B_OrdD_dictD___ge__ (B_OrdD_dict w, B_dict a, B_dict b) {
+    return !w->$class->__le__(w,b,a);
 }
 
 // B_MappingD_dict ///////////////////////////////////////////////////////////////
@@ -424,8 +424,8 @@ void B_IteratorD_dictD_init(B_IteratorD_dict self, B_dict dict) {
 }
 
 
-B_bool B_IteratorD_dictD_bool(B_IteratorD_dict self) {
-    return B_True;
+bool B_IteratorD_dictD_bool(B_IteratorD_dict self) {
+    return true;
 }
 
 B_str B_IteratorD_dictD_str(B_IteratorD_dict self) {
@@ -473,19 +473,19 @@ int64_t B_MappingD_dictD___len__ (B_MappingD_dict wit, B_dict dict) {
     return dict->numelements;
 }
   
-B_bool B_MappingD_dictD___contains__ (B_MappingD_dict wit, B_dict dict, $WORD key) {
+bool B_MappingD_dictD___contains__ (B_MappingD_dict wit, B_dict dict, $WORD key) {
     if (dict->numelements == 0)
-        return B_False;
+        return false;
     B_Hashable hashwit = wit->W_HashableD_AD_MappingD_dict;
     $WORD res;
     long h = 0;
     if (dict->table->tb_size > INIT_SIZE)
         h = B_hash(hashwit, key);
-    return toB_bool($lookdict(dict,hashwit,h,key,&res) >= 0);
+    return $lookdict(dict,hashwit,h,key,&res) >= 0;
 }
 
-B_bool B_MappingD_dictD___containsnot__ (B_MappingD_dict wit, B_dict dict, $WORD key) {
-    return toB_bool(!B_MappingD_dictD___contains__(wit, dict, key)->val);
+bool B_MappingD_dictD___containsnot__ (B_MappingD_dict wit, B_dict dict, $WORD key) {
+    return !B_MappingD_dictD___contains__(wit, dict, key);
 }
 
 $WORD B_MappingD_dictD_get (B_MappingD_dict wit, B_dict dict, $WORD key) {
@@ -606,8 +606,8 @@ void B_IteratorD_dict_values_init(B_IteratorD_dict_values self, B_dict dict) {
 }
 
 
-B_bool B_IteratorD_dict_values_bool(B_IteratorD_dict_values self) {
-    return B_True;
+bool B_IteratorD_dict_values_bool(B_IteratorD_dict_values self) {
+    return true;
 }
 
 B_str B_IteratorD_dict_values_str(B_IteratorD_dict_values self) {
@@ -661,8 +661,8 @@ void B_IteratorD_dict_items_init(B_IteratorD_dict_items self, B_dict dict) {
 }
 
 
-B_bool B_IteratorD_dict_items_bool(B_IteratorD_dict_items self) {
-    return B_True;
+bool B_IteratorD_dict_items_bool(B_IteratorD_dict_items self) {
+    return true;
 }
 
 B_str B_IteratorD_dict_items_str(B_IteratorD_dict_items self) {

--- a/base/builtin/dict.h
+++ b/base/builtin/dict.h
@@ -19,7 +19,7 @@ struct B_IteratorD_dictG_class {
     void (*__init__)(B_IteratorD_dict, B_dict);
     void (*__serialize__)(B_IteratorD_dict,$Serial$state);
     B_IteratorD_dict (*__deserialize__)(B_IteratorD_dict,$Serial$state);
-    B_bool (*__bool__)(B_IteratorD_dict);
+    bool (*__bool__)(B_IteratorD_dict);
     B_str (*__str__)(B_IteratorD_dict);
     B_str (*__repr__)(B_IteratorD_dict);
     $WORD(*__next__)(B_IteratorD_dict);
@@ -45,7 +45,7 @@ struct B_IteratorD_dict_valuesG_class {
     void (*__init__)(B_IteratorD_dict_values, B_dict);
     void (*__serialize__)(B_IteratorD_dict_values,$Serial$state);
     B_IteratorD_dict_values (*__deserialize__)(B_IteratorD_dict_values,$Serial$state);
-    B_bool (*__bool__)(B_IteratorD_dict_values);
+    bool (*__bool__)(B_IteratorD_dict_values);
     B_str (*__str__)(B_IteratorD_dict_values);
     B_str (*__repr__)(B_IteratorD_dict_values);
     $WORD(*__next__)(B_IteratorD_dict_values);
@@ -71,7 +71,7 @@ struct B_IteratorD_dict_itemsG_class {
     void (*__init__)(B_IteratorD_dict_items, B_dict);
     void (*__serialize__)(B_IteratorD_dict_items,$Serial$state);
     B_IteratorD_dict_items (*__deserialize__)(B_IteratorD_dict_items,$Serial$state);
-    B_bool (*__bool__)(B_IteratorD_dict_items);
+    bool (*__bool__)(B_IteratorD_dict_items);
     B_str (*__str__)(B_IteratorD_dict_items);
     B_str (*__repr__)(B_IteratorD_dict_items);
     $WORD(*__next__)(B_IteratorD_dict_items);

--- a/base/builtin/exceptions.c
+++ b/base/builtin/exceptions.c
@@ -13,7 +13,7 @@
  */
 
 void B_BaseExceptionD___serialize__ (B_BaseException, $Serial$state);
-B_bool B_valueD___bool__ (B_value);
+bool B_valueD___bool__ (B_value);
 B_str B_valueD___str__ (B_value);
 B_str B_valueD___repr__ (B_value);
 
@@ -44,7 +44,7 @@ struct $SEQG_class $SEQG_methods = {
     .$GCINFO            = "$SEQ",
     .$superclass        = ($SuperG_class)&B_ExceptionG_methods,
     .__init__           = $SEQD___init__,
-    .__bool__           = (B_bool (*) ($SEQ))B_valueD___bool__,
+    .__bool__           = (bool (*) ($SEQ))B_valueD___bool__,
     .__str__            = (B_str (*) ($SEQ))B_valueD___str__,
     .__repr__           = (B_str (*) ($SEQ))B_valueD___repr__,
     .__serialize__      = (void (*) ($SEQ, $Serial$state))B_BaseExceptionD___serialize__,
@@ -74,7 +74,7 @@ struct $BRKG_class $BRKG_methods = {
     .$GCINFO            = "$BRK",
     .$superclass        = ($SuperG_class)&B_ExceptionG_methods,
     .__init__           = (B_NoneType (*) ($BRK))$SEQD___init__,
-    .__bool__           = (B_bool (*) ($BRK))B_valueD___bool__,
+    .__bool__           = (bool (*) ($BRK))B_valueD___bool__,
     .__str__            = (B_str (*) ($BRK))B_valueD___str__,
     .__repr__           = (B_str (*) ($BRK))B_valueD___repr__,
     .__serialize__      = (void (*) ($BRK, $Serial$state))B_BaseExceptionD___serialize__,
@@ -104,7 +104,7 @@ struct $CNTG_class $CNTG_methods = {
     .$GCINFO            = "$CNT",
     .$superclass        = ($SuperG_class)&B_ExceptionG_methods,
     .__init__           = (B_NoneType (*) ($CNT))$SEQD___init__,
-    .__bool__           = (B_bool (*) ($CNT))B_valueD___bool__,
+    .__bool__           = (bool (*) ($CNT))B_valueD___bool__,
     .__str__            = (B_str (*) ($CNT))B_valueD___str__,
     .__repr__           = (B_str (*) ($CNT))B_valueD___repr__,
     .__serialize__      = (void (*) ($CNT, $Serial$state))B_BaseExceptionD___serialize__,
@@ -143,7 +143,7 @@ struct $RETG_class $RETG_methods = {
     .$GCINFO            = "$RET",
     .$superclass        = ($SuperG_class)&B_ExceptionG_methods,
     .__init__           = $RETD___init__,
-    .__bool__           = (B_bool (*) ($RET))B_valueD___bool__,
+    .__bool__           = (bool (*) ($RET))B_valueD___bool__,
     .__str__            = (B_str (*) ($RET))B_valueD___str__,
     .__repr__           = (B_str (*) ($RET))B_valueD___repr__,
     .__serialize__      = $RETD___serialize__,

--- a/base/builtin/exceptions.h
+++ b/base/builtin/exceptions.h
@@ -111,7 +111,7 @@ struct $SEQG_class {
     B_NoneType (*__init__) ($SEQ);
     void (*__serialize__) ($SEQ, $Serial$state);
     $SEQ (*__deserialize__) ($SEQ, $Serial$state);
-    B_bool (*__bool__) ($SEQ);
+    bool (*__bool__) ($SEQ);
     B_str (*__str__) ($SEQ);
     B_str (*__repr__) ($SEQ);
 };
@@ -126,7 +126,7 @@ struct $BRKG_class {
     B_NoneType (*__init__) ($BRK);
     void (*__serialize__) ($BRK, $Serial$state);
     $BRK (*__deserialize__) ($BRK, $Serial$state);
-    B_bool (*__bool__) ($BRK);
+    bool (*__bool__) ($BRK);
     B_str (*__str__) ($BRK);
     B_str (*__repr__) ($BRK);
 };
@@ -141,7 +141,7 @@ struct $CNTG_class {
     B_NoneType (*__init__) ($CNT);
     void (*__serialize__) ($CNT, $Serial$state);
     $CNT (*__deserialize__) ($CNT, $Serial$state);
-    B_bool (*__bool__) ($CNT);
+    bool (*__bool__) ($CNT);
     B_str (*__str__) ($CNT);
     B_str (*__repr__) ($CNT);
 };
@@ -156,7 +156,7 @@ struct $RETG_class {
     B_NoneType (*__init__) ($RET, B_value);
     void (*__serialize__) ($RET, $Serial$state);
     $RET (*__deserialize__) ($RET, $Serial$state);
-    B_bool (*__bool__) ($RET);
+    bool (*__bool__) ($RET);
     B_str (*__str__) ($RET);
     B_str (*__repr__) ($RET);
 };

--- a/base/builtin/float.c
+++ b/base/builtin/float.c
@@ -72,8 +72,8 @@ B_float B_floatD___deserialize__(B_float self, $Serial$state state) {
     return to$float(x);
 }
 
-B_bool B_floatD___bool__(B_float x) {
-    return toB_bool(x->val != 0.0);
+bool B_floatD___bool__(B_float x) {
+    return x->val != 0.0;
 }
 
 B_str B_floatD___str__(B_float x) {
@@ -194,39 +194,39 @@ B_float B_DivD_floatD___truediv__(B_DivD_float wit, B_float a, B_float b) {
 
 // B_OrdD_float  ////////////////////////////////////////////////////////////////////////////////////////
 
-B_bool B_OrdD_floatD___eq__ (B_OrdD_float wit, B_float a, B_float b) {
-    return toB_bool(a->val == b->val);
+bool B_OrdD_floatD___eq__ (B_OrdD_float wit, B_float a, B_float b) {
+    return a->val == b->val;
 }
 
-B_bool B_OrdD_floatD___ne__ (B_OrdD_float wit, B_float a, B_float b) {
-    return toB_bool(a->val != b->val);
+bool B_OrdD_floatD___ne__ (B_OrdD_float wit, B_float a, B_float b) {
+    return a->val != b->val;
 }
 
-B_bool B_OrdD_floatD___lt__ (B_OrdD_float wit, B_float a, B_float b) {
-    return toB_bool(a->val < b->val);
+bool B_OrdD_floatD___lt__ (B_OrdD_float wit, B_float a, B_float b) {
+    return a->val < b->val;
 }
 
-B_bool B_OrdD_floatD___le__ (B_OrdD_float wit, B_float a, B_float b) {
-    return toB_bool(a->val <= b->val);
+bool B_OrdD_floatD___le__ (B_OrdD_float wit, B_float a, B_float b) {
+    return a->val <= b->val;
 }
 
-B_bool B_OrdD_floatD___gt__ (B_OrdD_float wit, B_float a, B_float b) {
-    return toB_bool(a->val > b->val);
+bool B_OrdD_floatD___gt__ (B_OrdD_float wit, B_float a, B_float b) {
+    return a->val > b->val;
 }
 
-B_bool B_OrdD_floatD___ge__ (B_OrdD_float wit, B_float a, B_float b) {
-    return toB_bool(a->val >= b->val);
+bool B_OrdD_floatD___ge__ (B_OrdD_float wit, B_float a, B_float b) {
+    return a->val >= b->val;
 }
 
 
 // B_HashableD_float ///////////////////////////////////////////////////////////////////////////////////////////////////////
 
-B_bool B_HashableD_floatD___eq__(B_HashableD_float wit, B_float a, B_float b) {
-    return toB_bool(a->val == b->val);
+bool B_HashableD_floatD___eq__(B_HashableD_float wit, B_float a, B_float b) {
+    return a->val == b->val;
 }
 
-B_bool B_HashableD_floatD___neq__(B_HashableD_float wit, B_float a, B_float b) {
-    return toB_bool(a->val != b->val);
+bool B_HashableD_floatD___ne__(B_HashableD_float wit, B_float a, B_float b) {
+    return a->val != b->val;
 }
 
 B_NoneType B_HashableD_floatD_hash(B_HashableD_float wit, B_float a, B_hasher h) {

--- a/base/builtin/function.c
+++ b/base/builtin/function.c
@@ -14,29 +14,29 @@
 
 ////////////////////////////////////////////////////////////////////////////////////////
 
-B_bool $procD___bool__($proc self) {
-  return B_True;
+bool $procD___bool__($proc self) {
+  return true;
 }
 B_str $procD___str__($proc self) {
   return $FORMAT("<proc closure at %p>", self);
 }
 
-B_bool $actionD___bool__($action self) {
-  return B_True;
+bool $actionD___bool__($action self) {
+  return true;
 }
 B_str $actionD___str__($action self) {
   return $FORMAT("<action closure at %p>", self);
 }
 
-B_bool $mutD___bool__($mut self) {
-  return B_True;
+bool $mutD___bool__($mut self) {
+  return true;
 }
 B_str $mutD___str__($mut self) {
   return $FORMAT("<mut closure at %p>", self);
 }
 
-B_bool $pureD___bool__($pure self) {
-  return B_True;
+bool $pureD___bool__($pure self) {
+  return true;
 }
 B_str $pureD___str__($pure self) {
   return $FORMAT("<pure closure at %p>", self);
@@ -45,8 +45,8 @@ B_str $pureD___str__($pure self) {
 void $ContD___init__($Cont $this) {
     // Empty
 }
-B_bool $ContD___bool__($Cont self) {
-  return B_True;
+bool $ContD___bool__($Cont self) {
+  return true;
 }
 B_str $ContD___str__($Cont self) {
   return $FORMAT("<$Cont closure at %p>", self);

--- a/base/builtin/function.h
+++ b/base/builtin/function.h
@@ -7,7 +7,7 @@ struct $ContG_class {
     void (*__init__)($Cont);
     void (*__serialize__)($Cont, $Serial$state);
     $Cont (*__deserialize__)($Cont, $Serial$state);
-    B_bool (*__bool__)($Cont);
+    bool (*__bool__)($Cont);
     B_str (*__str__)($Cont);
     B_str (*__repr__)($Cont);
     $R (*__call__)($Cont, $WORD);
@@ -18,7 +18,7 @@ struct $Cont {
 extern struct $ContG_class $ContG_methods;
 
 void $ContD___init__($Cont);
-B_bool $ContD___bool__($Cont);
+bool $ContD___bool__($Cont);
 B_str $ContD___str__($Cont);
 void $ContD___serialize__($Cont, $Serial$state);
 $Cont $ContD___deserialize__($Cont, $Serial$state);
@@ -31,7 +31,7 @@ struct $procG_class {
     void (*__init__)($proc);
     void (*__serialize__)($proc, $Serial$state);
     $proc (*__deserialize__)($proc, $Serial$state);
-    B_bool (*__bool__)($proc);
+    bool (*__bool__)($proc);
     B_str (*__str__)($proc);
     B_str (*__repr__)($proc);
     $R (*__call__)($proc, $Cont, $WORD);
@@ -50,7 +50,7 @@ struct $actionG_class {
     void (*__init__)($action);
     void (*__serialize__)($action, $Serial$state);
     $action (*__deserialize__)($action, $Serial$state);
-    B_bool (*__bool__)($action);
+    bool (*__bool__)($action);
     B_str (*__str__)($action);
     B_str (*__repr__)($action);
     $R (*__call__)($action, $Cont, $WORD);
@@ -70,7 +70,7 @@ struct $mutG_class {
     void (*__init__)($mut);
     void (*__serialize__)($mut, $Serial$state);
     $mut (*__deserialize__)($mut, $Serial$state);
-    B_bool (*__bool__)($mut);
+    bool (*__bool__)($mut);
     B_str (*__str__)($mut);
     B_str (*__repr__)($mut);
     $R (*__call__)($mut, $Cont, $WORD);
@@ -90,7 +90,7 @@ struct $pureG_class {
     void (*__init__)($pure);
     void (*__serialize__)($pure, $Serial$state);
     $pure (*__deserialize__)($pure, $Serial$state);
-    B_bool (*__bool__)($pure);
+    bool (*__bool__)($pure);
     B_str (*__str__)($pure);
     B_str (*__repr__)($pure);
     $R (*__call__)($pure, $Cont, $WORD);
@@ -113,7 +113,7 @@ struct $action2G_class {
     void (*__init__)($action2);
     void (*__serialize__)($action2, $Serial$state);
     $action2 (*__deserialize__)($action2, $Serial$state);
-    B_bool (*__bool__)($action2);
+    bool (*__bool__)($action2);
     B_str (*__str__)($action2);
     B_str (*__repr__)($action2);
     $R (*__call__)($action2, $Cont, $WORD, $WORD);
@@ -133,7 +133,7 @@ struct $action3G_class {
     void (*__init__)($action3);
     void (*__serialize__)($action3, $Serial$state);
     $action3 (*__deserialize__)($action3, $Serial$state);
-    B_bool (*__bool__)($action3);
+    bool (*__bool__)($action3);
     B_str (*__str__)($action3);
     B_str (*__repr__)($action3);
     $R (*__call__)($action3, $Cont, $WORD, $WORD, $WORD);

--- a/base/builtin/hasher.c
+++ b/base/builtin/hasher.c
@@ -13,8 +13,8 @@ uint64_t B_hasherD_finalize (B_hasher self) {
     return h;
 }
 
-B_bool B_hasherD___bool__(B_hasher h) {
-    return B_True;
+bool B_hasherD___bool__(B_hasher h) {
+    return true;
 }
 
 B_str B_hasherD___str__(B_hasher self) {

--- a/base/builtin/i16.c
+++ b/base/builtin/i16.c
@@ -50,8 +50,8 @@ B_i16 B_i16D___deserialize__(B_i16 n, $Serial$state state) {
     return toB_i16((int16_t)(uintptr_t)$val_deserialize(state));
 }
 
-B_bool B_i16D___bool__(B_i16 n) {
-    return toB_bool(n->val != 0);
+bool B_i16D___bool__(B_i16 n) {
+    return n->val != 0;
 }
 
 B_str B_i16D___str__(B_i16 n) {
@@ -240,38 +240,38 @@ B_float B_DivD_i16D___truediv__ (B_DivD_i16 wit, B_i16 a, B_i16 b) {
 
 // B_OrdD_i16  ////////////////////////////////////////////////////////////////////////////////////////
 
-B_bool B_OrdD_i16D___eq__ (B_OrdD_i16 wit, B_i16 a, B_i16 b) {
-    return toB_bool(a->val == b->val);
+bool B_OrdD_i16D___eq__ (B_OrdD_i16 wit, B_i16 a, B_i16 b) {
+    return a->val == b->val;
 }
 
-B_bool B_OrdD_i16D___ne__ (B_OrdD_i16 wit, B_i16 a, B_i16 b) {
-    return toB_bool(a->val != b->val);
+bool B_OrdD_i16D___ne__ (B_OrdD_i16 wit, B_i16 a, B_i16 b) {
+    return a->val != b->val;
 }
 
-B_bool B_OrdD_i16D___lt__ (B_OrdD_i16 wit, B_i16 a, B_i16 b) {
-    return toB_bool(a->val < b->val);
+bool B_OrdD_i16D___lt__ (B_OrdD_i16 wit, B_i16 a, B_i16 b) {
+    return a->val < b->val;
 }
 
-B_bool B_OrdD_i16D___le__ (B_OrdD_i16 wit, B_i16 a, B_i16 b) {
-    return toB_bool(a->val <= b->val);
+bool B_OrdD_i16D___le__ (B_OrdD_i16 wit, B_i16 a, B_i16 b) {
+    return a->val <= b->val;
 }
 
-B_bool B_OrdD_i16D___gt__ (B_OrdD_i16 wit, B_i16 a, B_i16 b) {
-    return toB_bool(a->val > b->val);
+bool B_OrdD_i16D___gt__ (B_OrdD_i16 wit, B_i16 a, B_i16 b) {
+    return a->val > b->val;
 }
 
-B_bool B_OrdD_i16D___ge__ (B_OrdD_i16 wit, B_i16 a, B_i16 b) {
-    return toB_bool(a->val >= b->val);
+bool B_OrdD_i16D___ge__ (B_OrdD_i16 wit, B_i16 a, B_i16 b) {
+    return a->val >= b->val;
 }
 
 // B_HashableD_i16 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 
-B_bool B_HashableD_i16D___eq__(B_HashableD_i16 wit, B_i16 a, B_i16 b) {
-    return toB_bool(a->val == b->val);
+bool B_HashableD_i16D___eq__(B_HashableD_i16 wit, B_i16 a, B_i16 b) {
+    return a->val == b->val;
 }
 
-B_bool B_HashableD_i16D___ne__(B_HashableD_i16 wit, B_i16 a, B_i16 b) {
-    return toB_bool(a->val != b->val);
+bool B_HashableD_i16D___ne__(B_HashableD_i16 wit, B_i16 a, B_i16 b) {
+    return a->val != b->val;
 }
 
 B_NoneType B_HashableD_i16D_hash(B_HashableD_i16 wit, B_i16 a, B_hasher h) {

--- a/base/builtin/i32.c
+++ b/base/builtin/i32.c
@@ -50,8 +50,8 @@ B_i32 B_i32D___deserialize__(B_i32 n, $Serial$state state) {
     return toB_i32((int32_t)(uintptr_t)$val_deserialize(state));
 }
 
-B_bool B_i32D___bool__(B_i32 n) {
-    return toB_bool(n->val != 0);
+bool B_i32D___bool__(B_i32 n) {
+    return n->val != 0;
 }
 
 B_str B_i32D___str__(B_i32 n) {
@@ -240,38 +240,38 @@ B_float B_DivD_i32D___truediv__ (B_DivD_i32 wit, B_i32 a, B_i32 b) {
 
 // B_OrdD_i32  ////////////////////////////////////////////////////////////////////////////////////////
 
-B_bool B_OrdD_i32D___eq__ (B_OrdD_i32 wit, B_i32 a, B_i32 b) {
-    return toB_bool(a->val == b->val);
+bool B_OrdD_i32D___eq__ (B_OrdD_i32 wit, B_i32 a, B_i32 b) {
+    return a->val == b->val;
 }
 
-B_bool B_OrdD_i32D___ne__ (B_OrdD_i32 wit, B_i32 a, B_i32 b) {
-    return toB_bool(a->val != b->val);
+bool B_OrdD_i32D___ne__ (B_OrdD_i32 wit, B_i32 a, B_i32 b) {
+    return a->val != b->val;
 }
 
-B_bool B_OrdD_i32D___lt__ (B_OrdD_i32 wit, B_i32 a, B_i32 b) {
-    return toB_bool(a->val < b->val);
+bool B_OrdD_i32D___lt__ (B_OrdD_i32 wit, B_i32 a, B_i32 b) {
+    return a->val < b->val;
 }
 
-B_bool B_OrdD_i32D___le__ (B_OrdD_i32 wit, B_i32 a, B_i32 b) {
-    return toB_bool(a->val <= b->val);
+bool B_OrdD_i32D___le__ (B_OrdD_i32 wit, B_i32 a, B_i32 b) {
+    return a->val <= b->val;
 }
 
-B_bool B_OrdD_i32D___gt__ (B_OrdD_i32 wit, B_i32 a, B_i32 b) {
-    return toB_bool(a->val > b->val);
+bool B_OrdD_i32D___gt__ (B_OrdD_i32 wit, B_i32 a, B_i32 b) {
+    return a->val > b->val;
 }
 
-B_bool B_OrdD_i32D___ge__ (B_OrdD_i32 wit, B_i32 a, B_i32 b) {
-    return toB_bool(a->val >= b->val);
+bool B_OrdD_i32D___ge__ (B_OrdD_i32 wit, B_i32 a, B_i32 b) {
+    return a->val >= b->val;
 }
 
 // B_HashableD_i32 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 
-B_bool B_HashableD_i32D___eq__(B_HashableD_i32 wit, B_i32 a, B_i32 b) {
-    return toB_bool(a->val == b->val);
+bool B_HashableD_i32D___eq__(B_HashableD_i32 wit, B_i32 a, B_i32 b) {
+    return a->val == b->val;
 }
 
-B_bool B_HashableD_i32D___ne__(B_HashableD_i32 wit, B_i32 a, B_i32 b) {
-    return toB_bool(a->val != b->val);
+bool B_HashableD_i32D___ne__(B_HashableD_i32 wit, B_i32 a, B_i32 b) {
+    return a->val != b->val;
 }
 
 B_NoneType B_HashableD_i32D_hash(B_HashableD_i32 wit, B_i32 a, B_hasher h) {

--- a/base/builtin/i8.c
+++ b/base/builtin/i8.c
@@ -50,8 +50,8 @@ B_i8 B_i8D___deserialize__(B_i8 n, $Serial$state state) {
     return toB_i8((int8_t)(uintptr_t)$val_deserialize(state));
 }
 
-B_bool B_i8D___bool__(B_i8 n) {
-    return toB_bool(n->val != 0);
+bool B_i8D___bool__(B_i8 n) {
+    return n->val != 0;
 }
 
 B_str B_i8D___str__(B_i8 n) {
@@ -240,38 +240,38 @@ B_float B_DivD_i8D___truediv__ (B_DivD_i8 wit, B_i8 a, B_i8 b) {
 
 // B_OrdD_i8  ////////////////////////////////////////////////////////////////////////////////////////
 
-B_bool B_OrdD_i8D___eq__ (B_OrdD_i8 wit, B_i8 a, B_i8 b) {
-    return toB_bool(a->val == b->val);
+bool B_OrdD_i8D___eq__ (B_OrdD_i8 wit, B_i8 a, B_i8 b) {
+    return a->val == b->val;
 }
 
-B_bool B_OrdD_i8D___ne__ (B_OrdD_i8 wit, B_i8 a, B_i8 b) {
-    return toB_bool(a->val != b->val);
+bool B_OrdD_i8D___ne__ (B_OrdD_i8 wit, B_i8 a, B_i8 b) {
+    return a->val != b->val;
 }
 
-B_bool B_OrdD_i8D___lt__ (B_OrdD_i8 wit, B_i8 a, B_i8 b) {
-    return toB_bool(a->val < b->val);
+bool B_OrdD_i8D___lt__ (B_OrdD_i8 wit, B_i8 a, B_i8 b) {
+    return a->val < b->val;
 }
 
-B_bool B_OrdD_i8D___le__ (B_OrdD_i8 wit, B_i8 a, B_i8 b) {
-    return toB_bool(a->val <= b->val);
+bool B_OrdD_i8D___le__ (B_OrdD_i8 wit, B_i8 a, B_i8 b) {
+    return a->val <= b->val;
 }
 
-B_bool B_OrdD_i8D___gt__ (B_OrdD_i8 wit, B_i8 a, B_i8 b) {
-    return toB_bool(a->val > b->val);
+bool B_OrdD_i8D___gt__ (B_OrdD_i8 wit, B_i8 a, B_i8 b) {
+    return a->val > b->val;
 }
 
-B_bool B_OrdD_i8D___ge__ (B_OrdD_i8 wit, B_i8 a, B_i8 b) {
-    return toB_bool(a->val >= b->val);
+bool B_OrdD_i8D___ge__ (B_OrdD_i8 wit, B_i8 a, B_i8 b) {
+    return a->val >= b->val;
 }
 
 // B_HashableD_i8 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 
-B_bool B_HashableD_i8D___eq__(B_HashableD_i8 wit, B_i8 a, B_i8 b) {
-    return toB_bool(a->val == b->val);
+bool B_HashableD_i8D___eq__(B_HashableD_i8 wit, B_i8 a, B_i8 b) {
+    return a->val == b->val;
 }
 
-B_bool B_HashableD_i8D___ne__(B_HashableD_i8 wit, B_i8 a, B_i8 b) {
-    return toB_bool(a->val != b->val);
+bool B_HashableD_i8D___ne__(B_HashableD_i8 wit, B_i8 a, B_i8 b) {
+    return a->val != b->val;
 }
 
 B_NoneType B_HashableD_i8D_hash(B_HashableD_i8 wit, B_i8 a, B_hasher h) {

--- a/base/builtin/int.c
+++ b/base/builtin/int.c
@@ -49,8 +49,8 @@ B_int B_intD___deserialize__(B_int n, $Serial$state state) {
     return toB_int((long)$val_deserialize(state));
 }
 
-B_bool B_intD___bool__(B_int n) {
-    return toB_bool(n->val != 0);
+bool B_intD___bool__(B_int n) {
+    return n->val != 0;
 }
 
 B_str B_intD___str__(B_int n) {
@@ -243,38 +243,38 @@ B_float B_DivD_intD___truediv__ (B_DivD_int wit, B_int a, B_int b) {
 
 // B_OrdD_int  ////////////////////////////////////////////////////////////////////////////////////////
 
-B_bool B_OrdD_intD___eq__ (B_OrdD_int wit, B_int a, B_int b) {
-    return toB_bool(a->val == b->val);
+bool B_OrdD_intD___eq__ (B_OrdD_int wit, B_int a, B_int b) {
+    return a->val == b->val;
 }
 
-B_bool B_OrdD_intD___ne__ (B_OrdD_int wit, B_int a, B_int b) {
-    return toB_bool(a->val != b->val);
+bool B_OrdD_intD___ne__ (B_OrdD_int wit, B_int a, B_int b) {
+    return a->val != b->val;
 }
 
-B_bool B_OrdD_intD___lt__ (B_OrdD_int wit, B_int a, B_int b) {
-    return toB_bool(a->val < b->val);
+bool B_OrdD_intD___lt__ (B_OrdD_int wit, B_int a, B_int b) {
+    return a->val < b->val;
 }
 
-B_bool B_OrdD_intD___le__ (B_OrdD_int wit, B_int a, B_int b) {
-    return toB_bool(a->val <= b->val);
+bool B_OrdD_intD___le__ (B_OrdD_int wit, B_int a, B_int b) {
+    return a->val <= b->val;
 }
 
-B_bool B_OrdD_intD___gt__ (B_OrdD_int wit, B_int a, B_int b) {
-    return toB_bool(a->val > b->val);
+bool B_OrdD_intD___gt__ (B_OrdD_int wit, B_int a, B_int b) {
+    return a->val > b->val;
 }
 
-B_bool B_OrdD_intD___ge__ (B_OrdD_int wit, B_int a, B_int b) {
-    return toB_bool(a->val >= b->val);
+bool B_OrdD_intD___ge__ (B_OrdD_int wit, B_int a, B_int b) {
+    return a->val >= b->val;
 }
 
 // B_HashableD_int ///////////////////////////////////////////////////////////////////////////////////////////////////////
 
-B_bool B_HashableD_intD___eq__(B_HashableD_int wit, B_int a, B_int b) {
-    return toB_bool(a->val == b->val);
+bool B_HashableD_intD___eq__(B_HashableD_int wit, B_int a, B_int b) {
+    return a->val == b->val;
 }
 
-B_bool B_HashableD_intD___ne__(B_HashableD_int wit, B_int a, B_int b) {
-    return toB_bool(a->val != b->val);
+bool B_HashableD_intD___ne__(B_HashableD_int wit, B_int a, B_int b) {
+    return a->val != b->val;
 }
 
 B_NoneType B_HashableD_intD_hash(B_HashableD_int wit, B_int a, B_hasher h) {

--- a/base/builtin/list.c
+++ b/base/builtin/list.c
@@ -98,8 +98,8 @@ B_NoneType B_listD___init__(B_list lst, B_Iterable wit, $WORD iterable) {
     return B_None;
 }
   
-B_bool B_listD___bool__(B_list self) {
-    return toB_bool(self->length>0);
+bool B_listD___bool__(B_list self) {
+    return self->length>0;
 }
 
 B_str B_listD___str__(B_list self) {
@@ -216,8 +216,8 @@ int64_t B_listD_index(B_list self, B_Eq W_EqD_B, $WORD val, B_int start, B_int s
         stp = self->length;
     for (int i=strt; i < stp; i++) {
         B_value elem = (B_value)self->data[i];
-        B_bool eq = W_EqD_B->$class->__eq__(W_EqD_B, val, elem);
-        if (eq->val)
+        bool eq = W_EqD_B->$class->__eq__(W_EqD_B, val, elem);
+        if (eq)
             return i;
     }
     $RAISE((B_BaseException)$NEW(B_KeyError, val, to$str("element is not in list")));
@@ -228,8 +228,8 @@ int64_t B_listD_count(B_list self, B_Eq W_EqD_B, $WORD val) {
     int64_t count = 0;
     for (int i = 0; i < self->length; i++) {
         B_value elem = (B_value)self->data[i];
-        B_bool eq = W_EqD_B->$class->__eq__(W_EqD_B, val, elem);
-        if (eq->val)
+        bool eq = W_EqD_B->$class->__eq__(W_EqD_B, val, elem);
+        if (eq)
             count++;
     }
     return count;
@@ -239,48 +239,48 @@ int64_t B_listD_count(B_list self, B_Eq W_EqD_B, $WORD val) {
 
 // B_OrdD_list ////////////////////////////////////////////////////////
 
-B_bool B_OrdD_listD___eq__ (B_OrdD_list w, B_list a, B_list b) {
-    if (a->length != b->length) return B_False;                                
+bool B_OrdD_listD___eq__ (B_OrdD_list w, B_list a, B_list b) {
+    if (a->length != b->length) return false;                                
     B_Ord w2 = w->W_OrdD_AD_OrdD_list;
     for (int i = 0; i<a->length; i++) {
-        if ((w2->$class->__ne__(w2,a->data[i],b->data[i]))->val) return B_False;
+        if ((w2->$class->__ne__(w2,a->data[i],b->data[i]))) return false;
     }
-    return B_True;
+    return true;
 }
 
-B_bool B_OrdD_listD___ne__ (B_OrdD_list w, B_list a, B_list b) {
-    return toB_bool(!(w->$class->__eq__(w,a,b)->val));
+bool B_OrdD_listD___ne__ (B_OrdD_list w, B_list a, B_list b) {
+    return !(w->$class->__eq__(w,a,b));
 }
 
-B_bool B_OrdD_listD___lt__ (B_OrdD_list w, B_list a, B_list b) {
+bool B_OrdD_listD___lt__ (B_OrdD_list w, B_list a, B_list b) {
     int minl = a->length<b->length ? a->length : b->length;
     B_Ord wA = w->W_OrdD_AD_OrdD_list;
     int i=0;
     while (i<minl && wA->$class->__eq__(wA,a->data[i],b->data[i])) i++;
     if (i==a->length)
-        return toB_bool(i<b->length);
+        return i<b->length;
     if (i==b->length)
-        return B_False;
+        return false;
     return  wA->$class->__lt__(wA,a->data[i],b->data[i]);
 }
 
-B_bool B_OrdD_listD___le__ (B_OrdD_list w, B_list a, B_list b) {
+bool B_OrdD_listD___le__ (B_OrdD_list w, B_list a, B_list b) {
     int minl = a->length<b->length ? a->length : b->length;
     B_Ord wA = w->W_OrdD_AD_OrdD_list;
     int i=0;
     while (i<minl && wA->$class->__eq__(wA,a->data[i],b->data[i])) i++;
     if (i==a->length)
-        return toB_bool(i<=b->length);
+        return i<=b->length;
     if (i==b->length)
-        return B_False;
+        return false;
     return  wA->$class->__lt__(wA,a->data[i],b->data[i]);
 }
 
-B_bool B_OrdD_listD___gt__ (B_OrdD_list w, B_list a, B_list b) {
+bool B_OrdD_listD___gt__ (B_OrdD_list w, B_list a, B_list b) {
     return  B_OrdD_listD___lt__ (w,b,a);
 }
 
-B_bool B_OrdD_listD___ge__ (B_OrdD_list w, B_list a, B_list b) {
+bool B_OrdD_listD___ge__ (B_OrdD_list w, B_list a, B_list b) {
     return  B_OrdD_listD___le__ (w,b,a);
 }
 
@@ -339,8 +339,8 @@ void B_IteratorD_listD_init(B_IteratorD_list self, B_list lst) {
     self->nxt = 0;
 }
 
-B_bool B_IteratorD_listD_bool(B_IteratorD_list self) {
-    return B_True;
+bool B_IteratorD_listD_bool(B_IteratorD_list self) {
+    return true;
 }
 
 B_str B_IteratorD_listD_str(B_IteratorD_list self) {
@@ -553,21 +553,21 @@ B_NoneType B_SequenceD_listD_append(B_SequenceD_list wit, B_list lst, $WORD elem
 
 // B_ContainerD_list ///////////////////////////////////////////////////////////////////
 
-B_bool B_ContainerD_listD___contains__(B_ContainerD_list wit, B_list lst, $WORD elem) {
-    long res = 0;
+bool B_ContainerD_listD___contains__(B_ContainerD_list wit, B_list lst, $WORD elem) {
+    bool res = false;
     B_Eq w = wit->W_EqD_AD_ContainerD_list;
     for (int i=0; i < lst->length; i++) {
-        if (fromB_bool(w->$class->__eq__(w,elem,lst->data[i]))) {
-            res = 1;
+        if (w->$class->__eq__(w,elem,lst->data[i])) {
+            res = true;
             break;
         }
     }
 
-    return toB_bool(res);
+    return res;
 }
                  
-B_bool B_ContainerD_listD___containsnot__(B_ContainerD_list wit, B_list lst, $WORD elem) {
-    return toB_bool(!B_ContainerD_listD___contains__(wit,lst,elem)->val);
+bool B_ContainerD_listD___containsnot__(B_ContainerD_list wit, B_list lst, $WORD elem) {
+    return !B_ContainerD_listD___contains__(wit,lst,elem);
 }
 
 // Witnesses used in code generation
@@ -581,7 +581,7 @@ struct B_SequenceD_listG_class B_SequenceD_listG_methods = {
     NULL, //B_SequenceD_listD___init__,
     NULL, //B_SequenceD_listD___serialize__,
     NULL, //B_SequenceD_listD___deserialize__,
-    (B_bool (*)(B_SequenceD_list))$default__bool__,
+    (bool (*)(B_SequenceD_list))$default__bool__,
     (B_str (*)(B_SequenceD_list))$default__str__,
     (B_str (*)(B_SequenceD_list))$default__str__,
     B_SequenceD_listD___getitem__,
@@ -595,30 +595,3 @@ struct B_SequenceD_listG_class B_SequenceD_listG_methods = {
     B_SequenceD_listD_append,
     B_SequenceD_listD_reverse
 };
-
-/*
-struct B_TimesD_SequenceD_list B_TimesD_SequenceD_list_instance;
-struct B_SequenceD_list B_SequenceD_list_instance;
-
-struct B_CollectionD_SequenceD_list B_CollectionD_SequenceD_list_instance = {
-    &B_CollectionD_SequenceD_listG_methods,
-    (B_Sequence)&B_SequenceD_list_instance
-};
-
-B_CollectionD_SequenceD_list B_CollectionD_SequenceD_listG_witness = &B_CollectionD_SequenceD_list_instance;
-
-struct B_SequenceD_list B_SequenceD_list_instance = { 
-    &B_SequenceD_listG_methods,
-    (B_Eq)&B_OrdD_intG_methods,
-    (B_Collection)&B_CollectionD_SequenceD_list_instance,
-    (B_Times)&B_TimesD_SequenceD_list_instance
-};
-
-B_SequenceD_list B_SequenceD_listG_witness = &B_SequenceD_list_instance;
-
-struct B_TimesD_SequenceD_list B_TimesD_SequenceD_list_instance = {
-    &B_TimesD_SequenceD_listG_methods,
-    (B_Sequence)&B_SequenceD_list_instance
-};
-B_TimesD_SequenceD_list B_TimesD_SequenceD_listG_witness = &B_TimesD_SequenceD_list_instance;
-*/

--- a/base/builtin/list.h
+++ b/base/builtin/list.h
@@ -21,7 +21,7 @@ struct B_IteratorD_listG_class {
   void (*__init__)(B_IteratorD_list, B_list);
   void (*__serialize__)(B_IteratorD_list,$Serial$state);
   B_IteratorD_list (*__deserialize__)(B_IteratorD_list,$Serial$state);
-  B_bool (*__bool__)(B_IteratorD_list);
+  bool (*__bool__)(B_IteratorD_list);
   B_str (*__str__)(B_IteratorD_list);
   B_str (*__repr__)(B_IteratorD_list);
   $WORD(*__next__)(B_IteratorD_list);

--- a/base/builtin/none.c
+++ b/base/builtin/none.c
@@ -27,8 +27,8 @@ B_NoneType B_NoneTypeD__deserialize__(B_NoneType self, $Serial$state state) {
   return NULL;
 }
 
-B_bool B_NoneTypeD__bool__(B_NoneType self) {
-  return B_False;
+bool B_NoneTypeD__bool__(B_NoneType self) {
+  return false;
 }
 
 B_str B_NoneTypeD__str__(B_NoneType self) {

--- a/base/builtin/none.h
+++ b/base/builtin/none.h
@@ -5,7 +5,7 @@ struct B_NoneTypeG_class {
     void (*__init__)(B_NoneType);
     void (*__serialize__)(B_NoneType,$Serial$state);
     B_NoneType (*__deserialize__)(B_NoneType,$Serial$state);
-    B_bool (*__bool__)(B_NoneType);
+    bool (*__bool__)(B_NoneType);
     B_str (*__str__)(B_NoneType);
     B_str (*__repr__)(B_NoneType);
 };

--- a/base/builtin/range.c
+++ b/base/builtin/range.c
@@ -97,8 +97,8 @@ void B_IteratorD_rangeD_init(B_IteratorD_range self, B_range rng) {
 */
 
 
-B_bool B_rangeD___bool__(B_range self) {
-    return B_True;
+bool B_rangeD___bool__(B_range self) {
+    return true;
 }
 
 B_str B_rangeD___repr__(B_range self) {

--- a/base/builtin/registration.c
+++ b/base/builtin/registration.c
@@ -57,7 +57,7 @@ void $register_builtin() {
   $register_force(RANGE_ID,&B_rangeG_methods);
   $register_force(TUPLE_ID,&B_tupleG_methods);
   $register_force(BYTEARRAY_ID,&B_bytearrayG_methods);
-  $register_force(STRITERATOR_ID,&B_IteratorB_strG_methods);
+  $register_force(STRITERATOR_ID,&B_IteratorD_strG_methods);
   $register_force(LISTITERATOR_ID,&B_IteratorD_listG_methods);
   $register_force(DICTITERATOR_ID,&B_IteratorD_dictG_methods);
   $register_force(VALUESITERATOR_ID,&B_IteratorD_dict_valuesG_methods);
@@ -98,14 +98,14 @@ void $register_builtin() {
 }
 
 
-B_bool issubtype(int sub_id, int ancestor_id) {
+bool issubtype(int sub_id, int ancestor_id) {
   if (sub_id == ancestor_id)
-    return B_True;
+    return true;
   $SuperG_class c =  ($SuperG_class)$GET_METHODS(sub_id)->$superclass;
   while(c)
     if(c->$class_id == ancestor_id)
-      return B_True;
+      return true;
     else
       c = c->$superclass;
-  return B_False;
+  return false;
 }

--- a/base/builtin/registration.h
+++ b/base/builtin/registration.h
@@ -110,4 +110,4 @@ void $register_force(int classid, $WORD meths);
 
 extern B_list G_methods;
 
-B_bool issubtype(int sub_id, int ancestor_id); 
+bool issubtype(int sub_id, int ancestor_id); 

--- a/base/builtin/serialize.c
+++ b/base/builtin/serialize.c
@@ -41,12 +41,12 @@ B_HashableD_WORD B_HashableD_WORDD___deserialize__(B_HashableD_WORD self, $Seria
     return res;
 }
 
-B_bool B_HashableD_WORD_eq(B_HashableD_WORD wit, $WORD a, $WORD b) {
-    return toB_bool(a==b);
+bool B_HashableD_WORD_eq(B_HashableD_WORD wit, $WORD a, $WORD b) {
+    return a == b;
 }
 
-B_bool B_HashableD_WORD_ne(B_HashableD_WORD wit, $WORD a, $WORD b) {
-    return  toB_bool(a != b);
+bool B_HashableD_WORD_ne(B_HashableD_WORD wit, $WORD a, $WORD b) {
+    return  a != b;
 }
 
 B_NoneType B_HashableD_WORD_hash(B_HashableD_WORD wit, $WORD a, B_hasher h) {
@@ -61,7 +61,7 @@ struct B_HashableD_WORDG_class B_HashableD_WORDG_methods = {
     (void (*)(B_HashableD_WORD))$default__init__,
     B_HashableD_WORDD___serialize__,
     B_HashableD_WORDD___deserialize__,
-    (B_bool (*)(B_HashableD_WORD))$default__bool__,
+    (bool (*)(B_HashableD_WORD))$default__bool__,
     (B_str (*)(B_HashableD_WORD))$default__str__,
     (B_str (*)(B_HashableD_WORD))$default__str__,
     B_HashableD_WORD_eq,

--- a/base/builtin/serialize.h
+++ b/base/builtin/serialize.h
@@ -70,11 +70,11 @@ struct B_HashableD_WORDG_class {
     void (*__init__)(B_HashableD_WORD);
     void (*__serialize__)(B_HashableD_WORD,$Serial$state);
     B_HashableD_WORD (*__deserialize__)(B_HashableD_WORD,$Serial$state);
-    B_bool (*__bool__)(B_HashableD_WORD);
+    bool (*__bool__)(B_HashableD_WORD);
     B_str (*__str__)(B_HashableD_WORD);
     B_str (*__repr__)(B_HashableD_WORD);
-    B_bool (*__eq__)(B_HashableD_WORD, $WORD, $WORD);
-    B_bool (*__ne__)(B_HashableD_WORD, $WORD, $WORD);
+    bool (*__eq__)(B_HashableD_WORD, $WORD, $WORD);
+    bool (*__ne__)(B_HashableD_WORD, $WORD, $WORD);
     B_NoneType (* hash)(B_HashableD_WORD, $WORD, B_hasher);
 };
 

--- a/base/builtin/set.c
+++ b/base/builtin/set.c
@@ -117,7 +117,7 @@ static B_setentry *B_set_lookkey(B_set set, B_Hashable hashwit, $WORD key, long 
     }
 }
 
-static int B_set_contains_entry(B_set set,  B_Hashable hashwit, $WORD elem, long hash) {
+static bool B_set_contains_entry(B_set set,  B_Hashable hashwit, $WORD elem, long hash) {
     return B_set_lookkey(set, hashwit, elem, hash)->key != NULL;
 }
 
@@ -229,8 +229,8 @@ B_NoneType B_setD___init__(B_set set, B_Hashable hashwit, B_Iterable wit, $WORD 
     return B_None;
 }
 
-B_bool B_setD___bool__(B_set self) {
-    return toB_bool(self->numelements>0);
+bool B_setD___bool__(B_set self) {
+    return self->numelements>0;
 }
 
 B_str B_setD___str__(B_set self) {
@@ -345,8 +345,8 @@ void B_IteratorD_set_init(B_IteratorD_set self, B_set set) {
     self->nxt = 0;
 }
 
-B_bool B_IteratorD_set_bool(B_IteratorD_set self) {
-    return B_True;
+bool B_IteratorD_set_bool(B_IteratorD_set self) {
+    return true;
 }
 
 B_str B_IteratorD_set_str(B_IteratorD_set self) {
@@ -403,31 +403,31 @@ int64_t B_SetD_setD___len__ (B_SetD_set wit, B_set set) {
     return set->numelements;
 }
 
-B_bool B_SetD_setD___contains__ (B_SetD_set wit, B_set set, $WORD val) {
+bool B_SetD_setD___contains__ (B_SetD_set wit, B_set set, $WORD val) {
     B_Hashable hashwit = wit->W_HashableD_AD_SetD_set;
-    return toB_bool(B_set_contains_entry(set,hashwit,val,B_hash(hashwit, val)));
+    return B_set_contains_entry(set,hashwit,val,B_hash(hashwit, val));
 }
 
-B_bool B_SetD_setD___containsnot__ (B_SetD_set wit, B_set set, $WORD v) {
-    return  toB_bool(!B_SetD_setD___contains__(wit,set,v)->val);
+bool B_SetD_setD___containsnot__ (B_SetD_set wit, B_set set, $WORD v) {
+    return  !B_SetD_setD___contains__(wit,set,v);
 }
 
-B_bool B_SetD_setD_isdisjoint (B_SetD_set wit, B_set set, B_set other) {
+bool B_SetD_setD_isdisjoint (B_SetD_set wit, B_set set, B_set other) {
     B_Hashable hashwit = wit->W_HashableD_AD_SetD_set;
     if (set == other) 
-        return toB_bool(set->numelements == 0);
+        return set->numelements == 0;
     if (other->numelements > set->numelements)
         return B_SetD_setD_isdisjoint(wit,other,set);
     B_Iterator iter = B_set_iter_entry(other);
     $WORD w;
-    long res = 1;
+    long res = true;
     while((w = $next(iter))){
         if(B_set_contains_entry(set, hashwit,((B_setentry*)w)->key, ((B_setentry*)w)->hash)) {
-            res = 0;
+            res = false;
             break;
         }
     }
-    return toB_bool(res);
+    return res;
 }
 
 // TODO: ideally this could be defined in .act file instead of C since we just
@@ -484,66 +484,66 @@ $WORD B_SetD_setD_pop (B_SetD_set wit, B_set set) {
 
 // B_Ord
 
-B_bool B_OrdD_SetD_setD___eq__ (B_OrdD_SetD_set wit, B_set set, B_set other) {
+bool B_OrdD_SetD_setD___eq__ (B_OrdD_SetD_set wit, B_set set, B_set other) {
     B_Hashable hashwit = ((B_SetD_set)wit->W_Set)->W_HashableD_AD_SetD_set;
     if (set == other) 
-        return B_True;
+        return true;
     if (set->numelements != other->numelements)
-        return B_False;
+        return false;
     B_Iterator iter = B_set_iter_entry(other);
     long n = 0;
     while(n < set->numelements) {
         $WORD w = $next(iter);
         if(!B_set_contains_entry(set, hashwit, ((B_setentry*)w)->key, ((B_setentry*)w)->hash))
-            return B_False;
+            return false;
         n++;
     }
-    return B_True;
+    return true;
 }
   
-B_bool B_OrdD_SetD_setD___ne__ (B_OrdD_SetD_set wit, B_set set, B_set other) {
-    return toB_bool(!B_OrdD_SetD_setD___eq__ (wit,set,other)->val);
+bool B_OrdD_SetD_setD___ne__ (B_OrdD_SetD_set wit, B_set set, B_set other) {
+    return !B_OrdD_SetD_setD___eq__ (wit,set,other);
 }
   
-B_bool B_OrdD_SetD_setD___gt__ (B_OrdD_SetD_set wit, B_set set, B_set other) {
+bool B_OrdD_SetD_setD___gt__ (B_OrdD_SetD_set wit, B_set set, B_set other) {
     B_Hashable hashwit = ((B_SetD_set)wit->W_Set)->W_HashableD_AD_SetD_set;
     if (set == other) 
-        return B_False;    
+        return false;    
     if (set->numelements <= other->numelements)
-        return B_False;
+        return false;
     B_Iterator iter = B_set_iter_entry(other);
     long n = 0;
     while(n < other->numelements) {
         $WORD w = $next(iter);
         if(!B_set_contains_entry(set, hashwit, ((B_setentry*)w)->key, ((B_setentry*)w)->hash))
-            return B_False;
+            return false;
         n++;
     }
-    return B_True;
+    return true;
 }
   
-B_bool B_OrdD_SetD_setD___ge__ (B_OrdD_SetD_set wit, B_set set, B_set other) {
+bool B_OrdD_SetD_setD___ge__ (B_OrdD_SetD_set wit, B_set set, B_set other) {
     B_Hashable hashwit = ((B_SetD_set)wit->W_Set)->W_HashableD_AD_SetD_set;
     if (set == other) 
-        return B_False;    
+        return true;    
     if (set->numelements < other->numelements)
-        return B_False;
+        return false;
     B_Iterator iter = B_set_iter_entry(other);
     long n = 0;
     while(n < other->numelements) {
         $WORD w = $next(iter);
         if(!B_set_contains_entry(set, hashwit, ((B_setentry*)w)->key, ((B_setentry*)w)->hash))
-            return B_False;
+            return false;
         n++;
     }
-    return B_True;
+    return true;
 }
 
-B_bool B_OrdD_SetD_setD___lt__ (B_OrdD_SetD_set wit, B_set set, B_set other) {
+bool B_OrdD_SetD_setD___lt__ (B_OrdD_SetD_set wit, B_set set, B_set other) {
     return B_OrdD_SetD_setD___gt__(wit, other, set);
 }
   
-B_bool B_OrdD_SetD_setD___le__ (B_OrdD_SetD_set wit, B_set set, B_set other) {
+bool B_OrdD_SetD_setD___le__ (B_OrdD_SetD_set wit, B_set set, B_set other) {
     return  B_OrdD_SetD_setD___ge__(wit, other, set);
 }
   

--- a/base/builtin/set.h
+++ b/base/builtin/set.h
@@ -25,7 +25,7 @@ struct B_IteratorD_setG_class {
     void (*__init__)(B_IteratorD_set, B_set);
     void (*__serialize__)(B_IteratorD_set, $Serial$state);
     B_IteratorD_set (*__deserialize__)(B_IteratorD_set, $Serial$state);
-    B_bool (*__bool__)(B_IteratorD_set);
+    bool (*__bool__)(B_IteratorD_set);
     B_str (*__str__)(B_IteratorD_set);
     B_str (*__repr__)(B_IteratorD_set);
     $WORD(*__next__)(B_IteratorD_set);

--- a/base/builtin/slice.c
+++ b/base/builtin/slice.c
@@ -98,8 +98,8 @@ B_slice B_sliceD___deserialize__ (B_slice self, $Serial$state state) {
     return res;
 }
 
-B_bool B_sliceD___bool__(B_slice s) {
-    return B_True;
+bool B_sliceD___bool__(B_slice s) {
+    return true;
 }
 
 B_str B_sliceD___str__(B_slice s) {

--- a/base/builtin/str.c
+++ b/base/builtin/str.c
@@ -776,8 +776,8 @@ B_NoneType B_strD___init__(B_str self, B_value s) {
     return B_None;
 }
 
-B_bool B_strD___bool__(B_str s) {
-    return toB_bool(s->nchars > 0);
+bool B_strD___bool__(B_str s) {
+    return s->nchars > 0;
 };
 
 B_str B_strD___str__(B_str s) {
@@ -949,20 +949,20 @@ B_bytes B_strD_encode(B_str s) {
     return res;
 }
 
-B_bool B_strD_endswith(B_str s, B_str sub, B_int start, B_int end) {
+bool B_strD_endswith(B_str s, B_str sub, B_int start, B_int end) {
     B_int st = start;
     B_int en = end;
-    if (fix_start_end(s->nchars,&st,&en) < 0) return B_False;
-    if (en->val-st->val < sub->nbytes) return B_False;
+    if (fix_start_end(s->nchars,&st,&en) < 0) return false;
+    if (en->val-st->val < sub->nbytes) return false;
     int isascii = s->nchars==s->nbytes;
     unsigned char *p = skip_chars(s->str + s->nbytes,fromB_int(en) - s->nchars,isascii) - sub->nbytes;
     unsigned char *q = sub->str;
     for (int i=0; i<sub->nbytes; i++) {
         if (*p == 0 || *p++ != *q++) {
-            return B_False;
+            return false;
         }
     }
-    return B_True;
+    return true;
 }
 
 B_str B_strD_expandtabs(B_str s, B_int tabsize){
@@ -1021,23 +1021,23 @@ int64_t B_strD_index(B_str s, B_str sub, B_int start, B_int end) {
     return n;
 }
 
-B_bool B_strD_isalnum(B_str s) {
+bool B_strD_isalnum(B_str s) {
     unsigned char *p = s->str;
     int codepoint;
     int nbytes;
     if (s->nchars == 0)
-        return B_False;
+        return false;
     for (int i=0; i < s->nchars; i++) {
         nbytes = utf8proc_iterate(p,-1,&codepoint);
         utf8proc_category_t cat = utf8proc_category(codepoint);
         if ((cat <  UTF8PROC_CATEGORY_LU || cat >  UTF8PROC_CATEGORY_LO) && cat != UTF8PROC_CATEGORY_ND)
-            return B_False;
+            return false;
         p += nbytes;
     }
-    return B_True;
+    return true;
 }
 
-B_bool B_strD_isalpha(B_str s) {
+bool B_strD_isalpha(B_str s) {
     unsigned char *p = s->str;
     int codepoint;
     int nbytes;
@@ -1047,132 +1047,132 @@ B_bool B_strD_isalpha(B_str s) {
         nbytes = utf8proc_iterate(p,-1,&codepoint);
         utf8proc_category_t cat = utf8proc_category(codepoint);
         if (cat <  UTF8PROC_CATEGORY_LU || cat >  UTF8PROC_CATEGORY_LO)
-            return B_False;
+            return false;
         p += nbytes;
     }
-    return B_True;
+    return true;
 }
 
-B_bool B_strD_isascii(B_str s) {
+bool B_strD_isascii(B_str s) {
     unsigned char *p = s->str;
     for (int i=0; i < s->nbytes; i++) {
         if (*p > 127)
-            return B_False;
+            return false;
         p++;
     }
-    return B_True;
+    return true;
 }
 
-B_bool B_strD_isdecimal(B_str s) {
+bool B_strD_isdecimal(B_str s) {
     unsigned char *p = s->str;
     int codepoint;
     int nbytes;
     if (s->nchars == 0)
-        return B_False;
+        return false;
     for (int i=0; i < s->nchars; i++) {
         nbytes = utf8proc_iterate(p,-1,&codepoint);
         utf8proc_category_t cat = utf8proc_category(codepoint);
         if (cat != UTF8PROC_CATEGORY_ND)
-            return B_False;
+            return false;
         p += nbytes;
     }
-    return B_True;
+    return true;
 }
 
-B_bool B_strD_islower(B_str s) {
+bool B_strD_islower(B_str s) {
     unsigned char *p = s->str;
     int codepoint;
     int nbytes;
-    int has_cased = 0;
+    bool has_cased = false;
     if (s->nchars == 0)
-        return B_False;
+        return false;
     for (int i=0; i < s->nchars; i++) {
         nbytes = utf8proc_iterate(p,-1,&codepoint);
         utf8proc_category_t cat = utf8proc_category(codepoint);
         if (cat == UTF8PROC_CATEGORY_LT|| cat == UTF8PROC_CATEGORY_LU)
-            return B_False;
+            return false;
         if (cat == UTF8PROC_CATEGORY_LL)
-            has_cased = 1;
+            has_cased = true;
         p += nbytes;
     }
-    return toB_bool(has_cased);
+    return has_cased;
 }
 
-B_bool B_strD_isprintable(B_str s) {
+bool B_strD_isprintable(B_str s) {
     unsigned char *p = s->str;
     int codepoint;
     int nbytes;
     if (s->nchars == 0)
-        return B_False;
+        return false;
     for (int i=0; i < s->nchars; i++) {
         nbytes = utf8proc_iterate(p,-1,&codepoint);
         utf8proc_category_t cat = utf8proc_category(codepoint);
         if (cat >= UTF8PROC_CATEGORY_ZS && codepoint != 0x20)
-            return B_False;
+            return false;
         p += nbytes;
     }
-    return B_True;
+    return true;
 }
 
-B_bool B_strD_isspace(B_str s) {
+bool B_strD_isspace(B_str s) {
     unsigned char *p = s->str;
     int codepoint;
     int nbytes;
     if (s->nchars == 0)
-        return B_False;
+        return false;
     for (int i=0; i < s->nchars; i++) {
         nbytes = utf8proc_iterate(p,-1,&codepoint);
         if (!isspace_codepoint(codepoint))
-            return B_False;
+            return false;
         p += nbytes;
     }
-    return B_True;
+    return true;
 }
 
-B_bool B_strD_istitle(B_str s) {
+bool B_strD_istitle(B_str s) {
     unsigned char *p = s->str;
     int codepoint;
     int nbytes;
-    int hascased = 0;
-    int incasedrun = 0;
+    int hascased = false;
+    bool incasedrun = false;
     if (s->nchars == 0)
-        return B_False;
+        return false;
     for (int i=0; i < s->nchars; i++) {
         nbytes = utf8proc_iterate(p,-1,&codepoint);
         utf8proc_category_t cat = utf8proc_category(codepoint);
         if (cat == UTF8PROC_CATEGORY_LU || cat == UTF8PROC_CATEGORY_LT ) {
-            hascased = 1;
+            hascased = true;
             if (incasedrun)
-                return B_False;
-            incasedrun = 1;
+                return false;
+            incasedrun = true;
         } else if (cat == UTF8PROC_CATEGORY_LL) {
-            hascased = 1;
+            hascased = true;
             if (!incasedrun)
-                return B_False;
+                return false;
         } else
-            incasedrun = 0;
+            incasedrun = false;
         p += nbytes;
     }
-    return toB_bool(hascased);
+    return hascased;
 }
 
-B_bool B_strD_isupper(B_str s) {
+bool B_strD_isupper(B_str s) {
     unsigned char *p = s->str;
     int codepoint;
     int nbytes;
-    int hascased = 0;
+    int hascased = false;
     if (s->nchars == 0)
         return B_False;
     for (int i=0; i < s->nchars; i++) {
         nbytes = utf8proc_iterate(p,-1,&codepoint);
         utf8proc_category_t cat = utf8proc_category(codepoint);
         if (cat == UTF8PROC_CATEGORY_LL)
-            return B_False;
+            return false;
         if (cat == UTF8PROC_CATEGORY_LU || cat == UTF8PROC_CATEGORY_LT)
-            hascased = 1;
+            hascased = true;
         p += nbytes;
     }
-    return toB_bool(hascased);
+    return hascased;
 }
 
 B_str B_strD_join(B_str s, B_Iterable wit, $WORD iter) {
@@ -1512,19 +1512,19 @@ B_str B_strD_rstrip(B_str s, B_str cs) {
     return res;
 }
 
-B_bool B_strD_startswith(B_str s, B_str sub, B_int start, B_int end) {
+bool B_strD_startswith(B_str s, B_str sub, B_int start, B_int end) {
     B_int st = start;
     B_int en = end;
-    if (fix_start_end(s->nchars,&st,&en) < 0) return B_False;
+    if (fix_start_end(s->nchars,&st,&en) < 0) return false;
     int isascii = s->nchars==s->nbytes;
     unsigned char *p = skip_chars(s->str,fromB_int(st),isascii);
     unsigned char *q = sub->str;
     for (int i=0; i<sub->nbytes; i++) {
         if (*p == 0 || *p++ != *q++) {
-            return B_False;
+            return false;
         }
     }
-    return B_True;
+    return true;
 }
 
 
@@ -1573,38 +1573,38 @@ B_str B_strD_zfill(B_str s, int64_t width) {
 // The comparisons below do lexicographic byte-wise comparisons.
 // Thus they do not in general reflect locale-dependent order conventions.
 
-B_bool B_OrdD_strD___eq__ (B_OrdD_str wit, B_str a, B_str b) {
-    return toB_bool(strcmp((char *)a->str,(char *)b->str) == 0);
+bool B_OrdD_strD___eq__ (B_OrdD_str wit, B_str a, B_str b) {
+    return strcmp((char *)a->str,(char *)b->str) == 0;
 }
 
-B_bool B_OrdD_strD___ne__ (B_OrdD_str wit, B_str a, B_str b) {
-    return toB_bool(strcmp((char *)a->str,(char *)b->str) != 0);
+bool B_OrdD_strD___ne__ (B_OrdD_str wit, B_str a, B_str b) {
+    return strcmp((char *)a->str,(char *)b->str) != 0;
 }
 
-B_bool B_OrdD_strD___lt__ (B_OrdD_str wit, B_str a, B_str b) {
-    return toB_bool(strcmp((char *)a->str,(char *)b->str) < 0);
+bool B_OrdD_strD___lt__ (B_OrdD_str wit, B_str a, B_str b) {
+    return strcmp((char *)a->str,(char *)b->str) < 0;
 }
 
-B_bool B_OrdD_strD___le__ (B_OrdD_str wit, B_str a, B_str b) {
-    return toB_bool(strcmp((char *)a->str,(char *)b->str) <= 0);
+bool B_OrdD_strD___le__ (B_OrdD_str wit, B_str a, B_str b) {
+    return strcmp((char *)a->str,(char *)b->str) <= 0;
 }
 
-B_bool B_OrdD_strD___gt__ (B_OrdD_str wit, B_str a, B_str b) {
-    return toB_bool(strcmp((char *)a->str,(char *)b->str) > 0);
+bool B_OrdD_strD___gt__ (B_OrdD_str wit, B_str a, B_str b) {
+    return strcmp((char *)a->str,(char *)b->str) > 0;
 }
 
-B_bool B_OrdD_strD___ge__ (B_OrdD_str wit, B_str a, B_str b) {
-    return toB_bool(strcmp((char *)a->str,(char *)b->str) >= 0);
+bool B_OrdD_strD___ge__ (B_OrdD_str wit, B_str a, B_str b) {
+    return strcmp((char *)a->str,(char *)b->str) >= 0;
 }
 
 // B_Hashable ///////////////////////////////////////////////////////////////////////////////////
 
-B_bool B_HashableD_strD___eq__ (B_HashableD_str wit, B_str a, B_str b) {
-    return toB_bool(strcmp((char *)a->str,(char *)b->str) == 0);
+bool B_HashableD_strD___eq__ (B_HashableD_str wit, B_str a, B_str b) {
+    return strcmp((char *)a->str,(char *)b->str) == 0;
 }
 
-B_bool B_HashableD_strD___ne__ (B_HashableD_str wit, B_str a, B_str b) {
-    return toB_bool(strcmp((char *)a->str,(char *)b->str) != 0);
+bool B_HashableD_strD___ne__ (B_HashableD_str wit, B_str a, B_str b) {
+    return strcmp((char *)a->str,(char *)b->str) != 0;
 }
 
 B_NoneType B_HashableD_strD_hash(B_HashableD_str wit, B_str a, B_hasher h) {
@@ -1652,52 +1652,52 @@ int64_t B_ContainerD_strD___len__ (B_ContainerD_str wit, B_str s){
 // B_Container ///////////////////////////////////////////////////////////////////////////
 
 
-B_bool B_ContainerD_strD___contains__ (B_ContainerD_str wit, B_str s, B_str sub) {
-    return toB_bool(bmh(s->str,sub->str,s->nbytes,sub->nbytes) >= 0);
+bool B_ContainerD_strD___contains__ (B_ContainerD_str wit, B_str s, B_str sub) {
+    return bmh(s->str,sub->str,s->nbytes,sub->nbytes) >= 0;
 }
 
-B_bool B_ContainerD_strD___containsnot__ (B_ContainerD_str wit, B_str s, B_str sub) {
-    return toB_bool(!B_ContainerD_strD___contains__(wit, s, sub)->val);
+bool B_ContainerD_strD___containsnot__ (B_ContainerD_str wit, B_str s, B_str sub) {
+    return !B_ContainerD_strD___contains__(wit, s, sub);
 }
 
 // Iterable ///////////////////////////////////////////////////////////////////////////
 
 // first define Iterator class
 
-B_IteratorB_str B_IteratorB_strG_new(B_str str) {
-    return $NEW(B_IteratorB_str, str);
+B_IteratorD_str B_IteratorD_strG_new(B_str str) {
+    return $NEW(B_IteratorD_str, str);
 }
 
-B_NoneType B_IteratorB_strD_init(B_IteratorB_str self, B_str str) {
+B_NoneType B_IteratorD_strD_init(B_IteratorD_str self, B_str str) {
     self->src = str;
     self->nxt = 0;
     return B_None;
 }
 
-void B_IteratorB_strD_serialize(B_IteratorB_str self,$Serial$state state) {
+void B_IteratorD_strD_serialize(B_IteratorD_str self,$Serial$state state) {
     $step_serialize(self->src,state);
     $step_serialize(toB_int(self->nxt),state);
 }
 
 
-B_IteratorB_str B_IteratorB_str$_deserialize(B_IteratorB_str res, $Serial$state state) {
+B_IteratorD_str B_IteratorD_str$_deserialize(B_IteratorD_str res, $Serial$state state) {
     if (!res)
-        res = $DNEW(B_IteratorB_str,state);
+        res = $DNEW(B_IteratorD_str,state);
     res->src = (B_str)$step_deserialize(state);
     res->nxt = fromB_int((B_int)$step_deserialize(state));
     return res;
 }
 
-B_bool B_IteratorB_strD_bool(B_IteratorB_str self) {
-    return B_True;
+bool B_IteratorD_strD_bool(B_IteratorD_str self) {
+    return true;
 }
 
-B_str B_IteratorB_strD_str(B_IteratorB_str self) {
+B_str B_IteratorD_strD_str(B_IteratorD_str self) {
     return $FORMAT("<str iterator object at %p>", self);
 }
 
 // this is next function for forward iteration
-static B_str B_IteratorB_strD_next(B_IteratorB_str self) {
+static B_str B_IteratorD_strD_next(B_IteratorD_str self) {
     unsigned char *p = &self->src->str[self->nxt];
     if (*p != 0) {
         self->nxt +=byte_length2(*p);
@@ -1708,14 +1708,14 @@ static B_str B_IteratorB_strD_next(B_IteratorB_str self) {
 }
 
 
-struct B_IteratorB_strG_class B_IteratorB_strG_methods = {"B_IteratorB_str",UNASSIGNED,($SuperG_class)&B_IteratorG_methods, B_IteratorB_strD_init,
-                                                    B_IteratorB_strD_serialize, B_IteratorB_str$_deserialize,
-                                                    B_IteratorB_strD_bool, B_IteratorB_strD_str, B_IteratorB_strD_str, B_IteratorB_strD_next};
+struct B_IteratorD_strG_class B_IteratorD_strG_methods = {"B_IteratorD_str",UNASSIGNED,($SuperG_class)&B_IteratorG_methods, B_IteratorD_strD_init,
+                                                    B_IteratorD_strD_serialize, B_IteratorD_str$_deserialize,
+                                                    B_IteratorD_strD_bool, B_IteratorD_strD_str, B_IteratorD_strD_str, B_IteratorD_strD_next};
 
 // now, define __iter__
 
 B_Iterator B_ContainerD_strD___iter__ (B_ContainerD_str wit, B_str s) {
-    return (B_Iterator)$NEW(B_IteratorB_str,s);
+    return (B_Iterator)$NEW(B_IteratorD_str,s);
 }
 
 
@@ -1877,8 +1877,8 @@ B_NoneType B_bytearrayD___init__(B_bytearray self, B_bytes b) {
     return B_None;
 }
 
-B_bool B_bytearrayD___bool__(B_bytearray s) {
-    return toB_bool(s->nbytes > 0);
+bool B_bytearrayD___bool__(B_bytearray s) {
+    return s->nbytes > 0;
 };
 
 B_str B_bytearrayD___str__(B_bytearray s) {
@@ -1992,19 +1992,19 @@ B_str B_bytearrayD_decode(B_bytearray s) {
     return to$str((char*)s->str);
 }
 
-B_bool B_bytearrayD_endswith(B_bytearray s, B_bytearray sub, B_int start, B_int end) {
+bool B_bytearrayD_endswith(B_bytearray s, B_bytearray sub, B_int start, B_int end) {
     B_int st = start;
     B_int en = end;
-    if (fix_start_end(s->nbytes,&st,&en) < 0) return B_False;
+    if (fix_start_end(s->nbytes,&st,&en) < 0) return false;
     int enval = fromB_int(en);
     unsigned char *p = &s->str[enval-sub->nbytes];
     unsigned char *q = sub->str;
     for (int i=0; i<sub->nbytes; i++) {
         if (*p == 0 || *p++ != *q++) {
-            return B_False;
+            return false;
         }
     }
-    return B_True;
+    return true;
 }
 
 B_bytearray B_bytearrayD_expandtabs(B_bytearray s, B_int tabsz){
@@ -2128,101 +2128,101 @@ int64_t B_bytearrayD_index(B_bytearray s, B_bytearray sub, B_int start, B_int en
     return n;
 }
 
-B_bool B_bytearrayD_isalnum(B_bytearray s) {
+bool B_bytearrayD_isalnum(B_bytearray s) {
     if (s->nbytes==0)
-        return B_False;
+        return false;
     for (int i=0; i<s->nbytes; i++) {
         unsigned char c = s->str[i];
         if (c < '0' || c > 'z' || (c > '9' && c < 'A') || (c > 'Z' && c < 'a'))
-            return B_False;
+            return false;
     }
-    return B_True;
+    return true;
 }
 
-B_bool B_bytearrayD_isalpha(B_bytearray s) {
+bool B_bytearrayD_isalpha(B_bytearray s) {
     if (s->nbytes==0)
-        return B_False;
+        return false;
     for (int i=0; i<s->nbytes; i++) {
         unsigned char c = s->str[i];
         if (c < 'A' || c > 'z' || (c > 'Z' && c < 'a'))
-            return B_False;
+            return false;
     }
-    return B_True;
+    return true;
 }
 
-B_bool B_bytearrayD_isascii(B_bytearray s) {
+bool B_bytearrayD_isascii(B_bytearray s) {
     for (int i=0; i<s->nbytes; i++) {
         unsigned char c = s->str[i];
         if (c > 0x7f)
-            return B_False;
+            return false;
     }
-    return B_True;
+    return true;
 }
 
-B_bool B_bytearrayD_isdigit(B_bytearray s) {
+bool B_bytearrayD_isdigit(B_bytearray s) {
     if (s->nbytes==0)
-        return B_False;
+        return false;
     for (int i=0; i<s->nbytes; i++) {
         unsigned char c = s->str[i];
         if (c<'0' || c > '9')
-            return B_False;
+            return false;
     }
-    return B_True;
+    return true;
 }
 
 
-B_bool B_bytearrayD_islower(B_bytearray s) {
-    int has_lower = 0;
+bool B_bytearrayD_islower(B_bytearray s) {
+    bool has_lower = false;
     for (int i=0; i < s->nbytes; i++) {
         unsigned char c = s->str[i];
         if (c >= 'A' && c <= 'Z')
-            return B_False;
+            return false;
         if (c >= 'a' && c <= 'z')
-            has_lower = 1;
+            has_lower = true;
     }
-    return toB_bool(has_lower);
+    return has_lower;
 }
 
-B_bool B_bytearrayD_isspace(B_bytearray s) {
+bool B_bytearrayD_isspace(B_bytearray s) {
     if (s->nbytes==0)
-        return B_False;
+        return false;
     for (int i=0; i<s->nbytes; i++) {
         unsigned char c = s->str[i];
         if (c !=' ' && c != '\t' && c != '\n' && c != '\r' && c != '\x0b' && c != '\f')
-            return B_False;
+            return false;
     }
-    return B_True;
+    return true;
 }
 
-B_bool B_bytearrayD_istitle(B_bytearray s) {
+bool B_bytearrayD_istitle(B_bytearray s) {
     if (s->nbytes==0)
-        return B_False;
-    int incasedrun = 0;
+        return false;
+    bool incasedrun = false;
     for (int i=0; i < s->nbytes; i++) {
         unsigned char c = s->str[i];
         if (c >='A' && c <= 'Z') {
             if (incasedrun)
-                return B_False;
-            incasedrun = 1;
+                return false;
+            incasedrun = true;
         } else if (c >='a' && c <= 'z') {
             if (!incasedrun)
-                return B_False;
+                return false;
         } else
-            incasedrun = 0;
+            incasedrun = false;
     }
-    return B_True;
+    return true;
 }
 
-B_bool B_bytearrayD_isupper(B_bytearray s) {
-    int has_upper = 0;
+bool B_bytearrayD_isupper(B_bytearray s) {
+    bool has_upper = false;
     for (int i=0; i < s->nbytes; i++) {
         unsigned char c = s->str[i];
         if (c >= 'a' && c <= 'z')
-            return B_False;
+            return false;
         if (c >= 'a' && c <= 'z')
-            has_upper = 1;
+            has_upper = true;
     }
-    return toB_bool(has_upper);
+    return has_upper;
 }
 
 B_bytearray B_bytearrayD_join(B_bytearray s, B_Iterable wit, $WORD iter) {
@@ -2542,19 +2542,19 @@ B_list B_bytearrayD_splitlines(B_bytearray s, B_bool keepends) {
     return res;
 }
 
-B_bool B_bytearrayD_startswith(B_bytearray s, B_bytearray sub, B_int start, B_int end) {
+bool B_bytearrayD_startswith(B_bytearray s, B_bytearray sub, B_int start, B_int end) {
     B_int st = start;
     B_int en = end;
-    if (fix_start_end(s->nbytes,&st,&en) < 0) return B_False;
+    if (fix_start_end(s->nbytes,&st,&en) < 0) return false;
     unsigned char *p = s->str + fromB_int(st);
-    if (sub->nbytes > 0 && p+sub->nbytes > s->str+s->nbytes) return B_False;
+    if (sub->nbytes > 0 && p+sub->nbytes > s->str+s->nbytes) return false;
     unsigned char *q = sub->str;
     for (int i=0; i<sub->nbytes; i++) {
         if (p >= s->str + fromB_int(en) || *p++ != *q++) {
-            return B_False;
+            return false;
         }
     }
-    return B_True;
+    return true;
 }
 
 
@@ -2594,82 +2594,82 @@ B_bytearray B_bytearrayD_zfill(B_bytearray s, int64_t width) {
 // Ord
 
 
-B_bool B_OrdD_bytearrayD___eq__ (B_OrdD_bytearray wit, B_bytearray a, B_bytearray b) {
-    return toB_bool(strcmp((char *)a->str,(char *)b->str)==0);
+bool B_OrdD_bytearrayD___eq__ (B_OrdD_bytearray wit, B_bytearray a, B_bytearray b) {
+    return strcmp((char *)a->str,(char *)b->str)==0;
 }
 
-B_bool B_OrdD_bytearrayD___ne__ (B_OrdD_bytearray wit, B_bytearray a, B_bytearray b) {
-    return  toB_bool(strcmp((char *)a->str,(char *)b->str)!=0);
+bool B_OrdD_bytearrayD___ne__ (B_OrdD_bytearray wit, B_bytearray a, B_bytearray b) {
+    return strcmp((char *)a->str,(char *)b->str)!=0;
 }
 
-B_bool B_OrdD_bytearrayD___lt__ (B_OrdD_bytearray wit, B_bytearray a, B_bytearray b) {
-    return toB_bool(strcmp((char *)a->str,(char *)b->str)<0);
+bool B_OrdD_bytearrayD___lt__ (B_OrdD_bytearray wit, B_bytearray a, B_bytearray b) {
+    return strcmp((char *)a->str,(char *)b->str)<0;
 }
 
-B_bool B_OrdD_bytearrayD___le__ (B_OrdD_bytearray wit, B_bytearray a, B_bytearray b){
-    return toB_bool(strcmp((char *)a->str,(char *)b->str)<=0);
+bool B_OrdD_bytearrayD___le__ (B_OrdD_bytearray wit, B_bytearray a, B_bytearray b){
+    return strcmp((char *)a->str,(char *)b->str)<=0;
 }
 
-B_bool B_OrdD_bytearrayD___gt__ (B_OrdD_bytearray wit, B_bytearray a, B_bytearray b){
-    return toB_bool(strcmp((char *)a->str,(char *)b->str)>0);
+bool B_OrdD_bytearrayD___gt__ (B_OrdD_bytearray wit, B_bytearray a, B_bytearray b){
+    return strcmp((char *)a->str,(char *)b->str)>0;
 }
 
-B_bool B_OrdD_bytearrayD___ge__ (B_OrdD_bytearray wit, B_bytearray a, B_bytearray b){
-    return toB_bool(strcmp((char *)a->str,(char *)b->str)>=0);
+bool B_OrdD_bytearrayD___ge__ (B_OrdD_bytearray wit, B_bytearray a, B_bytearray b){
+    return strcmp((char *)a->str,(char *)b->str)>=0;
 }
 
 // Container
 
 // Iterable
 
-static B_int B_IteratorB_bytearrayD_next(B_IteratorB_bytearray self) {
+static B_int B_IteratorD_bytearrayD_next(B_IteratorD_bytearray self) {
     if (self->nxt >= self->src->nbytes)
         $RAISE ((B_BaseException)$NEW(B_StopIteration, to$str("bytearray iterator terminated")));
     return toB_int(self->src->str[self->nxt++]);
 }
 
-B_NoneType B_IteratorB_bytearrayD_init(B_IteratorB_bytearray self, B_bytearray b) {
+B_NoneType B_IteratorD_bytearrayD_init(B_IteratorD_bytearray self, B_bytearray b) {
     self->src = b;
     self->nxt = 0;
     return B_None;
 }
 
-B_bool B_IteratorB_bytearrayD_bool(B_IteratorB_bytearray self) {
-    return B_True;
+bool B_IteratorD_bytearrayD_bool(B_IteratorD_bytearray self) {
+    return true;
 }
 
-B_str B_IteratorB_bytearrayD_str(B_IteratorB_bytearray self) {
+B_str B_IteratorD_bytearrayD_str(B_IteratorD_bytearray self) {
     return $FORMAT("<bytearray iterator object at %p>", self);
 }
 
-void B_IteratorB_bytearrayD_serialize(B_IteratorB_bytearray self,$Serial$state state) {
+void B_IteratorD_bytearrayD_serialize(B_IteratorD_bytearray self,$Serial$state state) {
     $step_serialize(self->src,state);
     $step_serialize(toB_int(self->nxt),state);
 }
 
-B_IteratorB_bytearray B_IteratorB_bytearray$_deserialize(B_IteratorB_bytearray res, $Serial$state state) {
+B_IteratorD_bytearray B_IteratorD_bytearray$_deserialize(B_IteratorD_bytearray res, $Serial$state state) {
     if(!res)
-        res = $DNEW(B_IteratorB_bytearray,state);
+        res = $DNEW(B_IteratorD_bytearray,state);
     res->src = (B_bytearray)$step_deserialize(state);
     res->nxt = fromB_int((B_int)$step_deserialize(state));
     return res;
 }
 
-struct B_IteratorB_bytearrayG_class B_IteratorB_bytearrayG_methods = {
+struct B_IteratorD_bytearrayG_class B_IteratorD_bytearrayG_methods = {
     "",
     UNASSIGNED,
     ($SuperG_class)&B_IteratorG_methods,
-    B_IteratorB_bytearrayD_init,
-    B_IteratorB_bytearrayD_serialize,
-    B_IteratorB_bytearray$_deserialize,
-    B_IteratorB_bytearrayD_bool,
-    B_IteratorB_bytearrayD_str,
-    B_IteratorB_bytearrayD_str,
-    B_IteratorB_bytearrayD_next
+    B_IteratorD_bytearrayD_init,
+    B_IteratorD_bytearrayD_serialize,
+    B_IteratorD_bytearray$_deserialize,
+    B_IteratorD_bytearrayD_bool,
+    B_IteratorD_bytearrayD_str,
+    B_IteratorD_bytearrayD_str,
+    B_IteratorD_bytearrayD_next
 };
 
 B_Iterator B_ContainerD_bytearrayD___iter__ (B_ContainerD_bytearray wit, B_bytearray str) {
-    return (B_Iterator)$NEW(B_IteratorB_bytearray,str);
+    return (B_Iterator)$NEW(B_IteratorD_bytearray,str);
 }
 
 B_bytearray B_ContainerD_bytearrayD___fromiter__ (B_ContainerD_bytearray wit, B_Iterable wit2, $WORD iter) {
@@ -2680,19 +2680,19 @@ int64_t B_ContainerD_bytearrayD___len__ (B_ContainerD_bytearray wit, B_bytearray
     return (int64_t)str->nbytes;
 }
 
-B_bool B_ContainerD_bytearrayD___contains__(B_ContainerD_bytearray wit, B_bytearray self, B_int n) {
-    long res = 0;
+bool B_ContainerD_bytearrayD___contains__(B_ContainerD_bytearray wit, B_bytearray self, B_int n) {
+    bool res = false;
     for (int i=0; i < self->nbytes; i++) {
         if (self->str[i] == (unsigned char)n->val) {
-            res = 1;
+            res = true;
             break;
         }
     }
-    return toB_bool(res);
+    return res;
 }
 
-B_bool B_ContainerD_bytearrayD___containsnot__(B_ContainerD_bytearray wit, B_bytearray self, B_int n) {
-    return  toB_bool(!B_ContainerD_bytearrayD___contains__(wit,self,n)->val);
+bool B_ContainerD_bytearrayD___containsnot__(B_ContainerD_bytearray wit, B_bytearray self, B_int n) {
+    return !B_ContainerD_bytearrayD___contains__(wit,self,n);
 }
 
 // Sequence
@@ -2842,7 +2842,7 @@ B_NoneType B_SequenceD_bytearrayD___delslice__ (B_SequenceD_bytearray wit,  B_by
 
 
 B_Iterator B_CollectionD_SequenceD_bytearrayD___iter__ (B_CollectionD_SequenceD_bytearray wit, B_bytearray str) {
-    return (B_Iterator)$NEW(B_IteratorB_bytearray,str);
+    return (B_Iterator)$NEW(B_IteratorD_bytearray,str);
 }
 
 B_bytearray B_CollectionD_SequenceD_bytearrayD___fromiter__ (B_CollectionD_SequenceD_bytearray wit, B_Iterable wit2, $WORD iter) {
@@ -2976,8 +2976,8 @@ B_NoneType B_bytesD___init__(B_bytes self, B_Iterable wit, $WORD iter) {
     return B_None;
 }
 
-B_bool B_bytesD___bool__(B_bytes s) {
-    return toB_bool(s->nbytes > 0);
+bool B_bytesD___bool__(B_bytes s) {
+    return s->nbytes > 0;
 };
 
 B_str B_bytesD___str__(B_bytes s) {
@@ -3086,18 +3086,18 @@ B_str B_bytesD_decode(B_bytes s) {
     return to$str((char*)s->str);
 }
 
-B_bool B_bytesD_endswith(B_bytes s, B_bytes sub, B_int start, B_int end) {
+bool B_bytesD_endswith(B_bytes s, B_bytes sub, B_int start, B_int end) {
     B_int st = start;
     B_int en = end;
-    if (fix_start_end(s->nbytes,&st,&en) < 0) return B_False;
+    if (fix_start_end(s->nbytes,&st,&en) < 0) return false;
     unsigned char *p = &s->str[fromB_int(en)-sub->nbytes];
     unsigned char *q = sub->str;
     for (int i=0; i<sub->nbytes; i++) {
         if (*p == 0 || *p++ != *q++) {
-            return B_False;
+            return false;
         }
     }
-    return B_True;
+    return true;
 }
 
 B_bytes B_bytesD_expandtabs(B_bytes s, B_int tabsz){
@@ -3224,101 +3224,100 @@ int64_t B_bytesD_index(B_bytes s, B_bytes sub, B_int start, B_int end) {
     return n;
 }
 
-B_bool B_bytesD_isalnum(B_bytes s) {
+bool B_bytesD_isalnum(B_bytes s) {
     if (s->nbytes==0)
-        return B_False;
+        return false;
     for (int i=0; i<s->nbytes; i++) {
         unsigned char c = s->str[i];
         if (c < '0' || c > 'z' || (c > '9' && c < 'A') || (c > 'Z' && c < 'a'))
-            return B_False;
+            return false;
     }
-    return B_True;
+    return true;
 }
 
-B_bool B_bytesD_isalpha(B_bytes s) {
+bool B_bytesD_isalpha(B_bytes s) {
     if (s->nbytes==0)
-        return B_False;
+        return false;
     for (int i=0; i<s->nbytes; i++) {
         unsigned char c = s->str[i];
         if (c < 'A' || c > 'z' || (c > 'Z' && c < 'a'))
-            return B_False;
+            return false;
     }
-    return B_True;
+    return true;
 }
 
-B_bool B_bytesD_isascii(B_bytes s) {
+bool B_bytesD_isascii(B_bytes s) {
     for (int i=0; i<s->nbytes; i++) {
         unsigned char c = s->str[i];
         if (c > 0x7f)
-            return B_False;
+            return false;
     }
-    return B_True;
+    return true;
 }
 
-B_bool B_bytesD_isdigit(B_bytes s) {
+bool B_bytesD_isdigit(B_bytes s) {
     if (s->nbytes==0)
-        return B_False;
+        return false;
     for (int i=0; i<s->nbytes; i++) {
         unsigned char c = s->str[i];
         if (c<'0' || c > '9')
-            return B_False;
+            return false;
     }
-    return B_True;
+    return true;
 }
 
-
-B_bool B_bytesD_islower(B_bytes s) {
-    int has_lower = 0;
+bool B_bytesD_islower(B_bytes s) {
+    bool has_lower = false;
     for (int i=0; i < s->nbytes; i++) {
         unsigned char c = s->str[i];
         if (c >= 'A' && c <= 'Z')
-            return B_False;
+            return false;
         if (c >= 'a' && c <= 'z')
-            has_lower = 1;
+            has_lower = true;
     }
-    return toB_bool(has_lower);
+    return has_lower;
 }
 
-B_bool B_bytesD_isspace(B_bytes s) {
+bool B_bytesD_isspace(B_bytes s) {
     if (s->nbytes==0)
-        return B_False;
+        return false;
     for (int i=0; i<s->nbytes; i++) {
         unsigned char c = s->str[i];
         if (c !=' ' && c != '\t' && c != '\n' && c != '\r' && c != '\x0b' && c != '\f')
-            return B_False;
+            return false;
     }
-    return B_True;
+    return true;
 }
 
-B_bool B_bytesD_istitle(B_bytes s) {
+bool B_bytesD_istitle(B_bytes s) {
     if (s->nbytes==0)
-        return B_False;
-    int incasedrun = 0;
+        return false;
+    bool incasedrun = false;
     for (int i=0; i < s->nbytes; i++) {
         unsigned char c = s->str[i];
         if (c >='A' && c <= 'Z') {
             if (incasedrun)
-                return B_False;
-            incasedrun = 1;
+                return false;
+            incasedrun = true;
         } else if (c >='a' && c <= 'z') {
             if (!incasedrun)
-                return B_False;
+                return false;
         } else
-            incasedrun = 0;
+            incasedrun = false;
     }
-    return B_True;
+    return true;
 }
 
-B_bool B_bytesD_isupper(B_bytes s) {
-    int has_upper = 0;
+bool B_bytesD_isupper(B_bytes s) {
+    bool has_upper = false;
     for (int i=0; i < s->nbytes; i++) {
         unsigned char c = s->str[i];
         if (c >= 'a' && c <= 'z')
-            return B_False;
+            return false;
         if (c >= 'a' && c <= 'z')
-            has_upper = 1;
+            has_upper = true;
     }
-    return toB_bool(has_upper);
+    return has_upper;
 }
 
 B_bytes B_bytesD_join(B_bytes s, B_Iterable wit, $WORD iter) {
@@ -3663,19 +3662,19 @@ B_list B_bytesD_splitlines(B_bytes s, B_bool keepends) {
     return res;
 }
 
-B_bool B_bytesD_startswith(B_bytes s, B_bytes sub, B_int start, B_int end) {
+bool B_bytesD_startswith(B_bytes s, B_bytes sub, B_int start, B_int end) {
     B_int st = start;
     B_int en = end;
-    if (fix_start_end(s->nbytes,&st,&en) < 0) return B_False;
+    if (fix_start_end(s->nbytes,&st,&en) < 0) return false;
     unsigned char *p = s->str + fromB_int(st);
-    if (sub->nbytes > 0 && p+sub->nbytes > s->str+s->nbytes) return B_False;
+    if (sub->nbytes > 0 && p+sub->nbytes > s->str+s->nbytes) return false;
     unsigned char *q = sub->str;
     for (int i=0; i<sub->nbytes; i++) {
         if (p >= s->str + fromB_int(en) || *p++ != *q++) {
-            return B_False;
+            return false;
         }
     }
-    return B_True;
+    return true;
 }
 
 
@@ -3717,91 +3716,91 @@ B_bytes B_bytesD_zfill(B_bytes s, int64_t width) {
 // Ord
 
 
-B_bool B_OrdD_bytesD___eq__ (B_OrdD_bytes wit, B_bytes a, B_bytes b) {
+bool B_OrdD_bytesD___eq__ (B_OrdD_bytes wit, B_bytes a, B_bytes b) {
     if (a->nbytes != b->nbytes)
-        return B_False;
+        return false;
     for (int i=0; i < a->nbytes; i++)
         if (a->str[i] != b->str[i])
-            return B_False;
-    return B_True;
+            return false;
+    return true;
 }
 
-B_bool B_OrdD_bytesD___ne__ (B_OrdD_bytes wit, B_bytes a, B_bytes b) {
-    return  toB_bool(!B_OrdD_bytesD___eq__(wit,a,b)->val);
+bool B_OrdD_bytesD___ne__ (B_OrdD_bytes wit, B_bytes a, B_bytes b) {
+    return !B_OrdD_bytesD___eq__(wit,a,b);
 }
 
-B_bool B_OrdD_bytesD___lt__ (B_OrdD_bytes wit, B_bytes a, B_bytes b) {
+bool B_OrdD_bytesD___lt__ (B_OrdD_bytes wit, B_bytes a, B_bytes b) {
     int minl = a->nbytes<b->nbytes ? a->nbytes : b->nbytes;
     int i=0;
     while (i<minl && a->str[i]==b->str[i]) i++;
     if (i==a->nbytes)
-        return toB_bool(i<b->nbytes);
+        return i<b->nbytes;
     if (i==b->nbytes)
-        return B_False;
-    return toB_bool(a->str[i]<b->str[i]);
+        return false;
+    return a->str[i]<b->str[i];
 }
 
-B_bool B_OrdD_bytesD___le__ (B_OrdD_bytes wit, B_bytes a, B_bytes b){
-    return toB_bool(!B_OrdD_bytesD___lt__(wit,b,a)->val);
+bool B_OrdD_bytesD___le__ (B_OrdD_bytes wit, B_bytes a, B_bytes b){
+    return !B_OrdD_bytesD___lt__(wit,b,a);
 }
 
-B_bool B_OrdD_bytesD___gt__ (B_OrdD_bytes wit, B_bytes a, B_bytes b){
+bool B_OrdD_bytesD___gt__ (B_OrdD_bytes wit, B_bytes a, B_bytes b){
     return B_OrdD_bytesD___lt__(wit,b,a);
 }
 
-B_bool B_OrdD_bytesD___ge__ (B_OrdD_bytes wit, B_bytes a, B_bytes b){
-    return toB_bool(!B_OrdD_bytesD___lt__(wit,a,b)->val);
+bool B_OrdD_bytesD___ge__ (B_OrdD_bytes wit, B_bytes a, B_bytes b){
+    return !B_OrdD_bytesD___lt__(wit,a,b);
 }
 
 // Container
 
 // Iterable ///////////////////////////////////////////////////////////////////////////
 
-B_IteratorB_bytes B_IteratorB_bytesG_new(B_bytes str) {
-    return $NEW(B_IteratorB_bytes, str);
+B_IteratorD_bytes B_IteratorD_bytesG_new(B_bytes str) {
+    return $NEW(B_IteratorD_bytes, str);
 }
 
-B_NoneType B_IteratorB_bytesD_init(B_IteratorB_bytes self, B_bytes str) {
+B_NoneType B_IteratorD_bytesD_init(B_IteratorD_bytes self, B_bytes str) {
     self->src = str;
     self->nxt = 0;
     return B_None;
 }
 
-void B_IteratorB_bytesD_serialize(B_IteratorB_bytes self,$Serial$state state) {
+void B_IteratorD_bytesD_serialize(B_IteratorD_bytes self,$Serial$state state) {
     $step_serialize(self->src,state);
     $step_serialize(toB_int(self->nxt),state);
 }
 
 
-B_IteratorB_bytes B_IteratorB_bytes$_deserialize(B_IteratorB_bytes res, $Serial$state state) {
+B_IteratorD_bytes B_IteratorD_bytes$_deserialize(B_IteratorD_bytes res, $Serial$state state) {
     if (!res)
-        res = $DNEW(B_IteratorB_bytes,state);
+        res = $DNEW(B_IteratorD_bytes,state);
     res->src = (B_bytes)$step_deserialize(state);
     res->nxt = fromB_int((B_int)$step_deserialize(state));
     return res;
 }
 
-B_bool B_IteratorB_bytesD_bool(B_IteratorB_bytes self) {
-    return B_True;
+bool B_IteratorD_bytesD_bool(B_IteratorD_bytes self) {
+    return true;
 }
 
-B_str B_IteratorB_bytesD_str(B_IteratorB_bytes self) {
+B_str B_IteratorD_bytesD_str(B_IteratorD_bytes self) {
     return $FORMAT("<bytes iterator object at %p>", self);
 }
 
 // this is next function for forward iteration
-static B_int B_IteratorB_bytesD_next(B_IteratorB_bytes self) {
+static B_int B_IteratorD_bytesD_next(B_IteratorD_bytes self) {
     if (self->nxt >= self->src->nbytes)
         $RAISE ((B_BaseException)$NEW(B_StopIteration, to$str("bytes iterator terminated")));
     return toB_int(self->src->str[self->nxt++]);
 }
 
-struct B_IteratorB_bytesG_class B_IteratorB_bytesG_methods = {"B_IteratorB_bytes",UNASSIGNED,($SuperG_class)&B_IteratorG_methods, B_IteratorB_bytesD_init,
-                                                        B_IteratorB_bytesD_serialize, B_IteratorB_bytes$_deserialize,
-                                                        B_IteratorB_bytesD_bool, B_IteratorB_bytesD_str,  B_IteratorB_bytesD_str, B_IteratorB_bytesD_next};
+struct B_IteratorD_bytesG_class B_IteratorD_bytesG_methods = {"B_IteratorD_bytes",UNASSIGNED,($SuperG_class)&B_IteratorG_methods, B_IteratorD_bytesD_init,
+                                                        B_IteratorD_bytesD_serialize, B_IteratorD_bytes$_deserialize,
+                                                        B_IteratorD_bytesD_bool, B_IteratorD_bytesD_str,  B_IteratorD_bytesD_str, B_IteratorD_bytesD_next};
 
 B_Iterator B_ContainerD_bytesD___iter__ (B_ContainerD_bytes wit, B_bytes str) {
-    return (B_Iterator)$NEW(B_IteratorB_bytes,str);
+    return (B_Iterator)$NEW(B_IteratorD_bytes,str);
 }
 
 B_bytes B_ContainerD_bytesD___fromiter__ (B_ContainerD_bytes wit, B_Iterable wit2, $WORD iter) {
@@ -3812,19 +3811,19 @@ int64_t B_ContainerD_bytesD___len__ (B_ContainerD_bytes wit, B_bytes str) {
     return (int64_t)str->nbytes;
 }
 
-B_bool B_ContainerD_bytesD___contains__ (B_ContainerD_bytes wit, B_bytes str, B_int n) {
-    long res = 0;
+bool B_ContainerD_bytesD___contains__ (B_ContainerD_bytes wit, B_bytes str, B_int n) {
+    bool res = false;
     for (int i=0; i < str->nbytes; i++) {
         if (str->str[i] == (unsigned char)n->val) {
-            res = 1;
+            res = true;
             break;
         }
     }
-    return toB_bool(res);
+    return res;
 }
 
-B_bool B_ContainerD_bytesD___containsnot__ (B_ContainerD_bytes wit, B_bytes str, B_int n) {
-    return toB_bool(!B_ContainerD_bytesD___contains__(wit, str, n)->val);
+bool B_ContainerD_bytesD___containsnot__ (B_ContainerD_bytes wit, B_bytes str, B_int n) {
+    return !B_ContainerD_bytesD___contains__(wit, str, n);
 }
 
 // Sliceable
@@ -3902,17 +3901,17 @@ B_bytes B_TimesD_bytesD___mul__ (B_TimesD_bytes wit, B_bytes a, B_int n) {
 // Hashable
 
 
-B_bool B_HashableD_bytesD___eq__ (B_HashableD_bytes wit, B_bytes a, B_bytes b) {
+bool B_HashableD_bytesD___eq__ (B_HashableD_bytes wit, B_bytes a, B_bytes b) {
     if (a->nbytes != b->nbytes)
-        return B_False;
+        return false;
     for (int i=0; i < a->nbytes; i++)
         if (a->str[i] != b->str[i])
-            return B_False;
-    return B_True;
+            return false;
+    return true;
 }
 
-B_bool B_HashableD_bytesD___ne__ (B_HashableD_bytes wit, B_bytes a, B_bytes b) {
-    return  toB_bool(!B_HashableD_bytesD___eq__(wit,a,b)->val);
+bool B_HashableD_bytesD___ne__ (B_HashableD_bytes wit, B_bytes a, B_bytes b) {
+    return  !B_HashableD_bytesD___eq__(wit,a,b);
 }
 
 B_NoneType B_HashableD_bytesD_hash(B_HashableD_bytes wit, B_bytes a, B_hasher h) {
@@ -4083,326 +4082,7 @@ B_str $default__str__(B_value self) {
     return $FORMAT("<%s object at %p>", self->$class->$GCINFO, self);
 }
 
-
-
-// Static witnesses
-
-
-/*
-struct B_OrdD_strG_class  B_OrdD_strG_methods = {
-    "B_OrdD_str",
-    UNASSIGNED,
-    ($SuperG_class)&B_OrdG_methods,
-    (B_NoneType (*)(B_OrdD_str))$default__init__,
-    B_OrdD_strD___serialize__,
-    B_OrdD_strD___deserialize__,
-    (B_bool (*)(B_OrdD_str))$default__bool__,
-    (B_str (*)(B_OrdD_str))$default__str__,
-    (B_str (*)(B_OrdD_str))$default__str__,
-    B_OrdD_strD___eq__,
-    B_OrdD_strD___ne__,
-    B_OrdD_strD___lt__,
-    B_OrdD_strD___le__,
-    B_OrdD_strD___gt__,
-    B_OrdD_strD___ge__
-};
-
-struct B_OrdD_str B_OrdD_str_instance = {&B_OrdD_strG_methods};
-B_OrdD_str B_OrdD_strG_witness = &B_OrdD_str_instance;
-
-struct B_ContainerD_strG_class  B_ContainerD_strG_methods = {
-    "B_ContainerD_str",
-    UNASSIGNED,
-    ($SuperG_class)&B_ContainerG_methods,
-    (B_NoneType (*)(B_ContainerD_str))$default__init__,
-    B_ContainerD_strD___serialize__,
-    B_ContainerD_strD___deserialize__,
-    (B_bool (*)(B_ContainerD_str))$default__bool__,
-    (B_str (*)(B_ContainerD_str))$default__str__,
-    (B_str (*)(B_ContainerD_str))$default__str__,
-    B_ContainerD_strD___iter__,
-    NULL,
-    B_ContainerD_strD___len__,
-    B_ContainerD_strD___contains__,
-    B_ContainerD_strD___containsnot__
-};
-
-struct B_ContainerD_str B_ContainerD_str_instance = {&B_ContainerD_strG_methods};
-B_ContainerD_str B_ContainerD_strG_witness = &B_ContainerD_str_instance;
-
-
-struct B_SliceableD_strG_class  B_SliceableD_strG_methods = {
-    "B_SliceableD_str",
-    UNASSIGNED,
-    ($SuperG_class)&B_SliceableG_methods,
-    (B_NoneType (*)(B_SliceableD_str))$default__init__,
-    B_SliceableD_strD___serialize__,
-    B_SliceableD_strD___deserialize__,
-    (B_bool (*)(B_SliceableD_str))$default__bool__,
-    (B_str (*)(B_SliceableD_str))$default__str__,
-    (B_str (*)(B_SliceableD_str))$default__str__,
-    B_SliceableD_strD___getitem__,
-    B_SliceableD_strD___setitem__,
-    B_SliceableD_strD___delitem__,
-    B_SliceableD_strD___getslice__,
-    B_SliceableD_strD___setslice__,
-    B_SliceableD_strD___delslice__
-};
-
-struct B_SliceableD_str B_SliceableD_str_instance = {&B_SliceableD_strG_methods};
-B_SliceableD_str B_SliceableD_strG_witness = &B_SliceableD_str_instance;
-
-struct B_TimesD_strG_class  B_TimesD_strG_methods = {
-    "B_TimesD_str",
-    UNASSIGNED,
-    ($SuperG_class)&B_TimesG_methods,
-    (B_NoneType (*)(B_TimesD_str))$default__init__,
-    B_TimesD_strD___serialize__,
-    B_TimesD_strD___deserialize__,
-    (B_bool (*)(B_TimesD_str))$default__bool__,
-    (B_str (*)(B_TimesD_str))$default__str__,
-    (B_str (*)(B_TimesD_str))$default__str__,
-    B_TimesD_strD___add__,
-    (B_str (*)(B_TimesD_str, B_str, B_str))B_PlusD___iadd__,
-    B_TimesD_strD___mul__,
-    (B_str (*)(B_TimesD_str, B_str, B_int))B_TimesD___imul__,
-
-};
-
-struct B_TimesD_str B_TimesD_str_instance = {&B_TimesD_strG_methods};
-B_TimesD_str B_TimesD_strG_witness = &B_TimesD_str_instance;
-
-struct B_HashableD_strG_class  B_HashableD_strG_methods = {
-    "B_HashableD_str",
-    UNASSIGNED,
-    ($SuperG_class)&B_HashableG_methods,
-    (B_NoneType (*)(B_HashableD_str))$default__init__,
-    B_HashableD_strD___serialize__,
-    B_HashableD_strD___deserialize__,
-    (B_bool (*)(B_HashableD_str))$default__bool__,
-    (B_str (*)(B_HashableD_str))$default__str__,
-    (B_str (*)(B_HashableD_str))$default__str__,
-    B_HashableD_strD___eq__,
-    B_HashableD_strD___ne__
-};
-
-struct B_HashableD_str B_HashableD_str_instance = {&B_HashableD_strG_methods};
-B_HashableD_str B_HashableD_strG_witness = &B_HashableD_str_instance;
-
-struct B_SequenceD_bytearray  B_SequenceD_bytearray_instance;
-struct B_CollectionD_SequenceD_bytearray B_CollectionD_SequenceD_bytearray_instance;
-struct B_TimesD_SequenceD_bytearray B_TimesD_SequenceD_bytearray_instance;
-
-
-struct B_OrdD_bytearrayG_class  B_OrdD_bytearrayG_methods = {
-    "B_OrdD_bytearray",
-    UNASSIGNED,
-    ($SuperG_class)&B_OrdG_methods,
-    (B_NoneType (*)(B_OrdD_bytearray))$default__init__,
-    B_OrdD_bytearrayD___serialize__,
-    B_OrdD_bytearrayD___deserialize__,
-    (B_bool (*)(B_OrdD_bytearray))$default__bool__,
-    (B_str (*)(B_OrdD_bytearray))$default__str__,
-    (B_str (*)(B_OrdD_bytearray))$default__str__,
-    B_OrdD_bytearrayD___eq__, B_OrdD_bytearrayD___ne__,
-    B_OrdD_bytearrayD___lt__, B_OrdD_bytearrayD___le__,
-    B_OrdD_bytearrayD___gt__, B_OrdD_bytearrayD___ge__
-};
-
-struct B_OrdD_bytearray B_OrdD_bytearray_instance = {&B_OrdD_bytearrayG_methods};
-B_OrdD_bytearray B_OrdD_bytearrayG_witness = &B_OrdD_bytearray_instance;
-
-struct B_SequenceD_bytearrayG_class B_SequenceD_bytearrayG_methods = {
-    "B_SequenceD_bytearray",
-    UNASSIGNED,
-    ($SuperG_class)&B_SequenceG_methods,
-    (B_NoneType (*)(B_SequenceD_bytearray))$default__init__,
-    B_SequenceD_bytearrayD___serialize__,
-    B_SequenceD_bytearrayD___deserialize__,
-    (B_bool (*)(B_SequenceD_bytearray))$default__bool__,
-    (B_str (*)(B_SequenceD_bytearray))$default__str__,
-    (B_str (*)(B_SequenceD_bytearray))$default__str__,
-    B_SequenceD_bytearrayD___getitem__,
-    B_SequenceD_bytearrayD___setitem__,
-    B_SequenceD_bytearrayD___delitem__,
-    B_SequenceD_bytearrayD___getslice__,
-    B_SequenceD_bytearrayD___setslice__,
-    B_SequenceD_bytearrayD___delslice__,
-    B_SequenceD_bytearrayD___reversed__,
-    B_SequenceD_bytearray$insert,
-    B_SequenceD_bytearray$append,
-    B_SequenceD_bytearray$reverse
-};
-
-struct B_SequenceD_bytearray B_SequenceD_bytearray_instance = {
-    &B_SequenceD_bytearrayG_methods,
-    (B_Eq)&B_OrdD_intG_methods,
-    (B_Collection)&B_CollectionD_SequenceD_bytearray_instance,
-    (B_Times)&B_TimesD_SequenceD_bytearray_instance
-};
-B_SequenceD_bytearray B_SequenceD_bytearrayG_witness = &B_SequenceD_bytearray_instance;
-
-struct B_CollectionD_SequenceD_bytearrayG_class B_CollectionD_SequenceD_bytearrayG_methods = {
-    "B_CollectionD_SequenceD_bytearray",
-    UNASSIGNED,
-    ($SuperG_class)&B_CollectionG_methods,
-    B_CollectionD_SequenceD_bytearrayD___init__,
-    B_CollectionD_SequenceD_bytearrayD___serialize__,
-    B_CollectionD_SequenceD_bytearrayD___deserialize__,
-    (B_bool (*)(B_CollectionD_SequenceD_bytearray))$default__bool__,
-    (B_str (*)(B_CollectionD_SequenceD_bytearray))$default__str__,
-    (B_str (*)(B_CollectionD_SequenceD_bytearray))$default__str__,
-    B_CollectionD_SequenceD_bytearrayD___iter__,
-    B_CollectionD_SequenceD_bytearrayD___fromiter__,
-    B_CollectionD_SequenceD_bytearrayD___len__
-};
-
-struct B_CollectionD_SequenceD_bytearray B_CollectionD_SequenceD_bytearray_instance = {&B_CollectionD_SequenceD_bytearrayG_methods,(B_Sequence)&B_SequenceD_bytearray_instance};
-B_CollectionD_SequenceD_bytearray B_CollectionD_SequenceD_bytearrayG_witness = &B_CollectionD_SequenceD_bytearray_instance;
-
-struct B_TimesD_SequenceD_bytearrayG_class  B_TimesD_SequenceD_bytearrayG_methods = {
-    "B_TimesD_SequenceD_bytearray",
-    UNASSIGNED,
-    ($SuperG_class)&B_TimesG_methods,
-    B_TimesD_SequenceD_bytearrayD___init__,
-    B_TimesD_SequenceD_bytearrayD___serialize__,
-    B_TimesD_SequenceD_bytearrayD___deserialize__,
-    (B_bool (*)(B_TimesD_SequenceD_bytearray))$default__bool__,
-    (B_str (*)(B_TimesD_SequenceD_bytearray))$default__str__,
-    (B_str (*)(B_TimesD_SequenceD_bytearray))$default__str__,
-    B_TimesD_SequenceD_bytearrayD___add__,
-    (B_bytearray (*)(B_TimesD_SequenceD_bytearray, B_bytearray, B_bytearray))B_PlusD___iadd__,
-    B_TimesD_SequenceD_bytearrayD___mul__,
-    (B_bytearray (*)(B_TimesD_SequenceD_bytearray, B_bytearray, B_int))B_TimesD___imul__,
-};
-
-struct B_TimesD_SequenceD_bytearray B_TimesD_SequenceD_bytearray_instance = {&B_TimesD_SequenceD_bytearrayG_methods};
-B_TimesD_SequenceD_bytearray B_TimesD_SequenceD_bytearrayG_witness = &B_TimesD_SequenceD_bytearray_instance;
-
-struct B_ContainerD_bytearrayG_class B_ContainerD_bytearrayG_methods = {
-    "B_ContainerD_bytearray",
-    UNASSIGNED,
-    ($SuperG_class)&B_ContainerG_methods,
-    B_ContainerD_bytearrayD___init__,
-    B_ContainerD_bytearrayD___serialize__,
-    B_ContainerD_bytearrayD___deserialize__,
-    (B_bool (*)(B_ContainerD_bytearray))$default__bool__,
-    (B_str (*)(B_ContainerD_bytearray))$default__str__,
-    (B_str (*)(B_ContainerD_bytearray))$default__str__,
-    B_ContainerD_bytearrayD___iter__,
-    B_ContainerD_bytearrayD___fromiter__,
-    B_ContainerD_bytearrayD___len__,
-    B_ContainerD_bytearrayD___contains__,
-    B_ContainerD_bytearrayD___containsnot__
-};
-
-struct B_ContainerD_bytearray B_ContainerD_bytearray_instance = {&B_ContainerD_bytearrayG_methods};
-B_ContainerD_bytearray B_ContainerD_bytearrayG_witness = &B_ContainerD_bytearray_instance;
-
-
-
-struct B_OrdD_bytesG_class  B_OrdD_bytesG_methods = {
-    "B_OrdD_bytes",
-    UNASSIGNED,
-    ($SuperG_class)&B_OrdG_methods,
-    (B_NoneType (*)(B_OrdD_bytes))$default__init__,
-    B_OrdD_bytesD___serialize__,
-    B_OrdD_bytesD___deserialize__,
-    (B_bool (*)(B_OrdD_bytes))$default__bool__,
-    (B_str (*)(B_OrdD_bytes))$default__str__,
-    (B_str (*)(B_OrdD_bytes))$default__str__,
-    B_OrdD_bytesD___eq__,
-    B_OrdD_bytesD___ne__,
-    B_OrdD_bytesD___lt__,
-    B_OrdD_bytesD___le__,
-    B_OrdD_bytesD___gt__,
-    B_OrdD_bytesD___ge__
-};
-
-struct B_OrdD_bytes B_OrdD_bytes_instance = {&B_OrdD_bytesG_methods};
-B_OrdD_bytes B_OrdD_bytesG_witness = &B_OrdD_bytes_instance;
-
-struct B_ContainerD_bytesG_class  B_ContainerD_bytesG_methods = {
-    "B_ContainerD_bytes",
-    UNASSIGNED,
-    ($SuperG_class)&B_ContainerG_methods,
-    B_ContainerD_bytesD___init__,
-    B_ContainerD_bytesD___serialize__,
-    B_ContainerD_bytesD___deserialize__,
-    (B_bool (*)(B_ContainerD_bytes))$default__bool__,
-    (B_str (*)(B_ContainerD_bytes))$default__str__,
-    (B_str (*)(B_ContainerD_bytes))$default__str__,
-    B_ContainerD_bytesD___iter__,
-    NULL,
-    B_ContainerD_bytesD___len__,
-    B_ContainerD_bytesD___contains__,
-    B_ContainerD_bytesD___containsnot__
-};
-
-struct B_ContainerD_bytes B_ContainerD_bytes_instance = {&B_ContainerD_bytesG_methods};
-B_ContainerD_bytes B_ContainerD_bytesG_witness = &B_ContainerD_bytes_instance;
-
-
-struct B_SliceableD_bytesG_class  B_SliceableD_bytesG_methods = {
-    "B_SliceableD_bytes",
-    UNASSIGNED,
-    ($SuperG_class)&B_SliceableG_methods,
-    (B_NoneType (*)(B_SliceableD_bytes))$default__init__,
-    B_SliceableD_bytesD___serialize__,
-    B_SliceableD_bytesD___deserialize__,
-    (B_bool (*)(B_SliceableD_bytes))$default__bool__,
-    (B_str (*)(B_SliceableD_bytes))$default__str__,
-    (B_str (*)(B_SliceableD_bytes))$default__str__,
-    B_SliceableD_bytesD___getitem__,
-    B_SliceableD_bytesD___setitem__,
-    B_SliceableD_bytesD___delitem__,
-    B_SliceableD_bytesD___getslice__,
-    B_SliceableD_bytesD___setslice__,
-    B_SliceableD_bytesD___delslice__
-};
-
-struct B_SliceableD_bytes B_SliceableD_bytes_instance = {&B_SliceableD_bytesG_methods};
-B_SliceableD_bytes B_SliceableD_bytesG_witness = &B_SliceableD_bytes_instance;
-
-struct B_TimesD_bytesG_class  B_TimesD_bytesG_methods = {
-    "B_TimesD_bytes",
-    UNASSIGNED,
-    ($SuperG_class)&B_TimesG_methods,
-    (B_NoneType (*)(B_TimesD_bytes))$default__init__,
-    B_TimesD_bytesD___serialize__,
-    B_TimesD_bytesD___deserialize__,
-    (B_bool (*)(B_TimesD_bytes))$default__bool__,
-    (B_str (*)(B_TimesD_bytes))$default__str__,
-    (B_str (*)(B_TimesD_bytes))$default__str__,
-    B_TimesD_bytesD___add__,
-    (B_bytes (*)(B_TimesD_bytes, B_bytes, B_bytes))B_PlusD___iadd__,
-    B_TimesD_bytesD___mul__,
-    (B_bytes (*)(B_TimesD_bytes, B_bytes, B_int))B_TimesD___imul__,
-
-};
-
-struct B_TimesD_bytes B_TimesD_bytes_instance = {&B_TimesD_bytesG_methods};
-B_TimesD_bytes B_TimesD_bytesG_witness = &B_TimesD_bytes_instance;
-
-struct B_HashableD_bytesG_class  B_HashableD_bytesG_methods = {
-    "B_HashableD_bytes",
-    UNASSIGNED,
-    ($SuperG_class)&B_HashableG_methods,
-    (B_NoneType (*)(B_HashableD_bytes))$default__init__,
-    B_HashableD_bytesD___serialize__,
-    B_HashableD_bytesD___deserialize__,
-    (B_bool (*)(B_HashableD_bytes))$default__bool__,
-    (B_str (*)(B_HashableD_bytes))$default__str__,
-    (B_str (*)(B_HashableD_bytes))$default__str__,
-    B_HashableD_bytesD___eq__,
-    B_HashableD_bytesD___ne__
-};
-
-struct B_HashableD_bytes B_HashableD_bytes_instance = {&B_HashableD_bytesG_methods};
-B_HashableD_bytes B_HashableD_bytesG_witness = &B_HashableD_bytes_instance;
-
-*/
-
+ 
 B_str $FORMAT(const char *format, ...) {
     va_list args;
     va_start(args, format);

--- a/base/builtin/str.c
+++ b/base/builtin/str.c
@@ -1042,7 +1042,7 @@ bool B_strD_isalpha(B_str s) {
     int codepoint;
     int nbytes;
     if (s->nchars == 0)
-        return B_False;
+        return false;
     for (int i=0; i < s->nchars; i++) {
         nbytes = utf8proc_iterate(p,-1,&codepoint);
         utf8proc_category_t cat = utf8proc_category(codepoint);
@@ -1162,7 +1162,7 @@ bool B_strD_isupper(B_str s) {
     int nbytes;
     int hascased = false;
     if (s->nchars == 0)
-        return B_False;
+        return false;
     for (int i=0; i < s->nchars; i++) {
         nbytes = utf8proc_iterate(p,-1,&codepoint);
         utf8proc_category_t cat = utf8proc_category(codepoint);

--- a/base/builtin/str.h
+++ b/base/builtin/str.h
@@ -22,29 +22,29 @@ B_str $FORMAT(const char *format, ...);
 
 // Iterators over str's ///////////////////////////////////////////////////////
 
-typedef struct B_IteratorB_str *B_IteratorB_str; ;
+typedef struct B_IteratorD_str *B_IteratorD_str; ;
 
-struct B_IteratorB_strG_class {
+struct B_IteratorD_strG_class {
     char *$GCINFO;
     int $class_id;
     $SuperG_class $superclass;
-    B_NoneType (*__init__)(B_IteratorB_str, B_str);
-    void (*__serialize__)(B_IteratorB_str,$Serial$state);
-    B_IteratorB_str (*__deserialize__)(B_IteratorB_str,$Serial$state);
-    B_bool (*__bool__)(B_IteratorB_str);
-    B_str (*__str__)(B_IteratorB_str);
-    B_str (*__repr__)(B_IteratorB_str);
-    B_str (*__next__)(B_IteratorB_str);
+    B_NoneType (*__init__)(B_IteratorD_str, B_str);
+    void (*__serialize__)(B_IteratorD_str,$Serial$state);
+    B_IteratorD_str (*__deserialize__)(B_IteratorD_str,$Serial$state);
+    bool (*__bool__)(B_IteratorD_str);
+    B_str (*__str__)(B_IteratorD_str);
+    B_str (*__repr__)(B_IteratorD_str);
+    B_str (*__next__)(B_IteratorD_str);
 };
 
-struct B_IteratorB_str {
-    struct B_IteratorB_strG_class *$class;
+struct B_IteratorD_str {
+    struct B_IteratorD_strG_class *$class;
     B_str src;
     int nxt;
 };
 
-extern struct  B_IteratorB_strG_class  B_IteratorB_strG_methods;
-B_IteratorB_str B_IteratorB_strG_new(B_str);
+extern struct  B_IteratorD_strG_class  B_IteratorD_strG_methods;
+B_IteratorD_str B_IteratorD_strG_new(B_str);
 
 // bytearray /////////////////////////////////////////////////////////////////////////////////////
 
@@ -63,29 +63,29 @@ unsigned char *fromB_bytearray(B_bytearray b);
 
 // Iterators over bytearrays ///////////////////////////////////////////////////////
 
-typedef struct B_IteratorB_bytearray *B_IteratorB_bytearray; ;
+typedef struct B_IteratorD_bytearray *B_IteratorD_bytearray; ;
 
-struct B_IteratorB_bytearrayG_class {
+struct B_IteratorD_bytearrayG_class {
     char *$GCINFO;
     int $class_id;
     $SuperG_class $superclass;
-    B_NoneType (*__init__)(B_IteratorB_bytearray, B_bytearray);
-    void (*__serialize__)(B_IteratorB_bytearray,$Serial$state);
-    B_IteratorB_bytearray (*__deserialize__)(B_IteratorB_bytearray,$Serial$state);
-    B_bool (*__bool__)(B_IteratorB_bytearray);
-    B_str (*__str__)(B_IteratorB_bytearray);
-    B_str (*__repr__)(B_IteratorB_bytearray);
-    B_int (*__next__)(B_IteratorB_bytearray);
+    B_NoneType (*__init__)(B_IteratorD_bytearray, B_bytearray);
+    void (*__serialize__)(B_IteratorD_bytearray,$Serial$state);
+    B_IteratorD_bytearray (*__deserialize__)(B_IteratorD_bytearray,$Serial$state);
+    bool (*__bool__)(B_IteratorD_bytearray);
+    B_str (*__str__)(B_IteratorD_bytearray);
+    B_str (*__repr__)(B_IteratorD_bytearray);
+    B_int (*__next__)(B_IteratorD_bytearray);
 };
 
-struct B_IteratorB_bytearray {
-    struct B_IteratorB_bytearrayG_class *$class;
+struct B_IteratorD_bytearray {
+    struct B_IteratorD_bytearrayG_class *$class;
     B_bytearray src;
     int nxt;
 };
 
-extern struct  B_IteratorB_bytearrayG_class  B_IteratorB_bytearrayG_methods;
-B_IteratorB_bytearray B_IteratorB_bytearrayG_new(B_bytearray);
+extern struct  B_IteratorD_bytearrayG_class  B_IteratorD_bytearrayG_methods;
+B_IteratorD_bytearray B_IteratorD_bytearrayG_new(B_bytearray);
 
 // bytes /////////////////////////////////////////////////////////////////////////////////////
 
@@ -108,29 +108,29 @@ char *fromB_bytes(B_bytes b);
 // Iterators over bytes ///////////////////////////////////////////////////////
 
 
-typedef struct B_IteratorB_bytes *B_IteratorB_bytes; ;
+typedef struct B_IteratorD_bytes *B_IteratorD_bytes; ;
 
-struct B_IteratorB_bytesG_class {
+struct B_IteratorD_bytesG_class {
     char *$GCINFO;
     int $class_id;
     $SuperG_class $superclass;
-    B_NoneType (*__init__)(B_IteratorB_bytes, B_bytes);
-    void (*__serialize__)(B_IteratorB_bytes,$Serial$state);
-    B_IteratorB_bytes (*__deserialize__)(B_IteratorB_bytes,$Serial$state);
-    B_bool (*__bool__)(B_IteratorB_bytes);
-    B_str (*__str__)(B_IteratorB_bytes);
-    B_str (*__repr__)(B_IteratorB_bytes);
-    B_int (*__next__)(B_IteratorB_bytes);
+    B_NoneType (*__init__)(B_IteratorD_bytes, B_bytes);
+    void (*__serialize__)(B_IteratorD_bytes,$Serial$state);
+    B_IteratorD_bytes (*__deserialize__)(B_IteratorD_bytes,$Serial$state);
+    bool (*__bool__)(B_IteratorD_bytes);
+    B_str (*__str__)(B_IteratorD_bytes);
+    B_str (*__repr__)(B_IteratorD_bytes);
+    B_int (*__next__)(B_IteratorD_bytes);
 };
 
-struct B_IteratorB_bytes {
-    struct B_IteratorB_bytesG_class *$class;
+struct B_IteratorD_bytes {
+    struct B_IteratorD_bytesG_class *$class;
     B_bytes src;
     int nxt;
 };
 
-extern struct  B_IteratorB_bytesG_class  B_IteratorB_bytesG_methods;
-B_IteratorB_bytes B_IteratorB_bytesG_new(B_bytes);
+extern struct  B_IteratorD_bytesG_class  B_IteratorD_bytesG_methods;
+B_IteratorD_bytes B_IteratorD_bytesG_new(B_bytes);
 
 // Internal auxiliary function /////////////////////////////////////////////
 

--- a/base/builtin/str.h260606
+++ b/base/builtin/str.h260606
@@ -1,0 +1,217 @@
+struct B_strG_class;
+
+struct B_str {
+    struct B_strG_class *$class;
+    int nbytes;              // length of str in bytes
+    int nchars;              // length of str in Unicode chars
+    unsigned char *str;      // str is UTF-8 encoded.
+};
+
+// Constructor; str must be a null-terminated, correctly UTF-8-encoded string.
+// The constructor checks this and returns a B_str value.
+B_str to$str(char *str);  //Dare not remove this
+
+B_str toB_str(char *str);
+
+B_str to_str_noc(char *str);
+
+// Destructor; recover the internal string.
+unsigned char *fromB_str(B_str str);
+
+B_str $FORMAT(const char *format, ...);
+
+// Iterators over str's ///////////////////////////////////////////////////////
+
+typedef struct B_IteratorB_str *B_IteratorB_str; ;
+
+struct B_IteratorB_strG_class {
+    char *$GCINFO;
+    int $class_id;
+    $SuperG_class $superclass;
+    B_NoneType (*__init__)(B_IteratorB_str, B_str);
+    void (*__serialize__)(B_IteratorB_str,$Serial$state);
+    B_IteratorB_str (*__deserialize__)(B_IteratorB_str,$Serial$state);
+    B_bool (*__bool__)(B_IteratorB_str);
+    B_str (*__str__)(B_IteratorB_str);
+    B_str (*__repr__)(B_IteratorB_str);
+    B_str (*__next__)(B_IteratorB_str);
+};
+
+struct B_IteratorB_str {
+    struct B_IteratorB_strG_class *$class;
+    B_str src;
+    int nxt;
+};
+
+extern struct  B_IteratorB_strG_class  B_IteratorB_strG_methods;
+B_IteratorB_str B_IteratorB_strG_new(B_str);
+
+// bytearray /////////////////////////////////////////////////////////////////////////////////////
+
+
+
+struct B_bytearray {
+    struct B_bytearrayG_class *$class;
+    int nbytes;
+    unsigned char *str;
+    int capacity;
+};
+
+ 
+B_bytearray toB_bytearray(char *str); 
+unsigned char *fromB_bytearray(B_bytearray b);
+
+// Iterators over bytearrays ///////////////////////////////////////////////////////
+
+typedef struct B_IteratorB_bytearray *B_IteratorB_bytearray; ;
+
+struct B_IteratorB_bytearrayG_class {
+    char *$GCINFO;
+    int $class_id;
+    $SuperG_class $superclass;
+    B_NoneType (*__init__)(B_IteratorB_bytearray, B_bytearray);
+    void (*__serialize__)(B_IteratorB_bytearray,$Serial$state);
+    B_IteratorB_bytearray (*__deserialize__)(B_IteratorB_bytearray,$Serial$state);
+    B_bool (*__bool__)(B_IteratorB_bytearray);
+    B_str (*__str__)(B_IteratorB_bytearray);
+    B_str (*__repr__)(B_IteratorB_bytearray);
+    B_int (*__next__)(B_IteratorB_bytearray);
+};
+
+struct B_IteratorB_bytearray {
+    struct B_IteratorB_bytearrayG_class *$class;
+    B_bytearray src;
+    int nxt;
+};
+
+extern struct  B_IteratorB_bytearrayG_class  B_IteratorB_bytearrayG_methods;
+B_IteratorB_bytearray B_IteratorB_bytearrayG_new(B_bytearray);
+
+// bytes /////////////////////////////////////////////////////////////////////////////////////
+
+
+struct B_bytes {
+    struct B_bytesG_class *$class;
+    int nbytes;
+    unsigned char *str;
+};
+
+B_bytes to$bytes(char *str);
+B_bytes to$bytesD_len(char *str, int len);
+B_bytes actBytesFromCString(char *str);
+B_bytes actBytesFromCStringNoCopy(char *str);
+B_bytes actBytesFromCStringLength(char *str, int len);
+B_bytes actBytesFromCStringLengthNoCopy(char *str, int length);
+char *fromB_bytes(B_bytes b);
+
+
+// Iterators over bytes ///////////////////////////////////////////////////////
+
+
+typedef struct B_IteratorB_bytes *B_IteratorB_bytes; ;
+
+struct B_IteratorB_bytesG_class {
+    char *$GCINFO;
+    int $class_id;
+    $SuperG_class $superclass;
+    B_NoneType (*__init__)(B_IteratorB_bytes, B_bytes);
+    void (*__serialize__)(B_IteratorB_bytes,$Serial$state);
+    B_IteratorB_bytes (*__deserialize__)(B_IteratorB_bytes,$Serial$state);
+    B_bool (*__bool__)(B_IteratorB_bytes);
+    B_str (*__str__)(B_IteratorB_bytes);
+    B_str (*__repr__)(B_IteratorB_bytes);
+    B_int (*__next__)(B_IteratorB_bytes);
+};
+
+struct B_IteratorB_bytes {
+    struct B_IteratorB_bytesG_class *$class;
+    B_bytes src;
+    int nxt;
+};
+
+extern struct  B_IteratorB_bytesG_class  B_IteratorB_bytesG_methods;
+B_IteratorB_bytes B_IteratorB_bytesG_new(B_bytes);
+
+// Internal auxiliary function /////////////////////////////////////////////
+
+// used in defining __str__ method for collection types (list, dict, set)
+B_str B_strD_join_par(char lpar,B_list elems, char rpar);
+
+B_str $default__str__(B_value);
+
+B_bool B_OrdD_strD___eq__ (B_OrdD_str wit, B_str a, B_str b);
+B_bool B_OrdD_strD___ne__ (B_OrdD_str wit, B_str a, B_str b);
+B_bool B_OrdD_strD___lt__ (B_OrdD_str wit, B_str a, B_str b);
+B_bool B_OrdD_strD___le__ (B_OrdD_str wit, B_str a, B_str b);
+B_bool B_OrdD_strD___ge__ (B_OrdD_str wit, B_str a, B_str b);
+B_bool B_OrdD_strD___gt__ (B_OrdD_str wit, B_str a, B_str b);
+B_bool B_HashableD_strD___eq__ (B_HashableD_str wit, B_str a, B_str b);
+B_bool B_HashableD_strD___ne__ (B_HashableD_str wit, B_str a, B_str b);
+B_NoneType B_HashableD_strD_hash(B_HashableD_str wit, B_str a, B_hasher h);
+B_str B_TimesD_strD___add__ (B_TimesD_str wit, B_str s, B_str t);
+B_str B_TimesD_strD___iadd__ (B_TimesD_str wit, B_str s, B_str t);
+B_str B_TimesD_strD___zero__ (B_TimesD_str wit);
+B_str B_TimesD_strD___mul__ (B_TimesD_str wit, B_str a, B_int n);
+B_str B_TimesD_strD___imul__ (B_TimesD_str wit, B_str a, B_int n);
+B_str B_ContainerD_strD___fromiter__ (B_ContainerD_str wit, B_Iterable wit2, $WORD iter);
+int64_t B_ContainerD_strD___len__ (B_ContainerD_str wit, B_str s);
+B_bool B_ContainerD_strD___contains__ (B_ContainerD_str wit, B_str s, B_str sub);
+B_bool B_ContainerD_strD___containsnot__ (B_ContainerD_str wit, B_str s, B_str sub);
+B_Iterator B_ContainerD_strD___iter__ (B_ContainerD_str wit, B_str s);
+B_str B_SliceableD_strD___getitem__ (B_SliceableD_str wit, B_str s, B_int i);
+B_NoneType B_SliceableD_strD___setitem__ (B_SliceableD_str wit, B_str str, B_int i, B_str val);
+B_NoneType B_SliceableD_strD___delitem__ (B_SliceableD_str wit, B_str str, B_int i);
+B_str B_SliceableD_strD___getslice__ (B_SliceableD_str wit, B_str s, B_slice slc);
+B_NoneType B_SliceableD_strD___setslice__ (B_SliceableD_str wit, B_str str, B_Iterable wit2, B_slice slc, $WORD iter);
+B_NoneType B_SliceableD_strD___delslice__ (B_SliceableD_str wit, B_str str, B_slice slc);
+
+B_bool B_OrdD_bytearrayD___eq__ (B_OrdD_bytearray wit, B_bytearray a, B_bytearray b);
+B_bool B_OrdD_bytearrayD___ne__ (B_OrdD_bytearray wit, B_bytearray a, B_bytearray b);
+B_bool B_OrdD_bytearrayD___lt__ (B_OrdD_bytearray wit, B_bytearray a, B_bytearray b);
+B_bool B_OrdD_bytearrayD___le__ (B_OrdD_bytearray wit, B_bytearray a, B_bytearray b);
+B_bool B_OrdD_bytearrayD___ge__ (B_OrdD_bytearray wit, B_bytearray a, B_bytearray b);
+B_bool B_OrdD_bytearrayD___gt__ (B_OrdD_bytearray wit, B_bytearray a, B_bytearray b);
+// B_bool B_HashableD_bytearrayD___eq__ (B_HashableD_bytearray wit, B_bytearray a, B_bytearray b);
+// B_bool B_HashableD_bytearrayD___ne__ (B_HashableD_bytearray wit, B_bytearray a, B_bytearray b);
+// B_NoneType B_HashableD_bytearrayD_hash(B_HashableD_bytearray wit, B_bytearray a, B_hasher h);
+B_bytearray B_TimesD_SequenceD_bytearrayD___add__ (B_TimesD_SequenceD_bytearray wit, B_bytearray s, B_bytearray t);
+B_bytearray B_TimesD_SequenceD_bytearrayD___iadd__ (B_TimesD_SequenceD_bytearray wit, B_bytearray s, B_bytearray t);
+B_bytearray B_TimesD_SequenceD_bytearrayD___zero__ (B_TimesD_SequenceD_bytearray wit);
+B_bytearray B_TimesD_SequenceD_bytearrayD___mul__ (B_TimesD_SequenceD_bytearray wit, B_bytearray a, B_int n);
+B_bytearray B_TimesD_SequenceD_bytearrayD___imul__ (B_TimesD_SequenceD_bytearray wit, B_bytearray a, B_int n);
+B_bytearray B_ContainerD_bytearrayD___fromiter__ (B_ContainerD_bytearray wit, B_Iterable wit2, $WORD iter);
+int64_t B_ContainerD_bytearrayD___len__ (B_ContainerD_bytearray wit, B_bytearray s);
+B_bool B_ContainerD_bytearrayD___contains__ (B_ContainerD_bytearray wit, B_bytearray s, B_int sub);
+B_bool B_ContainerD_bytearrayD___containsnot__ (B_ContainerD_bytearray wit, B_bytearray s, B_int sub);
+B_Iterator B_ContainerD_bytearrayD___iter__ (B_ContainerD_bytearray wit, B_bytearray s);
+B_int B_SequenceD_bytearrayD___getitem__ (B_SequenceD_bytearray wit, B_bytearray s, B_int i);
+B_NoneType B_SequenceD_bytearrayD___setitem__ (B_SequenceD_bytearray wit, B_bytearray s, B_int i, B_int val);
+B_NoneType B_SequenceD_bytearrayD___delitem__ (B_SequenceD_bytearray wit, B_bytearray s, B_int i);
+B_NoneType B_SequenceD_bytearrayD_insert(B_SequenceD_bytearray wit, B_bytearray self, int64_t n, B_int elem);
+B_NoneType B_SequenceD_bytearrayD_append(B_SequenceD_bytearray wit, B_bytearray self, B_int elem);
+B_NoneType B_SequenceD_bytearrayD_reverse(B_SequenceD_bytearray wit, B_bytearray self);
+B_Iterator B_SequenceD_bytearrayD___reversed__(B_SequenceD_bytearray wit, B_bytearray self);
+B_bytearray B_SequenceD_bytearrayD___getslice__ (B_SequenceD_bytearray wit, B_bytearray self, B_slice slc);
+B_NoneType B_SequenceD_bytearrayD___setslice__ (B_SequenceD_bytearray wit,  B_bytearray self, B_Iterable wit2, B_slice slc, $WORD iter);
+B_NoneType B_SequenceD_bytearrayD___delslice__ (B_SequenceD_bytearray wit,  B_bytearray self, B_slice slc);
+
+B_bool B_OrdD_bytesD___eq__ (B_OrdD_bytes wit, B_bytes a, B_bytes b);
+B_bool B_OrdD_bytesD___ne__ (B_OrdD_bytes wit, B_bytes a, B_bytes b);
+B_bool B_OrdD_bytesD___lt__ (B_OrdD_bytes wit, B_bytes a, B_bytes b);
+B_bool B_OrdD_bytesD___le__ (B_OrdD_bytes wit, B_bytes a, B_bytes b);
+B_bool B_OrdD_bytesD___ge__ (B_OrdD_bytes wit, B_bytes a, B_bytes b);
+B_bool B_OrdD_bytesD___gt__ (B_OrdD_bytes wit, B_bytes a, B_bytes b);
+B_bytes B_ContainerD_bytesD___fromiter__ (B_ContainerD_bytes wit, B_Iterable wit2, $WORD iter);
+int64_t B_ContainerD_bytesD___len__ (B_ContainerD_bytes wit, B_bytes s);
+B_Iterator B_ContainerD_bytesD___iter__ (B_ContainerD_bytes wit, B_bytes s);
+B_bool B_ContainerD_bytesD___contains__ (B_ContainerD_bytes wit, B_bytes s, B_int sub);
+B_bool B_ContainerD_bytesD___containsnot__ (B_ContainerD_bytes wit, B_bytes s, B_int sub);
+B_int B_SliceableD_bytesD___getitem__ (B_SliceableD_bytes wit, B_bytes s, B_int i);
+B_NoneType B_SliceableD_bytesD___setitem__ (B_SliceableD_bytes wit, B_bytes s, B_int i, B_int val);
+B_NoneType B_SliceableD_bytesD___delitem__ (B_SliceableD_bytes wit, B_bytes s, B_int i);
+B_bytes B_SliceableD_bytesD___getslice__ (B_SliceableD_bytes wit, B_bytes self, B_slice slc);
+B_NoneType B_SliceableD_bytesD___setslice__ (B_SliceableD_bytes wit,  B_bytes self, B_Iterable wit2, B_slice slc, $WORD iter);
+B_NoneType B_SliceableD_bytesD___delslice__ (B_SliceableD_bytes wit,  B_bytes self, B_slice slc);
+B_bytes B_TimesD_bytesD___add__ (B_TimesD_bytes wit, B_bytes a, B_bytes b);
+B_bytes B_TimesD_bytesD___zero__ (B_TimesD_bytes wit);
+B_bytes B_TimesD_bytesD___mul__ (B_TimesD_bytes wit, B_bytes a, B_int n);

--- a/base/builtin/timsort.c
+++ b/base/builtin/timsort.c
@@ -60,7 +60,7 @@
 #endif
 
 #ifndef SORT_CMP
-#define SORT_CMP(w, x, y)  (w->$class->__lt__(w, x, y)->val ? -1 : (w->$class->__eq__(w, x, y)->val ? 0 : 1))     //((x) < (y) ? -1 : ((x) == (y) ? 0 : 1))
+#define SORT_CMP(w, x, y)  (w->$class->__lt__(w, x, y)? -1 : (w->$class->__eq__(w, x, y)? 0 : 1))     //((x) < (y) ? -1 : ((x) == (y) ? 0 : 1))
 #endif
 
 #ifndef TIM_SORT_STACK_SIZE

--- a/base/builtin/tuple.c
+++ b/base/builtin/tuple.c
@@ -25,8 +25,8 @@ B_NoneType B_tupleD___init__(B_tuple self,int size ,...) {
     return B_None;
 }
 
-B_bool B_tupleD___bool__(B_tuple self) {
-    return toB_bool(self->size>0);
+bool B_tupleD___bool__(B_tuple self) {
+    return self->size>0;
 }
 
 B_str B_tupleD___str__(B_tuple self) {
@@ -100,8 +100,8 @@ B_NoneType B_IteratorD_tupleD_init(B_IteratorD_tuple self, B_tuple lst) {
     return B_None;
 }
 
-B_bool B_IteratorD_tupleD_bool(B_IteratorD_tuple self) {
-    return B_True;
+bool B_IteratorD_tupleD_bool(B_IteratorD_tuple self) {
+    return true;
 }
 
 B_str B_IteratorD_tupleD_str(B_IteratorD_tuple self) {
@@ -148,7 +148,7 @@ struct B_IterableD_tupleG_class B_IterableD_tupleG_methods = {
     B_IterableD_tupleD___init__,
     B_IterableD_tupleD___serialize__,
     B_IterableD_tupleD___deserialize__,
-    (B_bool (*)(B_IterableD_tuple))$default__bool__,
+    (bool (*)(B_IterableD_tuple))$default__bool__,
     (B_str (*)(B_IterableD_tuple))$default__str__,
     (B_str (*)(B_IterableD_tuple))$default__str__,
     B_IterableD_tupleD___iter__
@@ -227,7 +227,7 @@ struct B_SliceableD_tupleG_class B_SliceableD_tupleG_methods = {
     B_SliceableD_tupleD___init__,
     B_SliceableD_tupleD___serialize__,
     B_SliceableD_tupleD___deserialize__,
-    (B_bool (*)(B_SliceableD_tuple))$default__bool__,
+    (bool (*)(B_SliceableD_tuple))$default__bool__,
     (B_str (*)(B_SliceableD_tuple))$default__str__,
     (B_str (*)(B_SliceableD_tuple))$default__str__,
     B_SliceableD_tupleD___getitem__,
@@ -258,16 +258,16 @@ B_HashableD_tuple B_HashableD_tupleD___deserialize__(B_HashableD_tuple self, $Se
     return res;
 }
 
-B_bool B_HashableD_tupleD___eq__ (B_HashableD_tuple wit, B_tuple tup1, B_tuple tup2) {
+bool B_HashableD_tupleD___eq__ (B_HashableD_tuple wit, B_tuple tup1, B_tuple tup2) {
     //type-checking guarantees that sizes are equal
     for (int i=0; i<tup1->size; i++)
         if (!wit->W_Hashable[i]->$class->__eq__(wit->W_Hashable[i],tup1->components[i],tup2->components[i]))
-            return B_False;
-    return B_True;
+            return false;
+    return true;
 }
 
-B_bool B_HashableD_tupleD___ne__ (B_HashableD_tuple wit, B_tuple tup1, B_tuple tup2) {
-    return toB_bool(!fromB_bool(B_HashableD_tupleD___eq__(wit,tup1,tup2)));
+bool B_HashableD_tupleD___ne__ (B_HashableD_tuple wit, B_tuple tup1, B_tuple tup2) {
+    return !B_HashableD_tupleD___eq__(wit,tup1,tup2);
 }
     
   
@@ -282,7 +282,7 @@ struct B_HashableD_tupleG_class B_HashableD_tupleG_methods = {
     B_HashableD_tupleD___init__,
     B_HashableD_tupleD___serialize__,
     B_HashableD_tupleD___deserialize__,
-    (B_bool (*)(B_HashableD_tuple))$default__bool__,
+    (bool (*)(B_HashableD_tuple))$default__bool__,
     (B_str (*)(B_HashableD_tuple))$default__str__,
     (B_str (*)(B_HashableD_tuple))$default__str__,
     B_HashableD_tupleD___eq__,

--- a/base/builtin/tuple.h
+++ b/base/builtin/tuple.h
@@ -5,7 +5,7 @@ struct B_tupleG_class {
     B_NoneType (*__init__)(B_tuple,int,...);
     void (*__serialize__)(B_tuple,$Serial$state); 
     B_tuple (*__deserialize__)(B_tuple,$Serial$state);
-    B_bool (*__bool__)(B_tuple);
+    bool (*__bool__)(B_tuple);
     B_str (*__str__)(B_tuple);
     B_str (*__repr__)(B_tuple);
 };
@@ -65,7 +65,7 @@ struct B_IterableD_tupleG_class {
     B_NoneType (*__init__)(B_IterableD_tuple);
     void (*__serialize__)(B_IterableD_tuple,$Serial$state);
     B_IterableD_tuple (*__deserialize__)(B_IterableD_tuple,$Serial$state);
-    B_bool (*__bool__)(B_IterableD_tuple);
+    bool (*__bool__)(B_IterableD_tuple);
     B_str (*__str__)(B_IterableD_tuple);
     B_str (*__repr__)(B_IterableD_tuple);
     B_Iterator (*__iter__)(B_IterableD_tuple, B_tuple);
@@ -94,7 +94,7 @@ struct B_SliceableD_tupleG_class {
     B_NoneType (*__init__)(B_SliceableD_tuple);
     void (*__serialize__)(B_SliceableD_tuple,$Serial$state);
     B_SliceableD_tuple (*__deserialize__)(B_SliceableD_tuple,$Serial$state);
-    B_bool (*__bool__)(B_SliceableD_tuple);
+    bool (*__bool__)(B_SliceableD_tuple);
     B_str (*__str__)(B_SliceableD_tuple);
     B_str (*__repr__)(B_SliceableD_tuple);
     $WORD (*__getitem__)(B_SliceableD_tuple, B_tuple, B_int);
@@ -133,19 +133,19 @@ struct B_HashableD_tupleG_class {
     B_NoneType (*__init__)(B_HashableD_tuple,int,B_Hashable*);
     void (*__serialize__)(B_HashableD_tuple,$Serial$state);
     B_HashableD_tuple (*__deserialize__)(B_HashableD_tuple,$Serial$state);
-    B_bool (*__bool__)(B_HashableD_tuple);
+    bool (*__bool__)(B_HashableD_tuple);
     B_str (*__str__)(B_HashableD_tuple);
     B_str (*__repr__)(B_HashableD_tuple);
-    B_bool (*__eq__)(B_HashableD_tuple, B_tuple, B_tuple);
-    B_bool (*__ne__)(B_HashableD_tuple, B_tuple, B_tuple);
+    bool (*__eq__)(B_HashableD_tuple, B_tuple, B_tuple);
+    bool (*__ne__)(B_HashableD_tuple, B_tuple, B_tuple);
     B_NoneType (*hash) (B_HashableD_tuple, B_tuple, B_hasher);
 };
   
 B_NoneType B_HashableD_tupleD___init__ (B_HashableD_tuple,int,B_Hashable*);
 void B_HashableD_tupleD___serialize__(B_HashableD_tuple, $Serial$state);
 B_HashableD_tuple B_HashableD_tupleD___deserialize__(B_HashableD_tuple, $Serial$state);
-B_bool B_HashableD_tupleD___eq__ (B_HashableD_tuple, B_tuple, B_tuple);
-B_bool B_HashableD_tupleD___ne__ (B_HashableD_tuple, B_tuple, B_tuple);
+bool B_HashableD_tupleD___eq__ (B_HashableD_tuple, B_tuple, B_tuple);
+bool B_HashableD_tupleD___ne__ (B_HashableD_tuple, B_tuple, B_tuple);
 B_NoneType B_HashableD_tupleD_hash (B_HashableD_tuple, B_tuple, B_hasher);
 
 extern struct B_HashableD_tupleG_class B_HashableD_tupleG_methods;
@@ -171,7 +171,7 @@ struct B_IteratorD_tupleG_class {
     B_NoneType (*__init__)(B_IteratorD_tuple, B_tuple);
     void (*__serialize__)(B_IteratorD_tuple,$Serial$state);
     B_IteratorD_tuple (*__deserialize__)(B_IteratorD_tuple,$Serial$state);
-    B_bool (*__bool__)(B_IteratorD_tuple);
+    bool (*__bool__)(B_IteratorD_tuple);
     B_str (*__str__)(B_IteratorD_tuple);
     B_str (*__repr__)(B_IteratorD_tuple);
     $WORD(*__next__)(B_IteratorD_tuple);

--- a/base/builtin/u1.c
+++ b/base/builtin/u1.c
@@ -65,8 +65,8 @@ B_u1 B_u1D___deserialize__(B_u1 n, $Serial$state state) {
     return toB_u1((uint8_t)$val_deserialize(state));
 }
 
-B_bool B_u1D___bool__(B_u1 n) {
-    return toB_bool(n->val != 0);
+bool B_u1D___bool__(B_u1 n) {
+    return n->val != 0;
 }
 
 B_str B_u1D___str__(B_u1 n) {
@@ -244,38 +244,38 @@ B_float B_DivD_u1D___truediv__ (B_DivD_u1 wit, B_u1 a, B_u1 b) {
 
 // B_OrdD_u1  ////////////////////////////////////////////////////////////////////////////////////////
 
-B_bool B_OrdD_u1D___eq__ (B_OrdD_u1 wit, B_u1 a, B_u1 b) {
-    return toB_bool(a->val == b->val);
+bool B_OrdD_u1D___eq__ (B_OrdD_u1 wit, B_u1 a, B_u1 b) {
+    return a->val == b->val;
 }
 
-B_bool B_OrdD_u1D___ne__ (B_OrdD_u1 wit, B_u1 a, B_u1 b) {
-    return toB_bool(a->val != b->val);
+bool B_OrdD_u1D___ne__ (B_OrdD_u1 wit, B_u1 a, B_u1 b) {
+    return a->val != b->val;
 }
 
-B_bool B_OrdD_u1D___lt__ (B_OrdD_u1 wit, B_u1 a, B_u1 b) {
-    return toB_bool(a->val < b->val);
+bool B_OrdD_u1D___lt__ (B_OrdD_u1 wit, B_u1 a, B_u1 b) {
+    return a->val < b->val;
 }
 
-B_bool B_OrdD_u1D___le__ (B_OrdD_u1 wit, B_u1 a, B_u1 b) {
-    return toB_bool(a->val <= b->val);
+bool B_OrdD_u1D___le__ (B_OrdD_u1 wit, B_u1 a, B_u1 b) {
+    return a->val <= b->val;
 }
 
-B_bool B_OrdD_u1D___gt__ (B_OrdD_u1 wit, B_u1 a, B_u1 b) {
-    return toB_bool(a->val > b->val);
+bool B_OrdD_u1D___gt__ (B_OrdD_u1 wit, B_u1 a, B_u1 b) {
+    return a->val > b->val;
 }
 
-B_bool B_OrdD_u1D___ge__ (B_OrdD_u1 wit, B_u1 a, B_u1 b) {
-    return toB_bool(a->val >= b->val);
+bool B_OrdD_u1D___ge__ (B_OrdD_u1 wit, B_u1 a, B_u1 b) {
+    return a->val >= b->val;
 }
 
 // B_HashableD_u1 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 
-B_bool B_HashableD_u1D___eq__(B_HashableD_u1 wit, B_u1 a, B_u1 b) {
-    return toB_bool(a->val == b->val);
+bool B_HashableD_u1D___eq__(B_HashableD_u1 wit, B_u1 a, B_u1 b) {
+    return a->val == b->val;
 }
 
-B_bool B_HashableD_u1D___ne__(B_HashableD_u1 wit, B_u1 a, B_u1 b) {
-    return toB_bool(a->val != b->val);
+bool B_HashableD_u1D___ne__(B_HashableD_u1 wit, B_u1 a, B_u1 b) {
+    return a->val != b->val;
 }
 
 B_NoneType B_HashableD_u1D_hash(B_HashableD_u1 wit, B_u1 a, B_hasher h) {

--- a/base/builtin/u16.c
+++ b/base/builtin/u16.c
@@ -50,8 +50,8 @@ B_u16 B_u16D___deserialize__(B_u16 n, $Serial$state state) {
     return toB_u16((uint16_t)$val_deserialize(state));
 }
 
-B_bool B_u16D___bool__(B_u16 n) {
-    return toB_bool(n->val != 0);
+bool B_u16D___bool__(B_u16 n) {
+    return n->val != 0;
 }
 
 B_str B_u16D___str__(B_u16 n) {
@@ -233,38 +233,38 @@ B_float B_DivD_u16D___truediv__ (B_DivD_u16 wit, B_u16 a, B_u16 b) {
 
 // B_OrdD_u16  ////////////////////////////////////////////////////////////////////////////////////////
 
-B_bool B_OrdD_u16D___eq__ (B_OrdD_u16 wit, B_u16 a, B_u16 b) {
-    return toB_bool(a->val == b->val);
+bool B_OrdD_u16D___eq__ (B_OrdD_u16 wit, B_u16 a, B_u16 b) {
+    return a->val == b->val;
 }
 
-B_bool B_OrdD_u16D___ne__ (B_OrdD_u16 wit, B_u16 a, B_u16 b) {
-    return toB_bool(a->val != b->val);
+bool B_OrdD_u16D___ne__ (B_OrdD_u16 wit, B_u16 a, B_u16 b) {
+    return a->val != b->val;
 }
 
-B_bool B_OrdD_u16D___lt__ (B_OrdD_u16 wit, B_u16 a, B_u16 b) {
-    return toB_bool(a->val < b->val);
+bool B_OrdD_u16D___lt__ (B_OrdD_u16 wit, B_u16 a, B_u16 b) {
+    return a->val < b->val;
 }
 
-B_bool B_OrdD_u16D___le__ (B_OrdD_u16 wit, B_u16 a, B_u16 b) {
-    return toB_bool(a->val <= b->val);
+bool B_OrdD_u16D___le__ (B_OrdD_u16 wit, B_u16 a, B_u16 b) {
+    return a->val <= b->val;
 }
 
-B_bool B_OrdD_u16D___gt__ (B_OrdD_u16 wit, B_u16 a, B_u16 b) {
-    return toB_bool(a->val > b->val);
+bool B_OrdD_u16D___gt__ (B_OrdD_u16 wit, B_u16 a, B_u16 b) {
+    return a->val > b->val;
 }
 
-B_bool B_OrdD_u16D___ge__ (B_OrdD_u16 wit, B_u16 a, B_u16 b) {
-    return toB_bool(a->val >= b->val);
+bool B_OrdD_u16D___ge__ (B_OrdD_u16 wit, B_u16 a, B_u16 b) {
+    return a->val >= b->val;
 }
 
 // B_HashableD_u16 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 
-B_bool B_HashableD_u16D___eq__(B_HashableD_u16 wit, B_u16 a, B_u16 b) {
-    return toB_bool(a->val == b->val);
+bool B_HashableD_u16D___eq__(B_HashableD_u16 wit, B_u16 a, B_u16 b) {
+    return a->val == b->val;
 }
 
-B_bool B_HashableD_u16D___ne__(B_HashableD_u16 wit, B_u16 a, B_u16 b) {
-    return toB_bool(a->val != b->val);
+bool B_HashableD_u16D___ne__(B_HashableD_u16 wit, B_u16 a, B_u16 b) {
+    return a->val != b->val;
 }
 
 B_NoneType B_HashableD_u16D_hash(B_HashableD_u16 wit, B_u16 a, B_hasher h) {

--- a/base/builtin/u32.c
+++ b/base/builtin/u32.c
@@ -50,8 +50,8 @@ B_u32 B_u32D___deserialize__(B_u32 n, $Serial$state state) {
     return toB_u32((uint32_t)$val_deserialize(state));
 }
 
-B_bool B_u32D___bool__(B_u32 n) {
-    return toB_bool(n->val != 0);
+bool B_u32D___bool__(B_u32 n) {
+    return n->val != 0;
 }
 
 B_str B_u32D___str__(B_u32 n) {
@@ -233,38 +233,38 @@ B_float B_DivD_u32D___truediv__ (B_DivD_u32 wit, B_u32 a, B_u32 b) {
 
 // B_OrdD_u32  ////////////////////////////////////////////////////////////////////////////////////////
 
-B_bool B_OrdD_u32D___eq__ (B_OrdD_u32 wit, B_u32 a, B_u32 b) {
-    return toB_bool(a->val == b->val);
+bool B_OrdD_u32D___eq__ (B_OrdD_u32 wit, B_u32 a, B_u32 b) {
+    return a->val == b->val;
 }
 
-B_bool B_OrdD_u32D___ne__ (B_OrdD_u32 wit, B_u32 a, B_u32 b) {
-    return toB_bool(a->val != b->val);
+bool B_OrdD_u32D___ne__ (B_OrdD_u32 wit, B_u32 a, B_u32 b) {
+    return a->val != b->val;
 }
 
-B_bool B_OrdD_u32D___lt__ (B_OrdD_u32 wit, B_u32 a, B_u32 b) {
-    return toB_bool(a->val < b->val);
+bool B_OrdD_u32D___lt__ (B_OrdD_u32 wit, B_u32 a, B_u32 b) {
+    return a->val < b->val;
 }
 
-B_bool B_OrdD_u32D___le__ (B_OrdD_u32 wit, B_u32 a, B_u32 b) {
-    return toB_bool(a->val <= b->val);
+bool B_OrdD_u32D___le__ (B_OrdD_u32 wit, B_u32 a, B_u32 b) {
+    return a->val <= b->val;
 }
 
-B_bool B_OrdD_u32D___gt__ (B_OrdD_u32 wit, B_u32 a, B_u32 b) {
-    return toB_bool(a->val > b->val);
+bool B_OrdD_u32D___gt__ (B_OrdD_u32 wit, B_u32 a, B_u32 b) {
+    return a->val > b->val;
 }
 
-B_bool B_OrdD_u32D___ge__ (B_OrdD_u32 wit, B_u32 a, B_u32 b) {
-    return toB_bool(a->val >= b->val);
+bool B_OrdD_u32D___ge__ (B_OrdD_u32 wit, B_u32 a, B_u32 b) {
+    return a->val >= b->val;
 }
 
 // B_HashableD_u32 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 
-B_bool B_HashableD_u32D___eq__(B_HashableD_u32 wit, B_u32 a, B_u32 b) {
-    return toB_bool(a->val == b->val);
+bool B_HashableD_u32D___eq__(B_HashableD_u32 wit, B_u32 a, B_u32 b) {
+    return a->val == b->val;
 }
 
-B_bool B_HashableD_u32D___ne__(B_HashableD_u32 wit, B_u32 a, B_u32 b) {
-    return toB_bool(a->val != b->val);
+bool B_HashableD_u32D___ne__(B_HashableD_u32 wit, B_u32 a, B_u32 b) {
+    return a->val != b->val;
 }
 
 B_NoneType B_HashableD_u32D_hash(B_HashableD_u32 wit, B_u32 a, B_hasher h) {

--- a/base/builtin/u64.c
+++ b/base/builtin/u64.c
@@ -50,8 +50,8 @@ B_u64 B_u64D___deserialize__(B_u64 n, $Serial$state state) {
     return toB_u64((uint64_t)(uintptr_t)$val_deserialize(state));
 }
 
-B_bool B_u64D___bool__(B_u64 n) {
-    return toB_bool(n->val != 0);
+bool B_u64D___bool__(B_u64 n) {
+    return n->val != 0;
 }
 
 B_str B_u64D___str__(B_u64 n) {
@@ -233,38 +233,38 @@ B_float B_DivD_u64D___truediv__ (B_DivD_u64 wit, B_u64 a, B_u64 b) {
 
 // B_OrdD_u64  ////////////////////////////////////////////////////////////////////////////////////////
 
-B_bool B_OrdD_u64D___eq__ (B_OrdD_u64 wit, B_u64 a, B_u64 b) {
-    return toB_bool(a->val == b->val);
+bool B_OrdD_u64D___eq__ (B_OrdD_u64 wit, B_u64 a, B_u64 b) {
+    return a->val == b->val;
 }
 
-B_bool B_OrdD_u64D___ne__ (B_OrdD_u64 wit, B_u64 a, B_u64 b) {
-    return toB_bool(a->val != b->val);
+bool B_OrdD_u64D___ne__ (B_OrdD_u64 wit, B_u64 a, B_u64 b) {
+    return a->val != b->val;
 }
 
-B_bool B_OrdD_u64D___lt__ (B_OrdD_u64 wit, B_u64 a, B_u64 b) {
-    return toB_bool(a->val < b->val);
+bool B_OrdD_u64D___lt__ (B_OrdD_u64 wit, B_u64 a, B_u64 b) {
+    return a->val < b->val;
 }
 
-B_bool B_OrdD_u64D___le__ (B_OrdD_u64 wit, B_u64 a, B_u64 b) {
-    return toB_bool(a->val <= b->val);
+bool B_OrdD_u64D___le__ (B_OrdD_u64 wit, B_u64 a, B_u64 b) {
+    return a->val <= b->val;
 }
 
-B_bool B_OrdD_u64D___gt__ (B_OrdD_u64 wit, B_u64 a, B_u64 b) {
-    return toB_bool(a->val > b->val);
+bool B_OrdD_u64D___gt__ (B_OrdD_u64 wit, B_u64 a, B_u64 b) {
+    return a->val > b->val;
 }
 
-B_bool B_OrdD_u64D___ge__ (B_OrdD_u64 wit, B_u64 a, B_u64 b) {
-    return toB_bool(a->val >= b->val);
+bool B_OrdD_u64D___ge__ (B_OrdD_u64 wit, B_u64 a, B_u64 b) {
+    return a->val >= b->val;
 }
 
 // B_HashableD_u64 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 
-B_bool B_HashableD_u64D___eq__(B_HashableD_u64 wit, B_u64 a, B_u64 b) {
-    return toB_bool(a->val == b->val);
+bool B_HashableD_u64D___eq__(B_HashableD_u64 wit, B_u64 a, B_u64 b) {
+    return a->val == b->val;
 }
 
-B_bool B_HashableD_u64D___ne__(B_HashableD_u64 wit, B_u64 a, B_u64 b) {
-    return toB_bool(a->val != b->val);
+bool B_HashableD_u64D___ne__(B_HashableD_u64 wit, B_u64 a, B_u64 b) {
+    return a->val != b->val;
 }
 
 B_NoneType B_HashableD_u64D_hash(B_HashableD_u64 wit, B_u64 a, B_hasher h) {

--- a/base/builtin/u8.c
+++ b/base/builtin/u8.c
@@ -50,8 +50,8 @@ B_u8 B_u8D___deserialize__(B_u8 n, $Serial$state state) {
     return toB_u8((uint8_t)$val_deserialize(state));
 }
 
-B_bool B_u8D___bool__(B_u8 n) {
-    return toB_bool(n->val != 0);
+bool B_u8D___bool__(B_u8 n) {
+    return n->val != 0;
 }
 
 B_str B_u8D___str__(B_u8 n) {
@@ -233,38 +233,38 @@ B_float B_DivD_u8D___truediv__ (B_DivD_u8 wit, B_u8 a, B_u8 b) {
 
 // B_OrdD_u8  ////////////////////////////////////////////////////////////////////////////////////////
 
-B_bool B_OrdD_u8D___eq__ (B_OrdD_u8 wit, B_u8 a, B_u8 b) {
-    return toB_bool(a->val == b->val);
+bool B_OrdD_u8D___eq__ (B_OrdD_u8 wit, B_u8 a, B_u8 b) {
+    return a->val == b->val;
 }
 
-B_bool B_OrdD_u8D___ne__ (B_OrdD_u8 wit, B_u8 a, B_u8 b) {
-    return toB_bool(a->val != b->val);
+bool B_OrdD_u8D___ne__ (B_OrdD_u8 wit, B_u8 a, B_u8 b) {
+    return a->val != b->val;
 }
 
-B_bool B_OrdD_u8D___lt__ (B_OrdD_u8 wit, B_u8 a, B_u8 b) {
-    return toB_bool(a->val < b->val);
+bool B_OrdD_u8D___lt__ (B_OrdD_u8 wit, B_u8 a, B_u8 b) {
+    return a->val < b->val;
 }
 
-B_bool B_OrdD_u8D___le__ (B_OrdD_u8 wit, B_u8 a, B_u8 b) {
-    return toB_bool(a->val <= b->val);
+bool B_OrdD_u8D___le__ (B_OrdD_u8 wit, B_u8 a, B_u8 b) {
+    return a->val <= b->val;
 }
 
-B_bool B_OrdD_u8D___gt__ (B_OrdD_u8 wit, B_u8 a, B_u8 b) {
-    return toB_bool(a->val > b->val);
+bool B_OrdD_u8D___gt__ (B_OrdD_u8 wit, B_u8 a, B_u8 b) {
+    return a->val > b->val;
 }
 
-B_bool B_OrdD_u8D___ge__ (B_OrdD_u8 wit, B_u8 a, B_u8 b) {
-    return toB_bool(a->val >= b->val);
+bool B_OrdD_u8D___ge__ (B_OrdD_u8 wit, B_u8 a, B_u8 b) {
+    return a->val >= b->val;
 }
 
 // B_HashableD_u8 ///////////////////////////////////////////////////////////////////////////////////////////////////////
 
-B_bool B_HashableD_u8D___eq__(B_HashableD_u8 wit, B_u8 a, B_u8 b) {
-    return toB_bool(a->val == b->val);
+bool B_HashableD_u8D___eq__(B_HashableD_u8 wit, B_u8 a, B_u8 b) {
+    return a->val == b->val;
 }
 
-B_bool B_HashableD_u8D___ne__(B_HashableD_u8 wit, B_u8 a, B_u8 b) {
-    return toB_bool(a->val != b->val);
+bool B_HashableD_u8D___ne__(B_HashableD_u8 wit, B_u8 a, B_u8 b) {
+    return a->val != b->val;
 }
 
 B_NoneType B_HashableD_u8D_hash(B_HashableD_u8 wit, B_u8 a, B_hasher h) {

--- a/base/rts/rts.c
+++ b/base/rts/rts.c
@@ -472,8 +472,8 @@ B_Msg B_MsgG_newXX( $Actor to, $Cont cont, time_t baseline, $WORD value) {
 
 ////////////////////////////////////////////////////////////////////////
 
-B_bool B_MsgD___bool__(B_Msg self) {
-  return B_True;
+bool B_MsgD___bool__(B_Msg self) {
+  return true;
 }
 
 B_str B_MsgD___str__(B_Msg self) {
@@ -526,8 +526,8 @@ void $ActorD___init__($Actor a) {
     rtsd_printf("# New Actor %ld at %p of class %s", a->$globkey, a, a->$class->$GCINFO);
 }
 
-B_bool $ActorD___bool__($Actor self) {
-  return B_True;
+bool $ActorD___bool__($Actor self) {
+  return true;
 }
 
 B_str $ActorD___str__($Actor self) {
@@ -577,8 +577,8 @@ void $CatcherD___init__($Catcher c, $Cont cont) {
     c->xval = NULL;
 }
 
-B_bool $CatcherD___bool__($Catcher self) {
-  return B_True;
+bool $CatcherD___bool__($Catcher self) {
+  return true;
 }
 
 B_str $CatcherD___str__($Catcher self) {
@@ -605,8 +605,8 @@ void $ConstContD___init__($ConstCont $this, $WORD val, $Cont cont) {
     $this->cont = cont;
 }
 
-B_bool $ConstContD___bool__($ConstCont self) {
-  return B_True;
+bool $ConstContD___bool__($ConstCont self) {
+  return true;
 }
 
 B_str $ConstContD___str__($ConstCont self) {
@@ -784,8 +784,8 @@ $R $DoneD___call__($Cont $this, $WORD val) {
     return $R_DONE(val);
 }
 
-B_bool $DoneD___bool__($Cont self) {
-  return B_True;
+bool $DoneD___bool__($Cont self) {
+  return true;
 }
 
 B_str $DoneD___str__($Cont self) {
@@ -822,8 +822,8 @@ $R $FailD___call__($Cont $this, $WORD ex) {
     return $R_FAIL(ex);
 }
 
-B_bool $FailD___bool__($Cont self) {
-  return B_True;
+bool $FailD___bool__($Cont self) {
+  return true;
 }
 
 B_str $FailD___str__($Cont self) {

--- a/base/rts/rts.h
+++ b/base/rts/rts.h
@@ -146,7 +146,7 @@ struct $ActorG_class {
     void (*__init__)($Actor);
     void (*__serialize__)($Actor, $Serial$state);
     $Actor (*__deserialize__)($Actor, $Serial$state);
-    B_bool (*__bool__)($Actor);
+    bool (*__bool__)($Actor);
     B_str (*__str__)($Actor);
     B_str (*__repr__)($Actor);
     B_NoneType (*__resume__)($Actor);
@@ -173,7 +173,7 @@ struct $CatcherG_class {
     void (*__init__)($Catcher, $Cont);
     void (*__serialize__)($Catcher, $Serial$state);
     $Catcher (*__deserialize__)($Catcher, $Serial$state);
-    B_bool (*__bool__)($Catcher);
+    bool (*__bool__)($Catcher);
     B_str (*__str__)($Catcher);
     B_str (*__repr__)($Catcher);
 };
@@ -192,7 +192,7 @@ struct $ConstContG_class {
     void (*__init__)($ConstCont, $WORD, $Cont);
     void (*__serialize__)($ConstCont, $Serial$state);
     $ConstCont (*__deserialize__)($ConstCont, $Serial$state);
-    B_bool (*__bool__)($ConstCont);
+    bool (*__bool__)($ConstCont);
     B_str (*__str__)($ConstCont);
     B_str (*__repr__)($ConstCont);
     $R (*__call__)($ConstCont, $WORD);
@@ -295,7 +295,7 @@ void $Actor$serialize($Actor, B_NoneType);
 void $Actor$deserialize($Actor, B_NoneType);
 B_NoneType $ActorD___cleanup__($Actor);
 
-B_bool B_MsgD___bool__(B_Msg self); 
+bool B_MsgD___bool__(B_Msg self); 
 B_str B_MsgD___str__(B_Msg self);
 B_str B_MsgD___repr__(B_Msg self); 
 void B_MsgD___serialize__(B_Msg self, $Serial$state state);

--- a/base/src/file.ext.c
+++ b/base/src/file.ext.c
@@ -21,52 +21,52 @@ $R fileQ_FSD__pin_affinityG_local (fileQ_FS self, $Cont c$cont) {
 }
 
 // def is_dir(self) -> bool:
-B_bool fileQ_FileStatD_is_dir (fileQ_FileStat self) {
-    return toB_bool(S_ISDIR(self->mode));
+bool fileQ_FileStatD_is_dir (fileQ_FileStat self) {
+    return S_ISDIR(self->mode);
 }
 
 // def is_file(self) -> bool:
-B_bool fileQ_FileStatD_is_file (fileQ_FileStat self) {
-    return toB_bool(S_ISREG(self->mode));
+bool fileQ_FileStatD_is_file (fileQ_FileStat self) {
+    return S_ISREG(self->mode);
 }
 
 // def is_symlink(self) -> bool:
-B_bool fileQ_FileStatD_is_symlink (fileQ_FileStat self) {
+bool fileQ_FileStatD_is_symlink (fileQ_FileStat self) {
 #if defined(_WIN32) || defined(_WIN64)
     // TODO: do better
-    return B_False;
+    return false;
 #else
-    return toB_bool(S_ISLNK(self->mode));
+    return S_ISLNK(self->mode);
 #endif
 }
 
 // def is_block_device(self) -> bool:
-B_bool fileQ_FileStatD_is_block_device (fileQ_FileStat self) {
-    return toB_bool(S_ISBLK(self->mode));
+bool fileQ_FileStatD_is_block_device (fileQ_FileStat self) {
+    return S_ISBLK(self->mode);
 }
 
 // def is_char_device(self) -> bool:
-B_bool fileQ_FileStatD_is_char_device (fileQ_FileStat self) {
-    return toB_bool(S_ISCHR(self->mode));
+bool fileQ_FileStatD_is_char_device (fileQ_FileStat self) {
+    return S_ISCHR(self->mode);
 }
 
 // def is_fifo(self) -> bool:
-B_bool fileQ_FileStatD_is_fifo (fileQ_FileStat self) {
+bool fileQ_FileStatD_is_fifo (fileQ_FileStat self) {
 #if defined(_WIN32) || defined(_WIN64)
     // TODO: do better
-    return B_False;
+    return false;
 #else
-    return toB_bool(S_ISFIFO(self->mode));
+    return S_ISFIFO(self->mode);
 #endif
 }
 
 // def is_socket(self) -> bool:
-B_bool fileQ_FileStatD_is_socket (fileQ_FileStat self) {
+bool fileQ_FileStatD_is_socket (fileQ_FileStat self) {
 #if defined(_WIN32) || defined(_WIN64)
     // TODO: do better
-    return B_False;
+    return false;
 #else
-    return toB_bool(S_ISSOCK(self->mode));
+    return S_ISSOCK(self->mode);
 #endif
 }
 

--- a/base/src/net.ext.c
+++ b/base/src/net.ext.c
@@ -24,21 +24,21 @@ void netQ___ext_init__() {
 }
 
 
-B_bool netQ_is_ipv4 (B_str address) {
+bool netQ_is_ipv4 (B_str address) {
     struct sockaddr_in sa;
     if (inet_pton(AF_INET, (const char *)fromB_str(address), &(sa.sin_addr)) == 0) {
-        return B_False;
+        return false;
     } else {
-        return B_True;
+        return true;
     }
 }
 
-B_bool netQ_is_ipv6 (B_str address) {
+bool netQ_is_ipv6 (B_str address) {
     struct sockaddr_in6 sa;
     if (inet_pton(AF_INET6, (const char *)fromB_str(address), &(sa.sin6_addr)) == 0) {
-        return B_False;
+        return false;
     } else {
-        return B_True;
+        return true;
     }
 }
 
@@ -1830,7 +1830,7 @@ $R netQ_TLSConnectionD__connect_tlsG_local (netQ_TLSConnection self, $Cont c$con
     }
 
     // Default is to verify TLS certificate. Should we disable verification?
-    if (fromB_bool(self->verify_tls) == false) {
+    if (self->verify_tls == false) {
         log_debug("TLS certificate verification disabled");
         stream->authmode = 0; // 0=none, 2=require (mbedtls specific)
     }

--- a/compiler/lib/src/Acton/Boxing.hs
+++ b/compiler/lib/src/Acton/Boxing.hs
@@ -563,7 +563,7 @@ instance {-# OVERLAPS #-} Boxing ([Stmt]) where
 instance Boxing Expr where
     boxing env e@(Var _ (NoQ n))
        | isWitness n                = return (HashSet.singleton n, e)
-       | isUnboxable t              = trace ("n = " ++nstr n) $ return (HashSet.empty, Box t e)
+       | isUnboxable t              = return (HashSet.empty, Box t e)
        where t                      = typeOf env e
     -- Qualified imported constants such as math.pi need the same boxed read
     -- as local unboxable variables, but typeOf is not safe for all Vars here.
@@ -669,27 +669,30 @@ instance Boxing Expr where
     boxing env (IsInstance l e qn)  = do (ws1,e1) <- boxing env e
                                     --     return (ws1, IsInstance l e1 qn)
                                          return (ws1, IsInstance l (boxValueExpr env e e1) qn) -- MZ
-    boxing env e@(BinOp l e1 op e2)
-      | op `notElem` [And, Or],
-        Just rt <- unboxedRepType t
-                                    = do (ws1,e1') <- boxing env e1
-                                         (ws2,e2') <- boxing env e2
-                                         return (HashSet.union ws1 ws2, Box rt $ Paren NoLoc $ BinOp l (unboxArg e1 e1') op (unboxArg e2 e2'))
-      where t                       = typeOf env e
-            unboxArg e0 e'          = maybe e' (\t -> forceUnbox env t e') (unboxedRepType (typeOf env e0))
+--    boxing env e@(BinOp l e1 op e2)
+--      | op `notElem` [And, Or],
+--        Just rt <- unboxedRepType t
+--                                    = do (ws1,e1') <- boxing env e1
+--                                         (ws2,e2') <- boxing env e2
+--                                         return (HashSet.union ws1 ws2, Box rt $ Paren NoLoc $ BinOp l (unboxArg e1 e1') op (unboxArg e2 e2'))
+--      where t                       = typeOf env e
+--            unboxArg e0 e'          = maybe e' (\t -> forceUnbox env t e') (unboxedRepType (typeOf env e0))
     boxing env e@(BinOp l e1 op e2)                                         -- MZ
       | op `elem` [And, Or]         = do (ws1,e1') <- boxing env e1         -- MZ
                                          (ws2,e2') <- boxing env e2         -- MZ
-                                         return (HashSet.union ws1 ws2, BinOp l (boxValueExpr env e1 e1') op (boxValueExpr env e2 e2'))  -- MZ
-    boxing env e@(BinOp l e1 op e2) = do (ws1,e1') <- boxing env e1
-                                         (ws2,e2') <- boxing env e2
-                                         return (HashSet.union ws1 ws2, BinOp l e1' op e2')
+                                         return (HashSet.union ws1 ws2, if t==tBool then Box tBool (BinOp l (unbox t e1') op (unbox t e2')) else BinOp l (boxValueExpr env e1 e1') op (boxValueExpr env e2 e2'))  -- MZ
+        where t                       = typeOf env e1
+--    boxing env e@(BinOp l e1 op e2) = do (ws1,e1') <- boxing env e1
+--                                         (ws2,e2') <- boxing env e2
+--                                         return (HashSet.union ws1 ws2, BinOp l e1' op e2')
     boxing env (CompOp l e os)      = do (ws1,e1) <- boxing env e
                                          (ws2,e2) <- boxing env os
                                          return (HashSet.union ws1 ws2, CompOp l e1 e2)
+    boxing env (UnOp l Not e)       = do (ws1,e1) <- boxing env e
+                                         return (ws1, if t == tBool then Box t (UnOp l Not (unbox t e1)) else UnOp l Not (boxValueExpr env e e1))
+       where t                      = typeOf env e
     boxing env (UnOp l uop e)
-      | uop /= Not,
-        Just rt <- unboxedRepType (typeOf env e)
+      | Just rt <- unboxedRepType (typeOf env e)
                                     = do (ws1,e') <- boxing env e
                                          return (ws1, Box rt $ Paren NoLoc $ UnOp l uop (unbox rt e'))
     boxing env (UnOp l uop e)       = do (ws1,e') <- boxing env e

--- a/compiler/lib/src/Acton/Boxing.hs
+++ b/compiler/lib/src/Acton/Boxing.hs
@@ -228,7 +228,7 @@ rtypeOf' env w f                     = rtypeOf env tc f
 
 integralTypes                      = [tBigint, tInt, tI32, tI16, tI8, tU64, tU32, tU16, tU8, tU1]
 numericTypes                       = integralTypes ++ [tFloat]
-unboxableTypes                     = tail numericTypes
+unboxableTypes                     = tBool : tail numericTypes
 
 isUnboxable t                      = t `elem` unboxableTypes
 
@@ -408,8 +408,8 @@ exprUnboxedRep env e@DotI{}      = Nothing
 -- After boxing, an And/Or expression has boxed operands and yields a boxed
 -- value (its result IS one of the operands), so it must not be re-boxed by a
 -- use-site fallback, even though its static type is unboxable.
-exprUnboxedRep env (BinOp _ _ op _)
-  | op `elem` [And, Or]           = Nothing
+exprUnboxedRep env (BinOp _ _ op _)           -- MZ
+  | op `elem` [And, Or]           = Nothing   -- MZ
 exprUnboxedRep env c@(Call _ f _ KwdNil)
   | Just t <- generatedCallableRawRep env f
                                   = Just t
@@ -441,8 +441,8 @@ fixassign env (TOpt _ t) e
     exprUnboxedRep env e == Just t = Box t e
 fixassign env t e
   | Just t' <- unboxedRepType t    = forceUnbox env t' e
-  | Box{} <- e                     = e
-  | Just rt <- exprUnboxedRep env e = Box rt e
+  | Box{} <- e                     = e          -- MZ
+  | Just rt <- exprUnboxedRep env e = Box rt e  -- MZ
   | otherwise                      = e
 
 fixarg env (TUnboxed _ t) e     = forceUnbox env t e
@@ -563,7 +563,7 @@ instance {-# OVERLAPS #-} Boxing ([Stmt]) where
 instance Boxing Expr where
     boxing env e@(Var _ (NoQ n))
        | isWitness n                = return (HashSet.singleton n, e)
-       | isUnboxable t              = return (HashSet.empty, Box t e)
+       | isUnboxable t              = trace ("n = " ++nstr n) $ return (HashSet.empty, Box t e)
        where t                      = typeOf env e
     -- Qualified imported constants such as math.pi need the same boxed read
     -- as local unboxable variables, but typeOf is not safe for all Vars here.
@@ -664,9 +664,11 @@ instance Boxing Expr where
                                          (ws3,e3') <- boxing env e3
                                          case unboxedRepType (typeOf env e) of
                                              Just t -> return (HashSet.unions [ws1, ws2, ws3], Box t $ Cond l (forceUnbox env t e1') e2' (forceUnbox env t e3'))
-                                             Nothing -> return (HashSet.unions [ws1, ws2, ws3], Cond l (boxValueExpr env e1 e1') e2' (boxValueExpr env e3 e3'))
+                                    --         Nothing -> return (HashSet.unions [ws1, ws2, ws3], Cond l e1' e2' e3')
+                                             Nothing -> return (HashSet.unions [ws1, ws2, ws3], Cond l (boxValueExpr env e1 e1') e2' (boxValueExpr env e3 e3'))  -- MZ
     boxing env (IsInstance l e qn)  = do (ws1,e1) <- boxing env e
-                                         return (ws1, IsInstance l (boxValueExpr env e e1) qn)
+                                    --     return (ws1, IsInstance l e1 qn)
+                                         return (ws1, IsInstance l (boxValueExpr env e e1) qn) -- MZ
     boxing env e@(BinOp l e1 op e2)
       | op `notElem` [And, Or],
         Just rt <- unboxedRepType t
@@ -675,10 +677,10 @@ instance Boxing Expr where
                                          return (HashSet.union ws1 ws2, Box rt $ Paren NoLoc $ BinOp l (unboxArg e1 e1') op (unboxArg e2 e2'))
       where t                       = typeOf env e
             unboxArg e0 e'          = maybe e' (\t -> forceUnbox env t e') (unboxedRepType (typeOf env e0))
-    boxing env e@(BinOp l e1 op e2)
-      | op `elem` [And, Or]         = do (ws1,e1') <- boxing env e1
-                                         (ws2,e2') <- boxing env e2
-                                         return (HashSet.union ws1 ws2, BinOp l (boxValueExpr env e1 e1') op (boxValueExpr env e2 e2'))
+    boxing env e@(BinOp l e1 op e2)                                         -- MZ
+      | op `elem` [And, Or]         = do (ws1,e1') <- boxing env e1         -- MZ
+                                         (ws2,e2') <- boxing env e2         -- MZ
+                                         return (HashSet.union ws1 ws2, BinOp l (boxValueExpr env e1 e1') op (boxValueExpr env e2 e2'))  -- MZ
     boxing env e@(BinOp l e1 op e2) = do (ws1,e1') <- boxing env e1
                                          (ws2,e2') <- boxing env e2
                                          return (HashSet.union ws1 ws2, BinOp l e1' op e2')

--- a/compiler/lib/src/Acton/Boxing.hs
+++ b/compiler/lib/src/Acton/Boxing.hs
@@ -483,7 +483,7 @@ rtypeOfFun env f@(TApp _ (Var _ n) _)
 rtypeOfFun env (TApp _ f0 [])       = rtypeOfFun env f0
 rtypeOfFun env f@(TApp _ f0 ts)     = matchTypes (typeOf env f) (typeInstOf env (map (const tWild) ts) f0)
 rtypeOfFun env (Async _ f)          = rtypeOfFun env f
-typeOfFun env f@(Dot _ (Var _ x) n)
+rtypeOfFun env f@(Dot _ (Var _ x) n)
   | NClass{} <- findQName x env      = case generalTypeC env x n of
                                          Just t  -> matchTypes (typeOf env f) t
                                          Nothing -> matchTypes (typeOf env f) (typeOf env f)
@@ -491,6 +491,9 @@ rtypeOfFun env f@(Dot _ e n)        = case typeOf env e of
                                         TCon _ tc -> rtypeOf env tc n
                                         TVar _ tv -> rtypeOf env (findTVBound env tv) n
                                         _         -> typeOf env f
+rtypeOfFun env f@(Var _ n)
+  | Just rt <- generatedMethodType env n []
+                                    = rt
 rtypeOfFun env f@(Var _ n)
   | boxedCPrim n                    = typeOf env f
   | otherwise                       = case findQName n env of

--- a/compiler/lib/src/Acton/Boxing.hs
+++ b/compiler/lib/src/Acton/Boxing.hs
@@ -483,20 +483,14 @@ rtypeOfFun env f@(TApp _ (Var _ n) _)
 rtypeOfFun env (TApp _ f0 [])       = rtypeOfFun env f0
 rtypeOfFun env f@(TApp _ f0 ts)     = matchTypes (typeOf env f) (typeInstOf env (map (const tWild) ts) f0)
 rtypeOfFun env (Async _ f)          = rtypeOfFun env f
-rtypeOfFun env f@(Dot _ (Var _ x) _)
-  | NClass{} <- findQName x env
-                                      = typeOf env f
-rtypeOfFun env f@(Dot _ e n)        = case generatedExprType env e of
-                                        Just (TCon _ tc) -> rtypeOf env tc n
-                                        Just (TVar _ tv) -> rtypeOf env (findTVBound env tv) n
-                                        Just _           -> typeOf env f
-                                        Nothing          -> case typeOf env e of
-                                          TCon _ tc -> rtypeOf env tc n
-                                          TVar _ tv -> rtypeOf env (findTVBound env tv) n
-                                          _         -> typeOf env f
-rtypeOfFun env f@(Var _ n)
-  | Just rt <- generatedMethodType env n []
-                                    = rt
+typeOfFun env f@(Dot _ (Var _ x) n)
+  | NClass{} <- findQName x env      = case generalTypeC env x n of
+                                         Just t  -> matchTypes (typeOf env f) t
+                                         Nothing -> matchTypes (typeOf env f) (typeOf env f)
+rtypeOfFun env f@(Dot _ e n)        = case typeOf env e of
+                                        TCon _ tc -> rtypeOf env tc n
+                                        TVar _ tv -> rtypeOf env (findTVBound env tv) n
+                                        _         -> typeOf env f
 rtypeOfFun env f@(Var _ n)
   | boxedCPrim n                    = typeOf env f
   | otherwise                       = case findQName n env of
@@ -680,7 +674,7 @@ instance Boxing Expr where
     boxing env e@(BinOp l e1 op e2)                                         -- MZ
       | op `elem` [And, Or]         = do (ws1,e1') <- boxing env e1         -- MZ
                                          (ws2,e2') <- boxing env e2         -- MZ
-                                         return (HashSet.union ws1 ws2, if t==tBool then Box tBool (BinOp l (unbox t e1') op (unbox t e2')) else BinOp l (boxValueExpr env e1 e1') op (boxValueExpr env e2 e2'))  -- MZ
+                                         return (HashSet.union ws1 ws2, if boxedRepType t == tBool then Box tBool (BinOp l (forceUnbox env tBool e1') op (forceUnbox env tBool e2')) else BinOp l (boxValueExpr env e1 e1') op (boxValueExpr env e2 e2'))  -- MZ
         where t                       = typeOf env e1
 --    boxing env e@(BinOp l e1 op e2) = do (ws1,e1') <- boxing env e1
 --                                         (ws2,e2') <- boxing env e2
@@ -689,7 +683,7 @@ instance Boxing Expr where
                                          (ws2,e2) <- boxing env os
                                          return (HashSet.union ws1 ws2, CompOp l e1 e2)
     boxing env (UnOp l Not e)       = do (ws1,e1) <- boxing env e
-                                         return (ws1, if t == tBool then Box t (UnOp l Not (unbox t e1)) else UnOp l Not (boxValueExpr env e e1))
+                                         return (ws1, if boxedRepType t == tBool then Box tBool (UnOp l Not (forceUnbox env tBool e1)) else UnOp l Not (boxValueExpr env e e1))
        where t                      = typeOf env e
     boxing env (UnOp l uop e)
       | Just rt <- unboxedRepType (typeOf env e)
@@ -716,11 +710,6 @@ instance Boxing Expr where
                                          return (ws1, Set l es1)
     boxing env (Dict l es)          = do (ws1,es1) <- boxing env es
                                          return (ws1, Dict l es1)
-    boxing env (Box t e)  =           do (ws1,e1) <- boxing env e
-                                         case e1 of
-                                            UnBox _ e' -> return (ws1,e')
-                                            _ -> return (ws1,Box t e1)
-                                         return (ws1, e1)
     boxing env e                    = return (HashSet.empty,e)
 
 boxingTupleArgs env (PosArg e p)    = do (ws1,e1) <- boxing env e

--- a/compiler/lib/src/Acton/Boxing.hs
+++ b/compiler/lib/src/Acton/Boxing.hs
@@ -205,7 +205,8 @@ matchTypes (TFun _ fx p _ r) (TFun _ fx' p' _ r')
                                     = tFun fx (matchTypes p p') kwdNil (matchTypes r r')
 matchTypes (TRow _ _ _ t r) (TRow _ _ _ t' r')
                                     = posRow (matchTypes t t') (matchTypes r r')
-matchTypes TNil{} TNil{}            = posNil                                    
+matchTypes TNil{} TNil{}            = posNil
+matchTypes t (TUnboxed _ t')        = matchTypes t t'
 matchTypes t _                      = t    -- ignore possibilities for unboxing 
 
 

--- a/compiler/lib/src/Acton/CodeGen.hs
+++ b/compiler/lib/src/Acton/CodeGen.hs
@@ -520,10 +520,6 @@ declDecl env (Class _ n q as b ddoc)
   where b'                          = vsubst [(tvSelf, tCon c)] b
         c                           = TC (NoQ n) (map tVar $ qbound q)
         env1                        = setInClass (defineTVars q env)
-<<<<<<< HEAD
-=======
---        env2                        = setGtypes env1 (findAttrSchemas env1 (NoQ n))
->>>>>>> 7a02ed10 (first version properly unboxing bool)
         props                       = [ (n,sctype sc) | (n, NSig sc Property _) <- fullAttrEnv env c ]
         sup_c                       = filter ((`elem` special_repr) . tcname) as
         special_repr                = [primActor] -- To be extended...
@@ -1274,8 +1270,6 @@ callableTypeReturnsBoxed rt         = case rt of
                                         _              -> False
 
 -- A callable whose return type is explicitly TUnboxed returns raw C.
-callableReturnsRaw env f
-  | generatedMethodCallable env f   = False
 callableReturnsRaw env f
   | Just rt <- directMethodCallableType env f
                                     = callableTypeReturnsRaw rt

--- a/compiler/lib/src/Acton/CodeGen.hs
+++ b/compiler/lib/src/Acton/CodeGen.hs
@@ -1188,9 +1188,12 @@ rawExpr env c@(Call _ f _ KwdNil)
 rawExpr env (Call _ (Var _ n) _ KwdNil)
   | n == primUNext                  = True
 rawExpr env e@(BinOp _ e1 op e2)
+  | op `elem` [And, Or]             = boxedRepType (typeOf env e) == tBool
+rawExpr env e@(BinOp _ e1 op e2)
   | op `notElem` [And, Or]          = B.isUnboxable (boxedRepType (typeOf env e)) ||
                                       rawExpr env e1 && rawExpr env e2
 rawExpr env CompOp{}                = True
+rawExpr env e@(UnOp _ Not _)        = boxedRepType (typeOf env e) == tBool
 rawExpr env e@(UnOp _ op e1)
   | op /= Not                       = B.isUnboxable (boxedRepType (typeOf env e)) ||
                                       rawExpr env e1
@@ -1636,12 +1639,13 @@ needsPrimCallableCast (TCon _ (TC q _)) n
   | q == primPure                   = n `elem` [attr_call_, attr_exec_, attr_eval_]
 needsPrimCallableCast _ _           = False
                                         
-classCast env ts x q n              = parens . (parens (gen env t) <>)
+classCallableType env ts x q n      = vsubst fullsubst $ addSelf (B.rtypeOf env tc n) dec
   where (ts0,ts1)                   = splitAt (length q) ts
         tc                          = TC x ts0
         (sc, dec)                   = findAttr' env tc n
-        t                           = vsubst fullsubst $ addSelf (sctype sc) dec
         fullsubst                   = (tvSelf,tCon tc) : (qbound (scbind sc) `zip` ts1)
+
+classCast env ts x q n              = parens . (parens (gen env (classCallableType env ts x q n)) <>)
 
 genNew env n p                      = newcon' env n <> parens (genUCallPosArgs env r p)
   where TFun _ _ r _ _              = sctype $ fst $ schemaOf env (Var NoLoc n)
@@ -1680,7 +1684,9 @@ comma' x                            = if isEmpty x then empty else comma <+> x
 
 genDotCall env ts dec e@(Var _ x) n p
   | NClass q _ _ _ <- info,
-    Just _ <- dec                   = classCast env ts x q n (methodtable' env x <> text "." <> gen env n) <> parens (gen env p)
+    Just _ <- dec                   =
+      let TFun _ _ r _ _            = classCallableType env ts x q n
+      in classCast env ts x q n (methodtable' env x <> text "." <> gen env n) <> parens (genCallPosArgs env r p)
   where info                        = findQName x env
 genDotCall env ts dec e n p
   | Just NoDec <- dec               = genEnter env ts e n p
@@ -1790,11 +1796,11 @@ instance Gen Expr where
        where n                      = nargs p
     gen env (List _ es)             = text "B_mk_list" <> parens (pretty (length es) <> hsep [comma <+> gen env e | e <- es])
     gen env (BinOp _ e1 And e2)
-         | t == tBool               = parens (gen env e1 <> binPretty And <> gen env e2) 
+         | boxedRepType t == tBool  = parens (genRawExprAs env tBool e1 <> binPretty And <> genRawExprAs env tBool e2)
          | otherwise                = gen env primAND <> parens (gen env t <> comma <+> gen env e1 <> comma <+> gen env e2)
       where t                       = typeOf env e1
     gen env (BinOp _ e1 Or e2)
-         | t == tBool               = parens (gen env e1 <> binPretty Or <> gen env e2)
+         | boxedRepType t == tBool  = parens (genRawExprAs env tBool e1 <> binPretty Or <> genRawExprAs env tBool e2)
          | otherwise                = gen env primOR <> parens (gen env t <> comma <+> gen env e1 <> comma <+> gen env e2)
       where t                       = typeOf env e1
 --    gen env (BinOp _ e1 Or e2)      = gen env primOR <> parens (gen env t <> comma <+> gen env e1 <> comma <+> gen env e2)
@@ -1817,7 +1823,7 @@ instance Gen Expr where
             opstr EuDiv             = "FLOORDIV"
     gen env (CompOp _ e [a])        = gen env e <+> gen env a
     gen env (UnOp _ Not e)
-        | t == tBool                = parens (text "!" <> gen env e)
+        | boxedRepType t == tBool   = parens (text "!" <> genRawExprAs env tBool e)
         | otherwise                 = gen env primNOT <> parens (gen env t <> comma <+> gen env e)
 --      | B.isUnboxable (boxedRepType t)
 --                                    = genBoxed env tBool (parens (text "!" <> parens (genRawExpr env e)))

--- a/compiler/lib/src/Acton/CodeGen.hs
+++ b/compiler/lib/src/Acton/CodeGen.hs
@@ -978,6 +978,8 @@ genTypeDecl env n t                 = genVolatile env n <+> storageType env t
 genVolatile env n                   = if isVolVar n env then text "volatile" else empty
 
 genStmt env (Decl _ ds)             = (empty, [])
+genStmt env (Assign _ [PVar _ n _] e)
+  | isIgnoredBinding n              = (discardIgnoredExpr env e, [])
 genStmt env (Assign _ [PVar _ n (Just t)] e)
   | not (n `HashSet.member` localDefined env)
                                     = (genTypeDecl env n t <+> gen env n <+> equals <+> rhs <> semi, [])
@@ -991,6 +993,26 @@ genStmt env s                       = (vcat [ genTypeDecl env n t <+> gen env n 
   where te                          = excludeDefined env (envOf s)
         env1                        = ldefine te env
         (s', vs)                    = genV env1 s
+
+isIgnoredBinding (Internal NormPass "ignore" _) = True
+isIgnoredBinding _                              = False
+
+discardIgnoredExpr env e
+  | discardableIgnoredExpr e       = empty
+  | otherwise                      = genExp' env e <> semi
+
+discardableIgnoredExpr (Var _ _)   = True
+discardableIgnoredExpr (Dot _ e _) = discardableIgnoredExpr e
+discardableIgnoredExpr (DotI _ e _)
+                                    = discardableIgnoredExpr e
+discardableIgnoredExpr (Rest _ e _)
+                                    = discardableIgnoredExpr e
+discardableIgnoredExpr (RestI _ e _)
+                                    = discardableIgnoredExpr e
+discardableIgnoredExpr (Paren _ e) = discardableIgnoredExpr e
+discardableIgnoredExpr (Box _ e)   = discardableIgnoredExpr e
+discardableIgnoredExpr (UnBox _ e) = discardableIgnoredExpr e
+discardableIgnoredExpr _           = False
 
 genStmt1 env s                      = fst $ genStmt env s
 

--- a/compiler/lib/src/Acton/CodeGen.hs
+++ b/compiler/lib/src/Acton/CodeGen.hs
@@ -520,6 +520,10 @@ declDecl env (Class _ n q as b ddoc)
   where b'                          = vsubst [(tvSelf, tCon c)] b
         c                           = TC (NoQ n) (map tVar $ qbound q)
         env1                        = setInClass (defineTVars q env)
+<<<<<<< HEAD
+=======
+--        env2                        = setGtypes env1 (findAttrSchemas env1 (NoQ n))
+>>>>>>> 7a02ed10 (first version properly unboxing bool)
         props                       = [ (n,sctype sc) | (n, NSig sc Property _) <- fullAttrEnv env c ]
         sup_c                       = filter ((`elem` special_repr) . tcname) as
         special_repr                = [primActor] -- To be extended...
@@ -1979,7 +1983,7 @@ unboxed_c_type t
     | t == tU8  = "uint8_t"
     | t == tU1  = "uint8_t"  -- ????
     | t == tFloat = "double"
---    | t == tBool  = "bool"
+    | t == tBool  = "bool"
     | otherwise = error ("Internal error: trying to find unboxed type for " ++ show t)
 
 class_id t
@@ -1993,4 +1997,5 @@ class_id t
     | t == tU8  = "U8_ID"
     | t == tU1  = "U1_ID"
     | t == tFloat = "FLOAT_ID"
+    | t == tBool = "BOOL_ID"
     | otherwise = error ("Internal error: trying to find class id for " ++ show t)

--- a/compiler/lib/src/Acton/CodeGen.hs
+++ b/compiler/lib/src/Acton/CodeGen.hs
@@ -1176,7 +1176,8 @@ genRawExprAs env t e                = gen env (B.unbox t' e)
   where t'                          = boxedRepType t
 
 -- True when gen will already produce the raw C representation for this
--- expression.  Operations are raw only when their operands/branches are raw.
+-- expression.  Unboxable arithmetic is raw even when its operands are boxed,
+-- since the arithmetic generator unboxes its operands internally.
 rawExpr env UnBox{}                 = True
 rawExpr env (Var _ n)               = unboxedVar env n
 rawExpr env (Dot _ e n)             = unboxedField env e n
@@ -1186,10 +1187,13 @@ rawExpr env c@(Call _ f _ KwdNil)
   | callableReturnsRaw env f        = True
 rawExpr env (Call _ (Var _ n) _ KwdNil)
   | n == primUNext                  = True
-rawExpr env (BinOp _ e1 op e2)
-  | op `notElem` [And, Or]          = rawExpr env e1 && rawExpr env e2
-rawExpr env (UnOp _ op e)
-  | op /= Not                       = rawExpr env e
+rawExpr env e@(BinOp _ e1 op e2)
+  | op `notElem` [And, Or]          = B.isUnboxable (boxedRepType (typeOf env e)) ||
+                                      rawExpr env e1 && rawExpr env e2
+rawExpr env CompOp{}                = True
+rawExpr env e@(UnOp _ op e1)
+  | op /= Not                       = B.isUnboxable (boxedRepType (typeOf env e)) ||
+                                      rawExpr env e1
 rawExpr env (Cond _ e1 _ e2)        = rawExpr env e1 && rawExpr env e2
 rawExpr env _                       = False
 
@@ -1785,12 +1789,16 @@ instance Gen Expr where
        | otherwise                  = gen env primNEWTUPLE <> parens (text (show n) <> comma' (gen env p))
        where n                      = nargs p
     gen env (List _ es)             = text "B_mk_list" <> parens (pretty (length es) <> hsep [comma <+> gen env e | e <- es])
-    gen env (BinOp _ e1 And e2)     = gen env primAND <> parens (gen env t <> comma <+> gen env e1 <> comma <+> gen env e2)
-      where t | containsGeneratedMethodCall env e1 = tBool
-              | otherwise          = typeOf env e1
-    gen env (BinOp _ e1 Or e2)      = gen env primOR <> parens (gen env t <> comma <+> gen env e1 <> comma <+> gen env e2)
-      where t | containsGeneratedMethodCall env e1 = tBool
-              | otherwise          = typeOf env e1
+    gen env (BinOp _ e1 And e2)
+         | t == tBool               = parens (gen env e1 <> binPretty And <> gen env e2) 
+         | otherwise                = gen env primAND <> parens (gen env t <> comma <+> gen env e1 <> comma <+> gen env e2)
+      where t                       = typeOf env e1
+    gen env (BinOp _ e1 Or e2)
+         | t == tBool               = parens (gen env e1 <> binPretty Or <> gen env e2)
+         | otherwise                = gen env primOR <> parens (gen env t <> comma <+> gen env e1 <> comma <+> gen env e2)
+      where t                       = typeOf env e1
+--    gen env (BinOp _ e1 Or e2)      = gen env primOR <> parens (gen env t <> comma <+> gen env e1 <> comma <+> gen env e2)
+--      where t                       = typeOf env e1
     gen env (BinOp _ e1 op e2)
             | boxedRepType t == tU1,
               Just d <- genU1RawBinOp env op e1 e2
@@ -1808,7 +1816,12 @@ instance Gen Expr where
             opstr Mod               = "MOD"
             opstr EuDiv             = "FLOORDIV"
     gen env (CompOp _ e [a])        = gen env e <+> gen env a
-    gen env (UnOp _ Not e)          = gen env primNOT <> parens (gen env t <> comma <+> gen env e)
+    gen env (UnOp _ Not e)
+        | t == tBool                = parens (text "!" <> gen env e)
+        | otherwise                 = gen env primNOT <> parens (gen env t <> comma <+> gen env e)
+--      | B.isUnboxable (boxedRepType t)
+--                                    = genBoxed env tBool (parens (text "!" <> parens (genRawExpr env e)))
+--      | otherwise                   = gen env primNOT <> parens (gen env t <> comma <+> gen env e)
       where t                       = typeOf env e
     gen env (UnOp _ op e)
       | t == tU1
@@ -1818,11 +1831,8 @@ instance Gen Expr where
     gen env (UnOp _ op e)           = parens (pretty op <+> gen env e)
     gen env (Cond _ e1 e e2)        = parens (parens (gen env (B.unbox tBool e)) <+> text "?" <+> gen env e1 <+> text ":" <+> gen env e2)
     gen env (Paren _ e)             = parens (gen env e)
-    gen env (Box t i@Int{})
-      | B.isUnboxable t'            = genBoxed env t' (gen env (UnBox t' i))
-      where t'                      = boxedRepType t
-    gen env (Box t f@Float{})
-      | B.isUnboxable t'            = genBoxed env t' (gen env (UnBox t' f))
+    gen env (Box t e)
+      | B.isUnboxable t'            = genBoxed env t' (genRawExprAs env t' e)
       where t'                      = boxedRepType t
     gen env (Box t e)
       | boxedExpr env e             = gen env e

--- a/compiler/lib/test/9-codegen/deact.c
+++ b/compiler/lib/test/9-codegen/deact.c
@@ -42,10 +42,10 @@ B_NoneType deactQ_L_4actionD___init__ (deactQ_L_4action L_self, deactQ_Apa L_3ob
     return B_None;
 }
 $R deactQ_L_4actionD___call__ (deactQ_L_4action L_self, $Cont L_cont, B_int G_1) {
-    return $AWAIT(L_cont, ((B_Msg)((B_Msg (*) ($WORD, B_int))((deactQ_L_4action)(L_self))->$class->__asyn__)(L_self, G_1)));
+    return $AWAIT(L_cont, ((B_Msg)((B_Msg (*) ($WORD, B_int))((deactQ_L_4action)(L_self))->$class->__asyn__)(L_self, toB_int(((B_int)G_1)->val))));
 }
 $R deactQ_L_4actionD___exec__ (deactQ_L_4action L_self, $Cont L_cont, B_int G_1) {
-    return $R_CONT(L_cont, ((B_value)((B_Msg (*) ($WORD, B_int))((deactQ_L_4action)(L_self))->$class->__asyn__)(L_self, G_1)));
+    return $R_CONT(L_cont, ((B_value)((B_Msg (*) ($WORD, B_int))((deactQ_L_4action)(L_self))->$class->__asyn__)(L_self, toB_int(((B_int)G_1)->val))));
 }
 B_Msg deactQ_L_4actionD___asyn__ (deactQ_L_4action L_self, B_int G_1) {
     deactQ_Apa L_3obj = ((deactQ_L_4action)(L_self))->L_3obj;
@@ -276,10 +276,10 @@ B_NoneType deactQ_L_14actionD___init__ (deactQ_L_14action L_self, deactQ_Apa L_1
     return B_None;
 }
 $R deactQ_L_14actionD___call__ (deactQ_L_14action L_self, $Cont L_cont, B_int G_1) {
-    return $AWAIT(L_cont, ((B_Msg)((B_Msg (*) ($WORD, B_int))((deactQ_L_14action)(L_self))->$class->__asyn__)(L_self, G_1)));
+    return $AWAIT(L_cont, ((B_Msg)((B_Msg (*) ($WORD, B_int))((deactQ_L_14action)(L_self))->$class->__asyn__)(L_self, toB_int(((B_int)G_1)->val))));
 }
 $R deactQ_L_14actionD___exec__ (deactQ_L_14action L_self, $Cont L_cont, B_int G_1) {
-    return $R_CONT(L_cont, ((B_value)((B_Msg (*) ($WORD, B_int))((deactQ_L_14action)(L_self))->$class->__asyn__)(L_self, G_1)));
+    return $R_CONT(L_cont, ((B_value)((B_Msg (*) ($WORD, B_int))((deactQ_L_14action)(L_self))->$class->__asyn__)(L_self, toB_int(((B_int)G_1)->val))));
 }
 B_Msg deactQ_L_14actionD___asyn__ (deactQ_L_14action L_self, B_int G_1) {
     deactQ_Apa L_13obj = ((deactQ_L_14action)(L_self))->L_13obj;
@@ -313,10 +313,10 @@ B_NoneType deactQ_L_16actionD___init__ (deactQ_L_16action L_self, deactQ_Bepa L_
     return B_None;
 }
 $R deactQ_L_16actionD___call__ (deactQ_L_16action L_self, $Cont L_cont, B_int G_1) {
-    return $AWAIT(L_cont, ((B_Msg)((B_Msg (*) ($WORD, B_int))((deactQ_L_16action)(L_self))->$class->__asyn__)(L_self, G_1)));
+    return $AWAIT(L_cont, ((B_Msg)((B_Msg (*) ($WORD, B_int))((deactQ_L_16action)(L_self))->$class->__asyn__)(L_self, toB_int(((B_int)G_1)->val))));
 }
 $R deactQ_L_16actionD___exec__ (deactQ_L_16action L_self, $Cont L_cont, B_int G_1) {
-    return $R_CONT(L_cont, ((B_value)((B_Msg (*) ($WORD, B_int))((deactQ_L_16action)(L_self))->$class->__asyn__)(L_self, G_1)));
+    return $R_CONT(L_cont, ((B_value)((B_Msg (*) ($WORD, B_int))((deactQ_L_16action)(L_self))->$class->__asyn__)(L_self, toB_int(((B_int)G_1)->val))));
 }
 B_Msg deactQ_L_16actionD___asyn__ (deactQ_L_16action L_self, B_int G_1) {
     deactQ_Bepa L_15obj = ((deactQ_L_16action)(L_self))->L_15obj;
@@ -350,10 +350,10 @@ B_NoneType deactQ_L_19actionD___init__ (deactQ_L_19action L_self, deactQ_main L_
     return B_None;
 }
 $R deactQ_L_19actionD___call__ (deactQ_L_19action L_self, $Cont L_cont, B_int G_1) {
-    return $AWAIT(L_cont, ((B_Msg)((B_Msg (*) ($WORD, B_int))((deactQ_L_19action)(L_self))->$class->__asyn__)(L_self, G_1)));
+    return $AWAIT(L_cont, ((B_Msg)((B_Msg (*) ($WORD, B_int))((deactQ_L_19action)(L_self))->$class->__asyn__)(L_self, toB_int(((B_int)G_1)->val))));
 }
 $R deactQ_L_19actionD___exec__ (deactQ_L_19action L_self, $Cont L_cont, B_int G_1) {
-    return $R_CONT(L_cont, ((B_value)((B_Msg (*) ($WORD, B_int))((deactQ_L_19action)(L_self))->$class->__asyn__)(L_self, G_1)));
+    return $R_CONT(L_cont, ((B_value)((B_Msg (*) ($WORD, B_int))((deactQ_L_19action)(L_self))->$class->__asyn__)(L_self, toB_int(((B_int)G_1)->val))));
 }
 B_Msg deactQ_L_19actionD___asyn__ (deactQ_L_19action L_self, B_int G_1) {
     deactQ_main L_18obj = ((deactQ_L_19action)(L_self))->L_18obj;
@@ -950,7 +950,7 @@ void deactQ___init__ () {
     {
         deactQ_L_2ContG_methods.$GCINFO = "deactQ_L_2Cont";
         deactQ_L_2ContG_methods.$superclass = ($SuperG_class)&$ContG_methods;
-        deactQ_L_2ContG_methods.__bool__ = (B_bool (*) (deactQ_L_2Cont))B_valueG_methods.__bool__;
+        deactQ_L_2ContG_methods.__bool__ = (bool (*) (deactQ_L_2Cont))B_valueG_methods.__bool__;
         deactQ_L_2ContG_methods.__str__ = (B_str (*) (deactQ_L_2Cont))B_valueG_methods.__str__;
         deactQ_L_2ContG_methods.__repr__ = (B_str (*) (deactQ_L_2Cont))B_valueG_methods.__repr__;
         deactQ_L_2ContG_methods.__init__ = (B_NoneType (*) (deactQ_L_2Cont, $Cont))deactQ_L_2ContD___init__;
@@ -962,7 +962,7 @@ void deactQ___init__ () {
     {
         deactQ_L_4actionG_methods.$GCINFO = "deactQ_L_4action";
         deactQ_L_4actionG_methods.$superclass = ($SuperG_class)&$actionG_methods;
-        deactQ_L_4actionG_methods.__bool__ = (B_bool (*) (deactQ_L_4action))B_valueG_methods.__bool__;
+        deactQ_L_4actionG_methods.__bool__ = (bool (*) (deactQ_L_4action))B_valueG_methods.__bool__;
         deactQ_L_4actionG_methods.__str__ = (B_str (*) (deactQ_L_4action))B_valueG_methods.__str__;
         deactQ_L_4actionG_methods.__repr__ = (B_str (*) (deactQ_L_4action))B_valueG_methods.__repr__;
         deactQ_L_4actionG_methods.__init__ = (B_NoneType (*) (deactQ_L_4action, deactQ_Apa))deactQ_L_4actionD___init__;
@@ -976,7 +976,7 @@ void deactQ___init__ () {
     {
         deactQ_L_6ContG_methods.$GCINFO = "deactQ_L_6Cont";
         deactQ_L_6ContG_methods.$superclass = ($SuperG_class)&$ContG_methods;
-        deactQ_L_6ContG_methods.__bool__ = (B_bool (*) (deactQ_L_6Cont))B_valueG_methods.__bool__;
+        deactQ_L_6ContG_methods.__bool__ = (bool (*) (deactQ_L_6Cont))B_valueG_methods.__bool__;
         deactQ_L_6ContG_methods.__str__ = (B_str (*) (deactQ_L_6Cont))B_valueG_methods.__str__;
         deactQ_L_6ContG_methods.__repr__ = (B_str (*) (deactQ_L_6Cont))B_valueG_methods.__repr__;
         deactQ_L_6ContG_methods.__init__ = (B_NoneType (*) (deactQ_L_6Cont, $action, $Cont))deactQ_L_6ContD___init__;
@@ -988,7 +988,7 @@ void deactQ___init__ () {
     {
         deactQ_L_7procG_methods.$GCINFO = "deactQ_L_7proc";
         deactQ_L_7procG_methods.$superclass = ($SuperG_class)&$procG_methods;
-        deactQ_L_7procG_methods.__bool__ = (B_bool (*) (deactQ_L_7proc))B_valueG_methods.__bool__;
+        deactQ_L_7procG_methods.__bool__ = (bool (*) (deactQ_L_7proc))B_valueG_methods.__bool__;
         deactQ_L_7procG_methods.__str__ = (B_str (*) (deactQ_L_7proc))B_valueG_methods.__str__;
         deactQ_L_7procG_methods.__repr__ = (B_str (*) (deactQ_L_7proc))B_valueG_methods.__repr__;
         deactQ_L_7procG_methods.__init__ = (B_NoneType (*) (deactQ_L_7proc, deactQ_Apa, $action))deactQ_L_7procD___init__;
@@ -1001,7 +1001,7 @@ void deactQ___init__ () {
     {
         deactQ_L_8procG_methods.$GCINFO = "deactQ_L_8proc";
         deactQ_L_8procG_methods.$superclass = ($SuperG_class)&$procG_methods;
-        deactQ_L_8procG_methods.__bool__ = (B_bool (*) (deactQ_L_8proc))B_valueG_methods.__bool__;
+        deactQ_L_8procG_methods.__bool__ = (bool (*) (deactQ_L_8proc))B_valueG_methods.__bool__;
         deactQ_L_8procG_methods.__str__ = (B_str (*) (deactQ_L_8proc))B_valueG_methods.__str__;
         deactQ_L_8procG_methods.__repr__ = (B_str (*) (deactQ_L_8proc))B_valueG_methods.__repr__;
         deactQ_L_8procG_methods.__init__ = (B_NoneType (*) (deactQ_L_8proc, deactQ_Apa, $action))deactQ_L_8procD___init__;
@@ -1014,7 +1014,7 @@ void deactQ___init__ () {
     {
         deactQ_L_9procG_methods.$GCINFO = "deactQ_L_9proc";
         deactQ_L_9procG_methods.$superclass = ($SuperG_class)&$procG_methods;
-        deactQ_L_9procG_methods.__bool__ = (B_bool (*) (deactQ_L_9proc))B_valueG_methods.__bool__;
+        deactQ_L_9procG_methods.__bool__ = (bool (*) (deactQ_L_9proc))B_valueG_methods.__bool__;
         deactQ_L_9procG_methods.__str__ = (B_str (*) (deactQ_L_9proc))B_valueG_methods.__str__;
         deactQ_L_9procG_methods.__repr__ = (B_str (*) (deactQ_L_9proc))B_valueG_methods.__repr__;
         deactQ_L_9procG_methods.__init__ = (B_NoneType (*) (deactQ_L_9proc, deactQ_Apa, int64_t))deactQ_L_9procD___init__;
@@ -1027,7 +1027,7 @@ void deactQ___init__ () {
     {
         deactQ_L_10procG_methods.$GCINFO = "deactQ_L_10proc";
         deactQ_L_10procG_methods.$superclass = ($SuperG_class)&$procG_methods;
-        deactQ_L_10procG_methods.__bool__ = (B_bool (*) (deactQ_L_10proc))B_valueG_methods.__bool__;
+        deactQ_L_10procG_methods.__bool__ = (bool (*) (deactQ_L_10proc))B_valueG_methods.__bool__;
         deactQ_L_10procG_methods.__str__ = (B_str (*) (deactQ_L_10proc))B_valueG_methods.__str__;
         deactQ_L_10procG_methods.__repr__ = (B_str (*) (deactQ_L_10proc))B_valueG_methods.__repr__;
         deactQ_L_10procG_methods.__init__ = (B_NoneType (*) (deactQ_L_10proc, deactQ_Bepa, int64_t))deactQ_L_10procD___init__;
@@ -1040,7 +1040,7 @@ void deactQ___init__ () {
     {
         deactQ_L_14actionG_methods.$GCINFO = "deactQ_L_14action";
         deactQ_L_14actionG_methods.$superclass = ($SuperG_class)&$actionG_methods;
-        deactQ_L_14actionG_methods.__bool__ = (B_bool (*) (deactQ_L_14action))B_valueG_methods.__bool__;
+        deactQ_L_14actionG_methods.__bool__ = (bool (*) (deactQ_L_14action))B_valueG_methods.__bool__;
         deactQ_L_14actionG_methods.__str__ = (B_str (*) (deactQ_L_14action))B_valueG_methods.__str__;
         deactQ_L_14actionG_methods.__repr__ = (B_str (*) (deactQ_L_14action))B_valueG_methods.__repr__;
         deactQ_L_14actionG_methods.__init__ = (B_NoneType (*) (deactQ_L_14action, deactQ_Apa))deactQ_L_14actionD___init__;
@@ -1054,7 +1054,7 @@ void deactQ___init__ () {
     {
         deactQ_L_16actionG_methods.$GCINFO = "deactQ_L_16action";
         deactQ_L_16actionG_methods.$superclass = ($SuperG_class)&$actionG_methods;
-        deactQ_L_16actionG_methods.__bool__ = (B_bool (*) (deactQ_L_16action))B_valueG_methods.__bool__;
+        deactQ_L_16actionG_methods.__bool__ = (bool (*) (deactQ_L_16action))B_valueG_methods.__bool__;
         deactQ_L_16actionG_methods.__str__ = (B_str (*) (deactQ_L_16action))B_valueG_methods.__str__;
         deactQ_L_16actionG_methods.__repr__ = (B_str (*) (deactQ_L_16action))B_valueG_methods.__repr__;
         deactQ_L_16actionG_methods.__init__ = (B_NoneType (*) (deactQ_L_16action, deactQ_Bepa))deactQ_L_16actionD___init__;
@@ -1068,7 +1068,7 @@ void deactQ___init__ () {
     {
         deactQ_L_19actionG_methods.$GCINFO = "deactQ_L_19action";
         deactQ_L_19actionG_methods.$superclass = ($SuperG_class)&$actionG_methods;
-        deactQ_L_19actionG_methods.__bool__ = (B_bool (*) (deactQ_L_19action))B_valueG_methods.__bool__;
+        deactQ_L_19actionG_methods.__bool__ = (bool (*) (deactQ_L_19action))B_valueG_methods.__bool__;
         deactQ_L_19actionG_methods.__str__ = (B_str (*) (deactQ_L_19action))B_valueG_methods.__str__;
         deactQ_L_19actionG_methods.__repr__ = (B_str (*) (deactQ_L_19action))B_valueG_methods.__repr__;
         deactQ_L_19actionG_methods.__init__ = (B_NoneType (*) (deactQ_L_19action, deactQ_main))deactQ_L_19actionD___init__;
@@ -1082,7 +1082,7 @@ void deactQ___init__ () {
     {
         deactQ_L_20ContG_methods.$GCINFO = "deactQ_L_20Cont";
         deactQ_L_20ContG_methods.$superclass = ($SuperG_class)&$ContG_methods;
-        deactQ_L_20ContG_methods.__bool__ = (B_bool (*) (deactQ_L_20Cont))B_valueG_methods.__bool__;
+        deactQ_L_20ContG_methods.__bool__ = (bool (*) (deactQ_L_20Cont))B_valueG_methods.__bool__;
         deactQ_L_20ContG_methods.__str__ = (B_str (*) (deactQ_L_20Cont))B_valueG_methods.__str__;
         deactQ_L_20ContG_methods.__repr__ = (B_str (*) (deactQ_L_20Cont))B_valueG_methods.__repr__;
         deactQ_L_20ContG_methods.__init__ = (B_NoneType (*) (deactQ_L_20Cont, deactQ_main, $Cont))deactQ_L_20ContD___init__;
@@ -1094,7 +1094,7 @@ void deactQ___init__ () {
     {
         deactQ_L_21ContG_methods.$GCINFO = "deactQ_L_21Cont";
         deactQ_L_21ContG_methods.$superclass = ($SuperG_class)&$ContG_methods;
-        deactQ_L_21ContG_methods.__bool__ = (B_bool (*) (deactQ_L_21Cont))B_valueG_methods.__bool__;
+        deactQ_L_21ContG_methods.__bool__ = (bool (*) (deactQ_L_21Cont))B_valueG_methods.__bool__;
         deactQ_L_21ContG_methods.__str__ = (B_str (*) (deactQ_L_21Cont))B_valueG_methods.__str__;
         deactQ_L_21ContG_methods.__repr__ = (B_str (*) (deactQ_L_21Cont))B_valueG_methods.__repr__;
         deactQ_L_21ContG_methods.__init__ = (B_NoneType (*) (deactQ_L_21Cont, deactQ_main, $Cont))deactQ_L_21ContD___init__;
@@ -1106,7 +1106,7 @@ void deactQ___init__ () {
     {
         deactQ_L_22ContG_methods.$GCINFO = "deactQ_L_22Cont";
         deactQ_L_22ContG_methods.$superclass = ($SuperG_class)&$ContG_methods;
-        deactQ_L_22ContG_methods.__bool__ = (B_bool (*) (deactQ_L_22Cont))B_valueG_methods.__bool__;
+        deactQ_L_22ContG_methods.__bool__ = (bool (*) (deactQ_L_22Cont))B_valueG_methods.__bool__;
         deactQ_L_22ContG_methods.__str__ = (B_str (*) (deactQ_L_22Cont))B_valueG_methods.__str__;
         deactQ_L_22ContG_methods.__repr__ = (B_str (*) (deactQ_L_22Cont))B_valueG_methods.__repr__;
         deactQ_L_22ContG_methods.__init__ = (B_NoneType (*) (deactQ_L_22Cont, deactQ_main, $Cont))deactQ_L_22ContD___init__;
@@ -1118,7 +1118,7 @@ void deactQ___init__ () {
     {
         deactQ_L_23procG_methods.$GCINFO = "deactQ_L_23proc";
         deactQ_L_23procG_methods.$superclass = ($SuperG_class)&$procG_methods;
-        deactQ_L_23procG_methods.__bool__ = (B_bool (*) (deactQ_L_23proc))B_valueG_methods.__bool__;
+        deactQ_L_23procG_methods.__bool__ = (bool (*) (deactQ_L_23proc))B_valueG_methods.__bool__;
         deactQ_L_23procG_methods.__str__ = (B_str (*) (deactQ_L_23proc))B_valueG_methods.__str__;
         deactQ_L_23procG_methods.__repr__ = (B_str (*) (deactQ_L_23proc))B_valueG_methods.__repr__;
         deactQ_L_23procG_methods.__init__ = (B_NoneType (*) (deactQ_L_23proc, deactQ_main, int64_t))deactQ_L_23procD___init__;
@@ -1131,7 +1131,7 @@ void deactQ___init__ () {
     {
         deactQ_L_25ContG_methods.$GCINFO = "deactQ_L_25Cont";
         deactQ_L_25ContG_methods.$superclass = ($SuperG_class)&$ContG_methods;
-        deactQ_L_25ContG_methods.__bool__ = (B_bool (*) (deactQ_L_25Cont))B_valueG_methods.__bool__;
+        deactQ_L_25ContG_methods.__bool__ = (bool (*) (deactQ_L_25Cont))B_valueG_methods.__bool__;
         deactQ_L_25ContG_methods.__str__ = (B_str (*) (deactQ_L_25Cont))B_valueG_methods.__str__;
         deactQ_L_25ContG_methods.__repr__ = (B_str (*) (deactQ_L_25Cont))B_valueG_methods.__repr__;
         deactQ_L_25ContG_methods.__init__ = (B_NoneType (*) (deactQ_L_25Cont, $Cont, deactQ_Apa))deactQ_L_25ContD___init__;
@@ -1143,7 +1143,7 @@ void deactQ___init__ () {
     {
         deactQ_L_26procG_methods.$GCINFO = "deactQ_L_26proc";
         deactQ_L_26procG_methods.$superclass = ($SuperG_class)&$procG_methods;
-        deactQ_L_26procG_methods.__bool__ = (B_bool (*) (deactQ_L_26proc))B_valueG_methods.__bool__;
+        deactQ_L_26procG_methods.__bool__ = (bool (*) (deactQ_L_26proc))B_valueG_methods.__bool__;
         deactQ_L_26procG_methods.__str__ = (B_str (*) (deactQ_L_26proc))B_valueG_methods.__str__;
         deactQ_L_26procG_methods.__repr__ = (B_str (*) (deactQ_L_26proc))B_valueG_methods.__repr__;
         deactQ_L_26procG_methods.__init__ = (B_NoneType (*) (deactQ_L_26proc, deactQ_Apa))deactQ_L_26procD___init__;
@@ -1156,7 +1156,7 @@ void deactQ___init__ () {
     {
         deactQ_L_28ContG_methods.$GCINFO = "deactQ_L_28Cont";
         deactQ_L_28ContG_methods.$superclass = ($SuperG_class)&$ContG_methods;
-        deactQ_L_28ContG_methods.__bool__ = (B_bool (*) (deactQ_L_28Cont))B_valueG_methods.__bool__;
+        deactQ_L_28ContG_methods.__bool__ = (bool (*) (deactQ_L_28Cont))B_valueG_methods.__bool__;
         deactQ_L_28ContG_methods.__str__ = (B_str (*) (deactQ_L_28Cont))B_valueG_methods.__str__;
         deactQ_L_28ContG_methods.__repr__ = (B_str (*) (deactQ_L_28Cont))B_valueG_methods.__repr__;
         deactQ_L_28ContG_methods.__init__ = (B_NoneType (*) (deactQ_L_28Cont, $Cont, deactQ_Bepa))deactQ_L_28ContD___init__;
@@ -1168,7 +1168,7 @@ void deactQ___init__ () {
     {
         deactQ_L_29procG_methods.$GCINFO = "deactQ_L_29proc";
         deactQ_L_29procG_methods.$superclass = ($SuperG_class)&$procG_methods;
-        deactQ_L_29procG_methods.__bool__ = (B_bool (*) (deactQ_L_29proc))B_valueG_methods.__bool__;
+        deactQ_L_29procG_methods.__bool__ = (bool (*) (deactQ_L_29proc))B_valueG_methods.__bool__;
         deactQ_L_29procG_methods.__str__ = (B_str (*) (deactQ_L_29proc))B_valueG_methods.__str__;
         deactQ_L_29procG_methods.__repr__ = (B_str (*) (deactQ_L_29proc))B_valueG_methods.__repr__;
         deactQ_L_29procG_methods.__init__ = (B_NoneType (*) (deactQ_L_29proc, deactQ_Bepa))deactQ_L_29procD___init__;
@@ -1181,7 +1181,7 @@ void deactQ___init__ () {
     {
         deactQ_L_31ContG_methods.$GCINFO = "deactQ_L_31Cont";
         deactQ_L_31ContG_methods.$superclass = ($SuperG_class)&$ContG_methods;
-        deactQ_L_31ContG_methods.__bool__ = (B_bool (*) (deactQ_L_31Cont))B_valueG_methods.__bool__;
+        deactQ_L_31ContG_methods.__bool__ = (bool (*) (deactQ_L_31Cont))B_valueG_methods.__bool__;
         deactQ_L_31ContG_methods.__str__ = (B_str (*) (deactQ_L_31Cont))B_valueG_methods.__str__;
         deactQ_L_31ContG_methods.__repr__ = (B_str (*) (deactQ_L_31Cont))B_valueG_methods.__repr__;
         deactQ_L_31ContG_methods.__init__ = (B_NoneType (*) (deactQ_L_31Cont, $Cont, deactQ_main))deactQ_L_31ContD___init__;
@@ -1193,7 +1193,7 @@ void deactQ___init__ () {
     {
         deactQ_L_32procG_methods.$GCINFO = "deactQ_L_32proc";
         deactQ_L_32procG_methods.$superclass = ($SuperG_class)&$procG_methods;
-        deactQ_L_32procG_methods.__bool__ = (B_bool (*) (deactQ_L_32proc))B_valueG_methods.__bool__;
+        deactQ_L_32procG_methods.__bool__ = (bool (*) (deactQ_L_32proc))B_valueG_methods.__bool__;
         deactQ_L_32procG_methods.__str__ = (B_str (*) (deactQ_L_32proc))B_valueG_methods.__str__;
         deactQ_L_32procG_methods.__repr__ = (B_str (*) (deactQ_L_32proc))B_valueG_methods.__repr__;
         deactQ_L_32procG_methods.__init__ = (B_NoneType (*) (deactQ_L_32proc, deactQ_main, B_Env))deactQ_L_32procD___init__;
@@ -1206,7 +1206,7 @@ void deactQ___init__ () {
     {
         deactQ_ApaG_methods.$GCINFO = "deactQ_Apa";
         deactQ_ApaG_methods.$superclass = ($SuperG_class)&$ActorG_methods;
-        deactQ_ApaG_methods.__bool__ = (B_bool (*) (deactQ_Apa))$ActorG_methods.__bool__;
+        deactQ_ApaG_methods.__bool__ = (bool (*) (deactQ_Apa))$ActorG_methods.__bool__;
         deactQ_ApaG_methods.__str__ = (B_str (*) (deactQ_Apa))$ActorG_methods.__str__;
         deactQ_ApaG_methods.__repr__ = (B_str (*) (deactQ_Apa))$ActorG_methods.__repr__;
         deactQ_ApaG_methods.__resume__ = (B_NoneType (*) (deactQ_Apa))$ActorG_methods.__resume__;
@@ -1225,7 +1225,7 @@ void deactQ___init__ () {
     {
         deactQ_BepaG_methods.$GCINFO = "deactQ_Bepa";
         deactQ_BepaG_methods.$superclass = ($SuperG_class)&$ActorG_methods;
-        deactQ_BepaG_methods.__bool__ = (B_bool (*) (deactQ_Bepa))$ActorG_methods.__bool__;
+        deactQ_BepaG_methods.__bool__ = (bool (*) (deactQ_Bepa))$ActorG_methods.__bool__;
         deactQ_BepaG_methods.__str__ = (B_str (*) (deactQ_Bepa))$ActorG_methods.__str__;
         deactQ_BepaG_methods.__repr__ = (B_str (*) (deactQ_Bepa))$ActorG_methods.__repr__;
         deactQ_BepaG_methods.__resume__ = (B_NoneType (*) (deactQ_Bepa))$ActorG_methods.__resume__;
@@ -1240,7 +1240,7 @@ void deactQ___init__ () {
     {
         deactQ_mainG_methods.$GCINFO = "deactQ_main";
         deactQ_mainG_methods.$superclass = ($SuperG_class)&$ActorG_methods;
-        deactQ_mainG_methods.__bool__ = (B_bool (*) (deactQ_main))$ActorG_methods.__bool__;
+        deactQ_mainG_methods.__bool__ = (bool (*) (deactQ_main))$ActorG_methods.__bool__;
         deactQ_mainG_methods.__str__ = (B_str (*) (deactQ_main))$ActorG_methods.__str__;
         deactQ_mainG_methods.__repr__ = (B_str (*) (deactQ_main))$ActorG_methods.__repr__;
         deactQ_mainG_methods.__resume__ = (B_NoneType (*) (deactQ_main))$ActorG_methods.__resume__;

--- a/compiler/lib/test/9-codegen/deact.h
+++ b/compiler/lib/test/9-codegen/deact.h
@@ -56,7 +56,7 @@ struct deactQ_L_2ContG_class {
     B_NoneType (*__init__) (deactQ_L_2Cont, $Cont);
     void (*__serialize__) (deactQ_L_2Cont, $Serial$state);
     deactQ_L_2Cont (*__deserialize__) (deactQ_L_2Cont, $Serial$state);
-    B_bool (*__bool__) (deactQ_L_2Cont);
+    bool (*__bool__) (deactQ_L_2Cont);
     B_str (*__str__) (deactQ_L_2Cont);
     B_str (*__repr__) (deactQ_L_2Cont);
     $R (*__call__) (deactQ_L_2Cont, B_NoneType);
@@ -72,7 +72,7 @@ struct deactQ_L_4actionG_class {
     B_NoneType (*__init__) (deactQ_L_4action, deactQ_Apa);
     void (*__serialize__) (deactQ_L_4action, $Serial$state);
     deactQ_L_4action (*__deserialize__) (deactQ_L_4action, $Serial$state);
-    B_bool (*__bool__) (deactQ_L_4action);
+    bool (*__bool__) (deactQ_L_4action);
     B_str (*__str__) (deactQ_L_4action);
     B_str (*__repr__) (deactQ_L_4action);
     $R (*__call__) (deactQ_L_4action, $Cont, B_int);
@@ -91,7 +91,7 @@ struct deactQ_L_6ContG_class {
     B_NoneType (*__init__) (deactQ_L_6Cont, $action, $Cont);
     void (*__serialize__) (deactQ_L_6Cont, $Serial$state);
     deactQ_L_6Cont (*__deserialize__) (deactQ_L_6Cont, $Serial$state);
-    B_bool (*__bool__) (deactQ_L_6Cont);
+    bool (*__bool__) (deactQ_L_6Cont);
     B_str (*__str__) (deactQ_L_6Cont);
     B_str (*__repr__) (deactQ_L_6Cont);
     $R (*__call__) (deactQ_L_6Cont, B_int);
@@ -108,7 +108,7 @@ struct deactQ_L_7procG_class {
     B_NoneType (*__init__) (deactQ_L_7proc, deactQ_Apa, $action);
     void (*__serialize__) (deactQ_L_7proc, $Serial$state);
     deactQ_L_7proc (*__deserialize__) (deactQ_L_7proc, $Serial$state);
-    B_bool (*__bool__) (deactQ_L_7proc);
+    bool (*__bool__) (deactQ_L_7proc);
     B_str (*__str__) (deactQ_L_7proc);
     B_str (*__repr__) (deactQ_L_7proc);
     $R (*__call__) (deactQ_L_7proc, $Cont);
@@ -126,7 +126,7 @@ struct deactQ_L_8procG_class {
     B_NoneType (*__init__) (deactQ_L_8proc, deactQ_Apa, $action);
     void (*__serialize__) (deactQ_L_8proc, $Serial$state);
     deactQ_L_8proc (*__deserialize__) (deactQ_L_8proc, $Serial$state);
-    B_bool (*__bool__) (deactQ_L_8proc);
+    bool (*__bool__) (deactQ_L_8proc);
     B_str (*__str__) (deactQ_L_8proc);
     B_str (*__repr__) (deactQ_L_8proc);
     $R (*__call__) (deactQ_L_8proc, $Cont);
@@ -144,7 +144,7 @@ struct deactQ_L_9procG_class {
     B_NoneType (*__init__) (deactQ_L_9proc, deactQ_Apa, int64_t);
     void (*__serialize__) (deactQ_L_9proc, $Serial$state);
     deactQ_L_9proc (*__deserialize__) (deactQ_L_9proc, $Serial$state);
-    B_bool (*__bool__) (deactQ_L_9proc);
+    bool (*__bool__) (deactQ_L_9proc);
     B_str (*__str__) (deactQ_L_9proc);
     B_str (*__repr__) (deactQ_L_9proc);
     $R (*__call__) (deactQ_L_9proc, $Cont);
@@ -162,7 +162,7 @@ struct deactQ_L_10procG_class {
     B_NoneType (*__init__) (deactQ_L_10proc, deactQ_Bepa, int64_t);
     void (*__serialize__) (deactQ_L_10proc, $Serial$state);
     deactQ_L_10proc (*__deserialize__) (deactQ_L_10proc, $Serial$state);
-    B_bool (*__bool__) (deactQ_L_10proc);
+    bool (*__bool__) (deactQ_L_10proc);
     B_str (*__str__) (deactQ_L_10proc);
     B_str (*__repr__) (deactQ_L_10proc);
     $R (*__call__) (deactQ_L_10proc, $Cont);
@@ -180,7 +180,7 @@ struct deactQ_L_14actionG_class {
     B_NoneType (*__init__) (deactQ_L_14action, deactQ_Apa);
     void (*__serialize__) (deactQ_L_14action, $Serial$state);
     deactQ_L_14action (*__deserialize__) (deactQ_L_14action, $Serial$state);
-    B_bool (*__bool__) (deactQ_L_14action);
+    bool (*__bool__) (deactQ_L_14action);
     B_str (*__str__) (deactQ_L_14action);
     B_str (*__repr__) (deactQ_L_14action);
     $R (*__call__) (deactQ_L_14action, $Cont, B_int);
@@ -198,7 +198,7 @@ struct deactQ_L_16actionG_class {
     B_NoneType (*__init__) (deactQ_L_16action, deactQ_Bepa);
     void (*__serialize__) (deactQ_L_16action, $Serial$state);
     deactQ_L_16action (*__deserialize__) (deactQ_L_16action, $Serial$state);
-    B_bool (*__bool__) (deactQ_L_16action);
+    bool (*__bool__) (deactQ_L_16action);
     B_str (*__str__) (deactQ_L_16action);
     B_str (*__repr__) (deactQ_L_16action);
     $R (*__call__) (deactQ_L_16action, $Cont, B_int);
@@ -216,7 +216,7 @@ struct deactQ_L_19actionG_class {
     B_NoneType (*__init__) (deactQ_L_19action, deactQ_main);
     void (*__serialize__) (deactQ_L_19action, $Serial$state);
     deactQ_L_19action (*__deserialize__) (deactQ_L_19action, $Serial$state);
-    B_bool (*__bool__) (deactQ_L_19action);
+    bool (*__bool__) (deactQ_L_19action);
     B_str (*__str__) (deactQ_L_19action);
     B_str (*__repr__) (deactQ_L_19action);
     $R (*__call__) (deactQ_L_19action, $Cont, B_int);
@@ -235,7 +235,7 @@ struct deactQ_L_20ContG_class {
     B_NoneType (*__init__) (deactQ_L_20Cont, deactQ_main, $Cont);
     void (*__serialize__) (deactQ_L_20Cont, $Serial$state);
     deactQ_L_20Cont (*__deserialize__) (deactQ_L_20Cont, $Serial$state);
-    B_bool (*__bool__) (deactQ_L_20Cont);
+    bool (*__bool__) (deactQ_L_20Cont);
     B_str (*__str__) (deactQ_L_20Cont);
     B_str (*__repr__) (deactQ_L_20Cont);
     $R (*__call__) (deactQ_L_20Cont, B_int);
@@ -253,7 +253,7 @@ struct deactQ_L_21ContG_class {
     B_NoneType (*__init__) (deactQ_L_21Cont, deactQ_main, $Cont);
     void (*__serialize__) (deactQ_L_21Cont, $Serial$state);
     deactQ_L_21Cont (*__deserialize__) (deactQ_L_21Cont, $Serial$state);
-    B_bool (*__bool__) (deactQ_L_21Cont);
+    bool (*__bool__) (deactQ_L_21Cont);
     B_str (*__str__) (deactQ_L_21Cont);
     B_str (*__repr__) (deactQ_L_21Cont);
     $R (*__call__) (deactQ_L_21Cont, deactQ_Bepa);
@@ -271,7 +271,7 @@ struct deactQ_L_22ContG_class {
     B_NoneType (*__init__) (deactQ_L_22Cont, deactQ_main, $Cont);
     void (*__serialize__) (deactQ_L_22Cont, $Serial$state);
     deactQ_L_22Cont (*__deserialize__) (deactQ_L_22Cont, $Serial$state);
-    B_bool (*__bool__) (deactQ_L_22Cont);
+    bool (*__bool__) (deactQ_L_22Cont);
     B_str (*__str__) (deactQ_L_22Cont);
     B_str (*__repr__) (deactQ_L_22Cont);
     $R (*__call__) (deactQ_L_22Cont, deactQ_Apa);
@@ -288,7 +288,7 @@ struct deactQ_L_23procG_class {
     B_NoneType (*__init__) (deactQ_L_23proc, deactQ_main, int64_t);
     void (*__serialize__) (deactQ_L_23proc, $Serial$state);
     deactQ_L_23proc (*__deserialize__) (deactQ_L_23proc, $Serial$state);
-    B_bool (*__bool__) (deactQ_L_23proc);
+    bool (*__bool__) (deactQ_L_23proc);
     B_str (*__str__) (deactQ_L_23proc);
     B_str (*__repr__) (deactQ_L_23proc);
     $R (*__call__) (deactQ_L_23proc, $Cont);
@@ -307,7 +307,7 @@ struct deactQ_L_25ContG_class {
     B_NoneType (*__init__) (deactQ_L_25Cont, $Cont, deactQ_Apa);
     void (*__serialize__) (deactQ_L_25Cont, $Serial$state);
     deactQ_L_25Cont (*__deserialize__) (deactQ_L_25Cont, $Serial$state);
-    B_bool (*__bool__) (deactQ_L_25Cont);
+    bool (*__bool__) (deactQ_L_25Cont);
     B_str (*__str__) (deactQ_L_25Cont);
     B_str (*__repr__) (deactQ_L_25Cont);
     $R (*__call__) (deactQ_L_25Cont, B_NoneType);
@@ -324,7 +324,7 @@ struct deactQ_L_26procG_class {
     B_NoneType (*__init__) (deactQ_L_26proc, deactQ_Apa);
     void (*__serialize__) (deactQ_L_26proc, $Serial$state);
     deactQ_L_26proc (*__deserialize__) (deactQ_L_26proc, $Serial$state);
-    B_bool (*__bool__) (deactQ_L_26proc);
+    bool (*__bool__) (deactQ_L_26proc);
     B_str (*__str__) (deactQ_L_26proc);
     B_str (*__repr__) (deactQ_L_26proc);
     $R (*__call__) (deactQ_L_26proc, $Cont);
@@ -342,7 +342,7 @@ struct deactQ_L_28ContG_class {
     B_NoneType (*__init__) (deactQ_L_28Cont, $Cont, deactQ_Bepa);
     void (*__serialize__) (deactQ_L_28Cont, $Serial$state);
     deactQ_L_28Cont (*__deserialize__) (deactQ_L_28Cont, $Serial$state);
-    B_bool (*__bool__) (deactQ_L_28Cont);
+    bool (*__bool__) (deactQ_L_28Cont);
     B_str (*__str__) (deactQ_L_28Cont);
     B_str (*__repr__) (deactQ_L_28Cont);
     $R (*__call__) (deactQ_L_28Cont, B_NoneType);
@@ -359,7 +359,7 @@ struct deactQ_L_29procG_class {
     B_NoneType (*__init__) (deactQ_L_29proc, deactQ_Bepa);
     void (*__serialize__) (deactQ_L_29proc, $Serial$state);
     deactQ_L_29proc (*__deserialize__) (deactQ_L_29proc, $Serial$state);
-    B_bool (*__bool__) (deactQ_L_29proc);
+    bool (*__bool__) (deactQ_L_29proc);
     B_str (*__str__) (deactQ_L_29proc);
     B_str (*__repr__) (deactQ_L_29proc);
     $R (*__call__) (deactQ_L_29proc, $Cont);
@@ -377,7 +377,7 @@ struct deactQ_L_31ContG_class {
     B_NoneType (*__init__) (deactQ_L_31Cont, $Cont, deactQ_main);
     void (*__serialize__) (deactQ_L_31Cont, $Serial$state);
     deactQ_L_31Cont (*__deserialize__) (deactQ_L_31Cont, $Serial$state);
-    B_bool (*__bool__) (deactQ_L_31Cont);
+    bool (*__bool__) (deactQ_L_31Cont);
     B_str (*__str__) (deactQ_L_31Cont);
     B_str (*__repr__) (deactQ_L_31Cont);
     $R (*__call__) (deactQ_L_31Cont, B_NoneType);
@@ -394,7 +394,7 @@ struct deactQ_L_32procG_class {
     B_NoneType (*__init__) (deactQ_L_32proc, deactQ_main, B_Env);
     void (*__serialize__) (deactQ_L_32proc, $Serial$state);
     deactQ_L_32proc (*__deserialize__) (deactQ_L_32proc, $Serial$state);
-    B_bool (*__bool__) (deactQ_L_32proc);
+    bool (*__bool__) (deactQ_L_32proc);
     B_str (*__str__) (deactQ_L_32proc);
     B_str (*__repr__) (deactQ_L_32proc);
     $R (*__call__) (deactQ_L_32proc, $Cont);
@@ -412,7 +412,7 @@ struct deactQ_ApaG_class {
     $R (*__init__) (deactQ_Apa, $Cont);
     void (*__serialize__) (deactQ_Apa, $Serial$state);
     deactQ_Apa (*__deserialize__) (deactQ_Apa, $Serial$state);
-    B_bool (*__bool__) (deactQ_Apa);
+    bool (*__bool__) (deactQ_Apa);
     B_str (*__str__) (deactQ_Apa);
     B_str (*__repr__) (deactQ_Apa);
     B_NoneType (*__resume__) (deactQ_Apa);
@@ -444,7 +444,7 @@ struct deactQ_BepaG_class {
     $R (*__init__) (deactQ_Bepa, $Cont);
     void (*__serialize__) (deactQ_Bepa, $Serial$state);
     deactQ_Bepa (*__deserialize__) (deactQ_Bepa, $Serial$state);
-    B_bool (*__bool__) (deactQ_Bepa);
+    bool (*__bool__) (deactQ_Bepa);
     B_str (*__str__) (deactQ_Bepa);
     B_str (*__repr__) (deactQ_Bepa);
     B_NoneType (*__resume__) (deactQ_Bepa);
@@ -472,7 +472,7 @@ struct deactQ_mainG_class {
     $R (*__init__) (deactQ_main, $Cont, B_Env);
     void (*__serialize__) (deactQ_main, $Serial$state);
     deactQ_main (*__deserialize__) (deactQ_main, $Serial$state);
-    B_bool (*__bool__) (deactQ_main);
+    bool (*__bool__) (deactQ_main);
     B_str (*__str__) (deactQ_main);
     B_str (*__repr__) (deactQ_main);
     B_NoneType (*__resume__) (deactQ_main);

--- a/compiler/lib/test/9-codegen/lines.c
+++ b/compiler/lib/test/9-codegen/lines.c
@@ -52,10 +52,10 @@ B_NoneType linesQ_L_4actionD___init__ (linesQ_L_4action L_self, linesQ_Apa L_3ob
     return B_None;
 }
 $R linesQ_L_4actionD___call__ (linesQ_L_4action L_self, $Cont L_cont, B_int G_1) {
-    return $AWAIT(L_cont, ((B_Msg)((B_Msg (*) ($WORD, B_int))((linesQ_L_4action)(L_self))->$class->__asyn__)(L_self, G_1)));
+    return $AWAIT(L_cont, ((B_Msg)((B_Msg (*) ($WORD, B_int))((linesQ_L_4action)(L_self))->$class->__asyn__)(L_self, toB_int(((B_int)G_1)->val))));
 }
 $R linesQ_L_4actionD___exec__ (linesQ_L_4action L_self, $Cont L_cont, B_int G_1) {
-    return $R_CONT(L_cont, ((B_value)((B_Msg (*) ($WORD, B_int))((linesQ_L_4action)(L_self))->$class->__asyn__)(L_self, G_1)));
+    return $R_CONT(L_cont, ((B_value)((B_Msg (*) ($WORD, B_int))((linesQ_L_4action)(L_self))->$class->__asyn__)(L_self, toB_int(((B_int)G_1)->val))));
 }
 B_Msg linesQ_L_4actionD___asyn__ (linesQ_L_4action L_self, B_int G_1) {
     linesQ_Apa L_3obj = ((linesQ_L_4action)(L_self))->L_3obj;
@@ -286,10 +286,10 @@ B_NoneType linesQ_L_14actionD___init__ (linesQ_L_14action L_self, linesQ_Apa L_1
     return B_None;
 }
 $R linesQ_L_14actionD___call__ (linesQ_L_14action L_self, $Cont L_cont, B_int G_1) {
-    return $AWAIT(L_cont, ((B_Msg)((B_Msg (*) ($WORD, B_int))((linesQ_L_14action)(L_self))->$class->__asyn__)(L_self, G_1)));
+    return $AWAIT(L_cont, ((B_Msg)((B_Msg (*) ($WORD, B_int))((linesQ_L_14action)(L_self))->$class->__asyn__)(L_self, toB_int(((B_int)G_1)->val))));
 }
 $R linesQ_L_14actionD___exec__ (linesQ_L_14action L_self, $Cont L_cont, B_int G_1) {
-    return $R_CONT(L_cont, ((B_value)((B_Msg (*) ($WORD, B_int))((linesQ_L_14action)(L_self))->$class->__asyn__)(L_self, G_1)));
+    return $R_CONT(L_cont, ((B_value)((B_Msg (*) ($WORD, B_int))((linesQ_L_14action)(L_self))->$class->__asyn__)(L_self, toB_int(((B_int)G_1)->val))));
 }
 B_Msg linesQ_L_14actionD___asyn__ (linesQ_L_14action L_self, B_int G_1) {
     linesQ_Apa L_13obj = ((linesQ_L_14action)(L_self))->L_13obj;
@@ -323,10 +323,10 @@ B_NoneType linesQ_L_16actionD___init__ (linesQ_L_16action L_self, linesQ_Bepa L_
     return B_None;
 }
 $R linesQ_L_16actionD___call__ (linesQ_L_16action L_self, $Cont L_cont, B_int G_1) {
-    return $AWAIT(L_cont, ((B_Msg)((B_Msg (*) ($WORD, B_int))((linesQ_L_16action)(L_self))->$class->__asyn__)(L_self, G_1)));
+    return $AWAIT(L_cont, ((B_Msg)((B_Msg (*) ($WORD, B_int))((linesQ_L_16action)(L_self))->$class->__asyn__)(L_self, toB_int(((B_int)G_1)->val))));
 }
 $R linesQ_L_16actionD___exec__ (linesQ_L_16action L_self, $Cont L_cont, B_int G_1) {
-    return $R_CONT(L_cont, ((B_value)((B_Msg (*) ($WORD, B_int))((linesQ_L_16action)(L_self))->$class->__asyn__)(L_self, G_1)));
+    return $R_CONT(L_cont, ((B_value)((B_Msg (*) ($WORD, B_int))((linesQ_L_16action)(L_self))->$class->__asyn__)(L_self, toB_int(((B_int)G_1)->val))));
 }
 B_Msg linesQ_L_16actionD___asyn__ (linesQ_L_16action L_self, B_int G_1) {
     linesQ_Bepa L_15obj = ((linesQ_L_16action)(L_self))->L_15obj;
@@ -360,10 +360,10 @@ B_NoneType linesQ_L_19actionD___init__ (linesQ_L_19action L_self, linesQ_main L_
     return B_None;
 }
 $R linesQ_L_19actionD___call__ (linesQ_L_19action L_self, $Cont L_cont, B_int G_1) {
-    return $AWAIT(L_cont, ((B_Msg)((B_Msg (*) ($WORD, B_int))((linesQ_L_19action)(L_self))->$class->__asyn__)(L_self, G_1)));
+    return $AWAIT(L_cont, ((B_Msg)((B_Msg (*) ($WORD, B_int))((linesQ_L_19action)(L_self))->$class->__asyn__)(L_self, toB_int(((B_int)G_1)->val))));
 }
 $R linesQ_L_19actionD___exec__ (linesQ_L_19action L_self, $Cont L_cont, B_int G_1) {
-    return $R_CONT(L_cont, ((B_value)((B_Msg (*) ($WORD, B_int))((linesQ_L_19action)(L_self))->$class->__asyn__)(L_self, G_1)));
+    return $R_CONT(L_cont, ((B_value)((B_Msg (*) ($WORD, B_int))((linesQ_L_19action)(L_self))->$class->__asyn__)(L_self, toB_int(((B_int)G_1)->val))));
 }
 B_Msg linesQ_L_19actionD___asyn__ (linesQ_L_19action L_self, B_int G_1) {
     linesQ_main L_18obj = ((linesQ_L_19action)(L_self))->L_18obj;
@@ -499,7 +499,7 @@ $R linesQ_L_17C_9cont (linesQ_main self, $Cont C_cont, int64_t C_10res) {
         while (true) {
             B_int j = ((B_int (*) ($WORD))((B_Iterator)(N_3iter))->$class->__next__)(N_3iter);
             #line 74 "test/src/lines.act"
-            if (((B_bool)((B_bool (*) ($WORD, B_int, B_int))((B_Eq)(linesQ_W_Apa_759))->$class->__eq__)(linesQ_W_Apa_759, j, toB_int(2LL)))->val) {
+            if (((bool (*) ($WORD, B_int, B_int))((B_Eq)(linesQ_W_Apa_759))->$class->__eq__)(linesQ_W_Apa_759, j, toB_int(2LL))) {
                 #line 75 "test/src/lines.act"
                 continue;
             }
@@ -521,7 +521,7 @@ $R linesQ_L_17C_9cont (linesQ_main self, $Cont C_cont, int64_t C_10res) {
     if ($PUSHF()) {
         if ($PUSH()) {
             #line 80 "test/src/lines.act"
-            if (((B_bool)((B_bool (*) ($WORD, B_int, B_int))((B_Eq)(linesQ_W_Apa_785))->$class->__eq__)(linesQ_W_Apa_785, toB_int(((int64_t)((linesQ_main)(self))->v)), toB_int(0LL)))->val) {
+            if (((bool (*) ($WORD, B_int, B_int))((B_Eq)(linesQ_W_Apa_785))->$class->__eq__)(linesQ_W_Apa_785, toB_int(((int64_t)((linesQ_main)(self))->v)), toB_int(0LL))) {
                 #line 81 "test/src/lines.act"
                 $RAISE(((B_BaseException)B_ValueErrorG_new(to$str("boom"))));
                 __builtin_unreachable();
@@ -1102,7 +1102,7 @@ $R linesQ_mainD_myprocG_local (linesQ_main self, $Cont C_cont, int64_t i) {
     #line 29 "test/src/lines.act"
     ((B_NoneType (*) (B_tuple, B_str, B_str, B_bool, B_bool))B_print)($NEWTUPLE(2, to$str("myproc"), toB_int(i)), B_None, B_None, B_None, B_None);
     #line 30 "test/src/lines.act"
-    if (((B_bool)((B_bool (*) ($WORD, B_int, B_int))((B_Eq)(linesQ_W_Apa_331))->$class->__eq__)(linesQ_W_Apa_331, toB_int(i), toB_int(2LL)))->val) {
+    if (((bool (*) ($WORD, B_int, B_int))((B_Eq)(linesQ_W_Apa_331))->$class->__eq__)(linesQ_W_Apa_331, toB_int(i), toB_int(2LL))) {
         #line 31 "test/src/lines.act"
         ((B_Msg (*) ($WORD, int64_t))((B_Env)(((linesQ_main)(self))->env))->$class->exit)(((linesQ_main)(self))->env, 0LL);
     }
@@ -1184,7 +1184,7 @@ void linesQ___init__ () {
     {
         linesQ_L_2ContG_methods.$GCINFO = "linesQ_L_2Cont";
         linesQ_L_2ContG_methods.$superclass = ($SuperG_class)&$ContG_methods;
-        linesQ_L_2ContG_methods.__bool__ = (B_bool (*) (linesQ_L_2Cont))B_valueG_methods.__bool__;
+        linesQ_L_2ContG_methods.__bool__ = (bool (*) (linesQ_L_2Cont))B_valueG_methods.__bool__;
         linesQ_L_2ContG_methods.__str__ = (B_str (*) (linesQ_L_2Cont))B_valueG_methods.__str__;
         linesQ_L_2ContG_methods.__repr__ = (B_str (*) (linesQ_L_2Cont))B_valueG_methods.__repr__;
         linesQ_L_2ContG_methods.__init__ = (B_NoneType (*) (linesQ_L_2Cont, linesQ_Apa, $Cont))linesQ_L_2ContD___init__;
@@ -1196,7 +1196,7 @@ void linesQ___init__ () {
     {
         linesQ_L_4actionG_methods.$GCINFO = "linesQ_L_4action";
         linesQ_L_4actionG_methods.$superclass = ($SuperG_class)&$actionG_methods;
-        linesQ_L_4actionG_methods.__bool__ = (B_bool (*) (linesQ_L_4action))B_valueG_methods.__bool__;
+        linesQ_L_4actionG_methods.__bool__ = (bool (*) (linesQ_L_4action))B_valueG_methods.__bool__;
         linesQ_L_4actionG_methods.__str__ = (B_str (*) (linesQ_L_4action))B_valueG_methods.__str__;
         linesQ_L_4actionG_methods.__repr__ = (B_str (*) (linesQ_L_4action))B_valueG_methods.__repr__;
         linesQ_L_4actionG_methods.__init__ = (B_NoneType (*) (linesQ_L_4action, linesQ_Apa))linesQ_L_4actionD___init__;
@@ -1210,7 +1210,7 @@ void linesQ___init__ () {
     {
         linesQ_L_6ContG_methods.$GCINFO = "linesQ_L_6Cont";
         linesQ_L_6ContG_methods.$superclass = ($SuperG_class)&$ContG_methods;
-        linesQ_L_6ContG_methods.__bool__ = (B_bool (*) (linesQ_L_6Cont))B_valueG_methods.__bool__;
+        linesQ_L_6ContG_methods.__bool__ = (bool (*) (linesQ_L_6Cont))B_valueG_methods.__bool__;
         linesQ_L_6ContG_methods.__str__ = (B_str (*) (linesQ_L_6Cont))B_valueG_methods.__str__;
         linesQ_L_6ContG_methods.__repr__ = (B_str (*) (linesQ_L_6Cont))B_valueG_methods.__repr__;
         linesQ_L_6ContG_methods.__init__ = (B_NoneType (*) (linesQ_L_6Cont, $action, $Cont))linesQ_L_6ContD___init__;
@@ -1222,7 +1222,7 @@ void linesQ___init__ () {
     {
         linesQ_L_7procG_methods.$GCINFO = "linesQ_L_7proc";
         linesQ_L_7procG_methods.$superclass = ($SuperG_class)&$procG_methods;
-        linesQ_L_7procG_methods.__bool__ = (B_bool (*) (linesQ_L_7proc))B_valueG_methods.__bool__;
+        linesQ_L_7procG_methods.__bool__ = (bool (*) (linesQ_L_7proc))B_valueG_methods.__bool__;
         linesQ_L_7procG_methods.__str__ = (B_str (*) (linesQ_L_7proc))B_valueG_methods.__str__;
         linesQ_L_7procG_methods.__repr__ = (B_str (*) (linesQ_L_7proc))B_valueG_methods.__repr__;
         linesQ_L_7procG_methods.__init__ = (B_NoneType (*) (linesQ_L_7proc, linesQ_Apa, $action))linesQ_L_7procD___init__;
@@ -1235,7 +1235,7 @@ void linesQ___init__ () {
     {
         linesQ_L_8procG_methods.$GCINFO = "linesQ_L_8proc";
         linesQ_L_8procG_methods.$superclass = ($SuperG_class)&$procG_methods;
-        linesQ_L_8procG_methods.__bool__ = (B_bool (*) (linesQ_L_8proc))B_valueG_methods.__bool__;
+        linesQ_L_8procG_methods.__bool__ = (bool (*) (linesQ_L_8proc))B_valueG_methods.__bool__;
         linesQ_L_8procG_methods.__str__ = (B_str (*) (linesQ_L_8proc))B_valueG_methods.__str__;
         linesQ_L_8procG_methods.__repr__ = (B_str (*) (linesQ_L_8proc))B_valueG_methods.__repr__;
         linesQ_L_8procG_methods.__init__ = (B_NoneType (*) (linesQ_L_8proc, linesQ_Apa, $action))linesQ_L_8procD___init__;
@@ -1248,7 +1248,7 @@ void linesQ___init__ () {
     {
         linesQ_L_9procG_methods.$GCINFO = "linesQ_L_9proc";
         linesQ_L_9procG_methods.$superclass = ($SuperG_class)&$procG_methods;
-        linesQ_L_9procG_methods.__bool__ = (B_bool (*) (linesQ_L_9proc))B_valueG_methods.__bool__;
+        linesQ_L_9procG_methods.__bool__ = (bool (*) (linesQ_L_9proc))B_valueG_methods.__bool__;
         linesQ_L_9procG_methods.__str__ = (B_str (*) (linesQ_L_9proc))B_valueG_methods.__str__;
         linesQ_L_9procG_methods.__repr__ = (B_str (*) (linesQ_L_9proc))B_valueG_methods.__repr__;
         linesQ_L_9procG_methods.__init__ = (B_NoneType (*) (linesQ_L_9proc, linesQ_Apa, int64_t))linesQ_L_9procD___init__;
@@ -1261,7 +1261,7 @@ void linesQ___init__ () {
     {
         linesQ_L_10procG_methods.$GCINFO = "linesQ_L_10proc";
         linesQ_L_10procG_methods.$superclass = ($SuperG_class)&$procG_methods;
-        linesQ_L_10procG_methods.__bool__ = (B_bool (*) (linesQ_L_10proc))B_valueG_methods.__bool__;
+        linesQ_L_10procG_methods.__bool__ = (bool (*) (linesQ_L_10proc))B_valueG_methods.__bool__;
         linesQ_L_10procG_methods.__str__ = (B_str (*) (linesQ_L_10proc))B_valueG_methods.__str__;
         linesQ_L_10procG_methods.__repr__ = (B_str (*) (linesQ_L_10proc))B_valueG_methods.__repr__;
         linesQ_L_10procG_methods.__init__ = (B_NoneType (*) (linesQ_L_10proc, linesQ_Bepa, int64_t))linesQ_L_10procD___init__;
@@ -1274,7 +1274,7 @@ void linesQ___init__ () {
     {
         linesQ_L_14actionG_methods.$GCINFO = "linesQ_L_14action";
         linesQ_L_14actionG_methods.$superclass = ($SuperG_class)&$actionG_methods;
-        linesQ_L_14actionG_methods.__bool__ = (B_bool (*) (linesQ_L_14action))B_valueG_methods.__bool__;
+        linesQ_L_14actionG_methods.__bool__ = (bool (*) (linesQ_L_14action))B_valueG_methods.__bool__;
         linesQ_L_14actionG_methods.__str__ = (B_str (*) (linesQ_L_14action))B_valueG_methods.__str__;
         linesQ_L_14actionG_methods.__repr__ = (B_str (*) (linesQ_L_14action))B_valueG_methods.__repr__;
         linesQ_L_14actionG_methods.__init__ = (B_NoneType (*) (linesQ_L_14action, linesQ_Apa))linesQ_L_14actionD___init__;
@@ -1288,7 +1288,7 @@ void linesQ___init__ () {
     {
         linesQ_L_16actionG_methods.$GCINFO = "linesQ_L_16action";
         linesQ_L_16actionG_methods.$superclass = ($SuperG_class)&$actionG_methods;
-        linesQ_L_16actionG_methods.__bool__ = (B_bool (*) (linesQ_L_16action))B_valueG_methods.__bool__;
+        linesQ_L_16actionG_methods.__bool__ = (bool (*) (linesQ_L_16action))B_valueG_methods.__bool__;
         linesQ_L_16actionG_methods.__str__ = (B_str (*) (linesQ_L_16action))B_valueG_methods.__str__;
         linesQ_L_16actionG_methods.__repr__ = (B_str (*) (linesQ_L_16action))B_valueG_methods.__repr__;
         linesQ_L_16actionG_methods.__init__ = (B_NoneType (*) (linesQ_L_16action, linesQ_Bepa))linesQ_L_16actionD___init__;
@@ -1302,7 +1302,7 @@ void linesQ___init__ () {
     {
         linesQ_L_19actionG_methods.$GCINFO = "linesQ_L_19action";
         linesQ_L_19actionG_methods.$superclass = ($SuperG_class)&$actionG_methods;
-        linesQ_L_19actionG_methods.__bool__ = (B_bool (*) (linesQ_L_19action))B_valueG_methods.__bool__;
+        linesQ_L_19actionG_methods.__bool__ = (bool (*) (linesQ_L_19action))B_valueG_methods.__bool__;
         linesQ_L_19actionG_methods.__str__ = (B_str (*) (linesQ_L_19action))B_valueG_methods.__str__;
         linesQ_L_19actionG_methods.__repr__ = (B_str (*) (linesQ_L_19action))B_valueG_methods.__repr__;
         linesQ_L_19actionG_methods.__init__ = (B_NoneType (*) (linesQ_L_19action, linesQ_main))linesQ_L_19actionD___init__;
@@ -1316,7 +1316,7 @@ void linesQ___init__ () {
     {
         linesQ_L_20procG_methods.$GCINFO = "linesQ_L_20proc";
         linesQ_L_20procG_methods.$superclass = ($SuperG_class)&$procG_methods;
-        linesQ_L_20procG_methods.__bool__ = (B_bool (*) (linesQ_L_20proc))B_valueG_methods.__bool__;
+        linesQ_L_20procG_methods.__bool__ = (bool (*) (linesQ_L_20proc))B_valueG_methods.__bool__;
         linesQ_L_20procG_methods.__str__ = (B_str (*) (linesQ_L_20proc))B_valueG_methods.__str__;
         linesQ_L_20procG_methods.__repr__ = (B_str (*) (linesQ_L_20proc))B_valueG_methods.__repr__;
         linesQ_L_20procG_methods.__init__ = (B_NoneType (*) (linesQ_L_20proc, linesQ_main))linesQ_L_20procD___init__;
@@ -1329,7 +1329,7 @@ void linesQ___init__ () {
     {
         linesQ_L_21ContG_methods.$GCINFO = "linesQ_L_21Cont";
         linesQ_L_21ContG_methods.$superclass = ($SuperG_class)&$ContG_methods;
-        linesQ_L_21ContG_methods.__bool__ = (B_bool (*) (linesQ_L_21Cont))B_valueG_methods.__bool__;
+        linesQ_L_21ContG_methods.__bool__ = (bool (*) (linesQ_L_21Cont))B_valueG_methods.__bool__;
         linesQ_L_21ContG_methods.__str__ = (B_str (*) (linesQ_L_21Cont))B_valueG_methods.__str__;
         linesQ_L_21ContG_methods.__repr__ = (B_str (*) (linesQ_L_21Cont))B_valueG_methods.__repr__;
         linesQ_L_21ContG_methods.__init__ = (B_NoneType (*) (linesQ_L_21Cont, linesQ_main, $Cont))linesQ_L_21ContD___init__;
@@ -1341,7 +1341,7 @@ void linesQ___init__ () {
     {
         linesQ_L_22ContG_methods.$GCINFO = "linesQ_L_22Cont";
         linesQ_L_22ContG_methods.$superclass = ($SuperG_class)&$ContG_methods;
-        linesQ_L_22ContG_methods.__bool__ = (B_bool (*) (linesQ_L_22Cont))B_valueG_methods.__bool__;
+        linesQ_L_22ContG_methods.__bool__ = (bool (*) (linesQ_L_22Cont))B_valueG_methods.__bool__;
         linesQ_L_22ContG_methods.__str__ = (B_str (*) (linesQ_L_22Cont))B_valueG_methods.__str__;
         linesQ_L_22ContG_methods.__repr__ = (B_str (*) (linesQ_L_22Cont))B_valueG_methods.__repr__;
         linesQ_L_22ContG_methods.__init__ = (B_NoneType (*) (linesQ_L_22Cont, linesQ_main, $Cont))linesQ_L_22ContD___init__;
@@ -1353,7 +1353,7 @@ void linesQ___init__ () {
     {
         linesQ_L_23ContG_methods.$GCINFO = "linesQ_L_23Cont";
         linesQ_L_23ContG_methods.$superclass = ($SuperG_class)&$ContG_methods;
-        linesQ_L_23ContG_methods.__bool__ = (B_bool (*) (linesQ_L_23Cont))B_valueG_methods.__bool__;
+        linesQ_L_23ContG_methods.__bool__ = (bool (*) (linesQ_L_23Cont))B_valueG_methods.__bool__;
         linesQ_L_23ContG_methods.__str__ = (B_str (*) (linesQ_L_23Cont))B_valueG_methods.__str__;
         linesQ_L_23ContG_methods.__repr__ = (B_str (*) (linesQ_L_23Cont))B_valueG_methods.__repr__;
         linesQ_L_23ContG_methods.__init__ = (B_NoneType (*) (linesQ_L_23Cont, linesQ_main, $Cont))linesQ_L_23ContD___init__;
@@ -1365,7 +1365,7 @@ void linesQ___init__ () {
     {
         linesQ_L_24procG_methods.$GCINFO = "linesQ_L_24proc";
         linesQ_L_24procG_methods.$superclass = ($SuperG_class)&$procG_methods;
-        linesQ_L_24procG_methods.__bool__ = (B_bool (*) (linesQ_L_24proc))B_valueG_methods.__bool__;
+        linesQ_L_24procG_methods.__bool__ = (bool (*) (linesQ_L_24proc))B_valueG_methods.__bool__;
         linesQ_L_24procG_methods.__str__ = (B_str (*) (linesQ_L_24proc))B_valueG_methods.__str__;
         linesQ_L_24procG_methods.__repr__ = (B_str (*) (linesQ_L_24proc))B_valueG_methods.__repr__;
         linesQ_L_24procG_methods.__init__ = (B_NoneType (*) (linesQ_L_24proc, linesQ_main, int64_t))linesQ_L_24procD___init__;
@@ -1378,7 +1378,7 @@ void linesQ___init__ () {
     {
         linesQ_L_25procG_methods.$GCINFO = "linesQ_L_25proc";
         linesQ_L_25procG_methods.$superclass = ($SuperG_class)&$procG_methods;
-        linesQ_L_25procG_methods.__bool__ = (B_bool (*) (linesQ_L_25proc))B_valueG_methods.__bool__;
+        linesQ_L_25procG_methods.__bool__ = (bool (*) (linesQ_L_25proc))B_valueG_methods.__bool__;
         linesQ_L_25procG_methods.__str__ = (B_str (*) (linesQ_L_25proc))B_valueG_methods.__str__;
         linesQ_L_25procG_methods.__repr__ = (B_str (*) (linesQ_L_25proc))B_valueG_methods.__repr__;
         linesQ_L_25procG_methods.__init__ = (B_NoneType (*) (linesQ_L_25proc, linesQ_main))linesQ_L_25procD___init__;
@@ -1391,7 +1391,7 @@ void linesQ___init__ () {
     {
         linesQ_L_27ContG_methods.$GCINFO = "linesQ_L_27Cont";
         linesQ_L_27ContG_methods.$superclass = ($SuperG_class)&$ContG_methods;
-        linesQ_L_27ContG_methods.__bool__ = (B_bool (*) (linesQ_L_27Cont))B_valueG_methods.__bool__;
+        linesQ_L_27ContG_methods.__bool__ = (bool (*) (linesQ_L_27Cont))B_valueG_methods.__bool__;
         linesQ_L_27ContG_methods.__str__ = (B_str (*) (linesQ_L_27Cont))B_valueG_methods.__str__;
         linesQ_L_27ContG_methods.__repr__ = (B_str (*) (linesQ_L_27Cont))B_valueG_methods.__repr__;
         linesQ_L_27ContG_methods.__init__ = (B_NoneType (*) (linesQ_L_27Cont, $Cont, linesQ_Apa))linesQ_L_27ContD___init__;
@@ -1403,7 +1403,7 @@ void linesQ___init__ () {
     {
         linesQ_L_28procG_methods.$GCINFO = "linesQ_L_28proc";
         linesQ_L_28procG_methods.$superclass = ($SuperG_class)&$procG_methods;
-        linesQ_L_28procG_methods.__bool__ = (B_bool (*) (linesQ_L_28proc))B_valueG_methods.__bool__;
+        linesQ_L_28procG_methods.__bool__ = (bool (*) (linesQ_L_28proc))B_valueG_methods.__bool__;
         linesQ_L_28procG_methods.__str__ = (B_str (*) (linesQ_L_28proc))B_valueG_methods.__str__;
         linesQ_L_28procG_methods.__repr__ = (B_str (*) (linesQ_L_28proc))B_valueG_methods.__repr__;
         linesQ_L_28procG_methods.__init__ = (B_NoneType (*) (linesQ_L_28proc, linesQ_Apa))linesQ_L_28procD___init__;
@@ -1416,7 +1416,7 @@ void linesQ___init__ () {
     {
         linesQ_L_30ContG_methods.$GCINFO = "linesQ_L_30Cont";
         linesQ_L_30ContG_methods.$superclass = ($SuperG_class)&$ContG_methods;
-        linesQ_L_30ContG_methods.__bool__ = (B_bool (*) (linesQ_L_30Cont))B_valueG_methods.__bool__;
+        linesQ_L_30ContG_methods.__bool__ = (bool (*) (linesQ_L_30Cont))B_valueG_methods.__bool__;
         linesQ_L_30ContG_methods.__str__ = (B_str (*) (linesQ_L_30Cont))B_valueG_methods.__str__;
         linesQ_L_30ContG_methods.__repr__ = (B_str (*) (linesQ_L_30Cont))B_valueG_methods.__repr__;
         linesQ_L_30ContG_methods.__init__ = (B_NoneType (*) (linesQ_L_30Cont, $Cont, linesQ_Bepa))linesQ_L_30ContD___init__;
@@ -1428,7 +1428,7 @@ void linesQ___init__ () {
     {
         linesQ_L_31procG_methods.$GCINFO = "linesQ_L_31proc";
         linesQ_L_31procG_methods.$superclass = ($SuperG_class)&$procG_methods;
-        linesQ_L_31procG_methods.__bool__ = (B_bool (*) (linesQ_L_31proc))B_valueG_methods.__bool__;
+        linesQ_L_31procG_methods.__bool__ = (bool (*) (linesQ_L_31proc))B_valueG_methods.__bool__;
         linesQ_L_31procG_methods.__str__ = (B_str (*) (linesQ_L_31proc))B_valueG_methods.__str__;
         linesQ_L_31procG_methods.__repr__ = (B_str (*) (linesQ_L_31proc))B_valueG_methods.__repr__;
         linesQ_L_31procG_methods.__init__ = (B_NoneType (*) (linesQ_L_31proc, linesQ_Bepa))linesQ_L_31procD___init__;
@@ -1441,7 +1441,7 @@ void linesQ___init__ () {
     {
         linesQ_L_33ContG_methods.$GCINFO = "linesQ_L_33Cont";
         linesQ_L_33ContG_methods.$superclass = ($SuperG_class)&$ContG_methods;
-        linesQ_L_33ContG_methods.__bool__ = (B_bool (*) (linesQ_L_33Cont))B_valueG_methods.__bool__;
+        linesQ_L_33ContG_methods.__bool__ = (bool (*) (linesQ_L_33Cont))B_valueG_methods.__bool__;
         linesQ_L_33ContG_methods.__str__ = (B_str (*) (linesQ_L_33Cont))B_valueG_methods.__str__;
         linesQ_L_33ContG_methods.__repr__ = (B_str (*) (linesQ_L_33Cont))B_valueG_methods.__repr__;
         linesQ_L_33ContG_methods.__init__ = (B_NoneType (*) (linesQ_L_33Cont, $Cont, linesQ_main))linesQ_L_33ContD___init__;
@@ -1453,7 +1453,7 @@ void linesQ___init__ () {
     {
         linesQ_L_34procG_methods.$GCINFO = "linesQ_L_34proc";
         linesQ_L_34procG_methods.$superclass = ($SuperG_class)&$procG_methods;
-        linesQ_L_34procG_methods.__bool__ = (B_bool (*) (linesQ_L_34proc))B_valueG_methods.__bool__;
+        linesQ_L_34procG_methods.__bool__ = (bool (*) (linesQ_L_34proc))B_valueG_methods.__bool__;
         linesQ_L_34procG_methods.__str__ = (B_str (*) (linesQ_L_34proc))B_valueG_methods.__str__;
         linesQ_L_34procG_methods.__repr__ = (B_str (*) (linesQ_L_34proc))B_valueG_methods.__repr__;
         linesQ_L_34procG_methods.__init__ = (B_NoneType (*) (linesQ_L_34proc, linesQ_main, B_Env))linesQ_L_34procD___init__;
@@ -1466,7 +1466,7 @@ void linesQ___init__ () {
     {
         linesQ_ApaG_methods.$GCINFO = "linesQ_Apa";
         linesQ_ApaG_methods.$superclass = ($SuperG_class)&$ActorG_methods;
-        linesQ_ApaG_methods.__bool__ = (B_bool (*) (linesQ_Apa))$ActorG_methods.__bool__;
+        linesQ_ApaG_methods.__bool__ = (bool (*) (linesQ_Apa))$ActorG_methods.__bool__;
         linesQ_ApaG_methods.__str__ = (B_str (*) (linesQ_Apa))$ActorG_methods.__str__;
         linesQ_ApaG_methods.__repr__ = (B_str (*) (linesQ_Apa))$ActorG_methods.__repr__;
         linesQ_ApaG_methods.__resume__ = (B_NoneType (*) (linesQ_Apa))$ActorG_methods.__resume__;
@@ -1485,7 +1485,7 @@ void linesQ___init__ () {
     {
         linesQ_BepaG_methods.$GCINFO = "linesQ_Bepa";
         linesQ_BepaG_methods.$superclass = ($SuperG_class)&$ActorG_methods;
-        linesQ_BepaG_methods.__bool__ = (B_bool (*) (linesQ_Bepa))$ActorG_methods.__bool__;
+        linesQ_BepaG_methods.__bool__ = (bool (*) (linesQ_Bepa))$ActorG_methods.__bool__;
         linesQ_BepaG_methods.__str__ = (B_str (*) (linesQ_Bepa))$ActorG_methods.__str__;
         linesQ_BepaG_methods.__repr__ = (B_str (*) (linesQ_Bepa))$ActorG_methods.__repr__;
         linesQ_BepaG_methods.__resume__ = (B_NoneType (*) (linesQ_Bepa))$ActorG_methods.__resume__;
@@ -1500,7 +1500,7 @@ void linesQ___init__ () {
     {
         linesQ_mainG_methods.$GCINFO = "linesQ_main";
         linesQ_mainG_methods.$superclass = ($SuperG_class)&$ActorG_methods;
-        linesQ_mainG_methods.__bool__ = (B_bool (*) (linesQ_main))$ActorG_methods.__bool__;
+        linesQ_mainG_methods.__bool__ = (bool (*) (linesQ_main))$ActorG_methods.__bool__;
         linesQ_mainG_methods.__str__ = (B_str (*) (linesQ_main))$ActorG_methods.__str__;
         linesQ_mainG_methods.__repr__ = (B_str (*) (linesQ_main))$ActorG_methods.__repr__;
         linesQ_mainG_methods.__resume__ = (B_NoneType (*) (linesQ_main))$ActorG_methods.__resume__;

--- a/compiler/lib/test/9-codegen/lines.h
+++ b/compiler/lib/test/9-codegen/lines.h
@@ -60,7 +60,7 @@ struct linesQ_L_2ContG_class {
     B_NoneType (*__init__) (linesQ_L_2Cont, linesQ_Apa, $Cont);
     void (*__serialize__) (linesQ_L_2Cont, $Serial$state);
     linesQ_L_2Cont (*__deserialize__) (linesQ_L_2Cont, $Serial$state);
-    B_bool (*__bool__) (linesQ_L_2Cont);
+    bool (*__bool__) (linesQ_L_2Cont);
     B_str (*__str__) (linesQ_L_2Cont);
     B_str (*__repr__) (linesQ_L_2Cont);
     $R (*__call__) (linesQ_L_2Cont, B_NoneType);
@@ -77,7 +77,7 @@ struct linesQ_L_4actionG_class {
     B_NoneType (*__init__) (linesQ_L_4action, linesQ_Apa);
     void (*__serialize__) (linesQ_L_4action, $Serial$state);
     linesQ_L_4action (*__deserialize__) (linesQ_L_4action, $Serial$state);
-    B_bool (*__bool__) (linesQ_L_4action);
+    bool (*__bool__) (linesQ_L_4action);
     B_str (*__str__) (linesQ_L_4action);
     B_str (*__repr__) (linesQ_L_4action);
     $R (*__call__) (linesQ_L_4action, $Cont, B_int);
@@ -96,7 +96,7 @@ struct linesQ_L_6ContG_class {
     B_NoneType (*__init__) (linesQ_L_6Cont, $action, $Cont);
     void (*__serialize__) (linesQ_L_6Cont, $Serial$state);
     linesQ_L_6Cont (*__deserialize__) (linesQ_L_6Cont, $Serial$state);
-    B_bool (*__bool__) (linesQ_L_6Cont);
+    bool (*__bool__) (linesQ_L_6Cont);
     B_str (*__str__) (linesQ_L_6Cont);
     B_str (*__repr__) (linesQ_L_6Cont);
     $R (*__call__) (linesQ_L_6Cont, B_int);
@@ -113,7 +113,7 @@ struct linesQ_L_7procG_class {
     B_NoneType (*__init__) (linesQ_L_7proc, linesQ_Apa, $action);
     void (*__serialize__) (linesQ_L_7proc, $Serial$state);
     linesQ_L_7proc (*__deserialize__) (linesQ_L_7proc, $Serial$state);
-    B_bool (*__bool__) (linesQ_L_7proc);
+    bool (*__bool__) (linesQ_L_7proc);
     B_str (*__str__) (linesQ_L_7proc);
     B_str (*__repr__) (linesQ_L_7proc);
     $R (*__call__) (linesQ_L_7proc, $Cont);
@@ -131,7 +131,7 @@ struct linesQ_L_8procG_class {
     B_NoneType (*__init__) (linesQ_L_8proc, linesQ_Apa, $action);
     void (*__serialize__) (linesQ_L_8proc, $Serial$state);
     linesQ_L_8proc (*__deserialize__) (linesQ_L_8proc, $Serial$state);
-    B_bool (*__bool__) (linesQ_L_8proc);
+    bool (*__bool__) (linesQ_L_8proc);
     B_str (*__str__) (linesQ_L_8proc);
     B_str (*__repr__) (linesQ_L_8proc);
     $R (*__call__) (linesQ_L_8proc, $Cont);
@@ -149,7 +149,7 @@ struct linesQ_L_9procG_class {
     B_NoneType (*__init__) (linesQ_L_9proc, linesQ_Apa, int64_t);
     void (*__serialize__) (linesQ_L_9proc, $Serial$state);
     linesQ_L_9proc (*__deserialize__) (linesQ_L_9proc, $Serial$state);
-    B_bool (*__bool__) (linesQ_L_9proc);
+    bool (*__bool__) (linesQ_L_9proc);
     B_str (*__str__) (linesQ_L_9proc);
     B_str (*__repr__) (linesQ_L_9proc);
     $R (*__call__) (linesQ_L_9proc, $Cont);
@@ -167,7 +167,7 @@ struct linesQ_L_10procG_class {
     B_NoneType (*__init__) (linesQ_L_10proc, linesQ_Bepa, int64_t);
     void (*__serialize__) (linesQ_L_10proc, $Serial$state);
     linesQ_L_10proc (*__deserialize__) (linesQ_L_10proc, $Serial$state);
-    B_bool (*__bool__) (linesQ_L_10proc);
+    bool (*__bool__) (linesQ_L_10proc);
     B_str (*__str__) (linesQ_L_10proc);
     B_str (*__repr__) (linesQ_L_10proc);
     $R (*__call__) (linesQ_L_10proc, $Cont);
@@ -185,7 +185,7 @@ struct linesQ_L_14actionG_class {
     B_NoneType (*__init__) (linesQ_L_14action, linesQ_Apa);
     void (*__serialize__) (linesQ_L_14action, $Serial$state);
     linesQ_L_14action (*__deserialize__) (linesQ_L_14action, $Serial$state);
-    B_bool (*__bool__) (linesQ_L_14action);
+    bool (*__bool__) (linesQ_L_14action);
     B_str (*__str__) (linesQ_L_14action);
     B_str (*__repr__) (linesQ_L_14action);
     $R (*__call__) (linesQ_L_14action, $Cont, B_int);
@@ -203,7 +203,7 @@ struct linesQ_L_16actionG_class {
     B_NoneType (*__init__) (linesQ_L_16action, linesQ_Bepa);
     void (*__serialize__) (linesQ_L_16action, $Serial$state);
     linesQ_L_16action (*__deserialize__) (linesQ_L_16action, $Serial$state);
-    B_bool (*__bool__) (linesQ_L_16action);
+    bool (*__bool__) (linesQ_L_16action);
     B_str (*__str__) (linesQ_L_16action);
     B_str (*__repr__) (linesQ_L_16action);
     $R (*__call__) (linesQ_L_16action, $Cont, B_int);
@@ -221,7 +221,7 @@ struct linesQ_L_19actionG_class {
     B_NoneType (*__init__) (linesQ_L_19action, linesQ_main);
     void (*__serialize__) (linesQ_L_19action, $Serial$state);
     linesQ_L_19action (*__deserialize__) (linesQ_L_19action, $Serial$state);
-    B_bool (*__bool__) (linesQ_L_19action);
+    bool (*__bool__) (linesQ_L_19action);
     B_str (*__str__) (linesQ_L_19action);
     B_str (*__repr__) (linesQ_L_19action);
     $R (*__call__) (linesQ_L_19action, $Cont, B_int);
@@ -239,7 +239,7 @@ struct linesQ_L_20procG_class {
     B_NoneType (*__init__) (linesQ_L_20proc, linesQ_main);
     void (*__serialize__) (linesQ_L_20proc, $Serial$state);
     linesQ_L_20proc (*__deserialize__) (linesQ_L_20proc, $Serial$state);
-    B_bool (*__bool__) (linesQ_L_20proc);
+    bool (*__bool__) (linesQ_L_20proc);
     B_str (*__str__) (linesQ_L_20proc);
     B_str (*__repr__) (linesQ_L_20proc);
     $R (*__call__) (linesQ_L_20proc, $Cont);
@@ -257,7 +257,7 @@ struct linesQ_L_21ContG_class {
     B_NoneType (*__init__) (linesQ_L_21Cont, linesQ_main, $Cont);
     void (*__serialize__) (linesQ_L_21Cont, $Serial$state);
     linesQ_L_21Cont (*__deserialize__) (linesQ_L_21Cont, $Serial$state);
-    B_bool (*__bool__) (linesQ_L_21Cont);
+    bool (*__bool__) (linesQ_L_21Cont);
     B_str (*__str__) (linesQ_L_21Cont);
     B_str (*__repr__) (linesQ_L_21Cont);
     $R (*__call__) (linesQ_L_21Cont, B_int);
@@ -275,7 +275,7 @@ struct linesQ_L_22ContG_class {
     B_NoneType (*__init__) (linesQ_L_22Cont, linesQ_main, $Cont);
     void (*__serialize__) (linesQ_L_22Cont, $Serial$state);
     linesQ_L_22Cont (*__deserialize__) (linesQ_L_22Cont, $Serial$state);
-    B_bool (*__bool__) (linesQ_L_22Cont);
+    bool (*__bool__) (linesQ_L_22Cont);
     B_str (*__str__) (linesQ_L_22Cont);
     B_str (*__repr__) (linesQ_L_22Cont);
     $R (*__call__) (linesQ_L_22Cont, linesQ_Bepa);
@@ -293,7 +293,7 @@ struct linesQ_L_23ContG_class {
     B_NoneType (*__init__) (linesQ_L_23Cont, linesQ_main, $Cont);
     void (*__serialize__) (linesQ_L_23Cont, $Serial$state);
     linesQ_L_23Cont (*__deserialize__) (linesQ_L_23Cont, $Serial$state);
-    B_bool (*__bool__) (linesQ_L_23Cont);
+    bool (*__bool__) (linesQ_L_23Cont);
     B_str (*__str__) (linesQ_L_23Cont);
     B_str (*__repr__) (linesQ_L_23Cont);
     $R (*__call__) (linesQ_L_23Cont, linesQ_Apa);
@@ -310,7 +310,7 @@ struct linesQ_L_24procG_class {
     B_NoneType (*__init__) (linesQ_L_24proc, linesQ_main, int64_t);
     void (*__serialize__) (linesQ_L_24proc, $Serial$state);
     linesQ_L_24proc (*__deserialize__) (linesQ_L_24proc, $Serial$state);
-    B_bool (*__bool__) (linesQ_L_24proc);
+    bool (*__bool__) (linesQ_L_24proc);
     B_str (*__str__) (linesQ_L_24proc);
     B_str (*__repr__) (linesQ_L_24proc);
     $R (*__call__) (linesQ_L_24proc, $Cont);
@@ -328,7 +328,7 @@ struct linesQ_L_25procG_class {
     B_NoneType (*__init__) (linesQ_L_25proc, linesQ_main);
     void (*__serialize__) (linesQ_L_25proc, $Serial$state);
     linesQ_L_25proc (*__deserialize__) (linesQ_L_25proc, $Serial$state);
-    B_bool (*__bool__) (linesQ_L_25proc);
+    bool (*__bool__) (linesQ_L_25proc);
     B_str (*__str__) (linesQ_L_25proc);
     B_str (*__repr__) (linesQ_L_25proc);
     $R (*__call__) (linesQ_L_25proc, $Cont);
@@ -346,7 +346,7 @@ struct linesQ_L_27ContG_class {
     B_NoneType (*__init__) (linesQ_L_27Cont, $Cont, linesQ_Apa);
     void (*__serialize__) (linesQ_L_27Cont, $Serial$state);
     linesQ_L_27Cont (*__deserialize__) (linesQ_L_27Cont, $Serial$state);
-    B_bool (*__bool__) (linesQ_L_27Cont);
+    bool (*__bool__) (linesQ_L_27Cont);
     B_str (*__str__) (linesQ_L_27Cont);
     B_str (*__repr__) (linesQ_L_27Cont);
     $R (*__call__) (linesQ_L_27Cont, B_NoneType);
@@ -363,7 +363,7 @@ struct linesQ_L_28procG_class {
     B_NoneType (*__init__) (linesQ_L_28proc, linesQ_Apa);
     void (*__serialize__) (linesQ_L_28proc, $Serial$state);
     linesQ_L_28proc (*__deserialize__) (linesQ_L_28proc, $Serial$state);
-    B_bool (*__bool__) (linesQ_L_28proc);
+    bool (*__bool__) (linesQ_L_28proc);
     B_str (*__str__) (linesQ_L_28proc);
     B_str (*__repr__) (linesQ_L_28proc);
     $R (*__call__) (linesQ_L_28proc, $Cont);
@@ -381,7 +381,7 @@ struct linesQ_L_30ContG_class {
     B_NoneType (*__init__) (linesQ_L_30Cont, $Cont, linesQ_Bepa);
     void (*__serialize__) (linesQ_L_30Cont, $Serial$state);
     linesQ_L_30Cont (*__deserialize__) (linesQ_L_30Cont, $Serial$state);
-    B_bool (*__bool__) (linesQ_L_30Cont);
+    bool (*__bool__) (linesQ_L_30Cont);
     B_str (*__str__) (linesQ_L_30Cont);
     B_str (*__repr__) (linesQ_L_30Cont);
     $R (*__call__) (linesQ_L_30Cont, B_NoneType);
@@ -398,7 +398,7 @@ struct linesQ_L_31procG_class {
     B_NoneType (*__init__) (linesQ_L_31proc, linesQ_Bepa);
     void (*__serialize__) (linesQ_L_31proc, $Serial$state);
     linesQ_L_31proc (*__deserialize__) (linesQ_L_31proc, $Serial$state);
-    B_bool (*__bool__) (linesQ_L_31proc);
+    bool (*__bool__) (linesQ_L_31proc);
     B_str (*__str__) (linesQ_L_31proc);
     B_str (*__repr__) (linesQ_L_31proc);
     $R (*__call__) (linesQ_L_31proc, $Cont);
@@ -416,7 +416,7 @@ struct linesQ_L_33ContG_class {
     B_NoneType (*__init__) (linesQ_L_33Cont, $Cont, linesQ_main);
     void (*__serialize__) (linesQ_L_33Cont, $Serial$state);
     linesQ_L_33Cont (*__deserialize__) (linesQ_L_33Cont, $Serial$state);
-    B_bool (*__bool__) (linesQ_L_33Cont);
+    bool (*__bool__) (linesQ_L_33Cont);
     B_str (*__str__) (linesQ_L_33Cont);
     B_str (*__repr__) (linesQ_L_33Cont);
     $R (*__call__) (linesQ_L_33Cont, B_NoneType);
@@ -433,7 +433,7 @@ struct linesQ_L_34procG_class {
     B_NoneType (*__init__) (linesQ_L_34proc, linesQ_main, B_Env);
     void (*__serialize__) (linesQ_L_34proc, $Serial$state);
     linesQ_L_34proc (*__deserialize__) (linesQ_L_34proc, $Serial$state);
-    B_bool (*__bool__) (linesQ_L_34proc);
+    bool (*__bool__) (linesQ_L_34proc);
     B_str (*__str__) (linesQ_L_34proc);
     B_str (*__repr__) (linesQ_L_34proc);
     $R (*__call__) (linesQ_L_34proc, $Cont);
@@ -451,7 +451,7 @@ struct linesQ_ApaG_class {
     $R (*__init__) (linesQ_Apa, $Cont);
     void (*__serialize__) (linesQ_Apa, $Serial$state);
     linesQ_Apa (*__deserialize__) (linesQ_Apa, $Serial$state);
-    B_bool (*__bool__) (linesQ_Apa);
+    bool (*__bool__) (linesQ_Apa);
     B_str (*__str__) (linesQ_Apa);
     B_str (*__repr__) (linesQ_Apa);
     B_NoneType (*__resume__) (linesQ_Apa);
@@ -487,7 +487,7 @@ struct linesQ_BepaG_class {
     $R (*__init__) (linesQ_Bepa, $Cont);
     void (*__serialize__) (linesQ_Bepa, $Serial$state);
     linesQ_Bepa (*__deserialize__) (linesQ_Bepa, $Serial$state);
-    B_bool (*__bool__) (linesQ_Bepa);
+    bool (*__bool__) (linesQ_Bepa);
     B_str (*__str__) (linesQ_Bepa);
     B_str (*__repr__) (linesQ_Bepa);
     B_NoneType (*__resume__) (linesQ_Bepa);
@@ -515,7 +515,7 @@ struct linesQ_mainG_class {
     $R (*__init__) (linesQ_main, $Cont, B_Env);
     void (*__serialize__) (linesQ_main, $Serial$state);
     linesQ_main (*__deserialize__) (linesQ_main, $Serial$state);
-    B_bool (*__bool__) (linesQ_main);
+    bool (*__bool__) (linesQ_main);
     B_str (*__str__) (linesQ_main);
     B_str (*__repr__) (linesQ_main);
     B_NoneType (*__resume__) (linesQ_main);

--- a/compiler/lib/test/9-codegen/lines.input
+++ b/compiler/lib/test/9-codegen/lines.input
@@ -216,7 +216,7 @@ proc def L_17C_9cont (self : main, C_cont : $Cont[None], C_10res : UNBOXED __bui
             print@[(__builtin__.str,)](("\"break path\"",), None, None, None, None)
             break
         print@[(__builtin__.str, __builtin__.int)](("\"loop body\"", (BOX __builtin__.int self.i)), None, None, None, None)
-    N_3iter: __builtin__.Iterator[?__builtin__.int] = W_Apa_779.__iter__([(BOX __builtin__.int (UNBOX __builtin__.int 1)), (BOX __builtin__.int (UNBOX __builtin__.int 2)), (BOX __builtin__.int (UNBOX __builtin__.int 3))])
+    N_3iter: __builtin__.Iterator[?__builtin__.int] = __builtin__.CollectionD_SequenceD_listD___iter__@[?__builtin__.int](__builtin__.SequenceD_list@[?__builtin__.int]().W_Collection, [(BOX __builtin__.int (UNBOX __builtin__.int 1)), (BOX __builtin__.int (UNBOX __builtin__.int 2)), (BOX __builtin__.int (UNBOX __builtin__.int 3))])
     if (BOX __builtin__.bool $PUSH()):
         while True:
             if True:

--- a/compiler/lib/test/9-codegen/lines.input
+++ b/compiler/lib/test/9-codegen/lines.input
@@ -216,15 +216,20 @@ proc def L_17C_9cont (self : main, C_cont : $Cont[None], C_10res : UNBOXED __bui
             print@[(__builtin__.str,)](("\"break path\"",), None, None, None, None)
             break
         print@[(__builtin__.str, __builtin__.int)](("\"loop body\"", (BOX __builtin__.int self.i)), None, None, None, None)
+<<<<<<< HEAD
     N_3iter: __builtin__.Iterator[?__builtin__.int] = __builtin__.CollectionD_SequenceD_listD___iter__@[?__builtin__.int](__builtin__.SequenceD_list@[?__builtin__.int]().W_Collection, [(BOX __builtin__.int (UNBOX __builtin__.int 1)), (BOX __builtin__.int (UNBOX __builtin__.int 2)), (BOX __builtin__.int (UNBOX __builtin__.int 3))])
     if $PUSH():
+=======
+    N_3iter: __builtin__.Iterator[?__builtin__.int] = W_Apa_779.__iter__([(BOX __builtin__.int (UNBOX __builtin__.int 1)), (BOX __builtin__.int (UNBOX __builtin__.int 2)), (BOX __builtin__.int (UNBOX __builtin__.int 3))])
+    if (BOX __builtin__.bool $PUSH()):
+>>>>>>> 9f5c03c6 (updated golden files)
         while True:
             if True:
                 pass
             else:
                 break
             j: ?__builtin__.int = N_3iter.__next__()
-            if W_Apa_759.__eq__(j, (BOX __builtin__.int (UNBOX __builtin__.int 2))):
+            if (BOX __builtin__.bool W_Apa_759.__eq__(j, (BOX __builtin__.int (UNBOX __builtin__.int 2)))):
                 continue
             print@[(__builtin__.str, ?__builtin__.int)](("\"for j\"", j), None, None, None, None)
         $DROP()
@@ -234,9 +239,9 @@ proc def L_17C_9cont (self : main, C_cont : $Cont[None], C_10res : UNBOXED __bui
             pass
         else:
             $RAISE(N_5x)
-    if $PUSHF():
-        if $PUSH():
-            if W_Apa_785.__eq__((BOX __builtin__.int self.v), (BOX __builtin__.int (UNBOX __builtin__.int 0))):
+    if (BOX __builtin__.bool $PUSHF()):
+        if (BOX __builtin__.bool $PUSH()):
+            if (BOX __builtin__.bool W_Apa_785.__eq__((BOX __builtin__.int self.v), (BOX __builtin__.int (UNBOX __builtin__.int 0)))):
                 $RAISE(ValueError("\"boom\""))
             print@[(__builtin__.str,)](("\"unreached\"",), None, None, None, None)
             $DROP()
@@ -484,7 +489,7 @@ class main ($Actor, __builtin__.value):
         return ApaG_newact(L_23Cont(self, C_cont))
     proc def myprocG_local (self : main, C_cont : $Cont[__builtin__.int], i : UNBOXED __builtin__.int) -> $R:
         print@[(__builtin__.str, __builtin__.int)](("\"myproc\"", (BOX __builtin__.int i)), None, None, None, None)
-        if W_Apa_331.__eq__((BOX __builtin__.int i), (BOX __builtin__.int (UNBOX __builtin__.int 2))):
+        if (BOX __builtin__.bool W_Apa_331.__eq__((BOX __builtin__.int i), (BOX __builtin__.int (UNBOX __builtin__.int 2)))):
             (async self.env.exit)((UNBOX __builtin__.int 0))
         return $R_CONT@[__builtin__.int](C_cont, (BOX __builtin__.int i))
     proc def nopG_local (self : main, C_cont : $Cont[None]) -> $R:

--- a/compiler/lib/test/9-codegen/lines.input
+++ b/compiler/lib/test/9-codegen/lines.input
@@ -216,13 +216,8 @@ proc def L_17C_9cont (self : main, C_cont : $Cont[None], C_10res : UNBOXED __bui
             print@[(__builtin__.str,)](("\"break path\"",), None, None, None, None)
             break
         print@[(__builtin__.str, __builtin__.int)](("\"loop body\"", (BOX __builtin__.int self.i)), None, None, None, None)
-<<<<<<< HEAD
-    N_3iter: __builtin__.Iterator[?__builtin__.int] = __builtin__.CollectionD_SequenceD_listD___iter__@[?__builtin__.int](__builtin__.SequenceD_list@[?__builtin__.int]().W_Collection, [(BOX __builtin__.int (UNBOX __builtin__.int 1)), (BOX __builtin__.int (UNBOX __builtin__.int 2)), (BOX __builtin__.int (UNBOX __builtin__.int 3))])
-    if $PUSH():
-=======
     N_3iter: __builtin__.Iterator[?__builtin__.int] = W_Apa_779.__iter__([(BOX __builtin__.int (UNBOX __builtin__.int 1)), (BOX __builtin__.int (UNBOX __builtin__.int 2)), (BOX __builtin__.int (UNBOX __builtin__.int 3))])
     if (BOX __builtin__.bool $PUSH()):
->>>>>>> 9f5c03c6 (updated golden files)
         while True:
             if True:
                 pass


### PR DESCRIPTION
This PR makes bool an unboxed type like float and the bounded integer types, i.e. boolean values are unboxed unless they are used as arguments to polymorphic functions or occur as a value in a slot with a broader declared type (e.g. ?bool or value).  Method __bool__ in the C code has result type bool, as has also various isXXX functions in types str, bytes and bytearray and all methods in protocols Eq and Ord.