### PR TITLE
Pre-seed zig's cache for transitive zig deps behind a proxy

### DIFF
--- a/compiler/lib/package.yaml.in
+++ b/compiler/lib/package.yaml.in
@@ -93,6 +93,7 @@ library:
     - Acton.Types
     - Acton.TypeEnv
     - Acton.WitKnots
+    - Acton.Zon
     - Utils
     - Pretty
     - InterfaceFiles

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -262,6 +262,7 @@ import Error.Diagnose (Diagnostic)
 import GHC.Conc (getNumCapabilities)
 import Acton.ArchiveDownload (downloadArchive)
 import Acton.HttpFetch (isHttpUrl, proxyEnvReportLines, readProxyEnv)
+import qualified Acton.Zon as Zon
 import System.Clock
 import System.Directory
 import System.Directory.Recursive (getFilesRecursive)
@@ -5001,12 +5002,15 @@ fetchDependencies gopts paths depOverrides = do
             cacheDir h  = joinPath [globalCache, "p", h]
         createDirectoryIfMissing True globalCache
         createDirectoryIfMissing True depsCache
+        -- Tracks zig package dirs / hashes already pre-seeded, so the transitive
+        -- walk over build.zig.zon files terminates on cycles and shared deps.
+        zigSeen <- newIORef Data.Set.empty
         let rootPins = BuildSpec.dependencies rootSpec
-        _ <- walkProject rootPins cacheDir zigExe globalCache depsCache
+        _ <- walkProject rootPins cacheDir zigExe globalCache depsCache zigSeen
                          Data.Set.empty (projPath paths) rootSpec
         return ()
   where
-    walkProject rootPins cacheDir zigExe globalCache depsCache seen projDir spec = do
+    walkProject rootPins cacheDir zigExe globalCache depsCache zigSeen seen projDir spec = do
       projAbs <- normalizePathSafe projDir
       if Data.Set.member projAbs seen
         then return seen
@@ -5023,8 +5027,26 @@ fetchDependencies gopts paths depOverrides = do
           let errs = [ e | Left e <- results ]
           unless (null errs) $ throwProjectError (unlines errs)
           forM_ selectedDeps $ \(name, dep) -> copyPkgDep cacheDir depsCache name dep
+          -- TODO: remove this transitive pre-seeding (this forM_ and
+          -- seedTransitiveZigDeps) once zig can fetch through an HTTP CONNECT
+          -- proxy. It exists only to work around zig writing an absolute-form
+          -- request URI into the tunnel, which the origin rejects; when zig is
+          -- fixed upstream / in our bundled toolchain, drop this and let zig
+          -- resolve transitive deps itself.
+          --
+          -- A zig dependency given as a local path may pull in transitive .url
+          -- dependencies via its build.zig.zon; seed those into zig's cache now
+          -- (through the proxy-aware HTTP client) so the build never lets zig
+          -- fetch them. A url+hash zig dependency is a self-contained archive,
+          -- already seeded above by mkZigFetch (see seedTransitiveZigDeps for why
+          -- url packages are not recursed into).
+          forM_ (M.toList (BuildSpec.zig_dependencies spec)) $ \(_, zdep) ->
+            case BuildSpec.zpath zdep of
+              Just p | not (null p) ->
+                seedTransitiveZigDeps zigSeen cacheDir zigExe globalCache (projAbs </> p)
+              _ -> return ()
           let seen' = Data.Set.insert projAbs seen
-          foldM (walkDependency rootPins cacheDir zigExe globalCache depsCache projAbs)
+          foldM (walkDependency rootPins cacheDir zigExe globalCache depsCache zigSeen projAbs)
                 seen' selectedDeps
 
     selectDependency rootPins base (depName, dep) = do
@@ -5041,7 +5063,7 @@ fetchDependencies gopts paths depOverrides = do
                     ++ " overridden by root pin")
       return (depName, chosenDep)
 
-    walkDependency rootPins cacheDir zigExe globalCache depsCache base seen (depName, dep) = do
+    walkDependency rootPins cacheDir zigExe globalCache depsCache zigSeen base seen (depName, dep) = do
       depBase <- resolveDepBase base depName dep
       depAbs <- normalizePathSafe depBase
       depExists <- doesDirectoryExist depAbs
@@ -5055,7 +5077,7 @@ fetchDependencies gopts paths depOverrides = do
         else do
           depSpec0 <- loadBuildSpec depAbs
           depSpec <- applyDepOverrides depAbs depOverrides depSpec0
-          walkProject rootPins cacheDir zigExe globalCache depsCache seen depAbs depSpec
+          walkProject rootPins cacheDir zigExe globalCache depsCache zigSeen seen depAbs depSpec
 
     mkPkgFetch cacheDir zigExe globalCache name dep =
       case BuildSpec.path dep of
@@ -5097,6 +5119,58 @@ fetchDependencies gopts paths depOverrides = do
                    if srcOk
                      then copyTree src dst
                      else extractCachedArchive srcArchive dst
+
+    -- Pre-seed zig's package cache for the transitive dependencies reachable from
+    -- a zig package's build.zig.zon. Path deps are followed in place, recursing
+    -- into their own build.zig.zon; url+hash deps are downloaded through the
+    -- proxy-aware HTTP client (via fetchOne) so zig finds them cached. Lazy deps
+    -- are left for zig to fetch on demand: eagerly seeding them would download
+    -- archives a normal build never uses.
+    --
+    -- A url dependency is seeded but not recursed into: the package archives that
+    -- occur in practice (lmdb, libssh, zlib upstream) are leaf C sources with no
+    -- nested build.zig.zon, and reading a manifest back out of every seeded
+    -- tarball would cost a per-build extraction on the common path.
+    seedTransitiveZigDeps zigSeen cacheDir zigExe globalCache = goDir
+      where
+        goDir dir = do
+          dirAbs <- normalizePathSafe dir
+          fresh <- claimVisited zigSeen ("d:" ++ dirAbs)
+          when fresh $ do
+            let zonPath = dirAbs </> "build.zig.zon"
+            edeps <- Zon.readZonDependencies zonPath
+            case edeps of
+              Left err ->
+                when (C.verbose gopts) $
+                  putStrLn ("Note: could not parse " ++ zonPath
+                            ++ " to pre-seed transitive zig dependencies: " ++ err)
+              Right deps -> forM_ deps (goDep dirAbs)
+
+        goDep pkgDir (name, dep)
+          | Zon.zdLazy dep                          = return ()
+          | Just p <- Zon.zdPath dep, not (null p)  = goDir (pkgDir </> p)
+          | Just u <- Zon.zdUrl dep
+          , Just h <- Zon.zdHash dep                = do
+              fresh <- claimVisited zigSeen ("h:" ++ h)
+              when fresh $ do
+                present <- cacheEntryExists cacheDir h
+                unless present $ do
+                  res <- fetchOne "zig" name u (Just h) cacheDir zigExe globalCache
+                  case res of
+                    -- Non-fatal: if pre-seeding fails, let zig try to fetch it
+                    -- during the build (its pre-change behaviour). On a direct
+                    -- build that just works; behind a proxy zig fails with its own
+                    -- diagnostic -- either way a seeding hiccup never breaks a
+                    -- build the old code would have completed.
+                    Left e  -> unless (C.quiet gopts) $
+                                 putStrLn ("Warning: could not pre-fetch transitive zig dependency "
+                                           ++ name ++ ": " ++ e)
+                    Right _ -> return ()
+          | otherwise                               = return ()
+
+    -- Atomically record a key; returns True the first time it is seen.
+    claimVisited ref key = atomicModifyIORef' ref $ \s ->
+      if Data.Set.member key s then (s, False) else (Data.Set.insert key s, True)
 
     fetchOne kind name url mh cacheDir zigExe globalCache = do
       case mh of

--- a/compiler/lib/src/Acton/Zon.hs
+++ b/compiler/lib/src/Acton/Zon.hs
@@ -1,0 +1,226 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | A small reader for Zig's ZON object notation (@build.zig.zon@).
+--
+-- Acton only needs enough of ZON to discover the dependencies a zig package
+-- declares, so it can pre-seed zig's package cache through the proxy-aware HTTP
+-- client. With the cache pre-populated, zig never has to fetch a transitive
+-- @.url@ dependency over its own network stack (which cannot traverse an HTTP
+-- CONNECT proxy). We therefore extract, for each entry of the top-level
+-- @.dependencies@ struct, its @url@ / @hash@ / @path@ / @lazy@ fields.
+--
+-- The parser is deliberately permissive: it understands the full ZON value
+-- grammar well enough to skip over fields it does not care about (name,
+-- version, fingerprint, paths, ...) and to reach @.dependencies@ regardless of
+-- field order.
+module Acton.Zon
+  ( ZonValue(..)
+  , ZonDep(..)
+  , parseZon
+  , zonDependencies
+  , readZonDependencies
+  ) where
+
+import Control.Monad (void)
+import Data.Char (chr, isAlphaNum, isDigit)
+import Data.List (intercalate)
+import Data.Void (Void)
+import Numeric (readHex)
+import System.Directory (doesFileExist)
+import qualified Data.ByteString as BS
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import qualified Data.Text.Encoding.Error as TEE
+import Text.Megaparsec
+import Text.Megaparsec.Char
+import qualified Text.Megaparsec.Char.Lexer as L
+
+type Parser = Parsec Void String
+
+-- | A parsed ZON value. Only the shapes that actually occur in build.zig.zon
+-- are distinguished; everything else is consumed but kept opaque.
+data ZonValue
+  = ZStruct [(String, ZonValue)]   -- ^ @.{ .field = value, ... }@
+  | ZArray  [ZonValue]             -- ^ @.{ value, value, ... }@
+  | ZString String
+  | ZEnum   String                 -- ^ @.identifier@
+  | ZBool   Bool
+  | ZNull
+  | ZNum    String                 -- ^ kept verbatim; we never interpret it
+  deriving (Eq, Show)
+
+-- | One entry of a @build.zig.zon@ @.dependencies@ struct.
+data ZonDep = ZonDep
+  { zdUrl  :: Maybe String
+  , zdHash :: Maybe String
+  , zdPath :: Maybe String
+  , zdLazy :: Bool
+  } deriving (Eq, Show)
+
+-- Lexing ---------------------------------------------------------------------
+
+-- | Whitespace and @//@ line comments (ZON has no block comments).
+sc :: Parser ()
+sc = L.space space1 (L.skipLineComment "//") empty
+
+lexeme :: Parser a -> Parser a
+lexeme = L.lexeme sc
+
+symbol :: String -> Parser String
+symbol = L.symbol sc
+
+-- Values ---------------------------------------------------------------------
+
+pValue :: Parser ZonValue
+pValue = choice
+  [ pStructOrArray
+  , pString
+  , pMultiString
+  , pBoolNull
+  , pEnum
+  , pChar
+  , pNumber
+  ]
+
+-- | Both structs and arrays start with @.{@. They are told apart by looking for
+-- a field head (@.name =@): present means a struct, absent means an array.
+pStructOrArray :: Parser ZonValue
+pStructOrArray = do
+  _ <- try (symbol ".{")
+  (ZStruct [] <$ symbol "}")
+    <|> do
+      isStruct <- option False (True <$ lookAhead (try pFieldHead))
+      if isStruct
+        then ZStruct <$> (pField `sepEndBy1` symbol ",") <* symbol "}"
+        else ZArray  <$> (pValue `sepEndBy1` symbol ",") <* symbol "}"
+
+-- | A field head, used only as look-ahead to classify a @.{ ... }@.
+pFieldHead :: Parser ()
+pFieldHead = char '.' *> lexeme pFieldName *> void (char '=')
+
+pField :: Parser (String, ZonValue)
+pField = do
+  _ <- char '.'
+  name <- lexeme pFieldName
+  _ <- symbol "="
+  v <- pValue
+  pure (name, v)
+
+-- | A field / enum name: a bare identifier or a @\@"quoted"@ identifier.
+pFieldName :: Parser String
+pFieldName = pAtString <|> pBareIdent
+  where
+    pBareIdent = (:) <$> (letterChar <|> char '_')
+                     <*> many (alphaNumChar <|> char '_')
+    pAtString  = char '@' *> pStringRaw
+
+pEnum :: Parser ZonValue
+pEnum = lexeme (ZEnum <$> (char '.' *> pFieldName))
+
+pBoolNull :: Parser ZonValue
+pBoolNull = lexeme $ choice
+  [ ZBool True  <$ keyword "true"
+  , ZBool False <$ keyword "false"
+  , ZNull       <$ keyword "null"
+  ]
+  where keyword w = try (string w <* notFollowedBy (alphaNumChar <|> char '_'))
+
+pString :: Parser ZonValue
+pString = lexeme (ZString <$> pStringRaw)
+
+pStringRaw :: Parser String
+pStringRaw = char '"' *> manyTill pStringChar (char '"')
+  where
+    pStringChar = (char '\\' *> pEscape)
+              <|> satisfy (\c -> c /= '"' && c /= '\n')
+
+pEscape :: Parser Char
+pEscape = choice
+  [ '\n' <$ char 'n'
+  , '\r' <$ char 'r'
+  , '\t' <$ char 't'
+  , '\\' <$ char '\\'
+  , '"'  <$ char '"'
+  , '\'' <$ char '\''
+  , char 'x' *> pHex 2
+  , char 'u' *> (char '{' *> pHexN <* char '}')
+  , anySingle   -- unknown escape: keep the char verbatim
+  ]
+  where
+    pHex n  = chrHex <$> count n hexDigitChar
+    pHexN   = chrHex <$> some hexDigitChar
+    chrHex ds = case readHex ds of
+                  [(v, _)] | v >= (0 :: Int) && v <= 0x10FFFF -> chr v
+                  _                                           -> '\xFFFD'
+
+-- | Zig multiline strings: one or more consecutive lines beginning with @\\\\@.
+pMultiString :: Parser ZonValue
+pMultiString = lexeme (ZString . intercalate "\n" <$> some (try pLine))
+  where
+    pLine = do
+      skipMany (oneOf (" \t" :: String))
+      _ <- string "\\\\"
+      l <- many (satisfy (/= '\n'))
+      _ <- optional eol
+      pure l
+
+pChar :: Parser ZonValue
+pChar = lexeme $ do
+  _ <- char '\''
+  c <- (char '\\' *> pEscape) <|> anySingleBut '\''
+  _ <- char '\''
+  pure (ZNum [c])
+
+-- | Consume a numeric literal in any zig form (decimal, @0x@/@0o@/@0b@, float,
+-- with @_@ separators). We never interpret the value, only skip it.
+pNumber :: Parser ZonValue
+pNumber = lexeme $ do
+  c0 <- satisfy (\c -> isDigit c || c == '-' || c == '+')
+  cs <- many (satisfy (\c -> isAlphaNum c || c `elem` ("._+-" :: String)))
+  pure (ZNum (c0 : cs))
+
+-- Entry points ---------------------------------------------------------------
+
+parseZon :: String -> Either String ZonValue
+parseZon input0 =
+  case parse (sc *> pValue <* eof) "build.zig.zon" input of
+    Left err -> Left (errorBundlePretty err)
+    Right v  -> Right v
+  where
+    -- Zig's tokenizer skips a leading UTF-8 BOM; do the same so a BOM-prefixed
+    -- build.zig.zon still parses (otherwise pre-seeding silently turns off).
+    input = dropWhile (== '\xFEFF') input0
+
+-- | Extract the entries of the top-level @.dependencies@ struct, if present.
+zonDependencies :: ZonValue -> [(String, ZonDep)]
+zonDependencies (ZStruct fields) =
+  case lookup "dependencies" fields of
+    Just (ZStruct deps) -> [ (name, toDep v) | (name, v) <- deps ]
+    _                   -> []
+zonDependencies _ = []
+
+toDep :: ZonValue -> ZonDep
+toDep (ZStruct fs) = ZonDep
+  { zdUrl  = strField "url"
+  , zdHash = strField "hash"
+  , zdPath = strField "path"
+  , zdLazy = case lookup "lazy" fs of
+               Just (ZBool b) -> b
+               _              -> False
+  }
+  where
+    strField k = case lookup k fs of
+                   Just (ZString s) -> Just s
+                   _                -> Nothing
+toDep _ = ZonDep Nothing Nothing Nothing False
+
+-- | Read and parse a @build.zig.zon@, returning its dependency entries. A
+-- missing file yields no dependencies; an unparseable file yields a 'Left'.
+readZonDependencies :: FilePath -> IO (Either String [(String, ZonDep)])
+readZonDependencies p = do
+  exists <- doesFileExist p
+  if not exists
+    then pure (Right [])
+    else do
+      content <- T.unpack . TE.decodeUtf8With TEE.lenientDecode <$> BS.readFile p
+      pure (zonDependencies <$> parseZon content)

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -25,6 +25,7 @@ import qualified Acton.Boxing
 import qualified Acton.CodeGen
 import qualified Acton.Diagnostics as Diag
 import qualified Acton.Compile as Compile
+import qualified Acton.Zon as Zon
 import qualified Acton.CommandLineParser as C
 import qualified Acton.Fingerprint as Fingerprint
 import qualified Acton.Completion as Completion
@@ -146,6 +147,77 @@ main = do
   env0 <- Acton.Env.initEnv sysTypesPath False
 
   sydTest $ do
+    describe "Zon (build.zig.zon reader)" $ do
+      let deps src = case Zon.parseZon src of
+                       Left e  -> error ("parse failed: " ++ e)
+                       Right v -> Zon.zonDependencies v
+      it "extracts url/hash and defaults lazy to false" $ do
+        let src = unlines
+              [ ".{"
+              , "    .name = .demo,"
+              , "    .version = \"0.0.0\","
+              , "    .fingerprint = 0x1234abcd5678ef00,"
+              , "    .dependencies = .{"
+              , "        .zlib_upstream = .{"
+              , "            .url = \"https://example.com/zlib.tar.gz\","
+              , "            .hash = \"N-V-__deadbeef\","
+              , "            .lazy = false,"
+              , "        },"
+              , "    },"
+              , "    .paths = .{ \"\" },"
+              , "}"
+              ]
+        deps src `shouldBe`
+          [ ("zlib_upstream", Zon.ZonDep (Just "https://example.com/zlib.tar.gz") (Just "N-V-__deadbeef") Nothing False) ]
+      it "skips line comments and tolerates trailing commas" $ do
+        let src = unlines
+              [ ".{"
+              , "    // a comment"
+              , "    .dependencies = .{"
+              , "        .a = .{ .url = \"u1\", .hash = \"h1\" }, // trailing comment"
+              , "        .b = .{ .path = \"vendor/b\", },"
+              , "    },"
+              , "}"
+              ]
+        deps src `shouldBe`
+          [ ("a", Zon.ZonDep (Just "u1") (Just "h1") Nothing False)
+          , ("b", Zon.ZonDep Nothing Nothing (Just "vendor/b") False)
+          ]
+      it "records lazy = true" $ do
+        let src = ".{ .dependencies = .{ .x = .{ .url = \"u\", .hash = \"h\", .lazy = true } } }"
+        deps src `shouldBe` [ ("x", Zon.ZonDep (Just "u") (Just "h") Nothing True) ]
+      it "returns no dependencies when the field is absent or empty" $ do
+        deps ".{ .name = .demo, .version = \"1.0.0\" }" `shouldBe` []
+        deps ".{ .dependencies = .{} }" `shouldBe` []
+      it "is robust to field order (dependencies before metadata)" $ do
+        let src = ".{ .dependencies = .{ .a = .{ .url = \"u\", .hash = \"h\" } }, .name = .demo }"
+        deps src `shouldBe` [ ("a", Zon.ZonDep (Just "u") (Just "h") Nothing False) ]
+      it "strips a leading UTF-8 BOM (zig accepts it)" $ do
+        deps ("\xFEFF" ++ ".{ .dependencies = .{ .a = .{ .url = \"u\", .hash = \"h\" } } }")
+          `shouldBe` [ ("a", Zon.ZonDep (Just "u") (Just "h") Nothing False) ]
+      it "skips char, hex and multiline-string sibling fields before dependencies" $ do
+        let src = unlines
+              [ ".{"
+              , "    .name = .demo,"
+              , "    .fingerprint = 0xdead_beef_1234_5678,"
+              , "    .ch = 'z',"
+              , "    .note ="
+              , "        \\\\hello"
+              , "        \\\\world"
+              , "    ,"
+              , "    .dependencies = .{ .a = .{ .url = \"u\", .hash = \"h\", .lazy = true } },"
+              , "    .paths = .{ \"\", \"src\" },"
+              , "}"
+              ]
+        deps src `shouldBe` [ ("a", Zon.ZonDep (Just "u") (Just "h") Nothing True) ]
+      it "readZonDependencies: missing file -> no deps; real file parses" $
+        withSystemTempDirectory "zon" $ \dir -> do
+          missing <- Zon.readZonDependencies (dir </> "nope.zon")
+          missing `shouldBe` Right []
+          let p = dir </> "build.zig.zon"
+          Prelude.writeFile p ".{ .dependencies = .{ .a = .{ .url = \"u\", .hash = \"h\" } } }"
+          got <- Zon.readZonDependencies p
+          got `shouldBe` Right [ ("a", Zon.ZonDep (Just "u") (Just "h") Nothing False) ]
     sequential $ describe "InterfaceFiles" $ do
       it "round-trips payloads and preserves ordered name entries" $ do
         withSystemTempDirectory "acton-iface" $ \dir -> do

--- a/test/proxy/README.md
+++ b/test/proxy/README.md
@@ -36,10 +36,12 @@ Two containers (`docker-compose.yml`):
 3. **control** — runs `curl` on the same internal-only network through the same
    proxy; it must reach GitHub (so a later failure is acton's fault, not the
    network/proxy);
-4. runs three scenarios with the proxy variables set, covering every HTTP path:
+4. runs four scenarios with the proxy variables set, covering every HTTP path:
    `acton fetch` (dependency archive download), `acton pkg update` (the package
-   index over http-client), and `acton pkg upgrade` (GitHub API ref resolution
-   plus archive re-hash).
+   index over http-client), `acton pkg upgrade` (GitHub API ref resolution plus
+   archive re-hash), and `acton build` (a dependency that itself carries a
+   *transitive* zig package dependency, which zig resolves during final
+   compilation).
 
 Because the acton box has no direct egress, a scenario can only succeed if acton
 routed that request through the proxy:
@@ -49,17 +51,35 @@ routed that request through the proxy:
 | **exit 0** | acton honoured `http(s)_proxy` — **PASS** |
 | **exit ≠ 0** | acton ignored the proxy and went direct — **FAIL** |
 
-## The bug this guards against
+## The bugs this guards against
 
-On Linux **x86_64** binaries linked `-no-pie` by `zig cc` (to target an older
-glibc), GHC's `getEnvironment` returns an empty list: an lld copy-relocation
-issue with the glibc `environ`/`__environ` alias. `http-client`'s
-`proxyEnvironment` reads `getEnvironment`, so it never sees the proxy variables
-and connects directly — which fails on a proxy-only network. (`getenv`/`lookupEnv`
-still work, so `curl` and `$HOME` are fine — which is exactly why this is so
-confusing in the field.) **aarch64 is unaffected**, so this test passes there
-regardless; on x86_64 it fails before the fix and passes after.
+**1. The `environ` bug (scenarios 1–3).** On Linux **x86_64** binaries linked
+`-no-pie` by `zig cc` (to target an older glibc), GHC's `getEnvironment` returns
+an empty list: an lld copy-relocation issue with the glibc `environ`/`__environ`
+alias. `http-client`'s `proxyEnvironment` reads `getEnvironment`, so it never
+sees the proxy variables and connects directly — which fails on a proxy-only
+network. (`getenv`/`lookupEnv` still work, so `curl` and `$HOME` are fine — which
+is exactly why this is so confusing in the field.) **aarch64 is unaffected**, so
+these scenarios pass there regardless; on x86_64 they fail before the fix and
+pass after.
 
-The fixture uses a `zig_dependency` (zlib v1.3.1) because `acton fetch` downloads
-and hashes it through the same HTTP path as a package dependency, without needing
-it to be a full Acton package.
+**2. The transitive zig-dependency bug (scenario 4).** A real Acton package can
+carry zig package dependencies, and those can have their own *transitive* `.url`
+dependencies (e.g. `actonlang/acton-zlib`'s `deps/zlib/build.zig.zon` pulls
+`zlib_upstream` from github). Acton fetches the Acton package itself through the
+proxy-aware http-client, but that nested `.url` is resolved by **zig** during
+final compilation — and zig's HTTPS-over-CONNECT-proxy support is broken (it
+writes an absolute-form request URI into the tunnel), so the fetch fails with
+`invalid HTTP response: HttpConnectionClosing`. This is the lmdb/libssh failure
+seen in the field, and it affects **all architectures**.
+
+> **Status:** scenario 4 currently **fails on purpose** — it reproduces the
+> still-unfixed transitive-dependency bug. The fix (Acton pre-seeding zig's cache
+> for transitive `.url` deps through the proxy-aware http-client) is a follow-up;
+> once it lands, this scenario passes too.
+
+The fixtures: `project/` (a `zig_dependency`) and `pkgproject/` (a github
+`dependency`) use zlib v1.3.1, downloaded + hashed through Acton's HTTP path
+without needing to be a full Acton package. `zigdepproject/` depends on the real
+`actonlang/acton-zlib` package and **builds** it, forcing zig to resolve the
+transitive `zlib_upstream` `.url` through the proxy.

--- a/test/proxy/acton/.dockerignore
+++ b/test/proxy/acton/.dockerignore
@@ -1,0 +1,10 @@
+# Keep fixtures source-only: never copy local build artifacts into the image.
+# A pre-populated out/ or zig-pkg/ would let the container skip the very fetch
+# the test is meant to exercise (a false PASS); a host-generated build.zig is
+# tied to the host's acton version and breaks the container build.
+**/out/
+**/zig-pkg/
+**/build.zig
+**/build.zig.zon
+**/.acton/
+**/.acton.lock

--- a/test/proxy/acton/Dockerfile
+++ b/test/proxy/acton/Dockerfile
@@ -20,6 +20,10 @@ COPY project /work/proxytest
 # A second project with a github 'dependency' (repo_url set) for the `acton pkg`
 # command tests (pkg upgrade resolves a ref + re-hashes through the proxy).
 COPY pkgproject /work/pkgtest
+# A third project that depends on a real Acton package (acton-zlib) carrying a
+# *transitive* zig package dependency. `acton build` must drive zig's resolution
+# of that nested .url through the proxy (the lmdb/libssh field failure).
+COPY zigdepproject /work/zigdeptest
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh

--- a/test/proxy/acton/entrypoint.sh
+++ b/test/proxy/acton/entrypoint.sh
@@ -4,8 +4,12 @@
 set -e
 
 TARBALL="${ACTON_TARBALL:-/acton-dist.tar.xz}"
+# Written only after extraction fully completes. The harness waits for THIS, not
+# for bin/acton, so it never exec's a still-being-written binary (e.g. zig/zig)
+# mid-untar -> avoids ETXTBSY "Text file busy" on the first scenario.
+MARKER=/opt/acton/.install-complete
 
-if [ ! -x /opt/acton/bin/acton ]; then
+if [ ! -f "$MARKER" ]; then
     if [ ! -f "$TARBALL" ]; then
         echo "[entrypoint] ERROR: tarball $TARBALL not mounted." >&2
         echo "[entrypoint] Build it first: run 'make test-proxy' (see test/proxy/run.sh)" >&2
@@ -14,6 +18,7 @@ if [ ! -x /opt/acton/bin/acton ]; then
     echo "[entrypoint] Installing Acton from tarball $TARBALL -> /opt/acton ..."
     mkdir -p /opt
     tar -C /opt -xf "$TARBALL"
+    touch "$MARKER"
     echo "[entrypoint] Installed. acton binary: $(ls -l /opt/acton/bin/acton)"
 fi
 

--- a/test/proxy/acton/zigdepproject/Build.act
+++ b/test/proxy/acton/zigdepproject/Build.act
@@ -1,0 +1,24 @@
+name = "zigdeptest"
+fingerprint = 0x0f2654ba77f95769
+
+# A real Acton package dependency (actonlang/acton-zlib) that itself carries a
+# *transitive* zig package dependency. acton-zlib wraps the C zlib via a
+# zig_dependency whose deps/zlib/build.zig.zon declares:
+#
+#   .zlib_upstream = .{ .url = "https://github.com/madler/zlib/.../v1.3.1.tar.gz",
+#                       .hash = "...", .lazy = false }
+#
+# Acton fetches acton-zlib itself through the proxy-aware http-client (fine), but
+# that nested zlib_upstream .url is never seen by acton -- it is resolved by *zig*
+# during "Final compilation". zig's HTTPS-over-CONNECT-proxy support is broken, so
+# the build fails fetching zlib_upstream. `acton build` (not just `acton fetch`)
+# is required to drive zig's transitive resolution.
+dependencies = {
+    "zlib": (
+        url="https://github.com/actonlang/acton-zlib/archive/aad0c3fd2dab64b3c4728ac96cd9362c793fb932.tar.gz",
+        hash="N-V-__8AAF8XAAAaNtxndtX1uIB1vN-tsG6h7ZIPoDoCQ226",
+        repo_url="https://github.com/actonlang/acton-zlib"
+    )
+}
+
+zig_dependencies = {}

--- a/test/proxy/acton/zigdepproject/src/main.act
+++ b/test/proxy/acton/zigdepproject/src/main.act
@@ -1,0 +1,10 @@
+import zlib.lib as z
+
+# Using the dependency forces acton to link acton-zlib's zig artifact, which pulls
+# in deps/zlib and its transitive zlib_upstream .url -- exactly the fetch that must
+# go through the proxy during "Final compilation".
+actor main(env):
+    c = z.compress(b"hello world")
+    d = z.decompress(c)
+    print("roundtrip ok:", d == b"hello world")
+    env.exit(0)

--- a/test/proxy/run.sh
+++ b/test/proxy/run.sh
@@ -47,7 +47,10 @@ docker compose version >/dev/null 2>&1 || { echo "ERROR: docker compose plugin n
 note "Packing $ACTON_DIST -> acton-dist.tar.xz"
 stage="$(mktemp -d)"
 ln -s "$(cd "$ACTON_DIST" && pwd)" "$stage/acton"
-tar -C "$stage" -ch acton | xz -z -0 --threads=0 > "$HERE/acton-dist.tar.xz"
+# COPYFILE_DISABLE=1 stops macOS bsdtar from emitting AppleDouble (._*) sidecar
+# files from xattrs; otherwise base/out/types/._*.c land in the Linux container
+# and zig tries to compile them as C. Ignored by GNU tar (Linux/CI).
+COPYFILE_DISABLE=1 tar -C "$stage" -ch acton | xz -z -0 --threads=0 > "$HERE/acton-dist.tar.xz"
 rm -rf "$stage"
 ls -lh "$HERE/acton-dist.tar.xz" | awk '{print "    tarball: " $5}'
 
@@ -58,7 +61,10 @@ note "docker compose up --build"
 note "Waiting for acton to install from the tarball"
 installed=
 for _ in $(seq 1 150); do
-    if "${COMPOSE[@]}" exec -T acton test -x /opt/acton/bin/acton >/dev/null 2>&1; then installed=1; break; fi
+    # Wait for the install-complete marker, not just bin/acton: the latter appears
+    # mid-untar, and exec'ing a scenario then can hit a still-being-written zig/zig
+    # (ETXTBSY). The marker is touched only after extraction fully finishes.
+    if "${COMPOSE[@]}" exec -T acton test -f /opt/acton/.install-complete >/dev/null 2>&1; then installed=1; break; fi
     sleep 2
 done
 [ -n "$installed" ] || { echo "ERROR: acton did not install" >&2; "${COMPOSE[@]}" logs acton >&2 || true; exit 2; }
@@ -105,17 +111,21 @@ check() {  # $1 = label, $2 = exit code, $3 = output, $4 = required success mark
 }
 
 set +e
-note "[1/3] acton fetch  (dependency archive download)"
+note "[1/4] acton fetch  (dependency archive download)"
 o="$(run_in_proxy /work/proxytest '/opt/acton/bin/acton fetch')"; c=$?
 check "acton fetch"       "$c" "$o" 'Dependencies fetched'
 
-note "[2/3] acton pkg update  (package index over http-client)"
+note "[2/4] acton pkg update  (package index over http-client)"
 o="$(run_in_proxy /work '/opt/acton/bin/acton pkg update')"; c=$?
 check "acton pkg update"  "$c" "$o" 'Updated package index'
 
-note "[3/3] acton pkg upgrade  (github ref resolve + archive re-hash)"
+note "[3/4] acton pkg upgrade  (github ref resolve + archive re-hash)"
 o="$(run_in_proxy /work/pkgtest '/opt/acton/bin/acton pkg upgrade')"; c=$?
 check "acton pkg upgrade" "$c" "$o" 'Wrote changes to Build.act'
+
+note "[4/4] acton build  (transitive zig dependency resolved by zig)"
+o="$(run_in_proxy /work/zigdeptest '/opt/acton/bin/acton build')"; c=$?
+check "acton build"       "$c" "$o" 'Final compilation done'
 set -e
 
 echo


### PR DESCRIPTION
Behind an HTTP CONNECT proxy, acton build fails when a dependency carries a transitive zig package dependency. Acton fetches the Acton package itself through its proxy-aware HTTP client, but the nested url in that package's build.zig.zon (for example acton-zlib's deps/zlib/build.zig.zon pulls zlib_upstream from github; lmdb and libssh hit this in the field) is resolved by zig itself during final compilation. zig's HTTPS-over-CONNECT support is broken, so the fetch fails with "invalid HTTP response: HttpConnectionClosing" and the build dies.

This change makes acton discover and pre-seed those transitive dependencies so zig never has to fetch over the network. While resolving dependencies, acton walks each zig dependency's build.zig.zon, follows path dependencies recursively, and downloads url and hash dependencies through the same proxy-aware HTTP client it already uses, placing them in zig's global cache by hash. zig then finds everything cached and builds without touching its own network stack. Lazy dependencies are left for zig to fetch on demand, so a normal build downloads no more than before, and a failed pre-fetch is a warning rather than an error, so a seeding hiccup can never break a build the old code would have completed.

A small new module, Acton.Zon, reads the subset of ZON needed to find a package's dependencies, with unit tests covering comments, trailing commas, field order, lazy and path entries, a leading UTF-8 BOM, and char, hex and multiline sibling fields.

The first commit adds the reproduction: a fourth scenario in the proxy test that runs acton build on a project depending on the real actonlang/acton-zlib package, which carries the transitive zlib_upstream url. That scenario fails on purpose without the fix. The second commit adds the fix, turning it green. The proxy test runs in CI on both amd64 and arm64 against the freshly built acton, so this path is exercised end to end there.

This is a workaround for zig's proxy bug; the code carries a TODO to remove the pre-seeding once zig can fetch through a CONNECT proxy, either upstream or in our bundled toolchain.
