### PR TITLE
Mark loop-carried locals volatile

### DIFF
--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -113,6 +113,12 @@ compilerTests =
         testBuild "" ExitSuccess False proj
         (returnCode, _cmdOut, cmdErr) <- readCreateProcessWithExitCode (proc "./out/bin/main" []){ cwd = Just proj } ""
         assertEqual ("unboxed bool method slot binary should run: " ++ cmdErr) ExitSuccess returnCode
+  , testCase "release-mode loop-carried local survives setjmp" $ do
+        -- A local assigned inside a for-loop and read afterwards must be emitted
+        -- as C volatile so it survives the loop's StopIteration setjmp/longjmp.
+        -- An optimized (--release=fast) build used to roll it back to its
+        -- pre-loop value, which dropped explicitly-provided argparse options.
+        testBuildAndRun "--release=fast" "" ExitSuccess False "../../test/compiler/release_loop_volatile.act"
   , testCase "dynamic module library build" $ do
         withSystemTempDirectory "acton-dynamic-module-build" $ \proj -> do
           actonExe <- canonicalizePath "../../dist/bin/acton"

--- a/compiler/lib/src/Acton/CodeGen.hs
+++ b/compiler/lib/src/Acton/CodeGen.hs
@@ -146,6 +146,14 @@ setVolVars as env                   = modX env $ \x -> x{ volVarsX = as }
 
 isVolVar a env                      = a `elem` volVarsX (envX env)
 
+-- The Boxing pass wraps a condition's value in a single Box/UnBox node; its
+-- combinators collapse adjacent ones, so they never nest. Strip that one layer
+-- so structural checks like isPUSH can still recognize the underlying primitive call
+-- (e.g. a for-loop's $PUSH() reaches CodeGen as `Box tBool (PUSH())`).
+stripBoxing (Box _ e)               = e
+stripBoxing (UnBox _ e)             = e
+stripBoxing e                       = e
+
 localDefined env                    = localX (envX env)
 
 -- Line emission helpers
@@ -1013,7 +1021,7 @@ instance Gen Stmt where
     genV _ (If _ (Branch (Bool _ True) [Pass _] : _) _)
                                     = (empty, [])
     genV env (If  _ [b@(Branch e ss)] fin)
-      | isPUSH e                    = (b' $+$ fin', v1 ++ v2 ++ volatiles)
+      | isPUSH (stripBoxing e)      = (b' $+$ fin', v1 ++ v2 ++ volatiles)
       where (b',v1)                 = genBranch env "if" b
             (fin',v2)               = genElse env fin
             volatiles               = filterDefined env (bound ss)

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -2083,6 +2083,9 @@ main = do
       testCodeGen env0 ["ints"]
       testCodeGen env0 ["deact"]
       testCodeGen env0 ["lines"]
+      -- A local that is live across a for-loop must be emitted as `volatile` so it
+      -- survives the loop's StopIteration setjmp/longjmp under optimization.
+      testCodeGenContains env0 "forloop_volatile" ["volatile B_str marker", "if ($PUSH())"]
 
     -- BuildSpec: parsing and update-in-place of Build.act (canonical layout)
     describe "BuildSpec" $ do
@@ -3186,6 +3189,31 @@ testCodeGen env0 modulePaths = do
         goldenTextFile h_golden $ return $ T.pack $ Pretty.print h
       it ("Check " ++ pass_name ++ " .c output") $ do
         goldenTextFile c_golden $ return $ T.pack $ Pretty.print c
+
+
+-- pass 9 CodeGen, targeted: run the full pipeline (through Boxing) and assert that
+-- specific substrings appear in the generated C, without a brittle full-file golden.
+testCodeGenContains :: Acton.Env.Env0 -> String -> [String] -> Spec
+testCodeGenContains env0 modulePath expected = do
+  c <- runIO $ do
+    (env, parsed) <- parseAct env0 modulePath
+    kchecked <- Acton.Kinds.check env parsed
+    (nmod, tchecked, env0Typed, _) <- Acton.Types.reconstruct Nothing Nothing env kchecked Nothing
+    (normalized, normEnv) <- Acton.Normalizer.normalize env0Typed tchecked
+    (deacted, deactEnv) <- Acton.Deactorizer.deactorize normEnv normalized
+    (cpstyled, cpsEnv) <- Acton.CPS.convert deactEnv deacted
+    (lifted, liftEnv) <- Acton.LambdaLifter.liftModule cpsEnv cpstyled
+    boxed <- Acton.Boxing.doBoxing liftEnv lifted
+    let act_file = "test" </> "src" </> modulePath ++ ".act"
+    srcText <- readFile act_file
+    let srcbase = "test" </> "src" </> modulePath
+    (_, _, c) <- Acton.CodeGen.generate liftEnv srcbase srcText True boxed "test-hash"
+    return c
+
+  describe modulePath $
+    forM_ expected $ \sub ->
+      it ("generated C contains " ++ show sub) $
+        c `shouldContain` sub
 
 
 testDocstrings :: Acton.Env.Env0 -> String -> Spec

--- a/compiler/lib/test/src/forloop_volatile.act
+++ b/compiler/lib/test/src/forloop_volatile.act
@@ -1,0 +1,17 @@
+# CodeGen regression fixture.
+#
+# A `for` loop is compiled with setjmp/longjmp-based StopIteration handling
+# (if ($PUSH()) { while (true) { ... } $DROP(); } else { ... }). A local that is
+# declared before the loop, assigned inside the loop body and read after the loop
+# must therefore be emitted as C `volatile`; otherwise C11 leaves its value
+# indeterminate after the longjmp and an optimizing build rolls it back.
+#
+# The Boxing pass wraps the loop's $PUSH() condition in a `Box tBool (...)`
+# coercion, which used to hide it from CodeGen's isPUSH-guarded volatile analysis,
+# so `volatile` was never emitted. The codegen test asserts it now is.
+def loop_marker(items: list[str], needle: str) -> ?str:
+    marker: ?str = None
+    for x in items:
+        if x == needle:
+            marker = x
+    return marker

--- a/test/compiler/release_loop_volatile.act
+++ b/test/compiler/release_loop_volatile.act
@@ -1,0 +1,52 @@
+# Regression test for a --release=fast (optimized) codegen bug.
+#
+# A `for` loop is compiled with setjmp/longjmp-based StopIteration handling
+# (if ($PUSH()) { while (true) { ... } $DROP(); } else { ... }). A local that
+# is declared before the loop, assigned inside the loop body and read after the
+# loop must therefore be emitted as C `volatile`; otherwise C11 leaves its value
+# indeterminate after the longjmp and an optimizing build rolls it back to its
+# pre-loop value. The Boxing pass wraps the loop's $PUSH() condition in a Box
+# node, which used to hide it from the codegen volatile analysis.
+#
+# This reproduced as argparse dropping explicitly-provided sub-command options:
+# Args.get_int() raised "Option '<name>' not found" only under --release=fast.
+
+import argparse
+
+# Bare codegen pattern: `marker` is set inside the loop and read afterwards.
+def loop_carried(items: list[str], needle: str) -> ?str:
+    marker: ?str = None
+    for x in items:
+        if x == needle:
+            marker = x
+    return marker
+
+proc def run(args: argparse.Args) -> None:
+    pass
+
+actor main(env):
+    # 1. bare loop-carried local must survive the loop
+    if loop_carried(["a", "Z", "b"], "Z") is None:
+        print("FAIL: loop-carried local rolled back to None", err=True)
+        env.exit(1)
+
+    # 2. argparse: an explicitly provided sub-command option must round-trip
+    p = argparse.Parser()
+    tp = p.add_cmd("test", "Run tests", run)
+    tp.add_arg("name", "Name of the test")
+    tp.add_option("min-iter", "int", default=3, help="")
+    try:
+        args = p.parse(["prog", "test", "simple", "--min-iter", "1"])
+        if args.get_int("min-iter") != 1:
+            print("FAIL: explicit option value lost", err=True)
+            env.exit(1)
+        # 3. the default path must still work too
+        args2 = p.parse(["prog", "test", "simple"])
+        if args2.get_int("min-iter") != 3:
+            print("FAIL: default option value lost", err=True)
+            env.exit(1)
+    except Exception as e:
+        print("FAIL: unexpected exception:", e, err=True)
+        env.exit(1)
+
+    env.exit(0)


### PR DESCRIPTION
For-loops are compiled with setjmp/longjmp StopIteration handling, so a local declared before the loop, assigned inside it and read afterwards must be emitted as volatile to survive the longjmp. CodeGen already had this analysis but it was gated on isPUSH, and the Boxing pass wraps the loop's $PUSH() condition in a Box node, so the check never matched and volatile was never emitted. In an optimized build the local was rolled back to its pre-loop value, which made argparse drop explicitly provided sub-command options under --release=fast while debug builds worked fine.

The fix strips the boxing layer before the isPUSH check so the analysis runs again and such locals get the volatile qualifier.

This includes a codegen test that runs the compiler pipeline and asserts the generated C marks the loop-carried local volatile, and an integration test that builds and runs a release binary exercising the pattern.