### PR TITLE
Enable LTO for release builds

### DIFF
--- a/backend/build.zig
+++ b/backend/build.zig
@@ -5,6 +5,7 @@ const ArrayList = std.ArrayList;
 pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
+    const enable_lto = optimize != .Debug and target.result.os.tag != .macos;
     const no_threads = b.option(bool, "no_threads", "") orelse false;
     const only_actondb = b.option(bool, "only_actondb", "") orelse false;
 
@@ -93,6 +94,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+    if (enable_lto) libactondb.lto = .full;
     libactondb.root_module.addCSourceFiles(.{
         .files = &libactondb_sources,
         .flags = flags.items
@@ -116,6 +118,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+    if (enable_lto) actondb.lto = .full;
     actondb.root_module.addCSourceFile(.{ .file = b.path("actondb.c"), .flags = &[_][]const u8{
         "-fno-sanitize=undefined",
     }});

--- a/base/build.zig
+++ b/base/build.zig
@@ -30,6 +30,7 @@ pub fn build(b: *std.Build) void {
     const buildroot_path = b.build_root.join(b.allocator, &.{}) catch unreachable;
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
+    const enable_lto = optimize != .Debug and target.result.os.tag != .macos;
     const cpedantic = b.option(bool, "cpedantic", "") orelse false;
     const use_db = b.option(bool, "db", "") orelse false;
     const no_threads = b.option(bool, "no_threads", "") orelse false;
@@ -243,6 +244,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+    if (enable_lto) libActon.lto = .full;
     for (c_files.items) |entry| {
         libActon.root_module.addCSourceFile(.{ .file = b.path(entry), .flags = flags.items });
     }
@@ -324,6 +326,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+    if (enable_lto) base_tests.lto = .full;
     base_tests.root_module.addIncludePath(.{ .cwd_relative = buildroot_path });
     base_tests.root_module.linkLibrary(dep_libbsdnt.artifact("bsdnt"));
     base_tests.root_module.linkLibrary(dep_libgc.artifact("gc"));

--- a/builder/build.zig
+++ b/builder/build.zig
@@ -36,6 +36,7 @@ pub fn build(b: *std.Build) void {
     const buildroot_path = b.build_root.join(b.allocator, &.{}) catch @panic("ASD");
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
+    const enable_lto = optimize != .Debug and target.result.os.tag != .macos;
     const db = b.option(bool, "db", "") orelse false;
     const no_threads = b.option(bool, "no_threads", "") orelse false;
     const acton_libraries = b.option([]const u8, "acton_libraries", "") orelse "";
@@ -173,6 +174,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+    if (enable_lto) libActonProject.lto = .full;
     var flags = std.ArrayList([]const u8).empty;
     defer flags.deinit(b.allocator);
 
@@ -250,6 +252,7 @@ pub fn build(b: *std.Build) void {
                 .optimize = optimize,
             }),
         });
+        if (enable_lto) libActonExplicit.lto = .full;
         if (lib_dynamic) {
             libActonExplicit.linker_allow_shlib_undefined = true;
         }
@@ -376,6 +379,7 @@ pub fn build(b: *std.Build) void {
                     .optimize = optimize,
                 }),
             });
+            if (enable_lto) executable.lto = .full;
             // Build relative path for the executable source file
             const exe_rel_path = b.allocator.alloc(u8, 9 + entry.file_path.len) catch @panic("OOM");
             @memcpy(exe_rel_path[0..9], "out/types");

--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -1492,6 +1492,12 @@ actonProjTests =
             ("const actdep_lmdb = b.dependency(\"lmdb\"" `isInfixOf` rootBuildZig)
           assertBool "root build.zig should namespace the zig dep lookup"
             ("const dep_lmdb = b.dependency(\"acton_zig_lmdb\"" `isInfixOf` rootBuildZig)
+          assertBool "root build.zig should skip LTO for macOS targets"
+            ("const enable_lto = optimize != .Debug and target.result.os.tag != .macos;" `isInfixOf` rootBuildZig)
+          assertBool "root build.zig should enable LTO for the project library"
+            ("if (enable_lto) libActonProject.lto = .full;" `isInfixOf` rootBuildZig)
+          assertBool "root build.zig should enable LTO for executables"
+            ("if (enable_lto) executable.lto = .full;" `isInfixOf` rootBuildZig)
   , testCase "transitive zig deps deduplicate by identity and split on collision" $ do
         withSystemTempDirectory "acton-zig-transitive-dedup" $ \tmp -> do
           actonExe <- canonicalizePath "../../dist/bin/acton"

--- a/deps/libargp/build.zig
+++ b/deps/libargp/build.zig
@@ -15,6 +15,7 @@ fn targetIsDarwin(t: std.Target) bool {
 pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
+    const enable_lto = optimize != .Debug and target.result.os.tag != .macos;
     const t = target.result;
 
     var flags = std.ArrayList([]const u8).empty;
@@ -45,6 +46,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+    if (enable_lto) lib.lto = .full;
 
     lib.root_module.addCSourceFiles(.{ .files = &.{
         "argp-ba.c",

--- a/deps/libbsdnt/build.zig
+++ b/deps/libbsdnt/build.zig
@@ -6,6 +6,7 @@ const tgt = @import("builtin").target;
 pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
+    const enable_lto = optimize != .Debug and target.result.os.tag != .macos;
     const t = target.result;
     const want_assert = b.option(bool, "want_assert", "Enable asserts") orelse false;
     const want_redzones = b.option(bool, "want_redzones", "Enable redzones") orelse true;
@@ -60,6 +61,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+    if (enable_lto) lib.lto = .full;
 
     lib.root_module.addConfigHeader(config_header);
 

--- a/deps/libgc/build.zig
+++ b/deps/libgc/build.zig
@@ -44,6 +44,7 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
     const t = target.result;
+    const enable_lto = optimize != .Debug and t.os.tag != .macos;
 
     const default_enable_threads = !t.cpu.arch.isWasm(); // emscripten/wasi
 
@@ -472,6 +473,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+    if (enable_lto) gc.lto = .full;
     gc.root_module.addCSourceFiles(.{
         .files = source_files.items,
         .flags = flags.items,
@@ -490,6 +492,7 @@ pub fn build(b: *std.Build) void {
                 .optimize = optimize,
             }),
         });
+        if (enable_lto) gccpp.lto = .full;
         gccpp.root_module.addCSourceFiles(.{
             .files = &.{
                 "gc_badalc.cc",
@@ -510,6 +513,7 @@ pub fn build(b: *std.Build) void {
                     .optimize = optimize,
                 }),
             });
+            if (enable_lto) gctba.lto = .full;
             gctba.root_module.addCSourceFiles(.{
                 .files = &.{
                     "gc_badalc.cc",
@@ -532,6 +536,7 @@ pub fn build(b: *std.Build) void {
                 .optimize = optimize,
             })
         });
+        if (enable_lto) cord.lto = .full;
         cord.root_module.addCSourceFiles(.{
             .files = &.{
                 "cord/cordbscs.c",
@@ -670,6 +675,7 @@ fn addTestExt(b: *std.Build, gc: *std.Build.Step.Compile,
             .target = gc.root_module.resolved_target.?,
         }),
     });
+    if (gc.root_module.optimize.? != .Debug and gc.root_module.resolved_target.?.result.os.tag != .macos) test_exe.lto = .full;
     test_exe.root_module.addCSourceFile(.{
         .file = b.path(filename),
         .flags = flags.items

--- a/deps/libnetstring/build.zig
+++ b/deps/libnetstring/build.zig
@@ -4,6 +4,7 @@ const print = @import("std").debug.print;
 pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
+    const enable_lto = optimize != .Debug and target.result.os.tag != .macos;
 
     const lib = b.addLibrary(.{
         .name = "netstring",
@@ -13,6 +14,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+    if (enable_lto) lib.lto = .full;
 
     const source_files = [_][]const u8{
         "netstring.c",

--- a/deps/libprotobuf_c/build.zig
+++ b/deps/libprotobuf_c/build.zig
@@ -4,6 +4,7 @@ const print = @import("std").debug.print;
 pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
+    const enable_lto = optimize != .Debug and target.result.os.tag != .macos;
 
     const lib = b.addLibrary(.{
         .name = "protobuf-c",
@@ -13,6 +14,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+    if (enable_lto) lib.lto = .full;
 
     lib.root_module.addCSourceFiles(.{
         .files = &.{

--- a/deps/libsnappy_c/build.zig
+++ b/deps/libsnappy_c/build.zig
@@ -4,6 +4,7 @@ const print = @import("std").debug.print;
 pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
+    const enable_lto = optimize != .Debug and target.result.os.tag != .macos;
     const t = target.result;
 
     var flags = std.ArrayList([]const u8).empty;
@@ -17,6 +18,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+    if (enable_lto) lib.lto = .full;
     lib.root_module.addIncludePath(b.path("."));
 
     //const libsnappy_version = "1.1.10";

--- a/deps/libutf8proc/build.zig
+++ b/deps/libutf8proc/build.zig
@@ -4,6 +4,7 @@ const print = @import("std").debug.print;
 pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
+    const enable_lto = optimize != .Debug and target.result.os.tag != .macos;
 
     const build_shared_libs = b.option(bool, "BUILD_SHARED_LIBS",
                 "Build shared libraries (otherwise static ones)") orelse true;
@@ -17,6 +18,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+    if (enable_lto) lib.lto = .full;
 
     var flags = std.ArrayList([]const u8).empty;
     defer flags.deinit(b.allocator);

--- a/deps/libuuid/build.zig
+++ b/deps/libuuid/build.zig
@@ -4,6 +4,7 @@ const print = @import("std").debug.print;
 pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
+    const enable_lto = optimize != .Debug and target.result.os.tag != .macos;
 
     const lib = b.addLibrary(.{
         .name = "uuid",
@@ -13,6 +14,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+    if (enable_lto) lib.lto = .full;
 
     const source_files = [_][]const u8{
         "src/clear.c",

--- a/deps/libuv/build.zig
+++ b/deps/libuv/build.zig
@@ -25,6 +25,7 @@ fn targetIsBSD(t: std.Target) bool {
 pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
+    const enable_lto = optimize != .Debug and target.result.os.tag != .macos;
     const t = target.result;
 
     const lib = b.addLibrary(.{
@@ -35,6 +36,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+    if (enable_lto) lib.lto = .full;
 
     var flags = std.ArrayList([]const u8).empty;
     defer flags.deinit(b.allocator);

--- a/deps/libxml2/build.zig
+++ b/deps/libxml2/build.zig
@@ -4,6 +4,7 @@ const print = @import("std").debug.print;
 pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
+    const enable_lto = optimize != .Debug and target.result.os.tag != .macos;
     const t = target.result;
 
     var flags = std.ArrayList([]const u8).empty;
@@ -17,6 +18,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+    if (enable_lto) lib.lto = .full;
     lib.root_module.addIncludePath(b.path("include"));
 
     const libxml_version = "2.12.0";

--- a/deps/libyyjson/build.zig
+++ b/deps/libyyjson/build.zig
@@ -4,6 +4,7 @@ const print = @import("std").debug.print;
 pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
+    const enable_lto = optimize != .Debug and target.result.os.tag != .macos;
 
     const lib = b.addLibrary(.{
         .name = "yyjson",
@@ -13,6 +14,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+    if (enable_lto) lib.lto = .full;
 
     const source_files = [_][]const u8{
         "yyjson.c",

--- a/deps/mbedtls/build.zig
+++ b/deps/mbedtls/build.zig
@@ -4,6 +4,7 @@ const print = @import("std").debug.print;
 pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
+    const enable_lto = optimize != .Debug and target.result.os.tag != .macos;
 
     const libcrypto = b.addLibrary(.{
         .name = "mbedcrypto",
@@ -13,6 +14,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+    if (enable_lto) libcrypto.lto = .full;
 
     const libx509 = b.addLibrary(.{
         .name = "mbedx509",
@@ -22,6 +24,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+    if (enable_lto) libx509.lto = .full;
 
     const libtls = b.addLibrary(.{
         .name = "mbedtls",
@@ -31,6 +34,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+    if (enable_lto) libtls.lto = .full;
 
     var flags = std.ArrayList([]const u8).empty;
     defer flags.deinit(b.allocator);

--- a/deps/pcre2/build.zig
+++ b/deps/pcre2/build.zig
@@ -9,6 +9,7 @@ pub const CodeUnitWidth = enum {
 pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
+    const enable_lto = optimize != .Debug and target.result.os.tag != .macos;
     const linkage = b.option(std.builtin.LinkMode, "linkage", "whether to statically or dynamically link the library") orelse @as(std.builtin.LinkMode, if (target.result.isGnuLibC()) .dynamic else .static);
     const codeUnitWidth = b.option(CodeUnitWidth, "code-unit-width", "Sets the code unit width") orelse .@"8";
 
@@ -25,6 +26,7 @@ pub fn build(b: *std.Build) !void {
             .link_libc = true,
         }),
     });
+    if (enable_lto) lib.lto = .full;
 
     if (linkage == .static) {
         try lib.root_module.c_macros.append(b.allocator, "-DPCRE2_STATIC");

--- a/deps/tlsuv/build.zig
+++ b/deps/tlsuv/build.zig
@@ -15,6 +15,7 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const t = target.result;
     const optimize = b.standardOptimizeOption(.{});
+    const enable_lto = optimize != .Debug and t.os.tag != .macos;
 
     const enable_http = b.option(bool, "http", "enable HTTP/websocket support") orelse true;
     const enable_keychain = b.option(bool, "keychain", "enable keychain support on platforms that support it") orelse true;
@@ -44,6 +45,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+    if (enable_lto) lib.lto = .full;
 
     var cflags = std.ArrayList([]const u8).empty;
     defer cflags.deinit(b.allocator);

--- a/std/build.zig
+++ b/std/build.zig
@@ -23,6 +23,7 @@ pub fn build(b: *std.Build) void {
     const buildroot_path = b.build_root.join(b.allocator, &.{}) catch unreachable;
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
+    const enable_lto = optimize != .Debug and target.result.os.tag != .macos;
     const db = b.option(bool, "db", "") orelse false;
     const no_threads = b.option(bool, "no_threads", "") orelse false;
 
@@ -176,6 +177,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+    if (enable_lto) libActonProject.lto = .full;
 
     for (c_files.items) |entry| {
         libActonProject.root_module.addCSourceFile(.{ .file = b.path(entry), .flags = flags.items });


### PR DESCRIPTION
Set Zig compile-step LTO for generated Acton projects, base, std, backend, and bundled runtime dependencies when optimization is not Debug.

Keep Debug builds without LTO so local development remains fast and also avoids the Zig 0.16 Debug LTO crash observed while compiling the large base library.

Fixes #2979 