### PR TITLE
Handle failed process spawns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
   reader fails, reporting the runner failure or captured output error instead
   of waiting forever for a missing completion event. [#2972]
 
+### Standard Library
+- Report missing or empty `process.Process` and `process.RunProcess` commands
+  through `on_error`, and mark failed spawns as not running so follow-up
+  process operations are safely ignored. [#2910]
+
 ## [0.28.3] - 2026-06-23
 
 This release is another proxy workaround release. Acton now keeps one more

--- a/base/src/process.ext.c
+++ b/base/src/process.ext.c
@@ -83,6 +83,15 @@ $R processQ_ProcessD_aidG_local(processQ_Process self, $Cont c$cont) {
 
 $R processQ_ProcessD__create_processG_local(processQ_Process self, $Cont c$cont) {
     pin_actor_affinity();
+
+    if (self->cmd->length == 0) {
+        char errmsg[1024] = "Failed to spawn process '<empty command>': empty command";
+        log_warn("%s", errmsg);
+        $action2 f = ($action2)self->on_error;
+        f->$class->__asyn__(f, self, to$str(errmsg));
+        return $R_CONT(c$cont, B_None);
+    }
+
     struct process_data *process_data = acton_calloc(1, sizeof(struct process_data));
     process_data->process = self;
     process_data->on_stdout = self->on_stdout;
@@ -153,11 +162,27 @@ $R processQ_ProcessD__create_processG_local(processQ_Process self, $Cont c$cont)
 
     int r = uv_spawn(get_uv_loop(), req, options);
     if (r != 0) {
-        char errmsg[1024] = "Failed to spawn process: ";
+        self->_p = 0;
+        uv_handle_t *process_handle = (uv_handle_t *)req;
+        uv_handle_t *stdin_handle = (uv_handle_t *)&process_data->stdin_pipe;
+        uv_handle_t *stdout_handle = (uv_handle_t *)&process_data->stdout_pipe;
+        uv_handle_t *stderr_handle = (uv_handle_t *)&process_data->stderr_pipe;
+        if (uv_handle_get_type(process_handle) != UV_UNKNOWN_HANDLE &&
+            uv_is_closing(process_handle) == 0)
+            uv_close(process_handle, NULL);
+        if (uv_is_closing(stdin_handle) == 0)
+            uv_close(stdin_handle, NULL);
+        if (uv_is_closing(stdout_handle) == 0)
+            uv_close(stdout_handle, NULL);
+        if (uv_is_closing(stderr_handle) == 0)
+            uv_close(stderr_handle, NULL);
+
+        char errmsg[1024];
+        snprintf(errmsg, sizeof(errmsg), "Failed to spawn process '%s': ", args[0]);
         uv_strerror_r(r, errmsg + strlen(errmsg), sizeof(errmsg) - strlen(errmsg));
-        log_warn(errmsg);
+        log_warn("%s", errmsg);
         $action2 f = ($action2)self->on_error;
-        f->$class->__asyn__(f, process_data->process, to$str(errmsg));
+        f->$class->__asyn__(f, self, to$str(errmsg));
         return $R_CONT(c$cont, B_None);
     }
     // TODO: do we need to do some magic to read any data produced before this
@@ -175,6 +200,11 @@ void close_cb(uv_handle_t *handle) {
 
 $R processQ_ProcessD_done_writingG_local(processQ_Process self, $Cont c$cont) {
     uv_process_t *p = (uv_process_t *)(intptr_t)self->_p;
+    if (p == 0) {
+        log_warn("Process is not running, ignoring done_writing request");
+        return $R_CONT(c$cont, B_None);
+    }
+
     struct process_data *process_data = (struct process_data *)p->data;
     uv_handle_t *stdin_handle = (uv_handle_t *)&process_data->stdin_pipe;
     // Ensure stdin is closed properly. stdin might be closed already from
@@ -187,18 +217,20 @@ $R processQ_ProcessD_done_writingG_local(processQ_Process self, $Cont c$cont) {
 $R processQ_ProcessD_pidG_local(processQ_Process self, $Cont c$cont) {
     uv_process_t *p = (uv_process_t *)(intptr_t)self->_p;
     if (p == 0) {
-        log_warn("Process has exited, ignoring PID request");
+        log_warn("Process is not running, ignoring PID request");
         return $R_CONT(c$cont, B_None);
     }
+
     return $R_CONT(c$cont, (B_atom)toB_int(p->pid));
 }
 
 $R processQ_ProcessD_signalG_local(processQ_Process self, $Cont c$cont, int64_t signal) {
     uv_process_t *p = (uv_process_t *)(intptr_t)self->_p;
     if (p == 0) {
-        log_warn("Process has exited, ignoring signal request");
+        log_warn("Process is not running, ignoring signal request");
         return $R_CONT(c$cont, B_None);
     }
+
     uv_process_kill(p, (int)signal);
     return $R_CONT(c$cont, B_None);
 }
@@ -206,7 +238,7 @@ $R processQ_ProcessD_signalG_local(processQ_Process self, $Cont c$cont, int64_t 
 $R processQ_ProcessD_writeG_local(processQ_Process self, $Cont c$cont, B_bytes data) {
     uv_process_t *p = (uv_process_t *)(intptr_t)self->_p;
     if (p == 0) {
-        log_warn("Process has exited, ignoring write request");
+        log_warn("Process is not running, ignoring write request");
         return $R_CONT(c$cont, B_None);
     }
 

--- a/test/stdlib_tests/src/test_process.act
+++ b/test/stdlib_tests/src/test_process.act
@@ -1,0 +1,219 @@
+import process
+import testing
+
+
+PROCESS_MISSING_CMD = "acton-stdlib-process-missing-binary-for-test"
+RUNPROCESS_MISSING_CMD = "acton-stdlib-runprocess-missing-binary-for-test"
+EMPTY_CMD_ERROR = "Failed to spawn process '<empty command>': empty command"
+
+
+actor _test_ProcessMissingBinary(t: testing.EnvT):
+    """Missing process binaries must report on_error"""
+    var done = False
+    var process_refs: list[process.Process] = []
+
+    def _finish_success():
+        if done:
+            return
+        done = True
+        t.success()
+
+    def _finish_failure(msg: str):
+        if done:
+            return
+        done = True
+        t.failure(AssertionError(msg))
+
+    def _finish_error(msg: str):
+        if done:
+            return
+        done = True
+        t.error(Exception(msg))
+
+    def _on_stdout(p, data):
+        if data is not None:
+            _finish_failure("Process unexpectedly produced stdout: " + str(data))
+
+    def _on_stderr(p, data):
+        if data is not None:
+            _finish_failure("Process unexpectedly produced stderr: " + str(data))
+
+    def _on_exit(p, exit_code, term_signal):
+        _finish_failure("Process unexpectedly exited instead of reporting spawn error")
+
+    def _on_error(p, error):
+        expected = "Failed to spawn process '" + PROCESS_MISSING_CMD + "': "
+        if not error.startswith(expected):
+            _finish_failure("Unexpected process error: " + error)
+            return
+        if p.pid() is not None:
+            _finish_failure("Failed process unexpectedly has a PID")
+            return
+        p.done_writing()
+        _finish_success()
+
+    def _start():
+        pc = process.ProcessCap(t.env.cap)
+        process_refs.append(process.Process(pc, [PROCESS_MISSING_CMD],
+                                            _on_stdout, _on_stderr, _on_exit,
+                                            _on_error))
+
+    def _watchdog():
+        if not done:
+            _finish_error("timeout waiting for missing process binary error")
+
+    after 0: _start()
+    after 5.0: _watchdog()
+
+
+actor _test_RunProcessMissingBinary(t: testing.EnvT):
+    """RunProcess must report spawn errors instead of waiting forever"""
+    var done = False
+    var process_refs: list[process.RunProcess] = []
+
+    def _finish_success():
+        if done:
+            return
+        done = True
+        t.success()
+
+    def _finish_failure(msg: str):
+        if done:
+            return
+        done = True
+        t.failure(AssertionError(msg))
+
+    def _finish_error(msg: str):
+        if done:
+            return
+        done = True
+        t.error(Exception(msg))
+
+    def _on_exit(p, exit_code, term_signal, stdout_buf, stderr_buf):
+        _finish_failure("RunProcess unexpectedly exited instead of reporting spawn error")
+
+    def _on_error(p, error):
+        expected = "Failed to spawn process '" + RUNPROCESS_MISSING_CMD + "': "
+        if not error.startswith(expected):
+            _finish_failure("Unexpected RunProcess error: " + error)
+            return
+        if p.pid() is not None:
+            _finish_failure("Failed RunProcess child unexpectedly has a PID")
+            return
+        _finish_success()
+
+    def _start():
+        pc = process.ProcessCap(t.env.cap)
+        process_refs.append(process.RunProcess(pc, [RUNPROCESS_MISSING_CMD],
+                                               _on_exit, _on_error))
+
+    def _watchdog():
+        if not done:
+            _finish_error("timeout waiting for missing RunProcess binary error")
+
+    after 0: _start()
+    after 5.0: _watchdog()
+
+
+actor _test_ProcessEmptyCommand(t: testing.EnvT):
+    """Empty process command lists must report on_error"""
+    var done = False
+    var process_refs: list[process.Process] = []
+
+    def _finish_success():
+        if done:
+            return
+        done = True
+        t.success()
+
+    def _finish_failure(msg: str):
+        if done:
+            return
+        done = True
+        t.failure(AssertionError(msg))
+
+    def _finish_error(msg: str):
+        if done:
+            return
+        done = True
+        t.error(Exception(msg))
+
+    def _on_stdout(p, data):
+        if data is not None:
+            _finish_failure("Process unexpectedly produced stdout: " + str(data))
+
+    def _on_stderr(p, data):
+        if data is not None:
+            _finish_failure("Process unexpectedly produced stderr: " + str(data))
+
+    def _on_exit(p, exit_code, term_signal):
+        _finish_failure("Process unexpectedly exited instead of reporting empty command")
+
+    def _on_error(p, error):
+        if error != EMPTY_CMD_ERROR:
+            _finish_failure("Unexpected empty command error: " + error)
+            return
+        if p.pid() is not None:
+            _finish_failure("Empty-command process unexpectedly has a PID")
+            return
+        _finish_success()
+
+    def _start():
+        pc = process.ProcessCap(t.env.cap)
+        process_refs.append(process.Process(pc, [],
+                                            _on_stdout, _on_stderr, _on_exit,
+                                            _on_error))
+
+    def _watchdog():
+        if not done:
+            _finish_error("timeout waiting for empty process command error")
+
+    after 0: _start()
+    after 5.0: _watchdog()
+
+
+actor _test_RunProcessEmptyCommand(t: testing.EnvT):
+    """RunProcess empty commands must report on_error"""
+    var done = False
+    var process_refs: list[process.RunProcess] = []
+
+    def _finish_success():
+        if done:
+            return
+        done = True
+        t.success()
+
+    def _finish_failure(msg: str):
+        if done:
+            return
+        done = True
+        t.failure(AssertionError(msg))
+
+    def _finish_error(msg: str):
+        if done:
+            return
+        done = True
+        t.error(Exception(msg))
+
+    def _on_exit(p, exit_code, term_signal, stdout_buf, stderr_buf):
+        _finish_failure("RunProcess unexpectedly exited instead of reporting empty command")
+
+    def _on_error(p, error):
+        if error != EMPTY_CMD_ERROR:
+            _finish_failure("Unexpected empty RunProcess command error: " + error)
+            return
+        if p.pid() is not None:
+            _finish_failure("Empty-command RunProcess child unexpectedly has a PID")
+            return
+        _finish_success()
+
+    def _start():
+        pc = process.ProcessCap(t.env.cap)
+        process_refs.append(process.RunProcess(pc, [], _on_exit, _on_error))
+
+    def _watchdog():
+        if not done:
+            _finish_error("timeout waiting for empty RunProcess command error")
+
+    after 0: _start()
+    after 5.0: _watchdog()


### PR DESCRIPTION
Handle failed process spawns.

Report missing and empty process commands through on_error before
libuv can leave Process in a half-started state.

When libuv reports a spawn error before a child exists, mark
Process as not running so later pid, signal, write, and done_writing
requests are ignored consistently.

If libuv has already activated the process handle, keep it live so
the normal exit callback can reap the child.

Cover missing binaries and empty command lists for both Process and
RunProcess in the stdlib process tests.

Fixes #2910.