### PR TITLE
Allow local bindings to shadow functions

### DIFF
--- a/compiler/lib/src/Acton/CodeGen.hs
+++ b/compiler/lib/src/Acton/CodeGen.hs
@@ -138,6 +138,8 @@ isDefined env n                     = n `HashSet.member` globalX x || n `HashSet
 
 excludeDefined env te               = filter (not . isDefined env . fst) te
 
+excludeLocalDefined env te          = filter (not . (`HashSet.member` localDefined env) . fst) te
+
 filterDefined env ns                = filter (isDefined env) ns
 
 ret env                             = retX $ envX env
@@ -988,7 +990,7 @@ genStmt env (Assign _ [PVar _ n (Just t)] e)
                                            _  -> genExp env t e
                                       else genExp env t e
 genStmt env s                       = (vcat [ genTypeDecl env n t <+> gen env n <> semi | (n,NVar t) <- te ] $+$ s', vs)
-  where te                          = excludeDefined env (envOf s)
+  where te                          = excludeLocalDefined env (envOf s)
         env1                        = ldefine te env
         (s', vs)                    = genV env1 s
 

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -2086,6 +2086,7 @@ main = do
       -- A local that is live across a for-loop must be emitted as `volatile` so it
       -- survives the loop's StopIteration setjmp/longjmp under optimization.
       testCodeGenContains env0 "forloop_volatile" ["volatile B_str marker", "if ($PUSH())"]
+      testCodeGenContains env0 "local_shadows_function" ["B_str boom;", "return boom;"]
 
     -- BuildSpec: parsing and update-in-place of Build.act (canonical layout)
     describe "BuildSpec" $ do

--- a/compiler/lib/test/src/local_shadows_function.act
+++ b/compiler/lib/test/src/local_shadows_function.act
@@ -1,0 +1,6 @@
+def boom(flag: bool) -> str:
+    if flag:
+        boom = "here"
+    else:
+        boom = "there"
+    return boom


### PR DESCRIPTION
When CodeGen emits declarations for local statements, only suppress names that are already local to the C scope. A global function with the same Acton name should not prevent a local variable declaration.

Add a CodeGen regression that binds and returns a local named boom inside def boom, which used to emit invalid C.

Fixes #2531