### PR TITLE
Bump Syntax version for Cell rename

### DIFF
--- a/compiler/lib/src/Acton/Syntax.hs
+++ b/compiler/lib/src/Acton/Syntax.hs
@@ -26,7 +26,7 @@ import Control.DeepSeq
 import Prelude hiding((<>))
 
 version :: [Int]
-version = [0,31]
+version = [0,32]
 
 data Module     = Module        { modname::ModName, imps::[Import], mdoc::Maybe String, mbody::Suite } deriving (Eq,Show,Generic,NFData)
 


### PR DESCRIPTION
The builtin cell type now serializes as $Cell rather than $Box.

Old .tydb files can still contain the previous internal name.

Bump the Syntax interface version so stale caches regenerate.