### PR TITLE
Synthesize __get_attr__ attribute getter

### DIFF
--- a/compiler/acton/test/typeerrors/reserved_get_attr.act
+++ b/compiler/acton/test/typeerrors/reserved_get_attr.act
@@ -1,0 +1,6 @@
+class Foo(object):
+    x: int
+    def __init__(self):
+        self.x = 1
+    def __get_attr__(self, name: str) -> ?value:
+        return self.x

--- a/compiler/acton/test/typeerrors/reserved_get_attr.golden
+++ b/compiler/acton/test/typeerrors/reserved_get_attr.golden
@@ -1,0 +1,9 @@
+Building file test/typeerrors/reserved_get_attr.act using temporary scratch directory
+   reserved_get_attr  Parse done                                                               0.000 s
+[error Compilation error]: Cannot define reserved compiler-synthesized method __get_attr__
+     +--> reserved_get_attr.act@5:9-5:21
+     |
+   5 |     def __get_attr__(self, name: str) -> ?value:
+     :         ^----------- 
+     :         `- Cannot define reserved compiler-synthesized method __get_attr__
+-----+

--- a/compiler/lib/src/Acton/Builtin.hs
+++ b/compiler/lib/src/Acton/Builtin.hs
@@ -42,6 +42,8 @@ serializeKW                         = name "__serialize__"
 deserializeKW                       = name "__deserialize__"
 cleanupKW                           = name "__cleanup__"
 resumeKW                            = name "__resume__"
+getAttrKW                           = name "__get_attr__"
+nameKW                              = name "name"
 
 valueKWs                            = [boolKW, strKW, reprKW]
 indexedKWs                          = [getitemKW, setitemKW, delitemKW]

--- a/compiler/lib/src/Acton/CodeGen.hs
+++ b/compiler/lib/src/Acton/CodeGen.hs
@@ -503,7 +503,16 @@ declDecl env (Def dloc n q p KwdNIL (Just t) b d fx ddoc)
             NClass q _ _ _ <- findQName (NoQ c) env
                                     = Just $ B.rtypeOf env (TC (NoQ c) (map tVar $ qbound q)) n0
         methodType n                = B.generalType env (methnm n)
-        (ss',vs)                    = genSuite env1 b
+        -- The synthesized reflective getter carries an empty body (return None)
+        -- through type checking and hashing so it pins no fields; here we ignore
+        -- that body and emit the real field-reflecting if-chain from the class
+        -- property set (see genGetAttr). __get_attr__ is a reserved name (a user
+        -- definition is rejected in Types), so the only method reaching this guard
+        -- is the compiler-synthesized placeholder.
+        (ss',vs)
+          | Derived c n0 <- n, n0 == getAttrKW
+                                    = (genGetAttr env1 c, [])
+          | otherwise               = genSuite env1 b
         decl                        = emit dloc $+$
                                       t3 <+> genTopName env n <+> parens (genPosPar (setVolVars vs env) n d t1 p) <+> char '{' $+$
                                       nest 4 ss' $+$ 
@@ -583,6 +592,31 @@ declDeserialize env n c props sup_c = (gen env (tCon c) <+> genTopName env (meth
                                       text "memcpy" <> parens (text "&" <> gen env self <> text "->" <> gen env i <> comma <+> text "&" <> gen env tmpV <> comma <+> text "sizeof" <> parens (gen env self <> text "->" <> gen env i)) <> semi
            | otherwise              = gen env self <> text "->" <> gen env i <+> text "=" <+> gen env primStepDeserialize <> parens (gen env st) <> semi
         ret                         = text "return" <+> gen env self <> semi
+
+
+-- Emit the body of the synthesized reflective getter __get_attr__(self, name).
+-- One branch per instance property: `if name == "attr": return self.attr`,
+-- keyed by the Acton attribute name, then `return None`. Object/list/value
+-- fields are returned by a plain pointer cast to B_value (valid even when the
+-- field's class was pruned to an opaque forward declaration); unboxable scalar
+-- fields are boxed with the builtin toB_* helpers. Reading an un-vivified
+-- optional field yields B_None, which the caller treats as absent.
+genGetAttr env cname                = case findQName (NoQ cname) env of
+                                        NClass q _ _ _ -> body (TC (NoQ cname) (map tVar $ qbound q))
+                                        _              -> retNone
+  where body c                      = vcat [ branch n t | (n, NSig sc Property _) <- fullAttrEnv env c, let t = sctype sc ] $+$ retNone
+        retNone                     = text "return" <+> gen env eNone <> semi
+        self                        = name "self"
+        branch n t                  = (text "if" <+> parens (nameEq n) <+> char '{') $+$
+                                      nest 4 (text "return" <+> parens (text "B_value") <> retval n t <> semi) $+$
+                                      char '}'
+        nameEq n                    = text "B_OrdD_strD___eq__" <>
+                                      parens (text "B_OrdD_strG_witness" <> comma <+> gen env nameKW <> comma <+>
+                                              gen env primToStr <> parens (doubleQuotes (text (nstr n))))
+        retval n t
+          | B.isUnboxable t         = genBoxed env t (field n)
+          | otherwise               = parens (field n)
+        field n                     = gen env self <> text "->" <> gen env n
 
 
 initTables env []                   = empty

--- a/compiler/lib/src/Acton/Types.hs
+++ b/compiler/lib/src/Acton/Types.hs
@@ -1035,6 +1035,8 @@ instance InfEnv Decl where
       | otherwise                       = case findName n env of
                                              NReserved -> do
                                                  --traceM ("\n## infEnv class " ++ prstr n)
+                                                 when (not (inBuiltin env) && getAttrKW `elem` userMethods) $
+                                                     err2 (filter (== getAttrKW) userMethods) "Cannot define reserved compiler-synthesized method"
                                                  pushFX fxPure tNone
                                                  te0 <- infProperties env1 as' b
                                                  (cs,te,b1) <- infEnv env1 b0
@@ -1054,7 +1056,23 @@ instance InfEnv Decl where
             q'                          = selfQuant (NoQ n) q
             props te0                   = [ Signature l0 [n] sc Property | (n,NSig sc Property _) <- te0 ]
             tc                          = TC (NoQ n) (map tVar $ qbound q)
-            b0                          = initComplement env n as' b
+            b0                          = addGetAttr (initComplement env n as' b)
+            -- Synthesize an empty-bodied reflective attribute getter
+            --   pure def __get_attr__(self, name: str) -> ?value: return None
+            -- on every user class. The body stays empty through type checking and
+            -- hashing, so it references no fields and pins nothing in the
+            -- dependency graph; CodeGen fills it from the class property set.
+            -- __get_attr__ is a reserved name: a user definition is rejected above,
+            -- which keeps CodeGen's unconditional replacement of the body sound.
+            -- Skipped for builtins (C-defined structs); the userMethods guard only
+            -- avoids synthesizing a duplicate on the rejected path.
+            addGetAttr body
+              | inBuiltin env           = body
+              | getAttrKW `elem` userMethods
+                                        = body
+              | otherwise               = getAttrDef : body
+            userMethods                 = [ dname d | Decl _ ds <- b, d@Def{} <- ds ]
+            getAttrDef                  = sDef getAttrKW (pospar [(selfKW,tSelf),(nameKW,tStr)]) (tOpt tValue) [sReturn eNone] fxPure
             relayInit te b              = --trace ("####### Creating relayInit for class " ++ prstr n) $
                                           case lookup initKW te' of
                                             Just ni@(NDef sc _ _) ->

--- a/compiler/lib/test/6-cps/cps_optchain.input
+++ b/compiler/lib/test/6-cps/cps_optchain.input
@@ -1,4 +1,6 @@
 class Cls (__builtin__.value):
+    pure def __get_attr__ (self : Self, name : __builtin__.str) -> ?__builtin__.value:
+        return None
     pure def G_init (self : Self) -> None:
         pass
         return None

--- a/compiler/lib/test/6-cps/cps_optchain.output
+++ b/compiler/lib/test/6-cps/cps_optchain.output
@@ -1,4 +1,6 @@
 class Cls (__builtin__.value):
+    pure def __get_attr__ (self : Self, name : __builtin__.str) -> ?__builtin__.value:
+        return None
     pure def G_init (self : Self) -> None:
         pass
         return None

--- a/test/core_lang_auto/get_attr.act
+++ b/test/core_lang_auto/get_attr.act
@@ -1,0 +1,61 @@
+# The compiler synthesizes a reflective attribute getter
+#   pure def __get_attr__(self, name: str) -> ?value
+# on every class. It returns the named instance attribute (boxed to value), or
+# None for an unset optional attribute or an unknown name.
+
+class Inner(object):
+    x: int
+    def __init__(self):
+        self.x = 42
+
+class Outer(object):
+    a: int
+    flag: u64
+    inner: ?Inner
+    def __init__(self):
+        self.a = 7
+        self.flag = 99
+        self.inner = None
+
+actor main(env):
+    o = Outer()
+    ok = True
+
+    # boxed-int attribute
+    va = o.__get_attr__("a")
+    if isinstance(va, int):
+        if va != 7:
+            print("FAIL: a ==", va); ok = False
+    else:
+        print("FAIL: a not int"); ok = False
+
+    # unboxable scalar (u64) attribute
+    vf = o.__get_attr__("flag")
+    if isinstance(vf, u64):
+        if vf != 99:
+            print("FAIL: flag ==", vf); ok = False
+    else:
+        print("FAIL: flag not u64"); ok = False
+
+    # unset optional object attribute -> None
+    if o.__get_attr__("inner") is not None:
+        print("FAIL: inner should be None"); ok = False
+
+    # set it, reflect again -> the object
+    o.inner = Inner()
+    vi = o.__get_attr__("inner")
+    if isinstance(vi, Inner):
+        if vi.x != 42:
+            print("FAIL: inner.x ==", vi.x); ok = False
+    else:
+        print("FAIL: inner not Inner"); ok = False
+
+    # unknown attribute name -> None
+    if o.__get_attr__("nope") is not None:
+        print("FAIL: nope should be None"); ok = False
+
+    if ok:
+        print("get_attr ok")
+        env.exit(0)
+    else:
+        env.exit(1)


### PR DESCRIPTION
Add a compiler-synthesized reflective getter

    pure def __get_attr__(self, name: str) -> ?value

on every class. The synthesized body is empty (return None) through type checking and hashing, so it references no instance attributes and contributes nothing to the dependency graph. CodeGen ignores that body and emits the real field-reflecting if-chain from the class property set: one `name == "attr"` branch per instance attribute (keyed by the Acton attribute name), boxing scalars and pointer-casting object attributes to value, falling through to None.

This is a language-level reflection primitive. Because the getter pins no attributes, a reachable serializer that reflects over attributes no longer forces every attribute and its subtree to be kept, which lets deferred-back-pass selection prune unused subtrees of large generated data models.