### PR TITLE
Fix bytes literal length for split hex escapes

### DIFF
--- a/compiler/lib/src/Acton/CodeGen.hs
+++ b/compiler/lib/src/Acton/CodeGen.hs
@@ -1771,8 +1771,9 @@ instance Gen Expr where
     gen env (Bool _ False)          = gen env qnFalse
     gen env (None _)                = gen env qnNone
     gen env e@Strings{}             = gen env primToStr <> parens(hsep (map pretty (sval e)))
-    gen env e@BStrings{}            = gen env primToBytes <> parens( hsep (map pretty es) <> comma <+>text(show(length(read(concat es) :: String))))
+    gen env e@BStrings{}            = gen env primToBytes <> parens( hsep (map pretty es) <> comma <+>text(show blen))
       where es                      = sval e
+            blen                    = sum [ length (read s :: String) | s <- es ]  -- decode each fragment separately; hexSplitString may split one literal into several
     gen env (Call l  (TApp _ e@(Var _ mk) _) p@(PosArg w (PosArg (Set _ es) PosNil)) KwdNil)
       | mk == primMkSet             = text "B_mk_set" <> parens (pretty (length es) <> comma <+> gen env w <> hsep [comma <+> gen env e | e <- es])
     gen env (Call l  (TApp _ e@(Var _ mk) _) p@(PosArg w (PosArg (Dict _ es) PosNil)) KwdNil)

--- a/test/regression_auto/bytes-hex-escape-split.act
+++ b/test/regression_auto/bytes-hex-escape-split.act
@@ -1,0 +1,21 @@
+# In C a \xHH escape is greedy: it keeps consuming hex-digit characters
+# (0-9a-fA-F), so "\x00b" would be read as the single byte 0x0b rather than
+# NUL followed by 'b'. To prevent that, when a hex escape is immediately
+# followed by a hex digit the compiler splits the literal into adjacent C
+# string fragments ("\x00" "b"), and the codegen length decodes each fragment
+# separately. This used to crash codegen with "Prelude.read: no parse".
+# bytes([...]) builds the expected value without going through the literal codegen.
+
+def check() -> bool:
+    return (b"a\x00b\x00c\x00d" == bytes([97, 0, 98, 0, 99, 0, 100]) and
+            b"\x41B" == bytes([65, 66]) and          # escape then hex digit -> split
+            b"\x00" == bytes([0]) and
+            b"\x009" == bytes([0, 57]) and           # escape then hex digit -> split
+            b"\xff\xfe\xfd\x80\x7f\x00\x11\x22" == bytes([255, 254, 253, 128, 127, 0, 17, 34]))
+
+actor main(env):
+    if check():
+        await async env.exit(0)
+    else:
+        print("bytes hex-escape split produced wrong value")
+        await async env.exit(1)


### PR DESCRIPTION
In C a \xHH escape is greedy and keeps consuming hex-digit characters (0-9a-fA-F), so a bytes literal is split into adjacent C string fragments whenever a hex escape is immediately followed by a hex digit (e.g. "\x00" "b"). The codegen length now decodes each fragment separately and sums them to compute the literal's byte count.