### PR TITLE
Implement serialize/deserialize builtins

### DIFF
--- a/base/builtin/serialize.c
+++ b/base/builtin/serialize.c
@@ -88,6 +88,9 @@ void $step_serialize($WORD self, $Serial$state state) {
     if (self) {
         int class_id = $GET_CLASSID((($Serializable)self)->$class);
         if (class_id > ITEM_ID) { // not one of the Acton builtin datatypes, which have hand-crafted serializations
+            if (!state->globmap && issubtype(class_id, ACTOR_ID))
+                // This also catches Msg or Cont because they reference the target actor transitively
+                $RAISE((B_BaseException)$NEW(B_ValueError, to$str("serialize: cannot serialize actors")));
             if (state->globmap) {
                 long key = (long)state->globmap(self);
                 if (key < 0) {
@@ -163,7 +166,7 @@ void $write_serialized($ROW row, char *file) {
         }
         memcpy(p,start,chunk_size);
         p+=chunk_size;
-    
+
         chunk_size = (row->blob_size)*sizeof($WORD);
         start =  (char*)row->blob;
         while (p+chunk_size > bufend) {
@@ -176,13 +179,13 @@ void $write_serialized($ROW row, char *file) {
         }
         memcpy(p,start,chunk_size);
         p+=chunk_size;
-    
+
         row = row->next;
     }
     fwrite(buf,1,p-buf,fileptr); // TODO:  handle file write error
     fclose(fileptr);
 }
- 
+
 $ROW $serialize($Serializable s, $WORD (*globmap)($WORD)) {
     $Serial$state state = acton_malloc(sizeof(struct $Serial$state));
     state->done = $NEW(B_dict,(B_Hashable)B_HashableD_WORDG_witness,NULL,NULL);
@@ -243,7 +246,7 @@ $ROW $read_serialized(char *file) {
     bufend = buf + fread(buf,1,sizeof(buf),fileptr);
     while(p < bufend || !feof(fileptr)) {
         int init[2];//4
-        chunk_size = 2*sizeof(int); 
+        chunk_size = 2*sizeof(int);
         start = (char*)init;
         if (p + chunk_size > bufend) {
             int fits = bufend - p;
@@ -274,7 +277,70 @@ $ROW $read_serialized(char *file) {
     }
     return header.fst;
 }
-       
+
 $Serializable $deserialize_file(char *file) {
     return $deserialize($read_serialized(file), NULL);
+}
+
+// Conversion between the $ROW list and a flat byte buffer ////////////////////////////////
+
+// Each row is written as its class_id (int) and blob_size (int) followed by
+// blob_size words of blob data. The in-memory `next` pointer is never written.
+
+static B_bytes $rows_to_bytes($ROW row) {
+    long size = 0;
+    for ($ROW r = row; r; r = r->next)
+        size += 2 * sizeof(int) + (long)r->blob_size * sizeof($WORD);
+    if (size > INT_MAX)
+        $RAISE((B_BaseException)$NEW(B_ValueError, to$str("serialize: object graph too large")));
+    B_bytes res;
+    NEW_UNFILLED_BYTES(res, (int)size);
+    unsigned char *p = res->str;
+    for ($ROW r = row; r; r = r->next) {
+        memcpy(p, &r->class_id, sizeof(int));  p += sizeof(int);
+        memcpy(p, &r->blob_size, sizeof(int)); p += sizeof(int);
+        long blob_bytes = (long)r->blob_size * sizeof($WORD);
+        memcpy(p, r->blob, blob_bytes);        p += blob_bytes;
+    }
+    return res;
+}
+
+static $ROW $bytes_to_rows(B_bytes data) {
+    unsigned char *p = data->str;
+    long remaining = data->nbytes;
+    struct $ROWLISTHEADER header = {NULL, NULL};
+    while (remaining > 0) {
+        if (remaining < (long)(2 * sizeof(int)))
+            $RAISE((B_BaseException)$NEW(B_ValueError, to$str("deserialize: truncated row header")));
+        int class_id, blob_size;
+        memcpy(&class_id, p, sizeof(int));  p += sizeof(int);
+        memcpy(&blob_size, p, sizeof(int)); p += sizeof(int);
+        remaining -= 2 * sizeof(int);
+        if (blob_size < 0)
+            $RAISE((B_BaseException)$NEW(B_ValueError, to$str("deserialize: invalid blob size")));
+        long blob_bytes = (long)blob_size * sizeof($WORD);
+        if (remaining < blob_bytes)
+            $RAISE((B_BaseException)$NEW(B_ValueError, to$str("deserialize: truncated row data")));
+        $ROW r = acton_malloc(2 * sizeof(int) + ((long)blob_size + 1) * sizeof($WORD));
+        r->next = NULL;
+        r->class_id = class_id;
+        r->blob_size = blob_size;
+        memcpy(r->blob, p, blob_bytes);
+        p += blob_bytes;
+        remaining -= blob_bytes;
+        $enqueue2(&header, r);
+    }
+    if (!header.fst)
+        $RAISE((B_BaseException)$NEW(B_ValueError, to$str("deserialize: empty input")));
+    return header.fst;
+}
+
+// Acton builtins: serialize() and deserialize() //////////////////////////////////////////
+
+B_bytes B_serialize(B_value obj) {
+    return $rows_to_bytes($serialize(($Serializable)obj, NULL));
+}
+
+B_value B_deserialize(B_bytes data) {
+    return (B_value)$deserialize($bytes_to_rows(data), NULL);
 }

--- a/base/src/__builtin__.act
+++ b/base/src/__builtin__.act
@@ -1027,6 +1027,19 @@ def reversed[A](seq : Sequence[A]) -> Iterator[A]:
 def round [A(Real)] (x : A, n : ?int) -> A:
     return x.__round__(n)
 
+def serialize(obj: value) -> bytes:
+    """Serialize an object graph into a compact binary representation.
+
+    The result can be turned back into an equivalent graph with deserialize().
+    Shared and cyclic references within the graph are preserved.
+    """
+    NotImplemented
+
+def deserialize(data: bytes) -> value:
+    """Reconstruct an object graph previously produced by serialize().
+    """
+    NotImplemented
+
 def sorted [A(Ord)] (iter: Iterable[A]) -> list[A]:
     NotImplemented
 

--- a/test/stdlib_tests/src/test_serialize.act
+++ b/test/stdlib_tests/src/test_serialize.act
@@ -1,0 +1,167 @@
+# Round-trip tests for the serialize() / deserialize() builtins.
+#
+# serialize() returns a flat byte string and deserialize() rebuilds the object
+# graph, handing it back as `value` (the root type). To compare a restored
+# scalar against its expected value we first narrow it with isinstance. Richer
+# graphs are checked by re-serializing the restored value and comparing the
+# bytes, which does not require the value itself to be Eq.
+
+import testing
+
+class Point(object):
+    x: int
+    y: int
+    def __init__(self, x: int, y: int):
+        self.x = x
+        self.y = y
+
+
+class Child(object):
+    val: int
+    def __init__(self, val: int):
+        self.val = val
+
+
+class Pair(object):
+    left: Child
+    right: Child
+    def __init__(self, left: Child, right: Child):
+        self.left = left
+        self.right = right
+
+
+class Node(object):
+    next: ?Node
+    def __init__(self):
+        self.next = None
+
+
+actor SampleActor():
+    def ping() -> int:
+        return 1
+
+
+def roundtrips(obj: value) -> bool:
+    payload = serialize(obj)
+    return serialize(deserialize(payload)) == payload
+
+
+def raises_value_error(data: bytes) -> bool:
+    try:
+        deserialize(data)
+        return False
+    except ValueError:
+        return True
+
+
+def assert_deserializes_to_int(payload: bytes, expected: int, msg: str) -> None:
+    restored = deserialize(payload)
+    testing.assertTrue(isinstance(restored, int), msg)
+    if isinstance(restored, int):
+        testing.assertEqual(restored, expected)
+
+
+def assert_deserializes_to_bigint(payload: bytes, expected: bigint, msg: str) -> None:
+    restored = deserialize(payload)
+    testing.assertTrue(isinstance(restored, bigint), msg)
+    if isinstance(restored, bigint):
+        testing.assertEqual(restored, expected)
+
+
+def _test_int():
+    assert_deserializes_to_int(serialize(123456789), 123456789, "int roundtrips")
+
+
+def _test_str():
+    restored = deserialize(serialize("héllo wörld"))
+    testing.assertTrue(isinstance(restored, str), "restored is a str")
+    if isinstance(restored, str):
+        testing.assertEqual(restored, "héllo wörld")
+
+
+def _test_bytes():
+    obj = b"\x00\x01hello\xff"
+    restored = deserialize(serialize(obj))
+    testing.assertTrue(isinstance(restored, bytes), "restored is bytes")
+    if isinstance(restored, bytes):
+        testing.assertEqual(restored, obj)
+
+
+def _test_scalars():
+    testing.assertTrue(roundtrips(0), "int zero")
+    testing.assertTrue(roundtrips(-42), "negative int")
+    testing.assertTrue(roundtrips(3.14159), "float")
+    testing.assertTrue(roundtrips(True), "True")
+    testing.assertTrue(roundtrips(False), "False")
+    testing.assertTrue(roundtrips(""), "empty str")
+
+
+def _test_bigint():
+    big = 123456789012345678901234567890123456789
+    neg = -98765432109876543210987654321098765432
+    zero = big - big
+    assert_deserializes_to_bigint(serialize(big), big, "big bigint")
+    assert_deserializes_to_bigint(serialize(neg), neg, "negative bigint")
+    assert_deserializes_to_bigint(serialize(zero), zero, "zero bigint")
+    testing.assertTrue(roundtrips([big, big]), "shared bigint back references")
+
+
+def _test_list():
+    testing.assertTrue(roundtrips([1, 2, 3, 4, 5]), "flat list")
+    testing.assertTrue(roundtrips([[1, 2], [3], []]), "nested list")
+
+
+def _test_dict():
+    testing.assertTrue(roundtrips({"nums": [1, 2, 3], "more": [4, 5, 6]}), "dict")
+
+
+def _test_set():
+    testing.assertTrue(roundtrips({1, 2, 3}), "set")
+
+
+def _test_tuple():
+    # A bare tuple is not a `value` subtype, but it can be wrapped
+    testing.assertTrue(roundtrips([([1, 2, 3], "hello", 42, True, b"raw")]), "tuple")
+
+
+def _test_optional():
+    testing.assertTrue(roundtrips([1, None, 3]), "list with None")
+
+
+def _test_object():
+    restored = deserialize(serialize(Point(3, 4)))
+    testing.assertTrue(isinstance(restored, Point), "restored is a Point")
+    if isinstance(restored, Point):
+        testing.assertEqual(restored.x, 3)
+        testing.assertEqual(restored.y, 4)
+
+
+def _test_shared_user_object():
+    child = Child(9)
+    testing.assertTrue(roundtrips(Pair(child, child)), "shared user object")
+
+
+def _test_user_object_cycle():
+    node = Node()
+    node.next = node
+    testing.assertTrue(roundtrips(node), "self-referential cycle")
+
+
+def _test_invalid_payload():
+    bad = serialize(7)[:-1]
+    testing.assertTrue(raises_value_error(bad), "truncated payload raises")
+
+
+def _test_empty_payload():
+    testing.assertTrue(raises_value_error(b""), "empty payload raises")
+
+
+def _test_rejects_actor() -> None:
+    # deserializing an actor without a globmap makes no sense, let's ensure it
+    # can't even be serialized
+    a = SampleActor()
+    try:
+        serialize([a])
+        testing.assertTrue(False, "serialize() of an actor should raise ValueError")
+    except ValueError:
+        pass


### PR DESCRIPTION
Add `serialize: (value) -> bytes` and `deserialize: (bytes) -> value` for writing and reading object graphs in memory. Shared and cyclic references are preserved. Closes #1614

serialize() runs without a globmap, so attempts to serialize an actor raise a ValueError.

This is quite a naive implementation that does lots of tiny allocations which could be further optimized in future. The existing $serialize_file and $deserialize_file are untouched - probably need to rewrite them to use capabilities. But nevertheless it is a good starting point for verifying whether we can serialize / deserialize the compiled YANG schema (DNode).