### PR TITLE
Fix augmented assign on boxed volatile cell

### DIFF
--- a/compiler/lib/src/Acton/Boxing.hs
+++ b/compiler/lib/src/Acton/Boxing.hs
@@ -346,6 +346,20 @@ unboxedFieldType' env e n           = case typeOf env e of
         boxedType (TUnboxed _ t)     = t
         boxedType t                  = t
 
+-- True when an assignment target physically stores an unboxed (raw) value, so
+-- an in-place raw augmented assignment ('+=' etc.) is sound.  A field of a
+-- generic cell such as $Cell.cell keeps the boxed representation even when its
+-- element type is unboxable (the field type stays a type variable), so a raw
+-- in-place update there would corrupt the stored boxed pointer.  This reuses
+-- unboxedFieldType, the same field-representation decision the read side relies
+-- on, so reads and writes agree on whether a slot is raw or boxed.  Every target
+-- that actually reaches the augmented-assignment rewrite is a Dot (a volatile
+-- cell slot or a class/actor field); the catch-all keeps the prior raw behavior.
+unboxedAugTarget env (Dot _ e n)    = case unboxedFieldType env e n of
+                                        Just _  -> True
+                                        Nothing -> False
+unboxedAugTarget env _              = True
+
 isTypeRef NAct{}                    = True
 isTypeRef NClass{}                  = True
 isTypeRef NProto{}                  = True
@@ -762,13 +776,22 @@ instance Boxing Stmt where
              where t               = assignTargetType env s n e
 
 
-    boxing env (MutAssign l _  e@(Call _ (Dot _ (Var _ (NoQ w)) attr) p KwdNil))  -- (re)introduce augmented arithmetic operator for unboxable types; MutAssign case
+    boxing env (MutAssign l tg e@(Call _ (Dot _ (Var _ (NoQ w)) attr) p KwdNil))  -- (re)introduce augmented arithmetic operator for unboxable types; MutAssign case
       | isWitness w && attr `elem` augopKWs  && isUnboxable t
                                     = do let [x1,x2] = posargs p
                                          (ws, x2') <- boxing env x2
-                                         return (ws, AugAssign l x1 op (unbox t x2'))
+                                         if unboxedAugTarget env tg
+                                           -- target physically stores an unboxed value: do a raw
+                                           -- in-place augmented assignment.
+                                           then return (ws, AugAssign l x1 op (unbox t x2'))
+                                           -- target physically stores a boxed value (e.g. a generic
+                                           -- $Cell cell holding an unboxable element): keep the
+                                           -- arithmetic unboxed but box the result for the store,
+                                           -- rather than doing raw arithmetic on the boxed slot.
+                                           else return (ws, MutAssign l tg (Box t (Paren NoLoc (BinOp NoLoc (unbox t x1) binop (unbox t x2')))))
           where t                   = typeOf env e
                 op                  = bin2Aug attr
+                binop               = bin2Binary (incr2bin attr)
     boxing env (MutAssign l tg e)   = do (ws0,tg1) <- boxingTarget env tg
                                          (ws1,e1) <- boxing env e
                                          return (HashSet.union ws0 ws1, MutAssign l tg1 (fixassign env t e1))
@@ -904,3 +927,22 @@ bin2Aug kw
    | kw == iorKW                   = BOrA
    | kw == ixorKW                  = BXorA
    | kw == iandKW                  = BAndA
+
+-- Map an augmented-assignment witness keyword to its plain binary counterpart.
+-- imatmulKW is deliberately omitted: it has no unboxable operand type (matmul is
+-- matrix-only), so it never reaches the only caller (which is guarded by
+-- isUnboxable), and bin2Binary has no matmul case either. Keeping the range a
+-- subset of bin2Binary's domain avoids a non-exhaustive crash on future changes.
+incr2bin kw
+   | kw == iaddKW                  = addKW
+   | kw == isubKW                  = subKW
+   | kw == imulKW                  = mulKW
+   | kw == ipowKW                  = powKW
+   | kw == itruedivKW              = truedivKW
+   | kw == imodKW                  = modKW
+   | kw == ifloordivKW             = floordivKW
+   | kw == ilshiftKW               = lshiftKW
+   | kw == irshiftKW               = rshiftKW
+   | kw == iorKW                   = orKW
+   | kw == ixorKW                  = xorKW
+   | kw == iandKW                  = andKW

--- a/test/regression_auto/183-unbox-int-across-await.act
+++ b/test/regression_auto/183-unbox-int-across-await.act
@@ -1,0 +1,54 @@
+# Regression: an unboxable primitive local (int/float) that is updated across an
+# awaited actor call lives in a volatile $Cell cell. That cell is a generic cell,
+# so its `.cell` slot physically holds a boxed pointer. The augmented-assignment
+# rewrite used to emit a raw in-place `+=` on that slot, doing integer arithmetic
+# directly on the boxed pointer; the corrupted (misaligned) pointer then crashed
+# when the value was read after the await with
+#   "member access within misaligned address ... for type 'struct B_int'".
+# The accumulator must keep its value across the await boundary.
+#
+# NOTE: the value MUST be forced through a use that dereferences the boxed slot
+# (here, `print`) for the regression to bite. A bare `==` comparison does not
+# reliably trap on the misaligned pointer, so it would let the buggy compiler
+# pass this test silently. Print each accumulator before the value check.
+
+actor Counter():
+    def get() -> int:
+        return 1
+    def getf() -> float:
+        return 1.5
+
+actor main(env):
+    c = Counter()
+
+    def run():
+        # accumulate an int across an awaited actor call, in a loop
+        n = 0
+        for _i in range(3):
+            n += c.get()
+
+        # single await (no loop) is enough to exercise the same path
+        s = 0
+        s += c.get()
+
+        # a different augmented operator across the await
+        m = 100
+        for _i in range(3):
+            m -= c.get()
+
+        # float accumulator across the await
+        x = 0.0
+        for _i in range(4):
+            x += c.getf()
+
+        # Force a dereference of each accumulator's boxed slot. Under the bug the
+        # slot holds a misaligned pointer and this traps ("misaligned address ...
+        # struct B_int"); under the fix it prints the values below.
+        print("n=", n, " s=", s, " m=", m, " x=", x)
+
+        if n == 3 and s == 1 and m == 97 and x == 6.0:
+            env.exit(0)
+        else:
+            env.exit(1)
+
+    run()


### PR DESCRIPTION
A local primitive (int/float) reassigned across an awaited actor call is held in a generic $Cell cell whose slot stores a boxed pointer even for unboxable element types. The Boxing pass rewrote the cell-slot update into a raw in-place `cell.cell += x`, performing integer arithmetic directly on the boxed pointer and corrupting it; the next read after the await crashed with a misaligned-address panic on struct B_int.

Gate the raw in-place augmented-assignment rewrite on the target actually storing an unboxed value (unboxedAugTarget). For a boxed slot keep the arithmetic unboxed but box the result for the store. Add regression test 183-unbox-int-across-await.