### PR TITLE
Bucket witness dedup in extWitnesses

### DIFF
--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -267,11 +267,18 @@ moduleQNameKeys m qn@(QName m' n)
 moduleQNameKeys _ qn        = [qn]
 
 extWitnesses                :: ModName -> TEnv -> [Witness]
-extWitnesses m exts         = foldl' add [] wits
+extWitnesses m exts         = fst (foldl' add ([], Map.empty) wits)
   where wits                = [ WClass q (tCon c) p (GName m n) ws (length opts) | (n, NExt q c ps _ opts _) <- exts, (ws,p) <- ps ]
-        add ws w
-          | any (same w) ws = ws
-          | otherwise       = w : ws
+        -- Duplicate checking scans only the (proto name, type name) bucket instead
+        -- of every accumulated witness: `same` implies equal proto names and equal
+        -- wtypes (hence equal type-name keys), so bucketing loses no duplicates,
+        -- while a linear `any (same w)` scan is quadratic in the witness count --
+        -- a 65k-extension generated module would spend hours in eqString here.
+        add (ws, seen) w
+          | any (same w) bucket = (ws, seen)
+          | otherwise           = (w : ws, Map.insertWith (++) k [w] seen)
+          where k               = (tcname (proto w), witnessTypeQName w)
+                bucket          = Map.findWithDefault [] k seen
         same w w'           = tcname (proto w) == tcname (proto w') && wtype w == wtype w'
 
 witnessTypeQName            :: Witness -> Maybe QName


### PR DESCRIPTION
extWitnesses deduplicated witnesses with a linear any-scan per witness, giving O(n^2) same-checks whose QName and Type equality compare Strings character by character. A generated module with 65k extension declarations and long shared-prefix class names spends hours in eqString there: type-checking a small consumer of such a freshly compiled module appeared to hang (over 28 minutes at 100% CPU, confirmed by sampling the process; the hot frames were eqString called from extWitnesses via the Eq instances).

This buckets the duplicate check by (protocol name, witnessTypeQName). Two witnesses that the old check considered equal have equal protocol names and equal wtypes, hence equal bucket keys, so no duplicates are lost; each witness now scans only its own bucket. With this change the same consumer type-checks in under 8 seconds.