### PR TITLE
Update tydb source metadata surgically

### DIFF
--- a/compiler/acton/test_incremental.hs
+++ b/compiler/acton/test_incremental.hs
@@ -1973,6 +1973,16 @@ p37_impl_refresh_missing_dep_hashes_reruns_front =
     depDir <- ensureDepProject proj "libfoo"
     let depSrc = depDir </> "src" </> "lib.act"
         tyMain = proj </> "out" </> "types" </> "incremental_cases" </> "main.tydb"
+    let mainV1 = T.unlines
+          [ "import libfoo.lib"
+          , ""
+          , "def value() -> int:"
+          , "    return libfoo.lib.foo() + libfoo.lib.bar()"
+          , ""
+          , "actor main(env: Env):"
+          , "    print(value())"
+          , "    env.exit(0)"
+          ]
     writeFileUtf8 depSrc $ T.unlines
       [ "def foo() -> int:"
       , "    return 1"
@@ -1980,33 +1990,25 @@ p37_impl_refresh_missing_dep_hashes_reruns_front =
       , "def bar() -> int:"
       , "    return 2"
       ]
-    writeFileUtf8 (src </> "main.act") $ T.unlines
-      [ "import libfoo.lib"
-      , ""
-      , "def value() -> int:"
-      , "    return libfoo.lib.foo() + libfoo.lib.bar()"
-      , ""
-      , "actor main(env: Env):"
-      , "    print(value())"
-      , "    env.exit(0)"
-      ]
+    writeFileUtf8 (src </> "main.act") mainV1
     res1 <- runActonIn proj ["build", "--color", "never", "--skip-build"]
     assertExitSuccess "initial build" res1
-    let mainV2 = T.unlines
-          [ "import libfoo.lib"
-          , ""
-          , "def value() -> int:"
-          , "    return libfoo.lib.foo()"
-          , ""
-          , "actor main(env: Env):"
-          , "    print(value())"
-          , "    env.exit(0)"
-          ]
-    writeFileUtf8 (src </> "main.act") mainV2
-    rewriteTySrcHashAndNameHashes tyMain (SHA256.hash (TE.encodeUtf8 mainV2)) (dropTyDepByLabel "libfoo.lib.bar")
+    -- Drop ALL of main's per-name dep rows for libfoo.lib while keeping main's
+    -- source (and stored source hash) unchanged. When the dep's impl then
+    -- changes, the staleness scan finds the module-level hash drifted but no
+    -- per-name rows to break the change down by -- exactly the missing-dep-row
+    -- condition that must fall back to rerunning the front passes. (The old
+    -- scenario dropped a single, no-longer-used name's row and only passed
+    -- because the source-meta refresh rewrote -- and thereby emptied -- ALL the
+    -- dep rows; the refresh no longer touches them.)
+    rewriteTySrcHashAndNameHashes tyMain (SHA256.hash (TE.encodeUtf8 mainV1))
+      (dropTyDepByLabel "libfoo.lib.foo" . dropTyDepByLabel "libfoo.lib.bar")
     writeFileUtf8 depSrc $ T.unlines
       [ "def foo() -> int:"
       , "    return 10"
+      , ""
+      , "def bar() -> int:"
+      , "    return 2"
       ]
     res2@(_ec2, out2) <- runActonIn proj ["build", "--color", "never", "--verbose", "--skip-build"]
     assertExitSuccess "rebuild after impl refresh dep hash miss" res2

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -2042,13 +2042,17 @@ readModuleHeader sp gopts opts paths actFile = do
                 Left _ -> return False
                 Right exeStatus -> return (fileStatusMTimeNs exeStatus > tyMTimeNs)
 
+    -- Surgical single-row update: a full readFile+writeFile here would re-derive
+    -- the dependency index rows from the stripped per-name hashes and silently
+    -- lose their users and hashes (degrading later per-name change detection),
+    -- besides rewriting a possibly multi-GB file for a pure mtime drift.
     refreshCachedSourceMeta currentSourceMeta = do
       let tyFilePath = tyDbPath paths (modName paths)
-      tyRes <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readFile tyFilePath
-      case tyRes of
-        Left _ -> return ()
-        Right (_ms, nmod, tmod, _oldSourceMeta, srcHash, pubHash, implHash, imps, depModules, nameHashes, roots, tests, mdoc) ->
-          InterfaceFiles.writeFile tyFilePath srcHash pubHash implHash currentSourceMeta imps depModules nameHashes roots tests mdoc nmod tmod
+      res <- (try :: IO a -> IO (Either SomeException a)) $
+        InterfaceFiles.updateSourceMeta tyFilePath currentSourceMeta
+      case res of
+        Left _  -> return ()
+        Right _ -> return ()
 
     verifyOrParse mn snap moduleSrcBytesHash modulePubHash moduleImplHash cachedSourceMeta currentSourceMeta imps depModules nameCount roots tests mdoc = do
       let curHash = SHA256.hash (Source.ssBytes snap)
@@ -3642,10 +3646,18 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
             TyTask{ tyDepModules = depModules } -> interestDepsFromDepRows depModules
             _ -> return Data.Set.empty
 
+          -- Restore BOTH the pub and the impl per-name external deps from the
+          -- module-level dep rows (the per-name rows on disk are stripped, see
+          -- InterfaceFiles.stripExternalDeps). The impl half matters: a header
+          -- rewrite (impl-hash refresh) re-derives the dep rows from these name
+          -- hashes, and losing the impl users would erase the per-name impl
+          -- change tracking for every dependency of this module.
           restorePubDepsFromRows depModules nameHashes = do
-            byOwner <- foldM addModule M.empty depModules
+            (pubByOwner, implByOwner) <- foldM addModule (M.empty, M.empty) depModules
             return
-              [ nh { InterfaceFiles.nhPubDeps = M.findWithDefault [] (InterfaceFiles.nhName nh) byOwner }
+              [ nh { InterfaceFiles.nhPubDeps = M.findWithDefault [] (InterfaceFiles.nhName nh) pubByOwner
+                   , InterfaceFiles.nhImplDeps = M.findWithDefault [] (InterfaceFiles.nhName nh) implByOwner
+                   }
               | nh <- nameHashes
               ]
             where
@@ -3654,17 +3666,21 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                 depNames <- InterfaceFiles.readDepNames tyFile depMn
                 foldM (addName depMn) acc depNames
 
-              addName depMn acc depInfo = do
+              addName depMn (pubAcc, implAcc) depInfo = do
                 users <- InterfaceFiles.readDepUsers tyFile depMn (InterfaceFiles.dniName depInfo)
-                let dep =
+                let mkDep h =
                       ( A.GName depMn (InterfaceFiles.dniName depInfo)
-                      , InterfaceFiles.dniPubHash depInfo
+                      , h
                       )
-                    addUser m user =
+                    addUser dep m user =
                       M.insertWith (++) user [dep] m
-                if B.null (InterfaceFiles.dniPubHash depInfo)
-                  then return acc
-                  else return (foldl' addUser acc (InterfaceFiles.duPubUsers users))
+                    pubAcc'
+                      | B.null (InterfaceFiles.dniPubHash depInfo) = pubAcc
+                      | otherwise = foldl' (addUser (mkDep (InterfaceFiles.dniPubHash depInfo))) pubAcc (InterfaceFiles.duPubUsers users)
+                    implAcc'
+                      | B.null (InterfaceFiles.dniImplHash depInfo) = implAcc
+                      | otherwise = foldl' (addUser (mkDep (InterfaceFiles.dniImplHash depInfo))) implAcc (InterfaceFiles.duImplUsers users)
+                return (pubAcc', implAcc')
 
           depModulesFromNameHashes nameHashes = do
             let depMods =

--- a/compiler/lib/src/InterfaceFiles.hs
+++ b/compiler/lib/src/InterfaceFiles.hs
@@ -137,6 +137,7 @@ module InterfaceFiles
   , writeFile
   , writeFileWithProgress
   , writeFileWithVersion
+  , updateSourceMeta
   ) where
 
 import Prelude hiding (readFile, writeFile)
@@ -1354,6 +1355,21 @@ interfaceEntries onProgress version moduleSrcBytesHash modulePubHash moduleImplH
 
 writeFile :: FilePath -> BS.ByteString -> BS.ByteString -> BS.ByteString -> Maybe SourceFileMeta -> [(A.ModName, BS.ByteString)] -> [DepModuleInfo] -> [NameHashInfo] -> [A.Name] -> [String] -> Maybe String -> I.NModule -> A.Module -> IO ()
 writeFile = writeFileWithVersion A.version
+
+-- | Update only the cached source-file metadata in the header, leaving every
+-- other row (name hashes, dep index rows, statements) untouched. Rewriting the
+-- whole file for a pure metadata drift would be both wasteful (the module
+-- content is unchanged; the file can be gigabytes) and LOSSY: a full write
+-- re-derives the dependency index rows from the per-name hashes, whose external
+-- deps are stripped on disk, so the rewritten rows would silently lose their
+-- users and hashes -- degrading later per-name change detection.
+updateSourceMeta :: FilePath -> Maybe SourceFileMeta -> IO ()
+updateSourceMeta f sourceMeta = do
+    size <- readMapSize f
+    withWriteTxn f size $ \txn dbi -> do
+      validateVersion txn dbi
+      (_oldMeta, srcH, pubH, implH) <- readMeta txn dbi
+      putValue txn dbi keyMeta (encodeStrict (sourceMeta, srcH, pubH, implH))
 
 writeFileWithVersion :: [Int] -> FilePath -> BS.ByteString -> BS.ByteString -> BS.ByteString -> Maybe SourceFileMeta -> [(A.ModName, BS.ByteString)] -> [DepModuleInfo] -> [NameHashInfo] -> [A.Name] -> [String] -> Maybe String -> I.NModule -> A.Module -> IO ()
 writeFileWithVersion version f moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta imps depModules nameHashes roots tests mdoc nmod tchecked =


### PR DESCRIPTION
A pure mtime drift on a cached module (touch, git checkout, cp) rewrote the module's entire .tydb via readFile plus writeFile just to store the new source metadata. That is wasteful, since the file can be gigabytes for large generated modules, and lossy: the write re-derives the dependency index rows from the per-name hashes, whose external deps are stripped on disk, so every dep row comes back empty. Losing the rows silently degrades later per-name change detection; the next dependency change cannot be broken down per name and falls back to rerunning the front passes.

This adds InterfaceFiles.updateSourceMeta, which updates the single meta row in place, and uses it for the drift refresh. It also restores the impl half of the per-name external deps in restorePubDepsFromRows: the impl-hash refresh path rewrites the header from these hashes, and restoring only the pub side dropped the impl users from the regenerated rows the same way.

Incremental test 37 was asserting the old corruption: it dropped a single no-longer-used name's row and relied on the meta rewrite emptying the remaining rows to trigger the missing-row fallback. It now drops all rows of a changed dependency, so the fallback is exercised directly.