### PR TITLE
Use zstd for RPM payloads

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -440,7 +440,7 @@ jobs:
           retry() { n=1; until "$@"; do [ $n -ge 3 ] && { echo "failed after 3 attempts: $*" >&2; return 1; }; echo "attempt $n failed, retrying in 15s: $*" >&2; sleep 15; n=$((n+1)); done; }
           retry sudo apt-get update
           retry sudo apt-get install -qy bzip2 curl g++ haskell-stack libgmp-dev libncurses-dev make procps zlib1g-dev
-          retry sudo apt-get install -qy bash-completion build-essential debhelper devscripts gnupg2 locales rpm xz-utils
+          retry sudo apt-get install -qy bash-completion build-essential debhelper devscripts gnupg2 locales rpm xz-utils zstd
           sudo apt-get clean || true
       - name: "Prepare stack directories"
         run: |

--- a/Makefile
+++ b/Makefile
@@ -794,6 +794,7 @@ rpms: package-dist-validate rpm/acton.spec.in LICENSE README.md
 	command -v rpmbuild >/dev/null 2>&1 || { echo "ERROR: rpmbuild is required to build RPM packages"; exit 1; }
 	command -v tar >/dev/null 2>&1 || { echo "ERROR: tar is required to build RPM packages"; exit 1; }
 	command -v xz >/dev/null 2>&1 || { echo "ERROR: xz is required to build RPM packages"; exit 1; }
+	command -v zstd >/dev/null 2>&1 || { echo "ERROR: zstd is required to build RPM packages"; exit 1; }
 	rm -rf rpmbuild/payload
 	mkdir -p rpmbuild/payload rpmbuild/SOURCES
 	$(MAKE) install DESTDIR="$(TD)/rpmbuild/payload"

--- a/rpm/acton.spec.in
+++ b/rpm/acton.spec.in
@@ -5,6 +5,7 @@
 %global __brp_strip %{nil}
 %global __brp_strip_static_archive %{nil}
 %global __brp_strip_comment_note %{nil}
+%global _binary_payload w19.zstdio
 
 Name:           acton
 Version:        @VERSION@
@@ -18,6 +19,7 @@ Source2:        README.md
 
 BuildRequires:  tar
 BuildRequires:  xz
+BuildRequires:  zstd
 
 %description
 Acton is a general purpose programming language designed for desktop,


### PR DESCRIPTION
The RPM tip repository stores packages as regular Git blobs, so an RPM over 100 MiB cannot be pushed to GitHub. After moving RPM builds into the Ubuntu package job, the builder no longer inherited Fedora zstd payload defaults and the generated packages crossed that limit.

Request zstd payload compression in the RPM spec and make zstd an explicit package-build dependency. This restores the compressed payload format used by the previous RPM path instead of relying on host macros.