### PR TITLE
Raise compiler open-file limit

### DIFF
--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -92,6 +92,7 @@ import System.IO.Unsafe (unsafePerformIO)
 import System.Info
 import System.Posix.Files
 import System.Posix.IO (createPipe, setFdOption, closeFd, FdOption(..))
+import System.Posix.Resource
 import System.Process hiding (createPipe)
 import qualified System.FSNotify as FS
 import qualified System.Environment
@@ -107,7 +108,27 @@ import TerminalProgress
 import TerminalSize
 import ZigProgress
 
+raiseOpenFileLimit :: IO ()
+raiseOpenFileLimit =
+    void (try go :: IO (Either IOException ()))
+  where
+    go = do
+        lim <- getResourceLimit ResourceOpenFiles
+#if defined(darwin_HOST_OS)
+        case (softLimit lim, hardLimit lim) of
+          (ResourceLimit soft, ResourceLimit hard) -> raise lim soft (min hard 10240)
+          (ResourceLimit soft, ResourceLimitInfinity) -> raise lim soft 10240
+          _ -> return ()
+#else
+        setResourceLimit ResourceOpenFiles lim{ softLimit = hardLimit lim }
+#endif
+
+    raise lim soft target =
+        when (soft < target) $
+            setResourceLimit ResourceOpenFiles lim{ softLimit = ResourceLimit target }
+
 main = do
+    raiseOpenFileLimit
     hSetBuffering stdout LineBuffering
     arg <- C.parseCmdLine
     let gopts = case arg of


### PR DESCRIPTION
macOS commonly starts processes with a low soft file descriptor limit. That can make Acton builds fail with EMFILE before users know how to tune launchd or ulimit.

Raise ResourceOpenFiles during compiler startup, using the current hard limit where POSIX allows it. On Darwin, cap the requested soft limit at OPEN_MAX because RLIM_INFINITY is invalid there for RLIMIT_NOFILE.

The helper is best-effort, so systems with a genuinely low hard limit keep existing behavior instead of turning process startup into a new failure mode.