### PR TITLE
Fix panic when using a tuple as a condition

### DIFF
--- a/compiler/lib/src/Acton/Boxing.hs
+++ b/compiler/lib/src/Acton/Boxing.hs
@@ -505,6 +505,7 @@ rtypeOfFun env f@(Dot _ (Var _ x) n)
 rtypeOfFun env f@(Dot _ e n)        = case typeOf env e of
                                         TCon _ tc -> rtypeOf env tc n
                                         TVar _ tv -> rtypeOf env (findTVBound env tv) n
+                                        TTuple{}  -> rtypeOf env cValue n     -- tuple value attrs (e.g. __bool__) use the value class slot ABI (cf. CodeGen.dotCast)
                                         _         -> typeOf env f
 rtypeOfFun env f@(Var _ n)
   | Just rt <- generatedMethodType env n []

--- a/test/core_lang_auto/tuple_bool.act
+++ b/test/core_lang_auto/tuple_bool.act
@@ -1,0 +1,34 @@
+# Tuples as truth values: a non-empty tuple is truthy, an empty tuple is falsy.
+# Regression test: the unboxed C bool returned by tuple __bool__ used to be
+# consumed as a boxed B_bool, dereferencing the raw value as a pointer.
+
+actor main(env):
+    t = (1, "x")
+    e = ()
+    if t:
+        pass
+    else:
+        env.exit(1)
+    if e:
+        env.exit(1)
+    if not t:
+        env.exit(1)
+    if not e:
+        pass
+    else:
+        env.exit(1)
+    n = 0
+    while t:
+        n += 1
+        if n == 3:
+            break
+    if n != 3:
+        env.exit(1)
+    while e:
+        env.exit(1)
+    x = "yes" if t else "no"
+    y = "yes" if e else "no"
+    if x != "yes" or y != "no":
+        env.exit(1)
+    print("Success")
+    env.exit(0)


### PR DESCRIPTION
Using a tuple in a truth-test position, like `if t:`, typechecked and compiled but panicked at runtime with a misaligned-address error: the raw C bool returned by the tuple's __bool__ slot was dereferenced as a boxed B_bool pointer.

The seam was between the Boxing pass and CodeGen. Boxing.rtypeOfFun had no case for tuple-typed receivers, so the callee type of the normalized t.__bool__() call fell back to the plain boxed () -> bool and no Box marker was inserted around the call result. CodeGen.dotCast, however, resolves tuple attributes via the value class and emits the unboxed slot ABI (bool return), so the condition ended up doing ((B_bool)raw_true)->val. The fix resolves tuple receivers via the value class in rtypeOfFun too, mirroring CodeGen.dotCast, so the two passes agree on the ABI and conditions consume the raw bool directly, the same as for list/str/bytes receivers.

Since every truth-test context (if, while, not, ternary, assert, comprehension guards) normalizes through the same __bool__ call, they were all affected for tuples and are all fixed by this change. The other tuple value attributes, __str__ and __repr__, return boxed types so their behavior is unchanged.

Adds a regression test covering truthy non-empty tuples and falsy empty tuples across if, not, while and ternary forms.