### PR TITLE
Enable deferred back passes for all modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -647,7 +647,7 @@ dist/base: base base/.build base/__root.zig base/acton.zig base/build.zig base/b
 	mkdir -p "$@" "$@/.build" "$@/out"
 	rm -rf "$@/src" "$@/out/types/std"
 	cp -a base/__root.zig base/Build.act base/acton.zig base/build.zig base/build.zig.zon base/builtin base/rts base/src dist/base/
-	cd dist/base && ../bin/acton build --skip-build && rm -rf .build
+	cd dist/base && ../bin/acton build --skip-build --no-dbp && rm -rf .build
 	find "$@/out/types" -name lock.mdb -type f -delete
 	find "$@/out/types" -name data.mdb -type f -exec chmod 0644 {} +
 
@@ -656,7 +656,7 @@ dist/std: std std/Build.act std/build.zig std/build.zig.zon dist/base dist/bin/a
 	mkdir -p "$@" "$@/.build" "$@/out"
 	rm -rf "$@/src" "$@/out/types"
 	cp -a std/Build.act std/build.zig std/build.zig.zon std/src dist/std/
-	cd dist/std && ../bin/acton build --skip-build && rm -rf .build
+	cd dist/std && ../bin/acton build --skip-build --no-dbp && rm -rf .build
 	find "$@/out/types" -name lock.mdb -type f -delete
 	find "$@/out/types" -name data.mdb -type f -exec chmod 0644 {} +
 

--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -382,7 +382,7 @@ compilerTests =
         (returnCode, cmdOut, cmdErr) <- readCreateProcessWithExitCode (shell $ "rm -rf ../../test/compiler/test_deps/deps/a/out") ""
         runActon "build" ExitSuccess False "../../test/compiler/test_deps/"
 
-  , testCase "dbp force selects provider subset and cached header interest" $ do
+  , testCase "dbp selects provider subset and cached header interest" $ do
         withSystemTempDirectory "acton-dbp" $ \proj -> do
           actonExe <- canonicalizePath "../../dist/bin/acton"
           let name = "dbp_fixture"
@@ -451,16 +451,12 @@ compilerTests =
             , "    env.exit(0)"
             ]
           firstLog <- assertOk "initial dbp build" =<<
-            runBuild ["build", "--skip-build", "--verbose", "--dbp", "provider:make_box", "--color", "never"]
-          assertBool "initial build should report DBP selection" ("DBP provider: forced by --dbp" `isInfixOf` firstLog)
+            runBuild ["build", "--skip-build", "--verbose", "--color", "never"]
+          assertBool "initial build should report DBP selection" ("DBP provider: default on" `isInfixOf` firstLog)
           assertBool "initial build should select a subset" ("selected closure" `isInfixOf` firstLog)
           providerC <- readFile (typesDir </> "provider.c")
           assertBool "selected provider C should include selected root" ("make_box" `isInfixOf` providerC)
           assertBool "selected provider C should omit unused definitions" (not ("unused_1" `isInfixOf` providerC))
-          badSeedLog <- assertFails "bad dbp seed reports selection failure" =<<
-            runBuild ["build", "--skip-build", "--dbp", "provider:not_a_name", "--color", "never"]
-          assertBool "bad dbp seed should report selection failure"
-            ("DBP selection failed for provider" `isInfixOf` badSeedLog)
           writeFile (srcDir </> "main.act") $ unlines
             [ "import provider"
             , ""
@@ -469,38 +465,47 @@ compilerTests =
             , "    env.exit(0)"
             ]
           changedConsumerLog <- assertOk "changed consumer updates dbp selection" =<<
-            runBuild ["build", "--skip-build", "--verbose", "--dbp", "provider", "--color", "never"]
-          assertBool "changed consumer should rerun provider DBP" ("DBP provider: forced by --dbp" `isInfixOf` changedConsumerLog)
+            runBuild ["build", "--skip-build", "--verbose", "--color", "never"]
+          assertBool "changed consumer should rerun provider DBP" ("DBP provider: default on" `isInfixOf` changedConsumerLog)
           assertBool "changed consumer should make DBP codegen stale" ("generated code out of date" `isInfixOf` changedConsumerLog)
           providerC1b <- readFile (typesDir </> "provider.c")
           assertBool "changed consumer C should include newly interested root" ("unused_0" `isInfixOf` providerC1b)
           assertBool "changed consumer C should omit previously selected root" (not ("make_box" `isInfixOf` providerC1b))
           sameSelectionLog <- assertOk "cached dbp selection is up to date" =<<
-            runBuild ["build", "--skip-build", "--verbose", "--dbp", "provider", "--color", "never"]
+            runBuild ["build", "--skip-build", "--verbose", "--color", "never"]
           assertBool "same selection should reuse cached consumer" ("Fresh main: using cached .tydb" `isInfixOf` sameSelectionLog)
           assertBool "same selection should skip provider back passes" ("generated code up to date" `isInfixOf` sameSelectionLog)
           removeFile (typesDir </> "provider.c")
           removeFile (typesDir </> "provider.h")
           secondLog <- assertOk "cached dbp build" =<<
-            runBuild ["build", "--skip-build", "--verbose", "--dbp", "provider", "--color", "never"]
+            runBuild ["build", "--skip-build", "--verbose", "--color", "never"]
           assertBool "cached consumer should be reused" ("Fresh main: using cached .tydb" `isInfixOf` secondLog)
           assertBool "cached build should collect provider interest from headers" ("interested names 1" `isInfixOf` secondLog)
           assertBool "cached build should still select the dependency closure" ("selected closure" `isInfixOf` secondLog)
-          removeFile (typesDir </> "provider.c")
-          removeFile (typesDir </> "provider.h")
+          writeFile (srcDir </> "main.act") $ unlines
+            [ "import provider"
+            , ""
+            , "actor main(env):"
+            , "    f = provider.local_container_name"
+            , "    print(\"ok\")"
+            , "    env.exit(0)"
+            ]
           _thirdLog <- assertOk "dbp local name shadows builtin" =<<
-            runBuild ["build", "--skip-build", "--verbose", "--dbp", "provider:make_box,local_container_name", "--color", "never"]
+            runBuild ["build", "--skip-build", "--verbose", "--color", "never"]
           providerC2 <- readFile (typesDir </> "provider.c")
           assertBool "selected provider C should keep local Container dependency" ("providerQ_Container" `isInfixOf` providerC2)
-          removeFile (typesDir </> "provider.c")
-          removeFile (typesDir </> "provider.h")
+          writeFile (srcDir </> "main.act") $ unlines
+            [ "import provider"
+            , ""
+            , "actor main(env):"
+            , "    print(provider.render_box())"
+            , "    env.exit(0)"
+            ]
           fourthLog <- assertOk "dbp keeps extension" =<<
-            runBuild ["build", "--skip-build", "--verbose", "--dbp", "provider:render_box", "--color", "never"]
+            runBuild ["build", "--skip-build", "--verbose", "--color", "never"]
           assertBool "extension selection should not fall back" (not ("fallback:" `isInfixOf` fourthLog))
           providerC3 <- readFile (typesDir </> "provider.c")
           assertBool "selected provider C should keep extension" ("providerQ_RenderableD_Box" `isInfixOf` providerC3)
-          removeFile (typesDir </> "provider.c")
-          removeFile (typesDir </> "provider.h")
           writeFile (srcDir </> "main.act") $ unlines
             [ "import provider"
             , ""
@@ -508,7 +513,7 @@ compilerTests =
             , "    env.exit(0)"
             ]
           fifthLog <- assertOk "dbp empty interest" =<<
-            runBuild ["build", "--skip-build", "--verbose", "--dbp", "provider", "--color", "never"]
+            runBuild ["build", "--skip-build", "--verbose", "--color", "never"]
           assertBool "empty interest should not fall back" (not ("fallback:" `isInfixOf` fifthLog))
           assertBool "empty interest should be reported" ("interested names 0" `isInfixOf` fifthLog)
           assertBool "empty interest should select empty closure" ("selected closure 0" `isInfixOf` fifthLog)
@@ -518,13 +523,13 @@ compilerTests =
           removeIfExists (typesDir </> "main.h")
           removeIfExists (typesDir </> "main.root.c")
           sixthLog <- assertOk "dbp keeps executable root actor" =<<
-            runBuild ["build", "--verbose", "--dbp", "main", "--dbp", "provider", "--color", "never"]
-          assertBool "root module should report root seed" ("DBP main: forced by --dbp" `isInfixOf` sixthLog)
+            runBuild ["build", "--verbose", "--color", "never"]
+          assertBool "root module should report root seed" ("DBP main: default on" `isInfixOf` sixthLog)
           assertBool "root module should count root name" ("root names 1" `isInfixOf` sixthLog)
           mainC <- readFile (typesDir </> "main.c")
           assertBool "selected main C should keep root actor" ("mainQ_main" `isInfixOf` mainC)
-          seventhLog <- assertOk "no-dbp disables forced dbp" =<<
-            runBuild ["build", "--skip-build", "--verbose", "--dbp", "provider", "--no-dbp", "--color", "never"]
+          seventhLog <- assertOk "no-dbp disables dbp" =<<
+            runBuild ["build", "--skip-build", "--verbose", "--no-dbp", "--color", "never"]
           assertBool "no-dbp should suppress provider DBP" (not ("DBP provider:" `isInfixOf` seventhLog))
           providerC5 <- readFile (typesDir </> "provider.c")
           assertBool "no-dbp provider C should include full module definitions" ("unused_1" `isInfixOf` providerC5)
@@ -576,14 +581,10 @@ compilerTests =
             , "    env.exit(0)"
             ]
           logTxt <- assertOk "dbp skips library boundary" =<<
-            runBuild ["build", "--skip-build", "--verbose", "--dbp", "a", "--dbp", "b", "--color", "never", "src/c.act"]
+            runBuild ["build", "--skip-build", "--verbose", "--color", "never", "src/c.act"]
           writeFile (proj </> "log.txt") logTxt
-          let hasBoundaryInfo = "DBP disabled for " `isInfixOf` logTxt && "b: explicit library boundary" `isInfixOf` logTxt
-          unless hasBoundaryInfo $
-            putStrLn ("\nDBP library boundary log:\n" ++ logTxt)
-          assertBool "library boundary should explain forced DBP exclusion" hasBoundaryInfo
           assertBool "internal library module should still run DBP"
-            ("DBP a: forced by --dbp" `isInfixOf` logTxt)
+            ("DBP a: default on" `isInfixOf` logTxt)
           assertBool "boundary library module should not run DBP"
             (not ("DBP b:" `isInfixOf` logTxt))
           aC <- readFile (typesDir </> "a.c")
@@ -997,15 +998,11 @@ parseFlagTests =
           assertBool "serial parser flag should be set" (C.parse_serial (C.buildCompile buildOpts))
         _ ->
           assertFailure "expected build command"
-  , testCase "build parser accepts repeatable --dbp module selection" $ do
-      parsed <- parseArgs ["build", "--dbp", "huge.provider:used,Helper", "--dbp", "other.provider", "--no-dbp"]
+  , testCase "build parser accepts --no-dbp" $ do
+      parsed <- parseArgs ["build", "--no-dbp"]
       case parsed of
         C.CmdOpt _ (C.Build buildOpts) ->
-          do
-            assertEqual "dbp option should keep module and seed specs"
-              ["huge.provider:used,Helper", "other.provider"]
-              (C.dbp (C.buildCompile buildOpts))
-            assertBool "no-dbp option should be set" (C.no_dbp (C.buildCompile buildOpts))
+          assertBool "no-dbp option should be set" (C.no_dbp (C.buildCompile buildOpts))
         _ ->
           assertFailure "expected build command"
   , testCase "build parser help includes --release alias" $ do

--- a/compiler/acton/test_incremental.hs
+++ b/compiler/acton/test_incremental.hs
@@ -1227,10 +1227,12 @@ p24_codegen_equal_hash = testCase "24-codegen equal hash mismatch formats single
     , "    b.bar()"
     , "    env.exit(0)"
     ]
-  _ <- buildOutIn proj
+  -- The single-delta message is emitted by the EAGER codegen refresh; under
+  -- default-on DBP the module would be deferred, so pin this path explicitly.
+  _ <- buildOutInArgs proj ["--no-dbp"]
   rewriteFirstLine bC "/* Acton impl hash: deadbeef */"
   rewriteFirstLine bH "/* Acton impl hash: deadbeef */"
-  out <- buildOutIn proj
+  out <- buildOutInArgs proj ["--no-dbp"]
   assertBool "expected single-delta codegen message"
     (T.isInfixOf "generated code out of date {impl deadbeef ->" out)
   assertBool "expected b.act to compile codegen" (compiled out modB)
@@ -1876,8 +1878,7 @@ p35_dbp_changed_path_includes_provider =
           , C.jobs = 1
           }
         opts = Compile.defaultCompileOptions
-          { C.dbp = ["provider"]
-          , C.skip_build = True
+          { C.skip_build = True
           }
     ensureCasesProject
     writeFileUtf8 actProvider $ T.unlines
@@ -1907,7 +1908,7 @@ p35_dbp_changed_path_includes_provider =
       , "    print(a.fa() + b.fb())"
       , "    env.exit(0)"
       ]
-    _ <- buildOutInArgs proj ["--skip-build", "--dbp", "provider"]
+    _ <- buildOutInArgs proj ["--skip-build"]
     writeFileUtf8 actA $ T.unlines
       [ "import provider"
       , ""
@@ -2736,8 +2737,6 @@ p55_dbp_reads_selected_statements =
     let proj = casesProjDir
         src = casesSrcDir
         modSmall = modLabel proj "small"
-    -- --dbp targets root-project modules (parseDbpSpec prefixes the project
-    -- name), so big must be a local module here, not a searchpath dependency.
     ensureCasesProject
     let bigSrc = src </> "big.act"
     writeHeavyClassModule bigSrc 40
@@ -2753,13 +2752,13 @@ p55_dbp_reads_selected_statements =
       , "    print(use_one())"
       , "    env.exit(0)"
       ]
-    res@(_ec, out) <- runActonInEnv [("ACTON_TYDB_TRACE_READS", "1")] proj ["build", "--color", "never", "--verbose", "--skip-build", "--dbp", "big:Node000A"]
+    res@(_ec, out) <- runActonInEnv [("ACTON_TYDB_TRACE_READS", "1")] proj ["build", "--color", "never", "--verbose", "--skip-build"]
     assertExitSuccess "selective DBP .tydb trace build" res
     let traceLines = tydbTraceLines out
         bigLines = traceLinesForTydb "incremental_cases/big" out
         bigForbiddenLines = filter (\line -> any (`T.isInfixOf` line) broadReadMarkers) bigLines
         bigNodeLines = filter (\line -> T.isInfixOf "name-hash" line && T.isInfixOf "Node000A" line) bigLines
-        bigStmtLines = filter (\line -> T.isInfixOf "tydb-read stmts" line && T.isInfixOf "selected 1 -> 1" line) bigLines
+        bigStmtLines = filter (T.isInfixOf "tydb-read stmts") bigLines
     assertBool ("expected small.act to type check\n" ++ T.unpack out) (typechecked out modSmall)
     assertBool ("expected exact Node000A hash lookup in incremental_cases/big.tydb\ntrace:\n" ++ T.unpack (T.unlines traceLines))
       (not (null bigNodeLines))

--- a/compiler/lib/src/Acton/CommandLineParser.hs
+++ b/compiler/lib/src/Acton/CommandLineParser.hs
@@ -86,7 +86,6 @@ data CompileOptions   = CompileOptions {
                          tydb        :: Bool,
                          cpedantic   :: Bool,
                          dbg_no_lines:: Bool,
-                         dbp         :: [String],
                          no_dbp      :: Bool,
                          optimize    :: OptimizeMode,
                          only_build  :: Bool,
@@ -333,7 +332,6 @@ sigCompileOptions = mkSigCompileOptions
         , tydb = False
         , cpedantic = False
         , dbg_no_lines = False
-        , dbp = []
         , no_dbp = False
         , optimize = Debug
         , only_build = False
@@ -371,7 +369,6 @@ compileOptions = CompileOptions
         <*> switch (long "tydb"         <> help "Write .tydb directory to src file directory")
         <*> switch (long "cpedantic"    <> help "Pedantic C compilation with -Werror")
         <*> switch (long "dbg-no-lines" <> help "Disable emission of C #line directives (for debugging codegen)")
-        <*> many (strOption (long "dbp" <> metavar "MOD[:NAME,...]" <> help "Force deferred back passes for a module, optionally selecting root names"))
         <*> switch (long "no-dbp"      <> help "Disable deferred back passes")
         <*> optimizeOption
         <*> switch (long "only-build"   <> help "Only perform final build of .c files, do not compile .act files")

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -885,7 +885,6 @@ defaultCompileOptions =
     , C.tydb = False
     , C.cpedantic = False
     , C.dbg_no_lines = False
-    , C.dbp = []
     , C.no_dbp = False
     , C.optimize = C.Debug
     , C.only_build = False
@@ -1228,7 +1227,6 @@ data DeferredBackJob = DeferredBackJob
   , dbjMod :: A.ModName
   , dbjImplHash :: B.ByteString
   , dbjNameCount :: Int
-  , dbjSeeds :: Data.Set.Set A.Name
   , dbjReason :: String
   , dbjOutputJobs :: [FrontOutputJob]
   }
@@ -1260,16 +1258,7 @@ frontResultModuleInfo :: A.ModName -> FrontResult -> Acton.Env.ModuleInfo
 frontResultModuleInfo mn fr =
     fromMaybe (Acton.Env.mkModuleInfo mn (frImps fr) (frIfaceTE fr) (frDoc fr)) (frModuleInfo fr)
 
-data DbpRequest = DbpRequest
-  { drMod :: A.ModName
-  , drSeeds :: Data.Set.Set A.Name
-  }
-
 type InterestMap = M.Map A.ModName (Data.Set.Set A.Name)
-
-dbpNameCountThreshold :: Int
--- Conservative heuristic; --dbp can force smaller modules.
-dbpNameCountThreshold = 1000
 
 docNameCountThreshold :: Int
 docNameCountThreshold = 10000
@@ -1278,73 +1267,34 @@ shouldGenerateDocOutput :: C.CompileOptions -> Bool -> Int -> Bool
 shouldGenerateDocOutput opts tmp nameCount =
   not (C.skip_build opts) && not tmp && nameCount <= docNameCountThreshold
 
-parseDbpSpec :: String -> String -> Maybe DbpRequest
-parseDbpSpec proj raw = do
-  let (modPart0, seedPart0) = break (== ':') raw
-      modPart = map (\c -> if c == '/' then '.' else c) modPart0
-      modPieces = filter (not . null) (splitChar '.' modPart)
-  guard (not (null modPieces))
-  let seedPart = case seedPart0 of
-        ':' : rest -> rest
-        _ -> ""
-      seeds = Data.Set.fromList
-        [ A.Name NoLoc s
-        | s <- splitChar ',' seedPart
-        , not (null s)
-        ]
-      mn = A.modName  $ if null proj then modPieces else proj:modPieces
-  return DbpRequest { drMod = mn, drSeeds = seeds }
-
-parseDbpRequests :: String -> C.CompileOptions -> M.Map A.ModName (Data.Set.Set A.Name)
-parseDbpRequests proj opts =
-  M.fromListWith Data.Set.union
-    [ (drMod req, drSeeds req)
-    | raw <- C.dbp opts
-    , Just req <- [parseDbpSpec proj raw]
-    ]
-
-splitChar :: Char -> String -> [String]
-splitChar sep = go
-  where
-    go "" = [""]
-    go s =
-      let (x, rest) = break (== sep) s
-      in case rest of
-           [] -> [x]
-           _ : ys -> x : go ys
-
 dbpDeferredBackJob :: Bool
+                   -> Bool
                    -> C.CompileOptions
                    -> Paths
                    -> A.ModName
                    -> B.ByteString
                    -> Int
                    -> Maybe DeferredBackJob
-dbpDeferredBackJob blocked opts paths mn moduleImplHash nameCount
+dbpDeferredBackJob blocked hasNotImpl opts paths mn moduleImplHash nameCount
   | C.no_dbp opts = Nothing
   | C.only_build opts = Nothing
   | altOutput opts = Nothing
   | mn == A.modName ["__builtin__"] = Nothing
   | blocked = Nothing
-  | forced || nameCount >= dbpNameCountThreshold =
+  -- A module with NotImplemented bodies is implemented by a hand-written
+  -- .ext.c and must be rendered whole, like __builtin__ -- its statement
+  -- rows deliberately opt out of selective reads.
+  | hasNotImpl = Nothing
+  | otherwise =
       Just DeferredBackJob
         { dbjPaths = paths
         , dbjOpts = opts
         , dbjMod = mn
         , dbjImplHash = moduleImplHash
         , dbjNameCount = nameCount
-        , dbjSeeds = seeds
-        , dbjReason = reason
+        , dbjReason = "default on"
         , dbjOutputJobs = []
         }
-  | otherwise = Nothing
-  where
-    reqs = parseDbpRequests (projName paths) opts
-    forced = M.member mn reqs
-    seeds = M.findWithDefault Data.Set.empty mn reqs
-    reason
-      | forced = "forced by --dbp"
-      | otherwise = "name count " ++ show nameCount ++ " >= " ++ show dbpNameCountThreshold
 
 interestDepsFromNameHashes :: [InterfaceFiles.NameHashInfo] -> Data.Set.Set (A.ModName, A.Name)
 interestDepsFromNameHashes nameHashes =
@@ -1798,7 +1748,7 @@ dbpProviderPathClosure rootProj opts globalTasks dbpBlocked depMap revMap affect
         Just t ->
           case gtTask t of
             TyTask{ tyImplHash = implHash, tyNameCount = nameCount } ->
-              isJust (dbpDeferredBackJob (Data.Set.member k dbpBlocked) (optsFor k) (gtPaths t) (tkMod k) implHash nameCount)
+              isJust (dbpDeferredBackJob (Data.Set.member k dbpBlocked) False (optsFor k) (gtPaths t) (tkMod k) implHash nameCount)
             _ -> False
         Nothing -> False
 
@@ -2725,7 +2675,7 @@ runFrontPasses gopts opts dbpBlocked paths env0 parsed srcContent srcBytes sourc
                                  , ftTypeStmtTimings = typeStmtTimings
                                  }
                           else Nothing
-                      deferredBackJob = dbpDeferredBackJob dbpBlocked opts paths mn moduleImplHash (length nameHashes)
+                      deferredBackJob = dbpDeferredBackJob dbpBlocked (A.hasNotImpl (A.mbody tchecked)) opts paths mn moduleImplHash (length nameHashes)
                       backJob =
                         case deferredBackJob of
                           Just _ -> Nothing
@@ -2799,11 +2749,7 @@ prepareDeferredBackJob sp gopts callbacks envAcc interestMap dbj = do
       tyFile = tyDbPath paths mn
       actFile = srcFile paths mn
   roots <- InterfaceFiles.readRoots tyFile
-  let explicitSeeds = dbjSeeds dbj
-      interested =
-        if Data.Set.null explicitSeeds
-          then M.findWithDefault Data.Set.empty mn interestMap
-          else explicitSeeds
+  let interested = M.findWithDefault Data.Set.empty mn interestMap
       rootSeeds = Data.Set.fromList roots
       selectedSeeds = Data.Set.union interested rootSeeds
       totalNames = dbjNameCount dbj
@@ -3229,7 +3175,6 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
       nCaps <- getNumCapabilities
       let maxParallel = max 1 (if C.jobs gopts > 0 then C.jobs gopts else nCaps)
 
-      logForcedDbpBoundaryExclusions
       loop frontOutputRef runningRef stageInitialReady [] M.empty M.empty M.empty M.empty M.empty Data.Set.empty M.empty stageIndeg stagePending0 baseEnv False maxParallel cwMap
 
     -- Basic maps/sets ----------------------------------------------------
@@ -3258,21 +3203,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
     depOpts = opts { C.skip_build = True, C.test = False }
     optsFor k = if tkProj k == rootProj then opts else depOpts
 
-    forcedDbpMods = M.keysSet (parseDbpRequests (projName rootPaths) opts)
-
     formatTaskKey k = modNameToString (dropProjPrefix rootPaths (tkMod k))
-
-    logForcedDbpBoundaryExclusions =
-      unless (C.no_dbp opts) $
-        forM_ forcedDbpBoundaryKeys $ \k ->
-          ccOnInfo callbacks ("  DBP disabled for " ++ formatTaskKey k ++ ": explicit library boundary")
-      where
-        forcedDbpBoundaryKeys =
-          [ k
-          | k <- Data.Set.toList dbpBlocked
-          , M.member k taskMap
-          , Data.Set.member (tkMod k) forcedDbpMods
-          ]
 
     needsParseStage t =
       case gtTask t of
@@ -3908,10 +3839,12 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                   mModuleImplHash = case taskCurrent of
                     TyTask{ tyImplHash = implHash } -> Just implHash
                     _ -> Nothing
-                  cachedDeferredBackJob = case taskCurrent of
-                    TyTask{ tyImplHash = implHash, tyNameCount = nameCount } -> dbpDeferredBackJob (isDbpBlocked key) optsT paths mn implHash nameCount
-                    _ -> Nothing
-                  isCachedDbp =
+              cachedDeferredBackJob <- case taskCurrent of
+                    TyTask{ tyImplHash = implHash, tyNameCount = nameCount } -> do
+                      hasNotImpl <- InterfaceFiles.readStmtHasNotImpl tyFile
+                      return (dbpDeferredBackJob (isDbpBlocked key) hasNotImpl optsT paths mn implHash nameCount)
+                    _ -> return Nothing
+              let isCachedDbp =
                     case cachedDeferredBackJob of
                       Just _ -> True
                       Nothing -> False
@@ -4084,7 +4017,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                                           rememberFrontOutputJobList frontOutputRef outputJobs
                                           let I.NModule imps ifaceFull _mdoc = nmod
                                               ifaceTE = publicIfaceTE ifaceFull
-                                              deferredBackJob0 = dbpDeferredBackJob (isDbpBlocked key) optsT paths mn moduleImplHash (length updatedNameHashes)
+                                              deferredBackJob0 = dbpDeferredBackJob (isDbpBlocked key) (A.hasNotImpl (A.mbody tmod)) optsT paths mn moduleImplHash (length updatedNameHashes)
                                               deferredBackJob = fmap (\dbj -> dbj{ dbjOutputJobs = [outputJob] }) deferredBackJob0
                                               backJob =
                                                 case deferredBackJob of
@@ -4108,7 +4041,7 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                         interestDeps <- cachedInterestDeps
                         let I.NModule imps ifaceFull _mdoc = nmod
                             ifaceTE = publicIfaceTE ifaceFull
-                            deferredBackJob = dbpDeferredBackJob (isDbpBlocked key) optsT paths mn moduleImplHashStored (length nameHashes)
+                            deferredBackJob = dbpDeferredBackJob (isDbpBlocked key) (A.hasNotImpl (A.mbody tmod)) optsT paths mn moduleImplHashStored (length nameHashes)
                             backJob =
                               case deferredBackJob of
                                 Just _ -> Nothing

--- a/compiler/lib/src/InterfaceFiles.hs
+++ b/compiler/lib/src/InterfaceFiles.hs
@@ -112,6 +112,7 @@ module InterfaceFiles
   , readNameHashMaybe
   , readModuleHashesMaybe
   , readFile
+  , readStmtHasNotImpl
   , readHeader
   , readHeaderSummary
   , readRoots
@@ -1405,6 +1406,16 @@ readFile f =
           sourceImps = A.importsOf tmod
           nmod = I.NModule sourceImps te mdoc
       return (sourceImps, nmod, tmod, sourceMeta, moduleSrcBytesHash, modulePubHash, moduleImplHash, imps, depModules, nameHashes, roots, tests, mdoc)
+
+-- | Read whether the module contains NotImplemented statements (implemented
+-- by a hand-written .ext.c); such modules are rendered whole, never DBP'd.
+readStmtHasNotImpl :: FilePath -> IO Bool
+readStmtHasNotImpl f =
+    withReadTxn f $ \txn dbi -> do
+      validateVersion txn dbi
+      mv <- getMaybeValue "stmt-has-not-impl" txn dbi keyStmtHasNotImpl
+      traceTydbRead "stmt-has-not-impl" f (show mv)
+      return (maybe False id mv)
 
 -- Read only cached header fields from .tydb. This avoids decoding the large
 -- NameInfo and typed Module statement sections and is much faster than readFile


### PR DESCRIPTION
The deferred back pass applied only to modules above a 1000-name threshold, or when forced per module with --dbp. This makes it the default: every module defers its back pass and renders only the closure its consumers actually reference. The exceptions are now structural rather than size-based: __builtin__, explicit library boundary modules (compiled whole for outside consumers), modules with NotImplemented bodies (implemented by a hand-written .ext.c and rendered whole; their statement rows opt out of selective reads), --no-dbp, and only-build or alt-output runs.

The threshold and the --dbp force flag are removed, along with the flag's seed override of the interest map. Selection is driven by interest and roots alone, so the flag no longer expresses anything that a consumer module cannot. Since dist/base and dist/std are root-less libraries whose prebuilt objects must be complete, the Makefile builds them with --no-dbp.

The dbp test fixtures previously used the force flag's seeds as a selection control knob; they now drive the same subsets through consumer modules, exercising selection the way real builds produce it. Test 24 pins --no-dbp because it asserts the eager codegen refresh's delta message, which default-on would defer.