### PR TITLE
Drop vestigial DBP selection fields

### DIFF
--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -452,7 +452,7 @@ compilerTests =
             ]
           firstLog <- assertOk "initial dbp build" =<<
             runBuild ["build", "--skip-build", "--verbose", "--color", "never"]
-          assertBool "initial build should report DBP selection" ("DBP provider: default on" `isInfixOf` firstLog)
+          assertBool "initial build should report DBP selection" ("DBP provider: total names" `isInfixOf` firstLog)
           assertBool "initial build should select a subset" ("selected closure" `isInfixOf` firstLog)
           providerC <- readFile (typesDir </> "provider.c")
           assertBool "selected provider C should include selected root" ("make_box" `isInfixOf` providerC)
@@ -466,7 +466,7 @@ compilerTests =
             ]
           changedConsumerLog <- assertOk "changed consumer updates dbp selection" =<<
             runBuild ["build", "--skip-build", "--verbose", "--color", "never"]
-          assertBool "changed consumer should rerun provider DBP" ("DBP provider: default on" `isInfixOf` changedConsumerLog)
+          assertBool "changed consumer should rerun provider DBP" ("DBP provider: total names" `isInfixOf` changedConsumerLog)
           assertBool "changed consumer should make DBP codegen stale" ("generated code out of date" `isInfixOf` changedConsumerLog)
           providerC1b <- readFile (typesDir </> "provider.c")
           assertBool "changed consumer C should include newly interested root" ("unused_0" `isInfixOf` providerC1b)
@@ -524,7 +524,7 @@ compilerTests =
           removeIfExists (typesDir </> "main.root.c")
           sixthLog <- assertOk "dbp keeps executable root actor" =<<
             runBuild ["build", "--verbose", "--color", "never"]
-          assertBool "root module should report root seed" ("DBP main: default on" `isInfixOf` sixthLog)
+          assertBool "root module should report root seed" ("DBP main: total names" `isInfixOf` sixthLog)
           assertBool "root module should count root name" ("root names 1" `isInfixOf` sixthLog)
           mainC <- readFile (typesDir </> "main.c")
           assertBool "selected main C should keep root actor" ("mainQ_main" `isInfixOf` mainC)
@@ -584,7 +584,7 @@ compilerTests =
             runBuild ["build", "--skip-build", "--verbose", "--color", "never", "src/c.act"]
           writeFile (proj </> "log.txt") logTxt
           assertBool "internal library module should still run DBP"
-            ("DBP a: default on" `isInfixOf` logTxt)
+            ("DBP a: total names" `isInfixOf` logTxt)
           assertBool "boundary library module should not run DBP"
             (not ("DBP b:" `isInfixOf` logTxt))
           aC <- readFile (typesDir </> "a.c")

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -1227,7 +1227,6 @@ data DeferredBackJob = DeferredBackJob
   , dbjMod :: A.ModName
   , dbjImplHash :: B.ByteString
   , dbjNameCount :: Int
-  , dbjReason :: String
   , dbjOutputJobs :: [FrontOutputJob]
   }
 
@@ -1292,7 +1291,6 @@ dbpDeferredBackJob blocked hasNotImpl opts paths mn moduleImplHash nameCount
         , dbjMod = mn
         , dbjImplHash = moduleImplHash
         , dbjNameCount = nameCount
-        , dbjReason = "default on"
         , dbjOutputJobs = []
         }
 
@@ -2725,7 +2723,6 @@ runFrontPasses gopts opts dbpBlocked paths env0 parsed srcContent srcBytes sourc
 
 data DbpSelection = DbpSelection
   { dbsModule :: A.Module
-  , dbsInterestedCount :: Int
   , dbsSelectedCount :: Int
   , dbsFallbackReason :: Maybe String
   }
@@ -2763,10 +2760,10 @@ prepareDeferredBackJob sp gopts callbacks envAcc interestMap dbj = do
     else do
       selectedTmod <- InterfaceFiles.readSelectedModule tyFile (dnsNameHashes nameSelection) (dnsSelectedNames nameSelection)
       selection <- case selectedTmod of
-        Just tmod -> return $ selectDbpModule totalNames (Data.Set.size interested) nameSelection tmod
+        Just tmod -> return $ selectDbpModule totalNames nameSelection tmod
         Nothing -> do
           (_ms, _nmod, tmod, _sourceMetaFull, _moduleSrcBytesHashFull, _modulePubHashFull, _moduleImplHashStoredFull, _impsFull, _depModulesFull, _nameHashesFull, _rootsFull, _testsFull, _mdocFull) <- InterfaceFiles.readFile tyFile
-          return $ selectDbpModule totalNames (Data.Set.size interested) nameSelection tmod
+          return $ selectDbpModule totalNames nameSelection tmod
       snap <- Source.readSource sp actFile
       env1 <- Acton.Env.mkEnv (searchPath paths) envAcc (dbsModule selection)
       logDbpSelection gopts callbacks mn dbj totalNames (Data.Set.size interested) (Data.Set.size rootSeeds) (dbsSelectedCount selection) (dbsFallbackReason selection) "generated code out of date"
@@ -2796,8 +2793,7 @@ logDbpSelection gopts callbacks mn dbj totalNames interestedCount rootCount sele
   when (C.verbose gopts) $
     ccOnInfo callbacks $
       "  DBP " ++ modNameToString (dropProjPrefix (dbjPaths dbj) mn)
-      ++ ": " ++ dbjReason dbj
-      ++ ", total names " ++ show totalNames
+      ++ ": total names " ++ show totalNames
       ++ ", interested names " ++ show interestedCount
       ++ ", root names " ++ show rootCount
       ++ ", selected closure " ++ show selectedCount
@@ -2837,18 +2833,16 @@ dbpSelectionError paths mn reason =
   throwIO (DbpSelectionError ("DBP selection failed for " ++ modNameToString (dropProjPrefix paths mn) ++ ": " ++ reason))
 
 selectDbpModule :: Int
-                -> Int
                 -> DbpNameSelection
                 -> A.Module
                 -> DbpSelection
-selectDbpModule totalNames interestedCount nameSelection tmod@(A.Module loc imps mdoc suite)
+selectDbpModule totalNames nameSelection tmod@(A.Module loc imps mdoc suite)
   | A.hasNotImpl suite = fallback "module contains NotImplemented/native extension hooks"
   | otherwise =
       let selected = dnsSelectedNames nameSelection
           suite' = mapMaybe (dbpPruneTopStmt selected) suite
       in DbpSelection
            { dbsModule = A.Module loc imps mdoc suite'
-           , dbsInterestedCount = interestedCount
            , dbsSelectedCount = Data.Set.size selected
            , dbsFallbackReason = Nothing
            }
@@ -2856,7 +2850,6 @@ selectDbpModule totalNames interestedCount nameSelection tmod@(A.Module loc imps
     fallback reason =
       DbpSelection
         { dbsModule = tmod
-        , dbsInterestedCount = interestedCount
         , dbsSelectedCount = totalNames
         , dbsFallbackReason = Just reason
         }


### PR DESCRIPTION
With deferred back passes default-on, dbjReason is a constant ("default on") read exactly once by the verbose log line. Remove the field and the log fragment; the DBP line now leads with the prune ratio (total names vs selected closure), which is the diagnostic that matters. The four test assertions anchored on the old fragment now anchor on the module name plus first metric.

dbsInterestedCount was constructed but never read -- the log line takes the interested count as a separate argument -- so it goes too, along with selectDbpModule's parameter that existed only to populate it.