### PR TITLE
Use pshared mutexes for LMDB locks on macOS

### DIFF
--- a/bdeps/lmdb/build.zig
+++ b/bdeps/lmdb/build.zig
@@ -1,5 +1,29 @@
 const std = @import("std");
 
+// macOS: shared pthread mutexes inside lock.mdb instead of upstream's POSIX
+// named semaphores, whose names live in a global kernel table
+// (kern.posix.sem.max, default 10000) where entries stranded by killed
+// processes and deleted caches survive until reboot - eventually failing
+// every locking mdb_env_open on the machine with ENOSPC ("No space left on
+// device"). macOS has no robust mutexes, but named semaphores are not robust
+// either, so behaviour on a crashed lock holder is unchanged. Upstream made
+// the same flip for FreeBSD >= 11.
+//
+// mdb.c hard-selects the semaphores on Apple systems before any -D override
+// is consulted, tripping its "Ambiguous shared-lock implementation" guard
+// when building with -DMDB_USE_POSIX_MUTEX. Rather than carrying a fork or a
+// vendored copy for one line, keep the fetched tarball pristine and guard
+// that selection at build time; the exact-match replacement fails the build
+// loudly if upstream ever changes the block.
+const sem_selection =
+    "#elif defined(__APPLE__) || defined (BSD) || defined(__FreeBSD_kernel__)\n" ++
+    "# define MDB_USE_POSIX_SEM\t1\n";
+const sem_selection_guarded =
+    "#elif defined(__APPLE__) || defined (BSD) || defined(__FreeBSD_kernel__)\n" ++
+    "# ifndef MDB_USE_POSIX_MUTEX\n" ++
+    "#  define MDB_USE_POSIX_SEM\t1\n" ++
+    "# endif\n";
+
 pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
     var target = b.standardTargetOptions(.{});
@@ -30,9 +54,20 @@ pub fn build(b: *std.Build) void {
     lib.root_module.link_libc = true;
     lib.root_module.addIncludePath(source.path("libraries/liblmdb"));
     const c_flags = [_][]const u8{"-DMDB_MAXKEYSIZE=512"};
-    lib.root_module.addCSourceFile(.{ .file = source.path("libraries/liblmdb/mdb.c"), .flags = &c_flags });
-    lib.root_module.addCSourceFile(.{ .file = source.path("libraries/liblmdb/midl.c"), .flags = &c_flags });
+    const c_flags_macos = [_][]const u8{ "-DMDB_MAXKEYSIZE=512", "-DMDB_USE_POSIX_MUTEX=1", "-DMDB_USE_ROBUST=0" };
+    const flags: []const []const u8 = if (target.result.os.tag == .macos) &c_flags_macos else &c_flags;
+    lib.root_module.addCSourceFile(.{ .file = patchedMdbC(b, source), .flags = flags });
+    lib.root_module.addCSourceFile(.{ .file = source.path("libraries/liblmdb/midl.c"), .flags = flags });
     lib.installHeader(source.path("libraries/liblmdb/lmdb.h"), "lmdb.h");
 
     b.installArtifact(lib);
+}
+
+fn patchedMdbC(b: *std.Build, source: *std.Build.Dependency) std.Build.LazyPath {
+    const raw = source.builder.build_root.handle.readFileAlloc(b.graph.io, "libraries/liblmdb/mdb.c", b.allocator, .limited(1 << 22)) catch |err|
+        std.debug.panic("lmdb: reading upstream mdb.c: {}", .{err});
+    if (std.mem.count(u8, raw, sem_selection) != 1)
+        @panic("lmdb: upstream mdb.c changed its lock-implementation selection; update the patch in build.zig");
+    const patched = std.mem.replaceOwned(u8, b.allocator, raw, sem_selection, sem_selection_guarded) catch @panic("OOM");
+    return b.addWriteFiles().add("mdb.c", patched);
 }

--- a/bdeps/lmdb/build.zig.zon
+++ b/bdeps/lmdb/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .source = .{
-            .url = "https://github.com/LMDB/lmdb/archive/LMDB_0.9.31.tar.gz",
-            .hash = "N-V-__8AAHEsCACb_b9D1HnCysDKIhKFOrITbxYh9JRh9ix5",
+            .url = "https://github.com/LMDB/lmdb/archive/LMDB_0.9.35.tar.gz",
+            .hash = "N-V-__8AAEVyCADP8PFZuyKz_iq-d6eg0lypXMEoZ5e-rb_8",
         },
     },
     .paths = .{

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -326,6 +326,22 @@ main = do
               names <$> InterfaceFiles.readInterfaceDBExtByType db (S.NoQ clsName) `shouldReturn` [extName]
               fst <$> InterfaceFiles.readInterfaceDBModuleInfo db `shouldReturn` [])
 
+      it "keeps lock files free of named-semaphore state" $ do
+        withSystemTempDirectory "acton-iface-lockfmt" $ \dir -> do
+          let tyPath = dir </> "lockfmt.tydb"
+              nmod = I.NModule [] [] Nothing
+              tmod = S.Module (S.modName ["lockfmt"]) [] Nothing []
+          InterfaceFiles.writeFile tyPath "src" "pub" "impl" Nothing [] [] [] [] [] Nothing nmod tmod
+          -- liblmdb's lock table must use process-shared mutexes, which live
+          -- inside lock.mdb, on every platform. Its POSIX-semaphore variant
+          -- (upstream's default on macOS) stores "/MDB[rw]..." names here
+          -- instead and registers them in a global kernel table capped at
+          -- kern.posix.sem.max, where entries stranded by killed processes
+          -- and deleted caches survive until reboot - eventually failing
+          -- every locking mdb_env_open on the machine with ENOSPC.
+          lockBytes <- B8.readFile (tyPath </> "lock.mdb")
+          B8.isInfixOf "/MDBr" lockBytes `shouldBe` False
+
       it "serves fresh data through a handle across rewrites" $ do
         withSystemTempDirectory "acton-iface-rewrite" $ \dir -> do
           let mn = S.modName ["iface_rewrite"]


### PR DESCRIPTION
Acton builds on macOS fail intermittently with LMDB_Error mdb_env_open "No space left on device" (errno 28) despite plenty of free disk. The error has nothing to do with disk: liblmdb on macOS guards every locking environment with two POSIX named semaphores, whose names live in a global kernel table capped at kern.posix.sem.max (10000 by default). LMDB unlinks the pair when the last user closes the environment cleanly, but a process that exits or is killed with an environment open leaves it registered, and deleting the .tydb afterwards orphans it until reboot. Heavy build and test churn - temp-dir test projects, scratch compiles, deleted worktrees - exhausts the table, and from that point every locking mdb_env_open in every process on the machine fails with ENOSPC. Only a reboot empties the table.

This switches macOS to process-shared pthread mutexes, which live inside lock.mdb and use no kernel namespace at all - the same flip upstream made for FreeBSD 11 and later. macOS supports process-shared mutexes (it did not when upstream chose semaphores) but not robust ones; named semaphores are not robust either, so behaviour when a lock holder crashes is unchanged. Cross-process mutual exclusion of the mutex build was verified directly, with a second process blocking on the write lock until the holder commits. Since mdb.c hard-selects semaphores on Apple systems before any -D override is consulted, build.zig guards that selection at build time with an exact-match replacement over the pristine fetched source, failing the build loudly if upstream ever changes the block; the tarball itself stays untouched and hash-verified. A new test asserts lock files stay free of semaphore names, so a regression to the semaphore flavor cannot pass unnoticed.

On the way there LMDB is updated from 0.9.31 to 0.9.35: 0.9.32 partially reverted a robust-mutex cleanup patch as incorrect and racy, which is the lock path our Linux builds use, 0.9.34 fixes a race condition freeing spilled pages at the end of a transaction, and 0.9.34/0.9.35 make macOS syncs use F_FULLFSYNC, the only real durability barrier there.

Existing .tydb caches are unaffected: the data format is unchanged, and a lock file whose environment nobody has open is reinitialized wholesale at the next open, so on-disk caches carry over seamlessly. The one thing to avoid is running an old semaphore-built acton and a new mutex-built one against the same project's caches at the same time, since the two lock-table layouts share a format word - stop long-running acton processes such as lsp-server-acton when upgrading. On a warm checkout, also run make clean-compiler once after pulling this, since stack does not notice that a bdeps archive changed and would otherwise not relink the compiler.