### PR TITLE
Refresh impl hashes from rows, not whole files

### DIFF
--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -1121,11 +1121,11 @@ printSigInterface paths mn mName tyFile = do
     exists <- InterfaceFiles.interfaceExists tyFile
     unless exists $
       printErrorAndExit ("Type interface not found for " ++ modNameToString mn)
-    tyRes <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readFile tyFile
+    tyRes <- (try :: IO a -> IO (Either SomeException a)) $ InterfaceFiles.readModuleIface tyFile
     case tyRes of
       Left err ->
         printErrorAndExit ("Could not read type interface for " ++ modNameToString mn ++ ": " ++ show err)
-      Right (ms, nmod, _, _, _, _, _, _, _, _, _, _, _) -> do
+      Right (ms, nmod) -> do
         env0 <- Acton.Env.initEnv (sysTypes paths) False
         let I.NModule imps te _ = nmod
             envImports = foldr Acton.Env.addImport env0 ms

--- a/compiler/lib/bench/CompilerBench.hs
+++ b/compiler/lib/bench/CompilerBench.hs
@@ -290,6 +290,7 @@ hashBenchFromHashes mn env nmod extMaps implItems nameSrcHashes nameImplHashes s
             nameSrcHashes
             pubHashes
             implHashes
+            nameImplHashes
             pubLocalDeps
             implLocalDeps
             pubExtHashes
@@ -489,6 +490,7 @@ runHashBreakdown reps typesPath sourcePath = do
             nameSrcHashes
             pubHashes
             implHashes
+            nameImplHashes
             pubLocalDeps
             implLocalDeps
             pubExtHashes
@@ -610,6 +612,7 @@ runHashBreakdown reps typesPath sourcePath = do
       nameSrcHashes' <- readIORef nameSrcHashesRef
       pubHashes' <- readIORef pubHashesRef
       implHashes' <- readIORef implHashesRef
+      nameImplHashes' <- readIORef nameImplHashesRef
       pubLocalDeps' <- readIORef pubLocalDepsRef
       implLocalDeps' <- readIORef implLocalDepsRef
       pubExtHashes' <- readIORef pubExtHashesRef
@@ -620,6 +623,7 @@ runHashBreakdown reps typesPath sourcePath = do
               nameSrcHashes'
               pubHashes'
               implHashes'
+              nameImplHashes'
               pubLocalDeps'
               implLocalDeps'
               pubExtHashes'

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -2605,6 +2605,7 @@ runFrontPasses gopts opts dbpBlocked paths env0 parsed srcContent srcBytes sourc
                           nameSrcHashes
                           pubHashes
                           implHashes
+                          nameImplHashes
                           pubLocalDeps
                           implLocalDeps
                           pubExtHashes
@@ -2759,11 +2760,12 @@ prepareDeferredBackJob sp gopts callbacks envAcc interestMap dbj = do
       return Nothing
     else do
       selectedTmod <- InterfaceFiles.readSelectedModule tyFile (dnsNameHashes nameSelection) (dnsSelectedNames nameSelection)
+      -- Same-version .tydb files always carry statement indices, so a failed
+      -- selective read means a corrupt or hand-doctored file -- an eager
+      -- whole-module fallback would mask that (and read gigabytes doing it).
       selection <- case selectedTmod of
         Just tmod -> return $ selectDbpModule totalNames nameSelection tmod
-        Nothing -> do
-          (_ms, _nmod, tmod, _sourceMetaFull, _moduleSrcBytesHashFull, _modulePubHashFull, _moduleImplHashStoredFull, _impsFull, _depModulesFull, _nameHashesFull, _rootsFull, _testsFull, _mdocFull) <- InterfaceFiles.readFile tyFile
-          return $ selectDbpModule totalNames nameSelection tmod
+        Nothing -> error ("Internal error: missing statement rows in " ++ tyFile)
       snap <- Source.readSource sp actFile
       env1 <- Acton.Env.mkEnv (searchPath paths) envAcc (dbsModule selection)
       logDbpSelection gopts callbacks mn dbj totalNames (Data.Set.size interested) (Data.Set.size rootSeeds) (dbsSelectedCount selection) (dbsFallbackReason selection) "generated code out of date"
@@ -3578,9 +3580,12 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
           -- change tracking for every dependency of this module.
           restorePubDepsFromRows depModules nameHashes = do
             (pubByOwner, implByOwner) <- foldM addModule (M.empty, M.empty) depModules
+            -- Canonical order: the hash combinators (computeHashesSortedDeps)
+            -- require dep lists sorted by name, exactly as the front pass
+            -- stores them -- row iteration order must not leak into hashes.
             return
-              [ nh { InterfaceFiles.nhPubDeps = M.findWithDefault [] (InterfaceFiles.nhName nh) pubByOwner
-                   , InterfaceFiles.nhImplDeps = M.findWithDefault [] (InterfaceFiles.nhName nh) implByOwner
+              [ nh { InterfaceFiles.nhPubDeps = Data.List.sortOn fst (M.findWithDefault [] (InterfaceFiles.nhName nh) pubByOwner)
+                   , InterfaceFiles.nhImplDeps = Data.List.sortOn fst (M.findWithDefault [] (InterfaceFiles.nhName nh) implByOwner)
                    }
               | nh <- nameHashes
               ]
@@ -3927,98 +3932,106 @@ compileTasks sp gopts opts rootPaths rootProj tasks dbpBlocked callbacks = do
                       when (C.verbose gopts) $ do
                         let fmtDelta (qn, old, new) = prstr qn ++ " " ++ short8 old ++ " → " ++ short8 new ++ fmtUsers implUsers qn
                         ccOnInfo callbacks ("  Stale " ++ modNameToString (dropProjPrefix paths mn) ++ ": impl changes in " ++ Data.List.intercalate ", " (map fmtDelta implDeltas))
-                      tyRes <- readTyFile
-                      case tyRes of
-                        Left diags -> return (key, Left diags)
-                        Right (_ms, nmod, tmod, sourceMeta, moduleSrcBytesHash, modulePubHash, _moduleImplHash, imps, depModules, nameHashes, roots, tests, mdoc) -> do
-                          parsedRes <- parseActFile optsT sp mn actFile Nothing
-                          case parsedRes of
-                            Left diags -> return (key, Left diags)
-                            Right (snap, parsedMod) -> do
-                              let nameSrcHashes =
-                                    M.fromList [ (InterfaceFiles.nhName nh, InterfaceFiles.nhSrcHash nh)
-                                               | nh <- nameHashes
-                                               ]
-                                  nameKeys = M.keysSet nameSrcHashes
-                                  implItems0 = Hashing.topLevelItems tmod
-                                  localNames = nameKeys
-                              let nameImplHashes0 = Hashing.nameHashesFromItems implItems0
-                                  nameImplHashes = M.filterWithKey (\k _ -> Data.Set.member k nameKeys) nameImplHashes0
-                              envRes <- (try :: IO Acton.Env.Env0 -> IO (Either SomeException Acton.Env.Env0)) $
-                                Acton.Env.mkEnv (searchPath paths) envSnap (adjustImports providers parsedMod)
-                              case envRes of
+                      -- The refresh is pure row math: every input is already stored.
+                      -- Own impl-hash components (nhOwnImplHash) and local deps come
+                      -- from the per-name rows, the external dep NAMES from the dep
+                      -- index rows (only their hashes changed -- the module's source
+                      -- is unchanged), and the new dep hashes are resolved fresh.
+                      -- No re-read of the typed module, no re-parse, no dep re-walk;
+                      -- the .tydb is updated surgically. The typed module is read
+                      -- only when the refresh must feed an EAGER back job -- then it
+                      -- is the compilation input.
+                      case taskCurrent of
+                        TyTask{ tyDepModules = depModules, tyPubHash = storedPubHash } -> do
+                          -- The task header carries only the name COUNT (selective
+                          -- reads); the refresh needs the module's own hash rows.
+                          storedNameHashes <- InterfaceFiles.readNameHashes tyFile
+                          moduleHasNotImpl <- InterfaceFiles.readStmtHasNotImpl tyFile
+                          restored <- restorePubDepsFromRows depModules storedNameHashes
+                          -- Only names with an impl item participate in the refresh --
+                          -- exactly the names the front pass gave a (non-empty) own
+                          -- impl-hash component. A signature-only name's impl hash is
+                          -- invariant under dependency changes.
+                          let refreshables =
+                                [ nh | nh <- restored
+                                     , not (B.null (InterfaceFiles.nhOwnImplHash nh)) ]
+                              ownImplHashes = M.fromList
+                                [ (InterfaceFiles.nhName nh, InterfaceFiles.nhOwnImplHash nh) | nh <- refreshables ]
+                              implLocalDeps = M.fromList
+                                [ (InterfaceFiles.nhName nh, InterfaceFiles.nhImplLocalDeps nh) | nh <- refreshables ]
+                              implExtDeps = M.fromList
+                                [ (InterfaceFiles.nhName nh, map fst (InterfaceFiles.nhImplDeps nh)) | nh <- refreshables ]
+                          do
+                              implExtRes <- (try :: IO a -> IO (Either SomeException a)) $
+                                resolveDepHashes "impl" InterfaceFiles.nhImplHash implExtDeps
+                              case implExtRes of
                                 Left err -> handleSyncFailure err
-                                Right env1 -> do
-                                  depRes <- (try :: IO a -> IO (Either SomeException a)) $ do
-                                    let hashEnv = setMod mn env1
-                                    let (implLocalDeps0, implExtDeps0) = Hashing.implSplitDepsFromItems mn hashEnv localNames implItems0
-                                        implLocalDeps = M.fromList
-                                          [ (n, M.findWithDefault [] n implLocalDeps0)
-                                          | n <- M.keys nameSrcHashes
-                                          ]
-                                        implExtDeps = M.fromList
-                                          [ (n, M.findWithDefault [] n implExtDeps0)
-                                          | n <- M.keys nameSrcHashes
-                                          ]
-                                        depCount = sum (map length (M.elems implLocalDeps))
-                                                 + sum (map length (M.elems implExtDeps))
-                                    -- Force dep maps now so stale aliases/missing names
-                                    -- are handled via the front-pass fallback path.
-                                    _ <- evaluate depCount
-                                    implExtRes <- resolveDepHashes "impl" InterfaceFiles.nhImplHash implExtDeps
-                                    return (implLocalDeps, implExtRes)
-                                  case depRes of
-                                    Left err -> handleSyncFailure err
-                                    Right (_, Left _) -> rerunFront
-                                    Right (implLocalDeps, Right implExtHashes) -> do
-                                      nameHashesWithPubDeps <- restorePubDepsFromRows depModules nameHashes
-                                      let updatedNameHashes =
-                                            Hashing.refreshImplHashes nameHashesWithPubDeps nameImplHashes implLocalDeps implExtHashes
-                                          moduleImplHash = Hashing.moduleImplHashFromNameHashes updatedNameHashes
-                                      depModulesRes <- depModulesFromNameHashes updatedNameHashes
-                                      case depModulesRes of
-                                        Left _ -> rerunFront
-                                        Right updatedDepModules -> mask_ $ do
-                                          evaluate (rnf (moduleSrcBytesHash, modulePubHash, moduleImplHash, sourceMeta, imps))
-                                          evaluate (rnf (updatedDepModules, updatedNameHashes, roots, tests, mdoc))
-                                          evaluate (rnf nmod)
-                                          evaluate (rnf tmod)
-                                          let outputKey = TaskKey (projPath paths) mn
-                                              tyDbProgress p =
-                                                ccOnFrontOutputProgress callbacks outputKey FrontOutputTydb (frontOutputTyDbProgress p)
-                                          outputJob <- startFrontOutputJob (ccOnFrontOutputStart callbacks)
-                                                                           (ccOnFrontOutputDone callbacks)
-                                                                           (ccShouldWriteFrontOutput callbacks)
-                                                                           outputKey
-                                                                           FrontOutputTydb $ do
-                                            InterfaceFiles.writeFileWithProgress
-                                              tyDbProgress
-                                              A.version
-                                              tyFile
-                                              moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta imps updatedDepModules updatedNameHashes roots tests mdoc nmod tmod
-                                          tyJobs <-
-                                            if C.tydb optsT
-                                              then (:[]) <$> startDependentFrontOutputJob (ccOnFrontOutputStart callbacks)
-                                                                                         (ccOnFrontOutputDone callbacks)
-                                                                                         (ccShouldWriteFrontOutput callbacks)
-                                                                                         outputJob
-                                                                                         outputKey
-                                                                                         FrontOutputTydbCopy
-                                                                                         (copyTydbInterface optsT paths mn)
-                                              else return []
-                                          let outputJobs = outputJob : tyJobs
-                                          rememberFrontOutputJobList frontOutputRef outputJobs
-                                          let I.NModule imps ifaceFull _mdoc = nmod
-                                              ifaceTE = publicIfaceTE ifaceFull
-                                              deferredBackJob0 = dbpDeferredBackJob (isDbpBlocked key) (A.hasNotImpl (A.mbody tmod)) optsT paths mn moduleImplHash (length updatedNameHashes)
-                                              deferredBackJob = fmap (\dbj -> dbj{ dbjOutputJobs = [outputJob] }) deferredBackJob0
-                                              backJob =
-                                                case deferredBackJob of
-                                                  Just _ -> Nothing
-                                                  Nothing -> Just (mkBackJob env1 tmod (Source.ssText snap) moduleImplHash)
-                                              fr = (mkFrontResult imps ifaceTE mdoc modulePubHash moduleImplHash (publicNameHashes updatedNameHashes) updatedNameHashes backJob deferredBackJob)
-                                                { frOutputJobs = outputJobs }
-                                          cacheFrontResult fr
+                                Right (Left _) -> rerunFront
+                                Right (Right implExtHashes) -> do
+                                  let updatedNameHashes =
+                                        Hashing.refreshImplHashes restored ownImplHashes implLocalDeps implExtHashes
+                                      moduleImplHash = Hashing.moduleImplHashFromNameHashes updatedNameHashes
+                                  depModulesRes <- depModulesFromNameHashes updatedNameHashes
+                                  case depModulesRes of
+                                    Left _ -> rerunFront
+                                    Right updatedDepModules -> do
+                                      evaluate (rnf (moduleImplHash, updatedDepModules, updatedNameHashes))
+                                      let outputKey = TaskKey (projPath paths) mn
+                                          mkOutputJobs = do
+                                            outputJob <- startFrontOutputJob (ccOnFrontOutputStart callbacks)
+                                                                             (ccOnFrontOutputDone callbacks)
+                                                                             (ccShouldWriteFrontOutput callbacks)
+                                                                             outputKey
+                                                                             FrontOutputTydb $
+                                              InterfaceFiles.updateImplRefresh tyFile moduleImplHash updatedDepModules updatedNameHashes
+                                            tyJobs <-
+                                              if C.tydb optsT
+                                                then (:[]) <$> startDependentFrontOutputJob (ccOnFrontOutputStart callbacks)
+                                                                                           (ccOnFrontOutputDone callbacks)
+                                                                                           (ccShouldWriteFrontOutput callbacks)
+                                                                                           outputJob
+                                                                                           outputKey
+                                                                                           FrontOutputTydbCopy
+                                                                                           (copyTydbInterface optsT paths mn)
+                                                else return []
+                                            return (outputJob, outputJob : tyJobs)
+                                          deferredBackJob0 = dbpDeferredBackJob (isDbpBlocked key) moduleHasNotImpl optsT paths mn moduleImplHash (length updatedNameHashes)
+                                      case deferredBackJob0 of
+                                        Just _ -> do
+                                          ifaceRes <- readIfaceFromTy paths mn "" (Just storedPubHash)
+                                          case ifaceRes of
+                                            Left diags -> return (key, Left diags)
+                                            Right (imps, ifaceTE, mdocI, storedPubH, _storedImplH, mModuleInfo) -> mask_ $ do
+                                              (outputJob, outputJobs) <- mkOutputJobs
+                                              rememberFrontOutputJobList frontOutputRef outputJobs
+                                              let deferredBackJob = fmap (\dbj -> dbj{ dbjOutputJobs = [outputJob] }) deferredBackJob0
+                                                  fr = (mkFrontResult imps ifaceTE mdocI storedPubH moduleImplHash (publicNameHashes updatedNameHashes) updatedNameHashes Nothing deferredBackJob)
+                                                    { frOutputJobs = outputJobs
+                                                    , frModuleInfo = mModuleInfo
+                                                    }
+                                              cacheFrontResult fr
+                                        Nothing -> do
+                                          tyRes <- readTyFile
+                                          case tyRes of
+                                            Left diags -> return (key, Left diags)
+                                            Right (_ms, nmod, tmod, _sourceMeta, _moduleSrcBytesHash, modulePubHash, _moduleImplHash, _imps, _depModules, _nameHashes, _roots, _tests, mdoc) -> do
+                                              snap <- Source.readSource sp actFile
+                                              envRes <- (try :: IO Acton.Env.Env0 -> IO (Either SomeException Acton.Env.Env0)) $
+                                                Acton.Env.mkEnv (searchPath paths) envSnap tmod
+                                              case envRes of
+                                                Left err -> handleSyncFailure err
+                                                Right env1 -> mask_ $ do
+                                                  evaluate (rnf nmod)
+                                                  evaluate (rnf tmod)
+                                                  (_outputJob, outputJobs) <- mkOutputJobs
+                                                  rememberFrontOutputJobList frontOutputRef outputJobs
+                                                  let I.NModule imps ifaceFull _mdoc = nmod
+                                                      ifaceTE = publicIfaceTE ifaceFull
+                                                      backJob = Just (mkBackJob env1 tmod (Source.ssText snap) moduleImplHash)
+                                                      fr = (mkFrontResult imps ifaceTE mdoc modulePubHash moduleImplHash (publicNameHashes updatedNameHashes) updatedNameHashes backJob Nothing)
+                                                        { frOutputJobs = outputJobs }
+                                                  cacheFrontResult fr
+                        _ -> rerunFront
                       ) `catch` handleImplRefreshException
                   runCodegenRefresh = do
                     --traceM ("\n## runCodegenRefresh " ++ prstr mn ++ "\n")

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -432,7 +432,7 @@ initEnv path True          = return $ EnvF{ activeNames = [],
                                             context = [],
                                             qlevel = 0,
                                             envX = () }
-initEnv path False         = do (_,nmod,_,_,_,_,_,_,_,_,_,_,_) <- InterfaceFiles.readFile (InterfaceFiles.interfacePath path (modName ["__builtin__"]))
+initEnv path False         = do (_,nmod) <- InterfaceFiles.readModuleIface (InterfaceFiles.interfacePath path (modName ["__builtin__"]))
                                 let NModule _ envBuiltin builtinDocstring = nmod
                                     envBuiltinPublic = publicTEnv envBuiltin
                                     initialNames = []

--- a/compiler/lib/src/Acton/Hashing.hs
+++ b/compiler/lib/src/Acton/Hashing.hs
@@ -1558,12 +1558,13 @@ assembleNameHashes :: Data.Set.Set A.Name
                    -> M.Map A.Name B.ByteString
                    -> M.Map A.Name B.ByteString
                    -> M.Map A.Name B.ByteString
+                   -> M.Map A.Name B.ByteString
                    -> M.Map A.Name [A.Name]
                    -> M.Map A.Name [A.Name]
                    -> M.Map A.Name [(A.QName, B.ByteString)]
                    -> M.Map A.Name [(A.QName, B.ByteString)]
                    -> [InterfaceFiles.NameHashInfo]
-assembleNameHashes nameKeys nameSrcHashes pubHashes implHashes pubLocalDeps implLocalDeps pubExtHashes implExtHashes =
+assembleNameHashes nameKeys nameSrcHashes pubHashes implHashes ownImplHashes pubLocalDeps implLocalDeps pubExtHashes implExtHashes =
   let namesSorted = Data.List.sortOn nameKey (Data.Set.toList nameKeys)
       localDeps m n = Data.List.sortOn nameKey (M.findWithDefault [] n m)
   in
@@ -1572,6 +1573,7 @@ assembleNameHashes nameKeys nameSrcHashes pubHashes implHashes pubLocalDeps impl
         , InterfaceFiles.nhSrcHash = M.findWithDefault B.empty n nameSrcHashes
         , InterfaceFiles.nhPubHash = M.findWithDefault B.empty n pubHashes
         , InterfaceFiles.nhImplHash = M.findWithDefault B.empty n implHashes
+        , InterfaceFiles.nhOwnImplHash = M.findWithDefault B.empty n ownImplHashes
         , InterfaceFiles.nhPubLocalDeps = localDeps pubLocalDeps n
         , InterfaceFiles.nhImplLocalDeps = localDeps implLocalDeps n
         , InterfaceFiles.nhPubDeps = M.findWithDefault [] n pubExtHashes
@@ -1597,7 +1599,7 @@ buildNameHashes nameKeys nameSrcHashes nameImplHashes nameInfoMap pubSigLocalDep
       selfImplHashes = nameImplHashes
       pubHashes = computeHashes selfPubHashes pubSigLocalDeps pubSigExtHashes
       implHashes = computeHashes selfImplHashes implLocalDeps implExtHashes
-  in assembleNameHashes nameKeys nameSrcHashes pubHashes implHashes pubLocalDeps implLocalDeps pubExtHashes implExtHashes
+  in assembleNameHashes nameKeys nameSrcHashes pubHashes implHashes selfImplHashes pubLocalDeps implLocalDeps pubExtHashes implExtHashes
 
 -- | Refresh impl hashes and impl deps for existing name hashes.
 refreshImplHashes :: [InterfaceFiles.NameHashInfo]
@@ -1607,15 +1609,21 @@ refreshImplHashes :: [InterfaceFiles.NameHashInfo]
                   -> [InterfaceFiles.NameHashInfo]
 refreshImplHashes nameHashes nameImplHashes implLocalDeps implExtHashes =
   let implHashes = computeHashesSortedDeps nameImplHashes implLocalDeps implExtHashes
-      infoMap = M.fromList [ (InterfaceFiles.nhName nh, nh) | nh <- nameHashes ]
-      namesSorted = Data.List.sortOn nameKey (M.keys nameImplHashes)
   in
-    [ let nh = infoMap M.! n
-      in nh { InterfaceFiles.nhImplHash = M.findWithDefault B.empty n implHashes
-            , InterfaceFiles.nhImplLocalDeps = Data.List.sortOn nameKey (M.findWithDefault [] n implLocalDeps)
-            , InterfaceFiles.nhImplDeps = M.findWithDefault [] n implExtHashes
-            }
-    | n <- namesSorted
+    -- Return EVERY input name, refreshed or not: the result feeds the module
+    -- impl hash, the dependency index rows and the dependency module list,
+    -- all of which must cover the whole module. A name outside the refresh
+    -- domain (no impl item, empty own hash) passes through unchanged -- its
+    -- stored (empty) impl hash is exactly what the front pass would produce,
+    -- and its pub/impl deps must keep their places in the regenerated rows.
+    [ if M.member n nameImplHashes
+        then nh { InterfaceFiles.nhImplHash = M.findWithDefault B.empty n implHashes
+                , InterfaceFiles.nhImplLocalDeps = Data.List.sortOn nameKey (M.findWithDefault [] n implLocalDeps)
+                , InterfaceFiles.nhImplDeps = M.findWithDefault [] n implExtHashes
+                }
+        else nh
+    | nh <- nameHashes
+    , let n = InterfaceFiles.nhName nh
     ]
 
 -- | Hash module-level pub/impl summaries from the final per-name hash maps.

--- a/compiler/lib/src/Acton/Syntax.hs
+++ b/compiler/lib/src/Acton/Syntax.hs
@@ -26,7 +26,7 @@ import Control.DeepSeq
 import Prelude hiding((<>))
 
 version :: [Int]
-version = [0,32]
+version = [0,33]
 
 data Module     = Module        { modname::ModName, imps::[Import], mdoc::Maybe String, mbody::Suite } deriving (Eq,Show,Generic,NFData)
 

--- a/compiler/lib/src/InterfaceFiles.hs
+++ b/compiler/lib/src/InterfaceFiles.hs
@@ -112,6 +112,8 @@ module InterfaceFiles
   , readNameHashMaybe
   , readModuleHashesMaybe
   , readFile
+  , readModuleIface
+  , readNameHashes
   , readStmtHasNotImpl
   , readHeader
   , readHeaderSummary
@@ -139,6 +141,7 @@ module InterfaceFiles
   , writeFileWithProgress
   , writeFileWithVersion
   , updateSourceMeta
+  , updateImplRefresh
   ) where
 
 import Prelude hiding (readFile, writeFile)
@@ -185,6 +188,11 @@ data NameHashInfo = NameHashInfo
   , nhSrcHash  :: BS.ByteString
   , nhPubHash  :: BS.ByteString
   , nhImplHash :: BS.ByteString
+  -- The name's OWN contribution to nhImplHash, before combining with the
+  -- hashes of its local and external deps. Storing it lets an impl-hash
+  -- refresh recombine hashes from rows alone -- no re-read of the typed
+  -- module, no re-parse and no dependency re-walk.
+  , nhOwnImplHash :: BS.ByteString
   , nhPubLocalDeps  :: [A.Name]
   , nhImplLocalDeps :: [A.Name]
   , nhPubDeps  :: [(A.QName, BS.ByteString)]
@@ -1372,6 +1380,44 @@ updateSourceMeta f sourceMeta = do
       (_oldMeta, srcH, pubH, implH) <- readMeta txn dbi
       putValue txn dbi keyMeta (encodeStrict (sourceMeta, srcH, pubH, implH))
 
+-- | Apply an impl-hash refresh surgically: update the meta row, upsert the
+-- dependency index rows and rewrite only the per-name rows whose stored
+-- encoding actually changed. Everything else (module header, statements,
+-- imports, roots, tests, doc) is left untouched. An impl refresh changes
+-- hashes, never content, so rewriting the whole file -- gigabytes for large
+-- generated modules -- is pure waste. The dep index row KEYS are stable here
+-- (the module's own source is unchanged, so it depends on the same names);
+-- only hash values inside the rows move, hence upserting is complete.
+updateImplRefresh :: FilePath -> BS.ByteString -> [DepModuleInfo] -> [NameHashInfo] -> IO ()
+updateImplRefresh f moduleImplHash depModules nameHashes = do
+    extra <- entryMapSize (depEntries ++ nameEntries)
+    existing <- readMapSize f
+    go (existing + extra)
+  where
+    depEntries = depIndexEntries depModules nameHashes
+    nameEntries = [ (keyNameHash (nhName nh), encodeStrict (stripExternalDeps nh)) | nh <- nameHashes ]
+    go size = do
+      res <- E.try $ withWriteTxn f size $ \txn dbi -> do
+        validateVersion txn dbi
+        (oldMeta, srcH, pubH, _oldImplH) <- readMeta txn dbi
+        putValue txn dbi keyMeta (encodeStrict (oldMeta :: Maybe SourceFileMeta, srcH, pubH, moduleImplHash))
+        mapM_ (uncurry (putValueIfChanged txn dbi)) depEntries
+        mapM_ (uncurry (putValueIfChanged txn dbi)) nameEntries
+      case res of
+        Right () -> return ()
+        Left err | isMapFull err -> go (size * 2)
+        Left (err :: E.SomeException) -> E.throwIO err
+
+-- | Write a row only when its bytes differ from what is stored, keeping
+-- surgical updates from touching (and growing) unchanged pages.
+putValueIfChanged :: LMDB.MDB_txn -> LMDB.MDB_dbi -> BS.ByteString -> BS.ByteString -> IO ()
+putValueIfChanged txn dbi k v = do
+    mOld <- withVal k (LMDB.mdb_get txn dbi)
+    changed <- case mOld of
+      Nothing -> return True
+      Just old -> (/= v) <$> copyVal old
+    when changed (putValue txn dbi k v)
+
 writeFileWithVersion :: [Int] -> FilePath -> BS.ByteString -> BS.ByteString -> BS.ByteString -> Maybe SourceFileMeta -> [(A.ModName, BS.ByteString)] -> [DepModuleInfo] -> [NameHashInfo] -> [A.Name] -> [String] -> Maybe String -> I.NModule -> A.Module -> IO ()
 writeFileWithVersion version f moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta imps depModules nameHashes roots tests mdoc nmod tchecked =
     writeFileWithProgress (\_ -> return ()) version f moduleSrcBytesHash modulePubHash moduleImplHash sourceMeta imps depModules nameHashes roots tests mdoc nmod tchecked
@@ -1416,6 +1462,30 @@ readStmtHasNotImpl f =
       mv <- getMaybeValue "stmt-has-not-impl" txn dbi keyStmtHasNotImpl
       traceTydbRead "stmt-has-not-impl" f (show mv)
       return (maybe False id mv)
+
+-- | Read every per-name hash row of a module (its own rows, not a
+-- dependency's) without touching the interface or statement rows.
+readNameHashes :: FilePath -> IO [NameHashInfo]
+readNameHashes f =
+    withReadTxn f $ \txn dbi -> do
+      validateVersion txn dbi
+      nameHashes <- readNameHashEntries txn dbi
+      traceTydbRead "name-hash-all" f (show (length nameHashes))
+      return nameHashes
+
+-- | Read a module's interface (imports and name infos) without decoding the
+-- typed statement rows -- for consumers that only need the NModule, an eager
+-- readFile pays for deserializing the entire typed module.
+readModuleIface :: FilePath -> IO ([A.ModName], I.NModule)
+readModuleIface f =
+    withReadTxn f $ \txn dbi -> do
+      validateVersion txn dbi
+      mdoc <- getValue "doc" txn dbi keyDoc
+      (te, _nameHashes) <- readNameEntries txn dbi
+      (tmn, timps, tdoc) <- getValue "module-header" txn dbi keyModuleHeader
+      traceTydbRead "iface" f ("names " ++ show (length te))
+      let sourceImps = A.importsOf (A.Module tmn timps tdoc [])
+      return (sourceImps, I.NModule sourceImps te mdoc)
 
 -- Read only cached header fields from .tydb. This avoids decoding the large
 -- NameInfo and typed Module statement sections and is much faster than readFile

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -74,6 +74,7 @@ nameHash n src pub impl =
     , InterfaceFiles.nhSrcHash = src
     , InterfaceFiles.nhPubHash = pub
     , InterfaceFiles.nhImplHash = impl
+    , InterfaceFiles.nhOwnImplHash = impl
     , InterfaceFiles.nhPubLocalDeps = []
     , InterfaceFiles.nhImplLocalDeps = []
     , InterfaceFiles.nhPubDeps = []


### PR DESCRIPTION
This removes the eager whole-module .tydb read (InterfaceFiles.readFile) from every code path where it is avoidable, leaving it only where the whole module is genuinely the input.

The main offender was the impl-hash refresh: when a dependency's implementation changed, the consumer read its ENTIRE .tydb, re-parsed the source, re-walked all dependencies and rewrote the entire file, just to update stored hashes -- gigabytes of read and write traffic on large generated modules for what is semantically a handful of row updates. The refresh is now pure row arithmetic. The one missing ingredient was each name's own impl-hash contribution before combining with dep hashes; the front pass already computes it, so it is now stored per name (nhOwnImplHash, .tydb version 0.33). Own components and local deps come from the module's per-name rows, external dep names from the dependency index rows (the module's own source is unchanged in this path, so only dep hashes move), and fresh dep hashes are resolved as before. The write is surgical (InterfaceFiles.updateImplRefresh): the meta row, the dep index rows, and only those per-name rows whose bytes changed -- statement rows are never touched. The typed module is read only when the refresh must feed an eager back job (library boundary, .ext.c and --no-dbp modules), where it is the compilation input.

Other eager reads narrowed: initEnv and acton sigs only need the interface, so they use a new readModuleIface that skips decoding statement rows; the deferred-back selection's whole-module fallback for missing statement indices is replaced by an internal error, since same-version files always carry the indices and modules with NotImplemented bodies are no longer deferred at all -- the fallback could only mask a corrupt file.

readFile remains for consumers of the whole module: the eager codegen refresh (which compiles what it reads), the dump commands, and the format tests.