### PR TITLE
Fix deserialization backref key type

### DIFF
--- a/base/builtin/common.h
+++ b/base/builtin/common.h
@@ -22,7 +22,7 @@ void $default__init__($WORD);
 
 #define $DNEW($T, $state)   ({ $T $t = acton_malloc(sizeof(struct $T)); \
                                $t->$class = &$T ## G_methods;                                     \
-                               B_dictD_setitem($state->done,(B_Hashable)B_HashableD_intG_witness,toB_bigint($state->row_no-1),$t); \
+                               B_dictD_setitem($state->done,(B_Hashable)B_HashableD_intG_witness,toB_int($state->row_no-1),$t); \
                                $t; })
 
 #define $AND(T, a, b)       ({ T $a = (a); ($a && ((B_value)$a)->$class->__bool__((B_value)$a)) ? (b) : $a; })

--- a/test/regression_auto/.gitignore
+++ b/test/regression_auto/.gitignore
@@ -1,4 +1,5 @@
 *
 !*.act
+!*.ext.c
 !.gitignore
 !Makefile

--- a/test/regression_auto/serialize_shared_ref.act
+++ b/test/regression_auto/serialize_shared_ref.act
@@ -1,0 +1,29 @@
+# Regression: $DNEW registered deserialized objects in the backref dict keyed
+# by toB_bigint, but $step_deserialize probes it with toB_int (both under the
+# int Hashable witness, which reads the B_int val slot). A bigint key can never
+# hash/compare equal to the probe, so any serialized graph referencing the same
+# object twice got NULL for the second reference after deserialization.
+
+class Node(object):
+    val: int
+    def __init__(self, val: int):
+        self.val = val
+
+def round_trip(x: list[Node]) -> list[Node]:
+    """Round-trip through the RTS C serializer ($serialize / $deserialize)"""
+    NotImplemented
+
+actor main(env):
+    n = Node(42)
+    r = round_trip([n, n])
+    if len(r) != 2 or r[0].val != 42:
+        print("bad round-trip result")
+        env.exit(1)
+    # Both elements must be the same object, as in the input; prove it by
+    # writing through one reference and reading through the other.
+    r[0].val = 99
+    if r[1].val == 99:
+        env.exit(0)
+    else:
+        print("shared reference lost in serialization round-trip")
+        env.exit(1)

--- a/test/regression_auto/serialize_shared_ref.ext.c
+++ b/test/regression_auto/serialize_shared_ref.ext.c
@@ -1,0 +1,8 @@
+void serialize_shared_refQ___ext_init__() {
+    // NOP
+}
+
+B_list serialize_shared_refQ_round_trip(B_list x) {
+    $ROW row = $serialize(($Serializable)x, NULL);
+    return (B_list)$deserialize(row, NULL);
+}


### PR DESCRIPTION
Deserializing any object graph that references the same object twice returned NULL for the second reference, corrupting restored actor state or crashing on first use. The $DNEW macro, used by every generated and most hand-written __deserialize__ implementations, registered each freshly created object in the backreference dict keyed by toB_bigint(row_no-1), while $step_deserialize probes that dict with toB_int(key). Both sides use the int Hashable witness, whose hash and eq functions read the B_int val slot at offset 8; in a B_bigint that offset holds the zz_struct limb pointer, so a bigint-registered key can never hash or compare equal to the int probe and the lookup always fell through to NULL.

This was introduced in 560888662 where to$int was renamed to toB_bigint instead of toB_int as part of the big type renaming. All hand-written builtin deserializers (list, dict, set, tuple, bigint) already use toB_int for the same bookkeeping, so the fix is the one-character-class rename back.

No existing test exercised the serializer at all, so this adds a regression test in regression_auto that round-trips a list containing the same object twice through $serialize/$deserialize via a NotImplemented C extension, and verifies the two elements still alias by writing through one reference and reading through the other. Reverting the fix makes the test panic on a NULL object exactly as in the field failure. The .gitignore in test/regression_auto ignored everything but .act files, so it gains an exception for .ext.c files.