### PR TITLE
Fix Json actor actions recursing

### DIFF
--- a/base/src/json.act
+++ b/base/src/json.act
@@ -1,3 +1,37 @@
+def _decode(data: str) -> dict[str, ?value]:
+    NotImplemented
+
+def _decode_list(data: str) -> list[?value]:
+    NotImplemented
+
+def _encode(data: dict[str, ?value], pretty=False) -> str:
+    NotImplemented
+
+def _encode_list(data: list[?value], pretty=False) -> str:
+    NotImplemented
+
+
+def decode(data: str) -> dict[str, ?value]:
+    """Decode a JSON string into a dictionary of values
+    """
+    return _decode(data)
+
+def decode_list(data: str) -> list[?value]:
+    """Decode a JSON string (containing an array) into a list of values
+    """
+    return _decode_list(data)
+
+def encode(data: dict[str, ?value], pretty=False) -> str:
+    """Encode a dictionary into a JSON string
+    """
+    return _encode(data, pretty)
+
+def encode_list(data: list[?value], pretty=False) -> str:
+    """Encode a list into a JSON array string
+    """
+    return _encode_list(data, pretty)
+
+
 actor Json():
     """JSON actor for distributed async processing
 
@@ -11,34 +45,13 @@ actor Json():
     JSON can be distributed across multiple actors / workers / CPUs.
     """
     action def decode(data: str) -> dict[str, ?value]:
-        return decode(data)
+        return _decode(data)
 
     action def decode_list(data: str) -> list[?value]:
-        return decode_list(data)
+        return _decode_list(data)
 
-    action def encode(data: dict[str, ?value]) -> str:
-        return encode(data)
+    action def encode(data: dict[str, ?value], pretty=False) -> str:
+        return _encode(data, pretty)
 
     action def encode_list(data: list[?value], pretty=False) -> str:
-        return encode_list(data, pretty)
-
-
-def decode(data: str) -> dict[str, ?value]:
-    """Decode a JSON string into a dictionary of values
-    """
-    NotImplemented
-
-def decode_list(data: str) -> list[?value]:
-    """Decode a JSON string (containing an array) into a list of values
-    """
-    NotImplemented
-
-def encode(data: dict[str, ?value], pretty=False) -> str:
-    """Encode a dictionary into a JSON string
-    """
-    NotImplemented
-
-def encode_list(data: list[?value], pretty=False) -> str:
-    """Encode a list into a JSON array string
-    """
-    NotImplemented
+        return _encode_list(data, pretty)

--- a/base/src/json.ext.c
+++ b/base/src/json.ext.c
@@ -271,7 +271,7 @@ B_list jsonQ_decode_arr(yyjson_val *arr) {
     return res;
 }
 
-B_dict jsonQ_decode (B_str data) {
+B_dict jsonQ__decode (B_str data) {
     // Read JSON and get root
     yyjson_read_err err;
     yyjson_doc *doc = yyjson_read_opts(fromB_str(data), strlen(fromB_str(data)), 0, &acton_alc, &err);
@@ -292,7 +292,7 @@ B_dict jsonQ_decode (B_str data) {
     return res;
 }
 
-B_list jsonQ_decode_list (B_str data) {
+B_list jsonQ__decode_list (B_str data) {
     // Read JSON and get root
     yyjson_read_err err;
     yyjson_doc *doc = yyjson_read_opts(fromB_str(data), strlen(fromB_str(data)), 0, &acton_alc, &err);
@@ -313,7 +313,7 @@ B_list jsonQ_decode_list (B_str data) {
     return res;
 }
 
-B_str jsonQ_encode (B_dict data, B_bool pretty) {
+B_str jsonQ__encode (B_dict data, B_bool pretty) {
     if (pretty == NULL)
         pretty = B_False;
 
@@ -334,7 +334,7 @@ B_str jsonQ_encode (B_dict data, B_bool pretty) {
     return to$str(json);
 }
 
-B_str jsonQ_encode_list (B_list data, B_bool pretty) {
+B_str jsonQ__encode_list (B_list data, B_bool pretty) {
     if (pretty == NULL)
         pretty = B_False;
 

--- a/std/src/json.act
+++ b/std/src/json.act
@@ -1,3 +1,37 @@
+def _decode(data: str) -> dict[str, ?value]:
+    NotImplemented
+
+def _decode_list(data: str) -> list[?value]:
+    NotImplemented
+
+def _encode(data: dict[str, ?value], pretty=False) -> str:
+    NotImplemented
+
+def _encode_list(data: list[?value], pretty=False) -> str:
+    NotImplemented
+
+
+def decode(data: str) -> dict[str, ?value]:
+    """Decode a JSON string into a dictionary of values
+    """
+    return _decode(data)
+
+def decode_list(data: str) -> list[?value]:
+    """Decode a JSON string (containing an array) into a list of values
+    """
+    return _decode_list(data)
+
+def encode(data: dict[str, ?value], pretty=False) -> str:
+    """Encode a dictionary into a JSON string
+    """
+    return _encode(data, pretty)
+
+def encode_list(data: list[?value], pretty=False) -> str:
+    """Encode a list into a JSON array string
+    """
+    return _encode_list(data, pretty)
+
+
 actor Json():
     """JSON actor for distributed async processing
 
@@ -11,34 +45,13 @@ actor Json():
     JSON can be distributed across multiple actors / workers / CPUs.
     """
     action def decode(data: str) -> dict[str, ?value]:
-        return decode(data)
+        return _decode(data)
 
     action def decode_list(data: str) -> list[?value]:
-        return decode_list(data)
+        return _decode_list(data)
 
-    action def encode(data: dict[str, ?value]) -> str:
-        return encode(data)
+    action def encode(data: dict[str, ?value], pretty=False) -> str:
+        return _encode(data, pretty)
 
     action def encode_list(data: list[?value], pretty=False) -> str:
-        return encode_list(data, pretty)
-
-
-def decode(data: str) -> dict[str, ?value]:
-    """Decode a JSON string into a dictionary of values
-    """
-    NotImplemented
-
-def decode_list(data: str) -> list[?value]:
-    """Decode a JSON string (containing an array) into a list of values
-    """
-    NotImplemented
-
-def encode(data: dict[str, ?value], pretty=False) -> str:
-    """Encode a dictionary into a JSON string
-    """
-    NotImplemented
-
-def encode_list(data: list[?value], pretty=False) -> str:
-    """Encode a list into a JSON array string
-    """
-    NotImplemented
+        return _encode_list(data, pretty)

--- a/std/src/json.ext.c
+++ b/std/src/json.ext.c
@@ -271,7 +271,7 @@ B_list stdQ_jsonQ_decode_arr(yyjson_val *arr) {
     return res;
 }
 
-B_dict stdQ_jsonQ_decode (B_str data) {
+B_dict stdQ_jsonQ__decode (B_str data) {
     // Read JSON and get root
     yyjson_read_err err;
     yyjson_doc *doc = yyjson_read_opts(fromB_str(data), strlen(fromB_str(data)), 0, &stdQ_jsonQ_acton_alc, &err);
@@ -292,7 +292,7 @@ B_dict stdQ_jsonQ_decode (B_str data) {
     return res;
 }
 
-B_list stdQ_jsonQ_decode_list (B_str data) {
+B_list stdQ_jsonQ__decode_list (B_str data) {
     // Read JSON and get root
     yyjson_read_err err;
     yyjson_doc *doc = yyjson_read_opts(fromB_str(data), strlen(fromB_str(data)), 0, &stdQ_jsonQ_acton_alc, &err);
@@ -313,7 +313,7 @@ B_list stdQ_jsonQ_decode_list (B_str data) {
     return res;
 }
 
-B_str stdQ_jsonQ_encode (B_dict data, B_bool pretty) {
+B_str stdQ_jsonQ__encode (B_dict data, B_bool pretty) {
     if (pretty == NULL)
         pretty = B_False;
 
@@ -334,7 +334,7 @@ B_str stdQ_jsonQ_encode (B_dict data, B_bool pretty) {
     return to$str(json);
 }
 
-B_str stdQ_jsonQ_encode_list (B_list data, B_bool pretty) {
+B_str stdQ_jsonQ__encode_list (B_list data, B_bool pretty) {
     if (pretty == NULL)
         pretty = B_False;
 

--- a/test/stdlib_tests/src/test_json.act
+++ b/test/stdlib_tests/src/test_json.act
@@ -56,3 +56,20 @@ def _test_json_encode_fixed_size_int():
         j,
         r"""{"int":4,"i8":-128,"i16":-32768,"i32":-2147483648,"i64":-9223372036854775808,"u1":1,"u8":255,"u16":65535,"u32":4294967295,"u64":18446744073709551615}"""
     )
+
+actor _test_json_actor(t: testing.AsyncT):
+    j = json.Json()
+
+    obj = r"""{"a":1,"b":[2,3]}"""
+    decoded = await async j.decode(obj)
+    testing.assertNotNone(decoded, "Json actor decode() returned None")
+    encoded = await async j.encode(decoded)
+    testing.assertEqual(obj, encoded, "Json actor dict round-trip mismatch")
+
+    arr = r"""[1,2,3]"""
+    decoded_list = await async j.decode_list(arr)
+    testing.assertNotNone(decoded_list, "Json actor decode_list() returned None")
+    encoded_list = await async j.encode_list(decoded_list)
+    testing.assertEqual(arr, encoded_list, "Json actor list round-trip mismatch")
+
+    t.success()


### PR DESCRIPTION
Avoid overlapping the json module function names with the Json actor actions. Use the _ prefix for the C implementations that are then called from both the free functions and actor actions. Fixes #3016