### PR TITLE
Fix panic on pure lambda returning tuple

### DIFF
--- a/compiler/lib/src/Acton/Transform.hs
+++ b/compiler/lib/src/Acton/Transform.hs
@@ -221,6 +221,7 @@ eta (Lambda _ p k (Call _ e p' k') fx)
 eta ee@(Lambda _ (PosPar n (Just t) Nothing PosNIL) KwdNIL (Tuple _ p k) (TFX _ FXPure))
   | idtup t p k                         = eLambda [(n,t)] (eVar n)
   where idtup (TTuple _ prow krow) p k  = ptup (eVar n) 0 prow p && ktup (eVar n) krow k
+        idtup _ _ _                     = False
         ptup e0 i TNil{} PosNil         = True
         ptup e0 i r@TRow{} (PosArg e p) = idot e0 i e && ptup e0 (i+1) (rtail r) p
         ptup e0 i r@TStar{} (PosStar e)

--- a/test/regression_auto/pure_lambda_tuple_eta.act
+++ b/test/regression_auto/pure_lambda_tuple_eta.act
@@ -1,0 +1,11 @@
+# Regression: a pure lambda returning a tuple over a non-tuple
+# parameter crashed eta reduction idtup with "Non-exhaustive
+# patterns in function idtup".
+actor main(env):
+    f: pure(int) -> (int, int) = lambda x: (x-1, x+1)
+    a, b = f(21)
+    if a + b == 42:
+        env.exit(0)
+    else:
+        print("ERROR: got a=%d b=%d" % (a, b))
+        env.exit(1)


### PR DESCRIPTION
idtup lacked a catch-all for non-tuple parameter types in the eta-reduction rule, crashing on any pure lambda returnign a tuple.