### PR TITLE
Type aliases

### DIFF
--- a/compiler/lib/src/Acton/Boxing.hs
+++ b/compiler/lib/src/Acton/Boxing.hs
@@ -363,6 +363,7 @@ unboxedAugTarget env _              = True
 isTypeRef NAct{}                    = True
 isTypeRef NClass{}                  = True
 isTypeRef NProto{}                  = True
+isTypeRef NType{}                   = True
 isTypeRef NExt{}                    = True
 isTypeRef _                         = False
 
@@ -845,6 +846,7 @@ instance Boxing Decl where
             keepSelf p r            = fixpars p r
             te                      = envOf pFinal
             env1                    = setReturnType (Just t') $ setInAction (fx == fxAction) $ define te env
+    boxing env d@Typedef{}          = return (HashSet.empty, d)
   
 instance Boxing Branch where
     boxing env (Branch e ss)       = do (ws1,e') <- boxing env e

--- a/compiler/lib/src/Acton/CPS.hs
+++ b/compiler/lib/src/Acton/CPS.hs
@@ -252,6 +252,8 @@ instance CPS Decl where
             p'                          = conv env p
             t'                          = conv env t
 
+    cps env (Typedef l n q t ddoc)      = return $ Typedef l n (conv env q) (conv env t) ddoc
+
     cps env d                           = error ("cps unexpected: " ++ prstr d)
 
 
@@ -346,6 +348,7 @@ instance NeedCont Stmt where
 instance NeedCont Decl where
     needCont env Class{}                = True
     needCont env d@Def{}                = contFX (dfx d)
+    needCont env _                      = False
 
 ------------------------------------------------
 ------------------------------------------------
@@ -395,6 +398,7 @@ instance PreCPS Decl where
     pre env (Def l n q p _k a b d fx ddoc)
                                         = Def l n q p _k a <$> preSuite env1 b <*> pure d <*> pure fx <*> pure ddoc
       where env1                        = define (envOf p) $ defineTVars q env
+    pre env d@Typedef{}                 = return d
 
 instance PreCPS Branch where
     pre env (Branch e ss)               = Branch  <$> pre env e <*> preSuite env ss
@@ -526,6 +530,7 @@ instance (Conv a) => Conv (Name, a) where
 
 instance Conv NameInfo where
     conv env (NClass q ps te doc)       = NClass q (conv env ps) (conv env te) doc
+    conv env (NType q t doc)            = NType q (conv env t) doc
     conv env (NSig sc dec doc)          = NSig (conv env sc) dec doc
     conv env (NDef sc dec doc)          = NDef (conv env sc) dec doc
     conv env (NVar t)                   = NVar (conv env t)

--- a/compiler/lib/src/Acton/CodeGen.hs
+++ b/compiler/lib/src/Acton/CodeGen.hs
@@ -246,9 +246,11 @@ hStmt _ env s                       = empty
 
 declstub env (Class _ n q a b ddoc) = text "struct" <+> genTopName env n <> semi
 declstub env Def{}                  = empty
+declstub env Typedef{}              = empty
 
 typedef env (Class _ n q a b ddoc)  = text "typedef" <+> text "struct" <+> genTopName env n <+> char '*' <> genTopName env n <> semi
 typedef env Def{}                   = empty
+typedef env Typedef{}               = empty
 
 decl env (Class _ n q a b ddoc)     = (text "struct" <+> classname env n <+> char '{') $+$
                                       nest 4 (vcat $ stdprefix env ++ initdef : serialize env tc : deserialize env tc : meths) $+$
@@ -264,6 +266,7 @@ decl env (Class _ n q a b ddoc)     = (text "struct" <+> classname env n <+> cha
         initNotImpl                 = any hasNotImpl [ b' | Decl _ ds <- b, Def{dname=n',dbody=b'} <- ds, n' == initKW ]
 decl env (Def _ n q p _ (Just t) _ _ fx ddoc)
                                     = repType env (exposeMsg fx t) <+> genTopName env n <+> parens (repParams env $ prowOf p) <> semi
+decl env Typedef{}                  = empty
 methstub env (Class _ n q a b ddoc) = text "extern" <+> text "struct" <+> classname env n <+> methodtable env n <> semi $+$
                                       constub env t n r b $+$
                                       vcat [ methodDefStub env1 d{ dname = methodname n (dname d) } | Decl _ ds <- b', d@Def{} <- ds ]
@@ -272,6 +275,7 @@ methstub env (Class _ n q a b ddoc) = text "extern" <+> text "struct" <+> classn
         c                           = TC (NoQ n) (map tVar $ qbound q)
         env1                        = setInClass (defineTVars q env)
 methstub env Def{}                  = empty
+methstub env Typedef{}              = empty
 
 constub env t n r b
   | null ns || hasNotImpl b         = rawType env t <+> newcon env n <> parens (rawParams env r) <> semi
@@ -544,6 +548,8 @@ declDecl env (Class _ n q as b ddoc)
         sup_c                       = filter ((`elem` special_repr) . tcname) as
         special_repr                = [primActor] -- To be extended...
         cDefinedClass               = inBuiltin env && any hasNotImpl [b' | Decl _ ds <- b, Def{dname=n',dbody=b'} <- ds, n' == initKW ]
+
+declDecl env Typedef{}              = empty
 
 declCleanup env n sup_c
   -- TODO: only match if this is an actor, or even better if this actor has a __cleanup__ method defined (not empty!?)

--- a/compiler/lib/src/Acton/Completion.hs
+++ b/compiler/lib/src/Acton/Completion.hs
@@ -764,6 +764,7 @@ typeOfInfo info =
     I.NSVar t -> Just t
     I.NDef schema _ _ -> Just (S.sctype schema)
     I.NSig schema _ _ -> Just (S.sctype schema)
+    I.NType _ t _ -> Just t
     _ -> Nothing
 
 callResultType :: Env.Env0 -> SourceContext -> [String] -> Maybe S.Type
@@ -845,6 +846,7 @@ docOfInfo info =
       I.NAct _ _ _ _ doc -> doc
       I.NClass _ _ _ doc -> doc
       I.NProto _ _ _ doc -> doc
+      I.NType _ _ doc -> doc
       I.NExt _ _ _ _ _ doc -> doc
       _ -> Nothing
 

--- a/compiler/lib/src/Acton/Converter.hs
+++ b/compiler/lib/src/Acton/Converter.hs
@@ -251,6 +251,7 @@ convEnvProtos env                       = convertModules convSources conv env
     conv m ni@(n, NExt q c us te opts doc)
                                         = map (fromClass env) $ convExtension (define [ni] env) n c q us [] [] (fromTEnv te) opts
     conv m (n, NClass q us te doc)      = [(n, NClass (noqual env q) us (convClassTEnv env q te) doc)]
+    conv m (n, NType q t doc)           = [(n, NType (noqual env q) (convT q t) doc)]
     conv m ni                           = [ni]
     convS (TSchema l q t)               = TSchema l (noqual env q) (convT q t)
     convT q (TFun l x p k t)            = TFun l x (qualWRow env q p) k t
@@ -272,6 +273,8 @@ fromDefs env (Def l n q p k a _ d fx ddoc : ds)
                                         = (n, NDef (TSchema NoLoc q (TFun NoLoc fx (prowOf' p d) (krowOf k) (fromJust a))) d ddoc) : fromDefs env ds
   where prowOf' p Static                = prowOf p
         prowOf' (PosPar _ _ _ p) _      = prowOf p
+fromDefs env (Typedef l n q t ddoc : ds)
+                                        = (n, NType q t ddoc) : fromDefs env ds
 fromDefs env (_ : ds)                   = fromDefs env ds
 fromDefs env []                         = []
 
@@ -281,6 +284,7 @@ fromTEnv ((n, NDef sc dec doc) : te)    = Decl NoLoc [def] : fromTEnv te
         def                             = Def NoLoc n q (pPar' dec p) (kPar attrKW k) (Just t) [sNotImpl] dec fx doc
         pPar' Static p                  = pPar pNames p
         pPar' _ p                       = pPar pNames (posRow tSelf p)
+fromTEnv ((n, NType q t doc) : te)      = Decl NoLoc [Typedef NoLoc n q t doc] : fromTEnv te
 fromTEnv ((n, NVar t) : te)             = sAssign (pVar n t) eNotImpl : fromTEnv te
 fromTEnv (_ : te)                       = fromTEnv te
 fromTEnv []                             = []

--- a/compiler/lib/src/Acton/Deactorizer.hs
+++ b/compiler/lib/src/Acton/Deactorizer.hs
@@ -185,6 +185,8 @@ instance Deact Decl where
                                     = Class l n q u <$> deactSuite env1 b <*> pure ddoc
       where env1                    = defineTVars (selfQuant (NoQ n) q) env
 
+    deact env d@Typedef{}           = return d
+
     deact env d                     = error ("deact unexpected decl: " ++ prstr d)
 
 newact env n q p ddoc               = Def l0 (newactName n) q p KwdNIL (Just t) [newassign, install_gc_finalizer, waitinit, sReturn x] NoDec fxProc ddoc

--- a/compiler/lib/src/Acton/Diagnostics.hs
+++ b/compiler/lib/src/Acton/Diagnostics.hs
@@ -56,6 +56,8 @@ customParseErrorToDiagnostic InvalidTopLevelAssignmentPattern  = ("Module top-le
 customParseErrorToDiagnostic (DuplicateTopLevelAssignment name) = ("Module top-level name '" ++ name ++ "' cannot be assigned more than once",
                                                                    [Note "Module top-level assignments define constants",
                                                                     Hint "Use a fresh name or move mutable state into an actor"])
+customParseErrorToDiagnostic (CyclicTypedef names)              = ("Type definitions " ++ show names ++ " are cyclically dependent",
+                                                                   [Hint "A dependency cycle among types must involve at least one class or actor name"])
 -- String interpolation errors
 customParseErrorToDiagnostic EmptyInterpolationExpression       = ("Empty expression in string interpolation",
                                                                   [Hint "Add an expression between the braces, e.g. {name}"])

--- a/compiler/lib/src/Acton/DocPrinter.hs
+++ b/compiler/lib/src/Acton/DocPrinter.hs
@@ -98,6 +98,7 @@ extractNameDocstring (NSig _ _ mdoc) = mdoc
 extractNameDocstring (NAct _ _ _ _ mdoc) = mdoc
 extractNameDocstring (NClass _ _ _ mdoc) = mdoc
 extractNameDocstring (NProto _ _ _ mdoc) = mdoc
+extractNameDocstring (NType _ _ mdoc) = mdoc
 extractNameDocstring (NExt _ _ _ _ _ mdoc) = mdoc
 extractNameDocstring _ = Nothing
 
@@ -247,6 +248,21 @@ docDeclWithTypes tenv (Protocol _ n q a b ddoc) =
         methods = docProtocolBodyWithTypes tenv b
     in header $+$ docstrDoc $+$
        (if isEmpty methods then empty else blank $+$ methods)
+
+docDeclWithTypes tenv (Typedef _ n q t ddoc) =
+    let (targetType, mdocstring) = case lookup n tenv of
+            Just info@(NType _ t' _) -> (t', extractNameDocstring info)
+            Just info -> (t, extractNameDocstring info)
+            _ -> (t, Nothing)
+        docstr = case mdocstring of
+            Just ds -> Just ds
+            Nothing -> ddoc
+        header = text "##" <+> text "*type*" <+> text "`" <> pretty n <> text "`" <>
+                 docGenerics q <+> text "=" <+> pretty targetType
+        docstrDoc = case docstr of
+            Just ds -> blank $+$ text ds
+            Nothing -> empty
+    in header $+$ docstrDoc
 
 docDeclWithTypes tenv (Extension _ q c a b ddoc) =
     let mdocstring = Nothing  -- Extensions don't have their own docstrings in TEnv
@@ -917,6 +933,22 @@ docDeclUnified useStyle tenv (Protocol _ n q a b ddoc) =
                 Just ds -> nest 2 (text ds)
                 Nothing -> empty
         in header $+$ (if isEmpty docstrDoc then empty else docstrDoc)
+
+docDeclUnified useStyle tenv (Typedef _ n q t ddoc) =
+    let (targetType, docstringFromTEnv) = case lookup n tenv of
+            Just info@(NType _ t' _) -> (t', extractNameDocstring info)
+            Just info -> (t, extractNameDocstring info)
+            _ -> (t, Nothing)
+        docstr = case docstringFromTEnv of
+            Just ds -> Just ds
+            Nothing -> ddoc
+        header = text (cyan useStyle ++ "type" ++ reset useStyle) <+>
+                 text (bold useStyle) <> pretty n <> text (reset useStyle) <>
+                 docGenerics q <+> text "=" <+> pretty targetType
+        docstrDoc = case docstr of
+            Just ds -> nest 2 (text ds)
+            Nothing -> empty
+    in header $+$ (if isEmpty docstrDoc then empty else docstrDoc)
 
 docDeclUnified useStyle tenv (Extension _ q c a b ddoc) =
     let docstringFromTEnv = Nothing  -- Extensions don't have docstrings in TEnv
@@ -2455,10 +2487,28 @@ docDeclHtmlWithTypesAndClassesAndModule tenv currentModule classNames decl =
         Protocol _ n q a b ddoc ->
             let wtcons = map (\pc -> ([], pc)) a
             in docProtocolHtmlWithModule tenv currentModule classNames n q wtcons b ddoc
+        Typedef _ n q t ddoc -> docTypedefHtmlWithModule tenv currentModule classNames n q t ddoc
         Extension _ q c a b ddoc ->
             let wtcons = map (\pc -> ([], pc)) a
             in docExtensionHtmlWithModule tenv currentModule classNames q c wtcons b ddoc
   where
+    docTypedefHtmlWithModule tenv curMod classNames n q t ddoc =
+        let generics = extractGenerics q
+            (targetType, mdocstring) = case Map.lookup n tenv of
+                Just info@(NType _ t' _) -> (t', extractNameDocstring info)
+                Just info -> (t, extractNameDocstring info)
+                _ -> (t, ddoc)
+            header = text "<h2 class=\"type-context\"><span class=\"keyword\">type</span> <code>" <> pretty n <> text "</code>" <>
+                     docGenericsHtmlWithHighlight generics q <> text " = <span class=\"type\">" <>
+                     text (renderTypeWithGenericsConstraintsAndClassesAndModule curMod generics [] classNames targetType) <>
+                     text "</span></h2>"
+            docstr = case mdocstring of
+                Just ds -> text "<div class=\"docstring\">" <> text (nl2br $ htmlEscape ds) <> text "</div>"
+                Nothing -> empty
+        in header $+$ docstr
+      where
+        nl2br = intercalate "<br>" . lines
+
     docDefHtmlWithModule tenv curMod classNames n q p k a b d ddoc =
         let explicitGenerics = extractGenerics q
             funcScope = "def-" ++ nstr n
@@ -2700,6 +2750,23 @@ docDeclHtmlWithTypesAndClasses tenv classNames (Protocol _ n q a b ddoc) =
         methods = docProtocolBodyHtmlWithGenericsTypesAndClasses tenv generics classNames b
     in header $+$ docstr $+$
        (if isEmpty methods then empty else blank $+$ methods)
+  where
+    nl2br = intercalate "<br>" . lines
+
+docDeclHtmlWithTypesAndClasses tenv classNames (Typedef _ n q t ddoc) =
+    let generics = extractGenerics q
+        (targetType, mdocstring) = case lookup n tenv of
+            Just info@(NType _ t' _) -> (t', extractNameDocstring info)
+            Just info -> (t, extractNameDocstring info)
+            _ -> (t, ddoc)
+        header = text "<h2 class=\"type-context\"><span class=\"keyword\">type</span> <code>" <> pretty n <> text "</code>" <>
+                 docGenericsHtmlWithHighlight generics q <> text " = <span class=\"type\">" <>
+                 text (renderTypeWithGenericsConstraintsAndClasses generics [] classNames targetType) <>
+                 text "</span></h2>"
+        docstr = case mdocstring of
+            Just ds -> text "<div class=\"docstring\">" <> text (nl2br $ htmlEscape ds) <> text "</div>"
+            Nothing -> empty
+    in header $+$ docstr
   where
     nl2br = intercalate "<br>" . lines
 

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -808,7 +808,7 @@ localCons env               = local (reverse (closedNames env)) ++ local (revers
 
 tExpand                     :: EnvF x -> TCon -> Maybe Type
 tExpand env (TC n ts)       = case findQName n env of
-                                NType q t _ -> Just $ vsubst (qbound q `zip` ts) t
+                                NType q t _ -> Just $ expanded env $ vsubst (qbound q `zip` ts) t
                                 _ -> Nothing
 
 expanded                    :: EnvF x -> Type -> Type

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -808,7 +808,7 @@ localCons env               = local (reverse (closedNames env)) ++ local (revers
 
 tExpand                     :: EnvF x -> TCon -> Maybe Type
 tExpand env (TC n ts)       = case findQName n env of
-                                NType q t _ -> Just $ expanded env $ vsubst (qbound q `zip` ts) t
+                                NType q t _ -> Just $ vsubst (qbound q `zip` ts) t
                                 _ -> Nothing
 
 expanded                    :: EnvF x -> Type -> Type

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -1076,6 +1076,11 @@ castable env (TCon _ c1) (TCon _ c2)
   | Just (wf,c') <- search                  = tcargs c2 == tcargs c'
   where search                              = findAncestor env c1 (tcname c2)
 
+castable env (TCon _ c1) t2
+  | Just t1 <- tExpand env c1               = castable env t1 t2
+castable env t1 (TCon _ c2)
+  | Just t2 <- tExpand env c2               = castable env t1 t2
+
 castable env (TFun _ fx1 p1 k1 t1) (TFun _ fx2 p2 k2 t2)
                                             = castable env fx1 fx2 && castable env p2 p1 && castable env k2 k1 && castable env t1 t2
 

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -806,6 +806,16 @@ localCons env               = local (reverse (closedNames env)) ++ local (revers
         isCon NAct{}        = True
         isCon _             = False
 
+tExpand                     :: EnvF x -> TCon -> Maybe Type
+tExpand env (TC n ts)       = case findQName n env of
+                                NType q t _ -> Just $ vsubst (qbound q `zip` ts) t
+                                _ -> Nothing
+
+expanded                    :: EnvF x -> Type -> Type
+expanded env (TCon _ c)
+  | Just t <- tExpand env c = expanded env t
+expanded env t              = t
+
 findCon                     :: EnvF x -> TCon -> ([WTCon],TEnv)
 findCon env (TC n ts)
   | map tVar tvs == ts      = (us, te)
@@ -997,7 +1007,6 @@ localProtos env             = local (reverse (closedNames env)) ++ local (revers
 hasAttr                     :: EnvF x -> TCon -> Name -> Bool
 hasAttr env tc n            = maybe False (const True) (findAttrInfo' env (tcname tc) n)
 
-
 -- TVar queries ------------------------------------------------------------------------------------------------------------------
 
 findSelf                    :: EnvF x -> TCon
@@ -1128,6 +1137,11 @@ glb env (TCon _ c1) (TCon _ c2)
   | hasAncestor env c1 c2               = pure $ tCon c1
   | hasAncestor env c2 c1               = pure $ tCon c2
 
+glb env (TCon _ c1) t2
+  | Just t1 <- tExpand env c1           = glb env t1 t2
+glb env t1 (TCon _ c2)
+  | Just t2 <- tExpand env c2           = glb env t1 t2
+
 glb env (TFun _ e1 p1 k1 t1) (TFun _ e2 p2 k2 t2)
                                         = do e <- glb env e1 e2
                                              (p, k) <- lub2 env p1 k1 p2 k2
@@ -1213,6 +1227,11 @@ lub env (TCon _ c1) (TCon _ c2)
   | hasAncestor env c2 c1               = pure $ tCon c1
   | not $ null common                   = pure $ tCon $ head common
   where common                          = commonAncestors env c1 c2
+
+lub env (TCon _ c1) t2
+  | Just t1 <- tExpand env c1           = lub env t1 t2
+lub env t1 (TCon _ c2)
+  | Just t2 <- tExpand env c2           = lub env t1 t2
 
 lub env f1@(TFun _ e1 p1 k1 t1) f2@(TFun _ e2 p2 k2 t2)
                                         = do e <- lub env e1 e2

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -391,6 +391,7 @@ instance Unalias NameInfo where
     unalias env (NAct q p k te doc) = NAct (unalias env q) (unalias env p) (unalias env k) (unalias env te) doc
     unalias env (NClass q us te doc)= NClass (unalias env q) (unalias env us) (unalias env te) doc
     unalias env (NProto q us te doc)= NProto (unalias env q) (unalias env us) (unalias env te) doc
+    unalias env (NType q t doc)     = NType (unalias env q) (unalias env t) doc
     unalias env (NExt q c ps te opts doc)= NExt (unalias env q) (unalias env c) (unalias env ps) (unalias env te) opts doc
     unalias env (NTVar k c ps)      = NTVar k (unalias env c) (unalias env ps)
     unalias env (NAlias qn)         = NAlias (unalias env qn)
@@ -713,6 +714,7 @@ tconKind n env              = case findQName n env of
                                 NAct q _ _ _ _ -> kind KType q
                                 NClass q _ _ _ -> kind KType q
                                 NProto q _ _ _ -> kind KProto q
+                                NType q _ _    -> kind KType q
                                 NReserved    -> nameReserved n
                                 _            -> notClassOrProto n
   where kind k []           = k
@@ -1410,6 +1412,7 @@ impName _ mi n              = case moduleLookupName mi n of
                                 Just NAct{}   -> imported
                                 Just NClass{} -> imported
                                 Just NProto{} -> imported
+                                Just NType{}  -> imported
                                 Just NExt{}   -> Nothing
                                 Just NAlias{} -> imported
                                 Just NVar{}   -> imported
@@ -1573,6 +1576,8 @@ instance Simp (Name, NameInfo) where
     simp env (n, NClass q us te doc)= (n, NClass (simp env' q) (simp env' us) (simp env' te) doc)
       where env'                    = defineTVars (stripQual q) env
     simp env (n, NProto q us te doc)= (n, NProto (simp env' q) (simp env' us) (simp env' te) doc)
+      where env'                    = defineTVars (stripQual q) env
+    simp env (n, NType q t doc)     = (n, NType (simp env' q) (simp env' t) doc)
       where env'                    = defineTVars (stripQual q) env
     simp env (n, NExt q c us te opts doc)
                                     = (n, NExt q' (vsubst s $ simp env' c) (vsubst s $ simp env' us) (vsubst s $ simp env' te) opts doc)

--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -818,6 +818,7 @@ findConName n env           = case findQName n env of
                                 NAct q p k te _  -> (q, [], notHidden te)
                                 NClass q us te _ -> (q, us, te)
                                 NProto q us te _ -> (q, us, te)
+                                NType q t _      -> (q, [], [])
                                 NExt q c us te _ _ -> (q, us, te)
                                 NReserved -> nameReserved n
                                 i -> err1 n ("findConName: Class or protocol name expected, got " ++ show i ++ " --- ")

--- a/compiler/lib/src/Acton/Hashing.hs
+++ b/compiler/lib/src/Acton/Hashing.hs
@@ -424,6 +424,9 @@ feedDecl decl sink = case decl of
   A.Protocol _ n q ps b doc ->
     feedTag 43 sink >> feedName n sink >> feedQBinds q sink >> feedList feedTCon ps sink >>
     feedSuite b sink >> feedMaybe feedString doc sink
+  A.Typedef _ n q t doc ->
+    feedTag 45 sink >> feedName n sink >> feedQBinds q sink >> feedType t sink >>
+    feedMaybe feedString doc sink
   A.Extension _ q c ps b doc ->
     feedTag 44 sink >> feedQBinds q sink >> feedTCon c sink >> feedList feedTCon ps sink >>
     feedSuite b sink >> feedMaybe feedString doc sink
@@ -702,6 +705,7 @@ feedNameInfo info sink = feedTag 249 sink >> case info of
   I.NAct q p k te _  -> feedTag 4 sink >> feedQBinds q sink >> feedType p sink >> feedType k sink >> feedTEnv te sink
   I.NClass q cs te _ -> feedTag 5 sink >> feedQBinds q sink >> feedList feedWTCon cs sink >> feedTEnv te sink
   I.NProto q ps te _ -> feedTag 6 sink >> feedQBinds q sink >> feedList feedWTCon ps sink >> feedTEnv te sink
+  I.NType q t _      -> feedTag 10 sink >> feedQBinds q sink >> feedType t sink
   I.NExt q c ps te o _ ->
     feedTag 7 sink >> feedQBinds q sink >> feedTCon c sink >> feedList feedWTCon ps sink >>
     feedTEnv te sink >> feedList feedName o sink
@@ -866,6 +870,7 @@ foldNameInfoDeps add info acc = case info of
   I.NAct q p k te _    -> foldDepsTEnv add te (foldDepsType add k (foldDepsType add p (foldDepsList (foldDepsQBind add) q acc)))
   I.NClass q ws te _   -> foldDepsTEnv add te (foldDepsList (foldDepsWTCon add) ws (foldDepsList (foldDepsQBind add) q acc))
   I.NProto q ws te _   -> foldDepsTEnv add te (foldDepsList (foldDepsWTCon add) ws (foldDepsList (foldDepsQBind add) q acc))
+  I.NType q t _        -> foldDepsType add t (foldDepsList (foldDepsQBind add) q acc)
   I.NExt q c ws te _ _ -> foldDepsTEnv add te (foldDepsList (foldDepsWTCon add) ws (foldDepsTCon add c (foldDepsList (foldDepsQBind add) q acc)))
   I.NTVar _ c ps       -> foldDepsList (foldDepsTCon add) ps (foldDepsTCon add c acc)
   I.NAlias qn          -> add qn acc
@@ -966,6 +971,7 @@ boundDecl decl acc = case decl of
   A.Actor _ n _ _ _ _ _     -> Data.Set.insert n acc
   A.Class _ n _ _ _ _       -> Data.Set.insert n acc
   A.Protocol _ n _ _ _ _    -> Data.Set.insert n acc
+  A.Typedef _ n _ _ _       -> Data.Set.insert n acc
   A.Extension{}             -> acc
 
 boundBranch :: A.Branch -> NameSet -> NameSet
@@ -1158,6 +1164,9 @@ implItemSplitDeps mn env localNames item =
       A.Protocol _ n q ps b _ ->
         let bound' = Data.Set.insert n (assignedSuite b (boundList boundQBind q bound))
         in splitSuiteDirect bound' b (splitListInto (splitTConDirect bound') ps acc)
+      A.Typedef _ n q t _ ->
+        let bound' = Data.Set.insert n (boundList boundQBind q bound)
+        in splitTypeDirect bound' t acc
       A.Extension _ q c ps b _ ->
         let bound' = assignedSuite b (boundList boundQBind q bound)
         in splitSuiteDirect bound' b (splitListInto (splitTConDirect bound') ps (splitTConDirect bound' c acc))

--- a/compiler/lib/src/Acton/Kinds.hs
+++ b/compiler/lib/src/Acton/Kinds.hs
@@ -106,6 +106,9 @@ autoQuantD env (Def l n q p k t b d x doc)
 autoQuantD env (Extension l q c ps b doc)
                                     = Extension l (q ++ auto_q) c ps b doc
   where auto_q                      = map qbind $ nub (vfree q ++ vfree c ++ vfree ps) \\ (tvSelf : qbound q ++ tvars env)
+autoQuantD env (Typedef l n q t doc)
+                                    = Typedef l n (q ++ auto_q) t doc
+  where auto_q                      = map qbind $ nub (vfree q ++ vfree t) \\ (qbound q ++ tvars env)
 autoQuantD env d                    = d
 
 
@@ -275,6 +278,7 @@ kchkSuite env (Decl l ds : ss)      = do ds <- instKWild (map (autoQuantD env) d
   where kinds (Actor _ n q _ _ _ _) = [(n, NAct q posNil kwdNil [] Nothing)]
         kinds (Class _ n q _ _ _)   = [(n, NClass q [] [] Nothing)]
         kinds (Protocol _ n q _ _ _)= [(n, NProto q [] [] Nothing)]
+        kinds (Typedef _ n q _ _)   = [(n, NType q tWild Nothing)]
         kinds _                     = []
         kind k []                   = k
         kind k q                    = KFun [ tvkind v | QBind v _ <- q ] k
@@ -335,6 +339,15 @@ instance KCheck Decl where
     kchk env (Protocol l n q us b doc)
                                     = do env1 <- extvars (tvSelf : qbound q) env
                                          Protocol l n <$> kchkQBinds env1 q <*> kchkPBounds env1 us <*> kchkSuite env1 b <*> pure doc
+    kchk env (Typedef l n q t doc)
+                                    = do tmp <- swapXVars []
+                                         q <- convPExist env q
+                                         t <- convPExist env t
+                                         q <- (q++) <$> swapXVars tmp
+                                         env1 <- extvars (qbound q) env
+                                         q <- convTWild env1 q
+                                         t <- convTWild env1 t
+                                         Typedef l n <$> kchkQBinds env1 q <*> kexp KType env1 t <*> pure doc
     kchk env (Extension l q c us b doc)
       | not $ null ambig            = err2 ambig "Ambiguous type variables in extension:"
       | not $ null undet            = err2 undet "Type variables undetermined by extended class:"
@@ -666,6 +679,8 @@ instance KSubst Decl where
     ksubst g (Class l n q as b doc) = Class l n <$> ksubst g q <*> ksubst g as <*> ksubst g b <*> return doc
     ksubst g (Protocol l n q as b doc)
                                     = Protocol l n <$> ksubst g q <*> ksubst g as <*> ksubst g b <*> return doc
+    ksubst g (Typedef l n q t doc)
+                                    = Typedef l n <$> ksubst g q <*> ksubst g t <*> return doc
     ksubst g (Extension l q c as b doc)
                                     = Extension l <$> ksubst g q <*> ksubst g c <*> ksubst g as <*> ksubst g b <*> return doc
 

--- a/compiler/lib/src/Acton/Kinds.hs
+++ b/compiler/lib/src/Acton/Kinds.hs
@@ -338,13 +338,7 @@ instance KCheck Decl where
                                     = do env1 <- extvars (tvSelf : qbound q) env
                                          Protocol l n <$> kchkQBinds env1 q <*> kchkPBounds env1 us <*> kchkSuite env1 b <*> pure doc
     kchk env (Typedef l n q t doc)
-                                    = do tmp <- swapXVars []
-                                         q <- convPExist env q
-                                         t <- convPExist env t
-                                         q <- (q++) <$> swapXVars tmp
-                                         env1 <- extvars (qbound q) env
-                                         q <- convTWild env1 q
-                                         t <- convTWild env1 t
+                                    = do env1 <- extvars (qbound q) env
                                          Typedef l n <$> kchkQBinds env1 q <*> kexp KType env1 t <*> pure doc
     kchk env (Extension l q c us b doc)
       | not $ null ambig            = err2 ambig "Ambiguous type variables in extension:"

--- a/compiler/lib/src/Acton/Kinds.hs
+++ b/compiler/lib/src/Acton/Kinds.hs
@@ -107,9 +107,6 @@ autoQuantD env (Def l n [] p k t b d x doc)
 autoQuantD env (Extension l [] c ps b doc)
                                     = Extension l auto_q c ps b doc
   where auto_q                      = map qbind $ nub (vfree c ++ vfree ps) \\ [tvSelf]
-autoQuantD env (Typedef l n [] t doc)
-                                    = Typedef l n auto_q t doc
-  where auto_q                      = map qbind $ nub (vfree t)
 autoQuantD env d                    = d
 
 

--- a/compiler/lib/src/Acton/Kinds.hs
+++ b/compiler/lib/src/Acton/Kinds.hs
@@ -97,18 +97,19 @@ instance Pretty (Name,Kind) where
     pretty (n,k)                    = pretty n <+> colon <+> pretty k
 
 
-autoQuantS env (TSchema l q t)      = TSchema l (q ++ auto_q) t
-  where auto_q                      = map qbind $ nub (vfree q ++ vfree t) \\ (tvSelf : qbound q ++ tvars env)
+autoQuantS env (TSchema l [] t)     = TSchema l auto_q t
+  where auto_q                      = map qbind $ nub (vfree t) \\ (tvSelf : tvars env)
+autoQuantS env sc                   = sc
 
-autoQuantD env (Def l n q p k t b d x doc)
-                                    = Def l n (q ++ auto_q) p k t b d x doc
-  where auto_q                      = map qbind $ nub (vfree q ++ vfree p ++ vfree k ++ vfree t) \\ (tvSelf : qbound q ++ tvars env)
-autoQuantD env (Extension l q c ps b doc)
-                                    = Extension l (q ++ auto_q) c ps b doc
-  where auto_q                      = map qbind $ nub (vfree q ++ vfree c ++ vfree ps) \\ (tvSelf : qbound q ++ tvars env)
-autoQuantD env (Typedef l n q t doc)
-                                    = Typedef l n (q ++ auto_q) t doc
-  where auto_q                      = map qbind $ nub (vfree q ++ vfree t) \\ (qbound q ++ tvars env)
+autoQuantD env (Def l n [] p k t b d x doc)
+                                    = Def l n auto_q p k t b d x doc
+  where auto_q                      = map qbind $ nub (vfree p ++ vfree k ++ vfree t) \\ (tvSelf : tvars env)
+autoQuantD env (Extension l [] c ps b doc)
+                                    = Extension l auto_q c ps b doc
+  where auto_q                      = map qbind $ nub (vfree c ++ vfree ps) \\ [tvSelf]
+autoQuantD env (Typedef l n [] t doc)
+                                    = Typedef l n auto_q t doc
+  where auto_q                      = map qbind $ nub (vfree t)
 autoQuantD env d                    = d
 
 

--- a/compiler/lib/src/Acton/LambdaLifter.hs
+++ b/compiler/lib/src/Acton/LambdaLifter.hs
@@ -240,6 +240,7 @@ instance Lift Decl where
     ll env (Class l n q cs b doc)       = do b' <- llSuite (setCtxt InClass env1) b
                                              return $ Class l n q (conv cs) b' doc
       where env1                        = defineTVars (selfQuant (NoQ n) q) env
+    ll env (Typedef l n q t doc)        = return $ Typedef l n (conv q) (conv t) doc
     ll env d                            = error ("ll unexpected: " ++ prstr d)
 
 instance Lift Branch where
@@ -454,6 +455,7 @@ instance (Conv a) => Conv (Name, a) where
 
 instance Conv NameInfo where
     conv (NClass q ps te doc)           = NClass (conv q) (conv ps) (conv te) doc
+    conv (NType q t doc)                = NType (conv q) (conv t) doc
     conv (NSig sc Property doc)         = NSig (conv sc) Property doc
     conv (NSig sc dec doc)              = NSig (convTop sc) dec doc
     conv (NDef sc dec doc)              = NDef (convTop sc) dec doc

--- a/compiler/lib/src/Acton/NameInfo.hs
+++ b/compiler/lib/src/Acton/NameInfo.hs
@@ -56,6 +56,7 @@ data NameInfo           = NVar      Type
                         | NAct      QBinds PosRow KwdRow TEnv (Maybe String)
                         | NClass    QBinds [WTCon] TEnv (Maybe String)
                         | NProto    QBinds [WTCon] TEnv (Maybe String)
+                        | NType     QBinds Type (Maybe String)
                         | NExt      QBinds TCon [WTCon] TEnv [Name] (Maybe String)
                         | NTVar     Kind CCon [PCon]
                         | NAlias    QName
@@ -81,6 +82,7 @@ stripDocsNI ni = case ni of
   NAct q p k te _     -> NAct q p k (map stripBind te) Nothing
   NClass q cs te _    -> NClass q cs (map stripBind te) Nothing
   NProto q ps te _    -> NProto q ps (map stripBind te) Nothing
+  NType q t _         -> NType q t Nothing
   NExt q c ps te o _  -> NExt q c ps (map stripBind te) o Nothing
   NDef sc dec _       -> NDef sc dec Nothing
   NSig sc dec _       -> NSig sc dec Nothing
@@ -105,6 +107,7 @@ stripLocsNI ni = case ni of
   NAct q p k te doc  -> NAct (stripLocsQBinds q) (stripLocsType p) (stripLocsType k) (stripLocsTEnv te) doc
   NClass q cs te doc -> NClass (stripLocsQBinds q) (map stripLocsWTCon cs) (stripLocsTEnv te) doc
   NProto q ps te doc -> NProto (stripLocsQBinds q) (map stripLocsWTCon ps) (stripLocsTEnv te) doc
+  NType q t doc      -> NType (stripLocsQBinds q) (stripLocsType t) doc
   NExt q c ps te o doc ->
     NExt (stripLocsQBinds q) (stripLocsTCon c) (map stripLocsWTCon ps) (stripLocsTEnv te) (map stripLocsName o) doc
   NTVar k c ps       -> NTVar k (stripLocsTCon c) (map stripLocsTCon ps)
@@ -202,6 +205,7 @@ instance Pretty (Name,NameInfo) where
     pretty (n, NProto q us te doc)
                                 = text "protocol" <+> pretty n <> nonEmpty brackets commaList q <+>
                                   nonEmpty parens commaList us <> colon $+$ nest 4 (prettyDocstring doc) $+$ (nest 4 $ prettyOrPass te)
+    pretty (n, NType q t doc)   = text "type" <+> pretty n <> nonEmpty brackets commaList q <+> equals <+> pretty t $+$ nest 4 (prettyDocstring doc)
     pretty (w, NExt [] c ps te opts doc)
                                 = {-pretty w  <+> colon <+> -}
                                   text "extension" <+> pretty c <+> parens (commaList ps) <>
@@ -231,6 +235,7 @@ instance VFree NameInfo where
     vfree (NAct q p k te _)     = (vfree q ++ vfree p ++ vfree k ++ vfree te) \\ (tvSelf : qbound q)
     vfree (NClass q us te _)    = (vfree q ++ vfree us ++ vfree te) \\ (tvSelf : qbound q)
     vfree (NProto q us te _)    = (vfree q ++ vfree us ++ vfree te) \\ (tvSelf : qbound q)
+    vfree (NType q t _)         = (vfree q ++ vfree t) \\ qbound q
     vfree (NExt q c ps te _ _)  = (vfree q ++ vfree c ++ vfree ps ++ vfree te) \\ (tvSelf : qbound q)
     vfree (NTVar k c ps)        = vfree c ++ vfree ps
     vfree (NAlias qn)           = []
@@ -244,6 +249,7 @@ instance VSubst NameInfo where
     vsubst s (NAct q p k te x)  = NAct (vsubst s q) (vsubst s p) (vsubst s k) (vsubst s te) x
     vsubst s (NClass q us te x) = NClass (vsubst s q) (vsubst s us) (vsubst s te) x
     vsubst s (NProto q us te x) = NProto (vsubst s q) (vsubst s us) (vsubst s te) x
+    vsubst s (NType q t x)      = NType (vsubst s q) (vsubst s t) x
     vsubst s (NExt q c ps te opts x) = NExt (vsubst s q) (vsubst s c) (vsubst s ps) (vsubst s te) opts x
     vsubst s (NTVar k c ps)        = NTVar k (vsubst s c) (vsubst s ps)
     vsubst s (NAlias qn)        = NAlias qn
@@ -257,6 +263,7 @@ instance UFree NameInfo where
     ufree (NAct q p k te _)     = ufree q ++ ufree p ++ ufree k ++ ufree te
     ufree (NClass q us te _)    = ufree q ++ ufree us ++ ufree te
     ufree (NProto q us te _)    = ufree q ++ ufree us ++ ufree te
+    ufree (NType q t _)         = ufree q ++ ufree t
     ufree (NExt q c ps te _ _)  = ufree q ++ ufree c ++ ufree ps ++ ufree te
     ufree (NTVar k c ps)        = ufree c ++ ufree ps
     ufree (NAlias qn)           = []
@@ -273,6 +280,7 @@ instance Polarity NameInfo where
     polvars (NAct q p k te _)   = polvars q `polcat` polneg (polvars p `polcat` polvars k) `polcat` polvars te
     polvars (NClass q us te _)  = polvars q `polcat` polvars us `polcat` polvars te
     polvars (NProto q us te _)  = polvars q `polcat` polvars us `polcat` polvars te
+    polvars (NType q t _)       = polvars q `polcat` polvars t
     polvars (NExt q c ps te _ _) = polvars q `polcat` polvars c `polcat` polvars ps `polcat` polvars te
     polvars (NTVar k c ps)      = polvars c `polcat` polvars ps
     polvars _                   = ([],[])
@@ -288,6 +296,7 @@ wildargs i                      = [ tWild | _ <- nbinds i ]
     nbinds (NAct q _ _ _ _)     = q
     nbinds (NClass q _ _ _)     = q
     nbinds (NProto q _ _ _)     = q
+    nbinds (NType q _ _)        = q
     nbinds (NExt q _ _ _ _ _)   = q
 
 -- TEnv filters --------------------------------------------------------------------------------------------------------
@@ -382,6 +391,7 @@ instance Vars NameInfo where
       NAct q p k te _ -> freeQ q ++ freeQ p ++ freeQ k ++ freeQTEnv te
       NClass q ws te _ -> freeQ q ++ freeQWTCons ws ++ freeQTEnv te
       NProto q ws te _ -> freeQ q ++ freeQWTCons ws ++ freeQTEnv te
+      NType q t _ -> freeQ q ++ freeQ t
       NExt q c ws te _ _ -> freeQ q ++ freeQ c ++ freeQWTCons ws ++ freeQTEnv te
       NTVar _ c ps -> freeQ c ++ freeQ ps
       NAlias qn -> freeQ qn

--- a/compiler/lib/src/Acton/Names.hs
+++ b/compiler/lib/src/Acton/Names.hs
@@ -239,12 +239,14 @@ instance Vars Decl where
     freeQ (Actor _ n q ps ks b _)   = (freeQ ps ++ freeQ ks ++ freeQ b) `diffQ` (n : self : bound q ++ bound ps ++ bound ks ++ assigned b)
     freeQ (Class _ n q cs b _)      = (freeQ cs ++ freeQ b) `diffQ` (n : bound q ++ assigned b)
     freeQ (Protocol _ n q ps b _)   = (freeQ ps ++ freeQ b) `diffQ` (n : bound q ++ assigned b)
+    freeQ (Typedef _ n q t _)       = freeQ t `diffQ` (n : bound q)
     freeQ (Extension _ q c ps b _)  = (freeQ c ++ freeQ ps ++ freeQ b) `diffQ` (bound q ++ assigned b)
 
     bound (Def _ n _ _ _ _ _ _ _ _) = [n]
     bound (Actor _ n _ _ _ _ _)     = [n]
     bound (Class _ n _ _ _ _)       = [n]
     bound (Protocol _ n _ _ _ _)    = [n]
+    bound (Typedef _ n _ _ _)       = [n]
     bound (Extension _ _ _ _ _ _)   = []
 
 instance Vars Branch where

--- a/compiler/lib/src/Acton/Names.hs
+++ b/compiler/lib/src/Acton/Names.hs
@@ -208,7 +208,7 @@ instance Vars Stmt where
     freeQ (Data _ p b)              = freeQ p ++ freeQ b
     freeQ (VarAssign _ ps e)        = freeQ ps ++ freeQ e
     freeQ (After _ e e')            = freeQ e ++ freeQ e'
-    freeQ (Decl _ ds)               = freeQ ds
+    freeQ (Decl _ ds)               = freeQ ds `diffQ` bound ds
     freeQ (Signature _ ns t d)      = freeQ t
 
     bound (Assign _ ps _)           = bound ps
@@ -235,11 +235,11 @@ assigned stmts                      = concatMap assig stmts
 
 instance Vars Decl where
     freeQ (Def _ n q ps ks t b d fx _)
-                                    = (freeQ ps ++ freeQ ks ++ freeQ b ++ freeQ fx) `diffQ` (n : bound q ++ bound ps ++ bound ks ++ assigned b)
-    freeQ (Actor _ n q ps ks b _)   = (freeQ ps ++ freeQ ks ++ freeQ b) `diffQ` (n : self : bound q ++ bound ps ++ bound ks ++ assigned b)
-    freeQ (Class _ n q cs b _)      = (freeQ cs ++ freeQ b) `diffQ` (n : bound q ++ assigned b)
-    freeQ (Protocol _ n q ps b _)   = (freeQ ps ++ freeQ b) `diffQ` (n : bound q ++ assigned b)
-    freeQ (Typedef _ n q t _)       = freeQ t `diffQ` (n : bound q)
+                                    = (freeQ ps ++ freeQ ks ++ freeQ b ++ freeQ fx) `diffQ` (bound q ++ bound ps ++ bound ks ++ assigned b)
+    freeQ (Actor _ n q ps ks b _)   = (freeQ ps ++ freeQ ks ++ freeQ b) `diffQ` (self : bound q ++ bound ps ++ bound ks ++ assigned b)
+    freeQ (Class _ n q cs b _)      = (freeQ cs ++ freeQ b) `diffQ` (bound q ++ assigned b)
+    freeQ (Protocol _ n q ps b _)   = (freeQ ps ++ freeQ b) `diffQ` (bound q ++ assigned b)
+    freeQ (Typedef _ n q t _)       = freeQ t `diffQ` bound q
     freeQ (Extension _ q c ps b _)  = (freeQ c ++ freeQ ps ++ freeQ b) `diffQ` (bound q ++ assigned b)
 
     bound (Def _ n _ _ _ _ _ _ _ _) = [n]

--- a/compiler/lib/src/Acton/Normalizer.hs
+++ b/compiler/lib/src/Acton/Normalizer.hs
@@ -495,6 +495,7 @@ instance Norm Decl where
             t0                      = tCon $ TC (NoQ n) (map tVar $ qbound q)
     norm env (Class l n q as b doc) = Class l n q as <$> normSuite env1 b <*> return doc
       where env1                    = defineTVars (selfQuant (NoQ n) q) env
+    norm env (Typedef l n q t doc)  = return $ Typedef l n q (conv t) doc
     norm env d                      = error ("norm unexpected: " ++ prstr d)
 
 
@@ -705,6 +706,7 @@ instance (Conv a) => Conv (Name, a) where
 instance Conv NameInfo where
     conv (NAct q p k te doc)        = NAct q (joinRow p k) kwdNil (conv te) doc
     conv (NClass q ps te doc)       = NClass q (conv ps) (conv te) doc
+    conv (NType q t doc)            = NType q (conv t) doc
     conv (NSig sc dec doc)          = NSig (conv sc) dec doc
     conv (NDef sc dec doc)          = NDef (conv sc) dec doc
     conv (NVar t)                   = NVar (conv t)

--- a/compiler/lib/src/Acton/Normalizer.hs
+++ b/compiler/lib/src/Acton/Normalizer.hs
@@ -310,7 +310,6 @@ instance Norm Stmt where
                                          ps2 <- norm env ps1
                                          let p'@(PVar _ n _) : ps' = ps2
                                          return $ Assign l [p'] e' : [ Assign l [p] (eVar n) | p <- ps' ] ++ concat stmts
-      where t                       = typeOf env e
     norm' env s@(For l p e b els)
       | Just r <- rangeIteratorArg e = do i <- newName "range_iter"
                                           v <- newName "val"
@@ -320,7 +319,7 @@ instance Norm Stmt where
                                          v <- newName "val"
                                          normSuite env [sAssign (pVar i $ conv env t) e,
                                                         handleStop (While l (eBool True) (body v i) []) els]
-      where t@(TCon _ (TC c [t']))  = typeOf env e
+      where t@(TCon _ (TC c [t']))  = expTypeOf env e
             next i                  = eCall (eDot (eVar i) nextKW) []
             rangeNext i             = eCall (eQVar primUNext) [eVar i]
             handleStop loop els     = Try l [loop] [Handler (Except l0 qnStopIteration) (mkBody els)] [] []
@@ -333,7 +332,7 @@ instance Norm Stmt where
             isPVar PVar{}           = True
             isPVar _                = False
             rangeIteratorArg (Call _ f (PosArg r PosNil) KwdNil)
-               | isIterCall f && typeOf env r == tRange = Just r
+               | isIterCall f && expTypeOf env r == tRange = Just r
             rangeIteratorArg (Paren _ e) = rangeIteratorArg e
             rangeIteratorArg _       = Nothing
             isIterCall (Dot _ _ n)   = n == iterKW
@@ -519,7 +518,7 @@ normBool env e
                                          return $ BinOp l e1 op e2
   | otherwise                       = do e' <- norm env e
                                          return $ eCall (eDot e' boolKW) []
-  where t                           = typeOf env e
+  where t                           = expTypeOf env e
 
 instance Norm Expr where
     norm env (Var l (NoQ n))
@@ -547,7 +546,7 @@ instance Norm Expr where
       | TTuple _ p k <- t,
         n `notElem` valueKWs        = DotI l <$> norm env e <*> pure (nargs p + narg n k)
       | otherwise                   = Dot l <$> norm env e <*> pure n
-      where t                       = typeOf env e
+      where t                       = expTypeOf env e
     norm env (Async l e)            = Async l <$> norm env e
     norm env (Await l e)            = Await l <$> norm env e
     norm env (Cond l e1 e2 e3)      = Cond l <$> norm env e1 <*> normBool env e2 <*> norm env e3
@@ -556,7 +555,7 @@ instance Norm Expr where
     norm env (BinOp l e1 And e2)    = BinOp l <$> norm env e1 <*> pure And <*> norm env e2
     norm env (UnOp l Not e)         = UnOp l Not <$> normBool env e
     norm env (Rest l e n)           = RestI l <$> norm env e <*> pure (nargs p + narg n k)
-      where TTuple _ p k            = typeOf env e
+      where TTuple _ p k            = expTypeOf env e
     norm env (DotI l e i)           = DotI l <$> norm env e <*> pure i
     norm env (RestI l e i)          = RestI l <$> norm env e <*> pure i
     norm env (Lambda l p k e fx)    = do p' <- joinPar <$> norm env p <*> norm (define (envOf p) env) k
@@ -576,7 +575,7 @@ instance Norm Expr where
 
 listGetItemCall env (Dot _ _ n) (PosArg e (PosArg ix PosNil))
   | n == getitemKW,
-    typeOf env ix == tInt,
+    expTypeOf env ix == tInt,
     Just t <- listElementType (typeOf env e)
                                     = Just (t, e, ix)
 listGetItemCall env (TApp _ e _) p  = listGetItemCall env e p

--- a/compiler/lib/src/Acton/Normalizer.hs
+++ b/compiler/lib/src/Acton/Normalizer.hs
@@ -30,7 +30,7 @@ import Debug.Trace
 normalize                           :: Env0 -> Module -> IO (Module, Env0)
 normalize env0 m                    = return (evalState (norm env m) (0,[]), env0')
   where env                         = normEnv env0
-        env0'                       = convertModules (const []) convEnv env0
+        env0'                       = convertModules (const []) (convEnv env) env0
 
 
 --  Normalization:
@@ -156,13 +156,13 @@ normSuite env (s : ss)              = do s' <- norm' env s
 
 
 normPat                             :: NormEnv -> Pattern -> NormM (Pattern,Suite)
-normPat _ (PWild l a)               = do n <- newName "ignore"
-                                         return (PVar l n $ conv a,[])
-normPat _ (PVar l n a)              = return (PVar l n $ conv a,[])
+normPat env (PWild l a)             = do n <- newName "ignore"
+                                         return (PVar l n $ conv env a,[])
+normPat env (PVar l n a)            = return (PVar l n $ conv env a,[])
 normPat env (PParen _ p)            = normPat env p
 normPat env p@(PTuple _ pp kp)      = do v <- newName "tup"
                                          ss <- normSuite (define [(v, NVar t)] env) $ normPP v 0 pp ++ normKP v [] kp
-                                         return (pVar v $ conv t, ss)
+                                         return (pVar v $ conv env t, ss)
   where normPP v n (PosPat p pp)    = Assign NoLoc [p] (DotI NoLoc (eVar v) n) : normPP v (n+1) pp
         normPP v n (PosPatStar p)   = [Assign NoLoc [p] (foldl (RestI NoLoc) (eVar v) [0..n-1])]
         normPP _ _ PosPatNil        = []
@@ -172,7 +172,7 @@ normPat env p@(PTuple _ pp kp)      = do v <- newName "tup"
         t                           = typeOf env p
 normPat env p@(PList _ ps pt)       = do v <- newName "lst"
                                          ss <- normSuite env $ normList v 0 ps pt
-                                         return (pVar v $ conv t, ss)
+                                         return (pVar v $ conv env t, ss)
   where normList v n (p:ps) pt      = s : normList v (n+1) ps pt
           where s                   = Assign NoLoc [p] (eCall (eDot (eQVar qnIndexed) getitemKW)
                                         [eVar v, Int NoLoc n (show n)])
@@ -208,7 +208,7 @@ handle env x hs                     = do bs <- sequence [ branch e b | Handler e
         branch (Except _ y) b       = Branch (eIsInstance x y) <$> normSuite env b
         branch (ExceptAs _ y z) b   = Branch (eIsInstance x y) <$> (bind:) <$> normSuite env' b
           where env'                = define [(z,NVar t)] env
-                bind                = sAssign (pVar z $ conv t) (eVar x)
+                bind                = sAssign (pVar z $ conv env t) (eVar x)
                 t                   = tCon $ TC y []
 
 exitContext env s
@@ -259,7 +259,7 @@ instance Norm Stmt where
     norm env (Data l mbp ss)        = Data l <$> norm env mbp <*> normSuite env ss
     norm env (VarAssign l ps e)     = VarAssign l <$> norm env ps <*> norm env e
     norm env (After l e e')         = After l <$> norm env e <*> norm env e'
-    norm env (Signature l ns t d)   = return $ Signature l ns (conv t) d
+    norm env (Signature l ns t d)   = return $ Signature l ns (conv env t) d
     norm env s                      = error ("norm unexpected stmt: " ++ prstr s)
 
     norm' env (Decl l ds)           = do (eqs,ds) <- normDecls env ds
@@ -301,7 +301,7 @@ instance Norm Stmt where
                                              True -> return $ retContext e
                                              False -> do
                                                  n <- newName "tmp"
-                                                 return $ sAssign (pVar n $ conv t) e : retContext (eVar n)
+                                                 return $ sAssign (pVar n $ conv env t) e : retContext (eVar n)
       where retContext e            = exitContext env $ Return l $ Just e
             t                       = typeOf env e
 
@@ -318,7 +318,7 @@ instance Norm Stmt where
                                                          handleStop (While l (eBool True) (rangeBody v i) []) els]
       | otherwise                   = do i <- newName "iter"
                                          v <- newName "val"
-                                         normSuite env [sAssign (pVar i $ conv t) e,
+                                         normSuite env [sAssign (pVar i $ conv env t) e,
                                                         handleStop (While l (eBool True) (body v i) []) els]
       where t@(TCon _ (TC c [t']))  = typeOf env e
             next i                  = eCall (eDot (eVar i) nextKW) []
@@ -476,7 +476,7 @@ instance Norm Decl where
     norm env (Def l n q p k t b d x doc)
                                     = do p' <- joinPar <$> norm env0 p <*> norm (define (envOf p) env0) k
                                          b' <- normSuite env1 b
-                                         return $ Def l n q p' KwdNIL (conv t) (ret b') d x doc
+                                         return $ Def l n q p' KwdNIL (conv env t) (ret b') d x doc
       where env1                    = setMarks [] $ setRet t $ define (envOf p ++ envOf k) env0
             env0                    = defineTVars q env00
             env00                   = case p of
@@ -495,7 +495,7 @@ instance Norm Decl where
             t0                      = tCon $ TC (NoQ n) (map tVar $ qbound q)
     norm env (Class l n q as b doc) = Class l n q as <$> normSuite env1 b <*> return doc
       where env1                    = defineTVars (selfQuant (NoQ n) q) env
-    norm env (Typedef l n q t doc)  = return $ Typedef l n q (conv t) doc
+    norm env (Typedef l n q t doc)  = return $ Typedef l n q (conv env t) doc
     norm env d                      = error ("norm unexpected: " ++ prstr d)
 
 
@@ -537,9 +537,9 @@ instance Norm Expr where
     norm env (BStrings l ss)        = return $ BStrings l (catStrings ss)
     norm env (Call l e p k)
       | Just (t, e1, e2) <- listGetItemCall env e (joinArg p k)
-                                    = eCall (tApp (eQVar primUGetItem) [conv t]) <$> mapM (norm env) [e1, e2]
+                                    = eCall (tApp (eQVar primUGetItem) [conv env t]) <$> mapM (norm env) [e1, e2]
       | otherwise                   = Call l <$> norm env e <*> norm env (joinArg p k) <*> pure KwdNil
-    norm env (TApp l e ts)          = TApp l <$> normInst env ts e <*> pure (conv ts)
+    norm env (TApp l e ts)          = TApp l <$> normInst env ts e <*> pure (conv env ts)
     norm env (Let l ss e)          = Let l <$> norm env ss <*> norm env e
     norm env (Dot l (Var l' x) n)
       | NClass{} <- findQName x env = pure $ Dot l (Var l' x) n
@@ -612,8 +612,8 @@ narg n (TStar _ _ _)
 narg n k                            = error ("### Bad narg " ++ prstr n ++ " " ++ prstr k)
 
 instance Norm Pattern where
-    norm env (PWild l a)            = return $ PWild l (conv a)
-    norm env (PVar l n a)           = return $ PVar l n (conv a)
+    norm env (PWild l a)            = return $ PWild l (conv env a)
+    norm env (PVar l n a)           = return $ PVar l n (conv env a)
     norm env (PTuple l ps ks)       = PTuple l <$> norm env ps <*> norm env ks
     norm env (PList l ps p)         = PList l <$> norm env ps <*> norm env p        -- TODO: eliminate here
     norm env (PParen l p)           = norm env p
@@ -626,13 +626,13 @@ instance Norm Handler where
       where env1                    = define (envOf ex) env
 
 instance Norm PosPar where
-    norm env (PosPar n t e p)       = PosPar n (conv t) <$> norm env e <*> norm (define [(n,NVar $ fromJust t)] env) p
-    norm env (PosSTAR n t)          = return $ PosSTAR n (conv t)
+    norm env (PosPar n t e p)       = PosPar n (conv env t) <$> norm env e <*> norm (define [(n,NVar $ fromJust t)] env) p
+    norm env (PosSTAR n t)          = return $ PosSTAR n (conv env t)
     norm env PosNIL                 = return PosNIL
 
 instance Norm KwdPar where
-    norm env (KwdPar n t e k)       = KwdPar n (conv t) <$> norm env e <*> norm (define [(n,NVar $ fromJust t)] env) k
-    norm env (KwdSTAR n t)          = return $ KwdSTAR n (conv t)
+    norm env (KwdPar n t e k)       = KwdPar n (conv env t) <$> norm env e <*> norm (define [(n,NVar $ fromJust t)] env) k
+    norm env (KwdSTAR n t)          = return $ KwdSTAR n (conv env t)
     norm env KwdNIL                 = return KwdNIL
 
 joinPar (PosPar n t e p) k          = PosPar n t e (joinPar p k)
@@ -688,54 +688,56 @@ instance Norm Assoc where
 
 -- Convert function types ---------------------------------------------------------------------------------
 
-convEnv m (n, i)                    = [(n, conv i)]
+convEnv env m (n, i)                = [(n, conv env i)]
 
 
 class Conv a where
-    conv                            :: a -> a
+    conv                            :: NormEnv -> a -> a
 
 instance (Conv a) => Conv [a] where
-    conv                            = map conv
+    conv env                        = map $ conv env
 
 instance (Conv a) => Conv (Maybe a) where
-    conv                            = fmap conv
+    conv env                        = fmap $ conv env
 
 instance (Conv a) => Conv (Name, a) where
-    conv (n, x)                     = (n, conv x)
+    conv env (n, x)                 = (n, conv env x)
 
 instance Conv NameInfo where
-    conv (NAct q p k te doc)        = NAct q (joinRow p k) kwdNil (conv te) doc
-    conv (NClass q ps te doc)       = NClass q (conv ps) (conv te) doc
-    conv (NType q t doc)            = NType q (conv t) doc
-    conv (NSig sc dec doc)          = NSig (conv sc) dec doc
-    conv (NDef sc dec doc)          = NDef (conv sc) dec doc
-    conv (NVar t)                   = NVar (conv t)
-    conv (NSVar t)                  = NSVar (conv t)
-    conv ni                         = ni
+    conv env (NAct q p k te doc)    = NAct q (joinRow env p k) kwdNil (conv env te) doc
+    conv env (NClass q ps te doc)   = NClass q (conv env ps) (conv env te) doc
+    conv env (NType q t doc)        = NType q (conv env t) doc
+    conv env (NSig sc dec doc)      = NSig (conv env sc) dec doc
+    conv env (NDef sc dec doc)      = NDef (conv env sc) dec doc
+    conv env (NVar t)               = NVar (conv env t)
+    conv env (NSVar t)              = NSVar (conv env t)
+    conv env ni                     = ni
 
 instance Conv WTCon where
-    conv (w,c)                      = (w, conv c)
+    conv env (w,c)                  = (w, conv env c)
 
 instance Conv TSchema where
-    conv (TSchema l q t)            = TSchema l q (conv t)
+    conv env (TSchema l q t)        = TSchema l q (conv env t)
 
 instance Conv Type where
-    conv (TFun l fx p k t)          = TFun l fx (joinRow p k) kwdNil (conv t)
-    conv (TCon l c)                 = TCon l (conv c)
-    conv (TTuple l p k)             = TTuple l (joinRow p k) kwdNil
-    conv (TOpt l t)                 = TOpt l (conv t)
-    conv (TRow l k n t r)           = TRow l PRow nWild (conv t) (conv r)
-    conv (TStar l k r)              = TRow l PRow nWild (TTuple l (conv r) kwdNil) posNil
-    conv (TNil l k)                 = TNil l PRow
-    conv t                          = t
+    conv env (TFun l fx p k t)      = TFun l fx (joinRow env p k) kwdNil (conv env t)
+    conv env (TCon l c)
+      | Just t <- tExpand env c     = conv env t
+      | otherwise                   = TCon l (conv env c)
+    conv env (TTuple l p k)         = TTuple l (joinRow env p k) kwdNil
+    conv env (TOpt l t)             = TOpt l (conv env t)
+    conv env (TRow l k n t r)       = TRow l PRow nWild (conv env t) (conv env r)
+    conv env (TStar l k r)          = TRow l PRow nWild (TTuple l (conv env r) kwdNil) posNil
+    conv env (TNil l k)             = TNil l PRow
+    conv env t                      = t
 
 instance Conv TCon where
-    conv (TC c ts)                  = TC c (conv ts)
+    conv env (TC c ts)              = TC c (conv env ts)
 
 -- Must mirror Syntax.tupleComponents, which the solver uses to derive tuple witnesses.
-joinRow (TRow l k n t p) r          = TRow l PRow nWild (conv t) (joinRow p r)
-joinRow (TStar l k p) r             = TRow l PRow nWild (TTuple l (conv p) kwdNil) (conv r)
-joinRow (TNil _ _) r                = conv r
+joinRow env (TRow l k n t p) r      = TRow l PRow nWild (conv env t) (joinRow env p r)
+joinRow env (TStar l k p) r         = TRow l PRow nWild (TTuple l (conv env p) kwdNil) (conv env r)
+joinRow env (TNil _ _) r            = conv env r
 -- To be removed:
-joinRow p (TNil _ _)                = conv p
-joinRow p r                         = error ("##### joinRow " ++ prstr p ++ "  AND  " ++ prstr r)
+joinRow env p (TNil _ _)            = conv env p
+joinRow env p r                     = error ("##### joinRow " ++ prstr p ++ "  AND  " ++ prstr r)

--- a/compiler/lib/src/Acton/Parser.hs
+++ b/compiler/lib/src/Acton/Parser.hs
@@ -1889,7 +1889,7 @@ decl_group = do p <- L.indentLevel
                 return [ S.Decl (loc ds) ds | ds <- Names.splitDeclGroup g ]
 
 decl :: Parser S.Decl
-decl = funcdef <|> classdef <|> protodef <|> extdef <|> actordef
+decl = funcdef <|> classdef <|> protodef <|> typedef <|> extdef <|> actordef
 
 decorator :: Bool -> Parser S.Deco
 decorator sig = do
@@ -1956,6 +1956,14 @@ classdefGen k pname ctx con = addLoc $ do
                 cs <- optbounds
                 (ss, docstring) <- suiteWithDocstring ctx s
                 return $ con NoLoc nm q cs ss docstring
+
+typedef = addLoc $ do
+                (s,l) <- withPos (rwordLoc "type")
+                assertTop l "type"
+                nm <- name
+                q <- optbinds
+                t <- ttype
+                return $ S.Typedef NoLoc nm q t Nothing
 
 extdef = addLoc $ do
                 (s,l) <- withPos (rwordLoc "extension")

--- a/compiler/lib/src/Acton/Parser.hs
+++ b/compiler/lib/src/Acton/Parser.hs
@@ -35,6 +35,7 @@ import Data.Void
 import Data.Char
 import qualified Data.List.NonEmpty as N
 import qualified Data.Set as Set
+import Data.Graph (SCC(..), stronglyConnComp)
 import GHC.Conc (getNumCapabilities)
 import Numeric
 import Text.Megaparsec
@@ -61,6 +62,7 @@ data CustomParseError = TypeVariableNameError String  -- Name that looks like ty
                       | InvalidModuleStatement
                       | InvalidTopLevelAssignmentPattern
                       | DuplicateTopLevelAssignment String
+                      | CyclicTypedef [String]
                       -- String interpolation errors
                       | EmptyInterpolationExpression
                       | MissingExpressionBeforeFormat
@@ -91,6 +93,8 @@ instance ShowErrorComponent CustomParseError where
     "Module top-level assignments must bind at least one name"
   showErrorComponent (DuplicateTopLevelAssignment name) =
     "Module top-level name '" ++ name ++ "' cannot be assigned more than once"
+  showErrorComponent (CyclicTypedef names) =
+    "Type definitions " ++ show names ++ " are cyclically dependent"
   -- String interpolation errors
   showErrorComponent EmptyInterpolationExpression = "Empty expression in string interpolation"
   showErrorComponent MissingExpressionBeforeFormat = "Missing expression before format specifier"
@@ -1217,7 +1221,11 @@ validateModuleSuite = go Set.empty
               seen' <- addNames seen names
               go seen' stmts
         S.Signature{} -> go seen stmts
-        S.Decl{}      -> go seen stmts
+        S.Decl _ ds
+          | null cycles -> go seen stmts
+          | otherwise -> parseException (S.sloc stmt) (CyclicTypedef $ map S.rawstr $ head cycles)
+          where cycles = [ map S.dname ds | CyclicSCC ds <- stronglyConnComp tdefs ]
+                tdefs  = [ (d, S.dname d, Names.free d) | d@S.Typedef{} <- ds ]
         _             -> parseException (S.sloc stmt) InvalidModuleStatement
 
     addNames seen [] = return seen

--- a/compiler/lib/src/Acton/Parser.hs
+++ b/compiler/lib/src/Acton/Parser.hs
@@ -1957,13 +1957,13 @@ classdefGen k pname ctx con = addLoc $ do
                 (ss, docstring) <- suiteWithDocstring ctx s
                 return $ con NoLoc nm q cs ss docstring
 
-typedef = addLoc $ do
+typedef = addLoc $ try $ do
                 (s,l) <- withPos (rwordLoc "type")
-                assertTop l "type"
                 nm <- name
                 q <- optbinds
                 equals
                 t <- ttype
+                assertTop l "type"
                 return $ S.Typedef NoLoc nm q t Nothing
 
 extdef = addLoc $ do

--- a/compiler/lib/src/Acton/Parser.hs
+++ b/compiler/lib/src/Acton/Parser.hs
@@ -1962,6 +1962,7 @@ typedef = addLoc $ do
                 assertTop l "type"
                 nm <- name
                 q <- optbinds
+                equals
                 t <- ttype
                 return $ S.Typedef NoLoc nm q t Nothing
 

--- a/compiler/lib/src/Acton/Printer.hs
+++ b/compiler/lib/src/Acton/Printer.hs
@@ -91,6 +91,10 @@ instance Pretty Decl where
                                       nonEmpty parens commaList a <> colon $+$ prettyDocSuite doc b
     pretty (Protocol _ n q a b doc) = text "protocol" <+> pretty n <> nonEmpty brackets commaList q <+>
                                       nonEmpty parens commaList a <> colon $+$ prettyDocSuite doc b
+    pretty (Typedef _ n q t doc)    = text "type" <+> pretty n <> nonEmpty brackets commaList q <+>
+                                      equals <+> pretty t $+$ prettyDoc doc
+      where prettyDoc Nothing       = empty
+            prettyDoc (Just s)      = nest 4 $ text "\"\"\"" <> text (escapeDocstring s) <> text "\"\"\""
     pretty (Extension _ q c a b doc)
       | tvs == tcargs c             = text "extension" <+> pretty (tcname c) <> nonEmpty brackets commaList q <+>
                                       nonEmpty parens commaList a <> colon $+$ prettyDocSuite doc b

--- a/compiler/lib/src/Acton/QuickType.hs
+++ b/compiler/lib/src/Acton/QuickType.hs
@@ -41,6 +41,8 @@ typecast t t' e
 typeOf env x                        = t
   where (t, fx, x')                 = qType env accept x
 
+expTypeOf env x                     = expanded env (typeOf env x)
+
 fxOf env x                          = fx
   where (t, fx, x')                 = qType env accept x
 
@@ -54,7 +56,7 @@ closedType                          :: EnvF x -> Expr -> Bool
 closedType env (Var _ n)            = isClosed $ findQName n env
 closedType env (Dot _ (Var _ x) n)
   | NClass q _ _ _ <- findQName x env = closedAttr env (TC x (map tVar $ qbound q)) n
-closedType env (Dot _ e n)          = case expanded env (typeOf env e) of
+closedType env (Dot _ e n)          = case expTypeOf env e of
                                         TCon _ c -> closedAttr env c n
                                         TVar _ v  -> closedAttr env (findTVBound env v) n
                                         TTuple _ p k -> n `notElem` valueKWs

--- a/compiler/lib/src/Acton/QuickType.hs
+++ b/compiler/lib/src/Acton/QuickType.hs
@@ -415,6 +415,7 @@ instance EnvOf Decl where
     envOf (Def _ n q p k (Just t) b dec fx doc)
                                     = [(n, NDef (TSchema NoLoc q $ TFun NoLoc fx (prowOf p) (krowOf k) t) dec doc)]
     envOf (Class _ n q as ss doc)   = [(n, NClass q (leftpath as) (map dropDefSelf $ envOf ss) doc)]
+    envOf (Typedef _ n q t doc)     = [(n, NType q t doc)]
 
     envOf (Actor _ n q p k ss doc)  = [(n, NAct q (prowOf p) (krowOf k) (map wrap te) doc)]
       where te                      = filter (not . isHidden . fst) $ envOf ss `exclude` statevars ss

--- a/compiler/lib/src/Acton/QuickType.hs
+++ b/compiler/lib/src/Acton/QuickType.hs
@@ -54,7 +54,7 @@ closedType                          :: EnvF x -> Expr -> Bool
 closedType env (Var _ n)            = isClosed $ findQName n env
 closedType env (Dot _ (Var _ x) n)
   | NClass q _ _ _ <- findQName x env = closedAttr env (TC x (map tVar $ qbound q)) n
-closedType env (Dot _ e n)          = case typeOf env e of
+closedType env (Dot _ e n)          = case expanded env (typeOf env e) of
                                         TCon _ c -> closedAttr env c n
                                         TVar _ v  -> closedAttr env (findTVBound env v) n
                                         TTuple _ p k -> n `notElem` valueKWs
@@ -126,7 +126,7 @@ qSchema env f e@(Dot _ (Var _ x) n)
                                           (TSchema _ q' t, mbdec) = findAttr' env tc n
                                       in (tSchema (q++q') $ vsubst [(tvSelf,tCon tc)] (addSelf t mbdec), fxPure, mbdec, e)
   where info                        = findQName x env
-qSchema env f e0@(Dot l e n)        = case t of
+qSchema env f e0@(Dot l e n)        = case expanded env t of
                                         TCon _ c -> addE e' $ findAttr' env c n
                                         TTuple _ p k
                                           | n `elem` valueKWs -> addE e' $ findAttr' env cValue n
@@ -170,14 +170,14 @@ instance QType Expr where
 --  qType env f (Ellipsis _)        = undefined
     qType env f e0@(Call l e ps KwdNil)
       | Just _ <- qGeneratedCallableType env e,
-        TFun{} <- t                 = (restype t, fx', Call l e' (qMatch f p (posrow t) ps') KwdNil)
+        TFun{} <- expanded env t    = (restype t, fx', Call l e' (qMatch f p (posrow t) ps') KwdNil)
       | Just _ <- qGeneratedCallableType env e
                                     = error ("###### qType Fun " ++ prstr e ++ " : " ++ prstr t)
       where (t, fx, e')             = qType env f e
             (p, fxp, ps')           = qTypeGeneratedPos env f (posrow t) ps
             fx'                     = upbound env [fx,fxp,effect t]
     qType env f e0@(Call l e ps ks)
-      | TFun{} <- t                 = --trace ("## qType Call " ++ prstr e0 ++ ", t = " ++ prstr t) $
+      | TFun{} <- expanded env t    = --trace ("## qType Call " ++ prstr e0 ++ ", t = " ++ prstr t) $
                                       (restype t, fx', Call l e' (qMatch f p (posrow t) ps') (qMatch f k (kwdrow t) ks'))
       | otherwise                   = error ("###### qType Fun " ++ prstr e ++ " : " ++ prstr t)
       where (t, fx, e')             = qType env f e
@@ -187,10 +187,10 @@ instance QType Expr where
     qType env f (Let l ss e)        = (t, fx, Let l ss e')
        where te                     = envOf ss
              (t,fx,e')              = qType (define te env) f e
-    qType env f (Async l e)         = case t of
+    qType env f (Async l e)         = case expanded env t of
                                         TFun _ (TFX _ FXAction) p k t' -> (tFun fxProc p k (tMsg t'), fx, Async l e')
       where (t, fx, e')             = qType env f e
-    qType env f (Await l e)         = case t of
+    qType env f (Await l e)         = case expanded env t of
                                         TCon _ (TC c [t]) | c == qnMsg -> (t, fxProc, Await l e')
       where (t, fx, e')             = qType env f e
     qType env f e@(BinOp l e1 op e2)
@@ -218,16 +218,16 @@ instance QType Expr where
             fx'                     = upbound env [fx1,fx,fx2]
     qType env f (IsInstance l e c)  = (tBool, fx, IsInstance l e' c)
       where (t, fx, e')             = qType env f e
-    qType env f (DotI l e i)        = case t of
+    qType env f (DotI l e i)        = case expanded env t of
                                         TTuple _ p _ -> (pick i p, fx, DotI l e' i)
       where (t, fx, e')             = qType env f e
             pick i (TRow _ _ _ t' p) = if i == 0 then t' else pick (i-1) p
-    qType env f (RestI l e i)       = case t of
+    qType env f (RestI l e i)       = case expanded env t of
                                         TTuple _ p _ -> (TTuple NoLoc (pick i p) kwdNil, fx, RestI l e' i)
       where (t, fx, e')             = qType env f e
             pick i (TRow l k x t r) = if i == 0 then r else TRow l k x t (pick (i-1) r)
             pick i (TNil l k)       = TNil l k
-    qType env f (Rest l e n)        = case t of
+    qType env f (Rest l e n)        = case expanded env t of
                                         TTuple _ p k -> (TTuple NoLoc posNil (pick n k), fx, Rest l e' n)
       where (t, fx, e')             = qType env f e
             pick n (TRow l k x t r) = if x == n then r else TRow l k x t (pick n r)
@@ -285,7 +285,7 @@ instance QType PosArg where
     qType env f (PosArg e p)        = (posRow t r, upbound env [fx,fxp], PosArg e' p')
       where (t, fx, e')             = qType env f e
             (r, fxp, p')            = qType env f p
-    qType env f (PosStar e)         = case t of TTuple _ p _ -> (p, fx, PosStar e')
+    qType env f (PosStar e)         = case expanded env t of TTuple _ p _ -> (p, fx, PosStar e')
       where (t, fx, e')             = qType env f e
     qType env f PosNil              = (posNil, fxPure, PosNil)
 
@@ -301,7 +301,7 @@ instance QType KwdArg where
     qType env f (KwdArg n e k)      = (kwdRow n t r, upbound env [fx,fxk], KwdArg n e' k')
       where (t, fx, e')             = qType env f e
             (r, fxk, k')            = qType env f k
-    qType env f (KwdStar e)         = case t of TTuple _ _ k -> (k, fx, KwdStar e')
+    qType env f (KwdStar e)         = case expanded env t of TTuple _ _ k -> (k, fx, KwdStar e')
       where (t, fx, e')             = qType env f e
     qType env f KwdNil              = (kwdNil, fxPure, KwdNil)
 

--- a/compiler/lib/src/Acton/Solver.hs
+++ b/compiler/lib/src/Acton/Solver.hs
@@ -641,6 +641,7 @@ reduce' eq c@(Proto _ env w t@(TCon _ tc) p)
                                                  return (mkEqn env w (proto2type t p) e : eq)
   | [wit] <- witSearch                      = do (eq',cs) <- solveProto env wit w t p
                                                  reduce (eq'++eq) cs
+  | Just t' <- tExpand env tc               = reduce' eq c{ type1 = t' }
   where witSearch                           = findWitness env t p
 
 reduce' eq c@(Proto _ env w t@(TFX _ tc) p)
@@ -721,6 +722,7 @@ reduce' eq c@(Mut _ env (TVar _ tv) n _)
 reduce' eq c@(Mut _ env (TCon _ tc) n _)
   | Just wsc <- attrSearch                  = do solveMutAttr wsc c
                                                  return eq
+  | Just t <- tExpand env tc                = reduce' eq c{ type1 = t }
   | otherwise                               = tyerr n "Attribute not found:"
   where attrSearch                          = findAttr env tc n
 

--- a/compiler/lib/src/Acton/Solver.hs
+++ b/compiler/lib/src/Acton/Solver.hs
@@ -99,7 +99,7 @@ groupCs env cs                              = do st <- currentState
   where mark n []                           = return n
         mark n (c : cs)                     = do tvs <- ufree <$> usubst c
                                                  tvs' <- ufree <$> usubst (map tUni $ attrfree c)
-                                                 sequence [ unify (noinfo 1) (newUnivarToken n) (tUni tv) | tv <- nub (tvs++tvs') ]
+                                                 sequence [ unify env (noinfo 1) (newUnivarToken n) (tUni tv) | tv <- nub (tvs++tvs') ]
                                                  mark (n+1) cs
         group m c                           = do tvs <- ufree <$> usubst c
                                                  let tv = case tvs of [] -> tv0; tv:_ -> tv
@@ -200,14 +200,14 @@ newsolve' env te eq cs                      = do let pol = closePolVars (polvars
                                                     R_amb v ts ->                               -- must-solve upper con
                                                         newtry env st te eq cs v ts
                                                     R_var v v' -> do                            -- var-var
-                                                        unify info0 (tUni v) (tUni v')
+                                                        unify env info0 (tUni v) (tUni v')
                                                         newsolve env te eq cs
                                                     R_ret -> do                                 -- acceptable upper con 
                                                         (eq,cs) <- validate env eq cs
                                                         coalesce env eq cs
 
 newtry env st te eq cs v []                 = noSolve0 env (Just $ tUni v) [] cs
-newtry env st te eq cs v (t:ts)             = (unify info0 (tUni v) t >> newsolve env te eq cs)
+newtry env st te eq cs v (t:ts)             = (unify env info0 (tUni v) t >> newsolve env te eq cs)
                                               `catchError`
                                               const (rollbackState st >> newtry env st te eq cs v ts)
 
@@ -284,7 +284,7 @@ solveGroups env select te eq (cs:css)       = do --traceM ("\n\n######### solveG
 solve' env select hist te eq cs
   | not $ null vargoals                     = do --traceM (unlines [ "### var goal " ++ prstr t ++ " ~ " ++ prstrs alts | RVar t alts <- vargoals ])
                                                  --traceM ("### var goals: " ++ show (sum [ length alts | RVar t alts <- vargoals ]))
-                                                 sequence [ unify (noinfo 2) (tUni v) t | RVar v alts <- vargoals, t <- alts ]
+                                                 sequence [ unify env (noinfo 2) (tUni v) t | RVar v alts <- vargoals, t <- alts ]
                                                  proceed hist eq cs
   | any not keep_evidence                   = noSolve0 env Nothing [] keep_cs
   | null solve_cs || null goals             = return (keep_cs, eq)
@@ -307,7 +307,7 @@ solve' env select hist te eq cs
                                                         tryAlts st v alts
                                                     RVar v alts -> do
                                                         --traceM ("### var goal " ++ prstr v ++ ", unifying with " ++ prstrs alts)
-                                                        unifyM (noinfo 3) alts (repeat $ tUni v) >> proceed hist eq cs
+                                                        unifyM env (noinfo 3) alts (repeat $ tUni v) >> proceed hist eq cs
                                                     RSkip ->
                                                         return (keep_cs, eq)
 
@@ -337,21 +337,21 @@ solve' env select hist te eq cs
         tryAlt v (TTuple _ _ _)
           | not $ null attrs                = do t <- instwild env KType (tTupleK $ foldr (\n -> kwdRow n tWild) tWild attrs)
                                                  --traceM ("  # trying tuple " ++ prstr v ++ " = " ++ prstr t)
-                                                 unify (noinfo 5) (tUni v) t
+                                                 unify env (noinfo 5) (tUni v) t
                                                  proceed (t:hist) eq cs
           where selsOf cs                   = sortBy (\a b -> compare (nstr a) (nstr b)) $ nub [ n | Sel _ _ _ (TUni _ v') n _ <- cs, v' == v ]
                 attrs                       = nub $ selsOf solve_cs \\ valueKWs
         tryAlt v t
           | uvkind v == KFX                 = do t <- instwild env (uvkind v) t
                                                  --traceM ("  # TRYING " ++ prstr v ++ " = " ++ prstr t)
-                                                 unify (noinfo 5) (tUni v) t
+                                                 unify env (noinfo 5) (tUni v) t
                                                  (cs,eq) <- quicksimp env eq cs
                                                  hist <- usubst hist
                                                  te <- usubst te
                                                  solve' env select hist te eq cs
         tryAlt v t                          = do t <- instwild env (uvkind v) t
                                                  --traceM ("  # trying " ++ prstr v ++ " = " ++ prstr t)
-                                                 unify (noinfo 5) (tUni v) t
+                                                 unify env (noinfo 5) (tUni v) t
                                                  proceed (t:hist) eq cs
         proceed hist eq cs                  = do te <- usubst te
                                                  (cs,eq) <- simplify' env te eq cs
@@ -741,7 +741,7 @@ reduce' eq c                                = noRed0 (scope c) c
 
 
 solveProto env wit w t p                    = do (cs,t',we) <- instWitness env p wit
-                                                 unify (noinfo 7) t t'
+                                                 unify env (noinfo 7) t t'
                                                  return ([mkEqn env w (proto2type t p) we], cs)
 
 solveSelAttr (wf,sc,d) (Sel info env w t1 n t2)
@@ -836,7 +836,7 @@ cast' env info (TCon _ c1) (TCon _ c2)
   | Just (wf,c') <- search                  = if tcname c1 == tcname c2 && tcname c1 `elem` covariant then
                                                   castM env info (tcargs c') (tcargs c2)
                                               else                                              -- TODO: infer polarities in general!
-                                                  unifyM info (tcargs c') (tcargs c2)
+                                                  unifyM env info (tcargs c') (tcargs c2)
   where search                              = findAncestor env c1 (tcname c2)
 
 cast' env info (TCon _ c1) t2
@@ -849,7 +849,7 @@ cast' env info t1 (TCon _ c2)
 --                 existing                  expected
 cast' env info t1@(TFun _ fx1 p1 k1 t1') t2@(TFun _ fx2 p2 k2 t2')
   | varTails [p1,p2] || varTails [k1,k2]    = do --traceM ("## Unifying funs: " ++ prstr t1 ++ " ~ " ++ prstr t2)
-                                                 unify info t1 t2
+                                                 unify env info t1 t2
                                                  return ()
   | otherwise                               = do --traceM ("### Aligning fun " ++ prstr t1 ++ " < " ++ prstr t2)
                                                  (cs1,ts) <- castpos env info p2 p1
@@ -862,7 +862,7 @@ cast' env info t1@(TFun _ fx1 p1 k1 t1') t2@(TFun _ fx2 p2 k2 t2')
 
 cast' env info t1@(TTuple _ p1 k1) t2@(TTuple _ p2 k2)
   | varTails [p1,p2] || varTails [k1,k2]    = do --traceM ("### Unifying tuples: " ++ prstr t1 ++ " ~ " ++ prstr t2)
-                                                 unify info t1 t2
+                                                 unify env info t1 t2
                                                  return ()
   | otherwise                               = do --traceM ("### Aligning tuple " ++ prstr t1 ++ " < " ++ prstr t2)
                                                  (cs1,ts) <- castpos env info p1 p2
@@ -989,15 +989,15 @@ castkwd env info r1 (TUni _ tv)             = do unif r1
           | otherwise                       = do --traceM (" ## castkwd Row - Var: " ++ prstr (tRow KRow n t r) ++ " = " ++ prstr tv)
                                                  t2 <- newUnivar env
                                                  r2 <- tRow KRow n t2 <$> newUnivarOfKind KRow env
-                                                 unify info (tUni tv) r2
+                                                 unify env info (tUni tv) r2
         unif (TStar _ _ r)
           | tv `elem` ufree r               = conflictingRow tv                     -- use rowTail?
           | otherwise                       = do --traceM (" ## castkwd Star - Var: " ++ prstr (tStar KRow r) ++ " = " ++ prstr tv)
                                                  r2 <- tStar KRow <$> newUnivarOfKind KRow env
-                                                 unify info (tUni tv) r2
+                                                 unify env info (tUni tv) r2
         unif TNil{}                         = do --traceM (" ## castkwd Nil - Var: " ++ prstr (tNil KRow) ++ " = " ++ prstr tv)
                                                  r2 <- pure $ tNil KRow
-                                                 unify info (tUni tv) r2
+                                                 unify env info (tUni tv) r2
 
 castkwd env info r1 (TRow _ _ n2 t2 r2)     = do (t1,r1') <- pick r1
                                                  r2 <- usubst r2
@@ -1007,7 +1007,7 @@ castkwd env info r1 (TRow _ _ n2 t2 r2)     = do (t1,r1') <- pick r1
           | tv `elem` ufree r2              = conflictingRow tv                     -- use rowTail?
           | otherwise                       = do --traceM (" ## castkwd Var - Row: " ++ prstr (tUni tv) ++ " = " ++ prstr (tRow KRow n2 t2 r2))
                                                  r1 <- tRow KRow n2 t2 <$> newUnivarOfKind KRow env
-                                                 unify info (tUni tv) r1
+                                                 unify env info (tUni tv) r1
                                                  pick r1
         pick (TRow _ _ n t r)
           | n == n2                         = do --traceM (" ## castkwd Row - Row: " ++ prstr (tRow KRow n t r) ++ " = " ++ prstr (tRow KRow n2 t2 r2))
@@ -1024,13 +1024,13 @@ castkwd env info r1 (TStar _ _ r2)          = match r1
           | tv `elem` ufree r2              = conflictingRow tv                     -- use rowTail?
           | otherwise                       = do --traceM (" ## castkwd Var - Star: " ++ prstr (tUni tv) ++ " = " ++ prstr (tStar KRow r2))
                                                  r1 <- tStar KRow <$> newUnivarOfKind KRow env
-                                                 unify info (tUni tv) r1
+                                                 unify env info (tUni tv) r1
                                                  match r1
         match (TRow _ _ n t r)              = do --traceM (" ## castkwd Row - Star: " ++ prstr (tRow KRow n t r) ++ " ≠ " ++ prstr (tStar KRow r2))
                                                  kwdUnexpected info n
         match r1@(TStar _ _ r)
           | TUni _ v <- r, TUni _ v2 <- r2  = do --traceM (" ## castkwd StarVar - StarVar: " ++ prstr (tStar KRow r) ++ " = " ++ prstr (tStar KRow r2))
-                                                 unify info r r2
+                                                 unify env info r r2
                                                  return []
           | TUni _ v <- r                   = do --traceM (" ## castkwd StarVar - Star: " ++ prstr (tStar KRow r) ++ " = " ++ prstr (tStar KRow r2))
                                                  castkwd env info r1 r2
@@ -1042,7 +1042,7 @@ castkwd env info r1 (TStar _ _ r2)          = match r1
 castkwd env info r1 r2@TNil{}               = term r1
   where term (TUni _ tv)                    = do --traceM (" ## castkwd Var - Nil: " ++ prstr (tUni tv) ++ " = " ++ prstr (tNil KRow))
                                                  r1 <- pure $ tNil KRow
-                                                 unify info (tUni tv) r1
+                                                 unify env info (tUni tv) r1
                                                  term (tNil KRow)
         term (TNil _ _)                     = do --traceM (" ## castkwd Nil - Nil: " ++ prstr (tNil KRow) ++ " = " ++ prstr (tNil KRow))
                                                  return []
@@ -1091,7 +1091,7 @@ sub' env _ eq w t1 t2@TWild{}               = return (idwit env w t1 t2 : eq)
 --                     existing                  expected
 sub' env info eq w t1@(TFun _ fx1 p1 k1 t1') t2@(TFun _ fx2 p2 k2 t2')
   | varTails [p1,p2] || varTails [k1,k2]    = do --traceM ("## Unifying funs: " ++ prstr w ++ ": " ++ prstr t1 ++ " ~ " ++ prstr t2)
-                                                 unify info t1 t2
+                                                 unify env info t1 t2
                                                  return (idwit env w t1 t2 : eq)
   | otherwise                               = do --traceM ("### Aligning fun " ++ prstr w ++ ": " ++ prstr t1 ++ " < " ++ prstr t2)
                                                  (cs1,ap,es) <- subpos env info ((map eVar pNames)!!) 0 p2 p1
@@ -1107,7 +1107,7 @@ sub' env info eq w t1@(TFun _ fx1 p1 k1 t1') t2@(TFun _ fx2 p2 k2 t2')
 --                     existing            expected
 sub' env info eq w t1@(TTuple _ p1 k1) t2@(TTuple _ p2 k2)
   | varTails [p1,p2] || varTails [k1,k2]    = do --traceM ("### Unifying tuples: " ++ prstr w ++ ": " ++ prstr t1 ++ " ~ " ++ prstr t2)
-                                                 unify info t1 t2
+                                                 unify env info t1 t2
                                                  return (idwit env w t1 t2 : eq)
   | otherwise                               = do --traceM ("### Aligning tuple " ++ prstr w ++ ": " ++ prstr t1 ++ " < " ++ prstr t2)
                                                  (cs1,ap,es) <- subpos env info (eDotI (eVar px0) . toInteger) 0 p1 p2
@@ -1228,15 +1228,15 @@ subkwd env info f seen r1 (TUni _ tv)       = do unif f seen r1
           | otherwise                       = do --traceM (" ## subkwd Row - Var: " ++ prstr (tRow KRow n t r) ++ " [" ++ prstrs seen ++ "] ≈ " ++ prstr tv)
                                                  t2 <- newUnivar env
                                                  r2 <- tRow KRow n t2 <$> newUnivarOfKind KRow env
-                                                 unify info (tUni tv) r2
+                                                 unify env info (tUni tv) r2
         unif f seen (TStar _ _ r)
           | tv `elem` ufree r               = conflictingRow tv                     -- use rowTail?
           | otherwise                       = do --traceM (" ## subkwd Star - Var: " ++ prstr (tStar KRow r) ++ " [" ++ prstrs seen ++ "] ≈ " ++ prstr tv)
                                                  r2 <- tStar KRow <$> newUnivarOfKind KRow env
-                                                 unify info (tUni tv) r2
+                                                 unify env info (tUni tv) r2
         unif f seen TNil{}                  = do --traceM (" ## subkwd Nil - Var: " ++ prstr (tNil KRow) ++ " [" ++ prstrs seen ++ "] ≈ " ++ prstr tv)
                                                  r2 <- pure $ tNil KRow
-                                                 unify info (tUni tv) r2
+                                                 unify env info (tUni tv) r2
 
 subkwd env info f seen r1 (TRow _ _ n2 t2 r2)
                                             = do (cs1,e) <- pick f seen r1
@@ -1248,7 +1248,7 @@ subkwd env info f seen r1 (TRow _ _ n2 t2 r2)
           | tv `elem` ufree r2              = conflictingRow tv                     -- use rowTail?
           | otherwise                       = do --traceM (" ## subkwd Var - Row: " ++ prstr (tVar tv) ++ " [" ++ prstrs seen ++ "] ≈ " ++ prstr (tRow KRow n2 t2 r2))
                                                  r1 <- tRow KRow n2 t2 <$> newUnivarOfKind KRow env
-                                                 unify info (tUni tv) r1
+                                                 unify env info (tUni tv) r1
                                                  pick f seen r1
         pick f seen (TRow _ _ n t r)
           | n `elem` seen                   = do --traceM (" ## subkwd (Row) - Row: " ++ prstr (tRow KRow n t r) ++ " [" ++ prstrs seen ++ "] ≈ " ++ prstr (tRow KRow n2 t2 r2))
@@ -1270,7 +1270,7 @@ subkwd env info f seen r1 (TStar _ _ r2)    = do (cs,e) <- match f seen r1
           | tv `elem` ufree r2              = conflictingRow tv                     -- use rowTail?
           | otherwise                       = do --traceM (" ## subkwd Var - Star: " ++ prstr (tVar tv) ++ " [" ++ prstrs seen ++ "] ≈ " ++ prstr (tStar KRow r2))
                                                  r1 <- tStar KRow <$> newUnivarOfKind KRow env
-                                                 unify info (tUni tv) r1
+                                                 unify env info (tUni tv) r1
                                                  match f seen r1
         match f seen r1@(TRow _ _ n t r)
           | n `elem` seen                   = do --traceM (" ## subkwd (Row) - Star: " ++ prstr (tRow KRow n t r) ++ " [" ++ prstrs seen ++ "] ≈ " ++ prstr (tStar KRow r2))
@@ -1280,7 +1280,7 @@ subkwd env info f seen r1 (TStar _ _ r2)    = do (cs,e) <- match f seen r1
                                                  return (cs, eTupleK as)
         match f seen r1@(TStar _ _ r)
           | TUni _ v <- r, TUni _ v2 <- r2  = do --traceM (" ## subkwd StarVar - StarVar: " ++ prstr (tStar KRow r) ++ " [" ++ prstrs seen ++ "] ≈ " ++ prstr (tStar KRow r2))
-                                                 unify info r r2
+                                                 unify env info r r2
                                                  return ([], f attrKW)
           | TUni _ v <- r                   = do --traceM (" ## subkwd StarVar - Star: " ++ prstr (tStar KRow r) ++ " [" ++ prstrs seen ++ "] ≈ " ++ prstr (tStar KRow r2))
                                                  (cs,as) <- subkwd env info f seen r1 r2
@@ -1294,7 +1294,7 @@ subkwd env info f seen r1 (TStar _ _ r2)    = do (cs,e) <- match f seen r1
 subkwd env info f seen r1 TNil{}            = term f seen r1
   where term f seen (TUni _ tv)             = do --traceM (" ## subkwd Var - Nil: " ++ prstr (tVar tv) ++ " [" ++ prstrs seen ++ "] ≈ " ++ prstr (tNil KRow))
                                                  r1 <- pure $ tNil KRow
-                                                 unify info (tUni tv) r1
+                                                 unify env info (tUni tv) r1
                                                  term f seen (tNil KRow)
         term f seen (TRow _ _ n t r)
           | n `elem` seen                   = do --traceM (" ## subkwd (Row) - Nil: " ++ prstr (tRow KRow n t r) ++ " [" ++ prstrs seen ++ "] ≈ " ++ prstr (tNil KRow))
@@ -1683,12 +1683,12 @@ improve env te eq cs
   | Nothing <- info                     = do --traceM ("  *Resubmit " ++ show (length cs))
                                              simplify' env te eq cs
   | Left (v,vs) <- closure              = do --traceM ("  *Unify cycle " ++ prstr v ++ " = " ++ prstrs vs)
-                                             sequence [ unify (noinfo 12) (tUni v) (tUni v') | v' <- vs ]
+                                             sequence [ unify env (noinfo 12) (tUni v) (tUni v') | v' <- vs ]
                                              simplify' env te eq cs
   | not $ null gsimple                  = do --traceM ("  *G-simplify " ++ prstrs [ (v,tUni v') | (v,v') <- gsimple ])
                                              --traceM ("  *obsvars: " ++ prstrs obsvars)
                                              --traceM ("  *varvars: " ++ prstrs (varvars vi))
-                                             sequence [ unify (noinfo 13) (tUni v) (tUni v') | (v,v') <- gsimple ]
+                                             sequence [ unify env (noinfo 13) (tUni v) (tUni v') | (v,v') <- gsimple ]
                                              simplify' env te eq cs
   | not $ null cyclic                   = tyerrs cyclic ("Cyclic subtyping:")
   | not $ null (multiUBnd++multiLBnd)   = do ub <- mapM (mkGLB env) multiUBnd   -- GLB of the upper bounds
@@ -1698,20 +1698,20 @@ improve env te eq cs
                                              simplify' env te eq (replace ub lb cs)
   | not $ null posLBnd                  = do --traceM ("  *S-simplify (dn) " ++ prstrs posLBnd)
                                              --traceM ("   posnames "  ++ prstrs (posnames $ envX env))
-                                             sequence [ unify (noinfo 15) (tUni v) t | (v,t) <- posLBnd ]
+                                             sequence [ unify env (noinfo 15) (tUni v) t | (v,t) <- posLBnd ]
                                              simplify' env te eq cs
   | not $ null negUBnd                  = do --traceM ("  *S-simplify (up) " ++ prstrs negUBnd)
                                              --traceM ("   posnames "  ++ prstrs (posnames $ envX env))
-                                             sequence [ unify (noinfo 16) (tUni v) t | (v,t) <- negUBnd ]
+                                             sequence [ unify env (noinfo 16) (tUni v) t | (v,t) <- negUBnd ]
                                              simplify' env te eq cs
   | not $ null closUBnd                 = do --traceM ("  *Simplify upper closed bound " ++ prstrs closUBnd)
-                                             sequence [ unify (noinfo 17) (tUni v) t | (v,t) <- closUBnd ]
+                                             sequence [ unify env (noinfo 17) (tUni v) t | (v,t) <- closUBnd ]
                                              simplify' env te eq cs
   | not $ null closLBnd                 = do --traceM ("  *Simplify lower closed bound " ++ prstrs closLBnd)
-                                             sequence [ unify (noinfo 18) (tUni v) t | (v,t) <- closLBnd ]
+                                             sequence [ unify env (noinfo 18) (tUni v) t | (v,t) <- closLBnd ]
                                              simplify' env te eq cs
   | not $ null redEq                    = do --traceM ("  *(Context red) " ++ prstrs (bound redEq))
-                                             sequence [ unify (noinfo 19) t1 t2 | (t1,t2) <- redUni ]
+                                             sequence [ unify env (noinfo 19) t1 t2 | (t1,t2) <- redUni ]
                                              simplify' env te (redEq++eq) (remove (bound redEq) cs)
   | not $ null dots                     = do --traceM ("  *Implied mutation/selection solutions " ++ prstrs dots)
                                              (eq',cs') <- solveDots mutC selC selP cs

--- a/compiler/lib/src/Acton/Solver.hs
+++ b/compiler/lib/src/Acton/Solver.hs
@@ -149,14 +149,14 @@ newrank pol (Cast _ env t (TUni _ v))
   | pos && not neg                          = R_pos v alts
   | otherwise                               = R_low v alts
   where (pos, neg)                          = (v `elem` fst pol, v `elem` snd pol)
-        alts                                = reverse $ allAbove (limitQuant v env) t
+        alts                                = reverse $ allAbove (limitQuant v env) (expanded env t)
 newrank pol (Cast _ env (TUni _ v) t)
   | TOpt _ (TUni _ v') <- t                 = R_var v v'
   | neg && pos                              = R_ret
   | neg                                     = R_neg v alts
   | otherwise                               = R_amb v alts
   where (pos, neg)                          = (v `elem` fst pol, v `elem` snd pol)
-        alts                                = allBelow (limitQuant v env) t
+        alts                                = allBelow (limitQuant v env) (expanded env t)
 newrank pol (Proto _ env _ (TUni _ v) p)                                                        -- Proto behaves as an upper type bound
   | neg && pos                              = R_ret
 --  | neg                                     = R_neg v alts                                    -- Later, when protos have become proper types
@@ -418,8 +418,8 @@ rank _ (Sub info env _ t1 t2)               = rank env (Cast info env t1 t2)
 rank _ (Cast _ env (TUni _ v) t2@TUni{})    = RVar v [t2]
 rank _ (Cast _ env (TUni _ v) t2)
   | TOpt _ t2@TUni{} <- t2                  = RVar v [t2]
-  | otherwise                               = RTry v (allBelow (limitQuant v env) t2) False
-rank _ (Cast _ env t1 (TUni _ v))           = RTry v (allAbove (limitQuant v env) t1) True
+  | otherwise                               = RTry v (allBelow (limitQuant v env) (expanded env t2)) False
+rank _ (Cast _ env t1 (TUni _ v))           = RTry v (allAbove (limitQuant v env) (expanded env t1)) True
 
 rank _ (Proto _ env _ (TUni _ v) p)         = RTry v ts False
   where ts                                  = allBelowProto (limitQuant v env) p
@@ -683,6 +683,7 @@ reduce' eq c@(Sel _ env w (TCon _ tc) n _)
                                                  reduce (eq'++eq) cs
   | Just p <- protoSearch                   = do (eq',cs) <- solveSelProto p c
                                                  reduce (eq'++eq) cs
+  | Just t <- tExpand env tc                = reduce' eq c{ type1 = t }
   | otherwise                               = tyerr n "Attribute not found"
   where attrSearch                          = findAttr env tc n
         protoSearch                         = findProtoByAttr env (tcname tc) n
@@ -837,6 +838,12 @@ cast' env info (TCon _ c1) (TCon _ c2)
                                               else                                              -- TODO: infer polarities in general!
                                                   unifyM info (tcargs c') (tcargs c2)
   where search                              = findAncestor env c1 (tcname c2)
+
+cast' env info (TCon _ c1) t2
+  | Just t1 <- tExpand env c1               = cast' env info t1 t2
+
+cast' env info t1 (TCon _ c2)
+  | Just t2 <- tExpand env c2               = cast' env info t1 t2
 
 --                 as declared               as called
 --                 existing                  expected

--- a/compiler/lib/src/Acton/Subst.hs
+++ b/compiler/lib/src/Acton/Subst.hs
@@ -90,6 +90,7 @@ instance VFree Decl where
     vfree (Actor _ n q p k ss doc)       = vfree q ++ vfree p ++ vfree k ++ vfree ss
     vfree (Class _ n q bs ss doc)        = vfree q ++ vfree bs ++ vfree ss
     vfree (Protocol _ n q bs ss doc)     = vfree q ++ vfree bs ++ vfree ss
+    vfree (Typedef _ n q t doc)          = vfree q ++ vfree t
     vfree (Extension _ q c bs ss doc)    = vfree q ++ vfree c ++ vfree bs ++ vfree ss
 
 instance VFree Stmt where
@@ -272,6 +273,8 @@ instance VSubst Decl where
       where r                               = quantsubst s q (vfree bs ++ vfree ss)
     vsubst s (Protocol l n q bs ss doc)     = Protocol l n (vsubst s q) (vsubst s bs) (vsubst s ss) doc
       where r                               = quantsubst s q (vfree bs ++ vfree ss)
+    vsubst s (Typedef l n q t doc)          = Typedef l n (vsubst r q) (vsubst r t) doc
+      where r                               = quantsubst s q (vfree t)
     vsubst s (Extension l q c bs ss doc)    = Extension l (vsubst s q) (vsubst s c) (vsubst s bs) (vsubst s ss) doc
       where r                               = quantsubst s q (vfree c ++ vfree bs ++ vfree ss)
 
@@ -439,6 +442,7 @@ instance UFree Decl where
     ufree (Actor _ n q p k ss _)        = ufree q ++ ufree p ++ ufree k ++ ufree ss
     ufree (Class _ n q bs ss _)         = ufree q ++ ufree bs ++ ufree ss
     ufree (Protocol _ n q bs ss _)      = ufree q ++ ufree bs ++ ufree ss
+    ufree (Typedef _ n q t _)           = ufree q ++ ufree t
     ufree (Extension _ q c bs ss _)     = ufree q ++ ufree c ++ ufree bs ++ ufree ss
 
 instance UFree Stmt where

--- a/compiler/lib/src/Acton/Syntax.hs
+++ b/compiler/lib/src/Acton/Syntax.hs
@@ -868,9 +868,12 @@ hasCleanup ss                       = any isCleanup ss
 
 isCleanup (Def _ n _ _ _ _ _ _ _ _) = n == Name NoLoc "__cleanup__"
 
+declbody Typedef{}                  = []
+declbody d                          = dbody d
+
 isNotImpl (Expr _ e)                = e == eNotImpl
 isNotImpl (Assign _ _ e)            = e == eNotImpl
-isNotImpl (Decl _ ds)               = any (hasNotImpl . dbody) ds
+isNotImpl (Decl _ ds)               = any (hasNotImpl . declbody) ds
 isNotImpl _                         = False
 
 notImplBody b                       = not $ null $ notImpls b

--- a/compiler/lib/src/Acton/Syntax.hs
+++ b/compiler/lib/src/Acton/Syntax.hs
@@ -64,7 +64,7 @@ data Decl       = Def           { dloc::SrcLoc, dname:: Name, qbinds::QBinds, po
                 | Actor         { dloc::SrcLoc, dname:: Name, qbinds::QBinds, pos::PosPar, kwd::KwdPar, dbody::Suite, ddoc::Maybe String }
                 | Class         { dloc::SrcLoc, dname:: Name, qbinds::QBinds, bounds::[TCon], dbody::Suite, ddoc::Maybe String }
                 | Protocol      { dloc::SrcLoc, dname:: Name, qbinds::QBinds, bounds::[PCon], dbody::Suite, ddoc::Maybe String }
---                | Extension     { dloc::SrcLoc, dqname::QName, qbinds::QBinds, bounds::[PCon], dbody::Suite }
+                | Typedef       { dloc::SrcLoc, dname:: Name, qbinds::QBinds, texp::Type, ddoc::Maybe String }
                 | Extension     { dloc::SrcLoc, qbinds::QBinds, tycon::TCon, bounds::[PCon], dbody::Suite, ddoc::Maybe String }
                 deriving (Show,Read,NFData,Generic)
 
@@ -692,6 +692,7 @@ instance Eq Decl where
     Actor _ n1 q1 p1 k1 b1 doc1          ==  Actor _ n2 q2 p2 k2 b2 doc2      = n1 == n2 && q1 == q2 && p1 == p2 && k1 == k2 && b1 == b2 && doc1 == doc2
     Class _ n1 q1 a1 b1 doc1             ==  Class _ n2 q2 a2 b2 doc2         = n1 == n2 && q1 == q2 && a1 == a2 && b1 == b2 && doc1 == doc2
     Protocol _ n1 q1 a1 b1 doc1          ==  Protocol _ n2 q2 a2 b2 doc2      = n1 == n2 && q1 == q2 && a1 == a2 && b1 == b2 && doc1 == doc2
+    Typedef _ n1 q1 t1 doc1              ==  Typedef _ n2 q2 t2 doc2          = n1 == n2 && q1 == q2 && t1 == t2 && doc1 == doc2
     Extension _ q1 c1 a1 b1 doc1         ==  Extension _ q2 c2 a2 b2 doc2     = q1 == q2 && c1 == c2 && a1 == a2 && b1 == b2 && doc1 == doc2
     _                               == _                            = False
 
@@ -845,7 +846,7 @@ isKeyword x                         = x `Data.Set.member` rws
                                         "assert","async","await","break","class","continue","def","del","elif","else",
                                         "except","extension","finally","for","from","if","import","in","is","isinstance",
                                         "lambda","mut","not","or","pass","proc","protocol","pure","raise","return","try",
-                                        "var","while","with","yield","_"
+                                        {-"type",-}"var","while","with","yield","_"
                                       ]
 
 isSig Signature{}                   = True

--- a/compiler/lib/src/Acton/Transform.hs
+++ b/compiler/lib/src/Acton/Transform.hs
@@ -124,6 +124,7 @@ instance Transform Decl where
       where env1                        = blockscope (bound p ++ bound k) env
     trans env (Class l n q us b doc)    = Class l n q us (wtrans env b) doc
     trans env (Protocol l n q us b doc) = Protocol l n q us (wtrans env b) doc
+    trans env (Typedef l n q t doc)     = Typedef l n q t doc
     trans env (Extension l n q us b doc)= Extension l n q us (wtrans env b) doc
 
 transCall (Dot _ (Var _ n) m) ts [e1,e2]

--- a/compiler/lib/src/Acton/TypeEnv.hs
+++ b/compiler/lib/src/Acton/TypeEnv.hs
@@ -852,6 +852,7 @@ instance USubst Decl where
     usubstWith s (Actor l n q p k ss doc)         = Actor l n (usubstWith s q) (usubstWith s p) (usubstWith s k) (usubstWith s ss) doc
     usubstWith s (Class l n q bs ss doc)          = Class l n (usubstWith s q) (usubstWith s bs) (usubstWith s ss) doc
     usubstWith s (Protocol l n q bs ss doc)       = Protocol l n (usubstWith s q) (usubstWith s bs) (usubstWith s ss) doc
+    usubstWith s (Typedef l n q t doc)            = Typedef l n (usubstWith s q) (usubstWith s t) doc
     usubstWith s (Extension l q c bs ss doc)      = Extension l (usubstWith s q) (usubstWith s c) (usubstWith s bs) (usubstWith s ss) doc
 
 instance USubst Stmt where
@@ -968,6 +969,7 @@ instance USubst NameInfo where
     usubstWith s (NAct q p k te doc)  = NAct (usubstWith s q) (usubstWith s p) (usubstWith s k) (usubstWith s te) doc
     usubstWith s (NClass q us te doc) = NClass (usubstWith s q) (usubstWith s us) (usubstWith s te) doc
     usubstWith s (NProto q us te doc) = NProto (usubstWith s q) (usubstWith s us) (usubstWith s te) doc
+    usubstWith s (NType q t doc)       = NType (usubstWith s q) (usubstWith s t) doc
     usubstWith s (NExt q c ps te opts doc) = NExt (usubstWith s q) (usubstWith s c) (usubstWith s ps) (usubstWith s te) opts doc
     usubstWith s (NTVar k c ps)       = NTVar k (usubstWith s c) (usubstWith s ps)
     usubstWith s (NAlias qn)          = NAlias qn
@@ -1013,6 +1015,7 @@ instance WellFormed TCon where
                                 NAct q p k te _ -> q
                                 NClass q us te _ -> q
                                 NProto q us te _ -> q
+                                NType q _ _ -> q
                                 NReserved -> nameReserved n
                                 i -> err1 n ("wf: Class or protocol name expected, got " ++ show i)
             s               = qbound q `zip` ts

--- a/compiler/lib/src/Acton/TypeEnv.hs
+++ b/compiler/lib/src/Acton/TypeEnv.hs
@@ -675,61 +675,66 @@ newUnivar env                           = newUnivarOfKind KType env
 
 -- unification ----------------------------------------------------------------------------------------------------------------------
 
-tryUnify info t1 t2                         = unify info t1 t2 `catchError` \err -> Control.Exception.throw err
+tryUnify env info t1 t2                     = unify env info t1 t2 `catchError` \err -> Control.Exception.throw err
 
-unify                                       :: ErrInfo -> Type -> Type -> TypeM ()
-unify info t1 t2                            = do t1' <- usubst t1
+unify                                       :: Env -> ErrInfo -> Type -> Type -> TypeM ()
+unify env info t1 t2                        = do t1' <- usubst t1
                                                  t2' <- usubst t2
                                                  --traceM ("  #unify " ++ prstr t1' ++ " and " ++ prstr t2')
-                                                 unify' info t1' t2'
+                                                 unify' env info t1' t2'
 
-unifyM info ts1 ts2                         = mapM_ (uncurry $ unify info) (ts1 `zip` ts2)
+unifyM env info ts1 ts2                     = mapM_ (uncurry $ unify env info) (ts1 `zip` ts2)
 
 
-unify' _ (TWild _) t2                       = return ()
-unify' _ t1 (TWild _)                       = return ()
+unify' env _ (TWild _) t2                   = return ()
+unify' env _ t1 (TWild _)                   = return ()
 
-unify' info (TCon _ c1) (TCon _ c2)
-  | tcname c1 == tcname c2                  = unifyM info (tcargs c1) (tcargs c2)
+unify' env info (TCon _ c1) (TCon _ c2)
+  | tcname c1 == tcname c2                  = unifyM env info (tcargs c1) (tcargs c2)
 
-unify' info (TFun _ fx1 p1 k1 t1) (TFun _ fx2 p2 k2 t2)
-                                            = do unify info fx1 fx2
-                                                 unify info p2 p1
-                                                 unify info k2 k1
-                                                 unify info t1 t2
+unify' env info (TCon _ c1) t2
+  | Just t1 <- tExpand env c1               = unify' env info t1 t2
+unify' env info t1 (TCon _ c2)
+  | Just t2 <- tExpand env c2               = unify' env info t1 t2
 
-unify' info (TTuple _ p1 k1) (TTuple _ p2 k2)
-                                            = do unify info p1 p2
-                                                 unify info k1 k2
+unify' env info (TFun _ fx1 p1 k1 t1) (TFun _ fx2 p2 k2 t2)
+                                            = do unify env info fx1 fx2
+                                                 unify env info p2 p1
+                                                 unify env info k2 k1
+                                                 unify env info t1 t2
 
-unify' info (TOpt _ t1) (TOpt _ t2)         = unify info t1 t2
-unify' _ (TNone _) (TNone _)                = return ()
+unify' env info (TTuple _ p1 k1) (TTuple _ p2 k2)
+                                            = do unify env info p1 p2
+                                                 unify env info k1 k2
 
-unify' _ (TFX _ fx1) (TFX _ fx2)
+unify' env info (TOpt _ t1) (TOpt _ t2)     = unify env info t1 t2
+unify' env _ (TNone _) (TNone _)            = return ()
+
+unify' env _ (TFX _ fx1) (TFX _ fx2)
   | fx1 == fx2                              = return ()
 
-unify' _ (TNil _ k1) (TNil _ k2)
+unify' env _ (TNil _ k1) (TNil _ k2)
   | k1 == k2                                = return ()
-unify' info (TRow _ k1 n1 t1 r1) (TRow _ k2 n2 t2 r2)
-  | k1 == k2 && n1 == n2                    = do unify info t1 t2
-                                                 unify info r1 r2
-unify' info (TStar _ k1 r1) (TStar _ k2 r2)
-  | k1 == k2                                = unify info r1 r2
+unify' env info (TRow _ k1 n1 t1 r1) (TRow _ k2 n2 t2 r2)
+  | k1 == k2 && n1 == n2                    = do unify env info t1 t2
+                                                 unify env info r1 r2
+unify' env info (TStar _ k1 r1) (TStar _ k2 r2)
+  | k1 == k2                                = unify env info r1 r2
 
-unify' info (TVar _ v1) (TVar _ v2)
+unify' env info (TVar _ v1) (TVar _ v2)
   | v1 == v2                                = return ()
 
-unify' info t1@(TUni _ v1) t2@(TUni _ v2)
+unify' env info t1@(TUni _ v1) t2@(TUni _ v2)
   | v1 == v2                                = return ()
   | uvlevel v1 < uvlevel v2                 = usubstitute v2 t1
   | otherwise                               = usubstitute v1 t2     -- Retain the var with the smallest ulevel (largest scope)
 
-unify' info (TUni _  v) t2                  = do when (v `elem` ufree t2) (infiniteType v t2)
+unify' env info (TUni _  v) t2              = do when (v `elem` ufree t2) (infiniteType v t2)
                                                  usubstitute v t2
-unify' info t1 (TUni _  v)                  = do when (v `elem` ufree t1) (infiniteType v t1)
+unify' env info t1 (TUni _  v)              = do when (v `elem` ufree t1) (infiniteType v t1)
                                                  usubstitute v t1
 
-unify' info t1 t2                           = noUnify info t1 t2
+unify' env info t1 t2                       = noUnify info t1 t2
 
 
 -- Asymmetric matching --------------------------------------------------------------------------------
@@ -1070,14 +1075,14 @@ instWitness env p0 wit      = case wit of
                                  WClass q t p w ws opts -> do
                                     (cs,tvs) <- instQBinds env q
                                     let s = (tvSelf,t) : qbound q `zip` tvs
-                                    unifyM (locinfo p0 22) (tcargs p0) (tcargs $ vsubst s p)
+                                    unifyM env (locinfo p0 22) (tcargs p0) (tcargs $ vsubst s p)
                                     t <- usubst (vsubst s t)
                                     cs <- usubst cs
                                     return (cs, t, wexpr ws (eCall (tApp (eQVar w) tvs) (wvars cs ++ replicate opts eNone)))
                                  WInst q t p w ws -> do
                                     (cs,tvs) <- instQBinds env q
                                     let s = (tvSelf,t) : qbound q `zip` tvs
-                                    unifyM (locinfo p0 23) (tcargs p0) (tcargs $ vsubst s p)
+                                    unifyM env (locinfo p0 23) (tcargs p0) (tcargs $ vsubst s p)
                                     t <- usubst (vsubst s t)
                                     return (cs, t, wexpr ws (eQVar w))
 

--- a/compiler/lib/src/Acton/TypeEnv.hs
+++ b/compiler/lib/src/Acton/TypeEnv.hs
@@ -1113,7 +1113,7 @@ instance UFree Equation where
     ufree (Eqn i w t e)                 = ufree t ++ ufree e
 
 instance Vars Equation where
-    free (Eqn i w t e)                  = free e
+    free (Eqn i w t e)                  = free t ++ free e
 
     bound (Eqn i w t e)                 = [w]
 

--- a/compiler/lib/src/Acton/Types.hs
+++ b/compiler/lib/src/Acton/Types.hs
@@ -494,8 +494,10 @@ pushEqns env eqs s
           where forward                 = free eq `intersect` bvs
 
 inject env [] s                         = s
-inject env eqs (Decl l ds)              = Decl l [ d{ dbody = prune [] (free d) reveqs ++ dbody d } | d <- ds ]
+inject env eqs (Decl l ds)              = Decl l (map injectDecl ds)
   where reveqs                          = reverse eqs
+        injectDecl d@Typedef{}          = d
+        injectDecl d                    = d{ dbody = prune [] (free d) reveqs ++ dbody d }
         prune inj fvs []                = --trace ("### Injecting " ++ prstrs (bound inj) ++ " into " ++ prstr n) $
                                           bindWits inj
         prune inj fvs (eq:eqs)
@@ -1104,6 +1106,13 @@ instance InfEnv Decl where
             te'                         = parentTEnv env ps
             q'                          = selfQuant (NoQ n) q
 
+    infEnv env d@(Typedef l n q t ddoc)
+                                        = case findName n env of
+                                             NReserved ->
+                                                 return ([], [(n, NType q t ddoc)], d)
+                                             _ ->
+                                                 illegalRedef n
+
     infEnv env (Extension l q c us b ddoc)
       | length us == 0                  = err (loc n) "Extension lacks a protocol"
 --      | length us > 1                   = notYet (loc n) "Extensions with multiple protocols"
@@ -1612,6 +1621,7 @@ checkDeclNoSelfReference self seen decl = case decl of
     Actor _ _ _ _ _ body _     -> checkNoSelfReferenceInSuite self [] body  -- Pass empty list to disallow ANY self reference
     Class _ _ _ _ body _       -> True  -- Nested classes don't capture self by default
     Protocol _ _ _ _ body _    -> True  -- Nested protocols don't capture self
+    Typedef _ _ _ _ _          -> True  -- Type aliases don't capture self
     Extension _ _ _ _ body _   -> True  -- Extensions don't capture self
 
 -- Infer all class attributes by scanning the entire __init__ method for any
@@ -1721,6 +1731,7 @@ abstractDefs env q b                    = qsigs ++ map absDef b
                                             p -> qualWPar env q p
                 qcopies                 = [ MutAssign NoLoc (eDot (eVar nSelf) n) (eVar n) | (v,p) <- quals env q, let n = tvarWit v p ]
                 qcopies'                = [ mkEqn env n (proto2type (tVar v) p) (eDot (eVar nSelf) n) | (v,p) <- quals env q, let n = tvarWit v p ]
+        absDef' d                       = d
 
 
 instance Check Decl where
@@ -1768,6 +1779,12 @@ instance Check Decl where
       where env1                        = reserve (bound (p,k) ++ assigned b) $ setInAct $
                                           define [(selfKW, NVar (tCon tc))] $ tydefineVars q env
             tc                          = TC (NoQ n) (map tVar $ qbound q)
+
+    checkEnv env (Typedef l n q t ddoc)
+                                        = do wellformed env1 q
+                                             wellformed env1 t
+                                             return ([], Typedef l n (noqual env q) t ddoc)
+      where env1                        = tydefineVars q env
 
     checkEnv' env (Class l n q us b ddoc)
                                         = do --traceM ("## checkEnv class " ++ prstr n)

--- a/compiler/lib/src/Acton/Types.hs
+++ b/compiler/lib/src/Acton/Types.hs
@@ -452,8 +452,6 @@ checkTopStmt env te (Decl l ds)         = do (cs,ds) <- checkEnv (tydefine te en
 
                                              (te,eq,ds) <- genEnv env cs te ds
                                              --traceM ("============ push\n" ++ render (nest 4 $ vcat $ map pretty eq))
-                                             --traceM ("~~~~~~~~~~~~ i.e. top:\n" ++ render (nest 4 $ vcat $ map pretty eq0))
-                                             --traceM ("============ and scoped:\n" ++ render (nest 4 $ vcat $ map pretty eq1))
                                              --traceM ("------------ onto\n" ++ render (nest 4 $ vcat $ map pretty ds))
                                              finishToStmt env te eq (Decl l ds)
 checkTopStmt env te (Signature l ns sc d)
@@ -465,10 +463,13 @@ checkTopStmt env te (Assign l pats e)   = do (_,t,pats) <- infEnvT env pats
 
 finishToStmt env te eq s                = do te <- defaultX env te
                                              --traceM ("===========\n" ++ render (nest 4 $ vcat $ map pretty te))
-                                             --traceM (".........................................."  ++ prstrs (bound s) ++ "\n")
+                                             --traceM ("-----------\n" ++ render (nest 4 $ pretty s))
                                              eq <- usubst eq
                                              let (eq0, eq1) = spliteqns eq
+                                             --traceM ("~~~~~~~~~~~~ top:\n" ++ render (nest 4 $ vcat $ map pretty eq0))
+                                             --traceM ("============ scoped:\n" ++ render (nest 4 $ vcat $ map pretty eq1))
                                              s <- defaultX env =<< termred eq1 <$> usubst (pushEqns env eq0 s)
+                                             --traceM (".........................................."  ++ prstrs (bound s) ++ "\n")
                                              tieWitKnots te [fixupSelf s]
 
 defaultX                                :: (UFree a, USubst a) => Env -> a -> TypeM a
@@ -497,7 +498,7 @@ pushEqns env eqs s
 inject env [] s                         = s
 inject env eqs (Decl l ds)              = Decl l (map injectDecl ds)
   where reveqs                          = reverse eqs
-        injectDecl d@Typedef{}          = d
+        injectDecl d@Typedef{}          = d -- A typedef can never refer to any witness names
         injectDecl d                    = d{ dbody = prune [] (free d) reveqs ++ dbody d }
         prune inj fvs []                = --trace ("### Injecting " ++ prstrs (bound inj) ++ " into " ++ prstr n) $
                                           bindWits inj

--- a/compiler/lib/src/Acton/Types.hs
+++ b/compiler/lib/src/Acton/Types.hs
@@ -582,7 +582,7 @@ genEnv env cs te ds
       | not $ null ambig_vs             = do --traceM ("  #defaulting: " ++ prstrs ambig_vs)
                                              (cs',eq') <- solve env isAmbig te eq cs
                                              refineAgain cs' eq'
-      | not $ null tail_vs              = do sequence [ tryUnify (Simple NoLoc "internal") (tUni v) (tNil $ uvkind v) | v <- tail_vs ]
+      | not $ null tail_vs              = do sequence [ tryUnify env (Simple NoLoc "internal") (tUni v) (tNil $ uvkind v) | v <- tail_vs ]
                                              refineAgain cs eq
       | otherwise                       = do eq <- usubst eq
                                              return (gen_vs, cs, te, eq)
@@ -719,7 +719,7 @@ wrapped l kw env cs ts args             = do tvx <- newUnivarOfKind KFX env
                                              let t1 = vsubst [(fxSelf,fx)] t0
                                                  t2 = tFun fxPure (foldr posRow posNil ts) kwdNil t'
                                              w <- newWitness
-                                             unify (locinfo l 30) t1 t2
+                                             unify env (locinfo l 30) t1 t2
                                              t' <- usubst t'
                                              cs' <- usubst (Proto (locinfo l 29) env w fx p : cs)
                                              return (cs', t', eCall (tApp (Dot l0 (eVar w) kw) tvs) args)
@@ -847,7 +847,7 @@ instance InfEnv Stmt where
                                              (cs1,e) <- inferSub env t e
                                              (cs2,stmt) <- asgn t0 t e0 e tg
                                              return (cs0++cs1++cs2, [], stmt)
-      where asgn t0 t e0 e (TgVar n)    = do tryUnify (locinfo l 40) t0 t
+      where asgn t0 t e0 e (TgVar n)    = do tryUnify env (locinfo l 40) t0 t
                                              return ( [], sAssign (pVar' n) e )
             asgn t0 t e0 e (TgIndex ix) = do ti <- newUnivar env
                                              (cs,ix) <- inferSub env ti ix
@@ -884,14 +884,14 @@ instance InfEnv Stmt where
             oper _ BAndA                = (pLogical,  iandKW)
             oper _ MMultA               = (pMatrix,   imatmulKW)
 
-            aug t0 t x f e (TgVar _)    = do tryUnify (locinfo l 46) t0 t
+            aug t0 t x f e (TgVar _)    = do tryUnify env (locinfo l 46) t0 t
                                              return ( [], sAssign (pVar' x) $ f [eVar x, e] )
             aug t0 t x f e (TgIndex ix) = do ti <- newUnivar env
                                              (cs,ix) <- inferSub env ti ix
                                              w <- newWitness
                                              return ( Proto (locinfo l 47) env w t0 (pIndexed ti t) :
                                                       cs, sExpr $ dotCall w setitemKW [eVar x, ix, f [dotCall w getitemKW [eVar x, ix], e]])
-            aug t0 t x f e (TgSlice sl) = do tryUnify (locinfo l 1115) t0 t
+            aug t0 t x f e (TgSlice sl) = do tryUnify env (locinfo l 1115) t0 t
                                              (cs,sl) <- inferSlice env sl
                                              t' <- newUnivar env
                                              w <- newWitness
@@ -1001,7 +1001,7 @@ initComplement env n as body
         baseHasAltInit                  = isJust $ findAttr env base altInit
         mkInit stmt                     = sDef altInit (pospar [(selfKW,tSelf)]) tNone [stmt] fxPure
 
-lockSelf l p k dec                      = tryUnify (Simple l "Type of first parameter of class method does not unify with Self") tSelf $ selfType p k dec
+lockSelf env l p k dec                  = tryUnify env (Simple l "Type of first parameter of class method does not unify with Self") tSelf $ selfType p k dec
 
 --------------------------------------------------------------------------------------------------------------------------
 
@@ -1010,10 +1010,10 @@ instance InfEnv Decl where
       | nodup (p,k)                     = case findName n env of
                                              NSig sc dec _ | t@TFun{} <- sctype sc, matchingDec n sc dec dec' -> do
                                                  --traceM ("\n## infEnv (sig) def " ++ prstr (n, NDef sc dec Nothing))
-                                                 when (inClass env) $ lockSelf l p k dec
+                                                 when (inClass env) $ lockSelf env l p k dec
                                                  return ([], [(n, NDef (fxUnwrapSc env sc) dec ddoc)], d{deco = dec})
                                              NReserved -> do
-                                                 when (inClass env) $ lockSelf l p k dec'
+                                                 when (inClass env) $ lockSelf env l p k dec'
                                                  t <- tFun (fxUnwrap env fx) (prowOf p) (krowOf k) <$> maybe (newUnivar env) return a
                                                  let sc = tSchema q (if inClass env then dropSelf t dec' else t)
                                                  --traceM ("\n## infEnv def " ++ prstr (n, NDef sc dec' Nothing))
@@ -1744,7 +1744,7 @@ instance Check Decl where
                                              wellformed env1 q
                                              wellformed env1 a
                                              when (inClass env) $
-                                                 tryUnify (Simple l "Type of first parameter of class method does not unify with Self") tSelf $ selfType p k dec
+                                                 tryUnify env (Simple l "Type of first parameter of class method does not unify with Self") tSelf $ selfType p k dec
                                              (csp,te0,p') <- infEnv env1 p
                                              (csk,te1,k') <- infEnv (define te0 env1) k
                                              (csb,_,b') <- infDefBody (define te1 (define te0 env1)) n p' k' b
@@ -2498,7 +2498,7 @@ instance InfEnvT PosPat where
                                              return (te1++te2, posRow t r, PosPat p' ps')
     infEnvT env (PosPatStar p)          = do (te,t,p') <- infEnvT env p
                                              r <- newUnivarOfKind PRow env
-                                             tryUnify (locinfo p 102) t (tTupleP r)
+                                             tryUnify env (locinfo p 102) t (tTupleP r)
                                              return (te, posStar r, PosPatStar p')
     infEnvT env PosPatNil               = return ([], posNil, PosPatNil)
 
@@ -2509,7 +2509,7 @@ instance InfEnvT KwdPat where
                                              return (te1++te2, kwdRow n t r, KwdPat n p' ps')
     infEnvT env (KwdPatStar p)          = do (te,t,p') <- infEnvT env p
                                              r <- newUnivarOfKind KRow env
-                                             tryUnify (locinfo p 103) t (tTupleK r)
+                                             tryUnify env (locinfo p 103) t (tTupleK r)
                                              return (te, kwdStar r, KwdPatStar p')
     infEnvT env KwdPatNil               = return ([], kwdNil, KwdPatNil)
 
@@ -2548,7 +2548,7 @@ instance InfEnvT Pattern where
                                              return (te1++te2, TTuple NoLoc prow krow, PTuple l ps' ks')
     infEnvT env (PList l ps p)          = do (te1,t1,ps') <- infEnvT env ps
                                              (te2,t2,p') <- infEnvT (define te1 env) p
-                                             tryUnify (locinfo l 108) t2 (tList t1)
+                                             tryUnify env (locinfo l 108) t2 (tList t1)
                                              return (te1++te2, t2, PList l ps' p')
     infEnvT env (PParen l p)            = do (te,t,p') <- infEnvT env p
                                              return (te, t, PParen l p')
@@ -2566,7 +2566,7 @@ instance InfEnvT [Pattern] where
                                              return (te1,t1,[p'])
     infEnvT env (p:ps)                  = do (te1,t1,p') <- infEnvT env p
                                              (te2,t2,ps') <- infEnvT env ps
-                                             tryUnify (locinfo p 109) t1 t2
+                                             tryUnify env (locinfo p 109) t1 t2
                                              return (te1++te2, t1, p':ps')
 
 

--- a/compiler/lib/src/Acton/Types.hs
+++ b/compiler/lib/src/Acton/Types.hs
@@ -466,6 +466,7 @@ checkTopStmt env te (Assign l pats e)   = do (_,t,pats) <- infEnvT env pats
 finishToStmt env te eq s                = do te <- defaultX env te
                                              --traceM ("===========\n" ++ render (nest 4 $ vcat $ map pretty te))
                                              --traceM (".........................................."  ++ prstrs (bound s) ++ "\n")
+                                             eq <- usubst eq
                                              let (eq0, eq1) = spliteqns eq
                                              s <- defaultX env =<< termred eq1 <$> usubst (pushEqns env eq0 s)
                                              tieWitKnots te [fixupSelf s]

--- a/compiler/lib/src/Acton/WitKnots.hs
+++ b/compiler/lib/src/Acton/WitKnots.hs
@@ -48,10 +48,10 @@ tieDeclKnots te ds
   | null cycledeps              = (te, ds)
   | not $ null insts            = error ("INTERNAL: #### Witness cycles with instantiations, not yet handled:\n" ++ 
                                          render (nest 4 $ vcat $ map pretty insts))
-  | otherwise                   = do --trace ("#### Local witness deps:\n" ++ render (nest 4 $ vcat $ map pretty wdeps)) $
-                                     --trace ("#### Chains:\n" ++ render (nest 4 $ vcat $ map pretty wchains)) $
-                                     --trace ("#### Cycles:\n" ++ render (nest 4 $ vcat $ map pretty cycles)) $
-                                     --trace ("#### Cycle dependencies:\n" ++ render (nest 4 $ vcat $ map pretty cycledeps )) $
+  | otherwise                   = do --traceM ("#### Local witness deps:\n" ++ render (nest 4 $ vcat $ map pretty wdeps))
+                                     --traceM ("#### Chains:\n" ++ render (nest 4 $ vcat $ map pretty wchains))
+                                     --traceM ("#### Cycles:\n" ++ render (nest 4 $ vcat $ map pretty cycles))
+                                     --traceM ("#### Cycle dependencies:\n" ++ render (nest 4 $ vcat $ map pretty cycledeps ))
                                      let ds' = map (tieknots cycledeps) ds
                                          te' = map (addopts cycledeps) te
                                      (te', ds')
@@ -160,7 +160,9 @@ addopts cycledeps (n, NExt q c us te _ doc)
 addopts cycledeps ni            = ni
 
 
-tieknots cycledeps dec          = dec{ dbody = map tie (dbody dec) }
+tieknots cycledeps dec
+  | Typedef{} <- dec            = dec
+  | otherwise                   = dec{ dbody = map tie (dbody dec) }
   where
     me                          = dname dec
     mydeps                      = depsof me cycledeps

--- a/compiler/lib/src/InterfaceFiles.hs
+++ b/compiler/lib/src/InterfaceFiles.hs
@@ -1259,6 +1259,7 @@ queryIndexes (I.NModule _ te _) = QueryIndexes (map fst pte) cons actors conattr
         isCons I.NClass{}      = True
         isCons I.NProto{}      = True
         isCons I.NAct{}        = True
+        isCons I.NType{}       = True
         isCons _               = False
         isCon I.NClass{}       = True
         isCon I.NAct{}         = True

--- a/compiler/lib/test/parser_golden/module_actor_before_import.golden
+++ b/compiler/lib/test/parser_golden/module_actor_before_import.golden
@@ -1,11 +1,11 @@
 ERROR: [error Parse error]: unexpected 'i'
-                     expecting "@static", "@staticmethod", "action", "actor", "class", "def", "extension", "mut", "proc", "protocol", "pure", '_', end of input, end of line, or statement
+                     expecting "@static", "@staticmethod", "action", "actor", "class", "def", "extension", "mut", "proc", "protocol", "pure", "type", '_', end of input, end of line, or statement
 
      ╭──▶ test.act@3:1-3:2
      │
    3 │ import math
      • ┬ 
      • ╰╸ unexpected 'i'
-     •    expecting "@static", "@staticmethod", "action", "actor", "class", "def", "extension", "mut", "proc", "protocol", "pure", '_', end of input, end of line, or statement
+     •    expecting "@static", "@staticmethod", "action", "actor", "class", "def", "extension", "mut", "proc", "protocol", "pure", "type", '_', end of input, end of line, or statement
      •    
 ─────╯

--- a/compiler/lib/test/parser_golden/module_class_before_import.golden
+++ b/compiler/lib/test/parser_golden/module_class_before_import.golden
@@ -1,11 +1,11 @@
 ERROR: [error Parse error]: unexpected 'i'
-                     expecting "@static", "@staticmethod", "action", "actor", "class", "def", "extension", "mut", "proc", "protocol", "pure", '_', end of input, end of line, or statement
+                     expecting "@static", "@staticmethod", "action", "actor", "class", "def", "extension", "mut", "proc", "protocol", "pure", "type", '_', end of input, end of line, or statement
 
      ╭──▶ test.act@3:1-3:2
      │
    3 │ import math
      • ┬ 
      • ╰╸ unexpected 'i'
-     •    expecting "@static", "@staticmethod", "action", "actor", "class", "def", "extension", "mut", "proc", "protocol", "pure", '_', end of input, end of line, or statement
+     •    expecting "@static", "@staticmethod", "action", "actor", "class", "def", "extension", "mut", "proc", "protocol", "pure", "type", '_', end of input, end of line, or statement
      •    
 ─────╯

--- a/compiler/lib/test/parser_golden/module_func_before_import.golden
+++ b/compiler/lib/test/parser_golden/module_func_before_import.golden
@@ -1,11 +1,11 @@
 ERROR: [error Parse error]: unexpected 'i'
-                     expecting "@static", "@staticmethod", "action", "actor", "class", "def", "extension", "mut", "proc", "protocol", "pure", '_', end of input, end of line, or statement
+                     expecting "@static", "@staticmethod", "action", "actor", "class", "def", "extension", "mut", "proc", "protocol", "pure", "type", '_', end of input, end of line, or statement
 
      ╭──▶ test.act@3:1-3:2
      │
    3 │ import math
      • ┬ 
      • ╰╸ unexpected 'i'
-     •    expecting "@static", "@staticmethod", "action", "actor", "class", "def", "extension", "mut", "proc", "protocol", "pure", '_', end of input, end of line, or statement
+     •    expecting "@static", "@staticmethod", "action", "actor", "class", "def", "extension", "mut", "proc", "protocol", "pure", "type", '_', end of input, end of line, or statement
      •    
 ─────╯

--- a/test/core_lang_auto/imported_type/.gitignore
+++ b/test/core_lang_auto/imported_type/.gitignore
@@ -1,0 +1,1 @@
+build.zig*

--- a/test/core_lang_auto/imported_type/Build.act
+++ b/test/core_lang_auto/imported_type/Build.act
@@ -1,0 +1,2 @@
+name = "proj"
+fingerprint = 0x520c3c90a1f67946

--- a/test/core_lang_auto/imported_type/src/foo.act
+++ b/test/core_lang_auto/imported_type/src/foo.act
@@ -1,0 +1,2 @@
+
+type Foo = str

--- a/test/core_lang_auto/imported_type/src/imported_type.act
+++ b/test/core_lang_auto/imported_type/src/imported_type.act
@@ -1,0 +1,5 @@
+import foo
+
+actor main(env):
+    f: foo.Foo = "abc"
+    env.exit(0)

--- a/test/core_lang_auto/typedef_cyclic__bf.act
+++ b/test/core_lang_auto/typedef_cyclic__bf.act
@@ -1,0 +1,3 @@
+type Apa = (int, Bepa[str])
+
+type Bepa[K(Hashable)] = dict[K,Apa]

--- a/test/core_lang_auto/typedef_weak_arg__bf.act
+++ b/test/core_lang_auto/typedef_weak_arg__bf.act
@@ -1,0 +1,3 @@
+type Apa = (int, Bepa[(str)->bool])
+
+type Bepa[K(Hashable)] = dict[K,int]

--- a/test/core_lang_auto/typedef_weak_context__bf.act
+++ b/test/core_lang_auto/typedef_weak_context__bf.act
@@ -1,0 +1,1 @@
+type Apa[K(Eq)] = dict[K,str]

--- a/test/core_lang_auto/typedef_witknots.act
+++ b/test/core_lang_auto/typedef_witknots.act
@@ -1,0 +1,49 @@
+class Apa ():
+    def __init__(self, bepas: list[Bepa]):
+        self.bepas = bepas
+
+class Bepa ():
+    def __init__(self, apas: ApaList):
+        self.apas = apas
+
+class Cepa ():
+    def __init__(self, bepas: MyList[Bepa]):
+        self.bepas = bepas
+
+type ApaList = MyList[Apa]
+
+type MyList[T] = list[T]
+
+extension Apa (Ord):
+    def __eq__(x, y):
+        return x.bepas == y.bepas
+    def __lt__(x, y):
+        return x.bepas < y.bepas
+
+extension Bepa (Ord):
+    def __eq__(x, y):
+        return x.apas == y.apas
+    def __lt__(x, y):
+        return x.apas < y.apas
+
+extension Cepa (Ord):
+    def __eq__(x, y):
+        return x.bepas == y.bepas
+    def __lt__(x, y):
+        return x.bepas < y.bepas
+
+bepa1 = Bepa([Apa([Bepa([])])])
+bepa2 = Bepa([])
+
+apa1 = Apa([bepa1])
+apa2 = Apa([bepa2,bepa2])
+
+cepa1 = Cepa([Bepa([Apa([Bepa([])])])])
+
+actor main(env):
+    if apa1 == apa1 and apa1 != apa2 and bepa1 == bepa1 and cepa1 == cepa1:
+        print("Ok")
+        env.exit(0)
+    else:
+        print("Error")
+        env.exit(1)

--- a/test/core_lang_auto/typedefs.act
+++ b/test/core_lang_auto/typedefs.act
@@ -1,0 +1,59 @@
+type Point = (float, float)
+
+def test1(p: Point):
+    return p
+
+def test2(q):
+    return test1(q)
+
+def test3(p: Point):
+    return p.0 + p.1
+
+#
+
+type MyError = LookupError
+
+def test4(err: MyError) -> Exception:
+    return err
+
+#
+
+type Apa = (int, Bepa[str])
+
+class Bepa[K]():
+    attr: Apa
+
+#
+
+class Root():
+    pass
+
+class Left(Root):
+    pass
+
+class Right(Root):
+    pass
+
+type LeftAlias = Left
+
+type RightAlias = Right
+
+def test5(l: LeftAlias, r: RightAlias):
+    return l if True else r
+
+#
+
+type String = str
+
+def test6(s: String):
+    return s.isspace()
+
+#
+
+type Dict[K(Hashable)] = dict[K, str]
+
+def test7(x: Dict[int]):
+    return x[1]
+
+actor main(env):
+    env.exit(0)


### PR DESCRIPTION
Add type definitions / aliases to the language.

**type** _name_ = _type expression_

Examples:
`type Point = (float, float)                  ` _Simple alias_
`type Pair[V] = (V, V)                        ` _Alias with a parameter_
`type Plot[K(Hashable)] = dict[K, Point]      ` _Parameter restricted to to fit context_
`type Branches = list[Tree]                   ` _Type alias in a cyclic definition_
`class Tree():                                ` _(must involve at least one class or actor)_
`    contents: (Pair[str], Branches)            `
A defined type is just a notational shorthand and can always be understood by replacing it with its right-hand side (while substituting any parameters).