### PR TITLE
Soft keywords

### DIFF
--- a/compiler/lib/src/Acton/Syntax.hs
+++ b/compiler/lib/src/Acton/Syntax.hs
@@ -842,11 +842,13 @@ isIdent s@(c:cs)                    = isAlpha c && all isAlphaNum cs && not (isK
 
 isKeyword x                         = x `Data.Set.member` rws
   where rws                         = Data.Set.fromDistinctAscList [
-                                        "False","None","NotImplemented","Self","True","action","actor","after","and","as",
-                                        "assert","async","await","break","class","continue","def","del","elif","else",
-                                        "except","extension","finally","for","from","if","import","in","is","isinstance",
-                                        "lambda","mut","not","or","pass","proc","protocol","pure","raise","return","try",
-                                        {-"type",-}"var","while","with","yield","_"
+                                        "False","None","NotImplemented","Self","True","action","after","and","as",
+                                        "assert","async","await","break","continue","def","del","elif","else",
+                                        "except","finally","for","if","in","is","isinstance",
+                                        "lambda","mut","not","or","pass","proc","pure","raise","return","try",
+                                        "var","while","with","yield","_"
+                                        -- The following are soft keywords and not included in the above list:
+                                        -- "actor","class","extension","from","import","protocol","type"
                                       ]
 
 isSig Signature{}                   = True

--- a/compiler/lib/test/parser_golden/module_actor_before_import.golden
+++ b/compiler/lib/test/parser_golden/module_actor_before_import.golden
@@ -1,11 +1,11 @@
-ERROR: [error Parse error]: unexpected 'i'
-                     expecting "@static", "@staticmethod", "action", "actor", "class", "def", "extension", "mut", "proc", "protocol", "pure", "type", '_', end of input, end of line, or statement
+ERROR: [error Parse error]: unexpected "mat"
+                     expecting "%=", "&=", "**=", "*=", "+=", "-=", "//=", "/=", "<<=", ">>=", "@=", "^=", "|=", ':', '=', call arguments, slice/index expression, or comma
 
-     ╭──▶ test.act@3:1-3:2
+     ╭──▶ test.act@3:8-3:9
      │
    3 │ import math
-     • ┬ 
-     • ╰╸ unexpected 'i'
-     •    expecting "@static", "@staticmethod", "action", "actor", "class", "def", "extension", "mut", "proc", "protocol", "pure", "type", '_', end of input, end of line, or statement
-     •    
+     •        ┬ 
+     •        ╰╸ unexpected "mat"
+     •           expecting "%=", "&=", "**=", "*=", "+=", "-=", "//=", "/=", "<<=", ">>=", "@=", "^=", "|=", ':', '=', call arguments, slice/index expression, or comma
+     •           
 ─────╯

--- a/compiler/lib/test/parser_golden/module_call_before_import.golden
+++ b/compiler/lib/test/parser_golden/module_call_before_import.golden
@@ -1,9 +1,11 @@
-ERROR: [error Syntax error]: Only declarations and assignments are allowed at the module top level
-     ╭──▶ test.act@1:1-1:15
+ERROR: [error Parse error]: unexpected "mat"
+                     expecting "%=", "&=", "**=", "*=", "+=", "-=", "//=", "/=", "<<=", ">>=", "@=", "^=", "|=", ':', '=', call arguments, slice/index expression, or comma
+
+     ╭──▶ test.act@2:8-2:9
      │
-   1 │ print("hello")
-     • ┬─────────────
-     • ╰╸ Only declarations and assignments are allowed at the module top level
-     •
-     │ Hint: Assign the value to a name or move runtime work into an actor or function
+   2 │ import math
+     •        ┬ 
+     •        ╰╸ unexpected "mat"
+     •           expecting "%=", "&=", "**=", "*=", "+=", "-=", "//=", "/=", "<<=", ">>=", "@=", "^=", "|=", ':', '=', call arguments, slice/index expression, or comma
+     •           
 ─────╯

--- a/compiler/lib/test/parser_golden/module_class_before_import.golden
+++ b/compiler/lib/test/parser_golden/module_class_before_import.golden
@@ -1,11 +1,11 @@
-ERROR: [error Parse error]: unexpected 'i'
-                     expecting "@static", "@staticmethod", "action", "actor", "class", "def", "extension", "mut", "proc", "protocol", "pure", "type", '_', end of input, end of line, or statement
+ERROR: [error Parse error]: unexpected "mat"
+                     expecting "%=", "&=", "**=", "*=", "+=", "-=", "//=", "/=", "<<=", ">>=", "@=", "^=", "|=", ':', '=', call arguments, slice/index expression, or comma
 
-     ╭──▶ test.act@3:1-3:2
+     ╭──▶ test.act@3:8-3:9
      │
    3 │ import math
-     • ┬ 
-     • ╰╸ unexpected 'i'
-     •    expecting "@static", "@staticmethod", "action", "actor", "class", "def", "extension", "mut", "proc", "protocol", "pure", "type", '_', end of input, end of line, or statement
-     •    
+     •        ┬ 
+     •        ╰╸ unexpected "mat"
+     •           expecting "%=", "&=", "**=", "*=", "+=", "-=", "//=", "/=", "<<=", ">>=", "@=", "^=", "|=", ':', '=', call arguments, slice/index expression, or comma
+     •           
 ─────╯

--- a/compiler/lib/test/parser_golden/module_dict_before_import.golden
+++ b/compiler/lib/test/parser_golden/module_dict_before_import.golden
@@ -1,9 +1,11 @@
-ERROR: [error Syntax error]: Only declarations and assignments are allowed at the module top level
-     ╭──▶ test.act@1:1-1:17
+ERROR: [error Parse error]: unexpected "mat"
+                     expecting "%=", "&=", "**=", "*=", "+=", "-=", "//=", "/=", "<<=", ">>=", "@=", "^=", "|=", ':', '=', call arguments, slice/index expression, or comma
+
+     ╭──▶ test.act@2:8-2:9
      │
-   1 │ {"key": "value"}
-     • ┬───────────────
-     • ╰╸ Only declarations and assignments are allowed at the module top level
-     •
-     │ Hint: Assign the value to a name or move runtime work into an actor or function
+   2 │ import math
+     •        ┬ 
+     •        ╰╸ unexpected "mat"
+     •           expecting "%=", "&=", "**=", "*=", "+=", "-=", "//=", "/=", "<<=", ">>=", "@=", "^=", "|=", ':', '=', call arguments, slice/index expression, or comma
+     •           
 ─────╯

--- a/compiler/lib/test/parser_golden/module_for_before_import.golden
+++ b/compiler/lib/test/parser_golden/module_for_before_import.golden
@@ -1,9 +1,11 @@
-ERROR: [error Syntax error]: Only declarations and assignments are allowed at the module top level
-     ╭──▶ test.act@1:1-1:1
+ERROR: [error Parse error]: unexpected "mat"
+                     expecting "%=", "&=", "**=", "*=", "+=", "-=", "//=", "/=", "<<=", ">>=", "@=", "^=", "|=", ':', '=', call arguments, slice/index expression, or comma
+
+     ╭──▶ test.act@3:8-3:9
      │
-   1 │ for i in range(10):
-     •  
-     • ╰╸ Only declarations and assignments are allowed at the module top level
-     •
-     │ Hint: Assign the value to a name or move runtime work into an actor or function
+   3 │ import math
+     •        ┬ 
+     •        ╰╸ unexpected "mat"
+     •           expecting "%=", "&=", "**=", "*=", "+=", "-=", "//=", "/=", "<<=", ">>=", "@=", "^=", "|=", ':', '=', call arguments, slice/index expression, or comma
+     •           
 ─────╯

--- a/compiler/lib/test/parser_golden/module_func_before_import.golden
+++ b/compiler/lib/test/parser_golden/module_func_before_import.golden
@@ -1,11 +1,11 @@
-ERROR: [error Parse error]: unexpected 'i'
-                     expecting "@static", "@staticmethod", "action", "actor", "class", "def", "extension", "mut", "proc", "protocol", "pure", "type", '_', end of input, end of line, or statement
+ERROR: [error Parse error]: unexpected "mat"
+                     expecting "%=", "&=", "**=", "*=", "+=", "-=", "//=", "/=", "<<=", ">>=", "@=", "^=", "|=", ':', '=', call arguments, slice/index expression, or comma
 
-     ╭──▶ test.act@3:1-3:2
+     ╭──▶ test.act@3:8-3:9
      │
    3 │ import math
-     • ┬ 
-     • ╰╸ unexpected 'i'
-     •    expecting "@static", "@staticmethod", "action", "actor", "class", "def", "extension", "mut", "proc", "protocol", "pure", "type", '_', end of input, end of line, or statement
-     •    
+     •        ┬ 
+     •        ╰╸ unexpected "mat"
+     •           expecting "%=", "&=", "**=", "*=", "+=", "-=", "//=", "/=", "<<=", ">>=", "@=", "^=", "|=", ':', '=', call arguments, slice/index expression, or comma
+     •           
 ─────╯

--- a/compiler/lib/test/parser_golden/module_if_before_import.golden
+++ b/compiler/lib/test/parser_golden/module_if_before_import.golden
@@ -1,9 +1,11 @@
-ERROR: [error Syntax error]: Only declarations and assignments are allowed at the module top level
-     ╭──▶ test.act@1:1-1:1
+ERROR: [error Parse error]: unexpected "mat"
+                     expecting "%=", "&=", "**=", "*=", "+=", "-=", "//=", "/=", "<<=", ">>=", "@=", "^=", "|=", ':', '=', call arguments, slice/index expression, or comma
+
+     ╭──▶ test.act@3:8-3:9
      │
-   1 │ if True:
-     •  
-     • ╰╸ Only declarations and assignments are allowed at the module top level
-     •
-     │ Hint: Assign the value to a name or move runtime work into an actor or function
+   3 │ import math
+     •        ┬ 
+     •        ╰╸ unexpected "mat"
+     •           expecting "%=", "&=", "**=", "*=", "+=", "-=", "//=", "/=", "<<=", ">>=", "@=", "^=", "|=", ':', '=', call arguments, slice/index expression, or comma
+     •           
 ─────╯

--- a/compiler/lib/test/parser_golden/module_list_before_import.golden
+++ b/compiler/lib/test/parser_golden/module_list_before_import.golden
@@ -1,9 +1,11 @@
-ERROR: [error Syntax error]: Only declarations and assignments are allowed at the module top level
-     ╭──▶ test.act@1:1-1:10
+ERROR: [error Parse error]: unexpected "mat"
+                     expecting "%=", "&=", "**=", "*=", "+=", "-=", "//=", "/=", "<<=", ">>=", "@=", "^=", "|=", ':', '=', call arguments, slice/index expression, or comma
+
+     ╭──▶ test.act@2:8-2:9
      │
-   1 │ [1, 2, 3]
-     • ┬────────
-     • ╰╸ Only declarations and assignments are allowed at the module top level
-     •
-     │ Hint: Assign the value to a name or move runtime work into an actor or function
+   2 │ import math
+     •        ┬ 
+     •        ╰╸ unexpected "mat"
+     •           expecting "%=", "&=", "**=", "*=", "+=", "-=", "//=", "/=", "<<=", ">>=", "@=", "^=", "|=", ':', '=', call arguments, slice/index expression, or comma
+     •           
 ─────╯

--- a/compiler/lib/test/parser_golden/module_number_before_import.golden
+++ b/compiler/lib/test/parser_golden/module_number_before_import.golden
@@ -1,9 +1,11 @@
-ERROR: [error Syntax error]: Only declarations and assignments are allowed at the module top level
-     ╭──▶ test.act@1:1-1:3
+ERROR: [error Parse error]: unexpected "mat"
+                     expecting "%=", "&=", "**=", "*=", "+=", "-=", "//=", "/=", "<<=", ">>=", "@=", "^=", "|=", ':', '=', call arguments, slice/index expression, or comma
+
+     ╭──▶ test.act@2:8-2:9
      │
-   1 │ 42
-     • ┬─
-     • ╰╸ Only declarations and assignments are allowed at the module top level
-     •
-     │ Hint: Assign the value to a name or move runtime work into an actor or function
+   2 │ import math
+     •        ┬ 
+     •        ╰╸ unexpected "mat"
+     •           expecting "%=", "&=", "**=", "*=", "+=", "-=", "//=", "/=", "<<=", ">>=", "@=", "^=", "|=", ':', '=', call arguments, slice/index expression, or comma
+     •           
 ─────╯

--- a/compiler/lib/test/parser_golden/module_var_before_import.golden
+++ b/compiler/lib/test/parser_golden/module_var_before_import.golden
@@ -1,11 +1,11 @@
-ERROR: [error Parse error]: unexpected 'i'
-                     expecting end of input, end of line, or statement
+ERROR: [error Parse error]: unexpected "mat"
+                     expecting "%=", "&=", "**=", "*=", "+=", "-=", "//=", "/=", "<<=", ">>=", "@=", "^=", "|=", ':', '=', call arguments, slice/index expression, or comma
 
-     ╭──▶ test.act@2:1-2:2
+     ╭──▶ test.act@2:8-2:9
      │
    2 │ import math
-     • ┬ 
-     • ╰╸ unexpected 'i'
-     •    expecting end of input, end of line, or statement
-     •    
+     •        ┬ 
+     •        ╰╸ unexpected "mat"
+     •           expecting "%=", "&=", "**=", "*=", "+=", "-=", "//=", "/=", "<<=", ">>=", "@=", "^=", "|=", ':', '=', call arguments, slice/index expression, or comma
+     •           
 ─────╯

--- a/test/core_lang_auto/soft_kwds.act
+++ b/test/core_lang_auto/soft_kwds.act
@@ -1,0 +1,14 @@
+import random
+from math import sqrt
+
+def softy(from, import, type, class, protocol, extension, actor):
+    pass
+
+import = 1
+
+from = 2
+
+#extension = 3
+
+actor main(env):
+    env.exit(0)


### PR DESCRIPTION
Let `actor`, `class`, `extension`, `from`, `import`, `protocol`, and `type` also be valid as variable names