### PR TITLE
Remove the macOS 26 DEVELOPER_DIR override

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -665,13 +665,6 @@ dist/std: std std/Build.act std/build.zig std/build.zig.zon dist/base dist/bin/a
 # the file and modify it, which the Linux kernel (and perhaps others?) will
 # prevent if the file to be modified is an executable program that is currently
 # running.  We work around it by moving / renaming the file in place instead!
-ifeq ($(OS),macos)
-# Workaround for macOS 26.4 CLI tools breaking Zig: point DEVELOPER_DIR to
-# /dev/null to prevent Zig from trying to use them and instead falling back to
-# its own implementation.
-# See https://codeberg.org/ziglang/zig/issues/31658.
-dist/bin/actondb: export DEVELOPER_DIR := /dev/null
-endif
 dist/bin/actondb: $(DIST_ZIG) $(DEPS)
 	@mkdir -p $(dir $@)
 	cd dist/backend && "$(ZIG)" build -Donly_actondb $(if $(ACTON_ZIG_TARGET),-Dtarget=$(ACTON_ZIG_TARGET)) --prefix "$(TD)/dist"

--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -2476,14 +2476,11 @@ runZig gopts opts zigExe zigArgs paths wd mProgressUI = do
               closeFd readFd `catch` ignoreIO
               takeMVar doneVar
         return (Just ("ZIG_PROGRESS", envVal), onStart', onStop', False)
-    let env1 = if System.Info.os == "darwin"
-               then ("DEVELOPER_DIR", "/dev/null") : filter ((/= "DEVELOPER_DIR") . fst) env0
-               else env0
     homeDir <- getHomeDirectory
     let zigEnv = [ ("ZIG_LOCAL_CACHE_DIR", joinPath [homeDir, ".cache", "acton", "zig-local-cache"])
                  , ("ZIG_GLOBAL_CACHE_DIR", joinPath [homeDir, ".cache", "acton", "zig-global-cache"])
                  ]
-        envWithZigCache = foldr (\(k, v) acc -> (k, v) : filter ((/= k) . fst) acc) env1 zigEnv
+        envWithZigCache = foldr (\(k, v) acc -> (k, v) : filter ((/= k) . fst) acc) env0 zigEnv
         env2 = case envOverride of
           Nothing -> Just envWithZigCache
           Just (k, v) -> Just ((k, v) : filter ((/= k) . fst) envWithZigCache)

--- a/test/Makefile
+++ b/test/Makefile
@@ -17,9 +17,6 @@ done
 TESTS= \
 	$(DDB_TESTS)
 TLS_TEST_SERVER_ENV=
-ifeq ($(shell uname -s),Darwin)
-TLS_TEST_SERVER_ENV=DEVELOPER_DIR=$(or $(DEVELOPER_DIR),/dev/null)
-endif
 test:
 	$(MAKE) $(TESTS)
 


### PR DESCRIPTION
macOS 26.4 Command Line Tools broke Zig (ziglang/zig#31658) for a while. We worked around it by forcing DEVELOPER_DIR=/dev/null so Zig fell back to its bundled headers. That issue seems to be resolved on my machine at least with the latest updates.