### PR TITLE
register $Fail & refuse unregistered serialize

### DIFF
--- a/base/builtin/serialize.c
+++ b/base/builtin/serialize.c
@@ -87,6 +87,10 @@ $ROW $add_header(int class_id, int blob_size, $Serial$state state) {
 void $step_serialize($WORD self, $Serial$state state) {
     if (self) {
         int class_id = $GET_CLASSID((($Serializable)self)->$class);
+        if (class_id == UNASSIGNED)
+            // An unregistered class would serialize without a header row, silently
+            // misaligning the blob and corrupting deserialization. Fail loudly.
+            $RAISE((B_BaseException)$NEW(B_ValueError, to$str("serialize: class not registered")));
         if (class_id > ITEM_ID) { // not one of the Acton builtin datatypes, which have hand-crafted serializations
             if (!state->globmap && issubtype(class_id, ACTOR_ID))
                 // This also catches Msg or Cont because they reference the target actor transitively

--- a/base/rts/rts.c
+++ b/base/rts/rts.c
@@ -1912,6 +1912,11 @@ void $register_rts () {
   $register(&$DoneG_methods);
   $register(&$InitRootG_methods);
   $register(&B_EnvG_methods);
+  // $Fail$instance ends up in message $cont slots when an exception propagates
+  // to a waiting actor ($RFAIL wake, and the await-on-failed-message path). It
+  // must be registered like $Done, or serializing such a message emits no
+  // header row for the $cont field and the blob misaligns on recovery.
+  $register(&$FailG_methods);
 }
  
 ////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The $Fail continuation singleton is written into a message $cont slot when an exception propagates to a waiting actor, but $FailG_methods was never registered (class_id -1). In DB mode, serializing such a message emits no header row for the $cont field, silently misaligning the blob so recovery deserializes shifted fields. Register $Fail like $Done (appended last to keep existing dynamic class ids stable), and make $step_serialize raise on any unregistered class so this failure mode is loud instead of corrupting.