### PR TITLE
Add tests of await semantics

### DIFF
--- a/test/core_lang_auto/await_already_done.act
+++ b/test/core_lang_auto/await_already_done.act
@@ -1,0 +1,53 @@
+# The $RWAIT frozen-VALUE fast arm, deterministically, for both awaiter
+# kinds — plus the zero-waiter completion.
+#
+# RTS coverage:
+#  - Zero-waiter freeze: produce() is issued in main's __init__ turn and
+#    completes while nobody awaits: its $RDONE runs FREEZE_waiting on an
+#    empty waiter list (the wake loop iterates zero times) and the value must
+#    be retained on the frozen message.
+#  - Structural determinism: phase2's warm = b.produce() is a fresh sync
+#    round trip; Prod's mailbox is FIFO (ENQ_msg tail-append), so warm
+#    returning proves the original produce was consumed and frozen — under
+#    any load, with no reliance on the 0.3s timer figure.
+#  - Foreign frozen read: Rel's `await fut` inside consume takes the $RWAIT
+#    frozen-value fast arm: ADD_waiting finds the message frozen, the stored
+#    value is copied into Rel's parked frame, and Rel is immediately
+#    ENQ_readyd — no waiter registration, no involvement of the producer.
+#  - Creator frozen read across turns: x lives in actor state (deactorized to
+#    a main attribute); phase2 arrives via the timer path (ENQ_timed ->
+#    handle_timeout -> ENQ_msg onto idle main -> ENQ_ready), and main's own
+#    `await x` hits the same frozen-value arm. Under an owner-local rewrite
+#    these two reads become DIFFERENT code paths (foreign request/reply vs
+#    owner-local read); today both are the same fast arm.
+#  - Ordering also exercises the single-waiter $RDONE wake when consume's
+#    result resumes parked main. Hangs are bounded by the Watchdog actor
+#    (in-main timers cannot fire behind a parked head).
+
+actor Watchdog(env):
+    after 10.0: env.exit(1)
+
+actor Prod():
+    def produce() -> int:
+        return 3
+
+actor Rel():
+    def consume(fut) -> int:
+        return await fut
+
+actor main(env):
+    wd = Watchdog(env)
+    b = Prod()
+    c = Rel()
+    x = async b.produce()
+
+    def phase2():
+        warm = b.produce()
+        v1 = c.consume(x)
+        v2 = await x
+        if warm == 3 and v1 == 3 and v2 == 3:
+            print("already-done ok")
+            env.exit(0)
+        env.exit(1)
+
+    after 0.3: phase2()

--- a/test/core_lang_auto/await_already_failed.act
+++ b/test/core_lang_auto/await_already_failed.act
@@ -1,0 +1,66 @@
+# The $RWAIT frozen-EXCEPTION fast arm, deterministically, for both awaiter
+# kinds — plus the genuinely waiter-less failure and producer survival.
+#
+# RTS coverage:
+#  - Waiter-less failure: boom() raises with NO waiter registered: $RFAIL
+#    no-catcher arm freezes the message as an exception, the propagation loop
+#    iterates zero times, and — uniquely in this suite — the "Unhandled
+#    exception" stderr notice prints (the branch taken only when
+#    FREEZE_waiting returns an empty list). Prod then DEQ_msgs and continues
+#    serving: the RFAIL arm must leave the actor schedulable.
+#  - Structural determinism + survival: phase2's alive = b.produce() both
+#    proves (FIFO mailbox) that boom was consumed and frozen before either
+#    await runs, and asserts the producer still answers after an unhandled
+#    failure.
+#  - Frozen-exception reads: both Rel's `await fut` and main's own
+#    check_self() hit the $RWAIT frozen-exception fast arm: ADD_waiting finds
+#    the message frozen-exceptional, the parked frame's cont is set to
+#    $Fail$instance with the stored exception as value, and the awaiter is
+#    immediately ENQ_readyd. Resume runs $Fail$instance -> $R_FAIL ->
+#    $RFAIL-with-catcher into the $PUSH_C catcher for the enclosing try ->
+#    typed except -> -1. Without this test, the frozen-exception arm is
+#    reached only on race arms of the other exception tests; an owner-local
+#    rewrite must store the exception and replay it, still typed, to late
+#    arrivals of either kind.
+#  - Hangs (e.g. a producer that never answers) park main and are bounded by
+#    the Watchdog actor.
+
+actor Watchdog(env):
+    after 10.0: env.exit(1)
+
+actor Prod():
+    def boom() -> int:
+        raise ValueError("boom")
+
+    def produce() -> int:
+        return 8
+
+actor Rel():
+    def consume(fut) -> int:
+        try:
+            return await fut
+        except ValueError:
+            return -1
+
+actor main(env):
+    wd = Watchdog(env)
+    b = Prod()
+    c = Rel()
+    x = async b.boom()
+
+    def check_self() -> int:
+        try:
+            return await x
+        except ValueError:
+            return -1
+
+    def phase2():
+        alive = b.produce()
+        v1 = c.consume(x)
+        v2 = check_self()
+        if alive == 8 and v1 == -1 and v2 == -1:
+            print("already-failed ok")
+            env.exit(0)
+        env.exit(1)
+
+    after 0.3: phase2()

--- a/test/core_lang_auto/await_chain.act
+++ b/test/core_lang_auto/await_chain.act
@@ -1,0 +1,53 @@
+# The fully deterministic pending park/wake baseline: three nested sync
+# calls, three simultaneously parked actors, LIFO unwind with the value
+# threaded through every resumed frame.
+#
+# RTS coverage:
+#  - Deterministic pending registration at every level: each sync call
+#    ($ASYNCf+$AWAITf -> $RWAIT) runs ADD_waiting BEFORE
+#    reverse_outgoing_queue/FLUSH_outgoing_local, so the caller is on the
+#    callee message's waiter list before the callee can possibly run: no
+#    interleaving reaches the frozen arms here.
+#  - Simultaneous park chain: while Leaf computes, main->$waitsfor,
+#    Top->$waitsfor and Mid->$waitsfor are all set; Top and Mid are each at
+#    once ON a waiter list (of their callee's message) and HOLDING a waiter
+#    list (on their own in-progress message) — the dual role an owner-local
+#    waiter redesign must preserve.
+#  - Unwind: three $RDONE freeze+single-waiter-wake sequences in strict LIFO
+#    order, each writing its value into the next parked frame's value slot
+#    and ENQ_readying exactly one actor. The +1 per hop makes any
+#    wrong-frame value write (cross-wiring) visible in the final sum.
+#  - No timers, escapes, or exceptions: a failure here isolates the plain
+#    ADD_waiting/FREEZE_waiting/wake machinery itself. A stuck unwind parks
+#    the whole chain; the Watchdog actor (never parked, mailbox empty, so
+#    its handle_timeout delivery DOES ENQ_ready it) bounds the run.
+
+actor Watchdog(env):
+    after 10.0: env.exit(1)
+
+actor Leaf():
+    def leaf() -> int:
+        return 1
+
+actor Mid(nxt):
+    def mid() -> int:
+        return nxt.leaf() + 1
+
+actor Top(nxt):
+    def top() -> int:
+        return nxt.mid() + 1
+
+actor main(env):
+    wd = Watchdog(env)
+    l = Leaf()
+    m = Mid(l)
+    t = Top(m)
+
+    def go():
+        v = t.top()
+        if v == 3:
+            print("chain ok")
+            env.exit(0)
+        env.exit(1)
+
+    go()

--- a/test/core_lang_auto/await_exc_escaped.act
+++ b/test/core_lang_auto/await_exc_escaped.act
@@ -1,0 +1,61 @@
+# Exception propagation through an escaped future to a foreign pending
+# waiter, while the future's creator is parked: the exception flavor of
+# await_relay.
+#
+# RTS coverage:
+#  - Producer failure: boom()'s raise longjmps to the worker's jump buffer;
+#    wt_work_cb's exceptional path converts it to $R_FAIL. Prod has no
+#    catcher, so the $RFAIL no-catcher arm runs: the message is frozen as an
+#    exception (FREEZE_waiting) and — because Rel IS registered — the waiter
+#    propagation loop writes $Fail$instance into Rel's parked consume frame's
+#    cont slot plus the exception as its value, clears $waitsfor, and
+#    ENQ_readys Rel. A registered waiter suppresses the "Unhandled exception"
+#    stderr notice (that waiter-less branch is owned by await_already_failed).
+#  - Waiter resume: Rel re-dispatches its parked frame; the cont is now
+#    $Fail$instance, whose __call__ returns $R_FAIL, hitting the
+#    $RFAIL-with-catcher arm: the catcher installed by $PUSH_C for Rel's
+#    `try` receives the exception, the frame's cont is set to the catcher
+#    cont with value False (the except branch selector), and the typed
+#    `except ValueError` runs — turning the failure into a normal -1 return
+#    that completes consume via the ordinary $RDONE freeze+wake of main.
+#  - Rel's pending registration rests on the spin margin (see await_relay);
+#    the degraded arm is the $RWAIT frozen-exception fast path, owned
+#    deterministically by await_already_failed.
+#  - Watchdog in a separate actor: timer envelopes tail-append behind a
+#    parked head (no ENQ_ready), so an in-main timer cannot guard the park.
+
+actor Watchdog(env):
+    after 10.0: env.exit(1)
+
+actor Prod():
+    var i = 0
+
+    def spin():
+        while i < 20000000:
+            i += 1
+
+    def boom() -> int:
+        raise ValueError("boom")
+
+actor Rel():
+    def consume(fut) -> int:
+        try:
+            return await fut
+        except ValueError:
+            return -1
+
+actor main(env):
+    wd = Watchdog(env)
+    b = Prod()
+    c = Rel()
+
+    def go():
+        async b.spin()
+        x = async b.boom()
+        v = c.consume(x)
+        if v == -1:
+            print("escaped exception ok")
+            env.exit(0)
+        env.exit(1)
+
+    go()

--- a/test/core_lang_auto/await_exc_multi.act
+++ b/test/core_lang_auto/await_exc_multi.act
@@ -1,0 +1,72 @@
+# The $RFAIL waiter propagation loop with SEVERAL registered waiters: one
+# failing message, three pending waiters, each woken with the exception
+# exactly once and each catching it independently.
+#
+# RTS coverage:
+#  - Registration as in await_fan_in: trivial-init Waiters, go() fired async,
+#    three ADD_waiting pending registrations building a 3-deep waiter chain
+#    on boom()'s message (spin margin keeps it unresolved).
+#  - Target path: boom() raises -> $R_FAIL -> $RFAIL no-catcher arm freezes
+#    the message as an exception and the propagation loop walks all three
+#    waiters, writing $Fail$instance + the exception into each parked go
+#    frame and ENQ_readying each. This is the only test where that loop
+#    iterates more than once. No "Unhandled exception" notice: waiters exist.
+#  - Each Waiter's resume runs $Fail$instance -> $RFAIL-with-catcher into its
+#    own $PUSH_C catcher -> typed except -> report(wid, -1) as an ordinary
+#    envelope to main.
+#  - Duplicate/lost accounting identical to await_fan_in: seen[wid] with the
+#    deferred success exit (a duplicate wake in the settle window beats the
+#    delayed exit(0)); a lost wake parks that Waiter and the Watchdog actor
+#    bounds the run.
+
+actor Watchdog(env):
+    after 10.0: env.exit(1)
+
+actor Prod():
+    var i = 0
+
+    def spin():
+        while i < 20000000:
+            i += 1
+
+    def boom() -> int:
+        raise ValueError("boom")
+
+actor Waiter(wid: int, fut, report):
+    def go():
+        try:
+            v = await fut
+            report(wid, v)
+        except ValueError:
+            report(wid, -1)
+
+actor main(env):
+    wd = Watchdog(env)
+    var seen = [False, False, False]
+    var count = 0
+    b = Prod()
+
+    def report(wid: int, v: int):
+        if v != -1:
+            env.exit(1)
+            return
+        if seen[wid]:
+            env.exit(1)
+            return
+        seen[wid] = True
+        count += 1
+        if count == 3:
+            print("multi-exception ok")
+            after 0.3: env.exit(0)
+
+    def go():
+        async b.spin()
+        x = async b.boom()
+        w0 = Waiter(0, x, report)
+        w1 = Waiter(1, x, report)
+        w2 = Waiter(2, x, report)
+        async w0.go()
+        async w1.go()
+        async w2.go()
+
+    go()

--- a/test/core_lang_auto/await_fan_in.act
+++ b/test/core_lang_auto/await_fan_in.act
@@ -1,0 +1,74 @@
+# The N-waiter wake loop: four actors registered on ONE unresolved message,
+# all woken by a single completion, each exactly once.
+#
+# RTS coverage:
+#  - Concurrent registration: Waiter construction is itself a sync await of
+#    __init__ (newact = $ASYNCf(init)+$AWAITf), so the inits are kept trivial
+#    and go() is fired with `async`, letting all four go() turns run
+#    concurrently. Each takes the $RWAIT pending arm: ADD_waiting pushes the
+#    waiter onto the message's singly-linked waiter list (linked through the
+#    waiters' own $next fields), guarded by the message's wait lock; the spin
+#    margin keeps produce unresolved throughout.
+#  - Target path: produce's $RDONE runs FREEZE_waiting once and the wake loop
+#    walks the 4-deep waiter chain: for each waiter it writes 42 into the
+#    waiter's parked go frame, clears $waitsfor, and ENQ_readys it. This is
+#    the only test where that loop iterates more than once for a value.
+#  - Duplicate accounting: each report(wid,...) is an ordinary envelope
+#    tail-appended to main's mailbox. Success is deferred (after 0.3:
+#    env.exit(0)) because env.exit sets rts_exit and halts dispatch: an
+#    immediate exit would discard a trailing duplicate-wake report still in
+#    main's queue. Within the settle window a duplicate trips seen[wid] and
+#    its env.exit(1) wins (first exit wins).
+#  - A lost wakeup leaves that Waiter parked with $waitsfor set forever; the
+#    (never-parked) Watchdog actor converts the hang to exit 1.
+
+actor Watchdog(env):
+    after 10.0: env.exit(1)
+
+actor Prod():
+    var i = 0
+
+    def spin():
+        while i < 20000000:
+            i += 1
+
+    def produce() -> int:
+        return 42
+
+actor Waiter(wid: int, fut, report):
+    def go():
+        v = await fut
+        report(wid, v)
+
+actor main(env):
+    wd = Watchdog(env)
+    var seen = [False, False, False, False]
+    var count = 0
+    b = Prod()
+
+    def report(wid: int, v: int):
+        if v != 42:
+            env.exit(1)
+            return
+        if seen[wid]:
+            env.exit(1)
+            return
+        seen[wid] = True
+        count += 1
+        if count == 4:
+            print("fan-in ok")
+            after 0.3: env.exit(0)
+
+    def go():
+        async b.spin()
+        x = async b.produce()
+        w0 = Waiter(0, x, report)
+        w1 = Waiter(1, x, report)
+        w2 = Waiter(2, x, report)
+        w3 = Waiter(3, x, report)
+        async w0.go()
+        async w1.go()
+        async w2.go()
+        async w3.go()
+
+    go()

--- a/test/core_lang_auto/await_fan_out.act
+++ b/test/core_lang_auto/await_fan_out.act
@@ -1,0 +1,60 @@
+# Per-future result routing: one actor with five outstanding futures must
+# get each producer's value delivered to the await of THAT future — the
+# direct probe for cross-wiring in per-message waiter bookkeeping.
+#
+# RTS coverage:
+#  - One turn issues five $ASYNCs (five messages PUSH_outgoing'd, restored
+#    to program order by reverse_outgoing_queue, flushed to five different
+#    producers at the first $RWAIT).
+#  - `await f4` is a same-turn await: its $RWAIT runs ADD_waiting before the
+#    flush, so it is a deterministic pending park and its wake comes from
+#    b4's $RDONE single-waiter loop.
+#  - The remaining awaits (f3..f0, reverse issue order) race their
+#    producers: each independently resolves via EITHER the pending
+#    park/wake OR the $RWAIT frozen-value fast arm. Both arms must key the
+#    value by message identity; the per-await assertions (v_i == i) catch a
+#    value delivered to the wrong await on either arm — a plain sum would be
+#    permutation-invariant and mask exactly that swap.
+#  - A lost completion parks main with $waitsfor set forever; the Watchdog
+#    actor bounds it.
+
+actor Watchdog(env):
+    after 10.0: env.exit(1)
+
+actor Prod(i: int):
+    def produce() -> int:
+        return i
+
+actor main(env):
+    wd = Watchdog(env)
+    b0 = Prod(0)
+    b1 = Prod(1)
+    b2 = Prod(2)
+    b3 = Prod(3)
+    b4 = Prod(4)
+
+    def go():
+        f0 = async b0.produce()
+        f1 = async b1.produce()
+        f2 = async b2.produce()
+        f3 = async b3.produce()
+        f4 = async b4.produce()
+        v4 = await f4
+        if v4 != 4:
+            env.exit(1)
+        v3 = await f3
+        if v3 != 3:
+            env.exit(1)
+        v2 = await f2
+        if v2 != 2:
+            env.exit(1)
+        v1 = await f1
+        if v1 != 1:
+            env.exit(1)
+        v0 = await f0
+        if v0 != 0:
+            env.exit(1)
+        print("fan-out ok")
+        env.exit(0)
+
+    go()

--- a/test/core_lang_auto/await_mixed_outcomes.act
+++ b/test/core_lang_auto/await_mixed_outcomes.act
@@ -1,0 +1,61 @@
+# One producer, two outstanding futures with DIVERGENT outcomes: the
+# exception stays keyed to bad()'s message and the value to good()'s, and
+# the producer keeps serving between them.
+#
+# RTS coverage:
+#  - Prod's mailbox receives [bad, good] in program order (LIFO outgoing
+#    buffer restored by reverse_outgoing_queue, ENQ_msg tail-append).
+#  - check_bad(h): a deterministic pending park (ADD_waiting on h's message
+#    precedes the flush). bad() raises -> $RFAIL no-catcher arm freezes h's
+#    message as an exception and the propagation loop writes $Fail$instance
+#    + the exception into main's parked frame (waiter present, so no
+#    "Unhandled exception" notice); main resumes through its $PUSH_C catcher
+#    into the typed except -> -1.
+#  - Producer survival on the $RFAIL path: after the failure Prod DEQ_msgs
+#    and runs good(), whose $RDONE freezes 21 onto g's message — good()
+#    delivering at all requires the failed actor to keep serving.
+#  - check_good(g): main's resume races Prod's good() turn, so this await
+#    exercises EITHER the pending park/wake or the $RWAIT frozen-value fast
+#    arm; both must key by message identity. Cross-contamination in either
+#    direction (value 21 surfacing at h's await, or the ValueError at g's)
+#    is converted by the sentinel excepts (-1 expected / -2 unexpected) into
+#    a failed final comparison rather than an uncaught abort.
+#  - Lost completions park main; the Watchdog actor bounds the run.
+
+actor Watchdog(env):
+    after 10.0: env.exit(1)
+
+actor Prod():
+    def good() -> int:
+        return 21
+
+    def bad() -> int:
+        raise ValueError("bad")
+
+actor main(env):
+    wd = Watchdog(env)
+    b = Prod()
+
+    def check_bad(fut) -> int:
+        try:
+            return await fut
+        except ValueError:
+            return -1
+
+    def check_good(fut) -> int:
+        try:
+            return await fut
+        except ValueError:
+            return -2
+
+    def go():
+        h = async b.bad()
+        g = async b.good()
+        hv = check_bad(h)
+        gv = check_good(g)
+        if hv == -1 and gv == 21:
+            print("mixed outcomes ok")
+            env.exit(0)
+        env.exit(1)
+
+    go()

--- a/test/core_lang_auto/await_queued_msgs.act
+++ b/test/core_lang_auto/await_queued_msgs.act
@@ -1,0 +1,60 @@
+# Ordinary messages queued behind a parked frame: not run while parked,
+# delivered exactly once each after resume, in send order.
+#
+# RTS coverage:
+#  - `async ping(1)` / `async ping(2)` are real self-addressed envelopes (a
+#    bare self-call would be a direct inline call): PUSH_outgoing'd in main's
+#    go() turn and flushed at the $RWAIT — FLUSH_outgoing_local ENQ_msgs
+#    them onto main's OWN mailbox, tail-appended behind the parked __init__
+#    head frame.
+#  - Parked semantics: while main sits in $RWAIT on produce()'s message,
+#    those envelopes must not be dispatched (the mailbox head is only
+#    advanced by DEQ_msg at $RDONE / final $RFAIL). The awaited-guard in
+#    ping() converts any early execution — e.g. a control-queue rewrite
+#    misclassifying an ordinary message as processable-while-parked — into
+#    exit 1.
+#  - Resume and drain: produce's $RDONE wake writes into the parked head and
+#    ENQ_readys main; the head's own $RDONE then DEQ_msgs, and the has_more
+#    self-re-ENQ_ready chain dispatches ping(1) then ping(2) in FIFO order.
+#    The [1, 2] log catches loss, duplication, and reordering.
+#  - finish() ordering is structural, not timing: its timer envelope is
+#    delivered by handle_timeout's ENQ_msg to the TAIL of main's queue,
+#    behind both pings queued since park time. A lost wake parks main; the
+#    Watchdog actor bounds the run.
+
+actor Watchdog(env):
+    after 10.0: env.exit(1)
+
+actor Prod():
+    def produce() -> int:
+        return 1
+
+actor main(env):
+    wd = Watchdog(env)
+    b = Prod()
+    var order = []
+    var awaited = False
+
+    def ping(n: int):
+        if not awaited:
+            env.exit(1)
+            return
+        order.append(n)
+
+    def finish():
+        if order == [1, 2]:
+            print("queued-msgs ok")
+            env.exit(0)
+        env.exit(1)
+
+    def go():
+        x = async b.produce()
+        async ping(1)
+        async ping(2)
+        v = await x
+        if v != 1:
+            env.exit(1)
+        awaited = True
+        after 0.4: finish()
+
+    go()

--- a/test/core_lang_auto/await_relay.act
+++ b/test/core_lang_auto/await_relay.act
@@ -1,0 +1,61 @@
+# Escaped future awaited by a foreign actor while the future's creator is
+# parked. The scenario an owner-mediated await rewrite is most likely to
+# break: if waking Rel required action from the (parked) creator, this
+# program would three-way deadlock.
+#
+# RTS coverage (rts.c wt_work_cb dispatch, q.c queues):
+#  - Deterministic pending park of main: c.consume(x) lowers to
+#    $ASYNCf+$AWAITf -> $RWAIT, and ADD_waiting(main, consume_msg) runs
+#    BEFORE reverse_outgoing_queue/FLUSH_outgoing_local, so main is on the
+#    consume message's waiter list before Rel has even received it.
+#  - Flush ordering: spin/produce/consume envelopes are PUSH_outgoing'd
+#    (LIFO), restored to program order by reverse_outgoing_queue, and
+#    tail-appended by ENQ_msg; spin keeps Prod's mailbox busy so produce runs
+#    tens of ms later.
+#  - Target path: Rel's `await fut` takes the $RWAIT pending arm
+#    (ADD_waiting under the wait lock finds the message unfrozen); produce's
+#    $RDONE then runs FREEZE_waiting (value) and the waiter wake loop, which
+#    writes 42 into Rel's parked consume frame, clears Rel->$waitsfor, and
+#    ENQ_ready(Rel) — all while main stays parked. Rel's consume $RDONE then
+#    repeats freeze+wake with main as the sole waiter.
+#  - Degraded arm (heavily loaded host, spin margin lost): Rel instead hits
+#    the $RWAIT frozen-value fast arm (stored value copied into the parked
+#    frame, immediate ENQ_ready) — still a pass; that arm is owned by
+#    await_already_done.
+#  - Watchdog is a separate never-parked actor because handle_timeout
+#    delivers timer messages with ENQ_msg, which tail-appends behind a parked
+#    actor's head frame and (queue non-empty) never ENQ_readys it: an
+#    in-main timer cannot guard main's own park.
+
+actor Watchdog(env):
+    after 10.0: env.exit(1)
+
+actor Prod():
+    var i = 0
+
+    def spin():
+        while i < 20000000:
+            i += 1
+
+    def produce() -> int:
+        return 42
+
+actor Rel():
+    def consume(fut) -> int:
+        return await fut
+
+actor main(env):
+    wd = Watchdog(env)
+    b = Prod()
+    c = Rel()
+
+    def go():
+        async b.spin()
+        x = async b.produce()
+        v = c.consume(x)
+        if v == 42:
+            print("relay ok")
+            env.exit(0)
+        env.exit(1)
+
+    go()

--- a/test/core_lang_auto/await_timer_mix.act
+++ b/test/core_lang_auto/await_timer_mix.act
@@ -1,0 +1,69 @@
+# Timer-fired messages arriving at a PARKED actor: queued behind the parked
+# frame (never run early), then delivered after resume — all of them, in
+# timer order.
+#
+# RTS coverage:
+#  - Timer machinery: both after-statements $AFTER into the global timerQ
+#    via ENQ_timed (baseline-ordered insert); main_timer_cb/handle_timeout
+#    DEQ_timeds each at its deadline and delivers with a plain ENQ_msg to
+#    main.
+#  - Target property: main is parked in $RWAIT on produce() (spin delays the
+#    producer past both timer deadlines), so its mailbox head is the parked
+#    __init__ frame and both tick envelopes TAIL-APPEND behind it; ENQ_msg
+#    returns false (queue non-empty) so handle_timeout does NOT ENQ_ready
+#    main — a parked actor must be neither run nor spuriously scheduled by
+#    timer delivery. The awaited-guard in tick() turns any early execution
+#    (e.g. a control-queue rewrite misclassifying an ordinary timer message)
+#    into exit 1.
+#  - After the wake and the head's $RDONE, DEQ_msg reports more messages and
+#    the self-re-ENQ_ready chain drains tick(1) then tick(2) in FIFO order;
+#    the [1, 2] log catches loss, duplication (including a loss masked by a
+#    duplicate), and reordering.
+#  - Spin is a busy-work margin, not a guarantee: on an extremely fast
+#    machine produce could resolve before the 0.1s tick and the run degrades
+#    to ordinary idle-actor timer delivery (still a pass, without the
+#    parked-arrival property). The Watchdog actor bounds lost-wake hangs.
+
+actor Watchdog(env):
+    after 10.0: env.exit(1)
+
+actor Prod():
+    var i = 0
+
+    def spin():
+        while i < 100000000:
+            i += 1
+
+    def produce() -> int:
+        return 11
+
+actor main(env):
+    wd = Watchdog(env)
+    b = Prod()
+    var order = []
+    var awaited = False
+
+    def tick(n: int):
+        if not awaited:
+            env.exit(1)
+            return
+        order.append(n)
+
+    def finish():
+        if order == [1, 2]:
+            print("timer-mix ok")
+            env.exit(0)
+        env.exit(1)
+
+    def go():
+        async b.spin()
+        x = async b.produce()
+        v = await x
+        if v != 11:
+            env.exit(1)
+        awaited = True
+        after 0.4: finish()
+
+    after 0.05: tick(1)
+    after 0.1: tick(2)
+    go()

--- a/test/core_lang_auto/await_values.act
+++ b/test/core_lang_auto/await_values.act
@@ -1,0 +1,56 @@
+# Result payloads of several types through the wake write, and effect
+# ordering around an awaited void call.
+#
+# RTS coverage:
+#  - The $RDONE wake loop delivers a result by writing a single word (a
+#    pointer) into the waiter's parked frame value slot; this test routes
+#    int, str and bool payloads through that write via implicit-await sync
+#    calls (all deterministic pending-path parks: ADD_waiting precedes the
+#    outgoing flush).
+#  - `await async b.bump()` is the suite's only await of a void method: the
+#    completion wake carries a None result. The observable is the wake
+#    itself — a rewrite that ships results as messages must not confuse a
+#    None payload with "no result yet"; that confusion parks main at this
+#    await and is bounded by the Watchdog actor.
+#  - Effect visibility: bump() and effects_seen() are tail-appended to
+#    Prod's FIFO mailbox across two successive parks of main, so
+#    effects_seen() must observe bump()'s write (n == 1) — mailbox FIFO
+#    ordering across await boundaries.
+
+actor Watchdog(env):
+    after 10.0: env.exit(1)
+
+actor Prod():
+    var effects = 0
+
+    def geti() -> int:
+        return 42
+
+    def gets() -> str:
+        return "hello"
+
+    def getb() -> bool:
+        return True
+
+    def bump():
+        effects += 1
+
+    def effects_seen() -> int:
+        return effects
+
+actor main(env):
+    wd = Watchdog(env)
+    b = Prod()
+
+    def go():
+        i = b.geti()
+        s = b.gets()
+        t = b.getb()
+        await async b.bump()
+        n = b.effects_seen()
+        if i == 42 and s == "hello" and t and n == 1:
+            print("values ok")
+            env.exit(0)
+        env.exit(1)
+
+    go()


### PR DESCRIPTION
Add 12 tests that pin down the observable semantics of await ahead of the planned runtime rework of message/future handling. They cover awaiting a pending result, already-frozen values and exceptions, exception propagation to one and to several waiters, escaped futures awaited by a foreign actor, chained awaits, fan-in, fan-out, interleaving with timers, mailbox ordering around a park, and divergent outcomes from one producer.

Each test carries a docstring describing exactly which RTS code paths it exercises (dispatch cases, waiter registration and flush ordering, freeze and wake loops) and why its outcome is deterministic. The tests are written to fail on missed wakes, duplicate wakes and ordering regressions, using a separate never-parked watchdog actor since a timer in a parked actor can never fire.
