### PR TITLE
Fix witness field loss in imported classes

### DIFF
--- a/compiler/lib/src/Acton/Converter.hs
+++ b/compiler/lib/src/Acton/Converter.hs
@@ -250,7 +250,8 @@ convEnvProtos env                       = convertModules convSources conv env
                                         = map (fromClass env) $ convProtocol (define [ni] env) n q us [] [] (fromTEnv te)
     conv m ni@(n, NExt q c us te opts doc)
                                         = map (fromClass env) $ convExtension (define [ni] env) n c q us [] [] (fromTEnv te) opts
-    conv m (n, NClass q us te doc)      = [(n, NClass (noqual env q) us (convClassTEnv env q te) doc)]
+    conv m (n, NClass q us te doc)      = [(n, NClass (noqual env q) us (witSigs ++ convClassTEnv env q te) doc)]
+      where witSigs                     = [ (w, NSig (monotype t) Property Nothing) | (w,t) <- qualWits env q ]
     conv m (n, NType q t doc)           = [(n, NType (noqual env q) (convT q t) doc)]
     conv m ni                           = [ni]
     convS (TSchema l q t)               = TSchema l (noqual env q) (convT q t)

--- a/test/regression_auto/.gitignore
+++ b/test/regression_auto/.gitignore
@@ -1,4 +1,6 @@
 *
+!*/
+out/
 !*.act
 !*.ext.c
 !.gitignore

--- a/test/regression_auto/constrained_generic_subclass/.gitignore
+++ b/test/regression_auto/constrained_generic_subclass/.gitignore
@@ -1,0 +1,1 @@
+build.zig*

--- a/test/regression_auto/constrained_generic_subclass/Build.act
+++ b/test/regression_auto/constrained_generic_subclass/Build.act
@@ -1,0 +1,2 @@
+name = "constrained_generic_subclass"
+fingerprint = 0x5db8e6191a2b3c4d

--- a/test/regression_auto/constrained_generic_subclass/src/constrained_generic_subclass.act
+++ b/test/regression_auto/constrained_generic_subclass/src/constrained_generic_subclass.act
@@ -1,0 +1,37 @@
+import keyed
+
+# Subclass a generic Eq-constrained class from another module and check
+# that the inherited hidden witness field stays in the subclass layouts
+# (see keyed.act).
+
+# K concretized to str.
+class Sub(keyed.Keyed[str]):
+    pass
+
+# Still generic: adds its own witness field after the inherited one.
+class GSub[J(Eq)](keyed.Keyed[J]):
+    pass
+
+actor main(env):
+    # The annotations make the reads below go through the subclass
+    # layouts; without them, s and g widen to keyed.Keyed and the base
+    # layout hides the witness slot shift.
+    s: Sub = Sub()
+    if s.marker is not None:
+        print("FAIL: Sub dropped the inherited witness field")
+        await async env.exit(1)
+    g: GSub[str] = GSub()
+    if g.marker is not None:
+        print("FAIL: GSub dropped the inherited witness field")
+        await async env.exit(1)
+    # The generated serializers walk the same attribute list as the
+    # struct layout, so round-trip an instance as well.
+    r = deserialize(serialize(s))
+    if isinstance(r, Sub):
+        if r.marker is not None:
+            print("FAIL: round-tripped Sub has misplaced fields")
+            await async env.exit(1)
+        print("OK")
+        await async env.exit(0)
+    print("FAIL: deserialize did not return a Sub")
+    await async env.exit(1)

--- a/test/regression_auto/constrained_generic_subclass/src/keyed.act
+++ b/test/regression_auto/constrained_generic_subclass/src/keyed.act
@@ -1,0 +1,10 @@
+# A class with an Eq-constrained type parameter stores a hidden Eq[K]
+# witness as its first instance field.
+
+class Keyed[K(Eq)](object):
+    # Always None. Sits right after the hidden witness field, so if a
+    # subclass loses that field, this slot shifts and reads invalid data or crashes
+    marker: ?int
+
+    mut def __init__(self) -> None:
+        self.marker = None


### PR DESCRIPTION
A generic type with a constraint on the protocol, like Keyed[K(Eq)], stores a hidden protocol witness as an instance field. When such a class was imported and subclassed in another module, convEnvProtos rebuilt its attributes without the witness field, so the subclass struct came out one slot short and the base class methods read and wrote fields at the wrong offsets, corrupting memory.

Include the witness fields when converting imported classes, like the protocol and extension conversions already do.

Add a regression test that subclasses a generic Eq-constrained class from another module, both concretized and still generic, and round-trips an instance through serialize()/deserialize().