### PR TITLE
Fix comprehensions in branch conditions

### DIFF
--- a/compiler/lib/src/Acton/Normalizer.hs
+++ b/compiler/lib/src/Acton/Normalizer.hs
@@ -102,10 +102,19 @@ normEnv env0                        = setX env0 NormX{ marksX = [], rtypeX = Not
 
 -- Normalize terms ---------------------------------------------------------------------------------------
 
-normSuite env []                    = return []
-normSuite env (s : ss)              = do s' <- norm' env s
+-- Comprehensions deferred while normalizing an enclosing statement's expressions
+-- (e.g. a branch condition) must be materialized before that statement, not
+-- inside a nested suite of it, so shield any comprehensions pending on entry
+-- from the getComps drain below.
+normSuite env ss                    = do pending <- getComps
+                                         ss' <- normSuite' env ss
+                                         mapM_ addComp (reverse pending)
+                                         return ss'
+
+normSuite' env []                   = return []
+normSuite' env (s : ss)             = do s' <- norm' env s
                                          comps <- getComps
-                                         ss' <- normSuite (define (envOf s) env) ss
+                                         ss' <- normSuite' (define (envOf s) env) ss
                                          defs <- mapM mkCompFun comps
                                          return (concat defs ++ s' ++ ss')
   where mkCompFun (f,lambound,comp) = do w <- newName "w"

--- a/compiler/lib/test/4-normalizer/norm_comprehension_condition.input
+++ b/compiler/lib/test/4-normalizer/norm_comprehension_condition.input
@@ -1,0 +1,25 @@
+W_check_18: __builtin__.Number[__builtin__.int] = __builtin__.IntegralD_int()
+
+W_check_26: __builtin__.Ord[__builtin__.int] = __builtin__.OrdD_int()
+
+pure def check (l : __builtin__.list[__builtin__.int]) -> __builtin__.bool:
+    W_check_6: __builtin__.Iterable[__builtin__.list[__builtin__.int], __builtin__.int] = __builtin__.SequenceD_list@[__builtin__.int]().W_Collection
+    W_check_21: __builtin__.Eq[__builtin__.list[__builtin__.int]] = __builtin__.OrdD_list@[__builtin__.int](W_check_26)
+    if W_check_21.__ne__([x for x: __builtin__.int in W_check_6.__iter__(l)], [W_check_18.__fromatom__(1), W_check_18.__fromatom__(2), W_check_18.__fromatom__(3)]):
+        return False
+    return True
+
+W_main_43: __builtin__.Number[__builtin__.int] = __builtin__.IntegralD_int()
+
+W_main_20: __builtin__.Times[__builtin__.int, __builtin__.int] = __builtin__.IntegralD_int()
+
+W_main_70: __builtin__.Ord[__builtin__.int] = __builtin__.OrdD_int()
+
+W_main_31: __builtin__.Eq[__builtin__.list[__builtin__.int]] = __builtin__.OrdD_list@[__builtin__.int](W_main_70)
+
+W_main_12: __builtin__.Iterable[__builtin__.list[__builtin__.int], __builtin__.int] = __builtin__.SequenceD_list@[__builtin__.int]().W_Collection
+
+actor main (env : __builtin__.Env):
+    if W_main_31.__eq__([W_main_20.__mul__(x, W_main_43.__fromatom__(2)) for x: __builtin__.int in W_main_12.__iter__([W_main_43.__fromatom__(1), W_main_43.__fromatom__(2)])], [W_main_43.__fromatom__(2), W_main_43.__fromatom__(4)]):
+        env.exit(n = W_main_43.__fromatom__(0))
+    env.exit(n = W_main_43.__fromatom__(1))

--- a/compiler/lib/test/4-normalizer/norm_comprehension_condition.output
+++ b/compiler/lib/test/4-normalizer/norm_comprehension_condition.output
@@ -5,27 +5,27 @@ W_check_26: __builtin__.Ord[__builtin__.int] = __builtin__.OrdD_int()
 pure def check (l : __builtin__.list[__builtin__.int]) -> __builtin__.bool:
     W_check_6: __builtin__.Iterable[__builtin__.list[__builtin__.int], __builtin__.int] = __builtin__.SequenceD_list@[__builtin__.int]().W_Collection
     W_check_21: __builtin__.Eq[__builtin__.list[__builtin__.int]] = __builtin__.OrdD_list@[__builtin__.int](W_check_26)
-    if W_check_21.__ne__(N_compfun(), [W_check_18.__fromatom__(1), W_check_18.__fromatom__(2), W_check_18.__fromatom__(3)]):
-        pure def N_compfun () -> __builtin__.list[__builtin__.int]:
-            N_1w: __builtin__.Sequence[__builtin__.list[__builtin__.int], __builtin__.int] = __builtin__.SequenceD_list@[__builtin__.int]()
-            N_2res: __builtin__.list[__builtin__.int] = []
-            N_3iter: __builtin__.Iterator[__builtin__.int] = W_check_6.__iter__(l)
-            if $PUSH():
-                while True:
-                    if True:
-                        pass
-                    else:
-                        break
-                    x: __builtin__.int = N_3iter.__next__()
-                    N_1w.append(N_2res, x)
-                $DROP()
-            else:
-                N_5x: __builtin__.BaseException = $POP()
-                if isinstance(N_5x, __builtin__.StopIteration):
+    pure def N_compfun () -> __builtin__.list[__builtin__.int]:
+        N_1w: __builtin__.Sequence[__builtin__.list[__builtin__.int], __builtin__.int] = __builtin__.SequenceD_list@[__builtin__.int]()
+        N_2res: __builtin__.list[__builtin__.int] = []
+        N_3iter: __builtin__.Iterator[__builtin__.int] = W_check_6.__iter__(l)
+        if $PUSH():
+            while True:
+                if True:
                     pass
                 else:
-                    $RAISE(N_5x)
-            return N_2res
+                    break
+                x: __builtin__.int = N_3iter.__next__()
+                N_1w.append(N_2res, x)
+            $DROP()
+        else:
+            N_5x: __builtin__.BaseException = $POP()
+            if isinstance(N_5x, __builtin__.StopIteration):
+                pass
+            else:
+                $RAISE(N_5x)
+        return N_2res
+    if W_check_21.__ne__(N_compfun(), [W_check_18.__fromatom__(1), W_check_18.__fromatom__(2), W_check_18.__fromatom__(3)]):
         return False
     return True
 
@@ -40,26 +40,26 @@ W_main_31: __builtin__.Eq[__builtin__.list[__builtin__.int]] = __builtin__.OrdD_
 W_main_12: __builtin__.Iterable[__builtin__.list[__builtin__.int], __builtin__.int] = __builtin__.SequenceD_list@[__builtin__.int]().W_Collection
 
 actor main (env : __builtin__.Env):
-    if W_main_31.__eq__(N_6compfun(), [W_main_43.__fromatom__(2), W_main_43.__fromatom__(4)]):
-        pure def N_6compfun () -> __builtin__.list[__builtin__.int]:
-            N_7w: __builtin__.Sequence[__builtin__.list[__builtin__.int], __builtin__.int] = __builtin__.SequenceD_list@[__builtin__.int]()
-            N_8res: __builtin__.list[__builtin__.int] = []
-            N_9iter: __builtin__.Iterator[__builtin__.int] = W_main_12.__iter__([W_main_43.__fromatom__(1), W_main_43.__fromatom__(2)])
-            if $PUSH():
-                while True:
-                    if True:
-                        pass
-                    else:
-                        break
-                    x: __builtin__.int = N_9iter.__next__()
-                    N_7w.append(N_8res, W_main_20.__mul__(x, W_main_43.__fromatom__(2)))
-                $DROP()
-            else:
-                N_11x: __builtin__.BaseException = $POP()
-                if isinstance(N_11x, __builtin__.StopIteration):
+    pure def N_6compfun () -> __builtin__.list[__builtin__.int]:
+        N_7w: __builtin__.Sequence[__builtin__.list[__builtin__.int], __builtin__.int] = __builtin__.SequenceD_list@[__builtin__.int]()
+        N_8res: __builtin__.list[__builtin__.int] = []
+        N_9iter: __builtin__.Iterator[__builtin__.int] = W_main_12.__iter__([W_main_43.__fromatom__(1), W_main_43.__fromatom__(2)])
+        if $PUSH():
+            while True:
+                if True:
                     pass
                 else:
-                    $RAISE(N_11x)
-            return N_8res
+                    break
+                x: __builtin__.int = N_9iter.__next__()
+                N_7w.append(N_8res, W_main_20.__mul__(x, W_main_43.__fromatom__(2)))
+            $DROP()
+        else:
+            N_11x: __builtin__.BaseException = $POP()
+            if isinstance(N_11x, __builtin__.StopIteration):
+                pass
+            else:
+                $RAISE(N_11x)
+        return N_8res
+    if W_main_31.__eq__(N_6compfun(), [W_main_43.__fromatom__(2), W_main_43.__fromatom__(4)]):
         env.exit(W_main_43.__fromatom__(0))
     env.exit(W_main_43.__fromatom__(1))

--- a/compiler/lib/test/4-normalizer/norm_comprehension_condition.output
+++ b/compiler/lib/test/4-normalizer/norm_comprehension_condition.output
@@ -1,0 +1,65 @@
+W_check_18: __builtin__.Number[__builtin__.int] = __builtin__.IntegralD_int()
+
+W_check_26: __builtin__.Ord[__builtin__.int] = __builtin__.OrdD_int()
+
+pure def check (l : __builtin__.list[__builtin__.int]) -> __builtin__.bool:
+    W_check_6: __builtin__.Iterable[__builtin__.list[__builtin__.int], __builtin__.int] = __builtin__.SequenceD_list@[__builtin__.int]().W_Collection
+    W_check_21: __builtin__.Eq[__builtin__.list[__builtin__.int]] = __builtin__.OrdD_list@[__builtin__.int](W_check_26)
+    if W_check_21.__ne__(N_compfun(), [W_check_18.__fromatom__(1), W_check_18.__fromatom__(2), W_check_18.__fromatom__(3)]):
+        pure def N_compfun () -> __builtin__.list[__builtin__.int]:
+            N_1w: __builtin__.Sequence[__builtin__.list[__builtin__.int], __builtin__.int] = __builtin__.SequenceD_list@[__builtin__.int]()
+            N_2res: __builtin__.list[__builtin__.int] = []
+            N_3iter: __builtin__.Iterator[__builtin__.int] = W_check_6.__iter__(l)
+            if $PUSH():
+                while True:
+                    if True:
+                        pass
+                    else:
+                        break
+                    x: __builtin__.int = N_3iter.__next__()
+                    N_1w.append(N_2res, x)
+                $DROP()
+            else:
+                N_5x: __builtin__.BaseException = $POP()
+                if isinstance(N_5x, __builtin__.StopIteration):
+                    pass
+                else:
+                    $RAISE(N_5x)
+            return N_2res
+        return False
+    return True
+
+W_main_43: __builtin__.Number[__builtin__.int] = __builtin__.IntegralD_int()
+
+W_main_20: __builtin__.Times[__builtin__.int, __builtin__.int] = __builtin__.IntegralD_int()
+
+W_main_70: __builtin__.Ord[__builtin__.int] = __builtin__.OrdD_int()
+
+W_main_31: __builtin__.Eq[__builtin__.list[__builtin__.int]] = __builtin__.OrdD_list@[__builtin__.int](W_main_70)
+
+W_main_12: __builtin__.Iterable[__builtin__.list[__builtin__.int], __builtin__.int] = __builtin__.SequenceD_list@[__builtin__.int]().W_Collection
+
+actor main (env : __builtin__.Env):
+    if W_main_31.__eq__(N_6compfun(), [W_main_43.__fromatom__(2), W_main_43.__fromatom__(4)]):
+        pure def N_6compfun () -> __builtin__.list[__builtin__.int]:
+            N_7w: __builtin__.Sequence[__builtin__.list[__builtin__.int], __builtin__.int] = __builtin__.SequenceD_list@[__builtin__.int]()
+            N_8res: __builtin__.list[__builtin__.int] = []
+            N_9iter: __builtin__.Iterator[__builtin__.int] = W_main_12.__iter__([W_main_43.__fromatom__(1), W_main_43.__fromatom__(2)])
+            if $PUSH():
+                while True:
+                    if True:
+                        pass
+                    else:
+                        break
+                    x: __builtin__.int = N_9iter.__next__()
+                    N_7w.append(N_8res, W_main_20.__mul__(x, W_main_43.__fromatom__(2)))
+                $DROP()
+            else:
+                N_11x: __builtin__.BaseException = $POP()
+                if isinstance(N_11x, __builtin__.StopIteration):
+                    pass
+                else:
+                    $RAISE(N_11x)
+            return N_8res
+        env.exit(W_main_43.__fromatom__(0))
+    env.exit(W_main_43.__fromatom__(1))

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -2081,6 +2081,7 @@ main = do
 
     describe "Pass 4: Normalizer" $ do
       testNorm env0 ["deact"]
+      testNorm env0 ["norm_comprehension_condition"]
 
     describe "Pass 5: Deactorizer" $ do
       testDeact env0 ["deact", "deact_from_import"]

--- a/compiler/lib/test/src/norm_comprehension_condition.act
+++ b/compiler/lib/test/src/norm_comprehension_condition.act
@@ -1,0 +1,13 @@
+# A comprehension in a branch condition: the Normalizer must emit the
+# generated comprehension function before the if statement, in scope of the
+# call in the condition — not inside the branch body.
+
+def check(l: list[int]) -> bool:
+    if [x for x in l] != [1, 2, 3]:
+        return False
+    return True
+
+actor main(env):
+    if [x * 2 for x in [1, 2]] == [2, 4]:
+        env.exit(0)
+    env.exit(1)

--- a/test/core_lang_auto/comprehension_in_condition.act
+++ b/test/core_lang_auto/comprehension_in_condition.act
@@ -1,0 +1,47 @@
+# A comprehension in a branch or loop condition is deferred by the Normalizer
+# to a generated function (compfun), whose def must be emitted before the
+# statement owning the condition. It used to be drained by the branch body's
+# suite instead, placing the def out of scope of the call in the condition
+# ("Back pass failed: NameNotFound (Internal NormPass compfun 0)").
+
+def check_if(l: list[int]) -> bool:
+    if [x for x in l] != [1, 2, 3]:
+        return False
+    return True
+
+def check_elif(l: list[int]) -> int:
+    if len(l) == 0:
+        return 0
+    elif [x for x in l] != [1, 2, 3]:
+        return 1
+    else:
+        return 2
+
+def count_while(l: list[int]) -> int:
+    n = 0
+    while [x for x in l if x > n] != []:
+        n += 1
+    return n
+
+actor main(env):
+    l = sorted([3, 1, 2])
+    if [x for x in l] != [1, 2, 3]:
+        await async env.exit(1)
+    if not check_if(l):
+        await async env.exit(2)
+    if check_elif(l) != 2:
+        await async env.exit(3)
+    if count_while(l) != 3:
+        await async env.exit(4)
+    d: dict[int, str] = {}
+    d[1] = "one"
+    if {k: v for k, v in d.items()} != {1: "one"}:
+        await async env.exit(5)
+    if {x for x in l} != {1, 2, 3}:
+        await async env.exit(6)
+    if [y + 1 for y in [x * 2 for x in l]] != [3, 5, 7]:
+        await async env.exit(7)
+    for i in [0, 1]:
+        if [x for x in l] != [1, 2, 3]:
+            await async env.exit(8)
+    await async env.exit(0)


### PR DESCRIPTION
The Normalizer rewrites each comprehension into a call to a generated function (compfun), deferring the function itself via shared NormM state. normSuite drains that state after normalizing each statement and emits the pending defs in front of it. But a comprehension in a branch condition is deferred while the statement is still being normalized, and the branch body's nested normSuite drained it first: the def ended up inside the branch body while the call sits in the condition, out of scope. The back pass then failed with NameNotFound (Internal NormPass "compfun" 0) when the Deactorizer looked up the call target. Any comprehension in an if, elif or while condition triggered this, in actors and plain functions alike.

Shield comprehensions pending on entry to a suite from that suite's drain, so they are materialized by the enclosing suite in front of the statement whose condition references them.