### PR TITLE
Keep boxed class-method params boxed

### DIFF
--- a/compiler/lib/src/Acton/Boxing.hs
+++ b/compiler/lib/src/Acton/Boxing.hs
@@ -12,6 +12,7 @@ import Acton.Subst
 import Pretty
 import Utils
 import Debug.Trace
+import Data.Maybe (isJust)
 import qualified Data.HashSet as HashSet
 import Control.Monad.State.Strict
 import Control.Monad.Except
@@ -30,6 +31,7 @@ data BoxX                          = BoxX { inClassX :: Maybe (TCon, TEnv)
                                           , inActionX :: Bool
                                           , returnTypeX :: Maybe Type
                                           , staticWitnessesX :: M.HashMap Name StaticWitness
+                                          , boxedParamsX :: HashSet.HashSet Name
                                           }
 
 
@@ -38,12 +40,33 @@ boxEnv env0                        = setX env0 BoxX{ inClassX = Nothing
                                                    , inActionX = False
                                                    , returnTypeX = Nothing
                                                    , staticWitnessesX = M.empty
+                                                   , boxedParamsX = HashSet.empty
                                                    }
 
 
 setInClass mtc env                  = modX env $ \x -> x{ inClassX = mtc }
 
 getInClass env                      = inClassX $ envX env
+
+-- A class method slot whose type is generic in the oldest superclass keeps its
+-- boxed ABI even when instantiated at an unboxable type (see rtypeOf), so such
+-- parameters hold boxed values, unlike every other unboxable-typed local.
+setBoxedParams ns env               = modX env $ \x -> x{ boxedParamsX = HashSet.fromList ns }
+
+isBoxedParam env n                  = n `HashSet.member` boxedParamsX (envX env)
+
+boxedPars                           :: PosPar -> [(Name, Type)]
+boxedPars (PosPar n (Just t) _ p)
+  | isUnboxable t                   = (n, t) : boxedPars p
+boxedPars (PosPar _ _ _ p)          = boxedPars p
+boxedPars _                         = []
+
+boxedPar n                          = Derived n (name "boxed")
+
+renamePars ns (PosPar n a e p)
+  | n `elem` ns                     = PosPar (boxedPar n) a e (renamePars ns p)
+  | otherwise                       = PosPar n a e (renamePars ns p)
+renamePars ns p                     = p
 
 setInAction b env                   = modX env $ \x -> x{ inActionX = b }
 
@@ -577,6 +600,7 @@ instance {-# OVERLAPS #-} Boxing ([Stmt]) where
 instance Boxing Expr where
     boxing env e@(Var _ (NoQ n))
        | isWitness n                = return (HashSet.singleton n, e)
+       | isBoxedParam env n         = return (HashSet.empty, e)
        | isUnboxable t              = return (HashSet.empty, Box t e)
        where t                      = typeOf env e
     -- Qualified imported constants such as math.pi need the same boxed read
@@ -830,8 +854,8 @@ instance Boxing Decl where
               env1                  = defineTVars q env
               env2                  = Acton.Boxing.setInClass (Just(c,findAttrSchemas env1 (NoQ n))) env1
     boxing env f@(Def l n q p KwdNIL t ss dec fx ddoc)
-                                    = do (ws2,ss') <- boxing env1 ss
-                                         return (ws2, Def l n q pFinal KwdNIL (Just t') ss' dec fx ddoc)
+                                    = do (ws2,ss') <- boxing env1 (copies ++ ss)
+                                         return (ws2, Def l n q pDone KwdNIL (Just t') ss' dec fx ddoc)
       where ft                      = tFun fx (prowOf p) kwdNil (fromJust t)
             (pFinal, t0@(TFun _ _ _ _ t'))
                                     = case getInClass env of
@@ -844,8 +868,15 @@ instance Boxing Decl where
             keepSelf (PosPar a b c p') r
                                     = PosPar a b c (fixpars p' r)
             keepSelf p r            = fixpars p r
-            te                      = envOf pFinal
-            env1                    = setReturnType (Just t') $ setInAction (fx == fxAction) $ define te env
+            bps                     = if isJust (getInClass env) then boxedPars pFinal else []
+            -- A boxed parameter the body assigns is renamed aside and copied
+            -- into an ordinary raw local up front, so stores follow the
+            -- standard raw convention and the caller's box is never written.
+            rebound                 = [ pn | (pn, _) <- bps, pn `elem` assigned ss ]
+            pDone                   = renamePars rebound pFinal
+            copies                  = [ sAssign (pVar pn pt) (eVar (boxedPar pn)) | (pn, pt) <- bps, pn `elem` rebound ]
+            te                      = envOf pDone
+            env1                    = setBoxedParams (map fst (boxedPars pDone)) $ setReturnType (Just t') $ setInAction (fx == fxAction) $ define te env
     boxing env d@Typedef{}          = return (HashSet.empty, d)
   
 instance Boxing Branch where

--- a/compiler/lib/test/8-boxing/boxparam.input
+++ b/compiler/lib/test/8-boxing/boxparam.input
@@ -1,0 +1,40 @@
+W_Base_30: __builtin__.Number[__builtin__.int] = __builtin__.IntegralD_int()
+
+W_Base_32: __builtin__.Ord[__builtin__.int] = __builtin__.OrdD_int()
+
+# recursive group:
+class Base[T] (__builtin__.object, __builtin__.value):
+    pure def __get_attr__ (self : Self, name : __builtin__.str) -> ?__builtin__.value:
+        return None
+    pure def G_init (self : Self) -> None:
+        pass
+        return None
+    pure def __init__ (self : Self) -> None:
+        pass
+        return None
+    pure def cmp (self : Self, x : T) -> __builtin__.bool:
+        return True
+    pure def bump (self : Self, x : T) -> T:
+        return x
+    pure def fwd (self : Self, x : T) -> T:
+        return x
+class Deriv (Base[__builtin__.int], __builtin__.object, __builtin__.value):
+    pure def __init__ (G_1p : Self) -> None:
+        Base.__init__@[__builtin__.int](G_1p)
+        return None
+    pure def __get_attr__ (self : Self, name : __builtin__.str) -> ?__builtin__.value:
+        return None
+    pure def G_init (self : Self) -> None:
+        Base.G_init@[__builtin__.int](self)
+        return None
+    pure def cmp (self : Self, x : __builtin__.int) -> __builtin__.bool:
+        N_tmp: __builtin__.bool = W_Base_32.__gt__(x, W_Base_30.__fromatom__(3))
+        return N_tmp
+    pure def bump (self : Self, x : __builtin__.int) -> __builtin__.int:
+        W_Base_39: __builtin__.Plus[__builtin__.int] = __builtin__.IntegralD_int()
+        x = W_Base_39.__iadd__(x, W_Base_30.__fromatom__(1))
+        return x
+    pure def fwd (self : Self, x : __builtin__.int) -> __builtin__.int:
+        N_1tmp: __builtin__.int = self.bump(x)
+        return N_1tmp
+# (recursive group)

--- a/compiler/lib/test/8-boxing/boxparam.output
+++ b/compiler/lib/test/8-boxing/boxparam.output
@@ -24,12 +24,13 @@ class Deriv (Base[__builtin__.int], __builtin__.object, __builtin__.value):
         Base.G_init@[__builtin__.int](self)
         return None
     pure def cmp (self : Deriv, x : __builtin__.int) -> UNBOXED __builtin__.bool:
-        N_tmp: UNBOXED __builtin__.bool = (x > (UNBOX __builtin__.int 3))
+        N_tmp: UNBOXED __builtin__.bool = ((UNBOX __builtin__.int x) > (UNBOX __builtin__.int 3))
         return (UNBOX __builtin__.bool N_tmp)
-    pure def bump (self : Deriv, x : __builtin__.int) -> __builtin__.int:
-        x += (UNBOX __builtin__.int 1)
+    pure def bump (self : Deriv, xD_boxed : __builtin__.int) -> __builtin__.int:
+        x: UNBOXED __builtin__.int = (UNBOX __builtin__.int xD_boxed)
+        (UNBOX __builtin__.int x) += (UNBOX __builtin__.int 1)
         return (BOX __builtin__.int x)
     pure def fwd (self : Deriv, x : __builtin__.int) -> __builtin__.int:
-        N_1tmp: UNBOXED __builtin__.int = (UNBOX __builtin__.int self.bump((BOX __builtin__.int x)))
+        N_1tmp: UNBOXED __builtin__.int = (UNBOX __builtin__.int self.bump(x))
         return (BOX __builtin__.int N_1tmp)
 # (recursive group)

--- a/compiler/lib/test/8-boxing/boxparam.output
+++ b/compiler/lib/test/8-boxing/boxparam.output
@@ -1,0 +1,35 @@
+# recursive group:
+class Base[T] (__builtin__.object, __builtin__.value):
+    pure def __get_attr__ (self : Base[T], name : __builtin__.str) -> ?__builtin__.value:
+        return None
+    pure def G_init (self : Base[T]) -> None:
+        pass
+        return None
+    pure def __init__ (self : Base[T]) -> None:
+        pass
+        return None
+    pure def cmp (self : Base[T], x : T) -> UNBOXED __builtin__.bool:
+        return (UNBOX __builtin__.bool True)
+    pure def bump (self : Base[T], x : T) -> T:
+        return x
+    pure def fwd (self : Base[T], x : T) -> T:
+        return x
+class Deriv (Base[__builtin__.int], __builtin__.object, __builtin__.value):
+    pure def __init__ (G_1p : Deriv) -> None:
+        Base.__init__@[__builtin__.int](G_1p)
+        return None
+    pure def __get_attr__ (self : Deriv, name : __builtin__.str) -> ?__builtin__.value:
+        return None
+    pure def G_init (self : Deriv) -> None:
+        Base.G_init@[__builtin__.int](self)
+        return None
+    pure def cmp (self : Deriv, x : __builtin__.int) -> UNBOXED __builtin__.bool:
+        N_tmp: UNBOXED __builtin__.bool = (x > (UNBOX __builtin__.int 3))
+        return (UNBOX __builtin__.bool N_tmp)
+    pure def bump (self : Deriv, x : __builtin__.int) -> __builtin__.int:
+        x += (UNBOX __builtin__.int 1)
+        return (BOX __builtin__.int x)
+    pure def fwd (self : Deriv, x : __builtin__.int) -> __builtin__.int:
+        N_1tmp: UNBOXED __builtin__.int = (UNBOX __builtin__.int self.bump((BOX __builtin__.int x)))
+        return (BOX __builtin__.int N_1tmp)
+# (recursive group)

--- a/compiler/lib/test/8-boxing/deact.output
+++ b/compiler/lib/test/8-boxing/deact.output
@@ -19,12 +19,12 @@ class L_4action ($action[(__builtin__.int,), __builtin__.int], $proc[(__builtin_
         return None
     # recursive group:
     proc def __call__ (L_self : L_4action, L_cont : $Cont[__builtin__.int], G_1 : __builtin__.int) -> $R:
-        return $AWAIT@[__builtin__.int](L_cont, L_self.__asyn__((BOX __builtin__.int G_1)))
+        return $AWAIT@[__builtin__.int](L_cont, L_self.__asyn__(G_1))
     proc def __exec__ (L_self : L_4action, L_cont : $Cont[__builtin__.value], G_1 : __builtin__.int) -> $R:
-        return $R_CONT@[__builtin__.value](L_cont, L_self.__asyn__((BOX __builtin__.int G_1)))
+        return $R_CONT@[__builtin__.value](L_cont, L_self.__asyn__(G_1))
     action def __asyn__ (L_self : L_4action, G_1 : __builtin__.int) -> __builtin__.int:
         L_3obj: Apa = L_self.L_3obj
-        return L_3obj.notice(G_1)
+        return L_3obj.notice((UNBOX __builtin__.int G_1))
     # (recursive group)
 proc def L_5C_3cont (cb : $action[(__builtin__.int,), __builtin__.int], C_cont : $Cont[__builtin__.int], C_4res : UNBOXED __builtin__.int) -> $R:
     v: UNBOXED __builtin__.int = (UNBOX __builtin__.int C_4res)
@@ -43,7 +43,7 @@ class L_6Cont ($Cont[__builtin__.int], __builtin__.value):
     proc def __call__ (L_self : L_6Cont, G_1 : __builtin__.int) -> $R:
         cb: $action[(__builtin__.int,), __builtin__.int] = L_self.cb
         C_cont: $Cont[__builtin__.int] = L_self.C_cont
-        return L_5C_3cont(cb, C_cont, G_1)
+        return L_5C_3cont(cb, C_cont, (UNBOX __builtin__.int G_1))
 class L_7proc ($proc[(), None], __builtin__.value):
     @property
     self : Apa
@@ -120,12 +120,12 @@ class L_14action ($action[(__builtin__.int,), __builtin__.int], $proc[(__builtin
         return None
     # recursive group:
     proc def __call__ (L_self : L_14action, L_cont : $Cont[__builtin__.int], G_1 : __builtin__.int) -> $R:
-        return $AWAIT@[__builtin__.int](L_cont, L_self.__asyn__((BOX __builtin__.int G_1)))
+        return $AWAIT@[__builtin__.int](L_cont, L_self.__asyn__(G_1))
     proc def __exec__ (L_self : L_14action, L_cont : $Cont[__builtin__.value], G_1 : __builtin__.int) -> $R:
-        return $R_CONT@[__builtin__.value](L_cont, L_self.__asyn__((BOX __builtin__.int G_1)))
+        return $R_CONT@[__builtin__.value](L_cont, L_self.__asyn__(G_1))
     action def __asyn__ (L_self : L_14action, G_1 : __builtin__.int) -> __builtin__.int:
         L_13obj: Apa = L_self.L_13obj
-        return L_13obj.notice(G_1)
+        return L_13obj.notice((UNBOX __builtin__.int G_1))
     # (recursive group)
 class L_16action ($action[(__builtin__.int,), __builtin__.int], $proc[(__builtin__.int,), __builtin__.int], __builtin__.value):
     @property
@@ -135,12 +135,12 @@ class L_16action ($action[(__builtin__.int,), __builtin__.int], $proc[(__builtin
         return None
     # recursive group:
     proc def __call__ (L_self : L_16action, L_cont : $Cont[__builtin__.int], G_1 : __builtin__.int) -> $R:
-        return $AWAIT@[__builtin__.int](L_cont, L_self.__asyn__((BOX __builtin__.int G_1)))
+        return $AWAIT@[__builtin__.int](L_cont, L_self.__asyn__(G_1))
     proc def __exec__ (L_self : L_16action, L_cont : $Cont[__builtin__.value], G_1 : __builtin__.int) -> $R:
-        return $R_CONT@[__builtin__.value](L_cont, L_self.__asyn__((BOX __builtin__.int G_1)))
+        return $R_CONT@[__builtin__.value](L_cont, L_self.__asyn__(G_1))
     action def __asyn__ (L_self : L_16action, G_1 : __builtin__.int) -> __builtin__.int:
         L_15obj: Bepa = L_self.L_15obj
-        return L_15obj.callback(G_1)
+        return L_15obj.callback((UNBOX __builtin__.int G_1))
     # (recursive group)
 class L_19action ($action[(__builtin__.int,), __builtin__.int], $proc[(__builtin__.int,), __builtin__.int], __builtin__.value):
     @property
@@ -150,12 +150,12 @@ class L_19action ($action[(__builtin__.int,), __builtin__.int], $proc[(__builtin
         return None
     # recursive group:
     proc def __call__ (L_self : L_19action, L_cont : $Cont[__builtin__.int], G_1 : __builtin__.int) -> $R:
-        return $AWAIT@[__builtin__.int](L_cont, L_self.__asyn__((BOX __builtin__.int G_1)))
+        return $AWAIT@[__builtin__.int](L_cont, L_self.__asyn__(G_1))
     proc def __exec__ (L_self : L_19action, L_cont : $Cont[__builtin__.value], G_1 : __builtin__.int) -> $R:
-        return $R_CONT@[__builtin__.value](L_cont, L_self.__asyn__((BOX __builtin__.int G_1)))
+        return $R_CONT@[__builtin__.value](L_cont, L_self.__asyn__(G_1))
     action def __asyn__ (L_self : L_19action, G_1 : __builtin__.int) -> __builtin__.int:
         L_18obj: main = L_self.L_18obj
-        return L_18obj.myproc(G_1)
+        return L_18obj.myproc((UNBOX __builtin__.int G_1))
     # (recursive group)
 proc def L_17C_9cont (self : main, C_cont : $Cont[None], C_10res : UNBOXED __builtin__.int) -> $R:
     self.r = (UNBOX __builtin__.int C_10res)
@@ -175,7 +175,7 @@ class L_20Cont ($Cont[__builtin__.int], __builtin__.value):
     proc def __call__ (L_self : L_20Cont, G_1 : __builtin__.int) -> $R:
         self: main = L_self.self
         C_cont: $Cont[None] = L_self.C_cont
-        return L_17C_9cont(self, C_cont, G_1)
+        return L_17C_9cont(self, C_cont, (UNBOX __builtin__.int G_1))
 proc def L_12C_7cont (self : main, C_cont : $Cont[None], C_8res : Bepa) -> $R:
     self.b = C_8res
     print@[(__builtin__.str,)](("\"-----\"",), None, None, None, None)

--- a/compiler/lib/test/9-codegen/boxparam.c
+++ b/compiler/lib/test/9-codegen/boxparam.c
@@ -62,19 +62,20 @@ B_NoneType boxparamQ_DerivG_init (boxparamQ_Deriv self) {
 }
 #line 15 "test/src/boxparam.act"
 bool boxparamQ_DerivD_cmp (boxparamQ_Deriv self, B_int x) {
-    bool N_tmp = (x > 3LL);
+    bool N_tmp = (((B_int)x)->val > 3LL);
     #line 16 "test/src/boxparam.act"
     return N_tmp;
 }
 #line 17 "test/src/boxparam.act"
-B_int boxparamQ_DerivD_bump (boxparamQ_Deriv self, B_int x) {
+B_int boxparamQ_DerivD_bump (boxparamQ_Deriv self, B_int xD_boxed) {
+    int64_t x = ((B_int)xD_boxed)->val;
     x += 1LL;
     #line 19 "test/src/boxparam.act"
-    return toB_int(((B_int)x)->val);
+    return toB_int(x);
 }
 #line 20 "test/src/boxparam.act"
 B_int boxparamQ_DerivD_fwd (boxparamQ_Deriv self, B_int x) {
-    int64_t N_1tmp = ((B_int)((B_int (*) ($WORD, B_int))((boxparamQ_Deriv)(self))->$class->bump)(self, toB_int(((B_int)x)->val)))->val;
+    int64_t N_1tmp = ((B_int)((B_int (*) ($WORD, B_int))((boxparamQ_Deriv)(self))->$class->bump)(self, x))->val;
     #line 21 "test/src/boxparam.act"
     return toB_int(N_1tmp);
 }

--- a/compiler/lib/test/9-codegen/boxparam.c
+++ b/compiler/lib/test/9-codegen/boxparam.c
@@ -1,0 +1,139 @@
+/* Acton impl hash: test-hash */
+#include "rts/common.h"
+#include "out/types/boxparam.h"
+B_value boxparamQ_BaseD___get_attr__ (boxparamQ_Base self, B_str name) {
+    return B_None;
+}
+B_NoneType boxparamQ_BaseG_init (boxparamQ_Base self) {
+    return B_None;
+}
+#line 5 "test/src/boxparam.act"
+B_NoneType boxparamQ_BaseD___init__ (boxparamQ_Base self) {
+    #line 6 "test/src/boxparam.act"
+    return B_None;
+}
+#line 7 "test/src/boxparam.act"
+bool boxparamQ_BaseD_cmp (boxparamQ_Base self, $WORD x) {
+    #line 8 "test/src/boxparam.act"
+    return true;
+}
+#line 9 "test/src/boxparam.act"
+$WORD boxparamQ_BaseD_bump (boxparamQ_Base self, $WORD x) {
+    #line 10 "test/src/boxparam.act"
+    return x;
+}
+#line 11 "test/src/boxparam.act"
+$WORD boxparamQ_BaseD_fwd (boxparamQ_Base self, $WORD x) {
+    #line 12 "test/src/boxparam.act"
+    return x;
+}
+void boxparamQ_BaseD___serialize__ (boxparamQ_Base self, $Serial$state state) {
+}
+boxparamQ_Base boxparamQ_BaseD___deserialize__ (boxparamQ_Base self, $Serial$state state) {
+    $WORD $tmp;
+    if (!self) {
+        if (!state) {
+            self = acton_malloc(sizeof(struct boxparamQ_Base));
+            self->$class = &boxparamQ_BaseG_methods;
+            return self;
+        }
+        self = $DNEW(boxparamQ_Base, state);
+    }
+    return self;
+}
+boxparamQ_Base boxparamQ_BaseG_new() {
+    boxparamQ_Base $tmp = acton_malloc(sizeof(struct boxparamQ_Base));
+    $tmp->$class = &boxparamQ_BaseG_methods;
+    boxparamQ_BaseG_methods.G_init($tmp);
+    boxparamQ_BaseG_methods.__init__($tmp);
+    return $tmp;
+}
+struct boxparamQ_BaseG_class boxparamQ_BaseG_methods;
+B_NoneType boxparamQ_DerivD___init__ (boxparamQ_Deriv G_1p) {
+    ((B_NoneType (*) (boxparamQ_Base))boxparamQ_BaseG_methods.__init__)(((boxparamQ_Base)G_1p));
+    return B_None;
+}
+B_value boxparamQ_DerivD___get_attr__ (boxparamQ_Deriv self, B_str name) {
+    return B_None;
+}
+B_NoneType boxparamQ_DerivG_init (boxparamQ_Deriv self) {
+    ((B_NoneType (*) (boxparamQ_Base))boxparamQ_BaseG_methods.G_init)(((boxparamQ_Base)self));
+    return B_None;
+}
+#line 15 "test/src/boxparam.act"
+bool boxparamQ_DerivD_cmp (boxparamQ_Deriv self, B_int x) {
+    bool N_tmp = (x > 3LL);
+    #line 16 "test/src/boxparam.act"
+    return N_tmp;
+}
+#line 17 "test/src/boxparam.act"
+B_int boxparamQ_DerivD_bump (boxparamQ_Deriv self, B_int x) {
+    x += 1LL;
+    #line 19 "test/src/boxparam.act"
+    return toB_int(((B_int)x)->val);
+}
+#line 20 "test/src/boxparam.act"
+B_int boxparamQ_DerivD_fwd (boxparamQ_Deriv self, B_int x) {
+    int64_t N_1tmp = ((B_int)((B_int (*) ($WORD, B_int))((boxparamQ_Deriv)(self))->$class->bump)(self, toB_int(((B_int)x)->val)))->val;
+    #line 21 "test/src/boxparam.act"
+    return toB_int(N_1tmp);
+}
+void boxparamQ_DerivD___serialize__ (boxparamQ_Deriv self, $Serial$state state) {
+}
+boxparamQ_Deriv boxparamQ_DerivD___deserialize__ (boxparamQ_Deriv self, $Serial$state state) {
+    $WORD $tmp;
+    if (!self) {
+        if (!state) {
+            self = acton_malloc(sizeof(struct boxparamQ_Deriv));
+            self->$class = &boxparamQ_DerivG_methods;
+            return self;
+        }
+        self = $DNEW(boxparamQ_Deriv, state);
+    }
+    return self;
+}
+boxparamQ_Deriv boxparamQ_DerivG_new() {
+    boxparamQ_Deriv $tmp = acton_malloc(sizeof(struct boxparamQ_Deriv));
+    $tmp->$class = &boxparamQ_DerivG_methods;
+    boxparamQ_DerivG_methods.G_init($tmp);
+    boxparamQ_DerivG_methods.__init__($tmp);
+    return $tmp;
+}
+struct boxparamQ_DerivG_class boxparamQ_DerivG_methods;
+int boxparamQ_done$ = 0;
+void boxparamQ___init__ () {
+    if (boxparamQ_done$) return;
+    boxparamQ_done$ = 1;
+    {
+        boxparamQ_BaseG_methods.$GCINFO = "boxparamQ_Base";
+        boxparamQ_BaseG_methods.$superclass = ($SuperG_class)&B_objectG_methods;
+        boxparamQ_BaseG_methods.__bool__ = (bool (*) (boxparamQ_Base))B_valueG_methods.__bool__;
+        boxparamQ_BaseG_methods.__str__ = (B_str (*) (boxparamQ_Base))B_valueG_methods.__str__;
+        boxparamQ_BaseG_methods.__repr__ = (B_str (*) (boxparamQ_Base))B_valueG_methods.__repr__;
+        boxparamQ_BaseG_methods.__get_attr__ = (B_value (*) (boxparamQ_Base, B_str))boxparamQ_BaseD___get_attr__;
+        boxparamQ_BaseG_methods.G_init = (B_NoneType (*) (boxparamQ_Base))boxparamQ_BaseG_init;
+        boxparamQ_BaseG_methods.__init__ = (B_NoneType (*) (boxparamQ_Base))boxparamQ_BaseD___init__;
+        boxparamQ_BaseG_methods.cmp = (bool (*) (boxparamQ_Base, $WORD))boxparamQ_BaseD_cmp;
+        boxparamQ_BaseG_methods.bump = ($WORD (*) (boxparamQ_Base, $WORD))boxparamQ_BaseD_bump;
+        boxparamQ_BaseG_methods.fwd = ($WORD (*) (boxparamQ_Base, $WORD))boxparamQ_BaseD_fwd;
+        boxparamQ_BaseG_methods.__serialize__ = boxparamQ_BaseD___serialize__;
+        boxparamQ_BaseG_methods.__deserialize__ = boxparamQ_BaseD___deserialize__;
+        $register(&boxparamQ_BaseG_methods);
+    }
+    {
+        boxparamQ_DerivG_methods.$GCINFO = "boxparamQ_Deriv";
+        boxparamQ_DerivG_methods.$superclass = ($SuperG_class)&boxparamQ_BaseG_methods;
+        boxparamQ_DerivG_methods.__bool__ = (bool (*) (boxparamQ_Deriv))B_valueG_methods.__bool__;
+        boxparamQ_DerivG_methods.__str__ = (B_str (*) (boxparamQ_Deriv))B_valueG_methods.__str__;
+        boxparamQ_DerivG_methods.__repr__ = (B_str (*) (boxparamQ_Deriv))B_valueG_methods.__repr__;
+        boxparamQ_DerivG_methods.__init__ = (B_NoneType (*) (boxparamQ_Deriv))boxparamQ_DerivD___init__;
+        boxparamQ_DerivG_methods.__get_attr__ = (B_value (*) (boxparamQ_Deriv, B_str))boxparamQ_DerivD___get_attr__;
+        boxparamQ_DerivG_methods.G_init = (B_NoneType (*) (boxparamQ_Deriv))boxparamQ_DerivG_init;
+        boxparamQ_DerivG_methods.cmp = (bool (*) (boxparamQ_Deriv, B_int))boxparamQ_DerivD_cmp;
+        boxparamQ_DerivG_methods.bump = (B_int (*) (boxparamQ_Deriv, B_int))boxparamQ_DerivD_bump;
+        boxparamQ_DerivG_methods.fwd = (B_int (*) (boxparamQ_Deriv, B_int))boxparamQ_DerivD_fwd;
+        boxparamQ_DerivG_methods.__serialize__ = boxparamQ_DerivD___serialize__;
+        boxparamQ_DerivG_methods.__deserialize__ = boxparamQ_DerivD___deserialize__;
+        $register(&boxparamQ_DerivG_methods);
+    }
+}

--- a/compiler/lib/test/9-codegen/boxparam.h
+++ b/compiler/lib/test/9-codegen/boxparam.h
@@ -58,6 +58,6 @@ B_NoneType boxparamQ_DerivD___init__(boxparamQ_Deriv G_1p);
 B_value boxparamQ_DerivD___get_attr__(boxparamQ_Deriv self, B_str name);
 B_NoneType boxparamQ_DerivG_init(boxparamQ_Deriv self);
 bool boxparamQ_DerivD_cmp(boxparamQ_Deriv self, B_int x);
-B_int boxparamQ_DerivD_bump(boxparamQ_Deriv self, B_int x);
+B_int boxparamQ_DerivD_bump(boxparamQ_Deriv self, B_int xD_boxed);
 B_int boxparamQ_DerivD_fwd(boxparamQ_Deriv self, B_int x);
 void boxparamQ___init__ ();

--- a/compiler/lib/test/9-codegen/boxparam.h
+++ b/compiler/lib/test/9-codegen/boxparam.h
@@ -1,0 +1,63 @@
+/* Acton impl hash: test-hash */
+#pragma once
+#include "builtin/builtin.h"
+#include "rts/rts.h"
+struct boxparamQ_Base;
+struct boxparamQ_Deriv;
+typedef struct boxparamQ_Base *boxparamQ_Base;
+typedef struct boxparamQ_Deriv *boxparamQ_Deriv;
+struct boxparamQ_BaseG_class {
+    char *$GCINFO;
+    int $class_id;
+    $SuperG_class $superclass;
+    B_NoneType (*__init__) (boxparamQ_Base);
+    void (*__serialize__) (boxparamQ_Base, $Serial$state);
+    boxparamQ_Base (*__deserialize__) (boxparamQ_Base, $Serial$state);
+    bool (*__bool__) (boxparamQ_Base);
+    B_str (*__str__) (boxparamQ_Base);
+    B_str (*__repr__) (boxparamQ_Base);
+    B_value (*__get_attr__) (boxparamQ_Base, B_str);
+    B_NoneType (*G_init) (boxparamQ_Base);
+    bool (*cmp) (boxparamQ_Base, $WORD);
+    $WORD (*bump) (boxparamQ_Base, $WORD);
+    $WORD (*fwd) (boxparamQ_Base, $WORD);
+};
+struct boxparamQ_Base {
+    struct boxparamQ_BaseG_class *$class;
+};
+struct boxparamQ_DerivG_class {
+    char *$GCINFO;
+    int $class_id;
+    $SuperG_class $superclass;
+    B_NoneType (*__init__) (boxparamQ_Deriv);
+    void (*__serialize__) (boxparamQ_Deriv, $Serial$state);
+    boxparamQ_Deriv (*__deserialize__) (boxparamQ_Deriv, $Serial$state);
+    bool (*__bool__) (boxparamQ_Deriv);
+    B_str (*__str__) (boxparamQ_Deriv);
+    B_str (*__repr__) (boxparamQ_Deriv);
+    B_value (*__get_attr__) (boxparamQ_Deriv, B_str);
+    B_NoneType (*G_init) (boxparamQ_Deriv);
+    bool (*cmp) (boxparamQ_Deriv, B_int);
+    B_int (*bump) (boxparamQ_Deriv, B_int);
+    B_int (*fwd) (boxparamQ_Deriv, B_int);
+};
+struct boxparamQ_Deriv {
+    struct boxparamQ_DerivG_class *$class;
+};
+extern struct boxparamQ_BaseG_class boxparamQ_BaseG_methods;
+boxparamQ_Base boxparamQ_BaseG_new();
+B_value boxparamQ_BaseD___get_attr__(boxparamQ_Base self, B_str name);
+B_NoneType boxparamQ_BaseG_init(boxparamQ_Base self);
+B_NoneType boxparamQ_BaseD___init__(boxparamQ_Base self);
+bool boxparamQ_BaseD_cmp(boxparamQ_Base self, $WORD x);
+$WORD boxparamQ_BaseD_bump(boxparamQ_Base self, $WORD x);
+$WORD boxparamQ_BaseD_fwd(boxparamQ_Base self, $WORD x);
+extern struct boxparamQ_DerivG_class boxparamQ_DerivG_methods;
+boxparamQ_Deriv boxparamQ_DerivG_new();
+B_NoneType boxparamQ_DerivD___init__(boxparamQ_Deriv G_1p);
+B_value boxparamQ_DerivD___get_attr__(boxparamQ_Deriv self, B_str name);
+B_NoneType boxparamQ_DerivG_init(boxparamQ_Deriv self);
+bool boxparamQ_DerivD_cmp(boxparamQ_Deriv self, B_int x);
+B_int boxparamQ_DerivD_bump(boxparamQ_Deriv self, B_int x);
+B_int boxparamQ_DerivD_fwd(boxparamQ_Deriv self, B_int x);
+void boxparamQ___init__ ();

--- a/compiler/lib/test/9-codegen/boxparam.input
+++ b/compiler/lib/test/9-codegen/boxparam.input
@@ -24,12 +24,13 @@ class Deriv (Base[__builtin__.int], __builtin__.object, __builtin__.value):
         Base.G_init@[__builtin__.int](self)
         return None
     pure def cmp (self : Deriv, x : __builtin__.int) -> UNBOXED __builtin__.bool:
-        N_tmp: UNBOXED __builtin__.bool = (x > (UNBOX __builtin__.int 3))
+        N_tmp: UNBOXED __builtin__.bool = ((UNBOX __builtin__.int x) > (UNBOX __builtin__.int 3))
         return (UNBOX __builtin__.bool N_tmp)
-    pure def bump (self : Deriv, x : __builtin__.int) -> __builtin__.int:
-        x += (UNBOX __builtin__.int 1)
+    pure def bump (self : Deriv, xD_boxed : __builtin__.int) -> __builtin__.int:
+        x: UNBOXED __builtin__.int = (UNBOX __builtin__.int xD_boxed)
+        (UNBOX __builtin__.int x) += (UNBOX __builtin__.int 1)
         return (BOX __builtin__.int x)
     pure def fwd (self : Deriv, x : __builtin__.int) -> __builtin__.int:
-        N_1tmp: UNBOXED __builtin__.int = (UNBOX __builtin__.int self.bump((BOX __builtin__.int x)))
+        N_1tmp: UNBOXED __builtin__.int = (UNBOX __builtin__.int self.bump(x))
         return (BOX __builtin__.int N_1tmp)
 # (recursive group)

--- a/compiler/lib/test/9-codegen/boxparam.input
+++ b/compiler/lib/test/9-codegen/boxparam.input
@@ -1,0 +1,35 @@
+# recursive group:
+class Base[T] (__builtin__.object, __builtin__.value):
+    pure def __get_attr__ (self : Base[T], name : __builtin__.str) -> ?__builtin__.value:
+        return None
+    pure def G_init (self : Base[T]) -> None:
+        pass
+        return None
+    pure def __init__ (self : Base[T]) -> None:
+        pass
+        return None
+    pure def cmp (self : Base[T], x : T) -> UNBOXED __builtin__.bool:
+        return (UNBOX __builtin__.bool True)
+    pure def bump (self : Base[T], x : T) -> T:
+        return x
+    pure def fwd (self : Base[T], x : T) -> T:
+        return x
+class Deriv (Base[__builtin__.int], __builtin__.object, __builtin__.value):
+    pure def __init__ (G_1p : Deriv) -> None:
+        Base.__init__@[__builtin__.int](G_1p)
+        return None
+    pure def __get_attr__ (self : Deriv, name : __builtin__.str) -> ?__builtin__.value:
+        return None
+    pure def G_init (self : Deriv) -> None:
+        Base.G_init@[__builtin__.int](self)
+        return None
+    pure def cmp (self : Deriv, x : __builtin__.int) -> UNBOXED __builtin__.bool:
+        N_tmp: UNBOXED __builtin__.bool = (x > (UNBOX __builtin__.int 3))
+        return (UNBOX __builtin__.bool N_tmp)
+    pure def bump (self : Deriv, x : __builtin__.int) -> __builtin__.int:
+        x += (UNBOX __builtin__.int 1)
+        return (BOX __builtin__.int x)
+    pure def fwd (self : Deriv, x : __builtin__.int) -> __builtin__.int:
+        N_1tmp: UNBOXED __builtin__.int = (UNBOX __builtin__.int self.bump((BOX __builtin__.int x)))
+        return (BOX __builtin__.int N_1tmp)
+# (recursive group)

--- a/compiler/lib/test/9-codegen/deact.c
+++ b/compiler/lib/test/9-codegen/deact.c
@@ -42,10 +42,10 @@ B_NoneType deactQ_L_4actionD___init__ (deactQ_L_4action L_self, deactQ_Apa L_3ob
     return B_None;
 }
 $R deactQ_L_4actionD___call__ (deactQ_L_4action L_self, $Cont L_cont, B_int G_1) {
-    return $AWAIT(L_cont, ((B_Msg)((B_Msg (*) ($WORD, B_int))((deactQ_L_4action)(L_self))->$class->__asyn__)(L_self, toB_int(((B_int)G_1)->val))));
+    return $AWAIT(L_cont, ((B_Msg)((B_Msg (*) ($WORD, B_int))((deactQ_L_4action)(L_self))->$class->__asyn__)(L_self, G_1)));
 }
 $R deactQ_L_4actionD___exec__ (deactQ_L_4action L_self, $Cont L_cont, B_int G_1) {
-    return $R_CONT(L_cont, ((B_value)((B_Msg (*) ($WORD, B_int))((deactQ_L_4action)(L_self))->$class->__asyn__)(L_self, toB_int(((B_int)G_1)->val))));
+    return $R_CONT(L_cont, ((B_value)((B_Msg (*) ($WORD, B_int))((deactQ_L_4action)(L_self))->$class->__asyn__)(L_self, G_1)));
 }
 B_Msg deactQ_L_4actionD___asyn__ (deactQ_L_4action L_self, B_int G_1) {
     deactQ_Apa L_3obj = ((deactQ_L_4action)(L_self))->L_3obj;
@@ -276,10 +276,10 @@ B_NoneType deactQ_L_14actionD___init__ (deactQ_L_14action L_self, deactQ_Apa L_1
     return B_None;
 }
 $R deactQ_L_14actionD___call__ (deactQ_L_14action L_self, $Cont L_cont, B_int G_1) {
-    return $AWAIT(L_cont, ((B_Msg)((B_Msg (*) ($WORD, B_int))((deactQ_L_14action)(L_self))->$class->__asyn__)(L_self, toB_int(((B_int)G_1)->val))));
+    return $AWAIT(L_cont, ((B_Msg)((B_Msg (*) ($WORD, B_int))((deactQ_L_14action)(L_self))->$class->__asyn__)(L_self, G_1)));
 }
 $R deactQ_L_14actionD___exec__ (deactQ_L_14action L_self, $Cont L_cont, B_int G_1) {
-    return $R_CONT(L_cont, ((B_value)((B_Msg (*) ($WORD, B_int))((deactQ_L_14action)(L_self))->$class->__asyn__)(L_self, toB_int(((B_int)G_1)->val))));
+    return $R_CONT(L_cont, ((B_value)((B_Msg (*) ($WORD, B_int))((deactQ_L_14action)(L_self))->$class->__asyn__)(L_self, G_1)));
 }
 B_Msg deactQ_L_14actionD___asyn__ (deactQ_L_14action L_self, B_int G_1) {
     deactQ_Apa L_13obj = ((deactQ_L_14action)(L_self))->L_13obj;
@@ -313,10 +313,10 @@ B_NoneType deactQ_L_16actionD___init__ (deactQ_L_16action L_self, deactQ_Bepa L_
     return B_None;
 }
 $R deactQ_L_16actionD___call__ (deactQ_L_16action L_self, $Cont L_cont, B_int G_1) {
-    return $AWAIT(L_cont, ((B_Msg)((B_Msg (*) ($WORD, B_int))((deactQ_L_16action)(L_self))->$class->__asyn__)(L_self, toB_int(((B_int)G_1)->val))));
+    return $AWAIT(L_cont, ((B_Msg)((B_Msg (*) ($WORD, B_int))((deactQ_L_16action)(L_self))->$class->__asyn__)(L_self, G_1)));
 }
 $R deactQ_L_16actionD___exec__ (deactQ_L_16action L_self, $Cont L_cont, B_int G_1) {
-    return $R_CONT(L_cont, ((B_value)((B_Msg (*) ($WORD, B_int))((deactQ_L_16action)(L_self))->$class->__asyn__)(L_self, toB_int(((B_int)G_1)->val))));
+    return $R_CONT(L_cont, ((B_value)((B_Msg (*) ($WORD, B_int))((deactQ_L_16action)(L_self))->$class->__asyn__)(L_self, G_1)));
 }
 B_Msg deactQ_L_16actionD___asyn__ (deactQ_L_16action L_self, B_int G_1) {
     deactQ_Bepa L_15obj = ((deactQ_L_16action)(L_self))->L_15obj;
@@ -350,10 +350,10 @@ B_NoneType deactQ_L_19actionD___init__ (deactQ_L_19action L_self, deactQ_main L_
     return B_None;
 }
 $R deactQ_L_19actionD___call__ (deactQ_L_19action L_self, $Cont L_cont, B_int G_1) {
-    return $AWAIT(L_cont, ((B_Msg)((B_Msg (*) ($WORD, B_int))((deactQ_L_19action)(L_self))->$class->__asyn__)(L_self, toB_int(((B_int)G_1)->val))));
+    return $AWAIT(L_cont, ((B_Msg)((B_Msg (*) ($WORD, B_int))((deactQ_L_19action)(L_self))->$class->__asyn__)(L_self, G_1)));
 }
 $R deactQ_L_19actionD___exec__ (deactQ_L_19action L_self, $Cont L_cont, B_int G_1) {
-    return $R_CONT(L_cont, ((B_value)((B_Msg (*) ($WORD, B_int))((deactQ_L_19action)(L_self))->$class->__asyn__)(L_self, toB_int(((B_int)G_1)->val))));
+    return $R_CONT(L_cont, ((B_value)((B_Msg (*) ($WORD, B_int))((deactQ_L_19action)(L_self))->$class->__asyn__)(L_self, G_1)));
 }
 B_Msg deactQ_L_19actionD___asyn__ (deactQ_L_19action L_self, B_int G_1) {
     deactQ_main L_18obj = ((deactQ_L_19action)(L_self))->L_18obj;

--- a/compiler/lib/test/9-codegen/deact.input
+++ b/compiler/lib/test/9-codegen/deact.input
@@ -19,12 +19,12 @@ class L_4action ($action[(__builtin__.int,), __builtin__.int], $proc[(__builtin_
         return None
     # recursive group:
     proc def __call__ (L_self : L_4action, L_cont : $Cont[__builtin__.int], G_1 : __builtin__.int) -> $R:
-        return $AWAIT@[__builtin__.int](L_cont, L_self.__asyn__((BOX __builtin__.int G_1)))
+        return $AWAIT@[__builtin__.int](L_cont, L_self.__asyn__(G_1))
     proc def __exec__ (L_self : L_4action, L_cont : $Cont[__builtin__.value], G_1 : __builtin__.int) -> $R:
-        return $R_CONT@[__builtin__.value](L_cont, L_self.__asyn__((BOX __builtin__.int G_1)))
+        return $R_CONT@[__builtin__.value](L_cont, L_self.__asyn__(G_1))
     action def __asyn__ (L_self : L_4action, G_1 : __builtin__.int) -> __builtin__.int:
         L_3obj: Apa = L_self.L_3obj
-        return L_3obj.notice(G_1)
+        return L_3obj.notice((UNBOX __builtin__.int G_1))
     # (recursive group)
 proc def L_5C_3cont (cb : $action[(__builtin__.int,), __builtin__.int], C_cont : $Cont[__builtin__.int], C_4res : UNBOXED __builtin__.int) -> $R:
     v: UNBOXED __builtin__.int = (UNBOX __builtin__.int C_4res)
@@ -43,7 +43,7 @@ class L_6Cont ($Cont[__builtin__.int], __builtin__.value):
     proc def __call__ (L_self : L_6Cont, G_1 : __builtin__.int) -> $R:
         cb: $action[(__builtin__.int,), __builtin__.int] = L_self.cb
         C_cont: $Cont[__builtin__.int] = L_self.C_cont
-        return L_5C_3cont(cb, C_cont, G_1)
+        return L_5C_3cont(cb, C_cont, (UNBOX __builtin__.int G_1))
 class L_7proc ($proc[(), None], __builtin__.value):
     @property
     self : Apa
@@ -120,12 +120,12 @@ class L_14action ($action[(__builtin__.int,), __builtin__.int], $proc[(__builtin
         return None
     # recursive group:
     proc def __call__ (L_self : L_14action, L_cont : $Cont[__builtin__.int], G_1 : __builtin__.int) -> $R:
-        return $AWAIT@[__builtin__.int](L_cont, L_self.__asyn__((BOX __builtin__.int G_1)))
+        return $AWAIT@[__builtin__.int](L_cont, L_self.__asyn__(G_1))
     proc def __exec__ (L_self : L_14action, L_cont : $Cont[__builtin__.value], G_1 : __builtin__.int) -> $R:
-        return $R_CONT@[__builtin__.value](L_cont, L_self.__asyn__((BOX __builtin__.int G_1)))
+        return $R_CONT@[__builtin__.value](L_cont, L_self.__asyn__(G_1))
     action def __asyn__ (L_self : L_14action, G_1 : __builtin__.int) -> __builtin__.int:
         L_13obj: Apa = L_self.L_13obj
-        return L_13obj.notice(G_1)
+        return L_13obj.notice((UNBOX __builtin__.int G_1))
     # (recursive group)
 class L_16action ($action[(__builtin__.int,), __builtin__.int], $proc[(__builtin__.int,), __builtin__.int], __builtin__.value):
     @property
@@ -135,12 +135,12 @@ class L_16action ($action[(__builtin__.int,), __builtin__.int], $proc[(__builtin
         return None
     # recursive group:
     proc def __call__ (L_self : L_16action, L_cont : $Cont[__builtin__.int], G_1 : __builtin__.int) -> $R:
-        return $AWAIT@[__builtin__.int](L_cont, L_self.__asyn__((BOX __builtin__.int G_1)))
+        return $AWAIT@[__builtin__.int](L_cont, L_self.__asyn__(G_1))
     proc def __exec__ (L_self : L_16action, L_cont : $Cont[__builtin__.value], G_1 : __builtin__.int) -> $R:
-        return $R_CONT@[__builtin__.value](L_cont, L_self.__asyn__((BOX __builtin__.int G_1)))
+        return $R_CONT@[__builtin__.value](L_cont, L_self.__asyn__(G_1))
     action def __asyn__ (L_self : L_16action, G_1 : __builtin__.int) -> __builtin__.int:
         L_15obj: Bepa = L_self.L_15obj
-        return L_15obj.callback(G_1)
+        return L_15obj.callback((UNBOX __builtin__.int G_1))
     # (recursive group)
 class L_19action ($action[(__builtin__.int,), __builtin__.int], $proc[(__builtin__.int,), __builtin__.int], __builtin__.value):
     @property
@@ -150,12 +150,12 @@ class L_19action ($action[(__builtin__.int,), __builtin__.int], $proc[(__builtin
         return None
     # recursive group:
     proc def __call__ (L_self : L_19action, L_cont : $Cont[__builtin__.int], G_1 : __builtin__.int) -> $R:
-        return $AWAIT@[__builtin__.int](L_cont, L_self.__asyn__((BOX __builtin__.int G_1)))
+        return $AWAIT@[__builtin__.int](L_cont, L_self.__asyn__(G_1))
     proc def __exec__ (L_self : L_19action, L_cont : $Cont[__builtin__.value], G_1 : __builtin__.int) -> $R:
-        return $R_CONT@[__builtin__.value](L_cont, L_self.__asyn__((BOX __builtin__.int G_1)))
+        return $R_CONT@[__builtin__.value](L_cont, L_self.__asyn__(G_1))
     action def __asyn__ (L_self : L_19action, G_1 : __builtin__.int) -> __builtin__.int:
         L_18obj: main = L_self.L_18obj
-        return L_18obj.myproc(G_1)
+        return L_18obj.myproc((UNBOX __builtin__.int G_1))
     # (recursive group)
 proc def L_17C_9cont (self : main, C_cont : $Cont[None], C_10res : UNBOXED __builtin__.int) -> $R:
     self.r = (UNBOX __builtin__.int C_10res)
@@ -175,7 +175,7 @@ class L_20Cont ($Cont[__builtin__.int], __builtin__.value):
     proc def __call__ (L_self : L_20Cont, G_1 : __builtin__.int) -> $R:
         self: main = L_self.self
         C_cont: $Cont[None] = L_self.C_cont
-        return L_17C_9cont(self, C_cont, G_1)
+        return L_17C_9cont(self, C_cont, (UNBOX __builtin__.int G_1))
 proc def L_12C_7cont (self : main, C_cont : $Cont[None], C_8res : Bepa) -> $R:
     self.b = C_8res
     print@[(__builtin__.str,)](("\"-----\"",), None, None, None, None)

--- a/compiler/lib/test/9-codegen/lines.c
+++ b/compiler/lib/test/9-codegen/lines.c
@@ -52,10 +52,10 @@ B_NoneType linesQ_L_4actionD___init__ (linesQ_L_4action L_self, linesQ_Apa L_3ob
     return B_None;
 }
 $R linesQ_L_4actionD___call__ (linesQ_L_4action L_self, $Cont L_cont, B_int G_1) {
-    return $AWAIT(L_cont, ((B_Msg)((B_Msg (*) ($WORD, B_int))((linesQ_L_4action)(L_self))->$class->__asyn__)(L_self, toB_int(((B_int)G_1)->val))));
+    return $AWAIT(L_cont, ((B_Msg)((B_Msg (*) ($WORD, B_int))((linesQ_L_4action)(L_self))->$class->__asyn__)(L_self, G_1)));
 }
 $R linesQ_L_4actionD___exec__ (linesQ_L_4action L_self, $Cont L_cont, B_int G_1) {
-    return $R_CONT(L_cont, ((B_value)((B_Msg (*) ($WORD, B_int))((linesQ_L_4action)(L_self))->$class->__asyn__)(L_self, toB_int(((B_int)G_1)->val))));
+    return $R_CONT(L_cont, ((B_value)((B_Msg (*) ($WORD, B_int))((linesQ_L_4action)(L_self))->$class->__asyn__)(L_self, G_1)));
 }
 B_Msg linesQ_L_4actionD___asyn__ (linesQ_L_4action L_self, B_int G_1) {
     linesQ_Apa L_3obj = ((linesQ_L_4action)(L_self))->L_3obj;
@@ -286,10 +286,10 @@ B_NoneType linesQ_L_14actionD___init__ (linesQ_L_14action L_self, linesQ_Apa L_1
     return B_None;
 }
 $R linesQ_L_14actionD___call__ (linesQ_L_14action L_self, $Cont L_cont, B_int G_1) {
-    return $AWAIT(L_cont, ((B_Msg)((B_Msg (*) ($WORD, B_int))((linesQ_L_14action)(L_self))->$class->__asyn__)(L_self, toB_int(((B_int)G_1)->val))));
+    return $AWAIT(L_cont, ((B_Msg)((B_Msg (*) ($WORD, B_int))((linesQ_L_14action)(L_self))->$class->__asyn__)(L_self, G_1)));
 }
 $R linesQ_L_14actionD___exec__ (linesQ_L_14action L_self, $Cont L_cont, B_int G_1) {
-    return $R_CONT(L_cont, ((B_value)((B_Msg (*) ($WORD, B_int))((linesQ_L_14action)(L_self))->$class->__asyn__)(L_self, toB_int(((B_int)G_1)->val))));
+    return $R_CONT(L_cont, ((B_value)((B_Msg (*) ($WORD, B_int))((linesQ_L_14action)(L_self))->$class->__asyn__)(L_self, G_1)));
 }
 B_Msg linesQ_L_14actionD___asyn__ (linesQ_L_14action L_self, B_int G_1) {
     linesQ_Apa L_13obj = ((linesQ_L_14action)(L_self))->L_13obj;
@@ -323,10 +323,10 @@ B_NoneType linesQ_L_16actionD___init__ (linesQ_L_16action L_self, linesQ_Bepa L_
     return B_None;
 }
 $R linesQ_L_16actionD___call__ (linesQ_L_16action L_self, $Cont L_cont, B_int G_1) {
-    return $AWAIT(L_cont, ((B_Msg)((B_Msg (*) ($WORD, B_int))((linesQ_L_16action)(L_self))->$class->__asyn__)(L_self, toB_int(((B_int)G_1)->val))));
+    return $AWAIT(L_cont, ((B_Msg)((B_Msg (*) ($WORD, B_int))((linesQ_L_16action)(L_self))->$class->__asyn__)(L_self, G_1)));
 }
 $R linesQ_L_16actionD___exec__ (linesQ_L_16action L_self, $Cont L_cont, B_int G_1) {
-    return $R_CONT(L_cont, ((B_value)((B_Msg (*) ($WORD, B_int))((linesQ_L_16action)(L_self))->$class->__asyn__)(L_self, toB_int(((B_int)G_1)->val))));
+    return $R_CONT(L_cont, ((B_value)((B_Msg (*) ($WORD, B_int))((linesQ_L_16action)(L_self))->$class->__asyn__)(L_self, G_1)));
 }
 B_Msg linesQ_L_16actionD___asyn__ (linesQ_L_16action L_self, B_int G_1) {
     linesQ_Bepa L_15obj = ((linesQ_L_16action)(L_self))->L_15obj;
@@ -360,10 +360,10 @@ B_NoneType linesQ_L_19actionD___init__ (linesQ_L_19action L_self, linesQ_main L_
     return B_None;
 }
 $R linesQ_L_19actionD___call__ (linesQ_L_19action L_self, $Cont L_cont, B_int G_1) {
-    return $AWAIT(L_cont, ((B_Msg)((B_Msg (*) ($WORD, B_int))((linesQ_L_19action)(L_self))->$class->__asyn__)(L_self, toB_int(((B_int)G_1)->val))));
+    return $AWAIT(L_cont, ((B_Msg)((B_Msg (*) ($WORD, B_int))((linesQ_L_19action)(L_self))->$class->__asyn__)(L_self, G_1)));
 }
 $R linesQ_L_19actionD___exec__ (linesQ_L_19action L_self, $Cont L_cont, B_int G_1) {
-    return $R_CONT(L_cont, ((B_value)((B_Msg (*) ($WORD, B_int))((linesQ_L_19action)(L_self))->$class->__asyn__)(L_self, toB_int(((B_int)G_1)->val))));
+    return $R_CONT(L_cont, ((B_value)((B_Msg (*) ($WORD, B_int))((linesQ_L_19action)(L_self))->$class->__asyn__)(L_self, G_1)));
 }
 B_Msg linesQ_L_19actionD___asyn__ (linesQ_L_19action L_self, B_int G_1) {
     linesQ_main L_18obj = ((linesQ_L_19action)(L_self))->L_18obj;

--- a/compiler/lib/test/9-codegen/lines.input
+++ b/compiler/lib/test/9-codegen/lines.input
@@ -32,12 +32,12 @@ class L_4action ($action[(__builtin__.int,), __builtin__.int], $proc[(__builtin_
         return None
     # recursive group:
     proc def __call__ (L_self : L_4action, L_cont : $Cont[__builtin__.int], G_1 : __builtin__.int) -> $R:
-        return $AWAIT@[__builtin__.int](L_cont, L_self.__asyn__((BOX __builtin__.int G_1)))
+        return $AWAIT@[__builtin__.int](L_cont, L_self.__asyn__(G_1))
     proc def __exec__ (L_self : L_4action, L_cont : $Cont[__builtin__.value], G_1 : __builtin__.int) -> $R:
-        return $R_CONT@[__builtin__.value](L_cont, L_self.__asyn__((BOX __builtin__.int G_1)))
+        return $R_CONT@[__builtin__.value](L_cont, L_self.__asyn__(G_1))
     action def __asyn__ (L_self : L_4action, G_1 : __builtin__.int) -> __builtin__.int:
         L_3obj: Apa = L_self.L_3obj
-        return L_3obj.notice(G_1)
+        return L_3obj.notice((UNBOX __builtin__.int G_1))
     # (recursive group)
 proc def L_5C_3cont (cb : $action[(__builtin__.int,), __builtin__.int], C_cont : $Cont[__builtin__.int], C_4res : UNBOXED __builtin__.int) -> $R:
     v: UNBOXED __builtin__.int = (UNBOX __builtin__.int C_4res)
@@ -56,7 +56,7 @@ class L_6Cont ($Cont[__builtin__.int], __builtin__.value):
     proc def __call__ (L_self : L_6Cont, G_1 : __builtin__.int) -> $R:
         cb: $action[(__builtin__.int,), __builtin__.int] = L_self.cb
         C_cont: $Cont[__builtin__.int] = L_self.C_cont
-        return L_5C_3cont(cb, C_cont, G_1)
+        return L_5C_3cont(cb, C_cont, (UNBOX __builtin__.int G_1))
 class L_7proc ($proc[(), None], __builtin__.value):
     @property
     self : Apa
@@ -133,12 +133,12 @@ class L_14action ($action[(__builtin__.int,), __builtin__.int], $proc[(__builtin
         return None
     # recursive group:
     proc def __call__ (L_self : L_14action, L_cont : $Cont[__builtin__.int], G_1 : __builtin__.int) -> $R:
-        return $AWAIT@[__builtin__.int](L_cont, L_self.__asyn__((BOX __builtin__.int G_1)))
+        return $AWAIT@[__builtin__.int](L_cont, L_self.__asyn__(G_1))
     proc def __exec__ (L_self : L_14action, L_cont : $Cont[__builtin__.value], G_1 : __builtin__.int) -> $R:
-        return $R_CONT@[__builtin__.value](L_cont, L_self.__asyn__((BOX __builtin__.int G_1)))
+        return $R_CONT@[__builtin__.value](L_cont, L_self.__asyn__(G_1))
     action def __asyn__ (L_self : L_14action, G_1 : __builtin__.int) -> __builtin__.int:
         L_13obj: Apa = L_self.L_13obj
-        return L_13obj.notice(G_1)
+        return L_13obj.notice((UNBOX __builtin__.int G_1))
     # (recursive group)
 class L_16action ($action[(__builtin__.int,), __builtin__.int], $proc[(__builtin__.int,), __builtin__.int], __builtin__.value):
     @property
@@ -148,12 +148,12 @@ class L_16action ($action[(__builtin__.int,), __builtin__.int], $proc[(__builtin
         return None
     # recursive group:
     proc def __call__ (L_self : L_16action, L_cont : $Cont[__builtin__.int], G_1 : __builtin__.int) -> $R:
-        return $AWAIT@[__builtin__.int](L_cont, L_self.__asyn__((BOX __builtin__.int G_1)))
+        return $AWAIT@[__builtin__.int](L_cont, L_self.__asyn__(G_1))
     proc def __exec__ (L_self : L_16action, L_cont : $Cont[__builtin__.value], G_1 : __builtin__.int) -> $R:
-        return $R_CONT@[__builtin__.value](L_cont, L_self.__asyn__((BOX __builtin__.int G_1)))
+        return $R_CONT@[__builtin__.value](L_cont, L_self.__asyn__(G_1))
     action def __asyn__ (L_self : L_16action, G_1 : __builtin__.int) -> __builtin__.int:
         L_15obj: Bepa = L_self.L_15obj
-        return L_15obj.callback(G_1)
+        return L_15obj.callback((UNBOX __builtin__.int G_1))
     # (recursive group)
 class L_19action ($action[(__builtin__.int,), __builtin__.int], $proc[(__builtin__.int,), __builtin__.int], __builtin__.value):
     @property
@@ -163,12 +163,12 @@ class L_19action ($action[(__builtin__.int,), __builtin__.int], $proc[(__builtin
         return None
     # recursive group:
     proc def __call__ (L_self : L_19action, L_cont : $Cont[__builtin__.int], G_1 : __builtin__.int) -> $R:
-        return $AWAIT@[__builtin__.int](L_cont, L_self.__asyn__((BOX __builtin__.int G_1)))
+        return $AWAIT@[__builtin__.int](L_cont, L_self.__asyn__(G_1))
     proc def __exec__ (L_self : L_19action, L_cont : $Cont[__builtin__.value], G_1 : __builtin__.int) -> $R:
-        return $R_CONT@[__builtin__.value](L_cont, L_self.__asyn__((BOX __builtin__.int G_1)))
+        return $R_CONT@[__builtin__.value](L_cont, L_self.__asyn__(G_1))
     action def __asyn__ (L_self : L_19action, G_1 : __builtin__.int) -> __builtin__.int:
         L_18obj: main = L_self.L_18obj
-        return L_18obj.myproc(G_1)
+        return L_18obj.myproc((UNBOX __builtin__.int G_1))
     # (recursive group)
 class L_20proc ($proc[(), __builtin__.int], __builtin__.value):
     @property
@@ -269,7 +269,7 @@ class L_21Cont ($Cont[__builtin__.int], __builtin__.value):
     proc def __call__ (L_self : L_21Cont, G_1 : __builtin__.int) -> $R:
         self: main = L_self.self
         C_cont: $Cont[None] = L_self.C_cont
-        return L_17C_9cont(self, C_cont, G_1)
+        return L_17C_9cont(self, C_cont, (UNBOX __builtin__.int G_1))
 proc def L_12C_7cont (self : main, C_cont : $Cont[None], C_8res : Bepa) -> $R:
     self.b = C_8res
     print@[(__builtin__.str,)](("\"-----\"",), None, None, None, None)

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -2095,12 +2095,14 @@ main = do
 
     describe "Pass 8: Boxing" $ do
       testBoxing env0 ["deact"]
+      testBoxing env0 ["boxparam"]
 
     describe "Pass 9: CodeGen" $ do
       testCodeGen env0 ["ints"]
       testCodeGen env0 ["deact"]
       testCodeGen env0 ["lines"]
       testCodeGen env0 ["chunking"]
+      testCodeGen env0 ["boxparam"]
       -- A local that is live across a for-loop must be emitted as `volatile` so it
       -- survives the loop's StopIteration setjmp/longjmp under optimization.
       testCodeGenContains env0 "forloop_volatile" ["volatile B_str marker", "if ($PUSH())"]

--- a/compiler/lib/test/src/boxparam.act
+++ b/compiler/lib/test/src/boxparam.act
@@ -1,0 +1,21 @@
+# Deriv overrides methods from Base[int]. The methods are generic in Base,
+# so their arguments always arrive boxed, even though Deriv takes plain ints.
+
+class Base[T](object):
+    def __init__(self):
+        pass
+    def cmp(self, x: T) -> bool:
+        return True
+    def bump(self, x: T) -> T:
+        return x
+    def fwd(self, x: T) -> T:
+        return x
+
+class Deriv(Base[int]):
+    def cmp(self, x: int) -> bool:
+        return x > 3
+    def bump(self, x: int) -> int:
+        x += 1
+        return x
+    def fwd(self, x: int) -> int:
+        return self.bump(x)

--- a/test/core_lang_auto/boxed_param_rebind.act
+++ b/test/core_lang_auto/boxed_param_rebind.act
@@ -1,0 +1,54 @@
+# Deriv overrides methods from Base[int]. The methods are generic in Base,
+# so their arguments always arrive boxed, even though Deriv takes plain
+# ints. Reads of such a parameter unbox it. Assignments are different: a
+# raw store into the boxed variable would corrupt later reads, and updating
+# the box in place would be visible to the caller. So when a body assigns a
+# boxed parameter, Boxing copies it into a raw local at function entry, and
+# the body uses only that local.
+#
+# This test checks the behavior: the caller's value must not change, and
+# rebinding must work through plain assignment, augmented assignment,
+# for-loop targets, and calls through the generic base type.
+
+class Base[T](object):
+    def __init__(self):
+        pass
+    def get(self, x: T) -> T:
+        return x
+    def bump(self, x: T) -> T:
+        return x
+    def last(self, x: T) -> T:
+        return x
+
+class Deriv(Base[int]):
+    def get(self, x: int) -> int:
+        x = x + 1
+        return x
+    def bump(self, x: int) -> int:
+        x += 41
+        return x
+    def last(self, x: int) -> int:
+        for x in [10, 20, 30]:
+            pass
+        return x
+
+actor main(env):
+    d = Deriv()
+    l = [7]
+    if d.bump(l[0]) != 48:
+        print("FAIL: augmented assignment of a boxed parameter")
+        await async env.exit(1)
+    if l[0] != 7:
+        print("FAIL: caller's box mutated by augmented assignment")
+        await async env.exit(1)
+    if d.get(1) != 2:
+        print("FAIL: rebound boxed parameter")
+        await async env.exit(1)
+    if d.last(5) != 30:
+        print("FAIL: for-loop rebinding of a boxed parameter")
+        await async env.exit(1)
+    b: Base[int] = d
+    if b.get(5) != 6 or b.bump(1) != 42:
+        print("FAIL: rebinding through the generic slot")
+        await async env.exit(1)
+    await async env.exit(0)


### PR DESCRIPTION
A method that overrides a method declared generic in its base class
receives its arguments boxed: calls can arrive through the base class's
method table, where the argument type is not known, so a Deriv(Base[int])
override of Base[T].f takes a B_int, never a raw machine integer.

The Boxing pass assumed that every scalar-typed local holds a raw value.
For these parameters that assumption is wrong. Code generation quietly
compensated at call boundaries, at the cost of box/unbox round-trips, but
the primitive operator paths cancelled the compensation away entirely, so
a body like "return x > 3" compared the pointer instead of the value:
Deriv().f(1) returned True on main.

Boxing now tracks these parameters and leaves their reads boxed; where a
raw value is needed, the unboxing survives to code generation and is
emitted as ->val. Assignments cannot follow the read convention: x += 1
would update the caller's box in place, and a plain rebinding would store
a raw value that later reads unbox again. So a boxed parameter that the
body assigns is renamed aside and copied into an ordinary raw local at
function entry, after which reads and stores follow the standard
raw-local rules and the caller's box is never written.

The first commit adds a small fixture and commits the golden files
produced by the unfixed compiler, so the second commit's diff shows
exactly what the fix changes in the generated code. The churn in the
deact and lines goldens is the removal of the now-unnecessary box/unbox
round-trips at call boundaries; behavior there was already correct.