### PR TITLE
Fix C keyword escaping

### DIFF
--- a/compiler/lib/src/Acton/CodeGen.hs
+++ b/compiler/lib/src/Acton/CodeGen.hs
@@ -969,7 +969,7 @@ mkCident (c:s)
 unCkeyword str
   | str `Data.Set.member` rws       = preEscape str
   | otherwise                       = str
-  where rws                         = Data.Set.fromDistinctAscList [
+  where rws                         = Data.Set.fromList [
                                         "alignas",
                                         "alignof",
                                         "auto",
@@ -1009,7 +1009,7 @@ unCkeyword str
                                         "true",
                                         "typedef",
                                         "typeof",
-                                        "typeof_unequal",
+                                        "typeof_unqual",
                                         "union",
                                         "unsigned",
                                         "void",

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -2098,6 +2098,9 @@ main = do
       testBoxing env0 ["deact"]
 
     describe "Pass 9: CodeGen" $ do
+      it "escapes C keywords" $
+        map Acton.CodeGen.unCkeyword ["switch", "typeof_unqual", "_Alignas"] `shouldBe`
+          ["A_switch", "A_typeof_unqual", "A__Alignas"]
       testCodeGen env0 ["ints"]
       testCodeGen env0 ["deact"]
       testCodeGen env0 ["lines"]


### PR DESCRIPTION
Use an order-independent set constructor for the C keyword table so underscore-prefixed entries cannot corrupt membership lookups. Also correct the C23 `typeof_unqual` spelling and add regression coverage for ordinary and underscore-prefixed keywords.

Fixes #3042.