### PR TITLE
Update changelog for C keyword escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 - Compile list, set, and dict comprehensions used in `if`, `elif`, and `while`
   conditions without moving the generated comprehension helper out of scope.
   [#3041]
+- Escape generated C identifiers that match C keywords using order-independent
+  lookup, including underscore-prefixed keywords and C23 `typeof_unqual`, so
+  generated code avoids reserved-word collisions. [#3044]
 
 ### Testing & CI
 - Add core-language regression tests for `await` values, exceptions, chaining,
@@ -4698,6 +4701,7 @@ then, this second incarnation has been in focus and 0.2.0 was its first version.
 [#3037]: https://github.com/actonlang/acton/pull/3037
 [#3038]: https://github.com/actonlang/acton/pull/3038
 [#3041]: https://github.com/actonlang/acton/pull/3041
+[#3044]: https://github.com/actonlang/acton/pull/3044
 
 
 [0.3.0]: https://github.com/actonlang/acton/releases/tag/v0.3.0


### PR DESCRIPTION
Update changelog with a note on generated C keyword escaping.