### PR TITLE
Define signed integer wraparound

### DIFF
--- a/base/build.zig
+++ b/base/build.zig
@@ -232,7 +232,7 @@ pub fn build(b: *std.Build) void {
     }
 
     flags.appendSlice(b.allocator, &.{
-        "-fno-sanitize=signed-integer-overflow",
+        "-fwrapv",
     }) catch unreachable;
 
     const libActon = b.addLibrary(.{

--- a/builder/build.zig
+++ b/builder/build.zig
@@ -212,7 +212,7 @@ pub fn build(b: *std.Build) void {
     }
 
     flags.appendSlice(b.allocator, &.{
-        "-fno-sanitize=signed-integer-overflow",
+        "-fwrapv",
     }) catch unreachable;
 
     for (c_files.items) |entry| {

--- a/std/build.zig
+++ b/std/build.zig
@@ -166,7 +166,7 @@ pub fn build(b: *std.Build) void {
     }
 
     flags.appendSlice(b.allocator, &.{
-        "-fno-sanitize=signed-integer-overflow",
+        "-fwrapv",
     }) catch unreachable;
 
     const libActonProject = b.addLibrary(.{

--- a/test/builtins_auto/int.act
+++ b/test/builtins_auto/int.act
@@ -204,6 +204,9 @@ def test_int():
         raise ValueError("unexpected: int(x) != 0")
     if int(2**63-1) + 1 != -2**63:
         raise ValueError("int wraparound failed")
+    shift_value: int = 9000000000000000000
+    if shift_value << 8 != -1843009213693952000:
+        raise ValueError("int left shift wraparound failed")
     return True
 
 def test_u1():


### PR DESCRIPTION
Acton intends fixed-size signed integer arithmetic to wrap consistently, but disabling the signed-overflow sanitizer did not cover overflowing left shifts and still allowed optimized C to assume that signed overflow cannot happen.

Compile base, std, and generated project C with `-fwrapv` so debug and release builds use the same two's-complement behavior. Add a regression for the reported 64-bit left-shift overflow.