### PR TITLE
Support bigint values in JSON

### DIFF
--- a/base/src/json.act
+++ b/base/src/json.act
@@ -4,10 +4,10 @@ def _decode(data: str) -> dict[str, ?value]:
 def _decode_list(data: str) -> list[?value]:
     NotImplemented
 
-def _encode(data: dict[str, ?value], pretty=False) -> str:
+def _encode(data: dict[str, ?value], pretty: bool, bigint_as_string: bool) -> str:
     NotImplemented
 
-def _encode_list(data: list[?value], pretty=False) -> str:
+def _encode_list(data: list[?value], pretty: bool, bigint_as_string: bool) -> str:
     NotImplemented
 
 
@@ -21,15 +21,21 @@ def decode_list(data: str) -> list[?value]:
     """
     return _decode_list(data)
 
-def encode(data: dict[str, ?value], pretty=False) -> str:
+def encode(data: dict[str, ?value], pretty=False, bigint_as_string=False) -> str:
     """Encode a dictionary into a JSON string
-    """
-    return _encode(data, pretty)
 
-def encode_list(data: list[?value], pretty=False) -> str:
-    """Encode a list into a JSON array string
+    Values of type bigint are encoded as JSON numbers by default. Set
+    bigint_as_string to encode them as JSON strings instead.
     """
-    return _encode_list(data, pretty)
+    return _encode(data, pretty, bigint_as_string)
+
+def encode_list(data: list[?value], pretty=False, bigint_as_string=False) -> str:
+    """Encode a list into a JSON array string
+
+    Values of type bigint are encoded as JSON numbers by default. Set
+    bigint_as_string to encode them as JSON strings instead.
+    """
+    return _encode_list(data, pretty, bigint_as_string)
 
 
 actor Json():
@@ -50,8 +56,8 @@ actor Json():
     action def decode_list(data: str) -> list[?value]:
         return _decode_list(data)
 
-    action def encode(data: dict[str, ?value], pretty=False) -> str:
-        return _encode(data, pretty)
+    action def encode(data: dict[str, ?value], pretty=False, bigint_as_string=False) -> str:
+        return _encode(data, pretty, bigint_as_string)
 
-    action def encode_list(data: list[?value], pretty=False) -> str:
-        return _encode_list(data, pretty)
+    action def encode_list(data: list[?value], pretty=False, bigint_as_string=False) -> str:
+        return _encode_list(data, pretty, bigint_as_string)

--- a/base/src/json.ext.c
+++ b/base/src/json.ext.c
@@ -24,8 +24,15 @@ void jsonQ___ext_init__() {
     acton_alc.free = my_free;
 }
 
-void jsonQ_encode_list_into(yyjson_mut_doc *doc, yyjson_mut_val *node, B_list data);
-void jsonQ_encode_dict(yyjson_mut_doc *doc, yyjson_mut_val *node, B_dict data) {
+static yyjson_mut_val *jsonQ_encode_bigint(yyjson_mut_doc *doc, B_bigint value, bool as_string) {
+    char *number = get_str(&value->val);
+    if (as_string)
+        return yyjson_mut_str(doc, number);
+    return yyjson_mut_raw(doc, number);
+}
+
+void jsonQ_encode_list_into(yyjson_mut_doc *doc, yyjson_mut_val *node, B_list data, bool bigint_as_string);
+void jsonQ_encode_dict(yyjson_mut_doc *doc, yyjson_mut_val *node, B_dict data, bool bigint_as_string) {
     B_IteratorD_dict_items iter = $NEW(B_IteratorD_dict_items, data);
     B_tuple item;
 
@@ -47,15 +54,18 @@ void jsonQ_encode_dict(yyjson_mut_doc *doc, yyjson_mut_val *node, B_dict data) {
                 case STR_ID:;
                     yyjson_mut_obj_add_str(doc, node, key,  (char *)fromB_str((B_str)v));
                     break;
+                case BIGINT_ID:;
+                    yyjson_mut_obj_add_val(doc, node, key, jsonQ_encode_bigint(doc, (B_bigint)v, bigint_as_string));
+                    break;
                 case LIST_ID:;
                     yyjson_mut_val *l = yyjson_mut_arr(doc);
                     yyjson_mut_obj_add_val(doc, node, key, l);
-                    jsonQ_encode_list_into(doc, l, (B_list)v);
+                    jsonQ_encode_list_into(doc, l, (B_list)v, bigint_as_string);
                     break;
                 case DICT_ID:;
                     yyjson_mut_val *d = yyjson_mut_obj(doc);
                     yyjson_mut_obj_add_val(doc, node, key, d);
-                    jsonQ_encode_dict(doc, d, (B_dict)v);
+                    jsonQ_encode_dict(doc, d, (B_dict)v, bigint_as_string);
                     break;
                 case I8_ID:;
                     yyjson_mut_obj_add_int(doc, node, key, ((B_i8)v)->val);
@@ -97,7 +107,7 @@ void jsonQ_encode_dict(yyjson_mut_doc *doc, yyjson_mut_val *node, B_dict data) {
     }
 }
 
-void jsonQ_encode_list_into(yyjson_mut_doc *doc, yyjson_mut_val *node, B_list data) {
+void jsonQ_encode_list_into(yyjson_mut_doc *doc, yyjson_mut_val *node, B_list data, bool bigint_as_string) {
     for (int i = 0; i < data->length; i++) {
         B_value v = data->data[i];
         if (v) {
@@ -114,10 +124,13 @@ void jsonQ_encode_list_into(yyjson_mut_doc *doc, yyjson_mut_val *node, B_list da
                 case STR_ID:;
                     yyjson_mut_arr_add_str(doc, node,  (char *)fromB_str((B_str)v));
                     break;
+                case BIGINT_ID:;
+                    yyjson_mut_arr_add_val(node, jsonQ_encode_bigint(doc, (B_bigint)v, bigint_as_string));
+                    break;
                 case LIST_ID:;
                     yyjson_mut_val *l = yyjson_mut_arr_add_arr(doc, node);
                     if (l) {
-                        jsonQ_encode_list_into(doc, l, (B_list)v);
+                        jsonQ_encode_list_into(doc, l, (B_list)v, bigint_as_string);
                     } else {
                         // TODO: raise exception
                     }
@@ -125,7 +138,7 @@ void jsonQ_encode_list_into(yyjson_mut_doc *doc, yyjson_mut_val *node, B_list da
                 case DICT_ID:;
                     yyjson_mut_val *d = yyjson_mut_arr_add_obj(doc, node);
                     if (d) {
-                        jsonQ_encode_dict(doc, d, (B_dict)v);
+                        jsonQ_encode_dict(doc, d, (B_dict)v, bigint_as_string);
                     } else {
                         // TODO: raise exception
                     }
@@ -337,20 +350,17 @@ B_list jsonQ__decode_list (B_str data) {
     return res;
 }
 
-B_str jsonQ__encode (B_dict data, B_bool pretty) {
-    if (pretty == NULL)
-        pretty = B_False;
-
+B_str jsonQ__encode (B_dict data, bool pretty, bool bigint_as_string) {
     // Create JSON document
     yyjson_mut_doc *doc = yyjson_mut_doc_new(&acton_alc);
     yyjson_mut_val *root = yyjson_mut_obj(doc);
     yyjson_mut_doc_set_root(doc, root);
 
-    jsonQ_encode_dict(doc, root, data);
+    jsonQ_encode_dict(doc, root, data, bigint_as_string);
 
     yyjson_write_err err;
     int flags = 0;
-    if (pretty == B_True)
+    if (pretty)
         flags += YYJSON_WRITE_PRETTY;
 
     char *json = yyjson_mut_write_opts(doc, flags, &acton_alc, NULL, &err);
@@ -358,20 +368,17 @@ B_str jsonQ__encode (B_dict data, B_bool pretty) {
     return to$str(json);
 }
 
-B_str jsonQ__encode_list (B_list data, B_bool pretty) {
-    if (pretty == NULL)
-        pretty = B_False;
-
+B_str jsonQ__encode_list (B_list data, bool pretty, bool bigint_as_string) {
     // Create JSON document
     yyjson_mut_doc *doc = yyjson_mut_doc_new(&acton_alc);
     yyjson_mut_val *root = yyjson_mut_arr(doc);
     yyjson_mut_doc_set_root(doc, root);
 
-    jsonQ_encode_list_into(doc, root, data);
+    jsonQ_encode_list_into(doc, root, data, bigint_as_string);
 
     yyjson_write_err err;
     int flags = 0;
-    if (pretty == B_True)
+    if (pretty)
         flags += YYJSON_WRITE_PRETTY;
 
     char *json = yyjson_mut_write_opts(doc, flags, &acton_alc, NULL, &err);

--- a/base/src/json.ext.c
+++ b/base/src/json.ext.c
@@ -173,6 +173,18 @@ void jsonQ_encode_list_into(yyjson_mut_doc *doc, yyjson_mut_val *node, B_list da
 B_list jsonQ_decode_arr(yyjson_val *);
 
 static B_value jsonQ_decode_integer(yyjson_val *val) {
+    if (yyjson_is_raw(val)) {
+        size_t len = yyjson_get_len(val);
+        const char *raw = yyjson_get_raw(val);
+        for (size_t i = 0; i < len; i++) {
+            if (raw[i] == '.' || raw[i] == 'e' || raw[i] == 'E')
+                $RAISE((B_BaseException)B_ValueErrorG_new(to$str("JSON floating-point number is out of range")));
+        }
+        char *number = acton_malloc_atomic(len + 1);
+        memcpy(number, raw, len);
+        number[len] = '\0';
+        return (B_value)toB_bigint2(number);
+    }
     if (yyjson_get_subtype(val) == YYJSON_SUBTYPE_UINT) {
         uint64_t number = yyjson_get_uint(val);
         if (number > INT64_MAX)
@@ -194,6 +206,9 @@ B_dict jsonQ_decode_obj(yyjson_val *obj) {
 
         switch (yyjson_get_type(val)) {
             case YYJSON_TYPE_NONE:;
+                break;
+            case YYJSON_TYPE_RAW:;
+                B_dictD_setitem(res, wit, to$str(yyjson_get_str(key)), jsonQ_decode_integer(val));
                 break;
             case YYJSON_TYPE_NULL:;
                 B_dictD_setitem(res, wit, to$str(yyjson_get_str(key)), B_None);
@@ -241,6 +256,9 @@ B_list jsonQ_decode_arr(yyjson_val *arr) {
         switch (yyjson_get_type(val)) {
             case YYJSON_TYPE_NONE:
                 break;
+            case YYJSON_TYPE_RAW:;
+                wit->$class->append(wit, res, jsonQ_decode_integer(val));
+                break;
             case YYJSON_TYPE_NULL:;
                 wit->$class->append(wit, res, B_None);
                 break;
@@ -280,7 +298,7 @@ B_list jsonQ_decode_arr(yyjson_val *arr) {
 B_dict jsonQ__decode (B_str data) {
     // Read JSON and get root
     yyjson_read_err err;
-    yyjson_doc *doc = yyjson_read_opts(fromB_str(data), strlen(fromB_str(data)), 0, &acton_alc, &err);
+    yyjson_doc *doc = yyjson_read_opts(fromB_str(data), strlen(fromB_str(data)), YYJSON_READ_BIGNUM_AS_RAW, &acton_alc, &err);
     yyjson_val *root = yyjson_doc_get_root(doc);
 
     B_dict res = $NEW(B_dict,(B_Hashable)B_HashableD_strG_witness,NULL,NULL);
@@ -301,7 +319,7 @@ B_dict jsonQ__decode (B_str data) {
 B_list jsonQ__decode_list (B_str data) {
     // Read JSON and get root
     yyjson_read_err err;
-    yyjson_doc *doc = yyjson_read_opts(fromB_str(data), strlen(fromB_str(data)), 0, &acton_alc, &err);
+    yyjson_doc *doc = yyjson_read_opts(fromB_str(data), strlen(fromB_str(data)), YYJSON_READ_BIGNUM_AS_RAW, &acton_alc, &err);
     if (!doc) {
         char errmsg[1024];
         snprintf(errmsg, sizeof(errmsg), "JSON parsing error: %s (%u) at position %ld", err.msg, err.code, err.pos);

--- a/std/src/json.act
+++ b/std/src/json.act
@@ -4,10 +4,10 @@ def _decode(data: str) -> dict[str, ?value]:
 def _decode_list(data: str) -> list[?value]:
     NotImplemented
 
-def _encode(data: dict[str, ?value], pretty=False) -> str:
+def _encode(data: dict[str, ?value], pretty: bool, bigint_as_string: bool) -> str:
     NotImplemented
 
-def _encode_list(data: list[?value], pretty=False) -> str:
+def _encode_list(data: list[?value], pretty: bool, bigint_as_string: bool) -> str:
     NotImplemented
 
 
@@ -21,15 +21,21 @@ def decode_list(data: str) -> list[?value]:
     """
     return _decode_list(data)
 
-def encode(data: dict[str, ?value], pretty=False) -> str:
+def encode(data: dict[str, ?value], pretty=False, bigint_as_string=False) -> str:
     """Encode a dictionary into a JSON string
-    """
-    return _encode(data, pretty)
 
-def encode_list(data: list[?value], pretty=False) -> str:
-    """Encode a list into a JSON array string
+    Values of type bigint are encoded as JSON numbers by default. Set
+    bigint_as_string to encode them as JSON strings instead.
     """
-    return _encode_list(data, pretty)
+    return _encode(data, pretty, bigint_as_string)
+
+def encode_list(data: list[?value], pretty=False, bigint_as_string=False) -> str:
+    """Encode a list into a JSON array string
+
+    Values of type bigint are encoded as JSON numbers by default. Set
+    bigint_as_string to encode them as JSON strings instead.
+    """
+    return _encode_list(data, pretty, bigint_as_string)
 
 
 actor Json():
@@ -50,8 +56,8 @@ actor Json():
     action def decode_list(data: str) -> list[?value]:
         return _decode_list(data)
 
-    action def encode(data: dict[str, ?value], pretty=False) -> str:
-        return _encode(data, pretty)
+    action def encode(data: dict[str, ?value], pretty=False, bigint_as_string=False) -> str:
+        return _encode(data, pretty, bigint_as_string)
 
-    action def encode_list(data: list[?value], pretty=False) -> str:
-        return _encode_list(data, pretty)
+    action def encode_list(data: list[?value], pretty=False, bigint_as_string=False) -> str:
+        return _encode_list(data, pretty, bigint_as_string)

--- a/std/src/json.ext.c
+++ b/std/src/json.ext.c
@@ -173,6 +173,18 @@ void stdQ_jsonQ_encode_list_into(yyjson_mut_doc *doc, yyjson_mut_val *node, B_li
 B_list stdQ_jsonQ_decode_arr(yyjson_val *);
 
 static B_value stdQ_jsonQ_decode_integer(yyjson_val *val) {
+    if (yyjson_is_raw(val)) {
+        size_t len = yyjson_get_len(val);
+        const char *raw = yyjson_get_raw(val);
+        for (size_t i = 0; i < len; i++) {
+            if (raw[i] == '.' || raw[i] == 'e' || raw[i] == 'E')
+                $RAISE((B_BaseException)B_ValueErrorG_new(to$str("JSON floating-point number is out of range")));
+        }
+        char *number = acton_malloc_atomic(len + 1);
+        memcpy(number, raw, len);
+        number[len] = '\0';
+        return (B_value)toB_bigint2(number);
+    }
     if (yyjson_get_subtype(val) == YYJSON_SUBTYPE_UINT) {
         uint64_t number = yyjson_get_uint(val);
         if (number > INT64_MAX)
@@ -194,6 +206,9 @@ B_dict stdQ_jsonQ_decode_obj(yyjson_val *obj) {
 
         switch (yyjson_get_type(val)) {
             case YYJSON_TYPE_NONE:;
+                break;
+            case YYJSON_TYPE_RAW:;
+                B_dictD_setitem(res, wit, to$str(yyjson_get_str(key)), stdQ_jsonQ_decode_integer(val));
                 break;
             case YYJSON_TYPE_NULL:;
                 B_dictD_setitem(res, wit, to$str(yyjson_get_str(key)), B_None);
@@ -241,6 +256,9 @@ B_list stdQ_jsonQ_decode_arr(yyjson_val *arr) {
         switch (yyjson_get_type(val)) {
             case YYJSON_TYPE_NONE:
                 break;
+            case YYJSON_TYPE_RAW:;
+                wit->$class->append(wit, res, stdQ_jsonQ_decode_integer(val));
+                break;
             case YYJSON_TYPE_NULL:;
                 wit->$class->append(wit, res, B_None);
                 break;
@@ -280,7 +298,7 @@ B_list stdQ_jsonQ_decode_arr(yyjson_val *arr) {
 B_dict stdQ_jsonQ__decode (B_str data) {
     // Read JSON and get root
     yyjson_read_err err;
-    yyjson_doc *doc = yyjson_read_opts(fromB_str(data), strlen(fromB_str(data)), 0, &stdQ_jsonQ_acton_alc, &err);
+    yyjson_doc *doc = yyjson_read_opts(fromB_str(data), strlen(fromB_str(data)), YYJSON_READ_BIGNUM_AS_RAW, &stdQ_jsonQ_acton_alc, &err);
     yyjson_val *root = yyjson_doc_get_root(doc);
 
     B_dict res = $NEW(B_dict,(B_Hashable)B_HashableD_strG_witness,NULL,NULL);
@@ -301,7 +319,7 @@ B_dict stdQ_jsonQ__decode (B_str data) {
 B_list stdQ_jsonQ__decode_list (B_str data) {
     // Read JSON and get root
     yyjson_read_err err;
-    yyjson_doc *doc = yyjson_read_opts(fromB_str(data), strlen(fromB_str(data)), 0, &stdQ_jsonQ_acton_alc, &err);
+    yyjson_doc *doc = yyjson_read_opts(fromB_str(data), strlen(fromB_str(data)), YYJSON_READ_BIGNUM_AS_RAW, &stdQ_jsonQ_acton_alc, &err);
     if (!doc) {
         char errmsg[1024];
         snprintf(errmsg, sizeof(errmsg), "JSON parsing error: %s (%u) at position %ld", err.msg, err.code, err.pos);

--- a/std/src/json.ext.c
+++ b/std/src/json.ext.c
@@ -24,8 +24,15 @@ void stdQ_jsonQ___ext_init__() {
     stdQ_jsonQ_acton_alc.free = my_free;
 }
 
-void stdQ_jsonQ_encode_list_into(yyjson_mut_doc *doc, yyjson_mut_val *node, B_list data);
-void stdQ_jsonQ_encode_dict(yyjson_mut_doc *doc, yyjson_mut_val *node, B_dict data) {
+static yyjson_mut_val *stdQ_jsonQ_encode_bigint(yyjson_mut_doc *doc, B_bigint value, bool as_string) {
+    char *number = get_str(&value->val);
+    if (as_string)
+        return yyjson_mut_str(doc, number);
+    return yyjson_mut_raw(doc, number);
+}
+
+void stdQ_jsonQ_encode_list_into(yyjson_mut_doc *doc, yyjson_mut_val *node, B_list data, bool bigint_as_string);
+void stdQ_jsonQ_encode_dict(yyjson_mut_doc *doc, yyjson_mut_val *node, B_dict data, bool bigint_as_string) {
     B_IteratorD_dict_items iter = $NEW(B_IteratorD_dict_items, data);
     B_tuple item;
 
@@ -47,15 +54,18 @@ void stdQ_jsonQ_encode_dict(yyjson_mut_doc *doc, yyjson_mut_val *node, B_dict da
                 case STR_ID:;
                     yyjson_mut_obj_add_str(doc, node, key,  (char *)fromB_str((B_str)v));
                     break;
+                case BIGINT_ID:;
+                    yyjson_mut_obj_add_val(doc, node, key, stdQ_jsonQ_encode_bigint(doc, (B_bigint)v, bigint_as_string));
+                    break;
                 case LIST_ID:;
                     yyjson_mut_val *l = yyjson_mut_arr(doc);
                     yyjson_mut_obj_add_val(doc, node, key, l);
-                    stdQ_jsonQ_encode_list_into(doc, l, (B_list)v);
+                    stdQ_jsonQ_encode_list_into(doc, l, (B_list)v, bigint_as_string);
                     break;
                 case DICT_ID:;
                     yyjson_mut_val *d = yyjson_mut_obj(doc);
                     yyjson_mut_obj_add_val(doc, node, key, d);
-                    stdQ_jsonQ_encode_dict(doc, d, (B_dict)v);
+                    stdQ_jsonQ_encode_dict(doc, d, (B_dict)v, bigint_as_string);
                     break;
                 case I8_ID:;
                     yyjson_mut_obj_add_int(doc, node, key, ((B_i8)v)->val);
@@ -97,7 +107,7 @@ void stdQ_jsonQ_encode_dict(yyjson_mut_doc *doc, yyjson_mut_val *node, B_dict da
     }
 }
 
-void stdQ_jsonQ_encode_list_into(yyjson_mut_doc *doc, yyjson_mut_val *node, B_list data) {
+void stdQ_jsonQ_encode_list_into(yyjson_mut_doc *doc, yyjson_mut_val *node, B_list data, bool bigint_as_string) {
     for (int i = 0; i < data->length; i++) {
         B_value v = data->data[i];
         if (v) {
@@ -114,10 +124,13 @@ void stdQ_jsonQ_encode_list_into(yyjson_mut_doc *doc, yyjson_mut_val *node, B_li
                 case STR_ID:;
                     yyjson_mut_arr_add_str(doc, node,  (char *)fromB_str((B_str)v));
                     break;
+                case BIGINT_ID:;
+                    yyjson_mut_arr_add_val(node, stdQ_jsonQ_encode_bigint(doc, (B_bigint)v, bigint_as_string));
+                    break;
                 case LIST_ID:;
                     yyjson_mut_val *l = yyjson_mut_arr_add_arr(doc, node);
                     if (l) {
-                        stdQ_jsonQ_encode_list_into(doc, l, (B_list)v);
+                        stdQ_jsonQ_encode_list_into(doc, l, (B_list)v, bigint_as_string);
                     } else {
                         // TODO: raise exception
                     }
@@ -125,7 +138,7 @@ void stdQ_jsonQ_encode_list_into(yyjson_mut_doc *doc, yyjson_mut_val *node, B_li
                 case DICT_ID:;
                     yyjson_mut_val *d = yyjson_mut_arr_add_obj(doc, node);
                     if (d) {
-                        stdQ_jsonQ_encode_dict(doc, d, (B_dict)v);
+                        stdQ_jsonQ_encode_dict(doc, d, (B_dict)v, bigint_as_string);
                     } else {
                         // TODO: raise exception
                     }
@@ -337,20 +350,17 @@ B_list stdQ_jsonQ__decode_list (B_str data) {
     return res;
 }
 
-B_str stdQ_jsonQ__encode (B_dict data, B_bool pretty) {
-    if (pretty == NULL)
-        pretty = B_False;
-
+B_str stdQ_jsonQ__encode (B_dict data, bool pretty, bool bigint_as_string) {
     // Create JSON document
     yyjson_mut_doc *doc = yyjson_mut_doc_new(&stdQ_jsonQ_acton_alc);
     yyjson_mut_val *root = yyjson_mut_obj(doc);
     yyjson_mut_doc_set_root(doc, root);
 
-    stdQ_jsonQ_encode_dict(doc, root, data);
+    stdQ_jsonQ_encode_dict(doc, root, data, bigint_as_string);
 
     yyjson_write_err err;
     int flags = 0;
-    if (pretty == B_True)
+    if (pretty)
         flags += YYJSON_WRITE_PRETTY;
 
     char *json = yyjson_mut_write_opts(doc, flags, &stdQ_jsonQ_acton_alc, NULL, &err);
@@ -358,20 +368,17 @@ B_str stdQ_jsonQ__encode (B_dict data, B_bool pretty) {
     return to$str(json);
 }
 
-B_str stdQ_jsonQ__encode_list (B_list data, B_bool pretty) {
-    if (pretty == NULL)
-        pretty = B_False;
-
+B_str stdQ_jsonQ__encode_list (B_list data, bool pretty, bool bigint_as_string) {
     // Create JSON document
     yyjson_mut_doc *doc = yyjson_mut_doc_new(&stdQ_jsonQ_acton_alc);
     yyjson_mut_val *root = yyjson_mut_arr(doc);
     yyjson_mut_doc_set_root(doc, root);
 
-    stdQ_jsonQ_encode_list_into(doc, root, data);
+    stdQ_jsonQ_encode_list_into(doc, root, data, bigint_as_string);
 
     yyjson_write_err err;
     int flags = 0;
-    if (pretty == B_True)
+    if (pretty)
         flags += YYJSON_WRITE_PRETTY;
 
     char *json = yyjson_mut_write_opts(doc, flags, &stdQ_jsonQ_acton_alc, NULL, &err);

--- a/test/stdlib_tests/src/test_json.act
+++ b/test/stdlib_tests/src/test_json.act
@@ -41,7 +41,8 @@ def _test_json_list_decode():
         testing.assertEqual(s, e, "JSON array roundtrip does not match")
 
 def _test_json_bigint_decode():
-    obj = json.decode(r"""{"foo":-18446744073709551617,"bar":18446744073709551616}""")
+    source = r"""{"foo":-18446744073709551617,"bar":18446744073709551616}"""
+    obj = json.decode(source)
     foo = obj["foo"]
     bar = obj["bar"]
     testing.assertTrue(isinstance(foo, bigint), "negative JSON bigint decoded with the wrong type")
@@ -50,6 +51,7 @@ def _test_json_bigint_decode():
         testing.assertEqual(foo, bigint("-18446744073709551617"))
     if isinstance(bar, bigint):
         testing.assertEqual(bar, bigint("18446744073709551616"))
+    testing.assertEqual(json.encode(obj), source)
 
     values = json.decode_list(r"""[-9223372036854775809,123456789012345678901234567890]""")
     first = values[0]
@@ -70,6 +72,29 @@ def _test_json_bigint_decode():
         testing.assertTrue(False, "out-of-range JSON float did not raise ValueError")
     except ValueError:
         pass
+
+def _test_json_bigint_encode():
+    positive = bigint("123456789012345678901234567890")
+    negative = bigint("-18446744073709551617")
+    obj = {"positive": positive, "nested": [negative]}
+    testing.assertEqual(
+        json.encode(obj),
+        r"""{"positive":123456789012345678901234567890,"nested":[-18446744073709551617]}"""
+    )
+    testing.assertEqual(
+        json.encode(obj, bigint_as_string=True),
+        r"""{"positive":"123456789012345678901234567890","nested":["-18446744073709551617"]}"""
+    )
+
+    values = [positive, {"negative": negative}]
+    testing.assertEqual(
+        json.encode_list(values),
+        r"""[123456789012345678901234567890,{"negative":-18446744073709551617}]"""
+    )
+    testing.assertEqual(
+        json.encode_list(values, bigint_as_string=True),
+        r"""["123456789012345678901234567890",{"negative":"-18446744073709551617"}]"""
+    )
 
 def _test_json_encode_fixed_size_int():
     d = {
@@ -104,5 +129,11 @@ actor _test_json_actor(t: testing.AsyncT):
     testing.assertNotNone(decoded_list, "Json actor decode_list() returned None")
     encoded_list = await async j.encode_list(decoded_list)
     testing.assertEqual(arr, encoded_list, "Json actor list round-trip mismatch")
+
+    bigint_obj = {"value": bigint("18446744073709551616")}
+    encoded_bigint = await async j.encode(bigint_obj)
+    testing.assertEqual(r"""{"value":18446744073709551616}""", encoded_bigint, "Json actor bigint encoding mismatch")
+    encoded_bigint_string = await async j.encode(bigint_obj, False, True)
+    testing.assertEqual(r"""{"value":"18446744073709551616"}""", encoded_bigint_string, "Json actor bigint string encoding mismatch")
 
     t.success()

--- a/test/stdlib_tests/src/test_json.act
+++ b/test/stdlib_tests/src/test_json.act
@@ -40,6 +40,37 @@ def _test_json_list_decode():
         testing.assertNotNone(e, "json.encode_list() returned None")
         testing.assertEqual(s, e, "JSON array roundtrip does not match")
 
+def _test_json_bigint_decode():
+    obj = json.decode(r"""{"foo":-18446744073709551617,"bar":18446744073709551616}""")
+    foo = obj["foo"]
+    bar = obj["bar"]
+    testing.assertTrue(isinstance(foo, bigint), "negative JSON bigint decoded with the wrong type")
+    testing.assertTrue(isinstance(bar, bigint), "positive JSON bigint decoded with the wrong type")
+    if isinstance(foo, bigint):
+        testing.assertEqual(foo, bigint("-18446744073709551617"))
+    if isinstance(bar, bigint):
+        testing.assertEqual(bar, bigint("18446744073709551616"))
+
+    values = json.decode_list(r"""[-9223372036854775809,123456789012345678901234567890]""")
+    first = values[0]
+    second = values[1]
+    testing.assertTrue(isinstance(first, bigint), "JSON array bigint decoded with the wrong type")
+    testing.assertTrue(isinstance(second, bigint), "large JSON array bigint decoded with the wrong type")
+    if isinstance(first, bigint):
+        testing.assertEqual(first, bigint("-9223372036854775809"))
+    if isinstance(second, bigint):
+        testing.assertEqual(second, bigint("123456789012345678901234567890"))
+
+    real_values = json.decode_list(r"""[18446744073709551616.0,-18446744073709551617e0]""")
+    testing.assertTrue(isinstance(real_values[0], float), "large JSON decimal decoded with the wrong type")
+    testing.assertTrue(isinstance(real_values[1], float), "large JSON exponent decoded with the wrong type")
+
+    try:
+        json.decode_list(r"""[1e999]""")
+        testing.assertTrue(False, "out-of-range JSON float did not raise ValueError")
+    except ValueError:
+        pass
+
 def _test_json_encode_fixed_size_int():
     d = {
         "int": 4,

--- a/test/stdlib_tests/src/test_std_namespace.act
+++ b/test/stdlib_tests/src/test_std_namespace.act
@@ -29,6 +29,8 @@ def _test_std_namespace_data_modules():
     testing.assertTrue(isinstance(json_bigint, bigint), "std.json bigint decoded with the wrong type")
     if isinstance(json_bigint, bigint):
         testing.assertEqual(json_bigint, bigint("-18446744073709551617"))
+    testing.assertEqual(json.encode({"value": json_bigint}), r"""{"value":-18446744073709551617}""")
+    testing.assertEqual(json.encode({"value": json_bigint}, bigint_as_string=True), r"""{"value":"-18446744073709551617"}""")
     testing.assertEqual(xml.encode(xml.Node("a", text="hello")), "<a>hello</a>")
     testing.assertEqual(snappy.decompress(snappy.compress(b"hello hello hello")), b"hello hello hello")
     testing.assertEqual(md5.hash(b"abc"), b"\x90\x01\x50\x98\x3c\xd2\x4f\xb0\xd6\x96\x3f\x7d\x28\xe1\x7f\x72")

--- a/test/stdlib_tests/src/test_std_namespace.act
+++ b/test/stdlib_tests/src/test_std_namespace.act
@@ -25,6 +25,10 @@ def _test_std_namespace_data_modules():
     testing.assertEqual(json.encode(json.decode(json_numbers)), json_numbers)
     json_number_list = r"""[1000000000000,-1000000000000,18446744073709551615]"""
     testing.assertEqual(json.encode_list(json.decode_list(json_number_list)), json_number_list)
+    json_bigint = json.decode(r"""{"value":-18446744073709551617}""")["value"]
+    testing.assertTrue(isinstance(json_bigint, bigint), "std.json bigint decoded with the wrong type")
+    if isinstance(json_bigint, bigint):
+        testing.assertEqual(json_bigint, bigint("-18446744073709551617"))
     testing.assertEqual(xml.encode(xml.Node("a", text="hello")), "<a>hello</a>")
     testing.assertEqual(snappy.decompress(snappy.compress(b"hello hello hello")), b"hello hello hello")
     testing.assertEqual(md5.hash(b"abc"), b"\x90\x01\x50\x98\x3c\xd2\x4f\xb0\xd6\x96\x3f\x7d\x28\xe1\x7f\x72")


### PR DESCRIPTION
JSON decoding currently lets yyjson convert integer tokens outside the 64-bit ranges to double, which loses precision.

This reads oversized integer tokens as raw JSON and constructs bigint values from their original digits in both json and std.json. It also teaches encoding to write bigint values as JSON numbers, with a bigint_as_string option for consumers that cannot represent arbitrary-precision numbers. The option applies recursively and is available through both the functions and Json actor methods.

Fixes #3051.