### PR TITLE
Fix forced unwrap chained into tuple selection

### DIFF
--- a/compiler/lib/src/Acton/Types.hs
+++ b/compiler/lib/src/Acton/Types.hs
@@ -2213,7 +2213,7 @@ instance Infer Expr where
                                             let env1 = define [(x,NVar te)] env
                                             (cs2,t,e2') <- infer env1 e2
                                             y <- newTmp
-                                            (cs3,t',e3) <- alt t te b
+                                            (cs3,t',e3) <- alt t b
                                             return (cs1++cs2++cs3,
                                                      t', eLet [sAssign (pVar y (tOpt te)) e1']
                                                                            (eCond (termsubst [(x,eCAST (tOpt te) te (eVar y))] e2')
@@ -2221,14 +2221,17 @@ instance Infer Expr where
                                                                                   e3))
       where split x (Opt l e b)         = (b, e, eVar x)
             split x (Dot l e n)         = (b, e1,Dot l e2 n) where (b,e1,e2) = split x e
+            split x (DotI l e i)        = (b, e1,DotI l e2 i) where (b,e1,e2) = split x e
+            split x (Rest l e n)        = (b, e1,Rest l e2 n) where (b,e1,e2) = split x e
+            split x (RestI l e i)       = (b, e1,RestI l e2 i) where (b,e1,e2) = split x e
             split x (Call l f ps ks)    = (b, e1,Call l e2 ps ks) where (b,e1,e2) = split x f
             split x (Index l e ix)      = (b, e1,Index l e2 ix) where (b,e1,e2) = split x e
             split x (Slice l e sz)      = (b, e1,Slice l e2 sz) where (b,e1,e2) = split x e
-            alt t te True               = do w <- newWitness
+            alt t True                  = do w <- newWitness
                                              w1 <- newWitness
                                              t1 <- newUnivar env
                                              return ([Sub (noinfo 444) env w tNone t1, Sub (noinfo 555) env w1 t t1],t1,eNone)
-            alt t te False              = return ([],t,eCall (tApp (eQVar primRaiseValueError) [te]) [Strings NoLoc ["Forced unwrapping applied to None"]] )
+            alt t False                 = return ([],t,eCall (tApp (eQVar primRaiseValueError) [t]) [Strings NoLoc ["Forced unwrapping applied to None"]] )
  
     infer env e@(Rest _ _ _)            = notYetExpr e
 --    infer env (Rest l e n)              = do p <- newUnivarOfKind PRow env

--- a/test/core_lang_auto/optchain9.act
+++ b/test/core_lang_auto/optchain9.act
@@ -1,0 +1,54 @@
+# Forced unwrapping (!) and optional chaining (?) on optional named tuples,
+# in particular `!` chained directly into a tuple field selection, which used
+# to crash the compiler ("Non-exhaustive patterns" in QuickType upbound).
+
+def force_key(x: ?(key: bytes, value: bytes)) -> bytes:
+    return x!.key
+
+def opt_key(x: ?(key: bytes, value: bytes)) -> ?bytes:
+    return x?.key
+
+def nested(x: ?(a: (b: int, c: str), d: str)) -> int:
+    return x!.a.b
+
+def plain_unwrap(x: ?(key: bytes, value: bytes)) -> (key: bytes, value: bytes):
+    return x!
+
+def force_pos(x: ?(int, str)) -> int:
+    return x!.0
+
+def opt_pos(x: ?(int, str)) -> ?str:
+    return x?.1
+
+actor main(env):
+    if force_key((key=b"k", value=b"v")) != b"k":
+        print("force_key is wrong")
+        env.exit(1)
+    if opt_key((key=b"o", value=b"v")) != b"o":
+        print("opt_key is wrong")
+        env.exit(1)
+    if opt_key(None) is not None:
+        print("opt_key(None) is wrong")
+        env.exit(1)
+    if nested((a=(b=42, c="x"), d="y")) != 42:
+        print("nested is wrong")
+        env.exit(1)
+    if plain_unwrap((key=b"p", value=b"q")).key != b"p":
+        print("plain_unwrap is wrong")
+        env.exit(1)
+    if force_pos((7, "s")) != 7:
+        print("force_pos is wrong")
+        env.exit(1)
+    if opt_pos((7, "s")) != "s":
+        print("opt_pos is wrong")
+        env.exit(1)
+    if opt_pos(None) is not None:
+        print("opt_pos(None) is wrong")
+        env.exit(1)
+    try:
+        force_key(None)
+        print("force_key(None) did not raise")
+        env.exit(1)
+    except ValueError:
+        pass
+    env.exit(0)


### PR DESCRIPTION
Forced unwrapping followed by a tuple field selection, like x!.key on a value of type ?(key: bytes, value: bytes), crashed the compiler with a non-exhaustive pattern error in QuickType during the back passes. The optional chain elaboration rewrites the chain into a conditional whose else branch calls $raiseValueError, and that branch was instantiated at the type of the unwrapped receiver (the tuple) while the then branch carries the type of the selection result (the field type). QuickType recomputes a conditional's type as the least upper bound of its branch types. Two class types always share a common ancestor, so class receivers never exposed the mismatch, but a tuple type and its field type have no upper bound at all and the computation had no answer. Since the raise branch never produces a value, its claimed type is free to choose: it is now instantiated at the type of the whole chain, making both branches agree for any receiver.

The splitter that divides an optional chain at its ?/! mark also lacked cases for some trailers the parser accepts inside a chain: positional tuple selection (x!.0, and x?.0 alike) crashed in split, as did the row-rest selectors x!.~key and x!.~0. The missing cases are added, so positional selection now compiles and runs, and the rest selectors produce their regular "not yet supported" error instead of crashing the compiler.

A new test, test/core_lang_auto/optchain8.act, covers ! and ? chained into named and positional selections on optional tuples, plain unwrap, and the ValueError raised when unwrapping None.
