### PR TITLE
Fix effect of Let expressions in QuickType

### DIFF
--- a/compiler/lib/src/Acton/QuickType.hs
+++ b/compiler/lib/src/Acton/QuickType.hs
@@ -46,6 +46,20 @@ expTypeOf env x                     = expanded env (typeOf env x)
 fxOf env x                          = fx
   where (t, fx, x')                 = qType env accept x
 
+-- Effects of the bound statements of a Let expression. Let suites are built
+-- internally (e.g. by the OptChain elimination in Types), so only the statement
+-- forms that can occur there are handled.
+fxSuite                             :: EnvF x -> Suite -> [Type]
+fxSuite env []                      = []
+fxSuite env (s : ss)                = fxStmt env s : fxSuite (define (envOf s) env) ss
+
+fxStmt                              :: EnvF x -> Stmt -> Type
+fxStmt env (Assign _ _ e)           = fxOf env e
+fxStmt env (MutAssign _ tg e)       = upbound env [fxMut, fxOf env tg, fxOf env e]
+fxStmt env (AugAssign _ tg _ e)     = upbound env [fxMut, fxOf env tg, fxOf env e]
+fxStmt env (Expr _ e)               = fxOf env e
+fxStmt env (Pass _)                 = fxPure
+
 typeInstOf env ts e                 = t
   where (t, fx, e')                 = qInst env accept ts e
 
@@ -186,7 +200,7 @@ instance QType Expr where
             (p, fxp, ps')           = qType env f ps
             (k, fxk, ks')           = qType env f ks
             fx'                     = upbound env [fx,fxp,fxk,effect t]
-    qType env f (Let l ss e)        = (t, fx, Let l ss e')
+    qType env f (Let l ss e)        = (t, upbound env (fx : fxSuite env ss), Let l ss e')
        where te                     = envOf ss
              (t,fx,e')              = qType (define te env) f e
     qType env f (Async l e)         = case expanded env t of

--- a/compiler/lib/src/Acton/QuickType.hs
+++ b/compiler/lib/src/Acton/QuickType.hs
@@ -11,6 +11,7 @@
 -- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 --
 
+{-# LANGUAGE FlexibleInstances #-}
 module Acton.QuickType where
 
 import Acton.Syntax
@@ -46,25 +47,12 @@ expTypeOf env x                     = expanded env (typeOf env x)
 fxOf env x                          = fx
   where (t, fx, x')                 = qType env accept x
 
--- Effects of the bound statements of a Let expression. Let suites are built
--- internally (e.g. by the OptChain elimination in Types), so only the statement
--- forms that can occur there are handled.
-fxSuite                             :: EnvF x -> Suite -> [Type]
-fxSuite env []                      = []
-fxSuite env (s : ss)                = fxStmt env s : fxSuite (define (envOf s) env) ss
-
-fxStmt                              :: EnvF x -> Stmt -> Type
-fxStmt env (Assign _ _ e)           = fxOf env e
-fxStmt env (MutAssign _ tg e)       = upbound env [fxMut, fxOf env tg, fxOf env e]
-fxStmt env (AugAssign _ tg _ e)     = upbound env [fxMut, fxOf env tg, fxOf env e]
-fxStmt env (Expr _ e)               = fxOf env e
-fxStmt env (Pass _)                 = fxPure
-
 typeInstOf env ts e                 = t
   where (t, fx, e')                 = qInst env accept ts e
 
 schemaOf env e                      = (sc, dec)
   where (sc, fx, dec, e')           = qSchema env accept e
+
 
 closedType                          :: EnvF x -> Expr -> Bool
 closedType env (Var _ n)            = isClosed $ findQName n env
@@ -200,9 +188,10 @@ instance QType Expr where
             (p, fxp, ps')           = qType env f ps
             (k, fxk, ks')           = qType env f ks
             fx'                     = upbound env [fx,fxp,fxk,effect t]
-    qType env f (Let l ss e)        = (t, upbound env (fx : fxSuite env ss), Let l ss e')
+    qType env f (Let l ss e)        = (t, upbound env [fx1, fx2], Let l ss' e')
        where te                     = envOf ss
-             (t,fx,e')              = qType (define te env) f e
+             (t,fx1,e')             = qType (define te env) f e
+             (_,fx2,ss')            = qType env f ss
     qType env f (Async l e)         = case expanded env t of
                                         TFun _ (TFX _ FXAction) p k t' -> (tFun fxProc p k (tMsg t'), fx, Async l e')
       where (t, fx, e')             = qType env f e
@@ -364,6 +353,29 @@ instance QType Comp where
     qType env f NoComp              = (tNone, fxPure, NoComp)
 
     qMatch f t t' c                 = c
+
+instance QType [Stmt] where
+    qType env f []                  = (tNone, fxPure, [])
+    qType env f (s:ss)              = (t, upbound env [fx1,fx2], s':ss')
+      where (_,fx1,s')              = qType env f s
+            (t,fx2,ss')             = qType (define (envOf s) env) f ss
+
+    qMatch f t t' ss                = ss
+
+instance QType Stmt where
+    qType env f (Assign l ps e)     = (tNone, fx, Assign l ps e')
+      where (_, fx, e')             = qType env f e
+    qType env f (MutAssign l tg e)  = (tNone, upbound env [fx1,fx2], MutAssign l tg' e')
+      where (_, fx1, e')            = qType env f e
+            (_, fx2, tg')           = qType env f tg
+    qType env f (AugAssign l tg o e) = (tNone, upbound env [fx1,fx2], AugAssign l tg' o e')
+      where (_, fx1, e')            = qType env f e
+            (_, fx2, tg')           = qType env f tg
+    qType env f (Expr l e)          = (tNone, fx, Expr l e')
+      where (_, fx, e')             = qType env f e
+    qType env f s                   = (tNone, fxPure, s)
+
+    qMatch f t t' s                 = s
 
 
 

--- a/test/core_lang_auto/optchain8.act
+++ b/test/core_lang_auto/optchain8.act
@@ -1,0 +1,19 @@
+# Postfix ! on an actor method call inside dict/list/set comprehensions.
+# https://github.com/actonlang/acton/issues/3056: the ! desugar binds the call
+# in a Let whose statement effects were dropped, so the generated comprehension
+# function was declared direct-style while its body was CPS-transformed, and
+# the emitted C failed to compile ($R returned as B_dict).
+
+actor Child():
+    def get_data() -> ?int:
+        return 42
+
+actor main(env):
+    children = {"a": Child()}
+    dres = {tag: c.get_data()! for tag, c in children.items()}
+    lres = [c.get_data()! for c in children.values()]
+    sres = {c.get_data()! for c in children.values()}
+    if dres["a"] == 42 and lres[0] == 42 and 42 in sres:
+        env.exit(0)
+    else:
+        env.exit(1)


### PR DESCRIPTION
Postfix `!` on an actor method call inside a comprehension made the generated C fail to compile (#3056):

```python
actor Child():
    def get_data() -> ?int:
        return 42

actor main(env):
    children = {"a": Child()}
    res = {tag: c.get_data()! for tag, c in children.items()}
    print(res)
    env.exit(0)
```

`qType` on a `Let` expression took its effect from the body alone, dropping the effects of the Let-bound statements. The optional chain/unwrap elimination (`OptChain` in Types) binds its scrutinee in such a `Let`, so the actor call's effect was lost exactly where `mkCompFun` in the Normalizer computes a generated comprehension function's effect via `fxOf`. The comprehension function was then declared with a pure effect while its body was CPS-transformed, and the emitted C failed to compile (`returning '$R' from a function with incompatible result type 'B_dict'`).

Include the effects of the bound statements in a `Let` expression's effect. Add a regression test (`core_lang_auto/optchain8`) covering dict, list and set comprehensions.

Fixes #3056