### PR TITLE
Do not narrow actor vars into nested defs

### DIFF
--- a/compiler/acton/test/typeerrors/narrowing_escape_def.act
+++ b/compiler/acton/test/typeerrors/narrowing_escape_def.act
@@ -1,0 +1,24 @@
+# A nested def reads a mutable actor variable at call time, so the narrowing
+# from the enclosing test must not apply inside it: the closure can escape the
+# branch and run after the variable was reset to None.
+
+def want_str(s: str) -> str:
+    return s
+
+actor main(env):
+    var state: ?str = None
+    var saved_cb: ?proc() -> str = None
+
+    def m() -> None:
+        if state is not None:
+            def cb() -> str:
+                return want_str(state)
+            saved_cb = cb
+
+    state = "hi"
+    m()
+    state = None
+    cb1 = saved_cb
+    if cb1 is not None:
+        print(cb1())
+    env.exit(0)

--- a/compiler/acton/test/typeerrors/narrowing_escape_def.golden
+++ b/compiler/acton/test/typeerrors/narrowing_escape_def.golden
@@ -1,0 +1,13 @@
+Building file test/typeerrors/narrowing_escape_def.act using temporary scratch directory
+   narrowing_escape_def  Parse done                                                               0.000 s
+[error]: Constraint violation
+     +--> narrowing_escape_def.act@15:24-15:39
+     |
+   5 | def want_str(s: str) -> str:
+     :     ^------- 
+     :     `- want_str is defined here
+     :
+  15 |                 return want_str(state)
+     :                        ^--------------
+     :                        `- Type incompatibility between definition of and call of want_str (?__builtin__.str must be a subclass of __builtin__.str)
+-----+

--- a/compiler/acton/test/typeerrors/narrowing_escape_isinstance.act
+++ b/compiler/acton/test/typeerrors/narrowing_escape_isinstance.act
@@ -1,0 +1,32 @@
+# isinstance narrowing of a mutable actor variable must not extend into a
+# nested def either: the variable may be rebound to a value of another class
+# before the closure runs, so treating it as the refined class inside the
+# closure is unsound (calling a method the object does not have).
+
+class Base(object):
+    def __init__(self):
+        pass
+
+class Derived(Base):
+    def __init__(self):
+        pass
+    def hello(self) -> str:
+        return "Derived"
+
+actor main(env):
+    var obj: Base = Base()
+    var saved: ?proc() -> str = None
+
+    def m() -> None:
+        if isinstance(obj, Derived):
+            def cb() -> str:
+                return obj.hello()
+            saved = cb
+
+    obj = Derived()
+    m()
+    obj = Base()
+    cb1 = saved
+    if cb1 is not None:
+        print(cb1())
+    env.exit(0)

--- a/compiler/acton/test/typeerrors/narrowing_escape_isinstance.golden
+++ b/compiler/acton/test/typeerrors/narrowing_escape_isinstance.golden
@@ -1,0 +1,9 @@
+Building file test/typeerrors/narrowing_escape_isinstance.act using temporary scratch directory
+   narrowing_escape_isinstance  Parse done                                                               0.000 s
+[error]: Attribute not found hello
+     +--> narrowing_escape_isinstance.act@23:28-23:33
+     |
+  23 |                 return obj.hello()
+     :                            ^---- 
+     :                            `- Attribute not found hello
+-----+

--- a/compiler/lib/src/Acton/Transform.hs
+++ b/compiler/lib/src/Acton/Transform.hs
@@ -31,8 +31,15 @@ termred eq s                            = --trace ("### equations:\n" ++ render 
                                           trans env0{ eqns = eq } s
 
 termsubst                               :: (Transform a) => [(Name,Expr)] -> a -> a
-termsubst [] x                          = x
-termsubst s x                           = trans (finalize $ extsubst s env0) x
+termsubst                               = termsubstFenced []
+
+-- Like termsubst, but entries for the names in ns are dropped when the
+-- traversal enters a def or a lambda. Type inference uses this for narrowing
+-- casts on mutable state variables, whose narrowing does not extend into
+-- closures (see unNarrow in Acton.TypeEnv).
+termsubstFenced                         :: (Transform a) => [Name] -> [(Name,Expr)] -> a -> a
+termsubstFenced ns [] x                 = x
+termsubstFenced ns s x                  = trans (finalize $ extsubst s env0{ fenced = ns }) x
 
 class Transform a where
     trans                               :: TransEnv -> a -> a
@@ -43,10 +50,13 @@ data TransEnv                           = TransEnv {
                                             eqns     :: Equations,                  -- Top-level constraint solutions
                                             trsubst  :: TSubst,                     -- Inlineable assignments and scope blockers
                                             witscope :: [(Name,Type,Expr)],         -- Preserved witness bindings in scope, for the purpose of duplicate removals
+                                            fenced   :: [Name],                     -- Substitutions dropped when entering a def or lambda
                                             final    :: Bool
                                           }
 
-env0                                    = TransEnv{ eqns = [], trsubst = M.empty, witscope = [], final = False }
+env0                                    = TransEnv{ eqns = [], trsubst = M.empty, witscope = [], fenced = [], final = False }
+
+enterFenced env                         = env{ trsubst = foldr M.delete (trsubst env) (fenced env), fenced = [] }
 
 blockscope ns env                       = env{ trsubst = foldr (`M.insert` Nothing) (trsubst env) ns }
 
@@ -119,9 +129,9 @@ instance Transform Stmt where
 instance Transform Decl where
     trans env (Def l n q p k t b d fx doc)
                                         = Def l n q (trans env1 p) (trans env1 k) t (wtrans env1 b) d fx doc
-      where env1                        = blockscope (bound p ++ bound k) env
+      where env1                        = blockscope (bound p ++ bound k) (enterFenced env)
     trans env (Actor l n q p k b doc)   = Actor l n q (trans env1 p) (trans env1 k) (wtrans env1 b) doc
-      where env1                        = blockscope (bound p ++ bound k) env
+      where env1                        = blockscope (bound p ++ bound k) (enterFenced env)
     trans env (Class l n q us b doc)    = Class l n q us (wtrans env b) doc
     trans env (Protocol l n q us b doc) = Protocol l n q us (wtrans env b) doc
     trans env (Typedef l n q t doc)     = Typedef l n q t doc
@@ -188,7 +198,7 @@ instance Transform Expr where
       | otherwise                       = eta $ Lambda l (trans env1 $ prename s p) (trans env1 $ krename s k) (trans env1 $ erename s e) fx
       where fvs                         = free e
             bvs                         = bound p ++ bound k
-            env1                        = limsubst bvs env
+            env1                        = limsubst bvs (enterFenced env)
             clash                       = bvs `intersect` free (trfinds fvs env1)
             s                           = clash `zip` (yNames \\ (fvs++bvs))
             e1                          = Lambda l (prename s p) (krename s k) (erename s e) fx

--- a/compiler/lib/src/Acton/TypeEnv.hs
+++ b/compiler/lib/src/Acton/TypeEnv.hs
@@ -66,7 +66,8 @@ data TypeX                      = TypeX {
                                     typrotos    :: IntSet,
                                     tyactors    :: IntSet,
                                     tyconAttrs  :: TyAttrMap,
-                                    typrotoAttrs:: TyAttrMap
+                                    typrotoAttrs:: TyAttrMap,
+                                    narrowed    :: TEnv
                                   }
 
 data TyInfo                     = TyInfo {
@@ -102,7 +103,8 @@ initTypeEnv env0                = setX env0 x0
                                     typrotos    = IntSet.empty,
                                     tyactors    = IntSet.empty,
                                     tyconAttrs  = Map.empty,
-                                    typrotoAttrs= Map.empty
+                                    typrotoAttrs= Map.empty,
+                                    narrowed    = []
                                   }
 
 
@@ -124,6 +126,28 @@ tyinfos0                        = IntMap.fromDistinctAscList pairs
         wFun                    = tFun tWild tWild tWild tWild
         wTuple                  = tTuple tWild tWild
         wOpt                    = tOpt tWild
+
+-- A narrowing test ('x is not None', 'isinstance(x,C)') rebinds x to its
+-- narrowed type for the duration of the guarded code. When x is a mutable
+-- state variable its original binding is recorded in 'narrowed' as well:
+-- def bodies and lambdas read state variables by live reference at call
+-- time, so a narrowing established outside them cannot be trusted inside,
+-- and inference of such scopes restores the recorded bindings (unNarrow).
+
+narrowedSVars                   :: Env -> TEnv
+narrowedSVars env               = narrowed (envX env)
+
+narrowName                      :: Name -> NameInfo -> Env -> Env
+narrowName n ni env             = case findName n env of
+                                    ni0@NSVar{} | n `notElem` dom (narrowedSVars env)
+                                                -> define [(n,ni)] (modX env $ \x -> x{ narrowed = (n,ni0) : narrowed x })
+                                    _           -> define [(n,ni)] env
+
+unNarrow                        :: Env -> Env
+unNarrow env
+  | null te                     = env
+  | otherwise                   = define te (modX env $ \x -> x{ narrowed = [] })
+  where te                      = narrowedSVars env
 
 instance Show TypeX where
     show _                      = ""

--- a/compiler/lib/src/Acton/Types.hs
+++ b/compiler/lib/src/Acton/Types.hs
@@ -769,7 +769,7 @@ instance InfEnv Stmt where
     infEnv env (While l e b els)        = do (cs1,env',s,_,e') <- inferTest env e
                                              (cs2,te1,b') <- infSuiteEnv env' b
                                              (cs3,te2,els') <- infSuiteEnv env els
-                                             return (cs1++cs2++cs3, [], While l e' (termsubst s b') els')
+                                             return (cs1++cs2++cs3, [], While l e' (narrowsubst env' s b') els')
     infEnv env (For l p e b els)
       | nodup p                         = do (te,t1,p') <- infEnvT env p
                                              t2 <- newUnivar env
@@ -1758,7 +1758,7 @@ instance Check Decl where
                                              let body = bindWits eq1 ++ defaultsP p' ++ defaultsK k' ++ b'
                                              (cs1,def) <- matchDefAssumption env cs0 (Def l n q p' k' (Just t) body dec fx' ddoc)
                                              return (cs1, def{ pos = noDefaultsP (pos def), kwd = noDefaultsK (kwd def) })
-      where env1                        = reserve (bound (p,k) ++ assigned b \\ stateScope env) $ tydefineVars q env
+      where env1                        = reserve (bound (p,k) ++ assigned b \\ stateScope env) $ tydefineVars q $ unNarrow env
             fx'                         = fxUnwrap env fx
 
     checkEnv env (Actor l n q p k b ddoc)
@@ -1901,7 +1901,7 @@ noDefaultsK k                           = k
 instance InfEnv Branch where
     infEnv env (Branch e b)             = do (cs1,env',s,_,e') <- inferTest env e
                                              (cs2,te,b') <- infEnv env' b
-                                             return (cs1++cs2, te, Branch e' (termsubst s b'))
+                                             return (cs1++cs2, te, Branch e' (narrowsubst env' s b'))
 
 instance InfEnv WithItem where
     infEnv env (WithItem e Nothing)     = do (cs,t,e') <- infer env e
@@ -2012,7 +2012,7 @@ instance Infer Expr where
                                              (cs0,env',s,_,e') <- inferTest env e
                                              (cs1,e1') <- inferSub env' t0 e1
                                              (cs2,e2') <- inferSub env t0 e2
-                                             return (cs0++cs1++cs2, t0, Cond l (termsubst s e1') e' e2')
+                                             return (cs0++cs1++cs2, t0, Cond l (narrowsubst env' s e1') e' e2')
     infer env (IsInstance l e c)        = case findQName c env of
                                              NClass q _ _ _ -> do
                                                 (cs,t,e') <- infer env e
@@ -2257,7 +2257,7 @@ instance Infer Expr where
                                              popFX
                                              return (cs0++cs1++cs2, tFun fx (prowOf p') (krowOf k') t, Lambda l (noDefaultsP p') (noDefaultsK k') e' fx)
                                                      -- TODO: replace defaulted params with Conds
-      where env1                        = reserve (bound (p,k)) env
+      where env1                        = reserve (bound (p,k)) (unNarrow env)
     infer env e@Yield{}                 = notYetExpr e
     infer env e@YieldFrom{}             = notYetExpr e
     infer env (Tuple l pargs kargs)     = do (cs1,prow,pargs') <- infer env pargs
@@ -2271,7 +2271,7 @@ instance Infer Expr where
                                              t0 <- newUnivar env
                                              (cs2,es) <- infElems env' [e] t0
                                              let [e'] = es
-                                             return (cs1++cs2, tList t0, ListComp l (termsubst s e') co')
+                                             return (cs1++cs2, tList t0, ListComp l (narrowsubst env' s e') co')
     infer env (Set l es)                = do t0 <- newUnivar env
                                              (cs,es')  <- infElems env es t0
                                              w <- newWitness
@@ -2283,7 +2283,7 @@ instance Infer Expr where
                                              w <- newWitness
                                              let Elem v = head es
                                                  e' = Elem (annot (tHashableW t0) (eVar w) t0 v)
-                                             return (Proto (locinfo l 89) env w t0 pHashable : cs1++cs2, tSet t0, SetComp l (termsubst s e') co')
+                                             return (Proto (locinfo l 89) env w t0 pHashable : cs1++cs2, tSet t0, SetComp l (narrowsubst env' s e') co')
     infer env (Dict l as)               = do tk <- newUnivar env
                                              tv <- newUnivar env
                                              (cs,as') <- infAssocs env as tk tv
@@ -2297,7 +2297,7 @@ instance Infer Expr where
                                              w <- newWitness
                                              let Assoc k v = head as
                                                  a' = Assoc (annot (tHashableW tk) (eVar w) tk k) v
-                                             return (Proto (locinfo l 90) env w tk pHashable : cs1++cs2, tDict tk tv, DictComp l (termsubst s a') co')
+                                             return (Proto (locinfo l 90) env w tk pHashable : cs1++cs2, tDict tk tv, DictComp l (narrowsubst env' s a') co')
 
     infer env (Paren l e)               = do (cs,t,e') <- infer env e
                                              return (cs, t, Paren l e')
@@ -2362,7 +2362,7 @@ inferTest env (BinOp l e1 And e2)       = do (cs1,env1,s1,t1,e1') <- inferTest e
                                              w1 <- newWitness
                                              w2 <- newWitness
                                              return (Sub (locinfo' l 91 e1) env w1 t1 t : Sub (locinfo' l 92 e2) env w2 t2 t :
-                                                     cs1++cs2, env2, s1++s2, t, BinOp l (eCall (eVar w1) [e1']) And (eCall (eVar w2) [termsubst s1 e2']))
+                                                     cs1++cs2, env2, s1++s2, t, BinOp l (eCall (eVar w1) [e1']) And (eCall (eVar w2) [narrowsubst env1 s1 e2']))
 inferTest env (BinOp l e1 Or e2)        = do (cs1,_,_,t1,e1') <- inferTest env e1
                                              (cs2,_,_,t2,e2') <- inferTest env e2
                                              t <- newUnivar env
@@ -2378,7 +2378,7 @@ inferTest env (CompOp l e [OpArg IsNot None{}])
                                              let e' = eCall (tApp (eQVar primISNOTNONE) [t]) [e1]
                                              case e of
                                                Var _ (NoQ n) ->
-                                                  return (cs1, define [(n,NVar t)] env, sCast n (tOpt t) t, tBool, e')
+                                                  return (cs1, narrowName n (NVar t) env, sCast n (tOpt t) t, tBool, e')
                                                _ ->
                                                  return (cs1, env, [], tBool, e')
 inferTest env (CompOp l e [OpArg Is None{}])
@@ -2391,7 +2391,7 @@ inferTest env (IsInstance l e@(Var _ (NoQ n)) c)
                                                 (cs,t,e') <- infer env e
                                                 ts <- newUnivars env [ tvkind v | v <- qbound q ]
                                                 let tc = tCon (TC c ts)
-                                                return (cs, define [(n,NVar tc)] env, sCast n t tc, tBool, IsInstance l e' c)
+                                                return (cs, narrowName n (NVar tc) env, sCast n t tc, tBool, IsInstance l e' c)
                                              _ -> nameUnexpected c
 inferTest env (Paren l e)               = do (cs,env',s,t,e') <- inferTest env e
                                              return (cs, env', s, t, Paren l e')
@@ -2400,6 +2400,12 @@ inferTest env e                         = do (cs,t,e') <- infer env e
 
 
 sCast n t t'                            = [(n, eCAST t t' (eVar n))]
+
+-- Apply the narrowing substitution s to x. Entries for mutable state
+-- variables are fenced off from def bodies and lambdas, whose inference
+-- restores the un-narrowed bindings (see unNarrow in Acton.TypeEnv).
+narrowsubst env s x                     = termsubstFenced [ n | (n,_) <- s, n `elem` ns ] s x
+  where ns                              = dom (narrowedSVars env)
 
 inferSlice env (Sliz l e1 e2 e3)        = do (cs1,e1') <- inferSub env tInt e1
                                              (cs2,e2') <- inferSub env tInt e2
@@ -2484,7 +2490,7 @@ instance Infer KwdArg where
 infComp env NoComp                      = return ([], env, [], NoComp)
 infComp env (CompIf l e c)              = do (cs1,env1,s,_,e') <- inferTest env e
                                              (cs2,env2,s',c') <- infComp env1 c
-                                             return (cs1++cs2, env2, s++s', CompIf l e' (termsubst s c'))
+                                             return (cs1++cs2, env2, s++s', CompIf l e' (narrowsubst env1 s c'))
 infComp env (CompFor l p e c)           = do (te1,t1,p') <- infEnvT (reserve (bound p) env) p
                                              t2 <- newUnivar env
                                              (cs2,e') <- inferSub env t2 e

--- a/docs/acton-guide/src/types/optionals.md
+++ b/docs/acton-guide/src/types/optionals.md
@@ -46,6 +46,34 @@ def residence_name(person: ?Person) -> ?str:
 Each access is guarded by a test that rules out `None` before the next
 access.
 
+Narrowing of a mutable actor variable (`var`) does not extend into
+nested function definitions. A nested `def` reads the actor variable at
+the time it is called, and by then the value may have changed, so the
+test that guarded the definition says nothing about the value the
+function will actually see. Inside the nested function the variable
+keeps its declared optional type. When the function needs the tested
+value, bind it to a local name inside the branch and use that instead:
+a local is captured by value when the nested function is created.
+
+```python
+actor Cache(env):
+    var current: ?str = None
+    var render: ?proc() -> str = None
+
+    def install() -> None:
+        if current is not None:
+            value = current
+            def render_current() -> str:
+                return value.upper()
+            render = render_current
+```
+
+Using `current` directly inside `render_current` is a compile-time
+error: `current` still has type `?str` there. The local `value` holds
+the string the test actually saw, and it does not change even if
+`current` is later reset to `None`. The same rule applies to
+`isinstance` narrowing of actor variables.
+
 ## Optional chaining
 
 Optional chaining is a shorter way to keep `None` flowing through a

--- a/test/core_lang_auto/narrowing_state_var.act
+++ b/test/core_lang_auto/narrowing_state_var.act
@@ -1,0 +1,55 @@
+# Narrowing of a mutable actor variable ('var') does not extend into nested
+# defs: a nested def reads the variable at call time, so a closure created
+# under 'x is not None' could otherwise observe a later reset to None while
+# typed non-optional (see typeerrors/narrowing_escape_def.act for the
+# rejected form). This test pins the forms that must keep working:
+#  - straight-line use of the narrowed variable in the guarded branch,
+#    including comprehensions and conditional expressions
+#  - the snapshot pattern: bind the narrowed value to a local inside the
+#    branch and close over the local, which is captured by value at closure
+#    creation and keeps its value when the state variable is reset
+#  - narrowing established inside the closure body itself
+
+def want_str(s: str) -> str:
+    return s
+
+def check_equal(env: Env, a: str, b: str) -> None:
+    if a != b:
+        print(a, "is not equal to", b)
+        env.exit(1)
+
+actor main(env):
+    var state: ?str = None
+    var saved_cb: ?proc() -> str = None
+
+    def make_cb() -> None:
+        if state is not None:
+            check_equal(env, want_str(state), "hi")
+            parts = [want_str(state) + str(i) for i in range(2)]
+            check_equal(env, parts[0], "hi0")
+            check_equal(env, parts[1], "hi1")
+            cond = want_str(state) if state is not None else "none"
+            check_equal(env, cond, "hi")
+            s = state
+            def cb() -> str:
+                return want_str(s)
+            saved_cb = cb
+
+    def renarrow() -> str:
+        # A fresh test inside the def body runs in the same activation as the
+        # use, so narrowing inside the body itself is fine.
+        if state is not None:
+            return want_str(state)
+        return "gone"
+
+    state = "hi"
+    make_cb()
+    state = None
+    check_equal(env, renarrow(), "gone")
+    cb1 = saved_cb
+    if cb1 is not None:
+        # The snapshot local was captured while state was "hi"; resetting the
+        # state variable afterwards must not reach the closure.
+        check_equal(env, cb1(), "hi")
+        env.exit(0)
+    env.exit(1)


### PR DESCRIPTION
Optional narrowing extended into the bodies of defs nested inside the guarded branch, but a nested def reads a mutable actor variable from the actor at the time it is called, not at the time it is defined. A method could therefore create a closure under "if state is not None:", store it in another actor variable and return, and when a later method call invoked the closure the variable might have been reset to None. The closure still typed the variable as str, no runtime check exists on that path, and the None flowed straight into non-optional code. The isinstance form of narrowing had the same escape with a worse outcome: the closure called a method of the refined class on whatever object the variable held by then, which crashed with a bus error in the reproduction that is now the narrowing_escape_isinstance test.

The type checker now records the original binding of every mutable state variable it narrows and restores those bindings when inference enters a def body or a lambda. Inside the nested function the variable keeps its declared type, so an unsound use is reported at the use site, for example that ?str must be a subclass of str at the call that passed the variable onward. The cast substitution that narrowing applies to the elaborated branch gets the same boundary: entries for state variables are dropped when the substitution traversal enters a def or a lambda, so the elaborated tree matches what inference typed.

The restriction is deliberately limited to mutable actor variables. A plain local is captured by value when a nested def or lambda is created, so a narrowed local inside a closure keeps the value the test saw and remains sound; that keeps working. The delayed expression of an after statement evaluates its free variables at scheduling time, so narrowing into after statements also keeps working. Code that needs the tested value of a state variable inside a closure binds it to a local inside the branch first, and the closure captures that local. The narrowing section of the user guide now documents the rule and this snapshot pattern, and the whole standard library builds unchanged under the stricter rule.
