### PR TITLE
Don't block HTTP actors on user callbacks

### DIFF
--- a/base/src/http.act
+++ b/base/src/http.act
@@ -350,7 +350,13 @@ def parse_response(i: bytes, log: logging.Logger) -> (?Response, bytes):
 
 
 actor Server(conn: net.TCPListenConnection, on_accept: action(Server) -> None, log_handler: ?logging.Handler):
-    """Server serves a single client connection"""
+    """Server serves a single client connection
+
+    User callbacks are invoked asynchronously and must not be awaited by the
+    server, so a callback is free to call back into this actor. Responses are
+    sent on the connection in request order; a response to a later request is
+    buffered until responses to all earlier requests have been sent.
+    """
     _log = logging.Logger(log_handler)
     var on_request_cb: ?action(Server, Request, action(int, dict[str, str], str) -> None) -> None = None
     var on_error_cb: ?action(Server, str) -> None = None
@@ -359,70 +365,78 @@ actor Server(conn: net.TCPListenConnection, on_accept: action(Server) -> None, l
     var close_connection: bool = True
     var query_count: u64 = 0
     var response_count: u64 = 0
-    var outstanding_requests: dict[u64, Response] = {}
+    var outstanding_responses: dict[u64, (int, dict[str, str], str)] = {}
 
     def cb_install(new_on_request: action(Server, Request, action(int, dict[str, str], str) -> None) -> None, new_on_error: action(Server, str) -> None):
         on_request_cb = new_on_request
         on_error_cb = new_on_error
-        if buf != b"":
-            req, buf = parse_request(buf, _log)
+        # Dispatch any requests that arrived before the callbacks were installed
+        _process_buf()
 
     def on_conn_receive(conn_obj, data: bytes) -> None:
-        # TODO: do we really need a buf?
-        if on_request_cb is None:
-            buf += data
-            return None
-        else:
-            if buf != b"":
-                data = buf + data
+        buf += data
+        if on_request_cb is not None:
+            _process_buf()
 
-        req, buf = parse_request(data, _log)
-        if req is not None:
-            if version is None:
-                version = req.version
-            elif version is not None and version != req.version:
-                _log.debug("Version mismatch", None)
-                conn.close()
-
-            if version is not None and version == b"1.0":
-                if "connection" in req.headers:
-                    if req.headers["connection"] == "close":
-                        _log.debug("HTTP 1.0 with connection: close, closing connection...", None)
-                        close_connection = True
-                    else:
-                        _log.debug("HTTP 1.0 with connection header, not closing connection...", None)
-                        _log.trace("connection header", {"connection": req.headers["connection"]})
-                else:
-                    close_connection = True
-            elif version is not None and version == b"1.1":
-                if "connection" in req.headers and req.headers["connection"] == "close":
-                    _log.debug("HTTP 1.1, closing connection...", None)
-                    close_connection = True
-                else:
-                    close_connection = False
-
-            query_count += 1
-            def respond(status_code: int, headers: dict[str, str], body: str):
-                _log.trace("Going to respond with query id", {"query_count": query_count})
-                if query_count == response_count + 1:
-                    # In order, send response immediately
-                    _log.trace("Sending response immediately", None)
-                    send_response(status_code, headers, body)
-                    response_count += 1
-                else:
-                    # Buffer up response
-                    _log.trace("Buffering response", None)
-                    # TODO: actually implement buffering?
-                    #outstanding_requests[query_count] = Response("GABBA", version, status_code, headers, body.encode())
-
-            if on_request_cb is not None:
-                response = on_request_cb(self, req, respond)
-                if response is not None:
-                    _log.trace("Sending response immediately", None)
-                else:
-                    _log.trace("Async response", None)
+    def _process_buf() -> None:
+        while True:
+            req, buf = parse_request(buf, _log)
+            if req is not None:
+                _handle_request(req)
             else:
-                _log.notice("No on_request callback set", None)
+                break
+
+    def _handle_request(req: Request) -> None:
+        if version is None:
+            version = req.version
+        elif version is not None and version != req.version:
+            _log.debug("Version mismatch", None)
+            conn.close()
+
+        if version is not None and version == b"1.0":
+            if "connection" in req.headers:
+                if req.headers["connection"] == "close":
+                    _log.debug("HTTP 1.0 with connection: close, closing connection...", None)
+                    close_connection = True
+                else:
+                    _log.debug("HTTP 1.0 with connection header, not closing connection...", None)
+                    _log.trace("connection header", {"connection": req.headers["connection"]})
+            else:
+                close_connection = True
+        elif version is not None and version == b"1.1":
+            if "connection" in req.headers and req.headers["connection"] == "close":
+                _log.debug("HTTP 1.1, closing connection...", None)
+                close_connection = True
+            else:
+                close_connection = False
+
+        query_count += 1
+        req_id = query_count
+        def respond(status_code: int, headers: dict[str, str], body: str):
+            _log.trace("Going to respond to query", {"query_id": req_id})
+            if req_id == response_count + 1:
+                # In order, send response immediately
+                _log.trace("Sending response immediately", None)
+                send_response(status_code, headers, body)
+                response_count += 1
+                # Send buffered responses that are next in line
+                while not close_connection and response_count + 1 in outstanding_responses:
+                    nxt = outstanding_responses[response_count + 1]
+                    del outstanding_responses[response_count + 1]
+                    send_response(nxt.0, nxt.1, nxt.2)
+                    response_count += 1
+            elif req_id > response_count + 1:
+                # Responses must go out in request order, so buffer this one
+                # until responses to all earlier requests have been sent
+                _log.trace("Buffering response", None)
+                outstanding_responses[req_id] = (status_code, headers, body)
+            else:
+                _log.notice("Duplicate response to query, ignoring", None)
+
+        if on_request_cb is not None:
+            on_request_cb(self, req, respond)
+        else:
+            _log.notice("No on_request callback set", None)
 
     def on_conn_error(conn, error):
         # TODO: the conn should really be in here, but type error!?
@@ -441,7 +455,13 @@ actor Server(conn: net.TCPListenConnection, on_accept: action(Server) -> None, l
 
 
 actor TLSServer(conn: net.TLSListenConnection, on_accept: action(TLSServer) -> None, log_handler: ?logging.Handler):
-    """Server serves a single TLS client connection"""
+    """Server serves a single TLS client connection
+
+    User callbacks are invoked asynchronously and must not be awaited by the
+    server, so a callback is free to call back into this actor. Responses are
+    sent on the connection in request order; a response to a later request is
+    buffered until responses to all earlier requests have been sent.
+    """
     _log = logging.Logger(log_handler)
     var on_request_cb: ?action(TLSServer, Request, action(int, dict[str, str], str) -> None) -> None = None
     var on_error_cb: ?action(TLSServer, str) -> None = None
@@ -450,70 +470,78 @@ actor TLSServer(conn: net.TLSListenConnection, on_accept: action(TLSServer) -> N
     var close_connection: bool = True
     var query_count: u64 = 0
     var response_count: u64 = 0
-    var outstanding_requests: dict[u64, Response] = {}
+    var outstanding_responses: dict[u64, (int, dict[str, str], str)] = {}
 
     def cb_install(new_on_request: action(TLSServer, Request, action(int, dict[str, str], str) -> None) -> None, new_on_error: action(TLSServer, str) -> None):
         on_request_cb = new_on_request
         on_error_cb = new_on_error
-        if buf != b"":
-            req, buf = parse_request(buf, _log)
+        # Dispatch any requests that arrived before the callbacks were installed
+        _process_buf()
 
     def on_conn_receive(conn_obj, data: bytes) -> None:
-        # TODO: do we really need a buf?
-        if on_request_cb is None:
-            buf += data
-            return None
-        else:
-            if buf != b"":
-                data = buf + data
+        buf += data
+        if on_request_cb is not None:
+            _process_buf()
 
-        req, buf = parse_request(data, _log)
-        if req is not None:
-            if version is None:
-                version = req.version
-            elif version is not None and version != req.version:
-                _log.debug("Version mismatch", None)
-                conn.close()
-
-            if version is not None and version == b"1.0":
-                if "connection" in req.headers:
-                    if req.headers["connection"] == "close":
-                        _log.debug("HTTP 1.0 with connection: close, closing connection...", None)
-                        close_connection = True
-                    else:
-                        _log.debug("HTTP 1.0 with connection header, not closing connection...", None)
-                        _log.trace("connection header", {"connection": req.headers["connection"]})
-                else:
-                    close_connection = True
-            elif version is not None and version == b"1.1":
-                if "connection" in req.headers and req.headers["connection"] == "close":
-                    _log.debug("HTTP 1.1, closing connection...", None)
-                    close_connection = True
-                else:
-                    close_connection = False
-
-            query_count += 1
-            def respond(status_code: int, headers: dict[str, str], body: str):
-                _log.trace("Going to respond with query id", {"query_count": query_count})
-                if query_count == response_count + 1:
-                    # In order, send response immediately
-                    _log.trace("Sending response immediately", None)
-                    send_response(status_code, headers, body)
-                    response_count += 1
-                else:
-                    # Buffer up response
-                    _log.trace("Buffering response", None)
-                    # TODO: actually implement buffering?
-                    #outstanding_requests[query_count] = Response("GABBA", version, status_code, headers, body.encode())
-
-            if on_request_cb is not None:
-                response = on_request_cb(self, req, respond)
-                if response is not None:
-                    _log.trace("Sending response immediately", None)
-                else:
-                    _log.trace("Async response", None)
+    def _process_buf() -> None:
+        while True:
+            req, buf = parse_request(buf, _log)
+            if req is not None:
+                _handle_request(req)
             else:
-                _log.notice("No on_request callback set", None)
+                break
+
+    def _handle_request(req: Request) -> None:
+        if version is None:
+            version = req.version
+        elif version is not None and version != req.version:
+            _log.debug("Version mismatch", None)
+            conn.close()
+
+        if version is not None and version == b"1.0":
+            if "connection" in req.headers:
+                if req.headers["connection"] == "close":
+                    _log.debug("HTTP 1.0 with connection: close, closing connection...", None)
+                    close_connection = True
+                else:
+                    _log.debug("HTTP 1.0 with connection header, not closing connection...", None)
+                    _log.trace("connection header", {"connection": req.headers["connection"]})
+            else:
+                close_connection = True
+        elif version is not None and version == b"1.1":
+            if "connection" in req.headers and req.headers["connection"] == "close":
+                _log.debug("HTTP 1.1, closing connection...", None)
+                close_connection = True
+            else:
+                close_connection = False
+
+        query_count += 1
+        req_id = query_count
+        def respond(status_code: int, headers: dict[str, str], body: str):
+            _log.trace("Going to respond to query", {"query_id": req_id})
+            if req_id == response_count + 1:
+                # In order, send response immediately
+                _log.trace("Sending response immediately", None)
+                send_response(status_code, headers, body)
+                response_count += 1
+                # Send buffered responses that are next in line
+                while not close_connection and response_count + 1 in outstanding_responses:
+                    nxt = outstanding_responses[response_count + 1]
+                    del outstanding_responses[response_count + 1]
+                    send_response(nxt.0, nxt.1, nxt.2)
+                    response_count += 1
+            elif req_id > response_count + 1:
+                # Responses must go out in request order, so buffer this one
+                # until responses to all earlier requests have been sent
+                _log.trace("Buffering response", None)
+                outstanding_responses[req_id] = (status_code, headers, body)
+            else:
+                _log.notice("Duplicate response to query, ignoring", None)
+
+        if on_request_cb is not None:
+            on_request_cb(self, req, respond)
+        else:
+            _log.notice("No on_request callback set", None)
 
     def on_conn_error(conn, error):
         # TODO: the conn should really be in here, but type error!?
@@ -547,8 +575,8 @@ actor Listener(cap: net.TCPListenCap, address: str, port: int, on_accept: action
 
     def on_listener_accept(conn):
         s = Server(conn, on_accept, log_handler)
-        await async on_accept(s)
-        await async conn.cb_install(s.on_conn_receive, s.on_conn_error, None)
+        on_accept(s)
+        conn.cb_install(s.on_conn_receive, s.on_conn_error, None)
 
     var _listener = net.TCPListener(cap, address, port, on_conn_listen, on_listener_accept)
 
@@ -569,8 +597,8 @@ actor TLSListener(cap: net.TCPListenCap, address: str, port: int, cert_pem: byte
 
     def on_listener_accept(conn):
         s = TLSServer(conn, on_accept, log_handler)
-        await async on_accept(s)
-        await async conn.cb_install(s.on_conn_receive, s.on_conn_error, None)
+        on_accept(s)
+        conn.cb_install(s.on_conn_receive, s.on_conn_error, None)
 
     var _listener = net.TLSListener(cap, address, port, cert_pem, key_pem, on_conn_listen, on_listener_accept)
 
@@ -581,6 +609,12 @@ actor Client(cap: net.TCPConnectCap, address: str, on_connect: action(Client) ->
 
     scheme is either 'http' or 'https', the default is 'https'
     port is optional, if not provided, it will be inferred from the scheme where http=80 and https=443
+
+    User callbacks (on_connect, on_error and the per-request on_response) are
+    invoked asynchronously and are not awaited by the client, so a callback is
+    free to call back into this actor, e.g. to issue the next request.
+    Responses are delivered to each request's on_response callback in request
+    order.
     """
     _log = logging.Logger(log_handler)
     var _on_response: list[(bytes, action(Client, Response) -> None)] = []
@@ -603,10 +637,11 @@ actor Client(cap: net.TCPConnectCap, address: str, on_connect: action(Client) ->
             raise ValueError(f"Only http and https schemes are supported. Unsupported scheme: {scheme}")
 
     def _on_conn_connect():
-        # If there are outstanding requests, it probably means we were
+        # If there are outstanding requests, the connection was probably lost
+        # and we just reconnected, so replay them on the new connection
         for r in _on_response:
             _conn_write(r.0)
-        await async on_connect(self)
+        on_connect(self)
 
     def _on_tcp_connect(conn: net.TCPConnection) -> None:
         _on_conn_connect()
@@ -639,8 +674,7 @@ actor Client(cap: net.TCPConnectCap, address: str, on_connect: action(Client) ->
                 outreq = _on_response[0]
                 del _on_response[0]
                 cb = outreq.1
-
-                await async cb(self, r)
+                cb(self, r)
             else:
                 break
 

--- a/test/stdlib_tests/src/test_http.act
+++ b/test/stdlib_tests/src/test_http.act
@@ -247,3 +247,331 @@ actor _test_HttpsClientServer(t: testing.EnvT):
     )
     after 0.05: _start_client()
     after 10: _timeout()
+
+
+actor _test_HttpClientAwaitInCallbacks(t: testing.EnvT):
+    """Client callbacks may await calls back into the Client actor
+
+    The client must not park itself while a user callback runs: a callback
+    that awaits a call back into the client (here: issuing the next request
+    and awaiting its completion) would deadlock with a parked client.
+    """
+    log = logging.Logger(t.log_handler)
+    var done = False
+    var attempts = 0
+    var listen_attempts = 0
+    var port = random.randint(20000, 45000)
+    var server = None
+
+    serv_cap = net.TCPListenCap(net.TCPCap(net.NetCap(t.env.cap)))
+    conn_cap = net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap)))
+
+    def _finish_success():
+        if done:
+            return
+        done = True
+        t.success()
+
+    def _finish_failure(msg: str):
+        if done:
+            return
+        done = True
+        t.failure(AssertionError(msg))
+
+    def _on_accept(server):
+        server.cb_install(_on_request, _on_server_error)
+
+    def _on_request(server, request, respond):
+        respond(200, {}, "Hello " + request.path)
+
+    def _on_server_error(server, error):
+        _finish_failure("HTTP server error: " + error)
+
+    def _on_listen_error(listener, error):
+        if listen_attempts < 10:
+            listen_attempts += 1
+            port = random.randint(20000, 45000)
+            _start_listener()
+        else:
+            _finish_failure("HTTP listen failed: " + error)
+
+    def _on_connect(c):
+        await async c.get("/first", _on_response1)
+
+    def _on_response1(c, r):
+        if r.status != 200 or r.body != b"Hello /first":
+            _finish_failure("Unexpected first response: " + str(r.status) + " " + str(r.body))
+            return
+        await async c.get("/second", _on_response2)
+
+    def _on_response2(c, r):
+        if r.status != 200 or r.body != b"Hello /second":
+            _finish_failure("Unexpected second response: " + str(r.status) + " " + str(r.body))
+            return
+        _finish_success()
+
+    def _on_client_error(c, errmsg):
+        if attempts < 5:
+            attempts += 1
+            after 0.1: _start_client()
+        else:
+            _finish_failure("HTTP client error: " + errmsg)
+
+    def _start_client():
+        http.Client(conn_cap, "127.0.0.1", _on_connect, _on_client_error, scheme="http", port=port)
+
+    def _start_listener():
+        server = http.Listener(serv_cap, "127.0.0.1", port, _on_accept, _on_listen_error)
+
+    def _timeout():
+        _finish_failure("timeout, deadlock between client and callback actor?")
+
+    _start_listener()
+    after 0.05: _start_client()
+    after 10: _timeout()
+
+
+actor _test_HttpServerAwaitRespond(t: testing.EnvT):
+    """Server request handlers may await the respond callback
+
+    The server must not park itself while the user's request handler runs: a
+    handler that awaits the respond callback (an action of the server actor)
+    would deadlock with a parked server.
+    """
+    log = logging.Logger(t.log_handler)
+    var done = False
+    var attempts = 0
+    var listen_attempts = 0
+    var port = random.randint(20000, 45000)
+    var server = None
+
+    serv_cap = net.TCPListenCap(net.TCPCap(net.NetCap(t.env.cap)))
+    conn_cap = net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap)))
+
+    def _finish_success():
+        if done:
+            return
+        done = True
+        t.success()
+
+    def _finish_failure(msg: str):
+        if done:
+            return
+        done = True
+        t.failure(AssertionError(msg))
+
+    def _on_accept(server):
+        server.cb_install(_on_request, _on_server_error)
+
+    def _on_request(server, request, respond):
+        await async respond(200, {}, "Hello, awaited!")
+
+    def _on_server_error(server, error):
+        _finish_failure("HTTP server error: " + error)
+
+    def _on_listen_error(listener, error):
+        if listen_attempts < 10:
+            listen_attempts += 1
+            port = random.randint(20000, 45000)
+            _start_listener()
+        else:
+            _finish_failure("HTTP listen failed: " + error)
+
+    def _on_connect(c):
+        c.get("/", _on_response)
+
+    def _on_response(c, r):
+        if r.status != 200 or r.body != b"Hello, awaited!":
+            _finish_failure("Unexpected response: " + str(r.status) + " " + str(r.body))
+            return
+        _finish_success()
+
+    def _on_client_error(c, errmsg):
+        if attempts < 5:
+            attempts += 1
+            after 0.1: _start_client()
+        else:
+            _finish_failure("HTTP client error: " + errmsg)
+
+    def _start_client():
+        http.Client(conn_cap, "127.0.0.1", _on_connect, _on_client_error, scheme="http", port=port)
+
+    def _start_listener():
+        server = http.Listener(serv_cap, "127.0.0.1", port, _on_accept, _on_listen_error)
+
+    def _timeout():
+        _finish_failure("timeout, deadlock between server and handler actor?")
+
+    _start_listener()
+    after 0.05: _start_client()
+    after 10: _timeout()
+
+
+actor _test_HttpServerDeferredCbInstall(t: testing.EnvT):
+    """Requests received before cb_install are dispatched on install
+
+    If the accept callback installs the request handler only later, requests
+    that arrive in the meantime are buffered by the server and must be
+    dispatched once the handler is installed.
+    """
+    log = logging.Logger(t.log_handler)
+    var done = False
+    var attempts = 0
+    var listen_attempts = 0
+    var port = random.randint(20000, 45000)
+    var server = None
+
+    serv_cap = net.TCPListenCap(net.TCPCap(net.NetCap(t.env.cap)))
+    conn_cap = net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap)))
+
+    def _finish_success():
+        if done:
+            return
+        done = True
+        t.success()
+
+    def _finish_failure(msg: str):
+        if done:
+            return
+        done = True
+        t.failure(AssertionError(msg))
+
+    def _on_accept(server):
+        def _install():
+            server.cb_install(_on_request, _on_server_error)
+        after 0.2: _install()
+
+    def _on_request(server, request, respond):
+        respond(200, {}, "Hello, late!")
+
+    def _on_server_error(server, error):
+        _finish_failure("HTTP server error: " + error)
+
+    def _on_listen_error(listener, error):
+        if listen_attempts < 10:
+            listen_attempts += 1
+            port = random.randint(20000, 45000)
+            _start_listener()
+        else:
+            _finish_failure("HTTP listen failed: " + error)
+
+    def _on_connect(c):
+        c.get("/", _on_response)
+
+    def _on_response(c, r):
+        if r.status != 200 or r.body != b"Hello, late!":
+            _finish_failure("Unexpected response: " + str(r.status) + " " + str(r.body))
+            return
+        _finish_success()
+
+    def _on_client_error(c, errmsg):
+        if attempts < 5:
+            attempts += 1
+            after 0.1: _start_client()
+        else:
+            _finish_failure("HTTP client error: " + errmsg)
+
+    def _start_client():
+        http.Client(conn_cap, "127.0.0.1", _on_connect, _on_client_error, scheme="http", port=port)
+
+    def _start_listener():
+        server = http.Listener(serv_cap, "127.0.0.1", port, _on_accept, _on_listen_error)
+
+    def _timeout():
+        _finish_failure("timeout, buffered request dropped by cb_install?")
+
+    _start_listener()
+    after 0.05: _start_client()
+    after 10: _timeout()
+
+
+actor _test_HttpServerResponseOrder(t: testing.EnvT):
+    """Responses are sent in request order even when respond is called out of order
+
+    Two pipelined requests are sent in a single write. The handler withholds
+    the response to the first request until the second has been responded to,
+    so the server must buffer the second response and send both in request
+    order on the connection.
+    """
+    log = logging.Logger(t.log_handler)
+    var done = False
+    var attempts = 0
+    var listen_attempts = 0
+    var port = random.randint(20000, 45000)
+    var server = None
+    var received = b""
+    var stored_respond: ?action(int, dict[str, str], str) -> None = None
+
+    serv_cap = net.TCPListenCap(net.TCPCap(net.NetCap(t.env.cap)))
+    conn_cap = net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap)))
+
+    def _finish_success():
+        if done:
+            return
+        done = True
+        t.success()
+
+    def _finish_failure(msg: str):
+        if done:
+            return
+        done = True
+        t.failure(AssertionError(msg))
+
+    def _on_accept(server):
+        server.cb_install(_on_request, _on_server_error)
+
+    def _on_request(server, request, respond):
+        if request.path == "/1":
+            # Withhold the first response until the second request arrives
+            stored_respond = respond
+        else:
+            respond(200, {}, "response-two")
+            sr = stored_respond
+            if sr is not None:
+                sr(200, {}, "response-one")
+            else:
+                _finish_failure("request /2 handled before request /1")
+
+    def _on_server_error(server, error):
+        _finish_failure("HTTP server error: " + error)
+
+    def _on_listen_error(listener, error):
+        if listen_attempts < 10:
+            listen_attempts += 1
+            port = random.randint(20000, 45000)
+            _start_listener()
+        else:
+            _finish_failure("HTTP listen failed: " + error)
+
+    def _on_raw_connect(c):
+        c.write(b"GET /1 HTTP/1.1\r\nHost: test\r\n\r\nGET /2 HTTP/1.1\r\nHost: test\r\n\r\n")
+
+    def _on_raw_receive(c, data):
+        received += data
+        pos_one = received.find(b"response-one", None, None)
+        pos_two = received.find(b"response-two", None, None)
+        if pos_one >= 0 and pos_two >= 0:
+            if pos_one < pos_two:
+                _finish_success()
+            else:
+                _finish_failure("responses out of order: " + str(received))
+
+    def _on_raw_error(c, errmsg):
+        if attempts < 5:
+            attempts += 1
+            after 0.1: _start_client()
+        else:
+            _finish_failure("TCP client error: " + errmsg)
+
+    def _start_client():
+        net.TCPConnection(conn_cap, "127.0.0.1", port, _on_raw_connect, _on_raw_receive, _on_raw_error, None)
+
+    def _start_listener():
+        server = http.Listener(serv_cap, "127.0.0.1", port, _on_accept, _on_listen_error)
+
+    def _timeout():
+        _finish_failure("timeout, response order machinery stuck? received: " + str(received))
+
+    _start_listener()
+    after 0.05: _start_client()
+    after 10: _timeout()


### PR DESCRIPTION
http.Client invoked user callbacks with an explicit await: _on_conn_connect did "await async on_connect(self)" and _on_con_receive did "await async cb(self, r)" for every parsed response. Awaiting parks the client actor until the user's callback activation has completed, so the client processes none of its own messages in the meantime. A callback that calls back into the client and waits for the result, for example by assigning the result of a post call, deadlocks both actors: the callback actor waits for the client to process its call, while the client waits for the callback activation to complete. Both actors then stop processing all further messages, including timers. The same pattern existed on the server side: http.Listener and http.TLSListener awaited the user's on_accept callback, and http.Server and http.TLSServer called the user's request handler in value position, which likewise waits for the handler activation to complete. A handler that awaits the respond callback, which is an action of the server actor, deadlocked the same way.

The awaits bought no ordering that the runtime does not already provide. Messages sent from one actor to another are delivered in the order they were sent, so invoking the callbacks as plain asynchronous calls still delivers each response to its request's callback in request order. All user callbacks are now invoked without awaiting them, and the actors keep serving their connections while user callbacks run. The listener also no longer stalls accepting further connections while one accept callback runs.

Two pieces of server machinery silently relied on the blocking behavior and are reworked to stand on their own. First, Server.cb_install parsed a request that had arrived before the handler was installed and then dropped it. This was masked by the listener awaiting on_accept before installing the receive callback on the accepted connection, which made buffered early data impossible as long as on_accept installed the handler synchronously; an on_accept that installs the handler later, for example after fetching configuration, would silently lose the first request. cb_install now dispatches requests buffered while no handler was installed, and request parsing loops, so several requests pipelined into a single TCP segment are all dispatched rather than only the first. Second, the respond closure handed to the request handler compared the live request counter instead of the id of its own request, which was only correct while the server was parked during the handler so that at most one request was in flight; a response to any concurrent request was silently dropped, with buffering left as a TODO in the code. respond now captures its request id, and a response to a later request is buffered until the responses to all earlier requests have been sent, so responses go out on the connection in request order even when handlers respond out of order.
