### PR TITLE
Use ThinLTO for release builds

### DIFF
--- a/backend/build.zig
+++ b/backend/build.zig
@@ -94,7 +94,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
-    if (enable_lto) libactondb.lto = .full;
+    if (enable_lto) libactondb.lto = .thin;
     libactondb.root_module.addCSourceFiles(.{
         .files = &libactondb_sources,
         .flags = flags.items
@@ -118,7 +118,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
-    if (enable_lto) actondb.lto = .full;
+    if (enable_lto) actondb.lto = .thin;
     actondb.root_module.addCSourceFile(.{ .file = b.path("actondb.c"), .flags = &[_][]const u8{
         "-fno-sanitize=undefined",
     }});

--- a/base/build.zig
+++ b/base/build.zig
@@ -244,7 +244,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
-    if (enable_lto) libActon.lto = .full;
+    if (enable_lto) libActon.lto = .thin;
     for (c_files.items) |entry| {
         libActon.root_module.addCSourceFile(.{ .file = b.path(entry), .flags = flags.items });
     }
@@ -326,7 +326,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
-    if (enable_lto) base_tests.lto = .full;
+    if (enable_lto) base_tests.lto = .thin;
     base_tests.root_module.addIncludePath(.{ .cwd_relative = buildroot_path });
     base_tests.root_module.linkLibrary(dep_libbsdnt.artifact("bsdnt"));
     base_tests.root_module.linkLibrary(dep_libgc.artifact("gc"));

--- a/builder/build.zig
+++ b/builder/build.zig
@@ -36,6 +36,7 @@ pub fn build(b: *std.Build) void {
     const buildroot_path = b.build_root.join(b.allocator, &.{}) catch @panic("ASD");
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
+    // LTO = ThinLTO, set in all packages explicitly
     const enable_lto = optimize != .Debug and target.result.os.tag != .macos;
     const db = b.option(bool, "db", "") orelse false;
     const no_threads = b.option(bool, "no_threads", "") orelse false;
@@ -174,7 +175,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
-    if (enable_lto) libActonProject.lto = .full;
+    if (enable_lto) libActonProject.lto = .thin;
     var flags = std.ArrayList([]const u8).empty;
     defer flags.deinit(b.allocator);
 
@@ -252,7 +253,7 @@ pub fn build(b: *std.Build) void {
                 .optimize = optimize,
             }),
         });
-        if (enable_lto) libActonExplicit.lto = .full;
+        if (enable_lto) libActonExplicit.lto = .thin;
         if (lib_dynamic) {
             libActonExplicit.linker_allow_shlib_undefined = true;
         }
@@ -379,7 +380,7 @@ pub fn build(b: *std.Build) void {
                     .optimize = optimize,
                 }),
             });
-            if (enable_lto) executable.lto = .full;
+            if (enable_lto) executable.lto = .thin;
             // Build relative path for the executable source file
             const exe_rel_path = b.allocator.alloc(u8, 9 + entry.file_path.len) catch @panic("OOM");
             @memcpy(exe_rel_path[0..9], "out/types");

--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -1492,9 +1492,9 @@ actonProjTests =
           assertBool "root build.zig should skip LTO for macOS targets"
             ("const enable_lto = optimize != .Debug and target.result.os.tag != .macos;" `isInfixOf` rootBuildZig)
           assertBool "root build.zig should enable LTO for the project library"
-            ("if (enable_lto) libActonProject.lto = .full;" `isInfixOf` rootBuildZig)
+            ("if (enable_lto) libActonProject.lto = .thin;" `isInfixOf` rootBuildZig)
           assertBool "root build.zig should enable LTO for executables"
-            ("if (enable_lto) executable.lto = .full;" `isInfixOf` rootBuildZig)
+            ("if (enable_lto) executable.lto = .thin;" `isInfixOf` rootBuildZig)
   , testCase "transitive zig deps deduplicate by identity and split on collision" $ do
         withSystemTempDirectory "acton-zig-transitive-dedup" $ \tmp -> do
           actonExe <- canonicalizePath "../../dist/bin/acton"

--- a/deps/libargp/build.zig
+++ b/deps/libargp/build.zig
@@ -46,7 +46,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
-    if (enable_lto) lib.lto = .full;
+    if (enable_lto) lib.lto = .thin;
 
     lib.root_module.addCSourceFiles(.{ .files = &.{
         "argp-ba.c",

--- a/deps/libbsdnt/build.zig
+++ b/deps/libbsdnt/build.zig
@@ -61,7 +61,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
-    if (enable_lto) lib.lto = .full;
+    if (enable_lto) lib.lto = .thin;
 
     lib.root_module.addConfigHeader(config_header);
 

--- a/deps/libgc/build.zig
+++ b/deps/libgc/build.zig
@@ -473,7 +473,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
-    if (enable_lto) gc.lto = .full;
+    if (enable_lto) gc.lto = .thin;
     gc.root_module.addCSourceFiles(.{
         .files = source_files.items,
         .flags = flags.items,
@@ -492,7 +492,7 @@ pub fn build(b: *std.Build) void {
                 .optimize = optimize,
             }),
         });
-        if (enable_lto) gccpp.lto = .full;
+        if (enable_lto) gccpp.lto = .thin;
         gccpp.root_module.addCSourceFiles(.{
             .files = &.{
                 "gc_badalc.cc",
@@ -513,7 +513,7 @@ pub fn build(b: *std.Build) void {
                     .optimize = optimize,
                 }),
             });
-            if (enable_lto) gctba.lto = .full;
+            if (enable_lto) gctba.lto = .thin;
             gctba.root_module.addCSourceFiles(.{
                 .files = &.{
                     "gc_badalc.cc",
@@ -536,7 +536,7 @@ pub fn build(b: *std.Build) void {
                 .optimize = optimize,
             })
         });
-        if (enable_lto) cord.lto = .full;
+        if (enable_lto) cord.lto = .thin;
         cord.root_module.addCSourceFiles(.{
             .files = &.{
                 "cord/cordbscs.c",
@@ -675,7 +675,7 @@ fn addTestExt(b: *std.Build, gc: *std.Build.Step.Compile,
             .target = gc.root_module.resolved_target.?,
         }),
     });
-    if (gc.root_module.optimize.? != .Debug and gc.root_module.resolved_target.?.result.os.tag != .macos) test_exe.lto = .full;
+    if (gc.root_module.optimize.? != .Debug and gc.root_module.resolved_target.?.result.os.tag != .macos) test_exe.lto = .thin;
     test_exe.root_module.addCSourceFile(.{
         .file = b.path(filename),
         .flags = flags.items

--- a/deps/libnetstring/build.zig
+++ b/deps/libnetstring/build.zig
@@ -14,7 +14,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
-    if (enable_lto) lib.lto = .full;
+    if (enable_lto) lib.lto = .thin;
 
     const source_files = [_][]const u8{
         "netstring.c",

--- a/deps/libprotobuf_c/build.zig
+++ b/deps/libprotobuf_c/build.zig
@@ -14,7 +14,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
-    if (enable_lto) lib.lto = .full;
+    if (enable_lto) lib.lto = .thin;
 
     lib.root_module.addCSourceFiles(.{
         .files = &.{

--- a/deps/libsnappy_c/build.zig
+++ b/deps/libsnappy_c/build.zig
@@ -18,7 +18,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
-    if (enable_lto) lib.lto = .full;
+    if (enable_lto) lib.lto = .thin;
     lib.root_module.addIncludePath(b.path("."));
 
     //const libsnappy_version = "1.1.10";

--- a/deps/libutf8proc/build.zig
+++ b/deps/libutf8proc/build.zig
@@ -18,7 +18,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
-    if (enable_lto) lib.lto = .full;
+    if (enable_lto) lib.lto = .thin;
 
     var flags = std.ArrayList([]const u8).empty;
     defer flags.deinit(b.allocator);

--- a/deps/libuuid/build.zig
+++ b/deps/libuuid/build.zig
@@ -14,7 +14,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
-    if (enable_lto) lib.lto = .full;
+    if (enable_lto) lib.lto = .thin;
 
     const source_files = [_][]const u8{
         "src/clear.c",

--- a/deps/libuv/build.zig
+++ b/deps/libuv/build.zig
@@ -36,7 +36,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
-    if (enable_lto) lib.lto = .full;
+    if (enable_lto) lib.lto = .thin;
 
     var flags = std.ArrayList([]const u8).empty;
     defer flags.deinit(b.allocator);

--- a/deps/libxml2/build.zig
+++ b/deps/libxml2/build.zig
@@ -18,7 +18,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
-    if (enable_lto) lib.lto = .full;
+    if (enable_lto) lib.lto = .thin;
     lib.root_module.addIncludePath(b.path("include"));
 
     const libxml_version = "2.12.0";

--- a/deps/libyyjson/build.zig
+++ b/deps/libyyjson/build.zig
@@ -14,7 +14,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
-    if (enable_lto) lib.lto = .full;
+    if (enable_lto) lib.lto = .thin;
 
     const source_files = [_][]const u8{
         "yyjson.c",

--- a/deps/mbedtls/build.zig
+++ b/deps/mbedtls/build.zig
@@ -14,7 +14,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
-    if (enable_lto) libcrypto.lto = .full;
+    if (enable_lto) libcrypto.lto = .thin;
 
     const libx509 = b.addLibrary(.{
         .name = "mbedx509",
@@ -24,7 +24,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
-    if (enable_lto) libx509.lto = .full;
+    if (enable_lto) libx509.lto = .thin;
 
     const libtls = b.addLibrary(.{
         .name = "mbedtls",
@@ -34,7 +34,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
-    if (enable_lto) libtls.lto = .full;
+    if (enable_lto) libtls.lto = .thin;
 
     var flags = std.ArrayList([]const u8).empty;
     defer flags.deinit(b.allocator);

--- a/deps/pcre2/build.zig
+++ b/deps/pcre2/build.zig
@@ -26,7 +26,7 @@ pub fn build(b: *std.Build) !void {
             .link_libc = true,
         }),
     });
-    if (enable_lto) lib.lto = .full;
+    if (enable_lto) lib.lto = .thin;
 
     if (linkage == .static) {
         try lib.root_module.c_macros.append(b.allocator, "-DPCRE2_STATIC");

--- a/deps/tlsuv/build.zig
+++ b/deps/tlsuv/build.zig
@@ -45,7 +45,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
-    if (enable_lto) lib.lto = .full;
+    if (enable_lto) lib.lto = .thin;
 
     var cflags = std.ArrayList([]const u8).empty;
     defer cflags.deinit(b.allocator);

--- a/std/build.zig
+++ b/std/build.zig
@@ -177,7 +177,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
-    if (enable_lto) libActonProject.lto = .full;
+    if (enable_lto) libActonProject.lto = .thin;
 
     for (c_files.items) |entry| {
         libActonProject.root_module.addCSourceFile(.{ .file = b.path(entry), .flags = flags.items });


### PR DESCRIPTION
ThinLTO keeps cross-module optimization, but partitions the optimizer and code generator per module, so the final link scales across cores rather than merging the whole program into a single LLVM module and processing it in one thread.

On sorespo this reduces the time spent linking a release build from ~150s to ~50s and also peak memory usage by about 40% on x86.