### PR TITLE
Fix base64 crashes on empty and invalid input

### DIFF
--- a/base/__root.zig
+++ b/base/__root.zig
@@ -29,7 +29,13 @@ export fn base64Q_decode(data: *acton.bytes) callconv(.c) *acton.bytes {
     };
     const res = acton.new_bytes(data.class, out_len);
     const buffer: []u8 = @constCast(res.str[0..out_len]);
-    decoder.decode(buffer, data_slice) catch unreachable;
+    // calcSizeForSlice only validates the length and trailing padding, so
+    // decode can still fail on characters outside the alphabet or on
+    // misplaced padding.
+    decoder.decode(buffer, data_slice) catch {
+        acton.raise_ValueError("Invalid base64 input data");
+        unreachable;
+    };
     return res;
 }
 

--- a/base/__root.zig
+++ b/base/__root.zig
@@ -3,27 +3,21 @@ const std = @import("std");
 const acton = @import("acton.zig");
 const gc = @import("rts/gc.zig");
 
+// Both base64 functions build their result with acton.new_bytes so that it
+// looks exactly like bytes built by the C runtime: NUL-terminated payload,
+// and a real (non-dangling) buffer even when the output is empty.
 export fn base64Q_encode(data: *acton.bytes) callconv(.c) *acton.bytes {
-    const alloc = gc.allocator();
     const encoder = std.base64.standard.Encoder;
     // For possible Unicode input, bytes and chars may not be 1:1
     const data_len: usize = @intCast(data.nbytes);
     const out_len = encoder.calcSize(data_len);
-    const buffer = alloc.alloc(u8, out_len) catch @panic("OOM");
-    const data_slice = data.str[0..data_len];
-    const encoded = encoder.encode(buffer, data_slice);
-
-    const res = alloc.create(acton.bytes) catch @panic("OOM");
-    res.* = .{
-        .class = data.class,
-        .nbytes = @intCast(out_len),
-        .str = @as([*:0]const u8, @ptrCast(encoded.ptr))
-    };
+    const res = acton.new_bytes(data.class, out_len);
+    const buffer: []u8 = @constCast(res.str[0..out_len]);
+    _ = encoder.encode(buffer, data.str[0..data_len]);
     return res;
 }
 
 export fn base64Q_decode(data: *acton.bytes) callconv(.c) *acton.bytes {
-    const alloc = gc.allocator();
     const decoder = std.base64.standard.Decoder;
     // Convert null-terminated string to slice for decoder
     const data_len: usize = @intCast(data.nbytes);
@@ -33,15 +27,9 @@ export fn base64Q_decode(data: *acton.bytes) callconv(.c) *acton.bytes {
         acton.raise_ValueError("Invalid base64 input data");
         unreachable; // raise above does longjmp so this is unreachable
     };
-    const buffer = alloc.alloc(u8, out_len) catch @panic("OOM");
+    const res = acton.new_bytes(data.class, out_len);
+    const buffer: []u8 = @constCast(res.str[0..out_len]);
     decoder.decode(buffer, data_slice) catch unreachable;
-
-    const res = alloc.create(acton.bytes) catch @panic("OOM");
-    res.* = .{
-        .class = data.class,
-        .nbytes = @intCast(out_len),
-        .str = @as([*:0]const u8, @ptrCast(buffer.ptr))
-    };
     return res;
 }
 

--- a/base/acton.zig
+++ b/base/acton.zig
@@ -10,6 +10,8 @@ extern fn to_str_noc(str: [*:0]u8) B_str;
 extern fn B_ValueErrorG_new(B_str) ?*B_ValueError;
 extern fn B_MemoryErrorG_new(B_str) ?*B_MemoryError;
 extern fn @"$RAISE"(?*B_BaseException) void;
+extern fn acton_malloc(size: usize) ?*anyopaque;
+extern fn acton_malloc_atomic(size: usize) ?*anyopaque;
 
 // B_bytes
 pub const bytes = extern struct {
@@ -17,6 +19,33 @@ pub const bytes = extern struct {
     nbytes: i32,              // length of str in bytes
     str: [*]const u8            // str is UTF-8 encoded.
 };
+
+// Allocate a bytes object with room for nbytes payload bytes, the same way
+// NEW_UNFILLED_BYTES in builtin/str.c does it: the object comes from
+// acton_malloc (scanned, it holds the str pointer), the payload from
+// acton_malloc_atomic (pointer-free) and is nbytes + 1 long with a
+// terminating NUL at str[nbytes]. bytes methods like decode() and endswith()
+// rely on that terminator. Since at least one byte is always allocated, an
+// empty result gets a real buffer instead of the dangling pointer a
+// zero-length Zig allocation yields. The caller fills str[0..nbytes]; class
+// is normally taken from an existing bytes value.
+pub fn new_bytes(class: usize, nbytes: usize) *bytes {
+    const res: *bytes = @ptrCast(@alignCast(acton_malloc(@sizeOf(bytes)) orelse {
+        raise_MemoryError("OOM while allocating bytes");
+        unreachable;
+    }));
+    const buf: [*]u8 = @ptrCast(acton_malloc_atomic(nbytes + 1) orelse {
+        raise_MemoryError("OOM while allocating bytes");
+        unreachable;
+    });
+    buf[nbytes] = 0;
+    res.* = .{
+        .class = class,
+        .nbytes = @intCast(nbytes),
+        .str = buf,
+    };
+    return res;
+}
 
 // B_NoneType
 pub const none = extern struct {

--- a/test/stdlib_tests/src/test_base64.act
+++ b/test/stdlib_tests/src/test_base64.act
@@ -54,3 +54,14 @@ def _test_base64_decode_garbage():
         testing.assertEqual(str(e), "ValueError: Invalid base64 input data")
     else:
         raise Exception("Expected ValueError")
+
+def _test_base64_decode_invalid_chars():
+    # Input of a valid length but with characters outside the alphabet or
+    # misplaced padding must raise ValueError, not abort the process.
+    for i in [b"!!!!", b"Zm9v=mFy", b"Zm9vYm=y", b"Zm9v\x00YmFy"]:
+        try:
+            d = base64.decode(i)
+        except ValueError as e:
+            testing.assertEqual(str(e), "ValueError: Invalid base64 input data")
+        else:
+            raise Exception("Expected ValueError for " + repr(i))

--- a/test/stdlib_tests/src/test_base64.act
+++ b/test/stdlib_tests/src/test_base64.act
@@ -16,6 +16,35 @@ def _test_base64():
     d = base64.decode(e)
     testing.assertEqual(h, d)
 
+def _test_base64_empty():
+    # The base64 encoding of empty input is empty. Both directions must hand
+    # back a proper bytes value that the bytes methods can work on;
+    # encode(b"") used to return a dangling buffer that made decode() crash.
+    e = base64.encode(b"")
+    testing.assertEqual(e, b"")
+    testing.assertEqual(len(e), 0)
+    testing.assertEqual(e.decode(), "")
+    testing.assertEqual(e + b"x", b"x")
+    d = base64.decode(e)
+    testing.assertEqual(d, b"")
+    testing.assertEqual(len(d), 0)
+    testing.assertEqual(d.decode(), "")
+    testing.assertEqual(base64.decode(b"").decode(), "")
+
+def _test_base64_roundtrip_lengths():
+    # Cover every output length residue: the encoded and decoded buffers are
+    # exactly sized, so decode() (a C string operation on the payload) needs
+    # the terminating NUL that all bytes values carry.
+    for n in range(0, 40):
+        s = "x" * n
+        i = s.encode()
+        e = base64.encode(i)
+        testing.assertEqual(len(e), (n + 2) // 3 * 4)
+        testing.assertEqual(len(e.decode()), len(e))
+        d = base64.decode(e)
+        testing.assertEqual(d, i)
+        testing.assertEqual(d.decode(), s)
+
 def _test_base64_decode_garbage():
     # Invalid base64
     i = b"garbage"


### PR DESCRIPTION
base64.encode(b"") returned a bytes value whose payload pointer came from a zero-length Zig allocation. Allocator.alloc(u8, 0) does not allocate anything, it hands back a dangling pointer, so any bytes method that reads the payload, such as decode(), dereferenced garbage and crashed the process with a segfault in B_bytesD_decode. base64.decode(b"") had the same problem. This bit stratoweave's etcd backend, which base64-encodes its key prefix and reached encode(b"") for an empty prefix.

Non-empty output was also allocated with exactly out_len bytes and no terminating NUL, while every bytes value built by the C runtime (NEW_UNFILLED_BYTES in builtin/str.c) is nbytes + 1 long with a NUL at str[nbytes], and methods like decode() and endswith() rely on that. It only worked because libgc, built with ALL_INTERIOR_POINTERS, adds one zeroed slop byte to every object.

The first commit adds acton.new_bytes to acton.zig, which allocates a bytes object the way NEW_UNFILLED_BYTES does: the object through acton_malloc, the payload through acton_malloc_atomic, nbytes + 1 long and NUL-terminated. Both base64 functions now build their result with it, so an empty result gets a real one-byte buffer and every result carries the terminator. Tests cover the empty round trip and round trips over a range of lengths.

The second commit fixes an adjacent crash found while looking at this: base64.decode only turned an error from calcSizeForSlice into a ValueError, but that check covers just the length and trailing padding. The decode step itself can still fail on characters outside the alphabet or on misplaced padding, and its result was unwrapped with catch unreachable, which in the default safe build is a Zig panic that aborts the whole process (undefined behaviour in a release build). base64.decode(b"!!!!") killed the program instead of raising. It now raises the same ValueError, with a test for valid-length but invalid-content inputs.
