### PR TITLE
Fix set lookup for hashes with the high bit set

### DIFF
--- a/base/builtin/set.c
+++ b/base/builtin/set.c
@@ -26,7 +26,9 @@ static $WORD _dummy;
 
 static void B_set_insert_clean(B_setentry *table, long mask, $WORD *key, long hash) {
     B_setentry *entry;
-    long perturb = hash;
+    // perturb is unsigned so >>= is logical: a signed high-bit hash would
+    // sign-extend, never reach 0, and let the probe loop forever (#2552).
+    uint64_t perturb = hash;
     long i = hash & mask;
     long j;
 
@@ -90,7 +92,7 @@ static int B_set_table_resize(B_set so, int minsize) {
 
 static B_setentry *B_set_lookkey(B_set set, B_Hashable hashwit, $WORD key, long hash) {
     B_setentry *entry;
-    long perturb;
+    uint64_t perturb;  // unsigned (#2552)
     long mask = set->mask;
     long i = hash & mask;
 
@@ -124,7 +126,7 @@ static bool B_set_contains_entry(B_set set,  B_Hashable hashwit, $WORD elem, lon
 void B_set_add_entry(B_set set, B_Hashable hashwit, $WORD key, long hash) {
     B_setentry *freeslot;
     B_setentry *entry;
-    long perturb;
+    uint64_t perturb;  // unsigned (#2552)
     long mask;
     long i;
     mask = set->mask;

--- a/test/builtins_auto/set_test.act
+++ b/test/builtins_auto/set_test.act
@@ -32,11 +32,67 @@ def test_set_update_str():
     if s1 != sexp:
         raise ValueError("update() did not work correctly, result is " + str(s1))
 
+def test_set_lookup_high_bit_after_empty():
+    # actonlang/acton#2552: 173418's hash has the high bit set, so looking it
+    # up on a set emptied by pop() used to loop forever in B_set_lookkey.
+    s = {1, 2, 3}
+    s.pop()
+    s.pop()
+    s.pop()
+    if 173418 in s:
+        raise ValueError("173418 should not be in an emptied set")
+
+def test_set_lookup_high_bit_delete_reinsert():
+    s = {173418}
+    s.discard(173418)
+    if 173418 in s:
+        raise ValueError("173418 should be absent after discard")
+    s.add(173418)
+    if 173418 not in s:
+        raise ValueError("173418 should be present after re-add")
+
+def test_set_lookup_tombstone_heavy():
+    s = {0}
+    for i in range(200):
+        s.add(i)
+    for i in range(200):
+        s.discard(i)
+    if 173418 in s:
+        raise ValueError("173418 should not be in a tombstone-heavy set")
+
+def test_set_lookup_after_resize_then_empty():
+    s = {0}
+    for i in range(1000):
+        s.add(i)
+    for i in range(1000):
+        s.discard(i)
+    if 173418 in s:
+        raise ValueError("173418 should not be in an emptied resized set")
+
+def test_set_lookup_many_hashes_terminate():
+    s = {0}
+    for i in range(500):
+        s.add(i * 173418)
+    for i in range(500):
+        if i % 2 == 0:
+            s.discard(i * 173418)
+    # odd i were kept, even i discarded; every lookup must terminate and match
+    for i in range(500):
+        if ((i * 173418) in s) != (i % 2 == 1):
+            raise ValueError("membership mismatch for " + str(i))
+    if 999999937 in s:
+        raise ValueError("unexpected membership in the mixed set")
+
 actor main(env):
     try:
         test_set_pop()
         test_set_update_int()
         test_set_update_str()
+        test_set_lookup_high_bit_after_empty()
+        test_set_lookup_high_bit_delete_reinsert()
+        test_set_lookup_tombstone_heavy()
+        test_set_lookup_after_resize_then_empty()
+        test_set_lookup_many_hashes_terminate()
     except Exception as e:
         print("Unexpected exception during testing:", e)
         await async env.exit(1)


### PR DESCRIPTION
`B_set_lookkey`, `B_set_add_entry`, and `B_set_insert_clean` declare the probe `perturb` as a signed `long`. The hash function produces a `uint64_t`, so a hash with the high bit set becomes a negative `long`, and `perturb >>= PERTURB_SHIFT` is then an arithmetic shift that keeps the sign bit and never decays to zero. The probe `i = (i * 5 + 1 + perturb) & mask` never gets its full permutation and can loop forever.

Reproducer from #2552: looking up `173418` (whose hash has the high bit set) on a set emptied by `pop()` spins in `B_set_lookkey` and never returns; even `SIGTERM` does not stop the tight loop.

## Fix

Make `perturb` a `uint64_t` in the three probe loops so the shift is logical and the sequence decays to zero. That matches the hash function's own type; `dict.c` already guards its probe the same way, with an unsigned perturb (`unsigned long`). Nothing else changes: `numelements`, `fill`, `mask`, and `finger` stay `long` (they never go negative, per @sydow's note on the issue), and the dummy sentinel (`hash == -1`) is untouched, so tombstone handling is identical.

## Tests

`set_test.act` gains regression tests for the reported case and other table histories that drive the probe through tombstones and resizes:

- the reported lookup on a set emptied by `pop()`
- delete then reinsert the same value
- a tombstone-heavy table (add many, discard all)
- a resized table emptied again
- many mixed hashes, checking each membership against what was kept

I checked each against the runtime both ways: with the current `set.c` the test binary has to be `SIGKILL`ed, and with the fix it exits cleanly.

Closes #2552
