### PR TITLE
Add Acton Object Notation support

### DIFF
--- a/base/src/adl.act
+++ b/base/src/adl.act
@@ -1,0 +1,602 @@
+"""Acton Data Layout encoding and decoding.
+
+ADL is a small, human-facing data format shaped like Acton values. A document
+is an implicit named tuple: fields use `name = value`, while `name:` opens an
+indented nested tuple. Lists use brackets and structured list items are named
+tuples in parentheses.
+
+```text
+name = "example"
+
+network:
+    port = 830
+    tls = True
+
+peers = [
+    (host = "one", port = 830),
+    (host = "two", port = 831),
+]
+```
+
+Values are strings, integers, floats, booleans, `None`, lists, and named
+tuples. Comments start with `#`. Documents, sections, and named tuples decode
+to `dict[str, ?value]`; the dictionary representation is necessary because a
+decoded document has a dynamic shape while Acton named-tuple types are static.
+
+## Grammar
+
+```text
+document    = fields
+fields      = { field | blank | comment }
+field       = indent key "=" value newline
+            | indent key ":" newline indented-fields
+value       = string | number | "True" | "False" | "None" | list | tuple
+list        = "[" [ value { "," value } [ "," ] ] "]"
+tuple       = "(" [ key "=" value { "," key "=" value } [ "," ] ] ")"
+key         = identifier | string
+identifier  = ( letter | "_" ) { letter | digit | "_" }
+comment     = "#" { character } newline
+```
+
+Indentation uses spaces; every field in a block has the same indentation and
+a nested block must indent further than its parent. Whitespace and comments
+are allowed inside lists and named tuples. Strings use single or double quotes
+with Acton escape sequences. Numbers use Acton decimal, hexadecimal, octal,
+and binary spellings; underscores are allowed only between digits.
+
+Encoding and decoding are pure; applications remain responsible for reading
+and writing files through their file capabilities.
+
+`encode()` writes dictionaries as ADL documents, while `encode_value()` writes
+standalone values. The deterministic encoder preserves dictionary field order,
+uses sections for non-empty dictionaries in documents, uses named tuples for
+dictionaries inside values, and always ends a non-empty document with a
+newline.
+
+ADL and JSON share the same dictionary/list/scalar representation, so no
+adapter is needed: `adl.encode(json.decode(json_text))` converts JSON to ADL,
+and `json.encode(adl.decode(adl_text))` converts ADL to JSON.
+"""
+
+
+def _is_identifier_start(char: str) -> bool:
+    return char != "" and char in "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_"
+
+
+def _is_identifier_continue(char: str) -> bool:
+    return _is_identifier_start(char) or (char != "" and char in "0123456789")
+
+
+def _is_identifier(text: str) -> bool:
+    if text == "" or not _is_identifier_start(text[0]):
+        return False
+    for char in text[1:]:
+        if not _is_identifier_continue(char):
+            return False
+    return True
+
+
+class AdlParseError(ValueError):
+    """An ADL syntax error with source location information."""
+
+    source: str
+    line: int
+    column: int
+
+    def __init__(self, message: str, source: str="<string>",
+                 line: int=1, column: int=1):
+        self.error_message = message
+        self.source = source
+        self.line = line
+        self.column = column
+
+    def __str__(self) -> str:
+        return f"{self.source}:{self.line}:{self.column}: {self.error_message}"
+
+    def __repr__(self) -> str:
+        return f"AdlParseError({repr(self.error_message)}, {repr(self.source)}, {self.line}, {self.column})"
+
+
+class _Parser(object):
+    text: str
+    source: str
+    pos: int
+    line: int
+    column: int
+
+    def __init__(self, text: str, source: str):
+        self.text = text
+        self.source = source
+        self.pos = 0
+        self.line = 1
+        self.column = 1
+
+    def _error(self, message: str) -> AdlParseError:
+        return AdlParseError(message, self.source, self.line, self.column)
+
+    def _peek(self, offset: int=0) -> str:
+        p = self.pos + offset
+        if p < 0 or p >= len(self.text):
+            return ""
+        return self.text[p]
+
+    def _advance(self) -> str:
+        if self.pos >= len(self.text):
+            return ""
+        char = self.text[self.pos]
+        self.pos += 1
+        if char == "\n":
+            self.line += 1
+            self.column = 1
+        else:
+            self.column += 1
+        return char
+
+    def _consume(self, text: str):
+        if self.text[self.pos:self.pos+len(text)] != text:
+            raise self._error(f"Expected {repr(text)}")
+        for _ in range(len(text)):
+            self._advance()
+
+    def _consume_newline(self):
+        if self._peek() == "\n":
+            self._advance()
+        elif self._peek() == "\r":
+            self._advance()
+            if self._peek() != "\n":
+                raise self._error("Expected LF or CRLF newline")
+            self._advance()
+        else:
+            raise self._error("Expected newline")
+
+    def _skip_horizontal(self):
+        while self._peek() == " " or self._peek() == "\t":
+            self._advance()
+
+    def _skip_comment(self):
+        if self._peek() == "#":
+            while self._peek() != "" and self._peek() != "\r" and self._peek() != "\n":
+                self._advance()
+
+    def _line_end(self):
+        self._skip_horizontal()
+        self._skip_comment()
+        if self._peek() == "\r" or self._peek() == "\n":
+            self._consume_newline()
+        elif self._peek() != "":
+            raise self._error("Expected end of line")
+
+    def _entry_indent(self) -> ?int:
+        while True:
+            indent = 0
+            while self._peek() == " ":
+                indent += 1
+                self._advance()
+            if self._peek() == "\t":
+                raise self._error("Tabs are not allowed for indentation")
+            if self._peek() == "#":
+                self._skip_comment()
+            if self._peek() == "\r" or self._peek() == "\n":
+                self._consume_newline()
+            elif self._peek() == "":
+                return None
+            else:
+                return indent
+
+    def _skip_value_whitespace(self):
+        while self._peek() != "" and self._peek().isspace():
+            if self._peek() == "\r" or self._peek() == "\n":
+                self._consume_newline()
+            else:
+                self._advance()
+
+    def _skip_value_space(self):
+        while True:
+            self._skip_value_whitespace()
+            if self._peek() == "#":
+                self._skip_comment()
+            else:
+                return
+
+    def _hex_escape(self, digits: int) -> str:
+        raw = ""
+        for _ in range(digits):
+            char = self._peek()
+            if char == "" or char.lower() not in "0123456789abcdef":
+                raise self._error(f"Expected {digits} hexadecimal digits in escape sequence")
+            raw += self._advance()
+        codepoint = 0
+        for char in raw:
+            codepoint = codepoint * 16 + "0123456789abcdef".find(char.lower())
+        if 0xd800 <= codepoint and codepoint <= 0xdfff:
+            raise self._error("Unicode escape cannot encode a surrogate")
+        try:
+            return chr(codepoint)
+        except ValueError:
+            raise self._error("Unicode escape is outside the Unicode range")
+
+    def _string(self) -> str:
+        quote = self._advance()
+        parts: list[str] = []
+        escapes = {
+            "\\": "\\",
+            "'": "'",
+            '"': '"',
+            "a": "\a",
+            "b": "\b",
+            "f": "\f",
+            "n": "\n",
+            "r": "\r",
+            "t": "\t",
+            "v": "\v",
+        }
+        while True:
+            char = self._peek()
+            if char == "":
+                raise self._error("Unterminated string")
+            if char == quote:
+                self._advance()
+                return "".join(parts)
+            if char == "\r" or char == "\n":
+                raise self._error("Newline in string")
+            if char == "\\":
+                self._advance()
+                escaped = self._peek()
+                if escaped in escapes:
+                    parts.append(escapes[escaped])
+                    self._advance()
+                elif escaped == "x":
+                    self._advance()
+                    parts.append(self._hex_escape(2))
+                elif escaped == "u":
+                    self._advance()
+                    parts.append(self._hex_escape(4))
+                elif escaped == "U":
+                    self._advance()
+                    parts.append(self._hex_escape(8))
+                elif escaped != "" and escaped in "01234567":
+                    codepoint = 0
+                    for _ in range(3):
+                        digit = self._peek()
+                        if digit == "" or digit not in "01234567":
+                            break
+                        codepoint = codepoint * 8 + ord(self._advance()) - ord("0")
+                    if codepoint > 0xff:
+                        raise self._error("Octal escape is outside the byte range")
+                    parts.append(chr(codepoint))
+                elif escaped == "\r" or escaped == "\n":
+                    self._consume_newline()
+                else:
+                    raise self._error("Invalid escape sequence in string")
+            else:
+                if ord(char) < 0x20 or char == "\x7f":
+                    raise self._error("Control character in string")
+                parts.append(self._advance())
+        raise self._error("Unterminated string")
+
+    def _bare_key(self) -> str:
+        start = self.pos
+        char = self._peek()
+        if char == "" or not _is_identifier_start(char):
+            raise self._error("Expected an identifier or quoted field name")
+        self._advance()
+        while True:
+            char = self._peek()
+            if char != "" and _is_identifier_continue(char):
+                self._advance()
+            else:
+                break
+        return self.text[start:self.pos]
+
+    def _key(self) -> str:
+        if self._peek() == '"' or self._peek() == "'":
+            return self._string()
+        return self._bare_key()
+
+    def _valid_separators(self, text: str, digits: str) -> bool:
+        if len(text) == 0:
+            return False
+        for i in range(len(text)):
+            if text[i] == "_":
+                if i == 0 or i + 1 >= len(text):
+                    return False
+                if text[i-1] not in digits or text[i+1] not in digits:
+                    return False
+        return True
+
+    def _atom(self) -> ?value:
+        start = self.pos
+        while True:
+            char = self._peek()
+            if char == "" or char.isspace() or char in ",])#":
+                break
+            self._advance()
+        raw = self.text[start:self.pos]
+        if raw == "True":
+            return True
+        if raw == "False":
+            return False
+        if raw == "None":
+            return None
+        magnitude = raw[1:] if raw.startswith("+") or raw.startswith("-") else raw
+        lower = magnitude.lower()
+        if lower.startswith("0x"):
+            digits = "0123456789abcdefABCDEF"
+            if not self._valid_separators(magnitude[2:], digits):
+                raise self._error(f"Invalid hexadecimal integer {repr(raw)}")
+        elif lower.startswith("0o"):
+            if not self._valid_separators(magnitude[2:], "01234567"):
+                raise self._error(f"Invalid octal integer {repr(raw)}")
+        elif lower.startswith("0b"):
+            if not self._valid_separators(magnitude[2:], "01"):
+                raise self._error(f"Invalid binary integer {repr(raw)}")
+        elif not self._valid_separators(raw, "0123456789"):
+            raise self._error(f"Invalid number {repr(raw)}")
+        clean = raw.replace("_", "")
+        if lower.startswith("0x") or lower.startswith("0o") or lower.startswith("0b"):
+            try:
+                return int(clean)
+            except ValueError:
+                raise self._error(f"Invalid value {repr(raw)}")
+        if "." in clean or "e" in clean or "E" in clean:
+            try:
+                val = float(clean)
+            except ValueError:
+                raise self._error(f"Invalid value {repr(raw)}")
+            if val != val or val == float("inf") or val == float("-inf"):
+                raise self._error(f"Non-finite float {repr(raw)}")
+            return val
+        try:
+            return int(clean)
+        except ValueError:
+            raise self._error(f"Invalid value {repr(raw)}")
+
+    def _list(self) -> list[?value]:
+        self._consume("[")
+        result: list[?value] = []
+        self._skip_value_space()
+        if self._peek() == "]":
+            self._advance()
+            return result
+        while True:
+            result.append(self._value())
+            self._skip_value_space()
+            if self._peek() == "]":
+                self._advance()
+                return result
+            if self._peek() != ",":
+                raise self._error("Expected ',' or ']' in list")
+            self._advance()
+            self._skip_value_space()
+            if self._peek() == "]":
+                self._advance()
+                return result
+        raise self._error("Unterminated list")
+
+    def _named_tuple(self) -> dict[str, ?value]:
+        self._consume("(")
+        result: dict[str, ?value] = {}
+        self._skip_value_space()
+        if self._peek() == ")":
+            self._advance()
+            return result
+        while True:
+            key = self._key()
+            self._skip_horizontal()
+            if self._peek() != "=":
+                raise self._error("Expected '=' after named tuple field")
+            self._advance()
+            self._skip_value_space()
+            if key in result:
+                raise self._error(f"Duplicate field {repr(key)}")
+            result[key] = self._value()
+            self._skip_value_space()
+            if self._peek() == ")":
+                self._advance()
+                return result
+            if self._peek() != ",":
+                raise self._error("Expected ',' or ')' in named tuple")
+            self._advance()
+            self._skip_value_space()
+            if self._peek() == ")":
+                self._advance()
+                return result
+        raise self._error("Unterminated named tuple")
+
+    def _value(self) -> ?value:
+        char = self._peek()
+        if char == '"' or char == "'":
+            return self._string()
+        if char == "[":
+            return self._list()
+        if char == "(":
+            return self._named_tuple()
+        return self._atom()
+
+    def _block(self, indent: int) -> (table: dict[str, ?value], next_indent: ?int):
+        table: dict[str, ?value] = {}
+        current = indent
+        while True:
+            if current < indent:
+                return (table=table, next_indent=current)
+            if current > indent:
+                raise self._error("Unexpected indentation")
+
+            key = self._key()
+            self._skip_horizontal()
+            if key in table:
+                raise self._error(f"Duplicate field {repr(key)}")
+            if self._peek() == "=":
+                self._advance()
+                self._skip_horizontal()
+                table[key] = self._value()
+                self._line_end()
+                next_indent = self._entry_indent()
+                if isinstance(next_indent, int):
+                    current = next_indent
+                else:
+                    return (table=table, next_indent=None)
+            elif self._peek() == ":":
+                self._advance()
+                self._line_end()
+                child_indent = self._entry_indent()
+                if isinstance(child_indent, int):
+                    if child_indent <= indent:
+                        raise self._error(f"Section {repr(key)} must contain an indented field")
+                    child = self._block(child_indent)
+                    table[key] = child.table
+                    next_indent = child.next_indent
+                    if isinstance(next_indent, int):
+                        current = next_indent
+                    else:
+                        return (table=table, next_indent=None)
+                else:
+                    raise self._error(f"Section {repr(key)} must contain an indented field")
+            else:
+                raise self._error("Expected '=' or ':' after field name")
+        return (table=table, next_indent=None)
+
+    def parse_value(self) -> ?value:
+        self._skip_value_space()
+        result = self._value()
+        self._skip_value_whitespace()
+        if self._peek() != "":
+            raise self._error("Unexpected text after value")
+        return result
+
+    def parse(self) -> dict[str, ?value]:
+        indent = self._entry_indent()
+        if indent is None:
+            return {}
+        if indent != 0:
+            raise self._error("Top-level fields must not be indented")
+        result = self._block(0)
+        if result.next_indent is not None:
+            raise self._error("Invalid dedent")
+        return result.table
+
+
+class _Encoder(object):
+    indent: int
+
+    def __init__(self, indent: int):
+        if indent <= 0:
+            raise ValueError("ADL indentation must be positive")
+        self.indent = indent
+
+    def _padding(self, level: int) -> str:
+        return " " * (self.indent * level)
+
+    def _string(self, text: str) -> str:
+        escapes = {
+            '"': '\\"',
+            "\\": "\\\\",
+            "\b": "\\b",
+            "\f": "\\f",
+            "\n": "\\n",
+            "\r": "\\r",
+            "\t": "\\t",
+        }
+        parts = ['"']
+        for char in text:
+            if char in escapes:
+                parts.append(escapes[char])
+            elif ord(char) < 0x20 or char == "\x7f":
+                parts.append("\\u" + hex(ord(char))[2:].zfill(4))
+            else:
+                parts.append(char)
+        parts.append('"')
+        return "".join(parts)
+
+    def _key(self, key: str) -> str:
+        if _is_identifier(key):
+            return key
+        return self._string(key)
+
+    def _scalar(self, val: ?value) -> str:
+        if val is None:
+            return "None"
+        if isinstance(val, bool):
+            return "True" if val else "False"
+        if isinstance(val, int):
+            return str(val)
+        if isinstance(val, float):
+            if val != val or val == float("inf") or val == float("-inf"):
+                raise ValueError("ADL cannot encode non-finite floats")
+            text = "%.17g" % val
+            if "." not in text and "e" not in text and "E" not in text:
+                text += ".0"
+            return text
+        if isinstance(val, str):
+            return self._string(val)
+        raise ValueError(f"ADL cannot encode value {repr(val)}")
+
+    def _value(self, val: ?value, level: int) -> str:
+        if isinstance(val, list):
+            return self._list(val, level)
+        if isinstance(val, dict):
+            return self._tuple(val, level)
+        return self._scalar(val)
+
+    def _list(self, items: list[?value], level: int) -> str:
+        if len(items) == 0:
+            return "[]"
+        simple = True
+        for item in items:
+            if isinstance(item, list) or isinstance(item, dict):
+                simple = False
+        if simple:
+            encoded: list[str] = []
+            for item in items:
+                encoded.append(self._scalar(item))
+            return "[" + ", ".join(encoded) + "]"
+
+        parts = ["["]
+        for item in items:
+            parts.append(self._padding(level + 1) + self._value(item, level + 1) + ",")
+        parts.append(self._padding(level) + "]")
+        return "\n".join(parts)
+
+    def _tuple(self, fields: dict[str, ?value], level: int) -> str:
+        if len(fields) == 0:
+            return "()"
+        parts = ["("]
+        for key, val in fields.items():
+            parts.append(
+                self._padding(level + 1) + self._key(key)
+                + " = " + self._value(val, level + 1) + ","
+            )
+        parts.append(self._padding(level) + ")")
+        return "\n".join(parts)
+
+    def document(self, fields: dict[str, ?value], level: int=0) -> str:
+        parts: list[str] = []
+        for key, val in fields.items():
+            prefix = self._padding(level) + self._key(key)
+            if isinstance(val, dict) and len(val) > 0:
+                parts.append(prefix + ":")
+                parts.append(self.document(val, level + 1))
+            else:
+                parts.append(prefix + " = " + self._value(val, level))
+        return "\n".join(parts)
+
+
+def decode(data: str, source: str="<string>") -> dict[str, ?value]:
+    """Decode an ADL document into nested dictionaries, lists, and values."""
+    return _Parser(data, source).parse()
+
+
+def decode_value(data: str, source: str="<string>") -> ?value:
+    """Decode one standalone ADL value."""
+    return _Parser(data, source).parse_value()
+
+
+def encode(data: dict[str, ?value], indent: int=4) -> str:
+    """Encode a dictionary as a deterministic, order-preserving ADL document."""
+    result = _Encoder(indent).document(data)
+    return result + "\n" if result != "" else ""
+
+
+def encode_value(data: ?value, indent: int=4) -> str:
+    """Encode one standalone ADL value."""
+    return _Encoder(indent)._value(data, 0)

--- a/std/src/adl.act
+++ b/std/src/adl.act
@@ -1,0 +1,602 @@
+"""Acton Data Layout encoding and decoding.
+
+ADL is a small, human-facing data format shaped like Acton values. A document
+is an implicit named tuple: fields use `name = value`, while `name:` opens an
+indented nested tuple. Lists use brackets and structured list items are named
+tuples in parentheses.
+
+```text
+name = "example"
+
+network:
+    port = 830
+    tls = True
+
+peers = [
+    (host = "one", port = 830),
+    (host = "two", port = 831),
+]
+```
+
+Values are strings, integers, floats, booleans, `None`, lists, and named
+tuples. Comments start with `#`. Documents, sections, and named tuples decode
+to `dict[str, ?value]`; the dictionary representation is necessary because a
+decoded document has a dynamic shape while Acton named-tuple types are static.
+
+## Grammar
+
+```text
+document    = fields
+fields      = { field | blank | comment }
+field       = indent key "=" value newline
+            | indent key ":" newline indented-fields
+value       = string | number | "True" | "False" | "None" | list | tuple
+list        = "[" [ value { "," value } [ "," ] ] "]"
+tuple       = "(" [ key "=" value { "," key "=" value } [ "," ] ] ")"
+key         = identifier | string
+identifier  = ( letter | "_" ) { letter | digit | "_" }
+comment     = "#" { character } newline
+```
+
+Indentation uses spaces; every field in a block has the same indentation and
+a nested block must indent further than its parent. Whitespace and comments
+are allowed inside lists and named tuples. Strings use single or double quotes
+with Acton escape sequences. Numbers use Acton decimal, hexadecimal, octal,
+and binary spellings; underscores are allowed only between digits.
+
+Encoding and decoding are pure; applications remain responsible for reading
+and writing files through their file capabilities.
+
+`encode()` writes dictionaries as ADL documents, while `encode_value()` writes
+standalone values. The deterministic encoder preserves dictionary field order,
+uses sections for non-empty dictionaries in documents, uses named tuples for
+dictionaries inside values, and always ends a non-empty document with a
+newline.
+
+ADL and JSON share the same dictionary/list/scalar representation, so no
+adapter is needed: `adl.encode(json.decode(json_text))` converts JSON to ADL,
+and `json.encode(adl.decode(adl_text))` converts ADL to JSON.
+"""
+
+
+def _is_identifier_start(char: str) -> bool:
+    return char != "" and char in "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_"
+
+
+def _is_identifier_continue(char: str) -> bool:
+    return _is_identifier_start(char) or (char != "" and char in "0123456789")
+
+
+def _is_identifier(text: str) -> bool:
+    if text == "" or not _is_identifier_start(text[0]):
+        return False
+    for char in text[1:]:
+        if not _is_identifier_continue(char):
+            return False
+    return True
+
+
+class AdlParseError(ValueError):
+    """An ADL syntax error with source location information."""
+
+    source: str
+    line: int
+    column: int
+
+    def __init__(self, message: str, source: str="<string>",
+                 line: int=1, column: int=1):
+        self.error_message = message
+        self.source = source
+        self.line = line
+        self.column = column
+
+    def __str__(self) -> str:
+        return f"{self.source}:{self.line}:{self.column}: {self.error_message}"
+
+    def __repr__(self) -> str:
+        return f"AdlParseError({repr(self.error_message)}, {repr(self.source)}, {self.line}, {self.column})"
+
+
+class _Parser(object):
+    text: str
+    source: str
+    pos: int
+    line: int
+    column: int
+
+    def __init__(self, text: str, source: str):
+        self.text = text
+        self.source = source
+        self.pos = 0
+        self.line = 1
+        self.column = 1
+
+    def _error(self, message: str) -> AdlParseError:
+        return AdlParseError(message, self.source, self.line, self.column)
+
+    def _peek(self, offset: int=0) -> str:
+        p = self.pos + offset
+        if p < 0 or p >= len(self.text):
+            return ""
+        return self.text[p]
+
+    def _advance(self) -> str:
+        if self.pos >= len(self.text):
+            return ""
+        char = self.text[self.pos]
+        self.pos += 1
+        if char == "\n":
+            self.line += 1
+            self.column = 1
+        else:
+            self.column += 1
+        return char
+
+    def _consume(self, text: str):
+        if self.text[self.pos:self.pos+len(text)] != text:
+            raise self._error(f"Expected {repr(text)}")
+        for _ in range(len(text)):
+            self._advance()
+
+    def _consume_newline(self):
+        if self._peek() == "\n":
+            self._advance()
+        elif self._peek() == "\r":
+            self._advance()
+            if self._peek() != "\n":
+                raise self._error("Expected LF or CRLF newline")
+            self._advance()
+        else:
+            raise self._error("Expected newline")
+
+    def _skip_horizontal(self):
+        while self._peek() == " " or self._peek() == "\t":
+            self._advance()
+
+    def _skip_comment(self):
+        if self._peek() == "#":
+            while self._peek() != "" and self._peek() != "\r" and self._peek() != "\n":
+                self._advance()
+
+    def _line_end(self):
+        self._skip_horizontal()
+        self._skip_comment()
+        if self._peek() == "\r" or self._peek() == "\n":
+            self._consume_newline()
+        elif self._peek() != "":
+            raise self._error("Expected end of line")
+
+    def _entry_indent(self) -> ?int:
+        while True:
+            indent = 0
+            while self._peek() == " ":
+                indent += 1
+                self._advance()
+            if self._peek() == "\t":
+                raise self._error("Tabs are not allowed for indentation")
+            if self._peek() == "#":
+                self._skip_comment()
+            if self._peek() == "\r" or self._peek() == "\n":
+                self._consume_newline()
+            elif self._peek() == "":
+                return None
+            else:
+                return indent
+
+    def _skip_value_whitespace(self):
+        while self._peek() != "" and self._peek().isspace():
+            if self._peek() == "\r" or self._peek() == "\n":
+                self._consume_newline()
+            else:
+                self._advance()
+
+    def _skip_value_space(self):
+        while True:
+            self._skip_value_whitespace()
+            if self._peek() == "#":
+                self._skip_comment()
+            else:
+                return
+
+    def _hex_escape(self, digits: int) -> str:
+        raw = ""
+        for _ in range(digits):
+            char = self._peek()
+            if char == "" or char.lower() not in "0123456789abcdef":
+                raise self._error(f"Expected {digits} hexadecimal digits in escape sequence")
+            raw += self._advance()
+        codepoint = 0
+        for char in raw:
+            codepoint = codepoint * 16 + "0123456789abcdef".find(char.lower())
+        if 0xd800 <= codepoint and codepoint <= 0xdfff:
+            raise self._error("Unicode escape cannot encode a surrogate")
+        try:
+            return chr(codepoint)
+        except ValueError:
+            raise self._error("Unicode escape is outside the Unicode range")
+
+    def _string(self) -> str:
+        quote = self._advance()
+        parts: list[str] = []
+        escapes = {
+            "\\": "\\",
+            "'": "'",
+            '"': '"',
+            "a": "\a",
+            "b": "\b",
+            "f": "\f",
+            "n": "\n",
+            "r": "\r",
+            "t": "\t",
+            "v": "\v",
+        }
+        while True:
+            char = self._peek()
+            if char == "":
+                raise self._error("Unterminated string")
+            if char == quote:
+                self._advance()
+                return "".join(parts)
+            if char == "\r" or char == "\n":
+                raise self._error("Newline in string")
+            if char == "\\":
+                self._advance()
+                escaped = self._peek()
+                if escaped in escapes:
+                    parts.append(escapes[escaped])
+                    self._advance()
+                elif escaped == "x":
+                    self._advance()
+                    parts.append(self._hex_escape(2))
+                elif escaped == "u":
+                    self._advance()
+                    parts.append(self._hex_escape(4))
+                elif escaped == "U":
+                    self._advance()
+                    parts.append(self._hex_escape(8))
+                elif escaped != "" and escaped in "01234567":
+                    codepoint = 0
+                    for _ in range(3):
+                        digit = self._peek()
+                        if digit == "" or digit not in "01234567":
+                            break
+                        codepoint = codepoint * 8 + ord(self._advance()) - ord("0")
+                    if codepoint > 0xff:
+                        raise self._error("Octal escape is outside the byte range")
+                    parts.append(chr(codepoint))
+                elif escaped == "\r" or escaped == "\n":
+                    self._consume_newline()
+                else:
+                    raise self._error("Invalid escape sequence in string")
+            else:
+                if ord(char) < 0x20 or char == "\x7f":
+                    raise self._error("Control character in string")
+                parts.append(self._advance())
+        raise self._error("Unterminated string")
+
+    def _bare_key(self) -> str:
+        start = self.pos
+        char = self._peek()
+        if char == "" or not _is_identifier_start(char):
+            raise self._error("Expected an identifier or quoted field name")
+        self._advance()
+        while True:
+            char = self._peek()
+            if char != "" and _is_identifier_continue(char):
+                self._advance()
+            else:
+                break
+        return self.text[start:self.pos]
+
+    def _key(self) -> str:
+        if self._peek() == '"' or self._peek() == "'":
+            return self._string()
+        return self._bare_key()
+
+    def _valid_separators(self, text: str, digits: str) -> bool:
+        if len(text) == 0:
+            return False
+        for i in range(len(text)):
+            if text[i] == "_":
+                if i == 0 or i + 1 >= len(text):
+                    return False
+                if text[i-1] not in digits or text[i+1] not in digits:
+                    return False
+        return True
+
+    def _atom(self) -> ?value:
+        start = self.pos
+        while True:
+            char = self._peek()
+            if char == "" or char.isspace() or char in ",])#":
+                break
+            self._advance()
+        raw = self.text[start:self.pos]
+        if raw == "True":
+            return True
+        if raw == "False":
+            return False
+        if raw == "None":
+            return None
+        magnitude = raw[1:] if raw.startswith("+") or raw.startswith("-") else raw
+        lower = magnitude.lower()
+        if lower.startswith("0x"):
+            digits = "0123456789abcdefABCDEF"
+            if not self._valid_separators(magnitude[2:], digits):
+                raise self._error(f"Invalid hexadecimal integer {repr(raw)}")
+        elif lower.startswith("0o"):
+            if not self._valid_separators(magnitude[2:], "01234567"):
+                raise self._error(f"Invalid octal integer {repr(raw)}")
+        elif lower.startswith("0b"):
+            if not self._valid_separators(magnitude[2:], "01"):
+                raise self._error(f"Invalid binary integer {repr(raw)}")
+        elif not self._valid_separators(raw, "0123456789"):
+            raise self._error(f"Invalid number {repr(raw)}")
+        clean = raw.replace("_", "")
+        if lower.startswith("0x") or lower.startswith("0o") or lower.startswith("0b"):
+            try:
+                return int(clean)
+            except ValueError:
+                raise self._error(f"Invalid value {repr(raw)}")
+        if "." in clean or "e" in clean or "E" in clean:
+            try:
+                val = float(clean)
+            except ValueError:
+                raise self._error(f"Invalid value {repr(raw)}")
+            if val != val or val == float("inf") or val == float("-inf"):
+                raise self._error(f"Non-finite float {repr(raw)}")
+            return val
+        try:
+            return int(clean)
+        except ValueError:
+            raise self._error(f"Invalid value {repr(raw)}")
+
+    def _list(self) -> list[?value]:
+        self._consume("[")
+        result: list[?value] = []
+        self._skip_value_space()
+        if self._peek() == "]":
+            self._advance()
+            return result
+        while True:
+            result.append(self._value())
+            self._skip_value_space()
+            if self._peek() == "]":
+                self._advance()
+                return result
+            if self._peek() != ",":
+                raise self._error("Expected ',' or ']' in list")
+            self._advance()
+            self._skip_value_space()
+            if self._peek() == "]":
+                self._advance()
+                return result
+        raise self._error("Unterminated list")
+
+    def _named_tuple(self) -> dict[str, ?value]:
+        self._consume("(")
+        result: dict[str, ?value] = {}
+        self._skip_value_space()
+        if self._peek() == ")":
+            self._advance()
+            return result
+        while True:
+            key = self._key()
+            self._skip_horizontal()
+            if self._peek() != "=":
+                raise self._error("Expected '=' after named tuple field")
+            self._advance()
+            self._skip_value_space()
+            if key in result:
+                raise self._error(f"Duplicate field {repr(key)}")
+            result[key] = self._value()
+            self._skip_value_space()
+            if self._peek() == ")":
+                self._advance()
+                return result
+            if self._peek() != ",":
+                raise self._error("Expected ',' or ')' in named tuple")
+            self._advance()
+            self._skip_value_space()
+            if self._peek() == ")":
+                self._advance()
+                return result
+        raise self._error("Unterminated named tuple")
+
+    def _value(self) -> ?value:
+        char = self._peek()
+        if char == '"' or char == "'":
+            return self._string()
+        if char == "[":
+            return self._list()
+        if char == "(":
+            return self._named_tuple()
+        return self._atom()
+
+    def _block(self, indent: int) -> (table: dict[str, ?value], next_indent: ?int):
+        table: dict[str, ?value] = {}
+        current = indent
+        while True:
+            if current < indent:
+                return (table=table, next_indent=current)
+            if current > indent:
+                raise self._error("Unexpected indentation")
+
+            key = self._key()
+            self._skip_horizontal()
+            if key in table:
+                raise self._error(f"Duplicate field {repr(key)}")
+            if self._peek() == "=":
+                self._advance()
+                self._skip_horizontal()
+                table[key] = self._value()
+                self._line_end()
+                next_indent = self._entry_indent()
+                if isinstance(next_indent, int):
+                    current = next_indent
+                else:
+                    return (table=table, next_indent=None)
+            elif self._peek() == ":":
+                self._advance()
+                self._line_end()
+                child_indent = self._entry_indent()
+                if isinstance(child_indent, int):
+                    if child_indent <= indent:
+                        raise self._error(f"Section {repr(key)} must contain an indented field")
+                    child = self._block(child_indent)
+                    table[key] = child.table
+                    next_indent = child.next_indent
+                    if isinstance(next_indent, int):
+                        current = next_indent
+                    else:
+                        return (table=table, next_indent=None)
+                else:
+                    raise self._error(f"Section {repr(key)} must contain an indented field")
+            else:
+                raise self._error("Expected '=' or ':' after field name")
+        return (table=table, next_indent=None)
+
+    def parse_value(self) -> ?value:
+        self._skip_value_space()
+        result = self._value()
+        self._skip_value_whitespace()
+        if self._peek() != "":
+            raise self._error("Unexpected text after value")
+        return result
+
+    def parse(self) -> dict[str, ?value]:
+        indent = self._entry_indent()
+        if indent is None:
+            return {}
+        if indent != 0:
+            raise self._error("Top-level fields must not be indented")
+        result = self._block(0)
+        if result.next_indent is not None:
+            raise self._error("Invalid dedent")
+        return result.table
+
+
+class _Encoder(object):
+    indent: int
+
+    def __init__(self, indent: int):
+        if indent <= 0:
+            raise ValueError("ADL indentation must be positive")
+        self.indent = indent
+
+    def _padding(self, level: int) -> str:
+        return " " * (self.indent * level)
+
+    def _string(self, text: str) -> str:
+        escapes = {
+            '"': '\\"',
+            "\\": "\\\\",
+            "\b": "\\b",
+            "\f": "\\f",
+            "\n": "\\n",
+            "\r": "\\r",
+            "\t": "\\t",
+        }
+        parts = ['"']
+        for char in text:
+            if char in escapes:
+                parts.append(escapes[char])
+            elif ord(char) < 0x20 or char == "\x7f":
+                parts.append("\\u" + hex(ord(char))[2:].zfill(4))
+            else:
+                parts.append(char)
+        parts.append('"')
+        return "".join(parts)
+
+    def _key(self, key: str) -> str:
+        if _is_identifier(key):
+            return key
+        return self._string(key)
+
+    def _scalar(self, val: ?value) -> str:
+        if val is None:
+            return "None"
+        if isinstance(val, bool):
+            return "True" if val else "False"
+        if isinstance(val, int):
+            return str(val)
+        if isinstance(val, float):
+            if val != val or val == float("inf") or val == float("-inf"):
+                raise ValueError("ADL cannot encode non-finite floats")
+            text = "%.17g" % val
+            if "." not in text and "e" not in text and "E" not in text:
+                text += ".0"
+            return text
+        if isinstance(val, str):
+            return self._string(val)
+        raise ValueError(f"ADL cannot encode value {repr(val)}")
+
+    def _value(self, val: ?value, level: int) -> str:
+        if isinstance(val, list):
+            return self._list(val, level)
+        if isinstance(val, dict):
+            return self._tuple(val, level)
+        return self._scalar(val)
+
+    def _list(self, items: list[?value], level: int) -> str:
+        if len(items) == 0:
+            return "[]"
+        simple = True
+        for item in items:
+            if isinstance(item, list) or isinstance(item, dict):
+                simple = False
+        if simple:
+            encoded: list[str] = []
+            for item in items:
+                encoded.append(self._scalar(item))
+            return "[" + ", ".join(encoded) + "]"
+
+        parts = ["["]
+        for item in items:
+            parts.append(self._padding(level + 1) + self._value(item, level + 1) + ",")
+        parts.append(self._padding(level) + "]")
+        return "\n".join(parts)
+
+    def _tuple(self, fields: dict[str, ?value], level: int) -> str:
+        if len(fields) == 0:
+            return "()"
+        parts = ["("]
+        for key, val in fields.items():
+            parts.append(
+                self._padding(level + 1) + self._key(key)
+                + " = " + self._value(val, level + 1) + ","
+            )
+        parts.append(self._padding(level) + ")")
+        return "\n".join(parts)
+
+    def document(self, fields: dict[str, ?value], level: int=0) -> str:
+        parts: list[str] = []
+        for key, val in fields.items():
+            prefix = self._padding(level) + self._key(key)
+            if isinstance(val, dict) and len(val) > 0:
+                parts.append(prefix + ":")
+                parts.append(self.document(val, level + 1))
+            else:
+                parts.append(prefix + " = " + self._value(val, level))
+        return "\n".join(parts)
+
+
+def decode(data: str, source: str="<string>") -> dict[str, ?value]:
+    """Decode an ADL document into nested dictionaries, lists, and values."""
+    return _Parser(data, source).parse()
+
+
+def decode_value(data: str, source: str="<string>") -> ?value:
+    """Decode one standalone ADL value."""
+    return _Parser(data, source).parse_value()
+
+
+def encode(data: dict[str, ?value], indent: int=4) -> str:
+    """Encode a dictionary as a deterministic, order-preserving ADL document."""
+    result = _Encoder(indent).document(data)
+    return result + "\n" if result != "" else ""
+
+
+def encode_value(data: ?value, indent: int=4) -> str:
+    """Encode one standalone ADL value."""
+    return _Encoder(indent)._value(data, 0)

--- a/test/stdlib_tests/src/test_adl.act
+++ b/test/stdlib_tests/src/test_adl.act
@@ -1,0 +1,300 @@
+import adl
+import json
+import testing
+
+
+def _field(table: dict[str, ?value], name: str) -> ?value:
+    try:
+        return table[name]
+    except KeyError:
+        raise ValueError(f"Missing ADL field {repr(name)}")
+
+
+def _str_field(table: dict[str, ?value], name: str) -> str:
+    val = _field(table, name)
+    if isinstance(val, str):
+        return val
+    raise ValueError(f"ADL field {repr(name)} is not a string")
+
+
+def _int_field(table: dict[str, ?value], name: str) -> int:
+    val = _field(table, name)
+    if isinstance(val, int):
+        return val
+    raise ValueError(f"ADL field {repr(name)} is not an integer")
+
+
+def _float_field(table: dict[str, ?value], name: str) -> float:
+    val = _field(table, name)
+    if isinstance(val, float):
+        return val
+    raise ValueError(f"ADL field {repr(name)} is not a float")
+
+
+def _bool_field(table: dict[str, ?value], name: str) -> bool:
+    val = _field(table, name)
+    if isinstance(val, bool):
+        return val
+    raise ValueError(f"ADL field {repr(name)} is not a boolean")
+
+
+def _table_field(table: dict[str, ?value], name: str) -> dict[str, ?value]:
+    val = _field(table, name)
+    if isinstance(val, dict):
+        return val
+    raise ValueError(f"ADL field {repr(name)} is not a named tuple")
+
+
+def _int_list_field(table: dict[str, ?value], name: str) -> list[int]:
+    val = _field(table, name)
+    result: list[int] = []
+    if isinstance(val, list):
+        for item in val:
+            if isinstance(item, int):
+                result.append(item)
+            else:
+                raise ValueError(f"ADL field {repr(name)} is not an integer list")
+        return result
+    raise ValueError(f"ADL field {repr(name)} is not an integer list")
+
+
+def _str_list_field(table: dict[str, ?value], name: str) -> list[str]:
+    val = _field(table, name)
+    result: list[str] = []
+    if isinstance(val, list):
+        for item in val:
+            if isinstance(item, str):
+                result.append(item)
+            else:
+                raise ValueError(f"ADL field {repr(name)} is not a string list")
+        return result
+    raise ValueError(f"ADL field {repr(name)} is not a string list")
+
+
+def _test_sections_and_scalar_values():
+    document = adl.decode(r'''
+name = "example"
+enabled = True
+limit = None
+
+network:
+    port = 830
+    ratio = 1.5
+    exponent = 1e3
+    mask = 0xdead_beef
+    capacity = 1_000
+    tls:
+        enabled = False
+
+"display name":
+    greeting = "hello\nworld"
+''', "settings.adl")
+
+    testing.assertEqual(_str_field(document, "name"), "example")
+    testing.assertEqual(_bool_field(document, "enabled"), True)
+    testing.assertTrue(_field(document, "limit") is None)
+    network = _table_field(document, "network")
+    testing.assertEqual(_int_field(network, "port"), 830)
+    testing.assertEqual(_float_field(network, "ratio"), 1.5)
+    testing.assertEqual(_float_field(network, "exponent"), 1000.0)
+    testing.assertEqual(_int_field(network, "mask"), 0xdeadbeef)
+    testing.assertEqual(_int_field(network, "capacity"), 1000)
+    tls = _table_field(network, "tls")
+    testing.assertEqual(_bool_field(tls, "enabled"), False)
+
+    display = _table_field(document, "display name")
+    testing.assertEqual(_str_field(display, "greeting"), "hello\nworld")
+
+
+def _test_lists_and_named_tuples():
+    document = adl.decode(r'''
+ports = [80, 443]
+peers = [
+    (host = "one", port = 830),
+    (
+        host = "two",
+        port = 831,
+        tags = ["edge", "backup"],
+    ),
+]
+''')
+
+    testing.assertEqual(_int_list_field(document, "ports"), [80, 443])
+    peers = _field(document, "peers")
+    if isinstance(peers, list):
+        testing.assertEqual(len(peers), 2)
+        first = peers[0]
+        second = peers[1]
+        if isinstance(first, dict) and isinstance(second, dict):
+            testing.assertEqual(_str_field(first, "host"), "one")
+            testing.assertEqual(_int_field(first, "port"), 830)
+            testing.assertEqual(_str_field(second, "host"), "two")
+            testing.assertEqual(_str_list_field(second, "tags"), ["edge", "backup"])
+        else:
+            raise ValueError("Expected named tuples in structured list")
+    else:
+        raise ValueError("Expected peers to be a list")
+
+
+def _test_standalone_values():
+    value = adl.decode_value('[(name = "one"), (name = "two")]')
+    if isinstance(value, list):
+        testing.assertEqual(len(value), 2)
+    else:
+        raise ValueError("Expected standalone ADL list")
+
+    commented = adl.decode_value("[1, # inner comment\n2]")
+    if isinstance(commented, list):
+        testing.assertEqual(len(commented), 2)
+    else:
+        raise ValueError("Expected comments inside a standalone ADL list")
+
+    try:
+        adl.decode_value("[1, 2] # trailing comment")
+    except adl.AdlParseError:
+        pass
+    else:
+        raise ValueError("Expected trailing text after an ADL value to fail")
+
+
+def _test_acton_string_escapes():
+    escaped = adl.decode_value(r'''"\a\v\x48\123"''')
+    continued = adl.decode_value('"one' + "\\" + "\n" + 'two"')
+    if isinstance(escaped, str) and isinstance(continued, str):
+        testing.assertEqual(escaped, "\a\vHS")
+        testing.assertEqual(continued, "onetwo")
+    else:
+        raise ValueError("Expected Acton string escapes to decode as a string")
+
+    for text in [r'''"\x4"''', r'''"\400"''']:
+        try:
+            adl.decode_value(text)
+        except adl.AdlParseError:
+            pass
+        else:
+            raise ValueError(f"Expected invalid Acton escape to fail: {repr(text)}")
+
+
+def _test_deterministic_encoding_and_json_conversion():
+    json_text = r'''{"name":"example","enabled":true,"limit":null,"ratio":1.25,"network":{"port":830,"tls":false},"empty":{},"tags":["edge","backup"],"peers":[{"host":"one","port":830},{"host":"two","port":831}]}'''
+    document = json.decode(json_text)
+    encoded = adl.encode(document)
+    testing.assertEqual(encoded, '''name = "example"
+enabled = True
+limit = None
+ratio = 1.25
+network:
+    port = 830
+    tls = False
+empty = ()
+tags = ["edge", "backup"]
+peers = [
+    (
+        host = "one",
+        port = 830,
+    ),
+    (
+        host = "two",
+        port = 831,
+    ),
+]
+''')
+    testing.assertEqual(json.encode(adl.decode(encoded)), json_text)
+
+    adl_text = '''service:
+  name = "example"
+  ports = [80, 443]
+'''
+    testing.assertEqual(
+        adl.encode(json.decode(json.encode(adl.decode(adl_text))), indent=2),
+        adl_text
+    )
+
+    unusual_keys: dict[str, ?value] = {
+        "": 1,
+        "display name": 2,
+        'say"hi': 3,
+        "line\nbreak": 4,
+        "räksmörgås": 5,
+        "_bare9": 6,
+    }
+    encoded_keys = adl.encode(unusual_keys)
+    testing.assertEqual(encoded_keys, r'''"" = 1
+"display name" = 2
+"say\"hi" = 3
+"line\nbreak" = 4
+"räksmörgås" = 5
+_bare9 = 6
+''')
+    testing.assertEqual(json.encode(adl.decode(encoded_keys)), json.encode(unusual_keys))
+
+
+def _test_standalone_encoding():
+    text = "line\n\"quoted\"\\tab\t\x01"
+    encoded = adl.encode_value(text)
+    testing.assertEqual(encoded, r'''"line\n\"quoted\"\\tab\t\u0001"''')
+    decoded = adl.decode_value(encoded)
+    if isinstance(decoded, str):
+        testing.assertEqual(decoded, text)
+    else:
+        raise ValueError("Expected encoded ADL string to round trip")
+
+    empty: dict[str, ?value] = {}
+    testing.assertEqual(adl.encode(empty), "")
+    testing.assertEqual(adl.encode_value(empty), "()")
+    testing.assertEqual(adl.encode_value([]), "[]")
+
+    testing.assertEqual(adl.encode_value(1.0), "1.0")
+    testing.assertEqual(adl.encode_value(-0.0), "-0.0")
+    precise = 1.2345678901234567
+    decoded_float = adl.decode_value(adl.encode_value(precise))
+    if isinstance(decoded_float, float):
+        testing.assertEqual(decoded_float, precise)
+    else:
+        raise ValueError("Expected encoded ADL float to retain its type")
+
+
+def _test_encoding_rejects_unrepresentable_values():
+    try:
+        adl.encode_value(float("inf"))
+    except ValueError:
+        pass
+    else:
+        raise ValueError("Expected non-finite float encoding to fail")
+
+    try:
+        adl.encode_value(b"bytes")
+    except ValueError:
+        pass
+    else:
+        raise ValueError("Expected unsupported value encoding to fail")
+
+    try:
+        adl.encode({}, indent=0)
+    except ValueError:
+        pass
+    else:
+        raise ValueError("Expected non-positive indentation to fail")
+
+
+def _test_invalid_layout_and_fields():
+    invalid = [
+        "  indented = 1\n",
+        "section:\nvalue = 1\n",
+        "section:\n\tvalue = 1\n",
+        "value = 1\nvalue = 2\n",
+        "items = [(a = 1, a = 2)]\n",
+        "value = _1\n",
+        "value = 1_\n",
+        "value = 1__0\n",
+        "value = 0x_FF\n",
+        "value = 1_e2\n",
+        "value = 1e309\n",
+    ]
+    for text in invalid:
+        try:
+            adl.decode(text, "invalid.adl")
+        except adl.AdlParseError as error:
+            testing.assertTrue("invalid.adl:" in str(error))
+        else:
+            raise ValueError(f"Expected invalid ADL to fail: {repr(text)}")


### PR DESCRIPTION
Adds Acton Object Notation (AON), a small indentation-based format shaped like Acton values. It supports nested sections, lists, named tuples, scalar values, comments, source-aware errors, and symmetric encoding and decoding. AON and JSON use the same data representation, so conversion is straightforward.

Includes matching base and std modules and tests for parsing, encoding, conversion, numeric round trips, escaping, and invalid input. The full build passes and all eight AON tests pass.