### PR TITLE
Effectively treat pure and mut as interchangeable (for now)

### DIFF
--- a/compiler/lib/src/Acton/Env.hs
+++ b/compiler/lib/src/Acton/Env.hs
@@ -1127,6 +1127,10 @@ castable env (TFX _ fx1) (TFX _ fx2)        = castable' fx1 fx2
         castable' FXProc   FXProc           = True
         castable' FXAction FXAction         = True
         castable' FXAction FXProc           = True
+
+        castable' FXMut    FXPure           = True      -- Hideous lies! But a temporarily justifiable deception.
+        castable' FXPure   FXAction         = True
+
         castable' fx1      fx2              = False
 
 castable env (TNil _ k1) (TNil _ k2)

--- a/compiler/lib/src/Acton/Solver.hs
+++ b/compiler/lib/src/Acton/Solver.hs
@@ -899,6 +899,10 @@ cast' env info t1@(TFX _ fx1) t2@(TFX _ fx2)
         castFX FXProc   FXProc              = True
         castFX FXAction FXAction            = True
         castFX FXAction FXProc              = True
+
+        castFX FXMut    FXPure              = True      -- Hideous lies! But a temporarily justifiable deception.
+        castFX FXPure   FXAction            = True
+
         castFX _        _                   = False
 
 cast' env info (TUni _ tv) t2@TFun{}


### PR DESCRIPTION
Also allow pure callouts in action callbacks (for now).

The first wart will be removed once we have good immutable data structures and a method of safely inferring/allowing local mutations inside otherwise pure functions. The second one goes away the day effects can be redefined as sets of effect tokens, with `pure` standing for the empty set.

Relaxing the effect hierarchy like we do now opens up for less contrieved application code, which currently is more important than fully "correct" effect inference.