### PR TITLE
Report build and test phase timings

### DIFF
--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -236,6 +236,13 @@ fmtTimePrecise t =
     secs :: Float
     secs = (fromIntegral (sec t)) + (fromIntegral (nsec t) / 1000000000)
 
+-- | Report elapsed wall time; parallel compiler/build steps can overlap.
+logTiming :: C.GlobalOptions -> C.CompileOptions -> (String -> IO ()) -> String -> TimeSpec -> IO ()
+logTiming gopts opts logLine label start =
+    when (C.timing gopts && not (quiet gopts opts)) $ do
+      end <- getTime Monotonic
+      logLine ("Timing: " ++ label ++ " " ++ fmtTimePrecise (diffTimeSpec end start))
+
 -- | Format a TimeSpec with second granularity for compact narrow logs.
 fmtTimeCompact :: TimeSpec -> String
 fmtTimeCompact t =
@@ -655,7 +662,9 @@ runTestsOnce gopts opts topts mode paths = do
         maxParallel0 <- testMaxParallel gopts
         let maxParallel = if mode == TestModeStress then 1 else maxParallel0
         useColorOut <- useColor gopts
+        testStart <- getTime Monotonic
         exitCode <- runProjectTests useColorOut gopts opts paths topts mode modules maxParallel
+        logTiming gopts opts putStrLn "test execution and cache" testStart
         exitWithTestCode exitCode
 
 -- | Watch mode for tests that rebuilds incrementally and reruns changed modules.
@@ -679,12 +688,16 @@ runTestsWatch gopts opts topts mode paths = do
                 hadErrors <- if null selected then return False else
                   compileFilesChanged sp gopts opts selected (selected == srcFiles) Nothing (Just (sched, gen)) (Just (progressUI, progressState))
                 unless hadErrors $ do
+                  selectStart <- getTime Monotonic
                   testModules <- mapM (fmap modNameToString . moduleNameFromFile (srcDir paths) (projName paths)) selected
                   modulesToTest <- selectTestModules paths srcFiles mChanged testModules
+                  logTiming gopts opts (progressLogLine progressUI) "affected test selection" selectStart
                   unless (null modulesToTest) $
                     do
                       useColorOut <- useColor gopts
+                      testStart <- getTime Monotonic
                       void $ runProjectTests useColorOut gopts opts paths topts mode modulesToTest testParallel
+                      logTiming gopts opts (progressLogLine progressUI) "test execution and cache" testStart
         runWatchProject gopts projDir srcRoot sched runOnce
 
 selectTestModules :: Paths -> [FilePath] -> Maybe [FilePath] -> [String] -> IO [String]
@@ -1406,8 +1419,10 @@ compileFilesChanged sp gopts opts srcFiles allowPrune mChangedPaths mSched mProg
     cleanupProgress
     let runCompile = do
           sp' <- overlayChangedPaths sp mChangedPaths
+          planStart <- getTime Monotonic
           planRes <- try $
             prepareCompilePlan sp' gopts sched opts srcFiles allowPrune mChangedPaths
+          logTiming gopts opts logLine "compile planning" planStart
           let reportPlanError (ProjectError msg) = do
                 if C.watch opts
                   then logLine msg
@@ -1431,6 +1446,7 @@ compileFilesChanged sp gopts opts srcFiles allowPrune mChangedPaths mSched mProg
                     reportCompileErrors =
                       finalizeCompile $
                         unless watchMode System.Exit.exitFailure
+                compileStart <- getTime Monotonic
                 compileRes <- runCompilePlan sp gopts plan sched gen (cchHooks cliHooks)
                 case compileRes of
                   Left err ->
@@ -1440,6 +1456,7 @@ compileFilesChanged sp gopts opts srcFiles allowPrune mChangedPaths mSched mProg
                       if C.only_build opts'
                         then return Nothing
                         else backQueueWait (csBackQueue sched) gen
+                    logTiming gopts opts' logLine "Acton compilation" compileStart
                     case backFailure of
                       Just failure ->
                         reportCompileError (backPassFailureMessage failure)
@@ -2030,6 +2047,7 @@ runCliPostCompile :: CliCompileHooks
                   -> Acton.Env.Env0
                   -> IO ()
 runCliPostCompile cliHooks gopts plan env = do
+    prepStart <- getTime Monotonic
     let logLine = cchLogLine cliHooks
     let cctx = cpContext plan
         opts' = ccOpts cctx
@@ -2080,6 +2098,7 @@ runCliPostCompile cliHooks gopts plan env = do
                 depPathOverrides = projectDepPathOverrides projMap p
             genBuildZigFiles (projBuildSpec pctx) rootPins (ccDepOverrides cctx) dummyPaths depOpts depPathOverrides
           Nothing -> return ()
+    logTiming gopts opts' logLine "dependency build preparation" prepStart
     let runFinal action = do
           cchFinalStart cliHooks
           action `onException` cchFinalDone cliHooks False
@@ -2499,10 +2518,17 @@ runZig gopts opts zigExe zigArgs paths wd mProgressUI = do
           Just (k, v) -> Just ((k, v) : filter ((/= k) . fst) envWithZigCache)
         cpBase = (proc zigExe zigArgs){ cwd = wd, env = env2 }
         cp = if closeFds then cpBase else cpBase { close_fds = False }
+    zigStart <- getTime Monotonic
     (returnCode, zigStdout, zigStderr) <- readProcessWithExitCodeCancelable cp onStart `finally` onStop
+    let logLine = maybe putStrLn progressLogLine mProgressUI
+    logTiming gopts opts logLine "Zig build" zigStart
     case returnCode of
         ExitSuccess -> do
           iff (C.verboseZig gopts) $ putStrLn zigStderr
+          when (C.timing gopts && not (quiet gopts opts) && not (C.verboseZig gopts)) $
+            -- Zig's summary includes cache hits and elapsed C/link build steps.
+            -- Their durations overlap when Zig runs them in parallel.
+            mapM_ logLine (dropWhile (not . isPrefixOf "Build Summary:") (lines zigStderr))
           return ()
         ExitFailure ret -> do
           printIce ("compilation of generated Zig code failed, returned error code" ++ show ret)
@@ -2789,6 +2815,7 @@ defCpuFlag = ["-Dcpu=x86_64_v2+aes"]
 -- | Run zig build for generated artifacts and prune stale outputs.
 zigBuild :: Acton.Env.Env0 -> C.GlobalOptions -> C.CompileOptions -> Paths -> BuildSpec.BuildSpec -> [CompileTask] -> [BinTask] -> Bool -> [FilePath] -> [BuildLibrary] -> M.Map String String -> M.Map String FilePath -> Maybe ProgressUI -> IO ()
 zigBuild env gopts opts paths rootSpec tasks binTasks allowPrune rootModules buildLibraries depModuleOpts depPathOverrides mProgressUI = do
+    prepStart <- getTime Monotonic
     allBinTasks <- mapM (writeRootC env gopts opts paths tasks) binTasks
     let realBinTasks = catMaybes allBinTasks
 
@@ -2823,7 +2850,8 @@ zigBuild env gopts opts paths rootSpec tasks binTasks allowPrune rootModules bui
     let zigExe = zig paths
         baseArgs = ["build","--cache-dir", local_cache_dir,
                             "--global-cache-dir", global_cache_dir] ++
-                   (if (C.verboseZig gopts) then ["--verbose"] else [])
+                   (if (C.verboseZig gopts) then ["--verbose"] else []) ++
+                   (if C.timing gopts && not (quiet gopts opts) then ["--summary", "all", "--color", "off"] else [])
         prefixArgs = ["--prefix", projOut paths, "--prefix-exe-dir", "bin"] ++
                      (if (C.verboseZig gopts) then ["--verbose"] else [])
         targetArgs = ["-Dtarget=" ++ C.target opts]
@@ -2850,6 +2878,7 @@ zigBuild env gopts opts paths rootSpec tasks binTasks allowPrune rootModules bui
                              ]
         zigArgs = baseArgs ++ prefixArgs ++ targetArgs ++ cpuArgs ++ optArgs ++ moduleArgs ++ featureArgs
 
+    logTiming gopts opts (maybe putStrLn progressLogLine mProgressUI) "root and build file preparation" prepStart
     runZig gopts opts zigExe zigArgs paths (Just (projPath paths)) mProgressUI
     -- if we are in a temp acton project, copy the outputted binary next to the source file
     if (isTmp paths && not (null realBinTasks))

--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -1448,15 +1448,14 @@ compileFilesChanged sp gopts opts srcFiles allowPrune mChangedPaths mSched mProg
                         unless watchMode System.Exit.exitFailure
                 compileStart <- getTime Monotonic
                 compileRes <- runCompilePlan sp gopts plan sched gen (cchHooks cliHooks)
+                backFailure <- case compileRes of
+                  Right _ | not (C.only_build opts') -> backQueueWait (csBackQueue sched) gen
+                  _ -> return Nothing
+                logTiming gopts opts' logLine "Acton compilation" compileStart
                 case compileRes of
                   Left err ->
                     reportCompileError (compileFailureMessage err)
                   Right (env, hadErrors) -> do
-                    backFailure <-
-                      if C.only_build opts'
-                        then return Nothing
-                        else backQueueWait (csBackQueue sched) gen
-                    logTiming gopts opts' logLine "Acton compilation" compileStart
                     case backFailure of
                       Just failure ->
                         reportCompileError (backPassFailureMessage failure)

--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -7,6 +7,7 @@ import Data.List.Split
 import Data.Maybe (catMaybes)
 import Data.Ord
 import Data.Time.Clock.POSIX
+import qualified Data.Aeson as Ae
 import qualified Data.ByteString.Lazy.Char8 as LBS
 
 import Control.Exception (catch, IOException)
@@ -1389,6 +1390,57 @@ parseFlagTests =
         -- Its inferred return type becomes eligible when the import changes.
         writeFile provider "def value():\n    return None\n"
         checkCount (1 :: Int)
+  , testCase "build and test timings respect output modes" $ do
+      withSystemTempDirectory "acton-build-timing" $ \proj -> do
+        acton <- canonicalizePath "../../dist/bin/acton"
+        let name = "build_timing"
+            fp = Fingerprint.formatFingerprint
+              (Fingerprint.updateFingerprintPrefix
+                (Fingerprint.fingerprintPrefixForName name) 1)
+            run args = do
+              (code, out, err) <- readCreateProcessWithExitCode (proc acton args) { cwd = Just proj } ""
+              assertEqual ("acton " ++ unwords args ++ " failed:\n" ++ out ++ err) ExitSuccess code
+              return out
+            checkNoTiming out = do
+              assertBool "timing details should be omitted" (not ("Timing:" `isInfixOf` out))
+              assertBool "Zig summary should be omitted" (not ("Build Summary:" `isInfixOf` out))
+            checkSummary out = do
+              let summaries = filter ("Build Summary:" `isPrefixOf`) (lines out)
+              assertEqual "Zig summary should be printed once" 1 (length summaries)
+              assertBool "Zig summary should not contain terminal escapes"
+                (all (notElem '\ESC') summaries)
+        createDirectoryIfMissing True (proj </> "src")
+        writeFile (proj </> "Build.act") $ unlines
+          [ "name = " ++ show name
+          , "fingerprint = " ++ fp
+          ]
+        writeFile (proj </> "src" </> "main.act") $ unlines
+          [ "import testing"
+          , ""
+          , "def _test_ready():"
+          , "    testing.assertEqual(1, 1)"
+          , ""
+          , "actor main(env):"
+          , "    env.exit(0)"
+          ]
+        buildOut <- run ["build", "--timing", "--color", "always"]
+        forM_ [ "compile planning", "Acton compilation", "dependency build preparation"
+              , "root and build file preparation", "Zig build" ] $ \phase ->
+          assertBool ("missing timing phase: " ++ phase)
+            (("Timing: " ++ phase) `isInfixOf` buildOut)
+        checkSummary buildOut
+        testOut <- run ["test", "--timing", "--no-cache", "--iter", "1"]
+        assertBool "test execution should be timed" ("Timing: test execution and cache" `isInfixOf` testOut)
+        checkSummary testOut
+        checkNoTiming =<< run ["build", "--timing", "--quiet"]
+        jsonOut <- run ["test", "--timing", "--json", "--no-cache", "--iter", "1"]
+        checkNoTiming jsonOut
+        assertBool "JSON output should remain valid"
+          (case Ae.eitherDecode (LBS.pack jsonOut) :: Either String Ae.Value of
+             Right _ -> True
+             Left _ -> False)
+        checkNoTiming =<< run ["build", "--timing", "--always-build", "--types", "src/main.act"]
+        checkSummary =<< run ["build", "--timing", "--verbose-zig"]
   , testCase "acton test reruns cached snapshot when expected file changes" $ do
       withSystemTempDirectory "acton-test-snapshot-cache" $ \proj -> do
         actonBinDir <- Paths_acton.getBinDir

--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -1441,6 +1441,18 @@ parseFlagTests =
              Left _ -> False)
         checkNoTiming =<< run ["build", "--timing", "--always-build", "--types", "src/main.act"]
         checkSummary =<< run ["build", "--timing", "--verbose-zig"]
+        -- Cyclic imports fail runCompilePlan itself, before normal type-error handling.
+        writeFile (proj </> "src" </> "cycle_a.act") "import cycle_b\n"
+        writeFile (proj </> "src" </> "cycle_b.act") "import cycle_a\n"
+        forM_ [([], True), (["--quiet"], False)] $ \(flags, visible) -> do
+          (code, out, err) <- readCreateProcessWithExitCode
+            (proc acton (["build", "--timing"] ++ flags)) { cwd = Just proj } ""
+          assertEqual ("cyclic imports should fail:\n" ++ out ++ err) (ExitFailure 1) code
+          assertBool ("failure should come from cyclic imports:\n" ++ out ++ err)
+            ("Cyclic imports:" `isInfixOf` (out ++ err))
+          assertEqual "failed compilation timing respects output mode" (if visible then 1 else 0)
+            (length (filter ("Timing: Acton compilation " `isPrefixOf`) (lines out)))
+          assertBool "failed Acton compilation should not run Zig" (not ("Timing: Zig build " `isInfixOf` out))
   , testCase "acton test reruns cached snapshot when expected file changes" $ do
       withSystemTempDirectory "acton-test-snapshot-cache" $ \proj -> do
         actonBinDir <- Paths_acton.getBinDir

--- a/docs/acton-guide/src/testing.md
+++ b/docs/acton-guide/src/testing.md
@@ -58,6 +58,12 @@ Note that test input need to be contained within .act source code files in order
 
 Snapshot tests are the main exception: even when the test code hash matches the cache, `acton test` still checks the expected snapshot file on disk against the cached `snapshots/output/...` metadata. If the output snapshot is missing, the expected file changed, or Acton cannot cheaply prove the expected file is older than the last produced output, the test is rerun instead of trusting the cached result.
 
+## Build timings
+
+Use `acton test --timing` (also with `--watch`) to see wall times for compile planning, Acton compilation, build preparation, Zig build, and test execution/cache handling. `acton build --timing` reports the same compilation and build phases.
+
+Zig's build summary shows which libraries and executables were rebuilt or cached. Each build step includes its C compilation and linking; steps can run in parallel, so their durations do not add up to the overall Zig build time. Quiet and JSON output omit timing details.
+
 ## Module Filtering
 
 You can run tests from specific modules using the `--module` flag:


### PR DESCRIPTION
`--timing` now reports wall time for build planning, Acton compilation, dependency and root build preparation, the Zig invocation, and test execution. Zig also reports its compile/link and cache summary, so slow edit cycles can be traced to a build phase.

The extra output respects quiet, JSON, and alternate compiler output modes and works for both one-shot and watch commands.
