### PR TITLE
Compile only selected test modules

### DIFF
--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -643,8 +643,12 @@ runTests gopts cmd = do
 -- | Build once and then list/run tests based on the selected mode.
 runTestsOnce :: C.GlobalOptions -> C.CompileOptions -> C.TestOptions -> TestMode -> Paths -> IO ()
 runTestsOnce gopts opts topts mode paths = do
-    buildProjectOnce gopts opts
-    modules <- listTestModules opts paths
+    modules <- withProjectLockNotice gopts (projPath paths) $ do
+      srcFiles <- projectSourceFiles paths
+      selected <- selectTestSources gopts opts paths topts srcFiles
+      unless (null selected) $
+        compileFiles Source.diskSourceProvider gopts opts selected (selected == srcFiles)
+      mapM (fmap modNameToString . moduleNameFromFile (srcDir paths) (projName paths)) selected
     case mode of
       TestModeList -> listProjectTests opts paths topts modules
       _ -> do
@@ -669,9 +673,13 @@ runTestsWatch gopts opts topts mode paths = do
               withProjectLockForGen gopts sched gen projDir $ do
                 logProjectBuild gopts progressUI progressState projDir
                 srcFiles <- projectSourceFiles paths
-                hadErrors <- compileFilesChanged sp gopts opts srcFiles True mChanged (Just (sched, gen)) (Just (progressUI, progressState))
+                selected <- selectTestSources gopts opts paths topts srcFiles
+                -- Link the complete selected closure; cached modules still skip
+                -- unchanged compiler passes.
+                hadErrors <- if null selected then return False else
+                  compileFilesChanged sp gopts opts selected (selected == srcFiles) Nothing (Just (sched, gen)) (Just (progressUI, progressState))
                 unless hadErrors $ do
-                  testModules <- listTestModules opts paths
+                  testModules <- mapM (fmap modNameToString . moduleNameFromFile (srcDir paths) (projName paths)) selected
                   modulesToTest <- selectTestModules paths srcFiles mChanged testModules
                   unless (null modulesToTest) $
                     do
@@ -2046,7 +2054,9 @@ runCliPostCompile cliHooks gopts plan env = do
         preBinTasks
           | null (C.root opts') = map (\t -> BinTask True (modNameToString (name t)) (A.GName (name t) (A.name "main")) False) rootTasks
           | otherwise        = [binTask]
-        preTestBinTasks = map (\t -> BinTask True (modNameToString (name t)) (A.GName (name t) (A.name "test_main")) True) rootTasks
+    requestedModules <- mapM (moduleNameFromFile (srcDir pathsRoot) proj) (cpSrcFiles plan)
+    let preTestBinTasks = [ BinTask True (modNameToString (name t)) (A.GName (name t) (A.name "test_main")) True
+                          | t <- rootTasks, name t `elem` requestedModules ]
         selectedTasksByProj = selectedTasksWithProvidersByProj globalTasks neededTasks
         depModuleOptsByProj = depModuleOptionsByProj selectedTasksByProj projMap
         rootSelectedModuleEntries = selectedCSourceEntriesForProj rootProj (M.findWithDefault [] rootProj selectedTasksByProj)

--- a/compiler/acton/TestRunner.hs
+++ b/compiler/acton/TestRunner.hs
@@ -1,14 +1,15 @@
 module TestRunner
   ( TestMode(..)
-  , listTestModules
   , listProjectTests
   , runProjectTests
+  , selectTestSources
   ) where
 
 import qualified Acton.CommandLineParser as C
 import Acton.Testing
 import Acton.Compile
 import qualified Acton.Syntax as A
+import qualified Acton.SourceProvider as Source
 import qualified InterfaceFiles
 import TestFormat
 import TestUI
@@ -27,7 +28,7 @@ import qualified Data.Set as Set
 import System.Clock
 import System.Directory
 import System.Exit
-import System.FilePath ((</>), (<.>), joinPath, takeExtension)
+import System.FilePath ((</>), (<.>), joinPath)
 import System.IO (hClose, hGetContents, hGetLine, hIsEOF)
 import System.Process
 import Text.Printf
@@ -87,16 +88,6 @@ printErrorAndExit msg = do
     errorWithoutStackTrace msg
     exitFailure
 
--- | List test modules by reading discovered tests from .tydb headers.
-listTestModules :: C.CompileOptions -> Paths -> IO [String]
-listTestModules _opts paths = do
-    srcFiles <- listActFilesRecursive (srcDir paths)
-    mods <- forM srcFiles $ \file -> do
-      mn <- moduleNameFromFile (srcDir paths) (projName paths) file
-      tests <- readModuleTests paths mn
-      return $ if null tests then Nothing else Just (modNameToString mn)
-    return (Data.List.sort (catMaybes mods))
-
 -- | Compute the test binary path for a module and target.
 testBinaryPath :: C.CompileOptions -> Paths -> String -> FilePath
 testBinaryPath opts paths modName =
@@ -116,6 +107,47 @@ isWindowsTarget targetTriple =
 
 modulesOpt paths topts = [ proj ++ "." ++ m | m <- C.testModules topts ]
   where proj = projName paths
+
+-- | Select compilation roots without changing the contents of module caches.
+-- A cached test list can confirm a match, but cannot rule one out: a changed
+-- import may change an inferred function type and make it eligible as a test.
+selectTestSources :: C.GlobalOptions -> C.CompileOptions -> Paths -> C.TestOptions -> [FilePath] -> IO [FilePath]
+selectTestSources gopts opts paths topts files = do
+    regexes <- compileTestNameRegexes (C.testNames topts)
+    let wanted = modulesOpt paths topts
+        matches = not . null . filterTests regexes
+    filterM (selected wanted matches) files
+  where
+    sp = Source.diskSourceProvider
+    selected wanted matches file = do
+      mn <- moduleNameFromFile (srcDir paths) (projName paths) file
+      if not (null wanted) && modNameToString mn `notElem` wanted
+        then return False
+        else if null (C.testNames topts)
+          then return True
+          else do
+            task <- readModuleTask sp gopts opts paths { modName = mn } file
+            case task of
+              TyTask{ tyTests = names } | matches names -> return True
+              ParseTask{ src = source } -> fromSource mn matches file source
+              ParseErrorTask{} -> return True
+              _ -> Source.spReadFile sp file >>= fromSource mn matches file . Source.ssText
+    fromSource mn matches file source = do
+      parsed <- parseActSource opts mn file source Nothing
+      -- Let the normal compilation path report parse failures.
+      return $ either (const True) (matches . candidates . A.mbody) parsed
+    candidates = concatMap names
+    names (A.With _ _ ss) = candidates ss
+    names (A.Decl _ ds) = concatMap declNames ds
+    names _ = []
+    declNames d@A.Def{}
+      | "_test_" `isPrefixOf` A.nstr (A.dname d) = [A.nstr (A.dname d)]
+    -- Actor parameter types are resolved later. Include possible wrapper
+    -- names here and leave exact discovery to the type checker.
+    declNames d@A.Actor{} =
+      let n = A.nstr (A.dname d)
+      in [if "_test_" `isPrefixOf` n then n ++ "_wrapper" else "_test_" ++ n]
+    declNames _ = []
 
 -- | List tests for selected modules and print them in a stable order.
 listProjectTests :: C.CompileOptions -> Paths -> C.TestOptions -> [String] -> IO ()
@@ -593,21 +625,6 @@ splitOnChar :: Char -> String -> [String]
 splitOnChar ch input = case break (== ch) input of
   (chunk, []) -> [chunk]
   (chunk, _ : rest) -> chunk : splitOnChar ch rest
-
-listActFilesRecursive :: FilePath -> IO [FilePath]
-listActFilesRecursive dir = do
-    exists <- doesDirectoryExist dir
-    if not exists
-      then return []
-      else do
-        entries <- listDirectory dir
-        paths <- forM entries $ \entry -> do
-          let path = dir </> entry
-          isDir <- doesDirectoryExist path
-          if isDir
-            then listActFilesRecursive path
-            else return [path]
-        return (filter (\f -> takeExtension f == ".act") (concat paths))
 
 -- | Run a single test case and stream JSON updates.
 runModuleTestStreaming :: C.CompileOptions

--- a/compiler/acton/TestRunner.hs
+++ b/compiler/acton/TestRunner.hs
@@ -113,10 +113,15 @@ modulesOpt paths topts = [ proj ++ "." ++ m | m <- C.testModules topts ]
 -- import may change an inferred function type and make it eligible as a test.
 selectTestSources :: C.GlobalOptions -> C.CompileOptions -> Paths -> C.TestOptions -> [FilePath] -> IO [FilePath]
 selectTestSources gopts opts paths topts files = do
+    start <- getTime Monotonic
     regexes <- compileTestNameRegexes (C.testNames topts)
     let wanted = modulesOpt paths topts
         matches = not . null . filterTests regexes
-    filterM (selected wanted matches) files
+    sources <- filterM (selected wanted matches) files
+    when (C.timing gopts && not (quiet gopts opts)) $ do
+      end <- getTime Monotonic
+      putStrLn ("Timing: test source selection " ++ fmtTime (diffTimeSpec end start))
+    return sources
   where
     sp = Source.diskSourceProvider
     selected wanted matches file = do

--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -1203,6 +1203,186 @@ parseFlagTests =
       assertEqual "acton test --help stderr" "" cmdErr
       assertBool "acton test --help should include --no-cache" ("--no-cache" `isInfixOf` cmdOut)
       assertBool "acton test --help should include --tag" ("--tag" `isInfixOf` cmdOut)
+  , testCase "acton test compiles selected modules and their imports" $ do
+      withSystemTempDirectory "acton-test-selection" $ \proj -> do
+        acton <- canonicalizePath "../../dist/bin/acton"
+        let name = "test_selection"
+            fp = Fingerprint.formatFingerprint
+              (Fingerprint.updateFingerprintPrefix
+                (Fingerprint.fingerprintPrefixForName name) 1)
+            srcDir = proj </> "src"
+            cFile m = proj </> "out" </> "types" </> name </> m <.> "c"
+            testBin m = proj </> "out" </> "bin" </> (".test_" ++ m)
+            appBin = proj </> "out" </> "bin" </> "app"
+            runTest args = readCreateProcessWithExitCode
+              (proc acton (["test", "--json", "--no-cache", "--iter", "1"] ++ args)) { cwd = Just proj } ""
+            checkTests args expected = do
+              (code, out, err) <- runTest args
+              assertEqual ("acton test " ++ unwords args ++ " failed:\nstdout:\n" ++ out ++ "\nstderr:\n" ++ err)
+                ExitSuccess code
+              assertBool ("unexpected test count for acton test " ++ unwords args ++ ":\n" ++ out)
+                (("\"total\":" ++ show (length expected)) `isInfixOf` out)
+              forM_ expected $ \raw ->
+                assertBool ("missing test " ++ raw ++ ":\n" ++ out)
+                  (("\"raw_name\":\"" ++ raw ++ "\"") `isInfixOf` out)
+            assertFile label expected file = do
+              exists <- doesFileExist file
+              assertEqual label expected exists
+            checkApp = do
+              (code, out, err) <- readCreateProcessWithExitCode (proc appBin []) ""
+              assertEqual ("standalone application should run: " ++ err) ExitSuccess code
+              assertEqual "standalone application output" "standalone app\n" out
+        createDirectoryIfMissing True srcDir
+        writeFile (proj </> "Build.act") $ unlines
+          [ "name = " ++ show name
+          , "fingerprint = " ++ fp
+          , "libraries = {"
+          , "    \"production\": (modules=[\"chosen\", \"broken\"], linkage=\"static\")"
+          , "}"
+          ]
+        writeFile (srcDir </> "chosen.act") $ unlines
+          [ "import std.math"
+          , "import testing"
+          , "import provider"
+          , ""
+          , "actor _test_foo(t: testing.EnvT):"
+          , "    assert provider.ready()"
+          , "    t.success()"
+          , ""
+          , "def _test_foobar() -> None:"
+          , "    assert std.math.sqrt(9.0) == 3.0"
+          ]
+        writeFile (srcDir </> "provider.act") $ unlines
+          [ "import testing"
+          , ""
+          , "def ready() -> bool:"
+          , "    return True"
+          , ""
+          , "def _test_provider() -> None:"
+          , "    pass"
+          ]
+        writeFile (srcDir </> "actors.act") $ unlines
+          [ "import testing"
+          , ""
+          , "actor _test_bar():"
+          , "    pass"
+          ]
+        writeFile (srcDir </> "named.act") $ unlines
+          [ "import testing"
+          , ""
+          , "actor Foo(t: testing.EnvT):"
+          , "    t.success()"
+          ]
+        writeFile (srcDir </> "broken.act") $ unlines
+          [ "import testing"
+          , ""
+          , "def _test_broken() -> str:"
+          , "    return 42"
+          ]
+        writeFile (srcDir </> "app.act") $ unlines
+          [ "actor main(env):"
+          , "    print(\"standalone app\")"
+          , "    env.exit(0)"
+          ]
+
+        checkTests ["--name", "oo"] []
+        (invalidCode, invalidOut, invalidErr) <- runTest ["--name", "["]
+        assertBool "invalid regex should fail" (invalidCode /= ExitSuccess)
+        assertBool "invalid regex should report the pattern error"
+          ("Invalid regex" `isInfixOf` (invalidOut ++ invalidErr))
+        forM_ ["chosen", "provider", "actors", "named", "broken", "app"] $ \m -> do
+          assertFile "no match or invalid regex should not compile modules" False (cFile m)
+          assertFile "no match or invalid regex should not build executables" False (testBin m)
+
+        forM_ ["Foo", "_test_Foo"] $ \pattern -> do
+          checkTests ["--name", pattern] ["_test_Foo"]
+          assertFile "actor without a test prefix should be selected from source" True (cFile "named")
+          -- Exercise both names without a cached discovered-test list.
+          cleanOut proj
+
+        (appCode, appOut, appErr) <- readCreateProcessWithExitCode
+          (proc acton ["build", "src/app.act"]) { cwd = Just proj } ""
+        assertEqual ("application build failed:\nstdout:\n" ++ appOut ++ "\nstderr:\n" ++ appErr)
+          ExitSuccess appCode
+        checkApp
+        appTime <- getModificationTime appBin
+
+        checkTests ["--name", "foo"] ["_test_foo_wrapper"]
+        assertFile "selected module should compile" True (cFile "chosen")
+        assertFile "selected module's import should compile" True (cFile "provider")
+        assertFile "selected test executable should exist" True (testBin "chosen")
+        assertFile "imported test module should not get an executable" False (testBin "provider")
+        assertFile "unselected actor module should not compile" False (cFile "actors")
+        assertFile "unselected module's type error should not be compiled" False (cFile "broken")
+        chosenTime <- getModificationTime (cFile "chosen")
+        (listCode, listOut, listErr) <- readCreateProcessWithExitCode
+          (proc acton ["test", "list", "--module", "chosen", "--name", "foo"]) { cwd = Just proj } ""
+        assertEqual ("listing selected tests failed:\n" ++ listOut ++ listErr) ExitSuccess listCode
+        assertBool "listing should include the selected test" ("foo" `isInfixOf` listOut)
+        assertBool "listing should omit other tests in the module" (not ("foobar" `isInfixOf` listOut))
+        checkTests ["--module", "actors", "--name", "foo"] []
+        assertFile "disjoint module/name selection should not compile the module" False (cFile "actors")
+        checkTests ["--name", "_test_foobar", "--name", "_test_bar_wrapper"]
+          ["_test_foobar", "_test_bar_wrapper"]
+        assertFile "selected actor executable should exist" True (testBin "actors")
+        checkTests ["--module", "actors", "--name", "bar"] ["_test_bar_wrapper"]
+        checkTests ["--module", "actors"] ["_test_bar_wrapper"]
+        checkTests ["--name", "foo.*"] ["_test_foo_wrapper", "_test_foobar"]
+        assertFile "switching selection should preserve other generated modules" True (cFile "actors")
+        assertFile "switching selection should preserve other test executables" True (testBin "actors")
+        assertFile "imported test module should still have no executable" False (testBin "provider")
+        assertEqual "unchanged selected source should reuse its generated C"
+          chosenTime =<< getModificationTime (cFile "chosen")
+
+        writeFile (srcDir </> "broken.act") $ unlines
+          [ "def ready() -> bool:"
+          , "    return True"
+          ]
+        checkTests [] ["_test_foo_wrapper", "_test_foobar", "_test_provider", "_test_bar_wrapper", "_test_Foo"]
+        assertFile "full selection should build the provider test executable" True (testBin "provider")
+        checkApp
+        assertEqual "test builds should preserve the standalone application"
+          appTime =<< getModificationTime appBin
+        let productionLib = proj </> "out" </> "lib" </> "libproduction.a"
+        assertFile "test builds should not produce declared production libraries" False productionLib
+        (productionCode, productionOut, productionErr) <- readCreateProcessWithExitCode
+          (proc acton ["build"]) { cwd = Just proj } ""
+        assertEqual ("production rebuild failed:\n" ++ productionOut ++ productionErr) ExitSuccess productionCode
+        assertFile "production builds should restore declared library grouping" True productionLib
+        checkApp
+  , testCase "acton test discovers selected tests after an imported type changes" $ do
+      withSystemTempDirectory "acton-test-selection-cache" $ \proj -> do
+        acton <- canonicalizePath "../../dist/bin/acton"
+        let name = "test_selection_cache"
+            fp = Fingerprint.formatFingerprint
+              (Fingerprint.updateFingerprintPrefix
+                (Fingerprint.fingerprintPrefixForName name) 1)
+            srcDir = proj </> "src"
+            provider = srcDir </> "provider.act"
+            runTest = readCreateProcessWithExitCode
+              (proc acton ["test", "--json", "--no-cache", "--iter", "1", "--name", "discovered"]) { cwd = Just proj } ""
+            checkCount expected = do
+              (code, out, err) <- runTest
+              assertEqual ("selected test failed:\n" ++ out ++ err) ExitSuccess code
+              assertBool ("unexpected selected test count:\n" ++ out)
+                (("\"total\":" ++ show expected) `isInfixOf` out)
+        createDirectoryIfMissing True srcDir
+        writeFile (proj </> "Build.act") $ unlines
+          [ "name = " ++ show name
+          , "fingerprint = " ++ fp
+          ]
+        writeFile (srcDir </> "chosen.act") $ unlines
+          [ "import testing"
+          , "import provider"
+          , "def _test_discovered():"
+          , "    return provider.value()"
+          ]
+        writeFile provider "def value():\n    return 42\n"
+        checkCount (0 :: Int)
+        -- The unchanged selected source has a cached interface with no tests.
+        -- Its inferred return type becomes eligible when the import changes.
+        writeFile provider "def value():\n    return None\n"
+        checkCount (1 :: Int)
   , testCase "acton test reruns cached snapshot when expected file changes" $ do
       withSystemTempDirectory "acton-test-snapshot-cache" $ \proj -> do
         actonBinDir <- Paths_acton.getBinDir

--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -1315,6 +1315,12 @@ parseFlagTests =
         assertFile "unselected actor module should not compile" False (cFile "actors")
         assertFile "unselected module's type error should not be compiled" False (cFile "broken")
         chosenTime <- getModificationTime (cFile "chosen")
+        forM_ [([], True), (["--quiet"], False), (["--json"], False), (["--types"], False)] $ \(outputFlags, visible) -> do
+          (timingCode, timingOut, timingErr) <- readCreateProcessWithExitCode
+            (proc acton (["test", "--name", "foo", "--timing", "--iter", "1"] ++ outputFlags)) { cwd = Just proj } ""
+          assertEqual ("timed selection failed:\n" ++ timingOut ++ timingErr) ExitSuccess timingCode
+          assertEqual "selection timing respects output mode" visible
+            ("Timing: test source selection " `isInfixOf` (timingOut ++ timingErr))
         (listCode, listOut, listErr) <- readCreateProcessWithExitCode
           (proc acton ["test", "list", "--module", "chosen", "--name", "foo"]) { cwd = Just proj } ""
         assertEqual ("listing selected tests failed:\n" ++ listOut ++ listErr) ExitSuccess listCode

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -710,7 +710,7 @@ prepareCompilePlanFromContext sp gopts ctx srcFiles allowPrune mChangedPaths = d
       sysAbs = ccSysAbs ctx
       incremental = isJust mChangedPaths
       allowPrune' = allowPrune && not incremental
-  projMap <- if isTmp pathsRoot
+  projMap0 <- if isTmp pathsRoot
     then do
       let ctx' = ProjCtx
             { projRoot = rootProj
@@ -724,6 +724,11 @@ prepareCompilePlanFromContext sp gopts ctx srcFiles allowPrune mChangedPaths = d
             }
       return (M.singleton rootProj ctx')
     else discoverProjects gopts sysAbs rootProj depOverrides
+  -- Test selection follows imports, not production library membership.
+  -- Library groups must not pull unrelated test modules into compilation.
+  let projMap = if C.test opts'
+                  then M.adjust (\pctx -> pctx { projBuildSpec = (projBuildSpec pctx) { BuildSpec.libraries = M.empty } }) rootProj projMap0
+                  else projMap0
   -- Keep generated module artifacts in sync with source removals.
   -- For full builds, scan and prune all orphan outputs.
   -- For incremental builds, prune only modules whose changed .act paths are now missing.

--- a/docs/acton-guide/src/testing.md
+++ b/docs/acton-guide/src/testing.md
@@ -66,7 +66,18 @@ You can run tests from specific modules using the `--module` flag:
 acton test --module foo --module bar
 ```
 
-This will only run tests from the `foo` and `bar` modules, skipping all other test modules.
+This compiles the selected modules and their imports, and runs tests from `foo` and `bar`.
+
+Use `--name` to select tests by an anchored regular expression matching either the raw name (such as `_test_simple`) or its displayed name (`simple`). Repeat the option to select several patterns:
+
+```sh
+acton test --name simple --watch
+acton test --module foo --name 'parse_.*'
+```
+
+Name selection also limits compilation to modules that may contain matching tests and their imports. Tests within a selected module share its compiled code; imported test modules are compiled as dependencies but do not get test executables unless selected themselves.
+
+Test builds follow the selected source files and their imports, and ignore the project's `libraries` groups in `Build.act`. This also applies when running all tests without selection flags. Application builds continue to honor those groups and their configured linkage.
 
 ## Capability-gated tests
 

--- a/docs/acton-guide/src/testing.md
+++ b/docs/acton-guide/src/testing.md
@@ -75,7 +75,7 @@ acton test --name simple --watch
 acton test --module foo --name 'parse_.*'
 ```
 
-Name selection also limits compilation to modules that may contain matching tests and their imports. Tests within a selected module share its compiled code; imported test modules are compiled as dependencies but do not get test executables unless selected themselves.
+Name selection also limits compilation to modules that may contain matching tests and their imports. Add `--timing` to see how long source selection takes. Tests within a selected module share its compiled code; imported test modules are compiled as dependencies but do not get test executables unless selected themselves.
 
 Test builds follow the selected source files and their imports, and ignore the project's `libraries` groups in `Build.act`. This also applies when running all tests without selection flags. Application builds continue to honor those groups and their configured linkage.
 


### PR DESCRIPTION
`acton test --module` and `--name` now select compilation roots before building. Selected modules and their imports are compiled, and only selected roots receive test executables. This applies to listing tests and watch mode as well as ordinary test runs.

Test builds follow that source closure independently of the root project's `libraries` groups in `Build.act`, including when running all tests. Application builds continue to honor their configured libraries and linkage.
