### PR TITLE
Cancel obsolete watch builds and test processes

### DIFF
--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -50,8 +50,10 @@ import qualified Repl
 import FileUtil (readFile, writeFile, writeFileAtomic)
 
 import Control.Concurrent.MVar
-import Control.Exception (throw,catch,finally,IOException,try,SomeException,onException,evaluate)
-import Control.Concurrent (ThreadId, forkIO, killThread, threadDelay)
+import Control.Exception (throw,catch,finally,IOException,try,SomeException,onException,evaluate,bracket,mask)
+import qualified Control.Concurrent.Async as Async
+import ProcessUtil (stopProcessGroup)
+import Control.Concurrent (ThreadId, forkIO, killThread, threadDelay, throwTo)
 import Control.Concurrent.Chan (Chan, newChan, writeChan, readChan)
 import Control.Monad
 import Data.Bits
@@ -94,6 +96,7 @@ import System.Info
 import System.Posix.Files
 import System.Posix.IO (createPipe, setFdOption, closeFd, FdOption(..))
 import System.Posix.Resource
+import System.Posix.Signals (installHandler, sigTERM, Handler(CatchOnce))
 import System.Process hiding (createPipe)
 import qualified System.FSNotify as FS
 import qualified System.Environment
@@ -512,11 +515,13 @@ withProjectLockNotice gopts projDir action =
       unless (C.quiet gopts) $
         putStrLn ("Waiting for compiler lock in " ++ projDir)
 
-withProjectLockForGen :: C.GlobalOptions -> CompileScheduler -> Int -> FilePath -> IO () -> IO ()
-withProjectLockForGen gopts sched gen projDir action =
+withProjectLockForGen :: C.GlobalOptions -> CompileScheduler -> Int -> FilePath -> IO Bool -> IO Bool
+withProjectLockForGen gopts sched gen projDir action = do
+    completed <- newIORef False
     whenCurrentGen sched gen $
       withProjectLockNotice gopts projDir $
-        whenCurrentGen sched gen action
+        whenCurrentGen sched gen (action >>= writeIORef completed)
+    readIORef completed
 
 requireProjectLayout :: Paths -> IO ()
 requireProjectLayout paths = do
@@ -595,13 +600,28 @@ withTempDirOpts opts action
   | otherwise = withScratchDirLock $ \scratchDir ->
       action opts { C.tempdir = scratchDir } True
 
-initCompileWatchContext :: C.GlobalOptions -> IO (CompileScheduler, ProgressUI, ProgressState)
-initCompileWatchContext gopts = do
-    maxParallel <- compileMaxParallel gopts
-    sched <- newCompileScheduler gopts maxParallel
-    progressUI <- initProgressUI gopts maxParallel
-    progressState <- newProgressState
-    return (sched, progressUI, progressState)
+data CliWatchContext = CliWatchContext
+  { cwScheduler :: CompileScheduler
+  , cwProgressUI :: ProgressUI
+  , cwProgressState :: ProgressState
+  }
+
+withCompileWatchContext :: C.GlobalOptions -> (CliWatchContext -> IO a) -> IO a
+withCompileWatchContext gopts action = do
+    owner <- myThreadId
+    bracket (installHandler sigTERM (CatchOnce (throwTo owner (ExitFailure 143))) Nothing)
+            (\previous -> void (installHandler sigTERM previous Nothing)) $ \_ ->
+      bracket create cleanup action
+  where
+    create = do
+      maxParallel <- compileMaxParallel gopts
+      CliWatchContext <$> newCompileScheduler gopts maxParallel <*> initProgressUI gopts maxParallel
+                      <*> newProgressState
+    cleanup ctx = do
+      modifyMVar_ (csAsyncRef (cwScheduler ctx)) $ \running -> do
+        mapM_ Async.cancel running
+        return Nothing
+      progressReset (cwProgressUI ctx) (cwProgressState ctx)
 
 logProjectBuild :: C.GlobalOptions -> ProgressUI -> ProgressState -> FilePath -> IO ()
 logProjectBuild gopts progressUI progressState projDir =
@@ -674,8 +694,11 @@ runTestsWatch gopts opts topts mode paths = do
         projDir = projPath paths
         srcRoot = srcDir paths
     withBackgroundCompilerLockOrExit projDir
-      "Another long-running Acton compiler is already running; cannot start test watch." $ do
-        (sched, progressUI, progressState) <- initCompileWatchContext gopts
+      "Another long-running Acton compiler is already running; cannot start test watch." $
+      withCompileWatchContext gopts $ \watchCtx -> do
+        let sched = cwScheduler watchCtx
+            progressUI = cwProgressUI watchCtx
+            progressState = cwProgressState watchCtx
         testParallel0 <- testMaxParallel gopts
         let testParallel = if mode == TestModeStress then 1 else testParallel0
         let runOnce gen mChanged = do
@@ -686,18 +709,19 @@ runTestsWatch gopts opts topts mode paths = do
                 -- Link the complete selected closure; cached modules still skip
                 -- unchanged compiler passes.
                 hadErrors <- if null selected then return False else
-                  compileFilesChanged sp gopts opts selected (selected == srcFiles) Nothing (Just (sched, gen)) (Just (progressUI, progressState))
-                unless hadErrors $ do
+                  compileFilesChanged sp gopts opts selected (selected == srcFiles) Nothing (Just (watchCtx, gen))
+                unless hadErrors $ whenCurrentGen sched gen $ do
                   selectStart <- getTime Monotonic
                   testModules <- mapM (fmap modNameToString . moduleNameFromFile (srcDir paths) (projName paths)) selected
                   modulesToTest <- selectTestModules paths srcFiles mChanged testModules
                   logTiming gopts opts (progressLogLine progressUI) "affected test selection" selectStart
-                  unless (null modulesToTest) $
+                  unless (null modulesToTest) $ whenCurrentGen sched gen $
                     do
                       useColorOut <- useColor gopts
                       testStart <- getTime Monotonic
                       void $ runProjectTests useColorOut gopts opts paths topts mode modulesToTest testParallel
                       logTiming gopts opts (progressLogLine progressUI) "test execution and cache" testStart
+                return (not hadErrors)
         runWatchProject gopts projDir srcRoot sched runOnce
 
 selectTestModules :: Paths -> [FilePath] -> Maybe [FilePath] -> [String] -> IO [String]
@@ -768,15 +792,19 @@ watchProjectAt gopts opts projDir = do
                 let sp = Source.diskSourceProvider
                 paths <- loadProjectPathsAt projDir opts
                 withBackgroundCompilerLockOrExit (projPath paths)
-                  "Another long-running Acton compiler is already running; cannot start watch." $ do
-                    (sched, progressUI, progressState) <- initCompileWatchContext gopts
+                  "Another long-running Acton compiler is already running; cannot start watch." $
+                  withCompileWatchContext gopts $ \watchCtx -> do
+                    let sched = cwScheduler watchCtx
+                        progressUI = cwProgressUI watchCtx
+                        progressState = cwProgressState watchCtx
                     let runOnce gen mChanged =
                           withProjectLockForGen gopts sched gen (projPath paths) $ do
                             logProjectBuild gopts progressUI progressState (projPath paths)
                             srcFiles <- projectSourceFiles paths
-                            void $ compileFilesChanged sp gopts opts srcFiles True mChanged (Just (sched, gen)) (Just (progressUI, progressState))
-                            when (isNothing mChanged) $
+                            hadErrors <- compileFilesChanged sp gopts opts srcFiles True mChanged (Just (watchCtx, gen))
+                            when (not hadErrors && isNothing mChanged) $
                               generateProjectDocIndex sp gopts opts paths srcFiles
+                            return (not hadErrors)
                     runWatchProject gopts (projPath paths) (srcDir paths) sched runOnce
 
 -- | Build a single file, optionally running in watch mode.
@@ -825,14 +853,12 @@ watchFile gopts opts file = do
       Just proj -> watchProjectAt gopts opts proj
       Nothing -> do
         let sp = Source.diskSourceProvider
-        (sched, progressUI, progressState) <- initCompileWatchContext gopts
-        let runWatch opts' =
-              let runOnce gen mChanged =
-                    whenCurrentGen sched gen $
-                      void $ compileFilesChanged sp gopts opts' [absFile] False mChanged (Just (sched, gen)) (Just (progressUI, progressState))
-              in runWatchFile gopts absFile sched runOnce
         withTempDirOpts opts $ \opts' _ ->
-          runWatch opts'
+          withCompileWatchContext gopts $ \watchCtx -> do
+            let sched = cwScheduler watchCtx
+                runOnce gen mChanged = whenCurrentGen sched gen $
+                  void $ compileFilesChanged sp gopts opts' [absFile] False mChanged (Just (watchCtx, gen))
+            runWatchFile gopts absFile sched runOnce
 
 data WatchTrigger = WatchFull | WatchIncremental FilePath deriving (Eq, Show)
 
@@ -908,12 +934,22 @@ runWatchProject :: C.GlobalOptions
                 -> FilePath
                 -> FilePath
                 -> CompileScheduler
-                -> (Int -> Maybe [FilePath] -> IO ())
+                -> (Int -> Maybe [FilePath] -> IO Bool)
                 -> IO ()
 runWatchProject gopts projDir srcRoot sched runOnce = do
     stampsRef <- newIORef M.empty
-    let schedule mpath = void $ startCompile sched 0 $ \gen ->
-          runOnce gen (fmap (:[]) mpath)
+    pendingRef <- newIORef (0 :: Int, Just [])
+    let schedule mpath = do
+          atomicModifyIORef' pendingRef $ \(version, pending) ->
+            let changed = nub <$> ((++) <$> pending <*> fmap (:[]) mpath)
+            in ((version + 1, changed), ())
+          void $ startCompile sched 0 $ \gen -> do
+            (version, changed) <- readIORef pendingRef
+            completed <- runOnce gen changed
+            -- Canceled and failed generations leave their paths pending. A
+            -- later save must still run tests affected by those earlier edits.
+            when completed $ atomicModifyIORef' pendingRef $ \current@(latest, _) ->
+              (if latest == version then (latest, Just []) else current, ())
         scheduleMaybe mpath =
           case mpath of
             Nothing -> schedule Nothing
@@ -1372,7 +1408,7 @@ printDocs gopts opts = do
 compileReplHook :: C.GlobalOptions -> C.CompileOptions -> FilePath -> [FilePath] -> IO Bool
 compileReplHook gopts opts projDir srcFiles =
     withProjectLockNotice gopts projDir $
-      compileFilesChanged Source.diskSourceProvider gopts opts srcFiles False Nothing Nothing Nothing
+      compileFilesChanged Source.diskSourceProvider gopts opts srcFiles False Nothing Nothing
 
 -- Compile Acton files ---------------------------------------------------------------------------------------------
 
@@ -1385,7 +1421,7 @@ compileMaxParallel gopts = do
 -- | Compile a set of files in a single-shot build.
 compileFiles :: Source.SourceProvider -> C.GlobalOptions -> C.CompileOptions -> [String] -> Bool -> IO ()
 compileFiles sp gopts opts srcFiles allowPrune =
-    void $ compileFilesChanged sp gopts opts srcFiles allowPrune Nothing Nothing Nothing
+    void $ compileFilesChanged sp gopts opts srcFiles allowPrune Nothing Nothing
 
 -- | Compile with optional change set, wiring progress UI and back jobs.
 compileFilesChanged :: Source.SourceProvider
@@ -1394,20 +1430,19 @@ compileFilesChanged :: Source.SourceProvider
                     -> [String]
                     -> Bool
                     -> Maybe [FilePath]
-                    -> Maybe (CompileScheduler, Int)
-                    -> Maybe (ProgressUI, ProgressState)
+                    -> Maybe (CliWatchContext, Int)
                     -> IO Bool
-compileFilesChanged sp gopts opts srcFiles allowPrune mChangedPaths mSched mProgress = do
+compileFilesChanged sp gopts opts srcFiles allowPrune mChangedPaths mWatch = do
     maxParallel <- compileMaxParallel gopts
-    (progressUI, progressState) <- case mProgress of
-      Just ps -> return ps
+    (progressUI, progressState) <- case mWatch of
+      Just (ctx, _) -> return (cwProgressUI ctx, cwProgressState ctx)
       Nothing -> do
         ui <- initProgressUI gopts maxParallel
         st <- newProgressState
         return (ui, st)
     let logLine = progressLogLine progressUI
-    (sched, gen) <- case mSched of
-      Just sg -> return sg
+    (sched, gen) <- case mWatch of
+      Just (ctx, gen) -> return (cwScheduler ctx, gen)
       Nothing -> do
         sched' <- newCompileScheduler gopts maxParallel
         return (sched', 0)
@@ -1460,8 +1495,11 @@ compileFilesChanged sp gopts opts srcFiles allowPrune mChangedPaths mSched mProg
                           then reportCompileErrors
                           else do
                             clearProgress
-                            whenCurrentGen sched gen (runCliPostCompile cliHooks gopts plan env)
-                            return False
+                            result <- newIORef False
+                            whenCurrentGen sched gen $ do
+                              success <- runCliPostCompile cliHooks gopts plan env
+                              writeIORef result success
+                            not <$> readIORef result
           either reportPlanError runPlan planRes
     runCompile `finally` cleanupProgress
 
@@ -2040,7 +2078,7 @@ runCliPostCompile :: CliCompileHooks
                   -> C.GlobalOptions
                   -> CompilePlan
                   -> Acton.Env.Env0
-                  -> IO ()
+                  -> IO Bool
 runCliPostCompile cliHooks gopts plan env = do
     prepStart <- getTime Monotonic
     let logLine = cchLogLine cliHooks
@@ -2093,19 +2131,20 @@ runCliPostCompile cliHooks gopts plan env = do
     logTiming gopts opts' logLine "dependency build preparation" prepStart
     let runFinal action = do
           cchFinalStart cliHooks
-          action `onException` cchFinalDone cliHooks False
-          cchFinalDone cliHooks True
+          success <- action `onException` cchFinalDone cliHooks False
+          cchFinalDone cliHooks success
+          return success
     if C.skip_build opts'
       then
-        logLine "  Skipping final build step"
+        logLine "  Skipping final build step" >> return True
       else
         if C.test opts'
           then do
             testBinTasks <- catMaybes <$> mapM (filterMainActor env pathsRoot) preTestBinTasks
-            unless (altOutput opts') $
+            if altOutput opts' then return True else
               runFinal (compileBins gopts opts' pathsRoot env rootSpec rootTasks testBinTasks allowPrune' rootModuleEntries rootBuildLibraries rootDepModuleOpts rootDepPathOverrides (Just (cchProgressUI cliHooks)))
           else do
-            unless (altOutput opts') $
+            if altOutput opts' then return True else
               runFinal (compileBins gopts opts' pathsRoot env rootSpec rootTasks preBinTasks allowPrune' rootModuleEntries rootBuildLibraries rootDepModuleOpts rootDepPathOverrides (Just (cchProgressUI cliHooks)))
 -- Generate documentation index for a project build by reading module names and
 -- docstrings from cached .tydb headers or source headers.
@@ -2377,7 +2416,7 @@ High-level Steps
 ================================================================================
 -}
 
-compileBins:: C.GlobalOptions -> C.CompileOptions -> Paths -> Acton.Env.Env0 -> BuildSpec.BuildSpec -> [CompileTask] -> [BinTask] -> Bool -> [FilePath] -> [BuildLibrary] -> M.Map String String -> M.Map String FilePath -> Maybe ProgressUI -> IO ()
+compileBins:: C.GlobalOptions -> C.CompileOptions -> Paths -> Acton.Env.Env0 -> BuildSpec.BuildSpec -> [CompileTask] -> [BinTask] -> Bool -> [FilePath] -> [BuildLibrary] -> M.Map String String -> M.Map String FilePath -> Maybe ProgressUI -> IO Bool
 compileBins gopts opts paths env rootSpec tasks binTasks allowPrune rootModules buildLibraries depModuleOpts depPathOverrides mProgressUI =
     zigBuild env gopts opts paths rootSpec tasks binTasks allowPrune rootModules buildLibraries depModuleOpts depPathOverrides mProgressUI
 
@@ -2435,28 +2474,31 @@ isWindowsOS targetTriple = case splitOn "-" targetTriple of
 
 -- | Run a process and capture output, canceling on exceptions.
 readProcessWithExitCodeCancelable :: CreateProcess -> (ProcessHandle -> IO ()) -> IO (ExitCode, String, String)
-readProcessWithExitCodeCancelable cp onStart = do
-    let cp' = cp { std_in = NoStream, std_out = CreatePipe, std_err = CreatePipe }
+readProcessWithExitCodeCancelable cp onStart = mask $ \restore -> do
+    let cp' = cp { std_in = NoStream, std_out = CreatePipe, std_err = CreatePipe, create_group = True }
     withCreateProcess cp' $ \_ mOut mErr ph -> do
-      onStart ph
-      outVar <- newEmptyMVar
-      errVar <- newEmptyMVar
-      let readHandle mH var =
-            case mH of
-              Nothing -> putMVar var ""
-              Just h -> do
-                txt <- hGetContents h
-                _ <- evaluate (length txt)
-                hClose h
-                putMVar var txt
-      _ <- forkIO $ readHandle mOut outVar
-      _ <- forkIO $ readHandle mErr errVar
-      code <- waitForProcess ph `onException` do
-                terminateProcess ph
-                void (waitForProcess ph)
-      out <- takeMVar outVar
-      err <- takeMVar errVar
-      return (code, out, err)
+      pid <- getPid ph
+      groupOwned <- newIORef True
+      let stop = mask $ \_ -> do
+            owned <- readIORef groupOwned
+            when owned $ do
+              stopProcessGroup ph pid
+              writeIORef groupOwned False
+          readHandle Nothing = return ""
+          readHandle (Just handle) = do
+            txt <- hGetContents handle
+            _ <- evaluate (length txt)
+            hClose handle
+            return txt
+      (restore $ do
+          onStart ph
+          Async.withAsync (readHandle mOut) $ \outReader ->
+            Async.withAsync (readHandle mErr) $ \errReader -> do
+              code <- waitForProcess ph
+              stop
+              out <- Async.wait outReader
+              err <- Async.wait errReader
+              return (code, out, err)) `finally` stop
 
 runZig gopts opts zigExe zigArgs paths wd mProgressUI = do
     let display = showCommandForUser zigExe zigArgs
@@ -2521,12 +2563,13 @@ runZig gopts opts zigExe zigArgs paths wd mProgressUI = do
             -- Zig's summary includes cache hits and elapsed C/link build steps.
             -- Their durations overlap when Zig runs them in parallel.
             mapM_ logLine (dropWhile (not . isPrefixOf "Build Summary:") (lines zigStderr))
-          return ()
+          return True
         ExitFailure ret -> do
           printIce ("compilation of generated Zig code failed, returned error code" ++ show ret)
           putStrLn $ "zig stdout:\n" ++ zigStdout
           putStrLn $ "zig stderr:\n" ++ zigStderr
           unless (C.watch opts) System.Exit.exitFailure
+          return False
 
 generateFingerprint :: String -> IO String
 generateFingerprint name = do
@@ -2805,7 +2848,7 @@ defCpuFlag = ["-Dcpu=x86_64_v2+aes"]
 #endif
 
 -- | Run zig build for generated artifacts and prune stale outputs.
-zigBuild :: Acton.Env.Env0 -> C.GlobalOptions -> C.CompileOptions -> Paths -> BuildSpec.BuildSpec -> [CompileTask] -> [BinTask] -> Bool -> [FilePath] -> [BuildLibrary] -> M.Map String String -> M.Map String FilePath -> Maybe ProgressUI -> IO ()
+zigBuild :: Acton.Env.Env0 -> C.GlobalOptions -> C.CompileOptions -> Paths -> BuildSpec.BuildSpec -> [CompileTask] -> [BinTask] -> Bool -> [FilePath] -> [BuildLibrary] -> M.Map String String -> M.Map String FilePath -> Maybe ProgressUI -> IO Bool
 zigBuild env gopts opts paths rootSpec tasks binTasks allowPrune rootModules buildLibraries depModuleOpts depPathOverrides mProgressUI = do
     prepStart <- getTime Monotonic
     allBinTasks <- mapM (writeRootC env gopts opts paths tasks) binTasks
@@ -2869,9 +2912,9 @@ zigBuild env gopts opts paths rootSpec tasks binTasks allowPrune rootModules bui
         zigArgs = baseArgs ++ prefixArgs ++ targetArgs ++ cpuArgs ++ optArgs ++ moduleArgs ++ featureArgs
 
     logTiming gopts opts (maybe putStrLn progressLogLine mProgressUI) "root and build file preparation" prepStart
-    runZig gopts opts zigExe zigArgs paths (Just (projPath paths)) mProgressUI
+    success <- runZig gopts opts zigExe zigArgs paths (Just (projPath paths)) mProgressUI
     -- if we are in a temp acton project, copy the outputted binary next to the source file
-    if (isTmp paths && not (null realBinTasks))
+    if (success && isTmp paths && not (null realBinTasks))
       then do
         let baseName   = binName (head binTasks)
             exeName    = if isWindowsOS (C.target opts) then baseName ++ ".exe" else baseName
@@ -2879,7 +2922,7 @@ zigBuild env gopts opts paths rootSpec tasks binTasks allowPrune rootModules bui
             dstBinFile = joinPath [ binDir paths, exeName ]
         copyFile srcBinFile dstBinFile
       else return ()
-    return ()
+    return success
 
 -- Remove executables that no longer have corresponding root actors
 -- | Remove binaries that no longer have corresponding roots.

--- a/compiler/acton/ProcessUtil.hs
+++ b/compiler/acton/ProcessUtil.hs
@@ -1,0 +1,32 @@
+-- Watch builds and test workers own separate process groups so cancellation
+-- can stop descendants even after their parent exits or closes its pipes.
+module ProcessUtil (stopProcessGroup) where
+
+import Control.Concurrent (threadDelay)
+import Control.Exception (IOException, catch, mask_)
+import Control.Monad
+import System.Posix.Signals
+import System.Posix.Types (ProcessID)
+import System.Process
+import System.Timeout
+
+stopProcessGroup :: ProcessHandle -> Maybe ProcessID -> IO ()
+stopProcessGroup process pid = mask_ $ do
+    let signal sig = forM_ pid $ \group ->
+          signalProcessGroup sig group `catch` ignoreIO
+        alive = case pid of
+          Nothing -> return False
+          Just group -> (signalProcessGroup nullSignal group >> return True)
+                          `catch` \err -> ignoreIO err >> return False
+        wait = do
+          -- Reap the leader before probing: a zombie also keeps its group alive.
+          void (getProcessExitCode process)
+          running <- alive
+          when running (threadDelay 10000 >> wait)
+    signal sigTERM
+    stopped <- timeout 1000000 wait
+    when (stopped == Nothing) (signal sigKILL)
+    void (waitForProcess process)
+  where
+    ignoreIO :: IOException -> IO ()
+    ignoreIO _ = return ()

--- a/compiler/acton/TestRunner.hs
+++ b/compiler/acton/TestRunner.hs
@@ -13,9 +13,7 @@ import qualified Acton.SourceProvider as Source
 import qualified InterfaceFiles
 import TestFormat
 import TestUI
-import Control.Concurrent (forkIO)
 import Control.Concurrent.Async
-import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
 import Control.Concurrent.Chan (Chan, newChan, readChan, writeChan)
 import Control.Monad
 import Data.IORef
@@ -31,6 +29,7 @@ import System.Exit
 import System.FilePath ((</>), (<.>), joinPath)
 import System.IO (hClose, hGetContents, hGetLine, hIsEOF)
 import System.Process
+import ProcessUtil (stopProcessGroup)
 import Text.Printf
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Types as AesonTypes
@@ -40,7 +39,7 @@ import qualified Data.ByteString.Lazy as BL
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import Data.Time.Clock (UTCTime)
-import Control.Exception (SomeException, SomeAsyncException, AsyncException(..), displayException, evaluate, mask, onException, try, fromException, throwIO)
+import Control.Exception (SomeException, SomeAsyncException, AsyncException(..), displayException, evaluate, mask, onException, try, fromException, throwIO, finally)
 import TerminalSize (termFitAnsiRight)
 import qualified Text.Regex.TDFA as TDFA
 import Data.Version (showVersion)
@@ -270,6 +269,7 @@ runProjectTests useColorOut gopts opts paths topts mode modules maxParallel = do
         ui <- initTestProgressUI gopts nameWidth (C.testShowLog topts) useColorOut
         let totalTests = length specs
         progressDoneRef <- newIORef 0
+        workers <- newIORef []
         let (effectiveMinTime, effectiveMaxTime) = effectiveTestTiming mode topts
             expectedDurationMs =
               fromIntegral
@@ -343,27 +343,29 @@ runProjectTests useColorOut gopts opts paths topts mode modules maxParallel = do
                         then return Nothing
                         else do
                           callbacks <- testProgressCallbacks ui eventChan key display expectedDurationMs
-                          void $ async $ mask $ \restore -> do
-                            resE <- try (restore (runModuleTestStreaming opts paths topts mode (tsModule spec) (tsName spec)
-                                                   (tpuEnabled ui) callbacks))
-                                      :: IO (Either SomeException TestResult)
-                            case resE of
-                              Right res ->
-                                writeChan eventChan (TestEventDone res)
-                              Left ex -> do
-                                let res = initRes
-                                      { trComplete = True
-                                      , trException = Just ("Test runner exception: " ++ displayException ex)
-                                      , trNumErrors = 1
-                                      }
-                                finishE <- try (restore (tpcOnDone callbacks res >> tpcOnFinal callbacks res))
-                                             :: IO (Either SomeException ())
-                                writeChan eventChan (TestEventDone res)
-                                case finishE of
-                                  Left finishEx | isJust (fromException finishEx :: Maybe SomeAsyncException) -> throwIO finishEx
-                                  _ -> return ()
-                                when (isJust (fromException ex :: Maybe SomeAsyncException)) $
-                                  throwIO ex
+                          mask $ \unmask -> do
+                            worker <- async $ unmask $ mask $ \restore -> do
+                              resE <- try (restore (runModuleTestStreaming opts paths topts mode (tsModule spec) (tsName spec)
+                                                     (tpuEnabled ui) callbacks))
+                                        :: IO (Either SomeException TestResult)
+                              case resE of
+                                Right res ->
+                                  writeChan eventChan (TestEventDone res)
+                                Left ex -> do
+                                  let res = initRes
+                                        { trComplete = True
+                                        , trException = Just ("Test runner exception: " ++ displayException ex)
+                                        , trNumErrors = 1
+                                        }
+                                  finishE <- try (restore (tpcOnDone callbacks res >> tpcOnFinal callbacks res))
+                                               :: IO (Either SomeException ())
+                                  writeChan eventChan (TestEventDone res)
+                                  case finishE of
+                                    Left finishEx | isJust (fromException finishEx :: Maybe SomeAsyncException) -> throwIO finishEx
+                                    _ -> return ()
+                                  when (isJust (fromException ex :: Maybe SomeAsyncException)) $
+                                    throwIO ex
+                            atomicModifyIORef' workers (\ws -> (worker : ws, ()))
                           return (Just (running + 1, results))
             startAvailable pending running results = do
               case pending of
@@ -391,7 +393,7 @@ runProjectTests useColorOut gopts opts paths topts mode modules maxParallel = do
                               else pending'
                       loop pending'' (running' - 1) (res : results')
                     TestEventRoom -> loop pending' running' results'
-        results <- loop specs 0 []
+        results <- loop specs 0 [] `finally` (readIORef workers >>= mapConcurrently_ cancel)
         timeEnd <- getTime Monotonic
         writeSnapshotOutputs paths results
         let resultsRun =
@@ -668,7 +670,11 @@ runModuleTestStreaming opts paths topts mode modName testName allowLive callback
             Just val -> case parseTestInfo val of
                           Just res -> onUpdate res
                           Nothing -> addStdErr line
-    let procSpec = (proc binPath cmd){ cwd = Just (projPath paths), delegate_ctlc = True }
+    let procSpec = (proc binPath cmd)
+          { cwd = Just (projPath paths)
+          , create_group = C.watch opts
+          , delegate_ctlc = not (C.watch opts)
+          }
     procRes <- try (readProcessWithExitCodeStreaming procSpec onErrLine) :: IO (Either SomeException (ExitCode, String, String))
     (exitCode, out, _err, interruptedByUser) <-
       case procRes of
@@ -1371,14 +1377,16 @@ writePerfData paths results = do
 
 -- | Run a process and stream stderr lines to a callback while capturing output.
 readProcessWithExitCodeStreaming :: CreateProcess -> (String -> IO ()) -> IO (ExitCode, String, String)
-readProcessWithExitCodeStreaming cp onErrLine = do
+readProcessWithExitCodeStreaming cp onErrLine = mask $ \restore -> do
     let cp' = cp { std_in = NoStream, std_out = CreatePipe, std_err = CreatePipe }
     withCreateProcess cp' $ \_ mOut mErr ph -> do
-      outVar <- newEmptyMVar
-      errVar <- newEmptyMVar
-      let readPipe var action = mask $ \restore -> do
-            res <- try (restore action) :: IO (Either SomeException String)
-            putMVar var res
+      pid <- getPid ph
+      groupOwned <- newIORef True
+      let stop = mask $ \_ -> do
+            owned <- readIORef groupOwned
+            when owned $ do
+              stopProcessGroup ph pid
+              writeIORef groupOwned False
           readStdout mH =
             case mH of
               Nothing -> return ""
@@ -1404,16 +1412,17 @@ readProcessWithExitCodeStreaming cp onErrLine = do
                     line <- hGetLine h
                     onErrLine line
                     go (line : acc)
-      _ <- forkIO $ readPipe outVar (readStdout mOut)
-      _ <- forkIO $ readPipe errVar (readStderr mErr)
-      code <- waitForProcess ph `onException` do
-                terminateProcess ph
-                void (waitForProcess ph)
-      outE <- takeMVar outVar
-      errE <- takeMVar errVar
-      out <- either throwIO return outE
-      err <- either throwIO return errE
-      return (code, out, err)
+      let capture = restore $
+            withAsync (readStdout mOut) $ \outReader ->
+              withAsync (readStderr mErr) $ \errReader -> do
+                code <- waitForProcess ph
+                when (create_group cp') stop
+                out <- wait outReader
+                err <- wait errReader
+                return (code, out, err)
+      if create_group cp'
+        then capture `finally` stop
+        else capture `onException` (terminateProcess ph >> void (waitForProcess ph))
 
 fmtTime :: TimeSpec -> String
 fmtTime t =

--- a/compiler/acton/WatchTests.hs
+++ b/compiler/acton/WatchTests.hs
@@ -1,0 +1,240 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+module WatchTests (watchProcessTests) where
+
+import Control.Concurrent (threadDelay)
+import Control.Exception (IOException, catch, finally, mask)
+import Control.Monad
+import qualified Data.ByteString.Char8 as BS
+import Data.List (isInfixOf)
+import Data.Maybe (isJust)
+import System.Directory
+import System.Exit
+import System.FilePath
+import System.IO
+import System.IO.Temp (withSystemTempDirectory)
+import System.Posix.Files (createSymbolicLink)
+import System.Posix.Signals
+import System.Posix.Types (ProcessID)
+import System.Process
+import qualified System.Timeout as Timeout
+import Text.Read (readMaybe)
+
+import Acton.Compile (withProjectLock)
+import qualified Acton.Fingerprint as Fingerprint
+import ProcessUtil (stopProcessGroup)
+import Test.Tasty
+import Test.Tasty.HUnit
+
+watchProcessTests :: TestTree
+watchProcessTests = testGroup "watch subprocesses"
+  [ testCase "stopping build watch stops Zig descendants" $
+      withProcessProject $ \acton proj system -> do
+        writeExecutable (system </> "zig/zig") (childProcess True ++ waitingParent)
+        withActon acton proj ["build", "--watch", "--syspath", system] $ \ph _ output -> do
+          child <- awaitPid proj "child.pid"
+          leader <- awaitPid proj "leader.pid"
+          terminateProcess ph
+          code <- await "build watch exit" (getProcessExitCode ph)
+          assertEqual "watch should handle TERM" (ExitFailure 143) code
+          assertStopped "Zig leader" leader
+          assertStopped "Zig descendant" child
+          assertBool "interrupted build should not report success" . not . isInfixOf "Final compilation done" =<< output
+  , testGroup "successful Zig exit stops descendants"
+      [ testCase pipes $ withProcessProject $ \acton proj system -> do
+          writeExecutable (system </> "zig/zig") (childProcess redirected ++ ["exit 0"])
+          withActon acton proj ["build", "--syspath", system] $ \ph _ output -> do
+            child <- awaitPid proj "child.pid"
+            assertStopped "Zig descendant" child
+            code <- await "build exit" (getProcessExitCode ph)
+            logText <- output
+            assertEqual logText ExitSuccess code
+      | (pipes, redirected) <- [("redirected pipes", True), ("inherited pipes", False)]
+      ]
+  , testCase "stopping test watch stops test descendants" $
+      withProcessProject $ \acton proj system -> do
+        writeExecutable (proj </> "out/bin/.test_main") (childProcess True ++ waitingParent)
+        withActon acton proj ["test", "--watch", "--no-cache", "--syspath", system] $ \ph _ _ -> do
+          child <- awaitPid proj "child.pid"
+          leader <- awaitPid proj "leader.pid"
+          terminateProcess ph
+          code <- await "test watch exit" (getProcessExitCode ph)
+          assertEqual "watch should handle TERM" (ExitFailure 143) code
+          assertStopped "test leader" leader
+          assertStopped "test descendant" child
+  , testGroup "successful test exit stops descendants"
+      [ testCase pipes $ withProcessProject $ \acton proj system -> do
+          writeExecutable (proj </> "out/bin/.test_main")
+            (childProcess redirected ++ [testInfo True, "exit 0"])
+          withActon acton proj ["test", "--watch", "--no-cache", "--syspath", system] $ \ph _ output -> do
+            child <- awaitPid proj "child.pid"
+            assertStopped "test descendant" child
+            await "successful test report" $ do
+              logText <- output
+              return $ if "All 1 tests passed" `isInfixOf` logText then Just () else Nothing
+            assertEqual "watch should remain running" Nothing =<< getProcessExitCode ph
+      | (pipes, redirected) <- [("redirected pipes", True), ("inherited pipes", False)]
+      ]
+  , testCase "failed final build skips retained test binary and recovers" $
+      withProcessProject $ \acton proj system -> do
+        writeFile (proj </> "fail-build") ""
+        writeExecutable (system </> "zig/zig")
+          [ "touch build-started"
+          , "while [ ! -e finish-build ]; do sleep 0.01; done"
+          , "if [ -e fail-build ]; then exit 1; fi"
+          ]
+        writeExecutable (proj </> "out/bin/.test_main") ["touch test-ran", testInfo True]
+        withActon acton proj ["test", "--watch", "--no-cache", "--syspath", system] $ \ph _ output -> do
+          awaitFile (proj </> "build-started")
+          writeFile (proj </> "finish-build") ""
+          await "failed build report" $ do
+            logText <- output
+            return $ if "compilation of generated Zig code failed" `isInfixOf` logText then Just () else Nothing
+          -- The lock covers the complete generation, including any test run.
+          awaitGeneration proj
+          assertBool "failed build must not run the retained binary" . not =<< doesFileExist (proj </> "test-ran")
+          assertEqual "watch should survive a failed build" Nothing =<< getProcessExitCode ph
+          removeFile (proj </> "fail-build")
+          appendFile (proj </> "src/main.act") "\n# Recover from failed build\n"
+          awaitReports 1 output
+          assertBool "the next successful build should run tests" =<< doesFileExist (proj </> "test-ran")
+  , testCase "interrupted test generation retains both edited modules" $
+      withProcessProject $ \acton proj system -> do
+        writeFile (proj </> "src/other.act") $ unlines
+          [ "import testing"
+          , "def _test_ready():"
+          , "    testing.assertEqual(1, 1)"
+          ]
+        writeExecutable (proj </> "out/bin/.test_main")
+          [ "if [ -e interrupt-main ]; then"
+          , "    touch main-started"
+          , "    while [ ! -e finish-main ]; do sleep 0.01; done"
+          , "fi"
+          , "touch main-ran"
+          , testInfo True
+          ]
+        writeExecutable (proj </> "out/bin/.test_other") ["touch other-ran", moduleTestInfo "other" True]
+        withActon acton proj ["test", "--watch", "--no-cache", "--syspath", system] $ \ph _ output -> do
+          awaitReports 1 output
+          awaitGeneration proj
+          forM_ ["main-ran", "other-ran"] $ \name -> removeFile (proj </> name)
+          writeFile (proj </> "interrupt-main") ""
+          appendFile (proj </> "src/main.act") "\n# First edit\n"
+          awaitFile (proj </> "main-started")
+          removeFile (proj </> "interrupt-main")
+          appendFile (proj </> "src/other.act") "\n# Second edit interrupts the first test run\n"
+          awaitReports 2 output
+          awaitGeneration proj
+          forM_ ["main-ran", "other-ran"] $ \name ->
+            assertBool (name ++ " should run after the interrupted generation") =<< doesFileExist (proj </> name)
+          assertEqual "watch should remain running" Nothing =<< getProcessExitCode ph
+  , testCase "one-shot stress Ctrl-C reports partial results" $
+      withProcessProject $ \acton proj system -> do
+        writeExecutable (proj </> "out/bin/.test_main")
+          [ "trap 'exit 130' INT"
+          , testInfo False
+          , "echo $$ > leader.pid"
+          , "while :; do sleep 1; done"
+          ]
+        withActon acton proj ["test", "stress", "--syspath", system] $ \ph group output -> do
+          _ <- awaitPid proj "leader.pid"
+          signalProcessGroup sigINT group
+          code <- await "interrupted stress exit" (getProcessExitCode ph)
+          logText <- output
+          assertEqual logText ExitSuccess code
+          assertBool logText ("Stress run interrupted by user; showing partial results collected so far." `isInfixOf` logText)
+  ]
+  where
+    -- Inherited child pipes prevent EOF after the leader exits; redirected
+    -- pipes allow capture to finish but must not let the child outlive its owner.
+    childProcess redirected =
+      [ "echo $$ > leader.pid"
+      , "sh -c 'trap \"\" TERM; echo $$ > child.pid; exec sleep 300' </dev/null" ++
+          (if redirected then " >/dev/null 2>&1" else "") ++ " &"
+      , "while [ ! -s child.pid ]; do sleep 0.01; done"
+      ]
+    waitingParent = ["trap '' TERM", "while :; do sleep 1; done"]
+    testInfo = moduleTestInfo "main"
+    moduleTestInfo modName complete = "echo '{\"test_info\":{\"definition\":{\"module\":\"" ++ modName ++ "\",\"name\":\"_test_ready\"},\"complete\":" ++
+      (if complete then "true" else "false") ++ ",\"success\":true,\"num_iterations\":1}}' >&2"
+    awaitFile path = await path $ do
+      exists <- doesFileExist path
+      return $ if exists then Just () else Nothing
+    awaitReports count output = await "successful test report" $ do
+      logText <- output
+      return $ if length (filter ("tests passed" `isInfixOf`) (lines logText)) >= count then Just () else Nothing
+    awaitGeneration proj = await "watch generation completion" (Just <$> withProjectLock proj (return ()))
+
+-- Real Acton compilation supplies test metadata; replacing Zig and the test
+-- binary with scripts makes process lifetime and signals deterministic.
+withProcessProject :: (FilePath -> FilePath -> FilePath -> IO ()) -> IO ()
+withProcessProject action =
+    withSystemTempDirectory "acton-watch-process" $ \proj -> do
+      acton <- canonicalizePath "../../dist/bin/acton"
+      let dist = takeDirectory (takeDirectory acton)
+          system = proj </> "system"
+          name = "watch_process"
+          fingerprint = Fingerprint.formatFingerprint
+            (Fingerprint.updateFingerprintPrefix (Fingerprint.fingerprintPrefixForName name) 1)
+      createDirectory system
+      entries <- listDirectory dist
+      forM_ (filter (/= "zig") entries) $ \entry ->
+        createSymbolicLink (dist </> entry) (system </> entry)
+      writeExecutable (system </> "zig/zig") ["exit 0"]
+      createDirectory (proj </> "src")
+      writeFile (proj </> "Build.act") ("name = " ++ show name ++ "\nfingerprint = " ++ fingerprint ++ "\n")
+      writeFile (proj </> "src/main.act") $ unlines
+        [ "import testing"
+        , "def _test_ready():"
+        , "    testing.assertEqual(1, 1)"
+        , "actor main(env):"
+        , "    env.exit(0)"
+        ]
+      action acton proj system `finally`
+        forM_ ["child.pid", "leader.pid"] (\name -> do
+          text <- readOutput (proj </> name)
+          forM_ (readMaybe text :: Maybe ProcessID) $ \pid ->
+            signalProcess sigKILL pid `catch` ignoreIO)
+
+writeExecutable :: FilePath -> [String] -> IO ()
+writeExecutable path body = do
+    createDirectoryIfMissing True (takeDirectory path)
+    writeFile path (unlines ("#!/bin/sh" : body))
+    permissions <- getPermissions path
+    setPermissions path permissions { executable = True }
+
+withActon :: FilePath -> FilePath -> [String] -> (ProcessHandle -> ProcessID -> IO String -> IO a) -> IO a
+withActon acton proj args action = mask $ \restore ->
+    withFile (proj </> "compiler.log") WriteMode $ \output ->
+      withCreateProcess (proc acton args)
+        { cwd = Just proj, std_in = NoStream, std_out = UseHandle output
+        , std_err = UseHandle output, create_group = True
+        } $ \_ _ _ ph -> do
+          Just pid <- getPid ph
+          restore (action ph pid (readOutput (proj </> "compiler.log"))) `finally` stopProcessGroup ph (Just pid)
+
+readOutput :: FilePath -> IO String
+readOutput path = (BS.unpack <$> BS.readFile path) `catch` \(_ :: IOException) -> return ""
+
+awaitPid :: FilePath -> FilePath -> IO ProcessID
+awaitPid proj name = await name (readMaybe <$> readOutput (proj </> name))
+
+await :: String -> IO (Maybe a) -> IO a
+await label check = do
+    result <- Timeout.timeout 120000000 loop
+    case result of
+      Just value -> return value
+      Nothing -> assertFailure ("Timed out waiting for " ++ label)
+  where
+    loop = do
+      result <- check
+      maybe (threadDelay 20000 >> loop) return result
+
+assertStopped :: String -> ProcessID -> Assertion
+assertStopped label pid = do
+    stopped <- Timeout.timeout 5000000 $ await label $ do
+      (code, status, _) <- readProcessWithExitCode "ps" ["-o", "stat=", "-p", show pid] ""
+      return $ if code /= ExitSuccess || 'Z' `elem` status then Just () else Nothing
+    assertBool (label ++ " should stop with its owner") (isJust stopped)
+
+ignoreIO :: IOException -> IO ()
+ignoreIO _ = return ()

--- a/compiler/acton/package.yaml.in
+++ b/compiler/acton/package.yaml.in
@@ -66,6 +66,7 @@ executables:
     source-dirs:         .
     other-modules:
       - FileUtil
+      - ProcessUtil
       - PkgCommands
       - Repl
       - Paths_acton

--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -32,6 +32,7 @@ import qualified Acton.Fingerprint as Fingerprint
 import qualified Options.Applicative as OA
 import qualified Paths_acton
 import qualified Repl
+import qualified WatchTests
 import qualified TestGolden
 
 -- The default is to build and run each test program with the expectation that
@@ -74,6 +75,7 @@ main = do
       , syntaxErrorAutoTests
       , typeErrorAutoTests
       , parseFlagTests
+      , WatchTests.watchProcessTests
       , crossCompileTests
       , pkgCliTests
       ]

--- a/docs/acton-guide/src/testing.md
+++ b/docs/acton-guide/src/testing.md
@@ -85,6 +85,8 @@ Name selection also limits compilation to modules that may contain matching test
 
 Test builds follow the selected source files and their imports, and ignore the project's `libraries` groups in `Build.act`. This also applies when running all tests without selection flags. Application builds continue to honor those groups and their configured linkage.
 
+`acton test --watch` waits for successful compilation and linking before running tests. If another edit interrupts a build or test run, the next run includes tests affected by both edits. Stopping watch mode also stops its compiler and test subprocesses.
+
 ## Capability-gated tests
 
 Some tests depend on external capabilities (for example network services, hardware, or system setup). In tests that receive a test context argument (`t`), use `t.require(...)` and pass available capabilities with `--tag`:


### PR DESCRIPTION
Interrupted watch runs now stop their compiler and test process groups, including descendants that outlive the parent or keep its output pipes open. Pending edits remain queued until a generation completes, and failed final compilation cannot run stale tests or copy an old scratch binary.

Watch shutdown cleans up active work while ordinary one-shot Ctrl-C behavior, including partial stress-test summaries, is preserved.

This is an independent prerequisite for keeping Zig alive across watch builds.
