### PR TITLE
Add dependency follows and require direct declarations

### DIFF
--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -1093,24 +1093,14 @@ sigModuleIndex projMap rootProj = do
 
 sigProjectSearchOrder :: M.Map FilePath ProjCtx -> FilePath -> [FilePath]
 sigProjectSearchOrder projMap rootProj =
-    rootProj : snd (go (Data.Set.singleton rootProj) rootProj)
-  where
-    go seen root =
-      case M.lookup root projMap of
-        Nothing -> (seen, [])
-        Just ctx -> foldl' step (seen, []) (projDeps ctx)
-
-    step (seen, acc) (_, depRoot)
-      | Data.Set.member depRoot seen = (seen, acc)
-      | otherwise =
-          let seen' = Data.Set.insert depRoot seen
-              (seenNext, sub) = go seen' depRoot
-          in (seenNext, acc ++ [depRoot] ++ sub)
+    rootProj : maybe [] (map snd . projDeps) (M.lookup rootProj projMap)
 
 sigTySearchPath :: C.CompileOptions -> Paths -> FilePath -> M.Map FilePath ProjCtx -> [FilePath]
 sigTySearchPath opts paths rootProj projMap =
     case M.lookup rootProj projMap of
-      Just rootCtx -> let ps = searchPathForProject opts projMap rootCtx
+      Just rootCtx -> let ps = [ projTypesDir ctx | root <- sigProjectSearchOrder projMap rootProj
+                                                        , Just ctx <- [M.lookup root projMap] ]
+                              ++ C.searchpath opts ++ systemTypePaths (sysPath paths) (sysTypes paths)
                       in ps ++ [projTypesDir rootCtx </> projName paths]        -- Add the prefixed type-dir as a last resort in case the source has been deleted
       Nothing      -> searchPath paths
 

--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -1149,7 +1149,7 @@ pkgShow gopts = do
     curDir <- getCurrentDirectory
     _ <- requireProjectConfigPath curDir
     spec <- loadBuildSpec curDir
-    let rootPins = BuildSpec.dependencies spec
+    let rootPins = M.map (rebaseDepPath curDir) (BuildSpec.concreteDependencies spec)
     unless (C.quiet gopts) $
       putStrLn "Dependency tree (hash overrides shown):"
     partial <- showTree rootPins curDir spec 0
@@ -1174,11 +1174,17 @@ pkgShow gopts = do
       let deps = M.toList (BuildSpec.dependencies spec)
       foldM (step pins dir depth) False deps
 
-    step pins dir depth partial (depName, dep) = do
+    step pins dir depth partial (depName, dep)
+      | Just ref <- BuildSpec.follows dep = do
+          putStrLn (replicate (2*depth) ' ' ++ "- " ++ depName ++ " (follows=" ++ ref ++ ")")
+          return partial
+      | otherwise = showConcrete pins dir depth partial depName dep
+
+    showConcrete pins dir depth partial depName dep = do
       let (chosen, conflict) =
             case M.lookup depName pins of
               Nothing -> (dep, False)
-              Just pinDep -> if pinDep == dep then (dep, False) else (pinDep, True)
+              Just pinDep -> (pinDep, pinDep /= rebaseDepPath dir dep)
       depBase <- resolveDepBase dir depName chosen
       depExists <- doesDirectoryExist depBase
       let notFetched = isHashDep chosen && not depExists
@@ -2029,7 +2035,6 @@ runCliPostCompile cliHooks gopts plan env = do
         rootProj = ccRootProj cctx
         sysAbs = ccSysAbs cctx
         rootTasks = cpRootTasks plan
-        rootPins = cpRootPins plan
         allowPrune' = cpAllowPrune plan
         globalTasks = cpGlobalTasks plan
         neededTasks = cpNeededTasks plan
@@ -2068,7 +2073,7 @@ runCliPostCompile cliHooks gopts plan env = do
             dummyPaths <- pathsForModule opts' projMap pctx (A.modName ["__gen_build__"])
             let depOpts = M.findWithDefault M.empty p depModuleOptsByProj
                 depPathOverrides = projectDepPathOverrides projMap p
-            genBuildZigFiles (projBuildSpec pctx) rootPins (ccDepOverrides cctx) dummyPaths depOpts depPathOverrides
+            genBuildZigFiles (projBuildSpec pctx) dummyPaths depOpts depPathOverrides
           Nothing -> return ()
     let runFinal action = do
           cchFinalStart cliHooks
@@ -2508,9 +2513,9 @@ generateFingerprint name = do
     return (Fingerprint.formatFingerprint fp)
 
 -- Render build.zig and build.zig.zon from templates and BuildSpec.
--- rootPins: dependency pins from the main project (applied to all deps, including transitive)
-genBuildZigFiles :: BuildSpec.BuildSpec -> M.Map String BuildSpec.PkgDep -> [(String, FilePath)] -> Paths -> M.Map String String -> M.Map String FilePath -> IO ()
-genBuildZigFiles spec rootPins depOverrides paths depModuleOpts depPathOverrides = do
+-- Dependency paths come from the selected, deduplicated project graph.
+genBuildZigFiles :: BuildSpec.BuildSpec -> Paths -> M.Map String String -> M.Map String FilePath -> IO ()
+genBuildZigFiles spec paths depModuleOpts depPathOverrides = do
     let proj = projPath paths
     projAbs <- canonicalizePath proj
     let sys              = sysPath paths
@@ -2522,7 +2527,7 @@ genBuildZigFiles spec rootPins depOverrides paths depModuleOpts depPathOverrides
     buildZonTemplate <- readFile distBuildZonPath
     let zonName = BuildSpec.specName spec
         fp = BuildSpec.fingerprint spec
-    (transPkgs, transZigs) <- collectDepsRecursive spec proj rootPins depOverrides
+    (transPkgs, transZigs) <- collectDepsRecursive spec proj depPathOverrides
     absSys <- canonicalizePath sys
     let relSys = relativeViaRoot projAbs absSys
     homeDir <- getHomeDirectory
@@ -2531,8 +2536,7 @@ genBuildZigFiles spec rootPins depOverrides paths depModuleOpts depPathOverrides
     let directZigs = [ ZigDepRef depName (rebaseZigDep projAbs proj dep)
                      | (depName, dep) <- M.toList (BuildSpec.zig_dependencies normalizedSpec)
                      ]
-        applyPins deps = M.mapWithKey (\n d -> M.findWithDefault d n rootPins) deps
-        mergedSpec0 = normalizedSpec { BuildSpec.dependencies = applyPins (BuildSpec.dependencies normalizedSpec) `M.union` transPkgs }
+        mergedSpec0 = normalizedSpec { BuildSpec.dependencies = BuildSpec.dependencies normalizedSpec `M.union` transPkgs }
         mergedSpec1 = applyPkgDepPathOverrides projAbs depPathOverrides mergedSpec0
         mergedSpec = addImplicitStdDependency absSys mergedSpec1
         resolvedZigs = resolveZigDepRefs (M.keys (BuildSpec.dependencies mergedSpec)) (directZigs ++ transZigs)
@@ -2547,7 +2551,7 @@ addImplicitStdDependency sys spec
   | otherwise = spec { BuildSpec.dependencies = M.insert "std" stdDep deps }
   where
     deps = BuildSpec.dependencies spec
-    stdDep = BuildSpec.PkgDep Nothing Nothing (Just (joinPath [sys, "std"])) Nothing Nothing
+    stdDep = BuildSpec.PkgDep Nothing Nothing (Just (joinPath [sys, "std"])) Nothing Nothing Nothing
 
 applyPkgDepPathOverrides :: FilePath -> M.Map String FilePath -> BuildSpec.BuildSpec -> BuildSpec.BuildSpec
 applyPkgDepPathOverrides projRoot depPathOverrides spec =
@@ -2557,7 +2561,8 @@ applyPkgDepPathOverrides projRoot depPathOverrides spec =
       case M.lookup depName depPathOverrides of
         Nothing -> dep
         Just depPath ->
-          dep { BuildSpec.path = Just (collapseDots (makeRelativeOrAbsolute projRoot depPath)) }
+          dep { BuildSpec.path = Just (collapseDots (makeRelativeOrAbsolute projRoot depPath))
+              , BuildSpec.follows = Nothing }
 
 data ZigDepRef = ZigDepRef
   { zigDepRefName :: String
@@ -2801,14 +2806,12 @@ zigBuild env gopts opts paths rootSpec tasks binTasks allowPrune rootModules bui
         no_threads = if isWindowsOS (C.target opts) then True else C.no_threads opts
     projAbs <- normalizePathSafe (projPath paths)
     sysAbs  <- normalizePathSafe (sysPath paths)
-    depOverrides <- normalizeDepOverrides (projPath paths) (C.dep_overrides opts)
     let sysRoot   = addTrailingPathSeparator sysAbs
         isSysProj = projAbs == sysAbs || sysRoot `isPrefixOf` projAbs
 
     -- Generate build.zig and build.zig.zon directly from Build.act.
-    iff (not isSysProj) $ do
-      let pins = BuildSpec.dependencies rootSpec
-      genBuildZigFiles rootSpec pins depOverrides paths depModuleOpts depPathOverrides
+    iff (not isSysProj) $
+      genBuildZigFiles rootSpec paths depModuleOpts depPathOverrides
 
     let zigExe = zig paths
         baseArgs = ["build","--cache-dir", local_cache_dir,
@@ -2913,43 +2916,32 @@ relativeViaRoot baseAbs targetAbs
   where
     cleanParts = filter (\c -> not (null c) && c /= "/") . splitDirectories
 
--- | Walk BuildSpec dependencies to collect transitive packages and zig deps.
-collectDepsRecursive :: BuildSpec.BuildSpec -> FilePath -> M.Map String BuildSpec.PkgDep -> [(String, FilePath)] -> IO (M.Map String BuildSpec.PkgDep, [ZigDepRef])
-collectDepsRecursive rootSpec projDir pins overrides = do
+-- | Collect build inputs from the canonical paths selected during discovery.
+-- References and version conflicts have already been resolved in that graph.
+collectDepsRecursive :: BuildSpec.BuildSpec -> FilePath -> M.Map String FilePath -> IO (M.Map String BuildSpec.PkgDep, [ZigDepRef])
+collectDepsRecursive rootSpec projDir depPaths = do
   root <- normalizePathSafe projDir
-  spec <- applyDepOverrides root overrides rootSpec
-  (\(_, pkgs, zigs) -> (pkgs, zigs)) <$> foldM (step root root) (Data.Set.empty, M.empty, []) (M.toList (BuildSpec.dependencies spec))
+  (\(_, pkgs, zigs) -> (pkgs, zigs)) <$> foldM (step root)
+    (Data.Set.singleton root, M.empty, []) (M.toList (BuildSpec.dependencies rootSpec))
   where
-    go root seen dir mSpec = do
-      spec0 <- case mSpec of
-                 Just s -> return s
-                 Nothing -> loadBuildSpec dir
-      spec <- applyDepOverrides dir overrides spec0
-      let depsHere = BuildSpec.dependencies spec
-          zigsHere = [ ZigDepRef depName (rebaseZigDep root dir dep)
+    go root seen dir = do
+      spec <- loadBuildSpec dir
+      let zigsHere = [ ZigDepRef depName (rebaseZigDep root dir dep)
                      | (depName, dep) <- M.toList (BuildSpec.zig_dependencies spec)
                      ]
-      foldM (step root dir) (seen, M.empty, zigsHere) (M.toList depsHere)
+      foldM (step root) (seen, M.empty, zigsHere) (M.toList (BuildSpec.dependencies spec))
 
-    step root base (seen, pkgAcc, zigAcc) (depName, dep) = do
-      let depChosen = case M.lookup depName pins of
-                        Nothing   -> dep
-                        Just pdep -> pdep
-      depBase <- resolveDepBase base depName depChosen
-      let seen' = Data.Set.insert depBase seen
-          rebasePkgPath d =
-            case BuildSpec.path d of
-              Just p | not (null p) ->
-                let absP = rebasePath base p
-                    relP = makeRelativeOrAbsolute root absP
-                in d { BuildSpec.path = Just (collapseDots relP) }
-              _ -> d
-          dep' = rebasePkgPath depChosen
+    step root (seen, pkgAcc, zigAcc) (depName, dep) = do
+      depBase <- case M.lookup depName depPaths of
+                   Just dir -> return dir
+                   Nothing -> throwProjectError ("Missing selected dependency '" ++ depName ++ "' for " ++ root)
+      let dep' = dep { BuildSpec.path = Just (collapseDots (makeRelativeOrAbsolute root depBase))
+                     , BuildSpec.follows = Nothing }
+          pkgAcc' = M.insertWith (\_ old -> old) depName dep' pkgAcc
       if Data.Set.member depBase seen
-        then return (seen', pkgAcc, zigAcc)
+        then return (seen, pkgAcc', zigAcc)
         else do
-          (seenNext, subPkgs, subZigs) <- go root seen' depBase Nothing
-          let pkgAcc' = M.insertWith (\_ old -> old) depName dep' pkgAcc
+          (seenNext, subPkgs, subZigs) <- go root (Data.Set.insert depBase seen) depBase
           return (seenNext, pkgAcc' `M.union` subPkgs, zigAcc ++ subZigs)
 
 rebaseZigDep :: FilePath -> FilePath -> BuildSpec.ZigDep -> BuildSpec.ZigDep

--- a/compiler/acton/PkgCommands.hs
+++ b/compiler/acton/PkgCommands.hs
@@ -200,6 +200,7 @@ resolveLibraryDependency depName = do
       , BuildSpec.path = Nothing
       , BuildSpec.repo_url = Just repoUrl
       , BuildSpec.repo_ref = Nothing
+      , BuildSpec.follows = Nothing
       }
 
 pkgRemoveCommand :: C.GlobalOptions -> C.PkgRemoveOptions -> IO ()
@@ -223,7 +224,7 @@ pkgUpgradeCommand _ opts = do
     let deps = BuildSpec.dependencies spec
     manager <- newProxyManager
     token <- resolveGithubToken (normalizeMaybe (C.pkgUpgradeGithubToken opts))
-    resolved <- mapM (resolveDep manager token) (M.toList deps)
+    resolved <- mapM (resolveDep manager token) (M.toList (BuildSpec.concreteDependencies spec))
     let newUrls = M.fromList [ (n,u) | Just (n,u) <- resolved ]
     if M.null newUrls
       then putStrLn "No dependencies to upgrade"
@@ -497,7 +498,7 @@ upsertPkgDep :: BuildSpec.BuildSpec -> String -> String -> String -> Maybe Strin
 upsertPkgDep spec depName depUrl depHash depRepoUrl depRepoRef =
     case M.lookup depName (BuildSpec.dependencies spec) of
       Just dep ->
-        let (msgs1, dep1) = updateUrl dep
+        let (msgs1, dep1) = updateUrl dep { BuildSpec.follows = Nothing }
             (msgs2, dep2) = updateHash dep1
             dep3 = case depRepoUrl of
                      Nothing -> dep2
@@ -511,6 +512,7 @@ upsertPkgDep spec depName depUrl depHash depRepoUrl depRepoRef =
               , BuildSpec.path = Nothing
               , BuildSpec.repo_url = depRepoUrl
               , BuildSpec.repo_ref = depRepoRef
+              , BuildSpec.follows = Nothing
               }
             deps' = M.insert depName newDep (BuildSpec.dependencies spec)
         in (spec { BuildSpec.dependencies = deps' }, ["Added new package dependency " ++ depName ++ " with hash " ++ depHash])

--- a/compiler/acton/Repl.hs
+++ b/compiler/acton/Repl.hs
@@ -287,6 +287,7 @@ renderReplBuildAct deps mproj =
               , BuildSpec.path = Just p
               , BuildSpec.repo_url = Nothing
               , BuildSpec.repo_ref = Nothing
+              , BuildSpec.follows = Nothing
               }
 
 replLoop :: MonadIO m => ReplShell m -> ReplContext -> ReplState -> m ()

--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 import Control.Monad
-import Data.Char (isAlphaNum, isSpace)
+import Data.Char (isAlphaNum, isSpace, toLower)
 import Data.List
 import Data.List.Split
 import Data.Maybe (catMaybes)
@@ -1301,7 +1301,9 @@ parseFlagTests =
 
 actonProjTests =
   testGroup "compiler project tests"
-  [ testCase "simple project" $ do
+  [ dependencyDeclarationTests
+
+  , testCase "simple project" $ do
         testBuild "" ExitSuccess False "test/project/simple"
         testBuild "" ExitSuccess False "test/project/simple"
 
@@ -1703,6 +1705,140 @@ actonProjTests =
         assertBool "bar root stub should be removed after source deletion" . not =<< doesFileExist barRoot
         assertBool "bar binary should be removed after source deletion" . not =<< doesFileExist barBin
   ]
+
+dependencyDeclarationTests =
+  testGroup "dependency declarations"
+  [ testCase "follows chains preserve dependency path ownership" $ withFixture $ \acton tmp app platform _ -> do
+      let adapter = tmp </> "deps" </> "adapter"
+      writeProject adapter "adapter" [("yang", pathDep "../../shared/yang")]
+      writeModule adapter "lib" answerSource
+      writeProject platform "platform"
+        [("adapter", pathDep "../adapter"), ("yang", followsDep "adapter.yang")]
+      writeModule app "main" "import yang.api\n\ndef answer() -> int:\n    return yang.api.answer()\n"
+      forM_ ["platform.yang", "platform.adapter.yang"] $ \ref -> do
+        writeProject app "app" [platformDep, ("yang", followsDep ref)]
+        expectSuccess ("following " ++ ref) =<< runBuild acton app
+
+  , testCase "follows leaves sibling version selection unchanged" $ withFixture $ \acton tmp app platform yang -> do
+      let first = tmp </> "first" </> "yang"
+          sibling = tmp </> "a"
+          concreteDeps = [("a", pathDep "../a"), platformDep]
+      writeProject first "yang" []
+      writeModule first "lib" answerSource
+      writeModule first "api" (answerSource ++ "\ndef first_only() -> int:\n    return 1\n")
+      writeProject sibling "a" [("yang", pathDep "../first/yang")]
+      writeModule sibling "lib" "import yang.api\n\ndef answer() -> int:\n    return yang.api.answer()\n"
+      writeProject app "app" concreteDeps
+      writeModule app "main" "import platform\n\ndef answer() -> int:\n    return platform.answer()\n"
+      expectSuccess "concrete graph with conflicting sibling versions" =<< runBuild acton app
+      doesDirectoryExist (first </> "out/types/yang/api.tydb")
+        >>= assertBool "the first concrete yang version should be selected"
+      doesDirectoryExist (yang </> "out/types/yang/api.tydb")
+        >>= assertBool "the later concrete yang version should be deduplicated" . not
+      writeProject app "app" (concreteDeps ++ [("yang", followsDep "platform.yang")])
+      writeModule app "main" "import yang.api\n\ndef answer() -> int:\n    return yang.api.first_only()\n"
+      result@(_, out, err) <- runBuild acton app
+      expectSuccess "follows binds the already selected sibling version" result
+      assertBool "follows should not introduce a root pin"
+        (not ("dependency 'yang'" `isInfixOf` (out ++ err)
+              && "overridden by root pin" `isInfixOf` (out ++ err)))
+      writeModule app "main" $ unlines
+        [ "import platform"
+        , "import yang.api"
+        , ""
+        , "actor main(env):"
+        , "    print(platform.answer() + yang.api.first_only())"
+        , "    env.exit(0)"
+        ]
+      expectSuccess "full build with the selected following dependency" =<<
+        readCreateProcessWithExitCode (proc acton ["build", "--color", "never"]){ cwd = Just app } ""
+      forM_ [app, platform] $ \dir -> do
+        zon <- readFile (dir </> "build.zig.zon")
+        assertBool (dir ++ " should use the selected yang path")
+          (any (`isInfixOf` zon) ["first/yang", "first\\\\yang"])
+        assertBool (dir ++ " should not use the discarded yang path")
+          (not (any (`isInfixOf` zon) ["shared/yang", "shared\\\\yang"]))
+      runResult@(_, runOut, _) <- readCreateProcessWithExitCode (proc (app </> "out/bin/main") []) ""
+      expectSuccess "following dependency binary" runResult
+      assertEqual "both imports should use the selected yang implementation" "43\n" runOut
+
+  , testCase "concrete root pins propagate through follows" $ withFixture $ \acton tmp app _ _ -> do
+      let pinned = tmp </> "pinned" </> "yang"
+          consumer = tmp </> "consumer"
+      writeProject pinned "yang" []
+      writeModule pinned "api" (answerSource ++ "\ndef pinned_only() -> int:\n    return 1\n")
+      writeProject consumer "consumer" [platformDep, ("yang", followsDep "platform.yang")]
+      writeModule consumer "lib" "import yang.api\n\ndef answer() -> int:\n    return yang.api.pinned_only()\n"
+      writeProject app "app"
+        [("consumer", pathDep "../consumer"), ("yang", pathDep "../pinned/yang")]
+      writeModule app "main" "import consumer\n\ndef answer() -> int:\n    return consumer.answer()\n"
+      expectSuccess "root pin selected through a downstream follows" =<< runBuild acton app
+
+  , testGroup "invalid follows references"
+      [ testCase ref $ withFixture $ \acton _ app _ _ -> do
+          writeProject app "app" [platformDep, ("yang", followsDep ref)]
+          writeModule app "main" answerSource
+          result@(_, out, err) <- runBuild acton app
+          expectFailure "missing follows target" ref result
+          assertBool "diagnostic should identify follows" ("follows" `isInfixOf` map toLower (out ++ err))
+      | ref <- ["missing.yang", "platform.missing", "platform.yang.missing"]
+      ]
+
+  , testCase "follows cycles fail with a diagnostic" $ withFixture $ \acton _ app platform _ -> do
+      writeProject app "app" [platformDep, ("yang", followsDep "platform.yang")]
+      writeProject platform "platform" [("app", pathDep "../../app"), ("yang", followsDep "app.yang")]
+      writeModule app "main" answerSource
+      result@(_, out, err) <- runBuild acton app
+      expectFailure "cyclic follows" "follows" result
+      assertBool "diagnostic should identify the cycle"
+        (any (`isInfixOf` map toLower (out ++ err)) ["cycle", "cyclic"])
+  ]
+  where
+    platformDep = ("platform", pathDep "../deps/platform")
+    pathDep path = "path=" ++ show path
+    followsDep ref = "follows=" ++ show ref
+    answerSource = "def answer() -> int:\n    return 42\n"
+
+    writeProject :: FilePath -> String -> [(String, String)] -> IO ()
+    writeProject dir name deps = do
+      createDirectoryIfMissing True (dir </> "src")
+      let fp = Fingerprint.formatFingerprint
+            (Fingerprint.updateFingerprintPrefix (Fingerprint.fingerprintPrefixForName name) 1)
+      writeFile (dir </> "Build.act") $ unlines
+        [ "name = " ++ show name
+        , "fingerprint = " ++ fp
+        , "dependencies = {"
+        , intercalate ",\n" ["    " ++ show dep ++ ": (" ++ fields ++ ")" | (dep, fields) <- deps]
+        , "}"
+        ]
+
+    writeModule dir name content = writeFile (dir </> "src" </> name <.> "act") content
+
+    withFixture action = withSystemTempDirectory "acton-dependency-declarations" $ \tmp -> do
+      acton <- canonicalizePath "../../dist/bin/acton"
+      let app = tmp </> "app"
+          platform = tmp </> "deps" </> "platform"
+          yang = tmp </> "shared" </> "yang"
+      writeProject yang "yang" []
+      writeModule yang "lib" answerSource
+      writeModule yang "api" answerSource
+      writeProject platform "platform" [("yang", pathDep "../../shared/yang")]
+      writeModule platform "lib" "import yang.api\n\ndef answer() -> int:\n    return yang.api.answer()\n"
+      writeProject app "app" [platformDep]
+      action acton tmp app platform yang
+
+    runBuild = runBuildWith []
+
+    runBuildWith flags acton dir = readCreateProcessWithExitCode
+      (proc acton (["build", "--skip-build", "--color", "never"] ++ flags)){ cwd = Just dir } ""
+
+    expectSuccess label (code, out, err) =
+      assertEqual (label ++ "\nstdout:\n" ++ out ++ "\nstderr:\n" ++ err) ExitSuccess code
+
+    expectFailure label detail (code, out, err) = do
+      assertEqual (label ++ "\nstdout:\n" ++ out ++ "\nstderr:\n" ++ err) (ExitFailure 1) code
+      assertBool (label ++ ": expected diagnostic containing " ++ show detail ++ "\n" ++ out ++ err)
+        (detail `isInfixOf` (out ++ err))
 
 actonRootArgTests =
   testGroup "compiler acton --root tests"

--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -1708,7 +1708,75 @@ actonProjTests =
 
 dependencyDeclarationTests =
   testGroup "dependency declarations"
-  [ testCase "follows chains preserve dependency path ownership" $ withFixture $ \acton tmp app platform _ -> do
+  [ testGroup "imports require direct declarations"
+      [ testCase label $ withFixture $ \acton _ app _ _ -> do
+          writeModule app "main" source
+          expectFailure "undeclared import" "yang" =<< runBuild acton app
+          writeProject app "app" [platformDep, ("yang", pathDep "../shared/yang")]
+          expectSuccess "direct dependency import" =<< runBuild acton app
+          expectSuccess "cached direct dependency import" =<< runBuild acton app
+          writeProject app "app" [platformDep]
+          expectFailure "cached undeclared import" "yang" =<< runBuild acton app
+          writeProject app "app" [platformDep, ("yang", followsDep "platform.yang")]
+          expectSuccess "following dependency import" =<< runBuild acton app
+      | (label, source) <-
+          [ ("bare", "import yang\n\ndef answer() -> int:\n    return yang.answer()\n")
+          , ("dotted", "import yang.api\n\ndef answer() -> int:\n    return yang.api.answer()\n")
+          , ("explicit lib", "import yang.lib\n\ndef answer() -> int:\n    return yang.lib.answer()\n")
+          , ("from bare", "from yang import answer\n\ndef value() -> int:\n    return answer()\n")
+          , ("from dotted", "from yang.api import answer\n\ndef value() -> int:\n    return answer()\n")
+          , ("from all", "from yang.api import *\n\ndef value() -> int:\n    return answer()\n")
+          ]
+      ]
+
+  , testGroup "cached dependency imports keep source spelling"
+      [ testCase label $ withFixture $ \acton _ app _ _ -> do
+          writeProject app "app" [platformDep, ("yang", followsDep "platform.yang")]
+          writeModule app "main" "import yang\n\ndef answer() -> int:\n    return yang.answer()\n"
+          expectSuccess "initial following dependency import" =<< runBuild acton app
+          writeProject app "app" [platformDep]
+          createDirectoryIfMissing True (takeDirectory (app </> "src" </> localModule <.> "act"))
+          writeModule app localModule answerSource
+          forM_ [("cached", []), ("rebuilt", ["--always-build"])] $ \(mode, flags) -> do
+            result <- runBuildWith flags acton app
+            if localImport
+              then expectSuccess (mode ++ " import of the replacement local module") result
+              else expectFailure (mode ++ " undeclared dependency import") "yang" result
+      | (label, localModule, localImport) <-
+          [ ("nested local lib is not a dependency declaration", "yang/lib", False)
+          , ("local module replaces dependency", "yang", True)
+          ]
+      ]
+
+  , testCase "root declarations do not authorize dependency imports" $ withFixture $ \acton _ app platform _ -> do
+      writeProject app "app" [platformDep, ("yang", pathDep "../shared/yang")]
+      writeProject platform "platform" []
+      writeModule app "main" "import platform\n\ndef answer() -> int:\n    return platform.answer()\n"
+      expectFailure "undeclared import in a dependency" "yang" =<< runBuild acton app
+
+  , testCase "dependency APIs retain transitive types" $ withFixture $ \acton _ app platform yang -> do
+      writeModule yang "api" $ unlines
+        [ "class Box(object):"
+        , "    value: int"
+        , "    def __init__(self, value: int):"
+        , "        self.value = value"
+        ]
+      writeModule platform "lib" $ unlines
+        [ "import yang.api"
+        , ""
+        , "def create() -> yang.api.Box:"
+        , "    return yang.api.Box(42)"
+        ]
+      writeModule app "main" $ unlines
+        [ "import platform"
+        , ""
+        , "def answer() -> int:"
+        , "    return platform.create().value"
+        ]
+      expectSuccess "transitive type in direct dependency API" =<< runBuild acton app
+      expectSuccess "cached transitive type in direct dependency API" =<< runBuild acton app
+
+  , testCase "follows chains preserve dependency path ownership" $ withFixture $ \acton tmp app platform _ -> do
       let adapter = tmp </> "deps" </> "adapter"
       writeProject adapter "adapter" [("yang", pathDep "../../shared/yang")]
       writeModule adapter "lib" answerSource

--- a/compiler/lib/src/Acton/BuildSpec.hs
+++ b/compiler/lib/src/Acton/BuildSpec.hs
@@ -5,6 +5,7 @@ module Acton.BuildSpec
   , ZigDep(..)
   , Library(..)
   , BuildSpec(..)
+  , concreteDependencies
   , encodeBuildSpecJSON
   , renderBuildAct
   , parseBuildAct
@@ -20,7 +21,7 @@ import qualified Data.Aeson as Ae
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.Map as Map
 import Data.Map (Map)
-import Data.Char (isSpace)
+import Data.Char (isAlpha, isAlphaNum, isSpace)
 import Data.Maybe (catMaybes, fromMaybe, isNothing, mapMaybe)
 import qualified Data.List as L
 import qualified Control.Exception as E
@@ -34,6 +35,7 @@ import qualified Acton.Syntax as S
 import qualified Acton.Printer as Pr
 import Utils (SrcLoc(..))
 import qualified Data.Aeson.KeyMap as KM
+import qualified Data.Aeson.Key as K
 
 -- Acton build configuration data model
 
@@ -59,23 +61,30 @@ data PkgDep = PkgDep
   , path      :: Maybe String
   , repo_url  :: Maybe String
   , repo_ref  :: Maybe String
+  , follows   :: Maybe String
   } deriving (Eq, Show, Generic)
 
 instance FromJSON PkgDep where
-  parseJSON = Ae.withObject "PkgDep" $ \o ->
+  parseJSON = Ae.withObject "PkgDep" $ \o -> do
+    f <- if KM.member "follows" o then Just <$> o .: "follows" else pure Nothing
+    case f of
+      Just ref -> either fail pure (checkFollows ref (map K.toString (KM.keys o)))
+      Nothing -> pure ()
     PkgDep <$> o .:? "url"
            <*> o .:? "hash"
            <*> o .:? "path"
            <*> o .:? "repo_url"
            <*> o .:? "repo_ref"
+           <*> pure f
 
 instance ToJSON PkgDep where
-  toJSON (PkgDep u h p ru rr) = Ae.object $ catMaybes
+  toJSON (PkgDep u h p ru rr f) = Ae.object $ catMaybes
     [ ("url"      .=) <$> u
     , ("hash"     .=) <$> h
     , ("path"     .=) <$> p
     , ("repo_url" .=) <$> ru
     , ("repo_ref" .=) <$> rr
+    , ("follows"  .=) <$> f
     ]
 
 data ZigDep = ZigDep
@@ -129,11 +138,16 @@ data BuildSpec = BuildSpec
   , libraries        :: Map String Library
   } deriving (Eq, Show, Generic)
 
+-- | Dependencies that contribute a source to project selection.
+concreteDependencies :: BuildSpec -> Map String PkgDep
+concreteDependencies = Map.filter (isNothing . follows) . dependencies
+
 data BuildSpecParseError
   = ParseError String
   | MissingProjectName
   | MissingFingerprint String
   | InvalidFingerprint String String
+  | InvalidDependency String String
   | UnsupportedOptions String
   | UnsupportedOptionValue String String
   deriving (Eq, Show)
@@ -148,6 +162,8 @@ renderBuildSpecParseError err =
       "Invalid fingerprint " ++ raw ++ " (project name: " ++ show name ++ "). "
       ++ "Expected an unquoted 64-bit hex fingerprint like "
       ++ "0x1234abcd5678ef00"
+    InvalidDependency dep msg ->
+      "Invalid dependency " ++ show dep ++ ": " ++ msg
     UnsupportedOptions dep ->
       "Unsupported options for zig dependency " ++ show dep ++ ". "
       ++ "Expected a dict of plain string literals"
@@ -429,12 +445,12 @@ extractSpecFromModule (S.Module _ _ _ stmts) = do
                                           then mfpErr <|> Just (renderExpr expr)
                                           else mfpErr)
                 else (mfp, mfpErr)
-            deps'  = if "dependencies" `elem` names
-                       then fromMaybe deps (exprToPkgDeps expr)
-                       else deps
             libs'  = if "libraries" `elem` names
                        then fromMaybe libs (exprToLibraries expr)
                        else libs
+        deps' <- if "dependencies" `elem` names
+                   then fromMaybe deps <$> exprToPkgDeps expr
+                   else Right deps
         zigs' <- if "zig_dependencies" `elem` names
                    then fromMaybe zigs <$> exprToZigDeps expr
                    else Right zigs
@@ -575,13 +591,14 @@ renderExpr e = Pr.render (Pr.pretty e)
 --     key2="val2"
 -- )
 renderPkgTuple :: PkgDep -> String
-renderPkgTuple (PkgDep u h p ru rr) =
+renderPkgTuple (PkgDep u h p ru rr f) =
   let fields = catMaybes
         [ fmap (\x -> ("repo_url", mkStr x)) ru
         , fmap (\x -> ("repo_ref", mkStr x)) rr
         , fmap (\x -> ("url", mkStr x)) u
         , fmap (\x -> ("hash", mkStr x)) h
         , fmap (\x -> ("path", mkStr x)) p
+        , fmap (\x -> ("follows", mkStr x)) f
         ]
   in case fields of
        [] -> "()"
@@ -654,27 +671,48 @@ renderFingerprint fp
         '0':'X':_ -> Fingerprint.formatFingerprint <$> Fingerprint.parseFingerprint raw
         _         -> Nothing
 
-exprToPkgDeps :: S.Expr -> Maybe (Map.Map String PkgDep)
-exprToPkgDeps (S.Dict _ assocs) = Just $ Map.fromList (mapMaybe assocToPkg assocs)
+exprToPkgDeps :: S.Expr -> Either BuildSpecParseError (Maybe (Map.Map String PkgDep))
+exprToPkgDeps (S.Dict _ assocs) = Just . Map.fromList . catMaybes <$> traverse assocToPkg assocs
   where
-    assocToPkg (S.Assoc k v) = do
-      key <- exprToSimpleString k
-      dep <- tupleToPkg v
-      pure (key, dep)
-    assocToPkg _ = Nothing
-exprToPkgDeps _ = Nothing
+    assocToPkg (S.Assoc k v)
+      | Just key <- exprToSimpleString k = fmap ((,) key) <$> tupleToPkg key v
+    assocToPkg _ = Right Nothing
+exprToPkgDeps _ = Right Nothing
 
-tupleToPkg :: S.Expr -> Maybe PkgDep
-tupleToPkg (S.Tuple _ _ kargs) =
+tupleToPkg :: String -> S.Expr -> Either BuildSpecParseError (Maybe PkgDep)
+tupleToPkg dep (S.Tuple _ _ kargs) = do
   let m = kwdToMap kargs
-  in Just PkgDep { url = Map.lookup "url" m >>= exprToSimpleString
-                 , hash = Map.lookup "hash" m >>= exprToSimpleString
-                 , path = Map.lookup "path" m >>= exprToSimpleString
-                 , repo_url = Map.lookup "repo_url" m >>= exprToSimpleString
-                 , repo_ref = Map.lookup "repo_ref" m >>= exprToSimpleString
-                 }
-tupleToPkg (S.Paren _ e) = tupleToPkg e
-tupleToPkg _ = Nothing
+  f <- case Map.lookup "follows" m of
+         Nothing -> Right Nothing
+         Just expr -> case exprToSimpleString expr of
+           Nothing -> Left (InvalidDependency dep "follows must be a plain string literal")
+           Just ref -> case checkFollows ref (Map.keys m) of
+             Left msg -> Left (InvalidDependency dep msg)
+             Right () -> Right (Just ref)
+  Right $ Just PkgDep { url = Map.lookup "url" m >>= exprToSimpleString
+                     , hash = Map.lookup "hash" m >>= exprToSimpleString
+                     , path = Map.lookup "path" m >>= exprToSimpleString
+                     , repo_url = Map.lookup "repo_url" m >>= exprToSimpleString
+                     , repo_ref = Map.lookup "repo_ref" m >>= exprToSimpleString
+                     , follows = f
+                     }
+tupleToPkg dep (S.Paren _ e) = tupleToPkg dep e
+tupleToPkg _ _ = Right Nothing
+
+checkFollows :: String -> [String] -> Either String ()
+checkFollows ref fields
+  | length names < 2 || not (all validName names) =
+      Left "follows must name a dependency through another dependency, for example \"stratoweave.yang\""
+  | any (`elem` fields) ["url", "hash", "path", "repo_url", "repo_ref"] =
+      Left "follows cannot be combined with url, hash, path, repo_url or repo_ref"
+  | otherwise = Right ()
+  where
+    names = split ref
+    split s = case break (== '.') s of
+                (n, []) -> [n]
+                (n, _:rest) -> n : split rest
+    validName (c:cs) = (isAlpha c || c == '_') && all (\c -> isAlphaNum c || c == '_') cs
+    validName [] = False
 
 exprToZigDeps :: S.Expr -> Either BuildSpecParseError (Maybe (Map.Map String ZigDep))
 exprToZigDeps (S.Dict _ assocs) = Just . Map.fromList . catMaybes <$> traverse assocToZig assocs

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -167,6 +167,7 @@ module Acton.Compile
   , discoverProjects
   , pathsForModule
   , searchPathForProject
+  , systemTypePaths
   , moduleNameFromFile
   , enumerateProjectModules
   , normalizeDepOverrides
@@ -1538,6 +1539,26 @@ checkImportPrefixes key proj modSets imps
         Just mods0      = M.lookup p0 modSets
         prefixed        = [ mn | mn <- imps, Data.Set.member mn mods0 ]
 
+-- | Source imports may name only local modules or directly declared projects.
+-- Transitive interfaces remain available for types mentioned by imported APIs.
+checkImportDependencies :: Paths -> M.Map FilePath ProjCtx -> M.Map FilePath (Data.Set.Set A.ModName) -> [A.ModName] -> IO ()
+checkImportDependencies paths projects modSets imps =
+    forM_ imps $ \mn ->
+      case A.modPath mn of
+        n:_ | Data.Set.member n projectNames
+            , n `notElem` directNames
+            , not (Data.Set.member (addProjPrefix paths mn) localMods) ->
+          throwProjectError ("Dependency '" ++ n ++ "' imported by " ++ srcFile paths (modName paths)
+                             ++ " is not declared in " ++ projPath paths ++ "/Build.act.\n"
+                             ++ "Add a direct dependency, using follows to share another dependency's selection.")
+        _ -> return ()
+  where
+    projectNames = Data.Set.fromList [ BuildSpec.specName (projBuildSpec ctx) | ctx <- M.elems projects ]
+    directNames = "std" : [ BuildSpec.specName (projBuildSpec ctx)
+                          | root <- maybe [] (map snd . projDeps) (M.lookup (projPath paths) projects)
+                          , Just ctx <- [M.lookup root projects] ]
+    localMods = M.findWithDefault Data.Set.empty (projPath paths) modSets
+
 -- | Resolve imports to in-graph providers using project search order.
 -- This chooses the first project in the search order that declares the module,
 -- producing TaskKeys for dependency edges.
@@ -1597,7 +1618,7 @@ buildGlobalTasks sp gopts opts projMap mSeeds = do
         allDeps :: M.Map ProjDir (Data.Set.Set ProjName)
         allDeps = M.fromList [ (projRoot ctx, Data.Set.fromList (map fst $ projDeps ctx)) | (ctx,_) <- perProj ]
         orderCache :: M.Map ProjDir [ProjDir]
-        orderCache = M.fromList [ (projRoot ctx, projDepClosure projMap (projRoot ctx)) | (ctx, _) <- perProj ]
+        orderCache = M.fromList [ (projRoot ctx, projRoot ctx : map snd (projDeps ctx)) | (ctx, _) <- perProj ]
         -- Declared modules in all reachable projects (paired with their project paths)
         allKeys = [ TaskKey (projRoot ctx) mn | (ctx, mods) <- perProj, (_, mn) <- mods ]
     seedKeys <- case mSeeds of
@@ -1619,11 +1640,19 @@ buildGlobalTasks sp gopts opts projMap mSeeds = do
             Just actFile -> do
               let ctx = projMap M.! tkProj k
               paths <- pathsForModule opts projMap ctx (tkMod k)
-              task  <- readModuleTask sp gopts opts paths actFile
+              task0 <- readModuleTask sp gopts opts paths actFile
+              -- Cached imports have canonical names: bare dep imports are stored
+              -- as dep.lib. If that namespace has become local, recover the
+              -- source spelling before resolving it and rebuild its interface.
+              task <- case task0 of
+                        TyTask{} | any (overlapsLocal paths modSets) (importsOf task0) ->
+                          materializeTask opts sp (tkMod k) actFile M.empty Nothing task0
+                        _ -> return task0
               let order = M.findWithDefault [tkProj k] (tkProj k) orderCache
                   deps = M.findWithDefault Data.Set.empty (tkProj k) allDeps
                   imps = restoredImportsOf paths task
               checkImportPrefixes k (projName paths) modSets imps
+              checkImportDependencies paths projMap modSets imps
               let providers = resolveProviders k (projName paths) order modSets deps imps
                   newKeys = M.elems providers
                   acc' = GlobalTask { gtKey = k
@@ -1632,6 +1661,15 @@ buildGlobalTasks sp gopts opts projMap mSeeds = do
                                     , gtImportProviders = providers
                                     } : acc
               go modMaps modSets allDeps orderCache (Data.Set.insert k seen) (qs ++ newKeys) acc'
+
+
+    overlapsLocal paths modSets mn =
+      case A.modPath mn of
+        n:ns | n /= projName paths ->
+          any (`Data.Set.member` localMods)
+              (addProjPrefix paths mn : [ addProjPrefix paths (A.modName [n]) | ns == ["lib"] ])
+        _ -> False
+      where localMods = M.findWithDefault Data.Set.empty (projPath paths) modSets
 
 
 -- | Select the subgraph needed for a given build request.
@@ -5473,17 +5511,3 @@ fmtTime t =
   where
     secs :: Float
     secs = (fromIntegral(sec t)) + (fromIntegral (nsec t) / 1000000000)
-
--- | Topologically order projects so dependencies come first.
--- Used to build search paths and providers in dependency order.
-projDepClosure :: M.Map FilePath ProjCtx -> FilePath -> [FilePath]
-projDepClosure ctxs root = reverse (dfs Data.Set.empty [] root)
-  where
-    depsOf p = maybe [] (map snd . projDeps) (M.lookup p ctxs)
-
-    dfs seen acc node
-      | Data.Set.member node seen = acc
-      | otherwise =
-          let seen' = Data.Set.insert node seen
-              acc'  = foldl' (\a n -> dfs seen' a n) acc (depsOf node)
-          in node : acc'

--- a/compiler/lib/src/Acton/Compile.hs
+++ b/compiler/lib/src/Acton/Compile.hs
@@ -199,6 +199,7 @@ module Acton.Compile
   , isAbsolutePath
   , collapseDots
   , rebasePath
+  , rebaseDepPath
   ) where
 
 import Prelude hiding (readFile, writeFile)
@@ -688,7 +689,6 @@ data CompilePlan = CompilePlan
   , cpNeededTasks :: [GlobalTask]
   , cpDbpBlocked :: Data.Set.Set TaskKey
   , cpRootTasks :: [CompileTask]
-  , cpRootPins :: M.Map String BuildSpec.PkgDep
   , cpIncremental :: Bool
   , cpAllowPrune :: Bool
   , cpChangedPaths :: Maybe [FilePath]
@@ -739,7 +739,6 @@ prepareCompilePlanFromContext sp gopts ctx srcFiles allowPrune mChangedPaths = d
     Just changed -> selectAffectedTasks rootProj opts' globalTasks dbpBlocked changed
   let neededTasks = expandBuildLibraryTasks projMap globalTasks neededTasks0
       rootTasks = [ gtTask t | t <- neededTasks0, tkProj (gtKey t) == rootProj ]
-      rootPins = maybe M.empty (BuildSpec.dependencies . projBuildSpec) (M.lookup rootProj projMap)
   return CompilePlan
     { cpContext = ctx
     , cpProjMap = projMap
@@ -747,7 +746,6 @@ prepareCompilePlanFromContext sp gopts ctx srcFiles allowPrune mChangedPaths = d
     , cpNeededTasks = neededTasks
     , cpDbpBlocked = dbpBlocked
     , cpRootTasks = rootTasks
-    , cpRootPins = rootPins
     , cpIncremental = incremental
     , cpAllowPrune = allowPrune'
     , cpChangedPaths = mChangedPaths
@@ -4419,9 +4417,10 @@ discoverProjects gopts sysAbs rootProj depOverrides = do
     rootAbs <- normalizePathSafe rootProj
     rootSpec0 <- loadBuildSpec rootAbs
     rootSpec  <- applyDepOverrides rootAbs depOverrides rootSpec0
-    let rootPins = BuildSpec.dependencies rootSpec
+    let rootPins = M.map (rebaseDepPath rootAbs) (BuildSpec.concreteDependencies rootSpec)
         (_, fpMap0, _) = applyFingerprint rootAbs rootSpec M.empty
-    fst <$> go rootAbs Data.Set.empty M.empty fpMap0 rootPins rootAbs (Just rootSpec)
+    (projects, _) <- go rootAbs Data.Set.empty M.empty fpMap0 rootPins rootAbs (Just rootSpec)
+    resolveFollows projects
   where
     go root seen acc fpMap pins dir mSpec = do
       dirAbs <- normalizePathSafe dir
@@ -4434,7 +4433,7 @@ discoverProjects gopts sysAbs rootProj depOverrides = do
           spec <- applyDepOverrides dirAbs depOverrides spec0
           let (_, fpMap1, _) = applyFingerprint dirAbs spec fpMap
           (deps, fpMap2) <- do
-            let depsList = M.toList (BuildSpec.dependencies spec)
+            let depsList = M.toList (BuildSpec.concreteDependencies spec)
             foldM (collectDep pins dirAbs) ([], fpMap1) depsList
           let outDir   = joinPath [dirAbs, "out"]
               typesDir = joinPath [outDir, "types"]
@@ -4457,8 +4456,8 @@ discoverProjects gopts sysAbs rootProj depOverrides = do
             case M.lookup depName pins of
               Nothing -> (dep, Nothing)
               Just pinDep ->
-                if pinDep == dep
-                  then (dep, Nothing)
+                if pinDep == rebaseDepPath base dep
+                  then (pinDep, Nothing)
                   else (pinDep, Just dep)
       when (isJust conflict) $
         unless (C.quiet gopts) $
@@ -4482,6 +4481,50 @@ discoverProjects gopts sysAbs rootProj depOverrides = do
 
     step root seen pins (acc, fpMap) (_, depBase, mSpec) =
       go root seen acc fpMap pins depBase mSpec
+
+-- | Bind passive dependency references after concrete selection and deduplication.
+-- A follows entry contributes neither a source nor a root pin. Every segment
+-- traverses the selected project's own dependency declarations.
+resolveFollows :: M.Map FilePath ProjCtx -> IO (M.Map FilePath ProjCtx)
+resolveFollows projects = M.traverseWithKey resolveProject projects
+  where
+    resolveProject root ctx = do
+      deps <- forM (M.keys (BuildSpec.dependencies (projBuildSpec ctx))) $ \name -> do
+        target <- resolve [] root name
+        return (name, target)
+      return ctx { projDeps = deps }
+
+    resolve seen root name
+      | (root, name) `elem` seen =
+          throwProjectError ("Cyclic dependency follows: " ++ intercalate " -> "
+                             [ p ++ ":" ++ n | (p, n) <- reverse ((root, name) : seen) ])
+      | otherwise =
+          case M.lookup root projects of
+            Nothing -> throwProjectError ("Missing project for dependency follows: " ++ root)
+            Just ctx ->
+              case M.lookup name (BuildSpec.dependencies (projBuildSpec ctx)) of
+                Nothing -> throwProjectError ("Dependency follows target '" ++ name
+                                               ++ "' is not declared in " ++ root ++ "/Build.act")
+                Just dep ->
+                  case BuildSpec.follows dep of
+                    Nothing -> case lookup name (projDeps ctx) of
+                                 Just target -> return target
+                                 Nothing -> throwProjectError ("Unresolved dependency '" ++ name ++ "' in " ++ root)
+                    Just ref -> do
+                      target <- foldM (resolve ((root, name) : seen)) root (splitRef ref)
+                                `catch` \(ProjectError msg) ->
+                                  throwProjectError ("Dependency '" ++ name ++ "' follows '" ++ ref
+                                                     ++ "' in " ++ root ++ "/Build.act:\n" ++ msg)
+                      let targetName = BuildSpec.specName (projBuildSpec (projects M.! target))
+                      unless (name == targetName) $
+                        throwProjectError ("Dependency '" ++ name ++ "' follows '" ++ ref
+                                           ++ "', which resolves to project '" ++ targetName
+                                           ++ "'. Use the project name as the dependency name.")
+                      return target
+
+    splitRef ref = case break (== '.') ref of
+                     (name, []) -> [name]
+                     (name, _:rest) -> name : splitRef rest
 
 -- Given a FILE and optionally --syspath PATH:
 -- 'sysPath' is the path to the system directory as given by PATH, defaulting to the acton executable directory.
@@ -4940,6 +4983,13 @@ rebasePath base p
   | isAbsolutePath p = normalise p
   | otherwise        = normalise (joinPath [base, p])
 
+-- | Keep a concrete source path relative to the project that declares it.
+rebaseDepPath :: FilePath -> BuildSpec.PkgDep -> BuildSpec.PkgDep
+rebaseDepPath base dep =
+    case BuildSpec.path dep of
+      Just p | not (null p) -> dep { BuildSpec.path = Just (rebasePath base p) }
+      _ -> dep
+
 -- | Normalize --dep overrides relative to a base directory.
 -- Absolute override paths are kept, relative paths are rebased and normalized.
 normalizeDepOverrides :: FilePath -> [(String, FilePath)] -> IO [(String, FilePath)]
@@ -4960,6 +5010,7 @@ applyDepOverrides base overrides spec = do
     applyOne depsMap (depName, depPath) =
       case M.lookup depName depsMap of
         Nothing -> return depsMap
+        Just dep | isJust (BuildSpec.follows dep) -> return depsMap
         Just dep -> do
           let absP0 = if isAbsolutePath depPath then depPath else joinPath [base, depPath]
           absP <- normalizePathSafe absP0
@@ -5002,7 +5053,7 @@ fetchDependencies gopts paths depOverrides = do
         -- Tracks zig package dirs / hashes already pre-seeded, so the transitive
         -- walk over build.zig.zon files terminates on cycles and shared deps.
         zigSeen <- newIORef Data.Set.empty
-        let rootPins = BuildSpec.dependencies rootSpec
+        let rootPins = M.map (rebaseDepPath (projPath paths)) (BuildSpec.concreteDependencies rootSpec)
         _ <- walkProject rootPins cacheDir zigExe globalCache depsCache zigSeen
                          Data.Set.empty (projPath paths) rootSpec
         return ()
@@ -5012,7 +5063,7 @@ fetchDependencies gopts paths depOverrides = do
       if Data.Set.member projAbs seen
         then return seen
         else do
-          selectedDeps <- forM (M.toList (BuildSpec.dependencies spec)) $
+          selectedDeps <- forM (M.toList (BuildSpec.concreteDependencies spec)) $
             selectDependency rootPins projAbs
           let pkgFetches = catMaybes
                 [ mkPkgFetch cacheDir zigExe globalCache name dep | (name, dep) <- selectedDeps ]
@@ -5051,8 +5102,8 @@ fetchDependencies gopts paths depOverrides = do
             case M.lookup depName rootPins of
               Nothing -> (dep, Nothing)
               Just pinDep ->
-                if pinDep == dep
-                  then (dep, Nothing)
+                if pinDep == rebaseDepPath base dep
+                  then (pinDep, Nothing)
                   else (pinDep, Just dep)
       when (isJust conflict) $
         unless (C.quiet gopts) $
@@ -5324,7 +5375,7 @@ collectDepTypePaths projDir overrides = do
     go seen fpMap dir spec0 = do
       spec <- applyDepOverrides dir overrides spec0
       let (_, fpMap1, _) = applyFingerprint dir spec fpMap
-      foldM (step dir) (seen, fpMap1, []) (M.toList (BuildSpec.dependencies spec))
+      foldM (step dir) (seen, fpMap1, []) (M.toList (BuildSpec.concreteDependencies spec))
 
     step base (seen, fpMap, acc) (depName, dep) = do
       depBase <- resolveDepBase base depName dep

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -2116,6 +2116,60 @@ main = do
 
     -- BuildSpec: parsing and update-in-place of Build.act (canonical layout)
     describe "BuildSpec" $ do
+      let followsBuildAct fields = unlines
+            [ "name = \"demo\""
+            , "fingerprint = 0x1234abcd5678ef00"
+            , "dependencies = {\"yang\": (" ++ fields ++ ")}"
+            ]
+
+      it "preserves followed dependencies through JSON, rendering and updates" $ do
+        let buildAct = followsBuildAct "follows=\"stratoweave.yang\""
+        case BuildSpec.parseBuildAct buildAct of
+          Left err -> expectationFailure err
+          Right (spec,_,_) -> do
+            (BuildSpec.follows =<< M.lookup "yang" (BuildSpec.dependencies spec))
+              `shouldBe` Just "stratoweave.yang"
+            let json = BuildSpec.encodeBuildSpecJSON spec
+            Ae.eitherDecode' json `shouldBe` Right spec
+            forM_ [ Right (BuildSpec.renderBuildAct spec)
+                  , BuildSpec.updateBuildActFromJSON buildAct json
+                  ] $ \result -> case result of
+              Left err -> expectationFailure err
+              Right rendered -> case BuildSpec.parseBuildAct rendered of
+                Left err -> expectationFailure err
+                Right (spec2,_,_) -> spec2 `shouldBe` spec
+
+      it "rejects malformed follows paths in Build.act and JSON" $ do
+        forM_ (["", "yang", ".yang", "stratoweave.", "stratoweave..yang", "stratoweave/yang", "stratoweave.1yang", "strato-weave.yang"] :: [String]) $ \ref -> do
+          case BuildSpec.parseBuildAct (followsBuildAct ("follows=" ++ show ref)) of
+            Left err -> err `shouldSatisfy` isInfixOf "follows must name a dependency"
+            Right _ -> expectationFailure ("Accepted malformed follows path: " ++ show ref)
+          let json = Ae.encode (Ae.object ["follows" Ae..= ref])
+          case Ae.eitherDecode' json :: Either String BuildSpec.PkgDep of
+            Left err -> err `shouldSatisfy` isInfixOf "follows must name a dependency"
+            Right _ -> expectationFailure ("Accepted malformed JSON follows path: " ++ show ref)
+
+      it "rejects non-string follows values" $ do
+        forM_ ["17", "None", "[\"stratoweave\", \"yang\"]", "\"{stratoweave}.yang\""] $ \value ->
+          case BuildSpec.parseBuildAct (followsBuildAct ("follows=" ++ value)) of
+            Left err -> err `shouldSatisfy` isInfixOf "follows must be a plain string literal"
+            Right _ -> expectationFailure ("Accepted non-string follows value: " ++ value)
+        forM_ ["17", "null", "[\"stratoweave\", \"yang\"]"] $ \value ->
+          case Ae.eitherDecode' (BL.fromStrict (B8.pack ("{\"follows\":" ++ value ++ "}"))) :: Either String BuildSpec.PkgDep of
+            Left _ -> pure ()
+            Right _ -> expectationFailure ("Accepted non-string JSON follows value: " ++ value)
+
+      it "rejects concrete source fields alongside follows" $ do
+        forM_ ["url", "hash", "path", "repo_url", "repo_ref"] $ \field -> do
+          let fields = "follows=\"stratoweave.yang\", " ++ field ++ "=\"value\""
+          case BuildSpec.parseBuildAct (followsBuildAct fields) of
+            Left err -> err `shouldSatisfy` isInfixOf "follows cannot be combined"
+            Right _ -> expectationFailure ("Accepted follows with " ++ field)
+          let json = BL.fromStrict (B8.pack ("{\"follows\":\"stratoweave.yang\", \"" ++ field ++ "\":null}"))
+          case Ae.eitherDecode' json :: Either String BuildSpec.PkgDep of
+            Left err -> err `shouldSatisfy` isInfixOf "follows cannot be combined"
+            Right _ -> expectationFailure ("Accepted JSON follows with " ++ field)
+
       it "parses canonical Build.act and dumps JSON" $ do
         let buildAct = unlines
               [ "# Canonical Build.act file"

--- a/compiler/lsp-server/Main.hs
+++ b/compiler/lsp-server/Main.hs
@@ -32,7 +32,6 @@ import Language.LSP.Protocol.Types hiding (Diagnostic, Position)
 import qualified Language.LSP.Protocol.Types as LSP
 import Language.LSP.Server
 
-import qualified Acton.BuildSpec as BuildSpec
 import qualified Acton.Compile as Compile
 import qualified Acton.CommandLineParser as C
 import qualified Acton.Completion as Completion
@@ -73,7 +72,6 @@ data ProjectBuildCache = ProjectBuildCache
   , cachedProjectMap :: M.Map FilePath Compile.ProjCtx
   , cachedGlobalTasks :: [Compile.GlobalTask]
   , cachedDbpBlocked :: Data.Set.Set Compile.TaskKey
-  , cachedRootPins :: M.Map String BuildSpec.PkgDep
   , cachedImportKeys :: HM.HashMap FilePath String
   }
 
@@ -281,7 +279,6 @@ cacheCompilePlan plan = do
         , cachedProjectMap = Compile.cpProjMap plan
         , cachedGlobalTasks = Compile.cpGlobalTasks plan
         , cachedDbpBlocked = Compile.cpDbpBlocked plan
-        , cachedRootPins = Compile.cpRootPins plan
         , cachedImportKeys = importKeys
         }
   atomicModifyIORef' projectBuildCachesRef $ \m ->
@@ -399,7 +396,6 @@ compilePlanFromCache ctx changedPath cache = do
         , Compile.cpNeededTasks = neededTasks
         , Compile.cpDbpBlocked = dbpBlocked
         , Compile.cpRootTasks = rootTasks
-        , Compile.cpRootPins = cachedRootPins cache
         , Compile.cpIncremental = True
         , Compile.cpAllowPrune = False
         , Compile.cpChangedPaths = Just [changedPath]

--- a/docs/acton-dev-guide/src/compiler/project_dependencies.md
+++ b/docs/acton-dev-guide/src/compiler/project_dependencies.md
@@ -31,7 +31,7 @@ dependencies before later compile planning uses them.
 
 ## Acton import prefixes
 
-Each reachable Acton project contributes modules under the dependency name used
+Each directly declared Acton dependency contributes modules under the name used
 by its consumer. A dependency entry named `foo` therefore exposes that
 dependency's modules under the `foo` import prefix:
 
@@ -50,6 +50,16 @@ Currently, dependency entries must use the same name as the dependency
 project's `name` field. The import-prefix rule is still described in terms of
 the dependency entry name so the docs continue to match the public model when
 separate dependency aliases are supported.
+
+Source imports must refer to the current project's modules, its directly
+declared dependencies, or system modules. Following declarations count as
+direct declarations. This check also applies when compilation reuses cached
+interfaces; removing a declaration must not leave its imports available.
+
+The compiler still needs the complete transitive interface closure to resolve
+types appearing in dependency APIs and to generate code. Internal interface
+loading therefore retains access to transitive projects. This access does not
+authorize a source import from an undeclared package.
 
 ## Generated `build.zig` inputs
 

--- a/docs/acton-dev-guide/src/compiler/project_dependencies.md
+++ b/docs/acton-dev-guide/src/compiler/project_dependencies.md
@@ -13,6 +13,15 @@ Project discovery in `Acton.Compile` only follows Acton package dependencies.
 Those edges determine the project graph used for module ordering, cache reuse,
 import visibility, and type-check planning.
 
+Concrete path and archive declarations determine version selection. A
+declaration such as `"seeds": (follows="garden.seeds")` contributes no
+root pin or version choice: after concrete dependency resolution and
+fingerprint deduplication, it points to the selected target of that dependency
+path. References are resolved in each declaring project's dependency scope;
+relative concrete paths retain their original declaring project as their base.
+Following chains are allowed, while missing targets and reference cycles fail
+before compilation.
+
 Zig dependencies are not Acton project edges. They do not contribute modules to
 the import graph and they are not used for project discovery.
 

--- a/docs/acton-guide/src/SUMMARY.md
+++ b/docs/acton-guide/src/SUMMARY.md
@@ -97,6 +97,7 @@
   - [Fingerprint and Lineage](pkg/fingerprint.md)
   - [Add Dependency](pkg/add_dependency.md)
   - [Local Dependencies](pkg/local_dependencies.md)
+  - [Follow a Dependency](pkg/follow_dependency.md)
   - [Override Dependency](pkg/override_dependency.md)
   - [Remove Dependency](pkg/remove_dependency.md)
   - [Fetch Deps (Airplane mode)](pkg/fetch_dependencies.md)

--- a/docs/acton-guide/src/modules.md
+++ b/docs/acton-guide/src/modules.md
@@ -27,6 +27,13 @@ dependency name comes from the key in the consuming project's
 Currently, that dependency name must match the dependency project's
 `name` field.
 
+To import modules from another package, declare that package in your
+project's `Build.act`. Builtins and the standard library are available
+without dependency declarations.
+
+Use a [following dependency](pkg/follow_dependency.md) to declare a package
+while sharing the version already selected through another dependency.
+
 Use modules to group code by responsibility. A good module has a clear
 job. For example:
 

--- a/docs/acton-guide/src/package_management.md
+++ b/docs/acton-guide/src/package_management.md
@@ -46,6 +46,10 @@ the same prefix, such as `import foo.parser` for `src/parser.act`.
 Currently, the dependency name must match the dependency project's
 `name` field.
 
+A [following dependency](pkg/follow_dependency.md) lets a declaration use
+the version selected through another dependency without adding a URL or
+content hash of its own.
+
 ## Project lineage fingerprint
 
 Each project must declare a **fingerprint** in `Build.act` to represent its lineage — the stable identity of the project across versions. This is separate from dependency content hashes:

--- a/docs/acton-guide/src/package_management.md
+++ b/docs/acton-guide/src/package_management.md
@@ -46,6 +46,7 @@ the same prefix, such as `import foo.parser` for `src/parser.act`.
 Currently, the dependency name must match the dependency project's
 `name` field.
 
+Each project must declare the packages it imports in its own `Build.act`.
 A [following dependency](pkg/follow_dependency.md) lets a declaration use
 the version selected through another dependency without adding a URL or
 content hash of its own.

--- a/docs/acton-guide/src/pkg/follow_dependency.md
+++ b/docs/acton-guide/src/pkg/follow_dependency.md
@@ -1,0 +1,51 @@
+# Follow a Dependency
+
+Sometimes another dependency already selects the package version you
+want to use. Declare `follows` to share that selection without specifying
+another archive URL, content hash, or local path.
+
+For example, suppose a fictional `garden` package depends on a `seeds`
+package. An application that imports modules from both can use:
+
+```python
+dependencies = {
+    "garden": (path="../garden"),
+    "seeds": (follows="garden.seeds"),
+}
+```
+
+The application can then write `import seeds` or `import seeds.catalog`.
+The `seeds` declaration points to the same selected project as
+`garden`'s `seeds` dependency. The dependency key must still match the
+selected project's name.
+
+The reference is a path through dependency names in `Build.act`. Its
+first component names a dependency of the declaring project, and each
+remaining component names a dependency of the project reached so far.
+Longer references such as `toolbox.garden.seeds` are supported, as
+are references whose target is itself a following dependency. The
+reference must contain at least two names, and every named dependency
+must exist. Cyclic references are errors.
+
+`follows` does not choose a version or override another declaration.
+Acton first resolves the concrete path and archive dependencies, including
+root pins and project deduplication, then binds following dependencies to
+the selected projects. If another concrete declaration causes `garden`
+to use a different `seeds` version, the application's following dependency
+uses that same version. Adding the following declaration cannot change
+which version wins.
+
+Relative paths still belong to the project that declares them. If
+`garden` declares `seeds` with `path="../seeds"`, that path is resolved
+relative to `garden`'s directory, regardless of where the application
+lives.
+
+Use `follows` on its own in a dependency tuple. It cannot be combined with
+`path`, `url`, `hash`, `repo_url`, or `repo_ref`. To select a different
+version yourself, replace the following declaration with a concrete
+dependency.
+
+`acton pkg upgrade` preserves following declarations. Upgrade the dependency
+that supplies the concrete version instead. A `--dep seeds=...` override
+changes concrete `seeds` declarations; following declarations observe that
+selection without becoming concrete dependencies themselves.

--- a/docs/acton-guide/src/pkg/follow_dependency.md
+++ b/docs/acton-guide/src/pkg/follow_dependency.md
@@ -1,8 +1,9 @@
 # Follow a Dependency
 
-Sometimes another dependency already selects the package version you
-want to use. Declare `follows` to share that selection without specifying
-another archive URL, content hash, or local path.
+A project must declare every package whose modules it imports. Sometimes
+another dependency already selects the package version you want to use.
+Declare `follows` to share that selection without specifying another
+archive URL, content hash, or local path.
 
 For example, suppose a fictional `garden` package depends on a `seeds`
 package. An application that imports modules from both can use:


### PR DESCRIPTION
Declaring a shared dependency currently requires a source specification that can override the version supplied by another dependency. Add follows declarations to Build.act so a project can use the package selected through another dependency. For example, "seeds": (follows="garden.seeds") shares garden's selected seeds dependency. Following declarations do not participate in version selection, root pinning or conflict resolution, and use the same deduplicated project.

Require each project to declare the packages it imports in its own Build.act. Apply this to source imports and signature lookup while retaining transitive interfaces for types exposed by dependency APIs.
