### PR TITLE
Remove Debian 11 run-linux job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -714,9 +714,6 @@ jobs:
       matrix:
         include:
           - os: "debian"
-            version: "11"
-            arch: "amd64"
-          - os: "debian"
             version: "12"
             arch: "amd64"
           - os: "ubuntu"


### PR DESCRIPTION
Debian 11 package repositories now return 404 errors, so the run-linux job can no longer install its prerequisites. Ubuntu 20.04 remains in the matrix to provide glibc 2.31 compatibility coverage.