### PR TITLE
Refresh unused dependency build files

### DIFF
--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -2077,21 +2077,19 @@ runCliPostCompile cliHooks gopts plan env = do
         rootDepModuleOpts = M.findWithDefault M.empty rootProj depModuleOptsByProj
         rootDepPathOverrides = projectDepPathOverrides projMap rootProj
 
-    -- Generate build.zig(.zon) for dependencies too, to satisfy Zig builder links.
-    let projKeys = Data.Set.fromList (map (tkProj . gtKey) globalTasks)
-    forM_ (Data.Set.toList projKeys) $ \p -> do
+    -- Zig follows every declared dependency, including projects with no
+    -- selected modules. Refresh their build files too so nested dependencies
+    -- cannot retain module selections from an earlier build.
+    forM_ (M.toList projMap) $ \(p, pctx) -> do
       let isRootProj = p == rootProj
           isSysProj  = p == sysAbs || sysRoot `isPrefixOf` p
-      unless (isRootProj || isSysProj) $
-        case M.lookup p projMap of
-          Just pctx -> do
-            when (C.verbose gopts) $
-              logLine ("Generating build.zig for dependency project " ++ p)
-            dummyPaths <- pathsForModule opts' projMap pctx (A.modName ["__gen_build__"])
-            let depOpts = M.findWithDefault M.empty p depModuleOptsByProj
-                depPathOverrides = projectDepPathOverrides projMap p
-            genBuildZigFiles (projBuildSpec pctx) dummyPaths depOpts depPathOverrides
-          Nothing -> return ()
+      unless (isRootProj || isSysProj) $ do
+        when (C.verbose gopts) $
+          logLine ("Generating build.zig for dependency project " ++ p)
+        dummyPaths <- pathsForModule opts' projMap pctx (A.modName ["__gen_build__"])
+        let depOpts = M.findWithDefault M.empty p depModuleOptsByProj
+            depPathOverrides = projectDepPathOverrides projMap p
+        genBuildZigFiles (projBuildSpec pctx) dummyPaths depOpts depPathOverrides
     logTiming gopts opts' logLine "dependency build preparation" prepStart
     let runFinal action = do
           cchFinalStart cliHooks

--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -1357,6 +1357,101 @@ parseFlagTests =
         assertEqual ("production rebuild failed:\n" ++ productionOut ++ productionErr) ExitSuccess productionCode
         assertFile "production builds should restore declared library grouping" True productionLib
         checkApp
+  , testCase "acton test refreshes unselected dependency build inputs" $ do
+      withSystemTempDirectory "acton-test-dependency-inputs" $ \tmp -> do
+        acton <- canonicalizePath "../../dist/bin/acton"
+        let app = tmp </> "app"
+            dep = tmp </> "dep"
+            helper = tmp </> "helper"
+            writeProject :: FilePath -> String -> [(String, FilePath)] -> IO ()
+            writeProject dir name deps = do
+              createDirectoryIfMissing True (dir </> "src")
+              let fp = Fingerprint.formatFingerprint
+                    (Fingerprint.updateFingerprintPrefix
+                      (Fingerprint.fingerprintPrefixForName name) 1)
+              writeFile (dir </> "Build.act") $ unlines
+                [ "name = " ++ show name
+                , "fingerprint = " ++ fp
+                , "dependencies = {" ++ intercalate ", "
+                    [show n ++ ": (path=" ++ show p ++ ")" | (n, p) <- deps] ++ "}"
+                ]
+            writeSource dir name = writeFile (dir </> "src" </> name <.> "act") . unlines
+            run args = do
+              (code, out, err) <- readCreateProcessWithExitCode
+                (proc acton args) { cwd = Just app } ""
+              assertEqual ("acton " ++ unwords args ++ " failed:\n" ++ out ++ err) ExitSuccess code
+              return out
+            checkTest m raw = do
+              out <- run ["test", "--json", "--no-cache", "--iter", "1", "--module", m]
+              assertBool ("expected one selected test:\n" ++ out) ("\"total\":1" `isInfixOf` out)
+              assertBool ("missing selected test " ++ raw ++ ":\n" ++ out)
+                (("\"raw_name\":\"" ++ raw ++ "\"") `isInfixOf` out)
+        writeProject dep "header_dep" []
+        writeProject helper "header_helper" [("header_dep", "../dep")]
+        writeProject app "header_app" [("header_dep", "../dep"), ("header_helper", "../helper")]
+        writeSource dep "provider"
+          [ "class Box(value):"
+          , "    def __init__(self, x: int):"
+          , "        self.x = x"
+          , "    def get(self) -> int:"
+          , "        return self.x"
+          , ""
+          , "def make_box() -> Box:"
+          , "    return Box(42)"
+          , ""
+          , "def ready() -> int:"
+          , "    return 1"
+          ]
+        writeSource dep "consumer"
+          [ "import provider"
+          , ""
+          , "def box() -> provider.Box:"
+          , "    return provider.make_box()"
+          ]
+        writeSource dep "bridge"
+          [ "import provider"
+          , ""
+          , "def ready() -> int:"
+          , "    return provider.ready()"
+          ]
+        writeSource helper "api"
+          [ "import header_dep.consumer"
+          , ""
+          , "def value() -> int:"
+          , "    return header_dep.consumer.box().get()"
+          ]
+        writeSource app "main"
+          [ "import header_helper.api"
+          , ""
+          , "actor main(env):"
+          , "    assert header_helper.api.value() == 42"
+          , "    env.exit(0)"
+          ]
+        writeSource app "chosen"
+          [ "import testing"
+          , "import header_dep.bridge"
+          , ""
+          , "def _test_indirect() -> None:"
+          , "    assert header_dep.bridge.ready() == 1"
+          ]
+        writeSource app "other"
+          [ "import testing"
+          , "import header_helper.api"
+          , ""
+          , "def _test_box() -> None:"
+          , "    assert header_helper.api.value() == 42"
+          ]
+
+        -- The full build caches helper's dependency on consumer and its Box API.
+        -- Selecting chosen narrows provider while leaving helper unselected.
+        void $ run ["build"]
+        checkTest "chosen" "_test_indirect"
+        checkTest "chosen" "_test_indirect"
+        checkTest "other" "_test_box"
+        void $ run ["build"]
+        (appCode, appOut, appErr) <- readCreateProcessWithExitCode
+          (proc (app </> "out" </> "bin" </> "main") []) ""
+        assertEqual ("rebuilt application failed:\n" ++ appOut ++ appErr) ExitSuccess appCode
   , testCase "acton test discovers selected tests after an imported type changes" $ do
       withSystemTempDirectory "acton-test-selection-cache" $ \proj -> do
         acton <- canonicalizePath "../../dist/bin/acton"


### PR DESCRIPTION
Switching from a full build to selected tests can leave a dependency's build file requesting modules from the earlier build. Those modules can then fail to compile against headers pruned for the test selection.

Refresh build files for every declared dependency, including projects with no selected sources, so Zig uses the current module selection throughout the dependency graph.
