### PR TITLE
Fix type arguments in protocol inheritance

### DIFF
--- a/compiler/lib/src/Acton/Converter.hs
+++ b/compiler/lib/src/Acton/Converter.hs
@@ -73,7 +73,8 @@ convProtocol env n0 q ps0 eq wmap b     = mainClass : sibClasses
           where sib ws ws0 p            = (ws, tcname p, us, witArgs w0 wmap, inherited ws0)
                   where us              = us0 ++ us1
                         us1             = [ convProto p | (ws',p) <- ps0, catRight ws' == ws ] ++ [cValue]
-                        us0             = [ TC (baseGName w) (tcargs $ head us1) | w <- zipWith (:) (wheads ws0) (wtails ws0) ]
+                        us0             = [ TC (baseGName w) (tcargs $ convProto p) |
+                                            w <- zipWith (:) (wheads ws0) (wtails ws0), (_,p) <- ps0, tcname p == head w ]
                         w0              = if inherited ws0 then tcname main else tcname p
 
         sibClasses                      = [ Class NoLoc (sibName ws n0) q1 us (sibClassBody ws n (head us) wes inh) Nothing | (ws,n,us,wes,inh) <- allsibs ]
@@ -140,7 +141,8 @@ convExtension env n1 c0 q ps0 eq wmap b opts
           where sib ws ws0 p            = (ws, tcname p, us, witArgs w0 wmap, inherited ws0)
                   where us              = us0 ++ us1
                         us1             = [ instProto t0 p | (ws',p) <- ps0, catRight ws' == ws ] ++ [cValue]
-                        us0             = [ TC (baseGName w) (tcargs $ head us1) | w <- zipWith (:) (wheads ws0) (wtails ws0) ]
+                        us0             = [ TC (baseGName w) (tcargs $ instProto t0 p) |
+                                            w <- zipWith (:) (wheads ws0) (wtails ws0), (_,p) <- ps0, tcname p == head w ]
                         w0              = if inherited ws0 then tcname main else tcname p
 
         sibClasses                      = [ Class NoLoc (sibName ws n1) q1 us (sibClassBody ws n (head us) wes inh) Nothing | (ws,n,us,wes,inh) <- allsibs ]

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -2109,6 +2109,7 @@ main = do
       testCodeGen env0 ["chunking"]
       testCodeGen env0 ["boxparam"]
       testCodeGen env0 ["witness_forward"]
+      testCodeGenContains env0 "protocol_generic_siblings" ["SecondD_InheritedD___init__"]
       -- A local that is live across a for-loop must be emitted as `volatile` so it
       -- survives the loop's StopIteration setjmp/longjmp under optimization.
       testCodeGenContains env0 "forloop_volatile" ["volatile B_str marker", "if ($PUSH())"]

--- a/compiler/lib/test/src/protocol_generic_siblings.act
+++ b/compiler/lib/test/src/protocol_generic_siblings.act
@@ -1,0 +1,11 @@
+protocol First:
+    pass
+
+protocol Second[T]:
+    pass
+
+protocol Joined(First, Second[int]):
+    pass
+
+protocol Inherited(Joined):
+    pass


### PR DESCRIPTION
The compiler can crash when a protocol inherits another protocol with a fixed type argument. This fixes the lookup so each generated base class gets the type arguments it expects, and adds a small example that reproduces the crash.