### PR TITLE
Preserve unchanged generated build files

### DIFF
--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -47,7 +47,7 @@ import  Pretty
 import qualified InterfaceFiles
 import qualified PkgCommands
 import qualified Repl
-import FileUtil (readFile, writeFile, writeFileAtomic)
+import FileUtil (readFile, writeFile, writeFileIfChanged)
 
 import Control.Concurrent.MVar
 import Control.Exception (throw,catch,finally,IOException,try,SomeException,onException,evaluate,bracket,mask)
@@ -2460,7 +2460,7 @@ writeRootC env gopts opts paths tasks binTask = do
             res <- (try :: IO a -> IO (Either SomeException a)) $ do
               c <- Acton.CodeGen.genRoot env qn
               createDirectoryIfMissing True (takeDirectory rootFile)
-              writeFile rootFile c
+              writeFileIfChanged rootFile c
             case res of
               Right _ -> return (Just binTask)
               Left _  -> return Nothing
@@ -2607,8 +2607,8 @@ genBuildZigFiles spec paths depModuleOpts depPathOverrides = do
         mergedSpec = addImplicitStdDependency absSys mergedSpec1
         resolvedZigs = resolveZigDepRefs (M.keys (BuildSpec.dependencies mergedSpec)) (directZigs ++ transZigs)
         zonWithFp = replace "{{fingerprint}}" fp . replace "{{name}}" zonName
-    writeFile buildZigPath (genBuildZig buildZigTemplate (absSys </> "deps") mergedSpec resolvedZigs depModuleOpts)
-    writeFileAtomic buildZonPath (genBuildZigZon buildZonTemplate relSys depsRootAbs projAbs fp zonName mergedSpec resolvedZigs)
+    writeFileIfChanged buildZigPath (genBuildZig buildZigTemplate (absSys </> "deps") mergedSpec resolvedZigs depModuleOpts)
+    writeFileIfChanged buildZonPath (genBuildZigZon buildZonTemplate relSys depsRootAbs projAbs fp zonName mergedSpec resolvedZigs)
 
 addImplicitStdDependency :: FilePath -> BuildSpec.BuildSpec -> BuildSpec.BuildSpec
 addImplicitStdDependency sys spec

--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -1487,6 +1487,40 @@ parseFlagTests =
         -- Its inferred return type becomes eligible when the import changes.
         writeFile provider "def value():\n    return None\n"
         checkCount (1 :: Int)
+  , testCase "build preserves unchanged root and Zig files" $ do
+      withSystemTempDirectory "acton-build-file-reuse" $ \proj -> do
+        acton <- canonicalizePath "../../dist/bin/acton"
+        let name = "build_file_reuse"
+            fp = Fingerprint.formatFingerprint
+              (Fingerprint.updateFingerprintPrefix
+                (Fingerprint.fingerprintPrefixForName name) 1)
+            rootFile = proj </> "out/types/main.root.c"
+            files = [rootFile, proj </> "build.zig", proj </> "build.zig.zon"]
+            oldTime = posixSecondsToUTCTime 1
+            build root = do
+              (code, out, err) <- readCreateProcessWithExitCode
+                (proc acton ["build", "--root", "main." ++ root]) { cwd = Just proj } ""
+              assertEqual ("build failed:\n" ++ out ++ err) ExitSuccess code
+        createDirectory (proj </> "src")
+        writeFile (proj </> "Build.act") ("name = " ++ show name ++ "\nfingerprint = " ++ fp ++ "\n")
+        writeFile (proj </> "src/main.act") $ unlines
+          [ "actor first(env: Env):"
+          , "    env.exit(11)"
+          , ""
+          , "actor second(env: Env):"
+          , "    env.exit(12)"
+          ]
+        build "first"
+        -- Use a known timestamp so this also detects rewrites on coarse filesystems.
+        forM_ files $ \file -> setModificationTime file oldTime
+        build "first"
+        forM_ files $ \file ->
+          assertEqual (file ++ " should retain its timestamp") oldTime =<< getModificationTime file
+        build "second"
+        assertBool "changing the root should update its stub" . (/= oldTime) =<< getModificationTime rootFile
+        (code, out, err) <- readCreateProcessWithExitCode
+          (proc (proj </> "out/bin/main") []) ""
+        assertEqual ("rebuilt executable should use the new root:\n" ++ out ++ err) (ExitFailure 12) code
   , testCase "build and test timings respect output modes" $ do
       withSystemTempDirectory "acton-build-timing" $ \proj -> do
         acton <- canonicalizePath "../../dist/bin/acton"


### PR DESCRIPTION
Keep generated root stubs, build.zig and build.zig.zon unchanged when their contents match. This preserves their timestamps between builds and avoids unnecessary cache invalidation. Changed contents still replace the files atomically.
