### PR TITLE
Implement Hashable for set

### DIFF
--- a/base/builtin/set.c
+++ b/base/builtin/set.c
@@ -554,6 +554,21 @@ bool B_OrdD_SetD_setD___le__ (B_OrdD_SetD_set wit, B_set set, B_set other) {
     return  B_OrdD_SetD_setD___ge__(wit, other, set);
 }
 
+// B_Hashable
+
+B_NoneType B_HashableD_setD_hash(B_HashableD_set wit, B_set set, B_hasher h) {
+    // Element hashes are already mixed. Sum them to ignore table order and
+    // include the count so cardinality contributes even when hashes collide.
+    uint64_t data[2] = {set->numelements, 0};
+    for (uint64_t i = 0; i <= set->mask; i++) {
+        B_setentry *entry = &set->table[i];
+        if (entry->key != NULL && entry->key != dummy)
+            data[1] += entry->hash;
+    }
+    zig_hash_wyhash_update(h->_hasher,to$bytesD_len((char *)data,sizeof(data)));
+    return B_None;
+}
+
 // B_Minus
 
 

--- a/base/src/__builtin__.act
+++ b/base/src/__builtin__.act
@@ -888,6 +888,8 @@ extension dict[A(Hashable),B(Eq)] (Ord):
 
 extension set[A(Hashable)] (Set[A]):
     NotImplemented
+extension set[A(Hashable)] (Hashable):
+    NotImplemented
 
 extension Iterator[A](Iterable[A]):
     NotImplemented

--- a/compiler/acton/test/parse/simple.all.golden
+++ b/compiler/acton/test/parse/simple.all.golden
@@ -66,7 +66,7 @@ pure def main () -> None:
     return None
 ===============================================
 
-/* Acton impl hash: d08c9793c890e917cbf7dfbd7d8d83d565b77536de5215cba908ef7093e36f72 */
+/* Acton impl hash: 31f25d3a82eee8f4de265e7b51942392f05fd7666bed5885e403eadbbaa5ea1e */
 #pragma once
 #include "builtin/builtin.h"
 #include "rts/rts.h"

--- a/compiler/acton/test/parse/simple.cgen.golden
+++ b/compiler/acton/test/parse/simple.cgen.golden
@@ -1,4 +1,4 @@
-/* Acton impl hash: d08c9793c890e917cbf7dfbd7d8d83d565b77536de5215cba908ef7093e36f72 */
+/* Acton impl hash: 31f25d3a82eee8f4de265e7b51942392f05fd7666bed5885e403eadbbaa5ea1e */
 #include "rts/common.h"
 #include "out/types/simple.h"
 B_NoneType simpleQ_main () {

--- a/compiler/acton/test/parse/simple.hgen.golden
+++ b/compiler/acton/test/parse/simple.hgen.golden
@@ -1,4 +1,4 @@
-/* Acton impl hash: d08c9793c890e917cbf7dfbd7d8d83d565b77536de5215cba908ef7093e36f72 */
+/* Acton impl hash: 31f25d3a82eee8f4de265e7b51942392f05fd7666bed5885e403eadbbaa5ea1e */
 #pragma once
 #include "builtin/builtin.h"
 #include "rts/rts.h"

--- a/docs/acton-guide/src/stdlib/builtin_protocols/hashable.md
+++ b/docs/acton-guide/src/stdlib/builtin_protocols/hashable.md
@@ -110,6 +110,11 @@ Many built-in value types implement `Hashable`, including:
 - `complex`
 - `str`
 - `bytes`
+- `set`, whose elements must also implement `Hashable`
 
-`dict` and `set` use `Hashable` for their key or element types, but are
-not themselves documented as `Hashable` here.
+A set's hash depends on its elements, regardless of insertion order.
+Sets can therefore be dictionary keys or elements of other sets. Keep a
+set unchanged while it is used as a dictionary key or stored in another
+set.
+
+`dict` requires `Hashable` keys but does not itself implement `Hashable`.

--- a/test/builtins_auto/set_hashable.act
+++ b/test/builtins_auto/set_hashable.act
@@ -1,0 +1,126 @@
+class CollidingKey:
+    value: int
+
+    def __init__(self, value: int):
+        self.value = value
+
+extension CollidingKey(Hashable):
+    def __eq__(self, other):
+        return self.value == other.value
+
+    def hash(self, h):
+        h.update(b"collision")
+
+def test_equal_hashes():
+    a = set(range(100))
+    b = set(range(99, -1, -1))
+    b.add(42)
+    return a == b and hash(a) == hash(b) and seed_hash(u64(17), a) == seed_hash(u64(17), b)
+
+def test_hash_after_resize_and_delete():
+    a = set(range(256))
+    for i in range(256):
+        if i not in {1, 2, 3}:
+            a.discard(i)
+    b = {3, 2, 1}
+    return a == b and hash(a) == hash(b) and hash(set(a)) == hash(b)
+
+def test_empty_hash():
+    a: set[int] = set()
+    b = set(range(100))
+    for i in range(100):
+        b.pop()
+    d = {a: "empty"}
+    return hash(a) == hash(b) and d[b] == "empty" and hash(a) != hash({1})
+
+def test_hash_contents():
+    return hash({1, 2}) != hash({1, 3}) and hash({"ab", "c"}) != hash({"a", "bc"})
+
+def test_dict_keys():
+    d = {{1, 2}: "first", {3}: "other"}
+    if d[{2, 1}] != "first" or {1, 3} in d:
+        return False
+    d[{2, 1}] = "updated"
+    if len(d) != 2 or d[{1, 2}] != "updated":
+        return False
+    del d[{2, 1}]
+    return len(d) == 1 and {1, 2} not in d and d[{3}] == "other"
+
+def test_set_elements():
+    s = {{1, 2}, {2, 1}, {3}}
+    if len(s) != 2 or {2, 1} not in s or {1, 3} in s:
+        return False
+    s.discard({2, 1})
+    s.add({4, 5})
+    return s == {{3}, {5, 4}}
+
+def test_nested_keys():
+    d = {{{1, 2}, {3}}: "nested"}
+    t = {({1, 2}, "tag"): 42}
+    return d[{{3}, {2, 1}}] == "nested" and t[({2, 1}, "tag")] == 42
+
+def test_mutation():
+    s = {1, 2}
+    before = hash(s)
+    s.add(3)
+    if hash(s) != hash({3, 2, 1}) or hash(s) == before:
+        return False
+    s.discard(3)
+    if hash(s) != before:
+        return False
+    s.update({3, 4})
+    popped = s.pop()
+    return hash(s) == hash({1, 2, 3, 4} - {popped})
+
+def test_seed_and_stream():
+    a = {1, 2, 3}
+    b = {3, 2, 1}
+    if seed_hash(u64(0), a) != hash(a) or seed_hash(u64(17), a) == hash(a):
+        return False
+    h1 = hasher(u64(17))
+    h2 = hasher(u64(17))
+    "prefix".hash(h1)
+    "prefix".hash(h2)
+    a.hash(h1)
+    b.hash(h2)
+    "suffix".hash(h1)
+    "suffix".hash(h2)
+    return h1.finalize() == h2.finalize() and h1.finalize() != seed_hash(u64(17), a)
+
+def test_colliding_elements():
+    a = {CollidingKey(1), CollidingKey(2)}
+    b = {CollidingKey(2), CollidingKey(1)}
+    c = {CollidingKey(3), CollidingKey(4)}
+    d = {a: "first", c: "other"}
+    s = {a, b, c}
+    return a == b and a != c and hash(a) == hash(b) and len(s) == 2 and d[b] == "first" and d[c] == "other"
+
+tests = {
+    "test_equal_hashes": test_equal_hashes,
+    "test_hash_after_resize_and_delete": test_hash_after_resize_and_delete,
+    "test_empty_hash": test_empty_hash,
+    "test_hash_contents": test_hash_contents,
+    "test_dict_keys": test_dict_keys,
+    "test_set_elements": test_set_elements,
+    "test_nested_keys": test_nested_keys,
+    "test_mutation": test_mutation,
+    "test_seed_and_stream": test_seed_and_stream,
+    "test_colliding_elements": test_colliding_elements,
+}
+
+actor main(env):
+    failed = []
+    for name, t in tests.items():
+        print("== test: " + name)
+        if not t():
+            print("-- FAILED test: " + name)
+            failed.append(name)
+        print()
+    if len(failed) == 0:
+        print("All {len(tests)} tests OK!")
+        env.exit(0)
+    else:
+        print("\n{len(failed)} of {len(tests)} tests failed:")
+        for name in failed:
+            print(" - {name}")
+        env.exit(1)


### PR DESCRIPTION
Allow sets to be dictionary keys and elements of other sets. Hash the element count and the sum of cached element hashes so equal sets hash equally regardless of insertion order or table history.

set should ideally not be mutable, but until we have proper mutable / immutable split, this will have to do.