### PR TITLE
Restore and extend performance test reports

### DIFF
--- a/base/build.zig
+++ b/base/build.zig
@@ -284,6 +284,7 @@ pub fn build(b: *std.Build) void {
     libActon.installHeader(b.path("rts/q.h"), "rts/q.h");
     libActon.installHeader(b.path("rts/rts.h"), "rts/rts.h");
     libActon.installHeader(b.path("rts/log.h"), "rts/log.h");
+    libActon.installHeader(b.path("rts/perf.h"), "rts/perf.h");
 
     libActon.root_module.addIncludePath(.{ .cwd_relative = buildroot_path });
     libActon.root_module.addIncludePath(dep_libtlsuv.path("include"));

--- a/base/rts/perf.c
+++ b/base/rts/perf.c
@@ -1,0 +1,143 @@
+#include "perf.h"
+
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <uv.h>
+
+#if defined(__linux__)
+#include <linux/perf_event.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+#elif defined(__APPLE__)
+#include <libproc.h>
+#include <sys/resource.h>
+#include <unistd.h>
+#endif
+
+static const char *perf_status = "not enabled at process start";
+static const char *perf_scope = "process:user+kernel";
+static bool perf_enabled;
+
+#if defined(__linux__) && defined(PERF_ATTR_SIZE_VER7)
+static int perf_cycles_fd = -1;
+static int perf_instructions_fd = -1;
+
+static int perf_open(uint64_t event, int group, bool user_only) {
+    struct perf_event_attr attr = {0};
+    attr.type = PERF_TYPE_HARDWARE;
+    attr.size = sizeof(attr);
+    attr.config = event;
+    attr.inherit = 1;
+    // Include future threads, but not processes spawned by the benchmark.
+    attr.inherit_thread = 1;
+    attr.exclude_kernel = user_only;
+    attr.exclude_hv = 1;
+    attr.read_format = PERF_FORMAT_TOTAL_TIME_ENABLED | PERF_FORMAT_TOTAL_TIME_RUNNING;
+    return (int)syscall(SYS_perf_event_open, &attr, 0, -1, group, PERF_FLAG_FD_CLOEXEC);
+}
+
+static bool perf_open_group(bool user_only) {
+    perf_cycles_fd = perf_open(PERF_COUNT_HW_CPU_CYCLES, -1, user_only);
+    if (perf_cycles_fd < 0)
+        return false;
+    perf_instructions_fd = perf_open(PERF_COUNT_HW_INSTRUCTIONS, perf_cycles_fd, user_only);
+    if (perf_instructions_fd < 0) {
+        int saved_errno = errno;
+        close(perf_cycles_fd);
+        perf_cycles_fd = -1;
+        errno = saved_errno;
+        return false;
+    }
+    return true;
+}
+
+static bool perf_read_event(int fd, uint64_t *count, uint64_t *enabled, uint64_t *running) {
+    uint64_t values[3];
+    ssize_t size;
+    do {
+        size = read(fd, values, sizeof(values));
+    } while (size < 0 && errno == EINTR);
+    if (size != (ssize_t)sizeof(values) || values[2] > values[1])
+        return false;
+    *count = values[0];
+    *enabled = values[1];
+    *running = values[2];
+    return true;
+}
+#endif
+
+void rts_perf_init(void) {
+    const char *enabled = getenv("ACTON_TEST_PERF");
+    perf_enabled = enabled != NULL && strcmp(enabled, "1") == 0;
+    // Do not change the behaviour of Acton subprocesses launched by a test.
+    uv_os_unsetenv("ACTON_TEST_PERF");
+    if (!perf_enabled)
+        return;
+#if defined(__linux__) && defined(PERF_ATTR_SIZE_VER7)
+    // Run before GC_INIT: both collector and RTS threads must inherit events.
+    if (perf_open_group(false)) {
+        perf_status = "available";
+    } else if ((errno == EACCES || errno == EPERM) && perf_open_group(true)) {
+        perf_scope = "process:user";
+        perf_status = "available";
+    } else {
+        perf_status = errno == EACCES || errno == EPERM
+            ? "permission denied" : "thread counters not supported";
+    }
+#elif defined(__APPLE__) && defined(RUSAGE_INFO_V4)
+    struct rusage_info_v4 usage = {0};
+    if (proc_pid_rusage(getpid(), RUSAGE_INFO_V4, (rusage_info_t *)&usage) == 0
+            && usage.ri_instructions > 0 && usage.ri_cycles > 0)
+        perf_status = "available";
+    else
+        perf_status = "not supported by this system";
+#else
+    perf_status = "not supported by this system";
+#endif
+}
+
+void rts_perf_read(struct rts_perf_sample *sample) {
+    memset(sample, 0, sizeof(*sample));
+    uv_rusage_t usage;
+    if (uv_getrusage(&usage) == 0) {
+        sample->cpu_available = true;
+        sample->user_ns = (uint64_t)usage.ru_utime.tv_sec * 1000000000 + (uint64_t)usage.ru_utime.tv_usec * 1000;
+        sample->system_ns = (uint64_t)usage.ru_stime.tv_sec * 1000000000 + (uint64_t)usage.ru_stime.tv_usec * 1000;
+    }
+    if (!perf_enabled || strcmp(perf_status, "available") != 0)
+        return;
+#if defined(__linux__) && defined(PERF_ATTR_SIZE_VER7)
+    // Inherited group reads are unsupported. Individual reads include all
+    // live and exited inherited threads. Keep coverage to detect multiplexing.
+    sample->hardware_available = perf_read_event(perf_cycles_fd, &sample->cycles,
+            &sample->cycles_enabled, &sample->cycles_running)
+        && perf_read_event(perf_instructions_fd, &sample->instructions,
+            &sample->instructions_enabled, &sample->instructions_running);
+#elif defined(__APPLE__) && defined(RUSAGE_INFO_V4)
+    struct rusage_info_v4 counters = {0};
+    if (proc_pid_rusage(getpid(), RUSAGE_INFO_V4, (rusage_info_t *)&counters) == 0
+            && counters.ri_instructions > 0 && counters.ri_cycles > 0) {
+        sample->hardware_available = true;
+        sample->instructions = counters.ri_instructions;
+        sample->cycles = counters.ri_cycles;
+        // These are maintained by the kernel without a multiplexed event set.
+        uint64_t now = uv_hrtime();
+        sample->instructions_enabled = sample->instructions_running = now;
+        sample->cycles_enabled = sample->cycles_running = now;
+    }
+#endif
+}
+
+const char *rts_perf_backend(void) {
+#if defined(__linux__)
+    return "perf_event_open";
+#elif defined(__APPLE__)
+    return "proc_pid_rusage";
+#else
+    return "none";
+#endif
+}
+
+const char *rts_perf_scope(void) { return perf_scope; }
+const char *rts_perf_status(void) { return perf_status; }

--- a/base/rts/perf.h
+++ b/base/rts/perf.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+struct rts_perf_sample {
+    bool cpu_available;
+    bool hardware_available;
+    uint64_t user_ns, system_ns;
+    uint64_t instructions, cycles;
+    uint64_t instructions_enabled, instructions_running;
+    uint64_t cycles_enabled, cycles_running;
+};
+
+void rts_perf_init(void);
+void rts_perf_read(struct rts_perf_sample *sample);
+const char *rts_perf_backend(void);
+const char *rts_perf_scope(void);
+const char *rts_perf_status(void);

--- a/base/rts/rts.c
+++ b/base/rts/rts.c
@@ -65,6 +65,7 @@
 #include "io.c"
 
 #include "log.c"
+#include "perf.c"
 #include "netstring.h"
 #include "../builtin/env.h"
 #include "../builtin/function.h"
@@ -2522,6 +2523,7 @@ void print_help(struct option *opt) {
 void DaveNull () {}
 
 int main(int argc, char **argv) {
+    rts_perf_init();
     // Init garbage collector and suppress warnings
     GC_INIT();
     GC_set_warn_proc(DaveNull);

--- a/base/src/acton/rts.act
+++ b/base/src/acton/rts.act
@@ -65,6 +65,13 @@ def get_rss(cap: SysCap) -> u64:
     """
     NotImplemented
 
+def get_peak_rss(cap: SysCap) -> ?u64:
+    """Get the process lifetime peak resident set size in bytes.
+
+    Includes startup and all threads. Returns None if unavailable.
+    """
+    NotImplemented
+
 # sleep is sort of dangerous - it will actually put the RTS thread executing the
 # actor calling this function to sleep. This could be seen as ultrabad, like we
 # would want to just pause execution of one actor and let the RTS thread process

--- a/base/src/acton/rts.act
+++ b/base/src/acton/rts.act
@@ -72,6 +72,20 @@ def get_peak_rss(cap: SysCap) -> ?u64:
     """
     NotImplemented
 
+def perf_snapshot(cap: SysCap) -> (user_ns: ?u64, system_ns: ?u64, instructions: ?u64, cycles: ?u64, instructions_enabled: u64, instructions_running: u64, cycles_enabled: u64, cycles_running: u64):
+    """Read cumulative process counters for the performance test harness.
+
+    Includes all runtime threads. Hardware counts require ACTON_TEST_PERF=1
+    at process start. Coverage fields detect intervals with uncounted work.
+    Unavailable measurements are None. Subtract integers before converting
+    to floating point, and reject intervals without full counter coverage.
+    """
+    NotImplemented
+
+def perf_info(cap: SysCap) -> dict[str, str]:
+    """Describe the counter backend, scope, availability and machine."""
+    NotImplemented
+
 # sleep is sort of dangerous - it will actually put the RTS thread executing the
 # actor calling this function to sleep. This could be seen as ultrabad, like we
 # would want to just pause execution of one actor and let the RTS thread process

--- a/base/src/acton/rts.ext.c
+++ b/base/src/acton/rts.ext.c
@@ -77,6 +77,14 @@ int64_t actonQ_rtsQ_rss (B_SysCap cap) {
     return (int64_t)rsm;
 }
 
+B_u64 actonQ_rtsQ_get_peak_rss (B_SysCap cap) {
+    uv_rusage_t usage;
+    if (uv_getrusage(&usage) != 0)
+        return (B_u64)B_None;
+    // libuv normalizes ru_maxrss to KiB on all supported platforms.
+    return toB_u64(usage.ru_maxrss * 1024);
+}
+
 B_NoneType actonQ_rtsQ_sleep (B_SysCap cap, double sleep_time) {
     double st = sleep_time;
     struct timespec ts;

--- a/base/src/acton/rts.ext.c
+++ b/base/src/acton/rts.ext.c
@@ -6,6 +6,7 @@
 
 #include "rts/io.h"
 #include "rts/log.h"
+#include "rts/perf.h"
 
 void actonQ_rtsQ___ext_init__() {
     // NOP
@@ -83,6 +84,41 @@ B_u64 actonQ_rtsQ_get_peak_rss (B_SysCap cap) {
         return (B_u64)B_None;
     // libuv normalizes ru_maxrss to KiB on all supported platforms.
     return toB_u64(usage.ru_maxrss * 1024);
+}
+
+B_tuple actonQ_rtsQ_perf_snapshot (B_SysCap cap) {
+    struct rts_perf_sample s;
+    rts_perf_read(&s);
+    return $NEWTUPLE(8,
+        s.cpu_available ? toB_u64(s.user_ns) : (B_u64)B_None,
+        s.cpu_available ? toB_u64(s.system_ns) : (B_u64)B_None,
+        s.hardware_available ? toB_u64(s.instructions) : (B_u64)B_None,
+        s.hardware_available ? toB_u64(s.cycles) : (B_u64)B_None,
+        toB_u64(s.instructions_enabled), toB_u64(s.instructions_running),
+        toB_u64(s.cycles_enabled), toB_u64(s.cycles_running));
+}
+
+B_dict actonQ_rtsQ_perf_info (B_SysCap cap) {
+    B_Hashable wit = (B_Hashable)B_HashableD_strG_witness;
+    B_dict info = $NEW(B_dict, wit, NULL, NULL);
+    B_dictD_setitem(info, wit, to$str("version"), to$str("1"));
+    B_dictD_setitem(info, wit, to$str("backend"), to$str((char *)rts_perf_backend()));
+    B_dictD_setitem(info, wit, to$str("scope"), to$str((char *)rts_perf_scope()));
+    B_dictD_setitem(info, wit, to$str("status"), to$str((char *)rts_perf_status()));
+    uv_utsname_t system;
+    if (uv_os_uname(&system) == 0) {
+        B_dictD_setitem(info, wit, to$str("os"), to$str(system.sysname));
+        B_dictD_setitem(info, wit, to$str("release"), to$str(system.release));
+        B_dictD_setitem(info, wit, to$str("arch"), to$str(system.machine));
+    }
+    uv_cpu_info_t *cpus;
+    int count;
+    if (uv_cpu_info(&cpus, &count) == 0) {
+        if (count > 0)
+            B_dictD_setitem(info, wit, to$str("cpu"), to$str(cpus[0].model));
+        uv_free_cpu_info(cpus, count);
+    }
+    return info;
 }
 
 B_NoneType actonQ_rtsQ_sleep (B_SysCap cap, double sleep_time) {

--- a/base/src/testing.act
+++ b/base/src/testing.act
@@ -4,6 +4,7 @@ import diff
 import file
 import json
 import logging
+import math
 import term
 import time
 
@@ -590,6 +591,7 @@ class TestResult(object):
     exception: ?str
     output: ?str
     duration: float
+    gc_duration: float
     mem_usage_delta: int
     non_gc_mem_usage_delta: int
 
@@ -601,13 +603,15 @@ class TestResult(object):
                  mem_usage_delta: int,
                  non_gc_mem_usage_delta: int,
                  skipped: bool=False,
-                 skip_reason: ?str=None):
+                 skip_reason: ?str=None,
+                 gc_duration: float=0.0):
         self.success = success
         self.skipped = skipped
         self.skip_reason = skip_reason
         self.exception = exception
         self.output = output
         self.duration = duration
+        self.gc_duration = gc_duration
         self.mem_usage_delta = mem_usage_delta
         self.non_gc_mem_usage_delta = non_gc_mem_usage_delta
 
@@ -619,34 +623,41 @@ class TestResult(object):
             "exception": self.exception,
             "output": self.output,
             "duration": self.duration,
+            "gc_duration": self.gc_duration,
             "mem_usage_delta": self.mem_usage_delta,
             "non_gc_mem_usage_delta": self.non_gc_mem_usage_delta,
         }
 
     @staticmethod
-    def from_json(data: dict[str, str]) -> TestResult:
+    def from_json(data: dict[str, ?value]) -> TestResult:
+        def optional_string(v: ?value) -> ?str:
+            if v is None:
+                return None
+            if isinstance(v, str):
+                return v
+            raise ValueError("Invalid TestResult JSON")
+
         success = data["success"]
         skipped = False
         if "skipped" in data:
             skipped = data["skipped"]
         skip_reason = None
         if "skip_reason" in data:
-            skip_reason = data["skip_reason"]
-        exception = data["exception"]
-        output = data["output"]
+            skip_reason = optional_string(data["skip_reason"])
+        exception = optional_string(data["exception"])
+        output = optional_string(data["output"])
         duration = data["duration"]
+        gc_duration = data["gc_duration"] if "gc_duration" in data else 0.0
         mem_usage_delta = data["mem_usage_delta"]
         non_gc_mem_usage_delta = data["non_gc_mem_usage_delta"]
         if (isinstance(success, bool)
             and isinstance(skipped, bool)
-            and (skip_reason is None or isinstance(skip_reason, str))
-            and (exception is None or isinstance(exception, str))
-            and (output is None or isinstance(output, str))
             and isinstance(duration, float)
+            and isinstance(gc_duration, float)
             and isinstance(mem_usage_delta, int)
             and isinstance(non_gc_mem_usage_delta, int)
             ):
-            return TestResult(success, exception, output, duration, mem_usage_delta, non_gc_mem_usage_delta, skipped, skip_reason)
+            return TestResult(success, exception, output, duration, mem_usage_delta, non_gc_mem_usage_delta, skipped, skip_reason, gc_duration)
         raise ValueError("Invalid TestResult JSON")
 
 
@@ -672,8 +683,8 @@ class TestInfo(object):
     num_skipped: int
     num_failures: int
     num_errors: int
-    mem_usage_delta_avg: int
-    non_gc_mem_usage_delta_avg: int
+    mem_usage_delta_avg: float
+    non_gc_mem_usage_delta_avg: float
     non_gc_mem_inc_count: int
     results: list[TestResult]
 
@@ -697,8 +708,8 @@ class TestInfo(object):
                  num_skipped: int=0,
                  num_failures: int=0,
                  num_errors: int=0,
-                 mem_usage_delta_avg: int=0,
-                 non_gc_mem_usage_delta_avg: int=0,
+                 mem_usage_delta_avg: float=0.0,
+                 non_gc_mem_usage_delta_avg: float=0.0,
                  non_gc_mem_inc_count: int=0,
                  results: list[TestResult]=[]):
         self.definition = definition
@@ -764,8 +775,8 @@ class TestInfo(object):
             self.max_duration = result.duration
             self.total_duration = result.duration
             self.avg_duration = result.duration
-            self.mem_usage_delta_avg = result.mem_usage_delta
-            self.non_gc_mem_usage_delta_avg = result.non_gc_mem_usage_delta
+            self.mem_usage_delta_avg = float(result.mem_usage_delta)
+            self.non_gc_mem_usage_delta_avg = float(result.non_gc_mem_usage_delta)
             self.non_gc_mem_inc_count = 1 if result.non_gc_mem_usage_delta > 0 else 0
         else:
             if result.duration < self.min_duration or self.min_duration < 0.0:
@@ -774,8 +785,8 @@ class TestInfo(object):
                 self.max_duration = result.duration
             self.total_duration += result.duration
             self.avg_duration = self.total_duration / float(self.num_iterations)
-            self.mem_usage_delta_avg = ((self.mem_usage_delta_avg * prev_iterations) + result.mem_usage_delta) // self.num_iterations
-            self.non_gc_mem_usage_delta_avg = ((self.non_gc_mem_usage_delta_avg * prev_iterations) + result.non_gc_mem_usage_delta) // self.num_iterations
+            self.mem_usage_delta_avg = (self.mem_usage_delta_avg * float(prev_iterations) + float(result.mem_usage_delta)) / float(self.num_iterations)
+            self.non_gc_mem_usage_delta_avg = (self.non_gc_mem_usage_delta_avg * float(prev_iterations) + float(result.non_gc_mem_usage_delta)) / float(self.num_iterations)
             if result.non_gc_mem_usage_delta > 0:
                 self.non_gc_mem_inc_count += 1
 
@@ -822,13 +833,55 @@ class TestInfo(object):
             fmt_diff(self.non_gc_mem_inc_count, old.non_gc_mem_inc_count if old is not None else None)
         )
 
-    def to_json(self, include_results: bool=False):
+    def performance(self) -> dict[str, value]:
+        """Summarize all samples without discarding outliers.
+
+        Quartiles interpolate at (n - 1) * p. Standard deviation uses n - 1.
+        Call after measurement; sorting allocates and takes time.
+        """
+        n = len(self.results)
+        if n == 0:
+            return {}
+        def summarize(stem: str, mean_key: str, samples: list[float]) -> dict[str, value]:
+            ordered = sorted(samples)
+            def quantile(p: float) -> float:
+                pos = float(n - 1) * p
+                lo = int(pos)
+                hi = min([lo + 1, n - 1])
+                return ordered[lo] + (pos - float(lo)) * (ordered[hi] - ordered[lo])
+            mean = sum(samples) / float(n)
+            q1 = quantile(0.25)
+            q3 = quantile(0.75)
+            spread = q3 - q1
+            outliers = len([v for v in samples if v < q1 - 1.5 * spread or v > q3 + 1.5 * spread])
+            outlier_key = "outlier_count" if stem == "duration" else "outlier_count_" + stem
+            stats: dict[str, value] = {
+                mean_key: mean,
+                "min_" + stem: ordered[0],
+                "max_" + stem: ordered[-1],
+                "median_" + stem: quantile(0.5),
+                "q1_" + stem: q1,
+                "q3_" + stem: q3,
+                outlier_key: outliers,
+            }
+            if n > 1:
+                variance = sum([(v - mean) * (v - mean) for v in samples]) / float(n - 1)
+                stats["stdev_" + stem] = math.sqrt(variance)
+            return stats
+        stats: dict[str, value] = summarize("duration", "avg_duration", [r.duration for r in self.results])
+        stats.update(summarize("wall_duration", "avg_wall_duration", [r.duration + r.gc_duration for r in self.results]).items())
+        stats.update(summarize("gc_duration", "avg_gc_duration", [r.gc_duration for r in self.results]).items())
+        stats.update(summarize("mem_usage_delta", "mem_usage_delta_avg", [float(r.mem_usage_delta) for r in self.results]).items())
+        stats.update(summarize("non_gc_mem_usage_delta", "non_gc_mem_usage_delta_avg", [float(r.non_gc_mem_usage_delta) for r in self.results]).items())
+        return stats
+
+    def to_json(self, include_results: bool=False, include_perf: bool=False):
         test_results = []
         if include_results:
             for r in self.results:
                 test_results.append(r.to_json())
 
-        return {
+        data: dict[str, ?value] = {
             "definition": self.definition.to_json(),
             "complete": self.complete,
             "success": self.success,
@@ -853,9 +906,20 @@ class TestInfo(object):
             "non_gc_mem_inc_count": self.non_gc_mem_inc_count,
             "results": test_results
         }
+        if include_perf:
+            for key, val in self.performance().items():
+                data[key] = val
+        return data
 
     @staticmethod
     def from_json(json_data: dict[str, ?value]) -> TestInfo:
+        def take_mean(key: str) -> float:
+            v = json_data[key]
+            if isinstance(v, float):
+                return v
+            if isinstance(v, int):
+                return float(v)
+            raise ValueError("Invalid TestInfo mean: " + key)
         def take_definition(jd: dict[str, ?value]) -> Test:
             if "definition" in jd:
                 test_definition = jd["definition"]
@@ -908,8 +972,8 @@ class TestInfo(object):
             num_skipped = json_data["num_skipped"]
         num_failures = json_data["num_failures"]
         num_errors = json_data["num_errors"]
-        mem_usage_delta_avg = json_data["mem_usage_delta_avg"]
-        non_gc_mem_usage_delta_avg = json_data["non_gc_mem_usage_delta_avg"]
+        mem_usage_delta_avg = take_mean("mem_usage_delta_avg")
+        non_gc_mem_usage_delta_avg = take_mean("non_gc_mem_usage_delta_avg")
         non_gc_mem_inc_count = json_data["non_gc_mem_inc_count"]
         results: list[TestResult] = []
         # We don't support results in the JSON, since we don't want it for
@@ -926,8 +990,6 @@ class TestInfo(object):
             and isinstance(num_skipped, int)
             and isinstance(num_failures, int)
             and isinstance(num_errors, int)
-            and isinstance(mem_usage_delta_avg, int)
-            and isinstance(non_gc_mem_usage_delta_avg, int)
             and isinstance(non_gc_mem_inc_count, int)
             ):
             return TestInfo(definition,
@@ -1210,13 +1272,18 @@ actor TestExecutor(syscap, config, t: Test, report_complete, report_progress, en
 
         if test_info is not None:
             exc = str(exception) if exception is not None else None
-            test_info.update(complete, TestResult(success, exc, val, testiter_dur, mem_usage_delta, non_gc_mem_usage_delta, skipped=skipped, skip_reason=skip_reason), test_dur*1000.0)
+            test_info.update(complete, TestResult(success, exc, val, testiter_dur, mem_usage_delta, non_gc_mem_usage_delta, skipped=skipped, skip_reason=skip_reason, gc_duration=gc_dur), test_dur*1000.0)
             if config.stress_mode and not config.perf_mode and executor_id >= stress_nodrift_workers:
                 _maybe_refine_stress_phase(test_info.num_iterations)
         iteration = completed_iterations
         if last_report.elapsed().to_float() > 0.05 or complete:
             if test_info is not None and config.output_enabled:
-                print("\n" + json.encode({"test_info": test_info.to_json()}), err=True)
+                # Capture the process peak before allocating the final summary.
+                peak_rss = acton.rts.get_peak_rss(syscap) if config.perf_mode and complete else None
+                payload = test_info.to_json(include_perf=config.perf_mode and complete)
+                if peak_rss is not None:
+                    payload["peak_rss"] = int(peak_rss)
+                print("\n" + json.encode({"test_info": payload}), err=True)
             last_report.reset()
         if config.stress_mode and (iteration == 1 or iteration % 32 == 0 or progress_report_sw.elapsed().to_float() > 0.08 or complete):
             report_progress(executor_id,
@@ -1488,8 +1555,8 @@ class ProjectTestResults(object):
                 if self.perf_mode and perf_mem:
                     indent = " " * 10
                     diffs = tinfo.diff(last_tinfo)
-                    print(f"{indent}Memory usage     : {tinfo.mem_usage_delta_avg // 1024:6d}KB {diffs.mem_usage_delta_avg}")
-                    print(f"{indent}non-GC usage     : {tinfo.non_gc_mem_usage_delta_avg // 1024:6d}KB {diffs.non_gc_mem_usage_delta_avg}")
+                    print(f"{indent}Memory usage     : {int(tinfo.mem_usage_delta_avg) // 1024:6d}KB {diffs.mem_usage_delta_avg}")
+                    print(f"{indent}non-GC usage     : {int(tinfo.non_gc_mem_usage_delta_avg) // 1024:6d}KB {diffs.non_gc_mem_usage_delta_avg}")
                     print(indent + "non-GC usage > 0 : %d%% (%d out of %d)" % ((tinfo.non_gc_mem_inc_count * 100 // tinfo.num_iterations) if tinfo.num_iterations > 0 else 0,
                                                                         tinfo.non_gc_mem_inc_count,
                                                                         tinfo.num_iterations))

--- a/base/src/testing.act
+++ b/base/src/testing.act
@@ -594,6 +594,7 @@ class TestResult(object):
     gc_duration: float
     mem_usage_delta: int
     non_gc_mem_usage_delta: int
+    counters: ?dict[str, float]
 
     def __init__(self,
                  success: ?bool,
@@ -604,7 +605,8 @@ class TestResult(object):
                  non_gc_mem_usage_delta: int,
                  skipped: bool=False,
                  skip_reason: ?str=None,
-                 gc_duration: float=0.0):
+                 gc_duration: float=0.0,
+                 counters: ?dict[str, float]=None):
         self.success = success
         self.skipped = skipped
         self.skip_reason = skip_reason
@@ -614,9 +616,10 @@ class TestResult(object):
         self.gc_duration = gc_duration
         self.mem_usage_delta = mem_usage_delta
         self.non_gc_mem_usage_delta = non_gc_mem_usage_delta
+        self.counters = counters
 
     def to_json(self):
-        return {
+        data = {
             "success": self.success,
             "skipped": self.skipped,
             "skip_reason": self.skip_reason,
@@ -627,6 +630,9 @@ class TestResult(object):
             "mem_usage_delta": self.mem_usage_delta,
             "non_gc_mem_usage_delta": self.non_gc_mem_usage_delta,
         }
+        if self.counters is not None:
+            data["counters"] = self.counters
+        return data
 
     @staticmethod
     def from_json(data: dict[str, ?value]) -> TestResult:
@@ -650,6 +656,22 @@ class TestResult(object):
         gc_duration = data["gc_duration"] if "gc_duration" in data else 0.0
         mem_usage_delta = data["mem_usage_delta"]
         non_gc_mem_usage_delta = data["non_gc_mem_usage_delta"]
+        counters: ?dict[str, float] = None
+        if "counters" in data:
+            raw_counters = data["counters"]
+            if isinstance(raw_counters, dict):
+                parsed: dict[str, float] = {}
+                entries: dict[str, ?value] = raw_counters
+                for key, val in entries.items():
+                    if isinstance(key, str) and isinstance(val, float):
+                        parsed[key] = val
+                    elif isinstance(key, str) and isinstance(val, int):
+                        parsed[key] = float(val)
+                    else:
+                        raise ValueError("Invalid TestResult counters")
+                counters = parsed
+            else:
+                raise ValueError("Invalid TestResult counters")
         if (isinstance(success, bool)
             and isinstance(skipped, bool)
             and isinstance(duration, float)
@@ -657,7 +679,7 @@ class TestResult(object):
             and isinstance(mem_usage_delta, int)
             and isinstance(non_gc_mem_usage_delta, int)
             ):
-            return TestResult(success, exception, output, duration, mem_usage_delta, non_gc_mem_usage_delta, skipped, skip_reason, gc_duration)
+            return TestResult(success, exception, output, duration, mem_usage_delta, non_gc_mem_usage_delta, skipped, skip_reason, gc_duration, counters)
         raise ValueError("Invalid TestResult JSON")
 
 
@@ -687,6 +709,7 @@ class TestInfo(object):
     non_gc_mem_usage_delta_avg: float
     non_gc_mem_inc_count: int
     results: list[TestResult]
+    counter_info: dict[str, str]
 
     def __init__(self,
                  definition: Test,
@@ -711,7 +734,8 @@ class TestInfo(object):
                  mem_usage_delta_avg: float=0.0,
                  non_gc_mem_usage_delta_avg: float=0.0,
                  non_gc_mem_inc_count: int=0,
-                 results: list[TestResult]=[]):
+                 results: list[TestResult]=[],
+                 counter_info: ?dict[str, str]=None):
         self.definition = definition
         self.complete = complete
         self.success = success
@@ -737,6 +761,7 @@ class TestInfo(object):
         self.non_gc_mem_usage_delta_avg = non_gc_mem_usage_delta_avg
         self.non_gc_mem_inc_count = non_gc_mem_inc_count
         self.results = results
+        self.counter_info = counter_info if counter_info is not None else {}
 
     def update(self, complete, result: TestResult, test_duration: float=-1.0):
         self.complete = complete
@@ -873,6 +898,16 @@ class TestInfo(object):
         stats.update(summarize("gc_duration", "avg_gc_duration", [r.gc_duration for r in self.results]).items())
         stats.update(summarize("mem_usage_delta", "mem_usage_delta_avg", [float(r.mem_usage_delta) for r in self.results]).items())
         stats.update(summarize("non_gc_mem_usage_delta", "non_gc_mem_usage_delta_avg", [float(r.non_gc_mem_usage_delta) for r in self.results]).items())
+        for metric in ["cpu_user", "cpu_system", "instructions", "cycles", "ipc"]:
+            samples: list[float] = []
+            for r in self.results:
+                counters = r.counters
+                if counters is not None and metric in counters:
+                    samples.append(counters[metric])
+            # Missing samples must not masquerade as zeros, or use the full
+            # iteration count when estimating uncertainty from a partial set.
+            if len(samples) == n:
+                stats.update(summarize(metric, "avg_" + metric, samples).items())
         return stats
 
     def to_json(self, include_results: bool=False, include_perf: bool=False):
@@ -909,6 +944,11 @@ class TestInfo(object):
         if include_perf:
             for key, val in self.performance().items():
                 data[key] = val
+            if len(self.counter_info) > 0:
+                info = {key: val for key, val in self.counter_info.items()}
+                if info.get("status") == "available" and "avg_instructions" not in data:
+                    info["status"] = "incomplete or multiplexed counter samples"
+                data["counter_info"] = info
         return data
 
     @staticmethod
@@ -975,6 +1015,18 @@ class TestInfo(object):
         mem_usage_delta_avg = take_mean("mem_usage_delta_avg")
         non_gc_mem_usage_delta_avg = take_mean("non_gc_mem_usage_delta_avg")
         non_gc_mem_inc_count = json_data["non_gc_mem_inc_count"]
+        counter_info: dict[str, str] = {}
+        if "counter_info" in json_data:
+            raw_info = json_data["counter_info"]
+            if isinstance(raw_info, dict):
+                entries: dict[str, ?value] = raw_info
+                for key, val in entries.items():
+                    if isinstance(key, str) and isinstance(val, str):
+                        counter_info[key] = val
+                    else:
+                        raise ValueError("Invalid performance counter metadata")
+            else:
+                raise ValueError("Invalid performance counter metadata")
         results: list[TestResult] = []
         # We don't support results in the JSON, since we don't want it for
         # performance reasons but for very generic JSON serialization support it
@@ -1014,7 +1066,8 @@ class TestInfo(object):
                             mem_usage_delta_avg,
                             non_gc_mem_usage_delta_avg,
                             non_gc_mem_inc_count,
-                            results)
+                            results,
+                            counter_info)
         else:
             raise ValueError("Invalid TestInfo JSON")
 
@@ -1058,6 +1111,35 @@ class TestRunnerConfig(object):
 
 class TimeoutError(Exception):
     pass
+
+def perf_delta(before: (user_ns: ?u64, system_ns: ?u64, instructions: ?u64, cycles: ?u64, instructions_enabled: u64, instructions_running: u64, cycles_enabled: u64, cycles_running: u64),
+               end: (user_ns: ?u64, system_ns: ?u64, instructions: ?u64, cycles: ?u64, instructions_enabled: u64, instructions_running: u64, cycles_enabled: u64, cycles_running: u64)) -> dict[str, float]:
+    """Convert cumulative runtime counters to one complete iteration sample."""
+    def delta(old: ?u64, new: ?u64) -> ?u64:
+        if old is not None and new is not None and new >= old:
+            return new - old
+        return None
+
+    def covered(old_enabled: u64, old_running: u64, enabled: u64, running: u64) -> bool:
+        return (enabled >= old_enabled and running > old_running
+                and enabled - old_enabled == running - old_running)
+
+    counters: dict[str, float] = {}
+    for metric, old, new in [("cpu_user", before.user_ns, end.user_ns),
+                              ("cpu_system", before.system_ns, end.system_ns)]:
+        elapsed = delta(old, new)
+        if elapsed is not None:
+            counters[metric] = float(elapsed) / 1000000.0
+    instructions = delta(before.instructions, end.instructions)
+    cycles = delta(before.cycles, end.cycles)
+    if (instructions is not None and cycles is not None
+        and covered(before.instructions_enabled, before.instructions_running, end.instructions_enabled, end.instructions_running)
+        and covered(before.cycles_enabled, before.cycles_running, end.cycles_enabled, end.cycles_running)):
+        counters["instructions"] = float(instructions)
+        counters["cycles"] = float(cycles)
+        if cycles > 0:
+            counters["ipc"] = float(instructions) / float(cycles)
+    return counters
 
 actor TestExecutor(syscap, config, t: Test, report_complete, report_progress, env, executor_id: int, stress_workers: int, stress_nodrift_workers: int):
     """The actual executor of tests
@@ -1223,13 +1305,14 @@ actor TestExecutor(syscap, config, t: Test, report_complete, report_progress, en
         legacy_path = file.join_path([fs.cwd(), "test", "golden", module, test])
         return _read_expected(legacy_path)
 
-    action def _report_result(test: Test, sw, non_gc_mem_usage_before, gc_total_bytes_start, gc_time_start, success: ?bool, exception: ?Exception, val: ?str):
+    action def _report_result(test: Test, sw, non_gc_mem_usage_before, gc_total_bytes_start, gc_time_start, counter_start, success: ?bool, exception: ?Exception, val: ?str):
         full_dur = sw.elapsed().to_float() * 1000.0
         gc_time_end = acton.rts.get_gc_time(syscap).total
         gc_dur = float(gc_time_end - gc_time_start)
         testiter_dur = full_dur - gc_dur
         gc_total_bytes_end = int(acton.rts.get_gc_total_bytes(syscap))
         mem_usage_delta = gc_total_bytes_end - gc_total_bytes_start
+        counters = perf_delta(counter_start, acton.rts.perf_snapshot(syscap)) if counter_start is not None else None
         test_dur = test_sw.elapsed().to_float()
         if config.stress_mode and not config.perf_mode:
             _update_stress_timing_estimate(testiter_dur)
@@ -1272,7 +1355,7 @@ actor TestExecutor(syscap, config, t: Test, report_complete, report_progress, en
 
         if test_info is not None:
             exc = str(exception) if exception is not None else None
-            test_info.update(complete, TestResult(success, exc, val, testiter_dur, mem_usage_delta, non_gc_mem_usage_delta, skipped=skipped, skip_reason=skip_reason, gc_duration=gc_dur), test_dur*1000.0)
+            test_info.update(complete, TestResult(success, exc, val, testiter_dur, mem_usage_delta, non_gc_mem_usage_delta, skipped=skipped, skip_reason=skip_reason, gc_duration=gc_dur, counters=counters), test_dur*1000.0)
             if config.stress_mode and not config.perf_mode and executor_id >= stress_nodrift_workers:
                 _maybe_refine_stress_phase(test_info.num_iterations)
         iteration = completed_iterations
@@ -1311,6 +1394,7 @@ actor TestExecutor(syscap, config, t: Test, report_complete, report_progress, en
             acton.rts.gc(syscap)
             acton.rts.gc(syscap)
         non_gc_mem_usage_before = int(acton.rts.get_rss(syscap) - acton.rts.get_mem_usage(syscap))
+        counter_start = acton.rts.perf_snapshot(syscap) if config.perf_mode else None
         gc_total_bytes_start = int(acton.rts.get_gc_total_bytes(syscap))
         gc_time_start = acton.rts.get_gc_time(syscap).total
         sw = time.Stopwatch()
@@ -1321,23 +1405,23 @@ actor TestExecutor(syscap, config, t: Test, report_complete, report_progress, en
                 exp_val = get_expected(t.module, t.display_name())
                 if exp_val is None or exp_val is not None and val != exp_val:
                     exc = NotEqualError(val, exp_val, f"Test output does not match expected snapshot value.", diff_str=f"{term.normal}{diff.diff(str(exp_val), val, color=True)}", print_vals=False)
-                    _report_result(t, sw, non_gc_mem_usage_before, gc_total_bytes_start, gc_time_start, False, exc, val)
+                    _report_result(t, sw, non_gc_mem_usage_before, gc_total_bytes_start, gc_time_start, counter_start, False, exc, val)
                     return
-            _report_result(t, sw, non_gc_mem_usage_before, gc_total_bytes_start, gc_time_start, s, e, val)
+            _report_result(t, sw, non_gc_mem_usage_before, gc_total_bytes_start, gc_time_start, counter_start, s, e, val)
 
         try:
             t.run(repres, env, log_handler, config.tags)
         except SkipTest as e:
-            _report_result(t, sw, non_gc_mem_usage_before, gc_total_bytes_start, gc_time_start, True, e, None)
+            _report_result(t, sw, non_gc_mem_usage_before, gc_total_bytes_start, gc_time_start, counter_start, True, e, None)
         except AssertionError as e:
-            _report_result(t, sw, non_gc_mem_usage_before, gc_total_bytes_start, gc_time_start, False, e, None)
+            _report_result(t, sw, non_gc_mem_usage_before, gc_total_bytes_start, gc_time_start, counter_start, False, e, None)
         except Exception as e:
-            _report_result(t, sw, non_gc_mem_usage_before, gc_total_bytes_start, gc_time_start, None, e, None)
+            _report_result(t, sw, non_gc_mem_usage_before, gc_total_bytes_start, gc_time_start, counter_start, None, e, None)
 
     def _run_test():
         """Get the next available test and run it"""
         test_sw = time.Stopwatch()
-        test_info = TestInfo(t)
+        test_info = TestInfo(t, counter_info=acton.rts.perf_info(syscap) if config.perf_mode else None)
         _run_fn(t)
 
     after 0: _run_test()

--- a/base/src/testing.act
+++ b/base/src/testing.act
@@ -1663,6 +1663,8 @@ actor test_runner(env: Env,
         test_timeout = 0.0
         if config.max_time > 0:
             test_timeout = max([config.max_time, 2.0]) + _stress_timeout_slack_s()
+            if config.perf_mode:
+                test_timeout = max([test_timeout, 300.0])
 
         test_name = args.get_str("name")
         if test_name not in all_tests:

--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -655,6 +655,8 @@ runTests gopts cmd = do
             C.TestStress opts -> (TestModeStress, opts)
         gopts' = if C.testJson topts then gopts { C.quiet = True } else gopts
         opts0 = C.testCompile topts
+    when (C.testRecord topts && mode /= TestModePerf) $
+      printErrorAndExit "--record requires acton test perf"
     let opts = opts0
           { C.test = True
           , C.skip_build = mode == TestModeList
@@ -680,7 +682,7 @@ runTestsOnce gopts opts topts mode paths = do
       TestModeList -> listProjectTests opts paths topts modules
       _ -> do
         maxParallel0 <- testMaxParallel gopts
-        let maxParallel = if mode == TestModeStress then 1 else maxParallel0
+        let maxParallel = if mode `elem` [TestModePerf, TestModeStress] then 1 else maxParallel0
         useColorOut <- useColor gopts
         testStart <- getTime Monotonic
         exitCode <- runProjectTests useColorOut gopts opts paths topts mode modules maxParallel
@@ -700,7 +702,7 @@ runTestsWatch gopts opts topts mode paths = do
             progressUI = cwProgressUI watchCtx
             progressState = cwProgressState watchCtx
         testParallel0 <- testMaxParallel gopts
-        let testParallel = if mode == TestModeStress then 1 else testParallel0
+        let testParallel = if mode `elem` [TestModePerf, TestModeStress] then 1 else testParallel0
         let runOnce gen mChanged = do
               withProjectLockForGen gopts sched gen projDir $ do
                 logProjectBuild gopts progressUI progressState projDir

--- a/compiler/acton/PerfTests.hs
+++ b/compiler/acton/PerfTests.hs
@@ -5,7 +5,8 @@ import Control.Monad
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KM
 import qualified Data.ByteString.Lazy as BL
-import Data.List (isInfixOf)
+import Data.List (isInfixOf, isSuffixOf, find, elemIndices)
+import TerminalSize (termVisibleLength, termFitAnsiRight, termRenderedRows)
 import qualified Data.Map as M
 import System.Directory
 import System.Exit
@@ -18,30 +19,168 @@ import Test.Tasty.HUnit
 import qualified Acton.Fingerprint as Fingerprint
 import Acton.Testing (TestResult(..))
 import TestFormat (formatTestPerfLines)
+import TestPerf (perfMeanInterval, perfJson)
 
 perfTests :: TestTree
 perfTests = testGroup "performance baselines"
   [ testCase "timing and allocation changes use the recorded measurement" $ do
       let old = KM.fromList [("avg_duration", Aeson.Number 10), ("mem_usage_delta_avg", Aeson.Number 100)]
           new = KM.fromList [("avg_duration", Aeson.Number 12), ("mem_usage_delta_avg", Aeson.Number 50)]
-          rendered = unlines (formatTestPerfLines False (Just old) (result new))
-      assertBool rendered ("12.000 ms (+20.00%)" `isInfixOf` rendered)
-      assertBool rendered ("50 B (-50.00%)" `isInfixOf` rendered)
+          rendered = unlines (renderPerf 79 False (Just old) (result new))
+      assertBool rendered ("+20.0%" `isInfixOf` rendered)
+      assertBool rendered ("-50.0%" `isInfixOf` rendered)
+  , testCase "mean interval accounts for unequal variance and sample counts" $ do
+      let old = sample 8 4 5
+          new = sample 10 1 20
+          half = 2.777 * sqrt 3.25
+      case perfMeanInterval "duration" old new of
+        Just (lo, hi) -> do
+          assertBool (show (lo, hi)) (abs (lo - (2 - half)) < 0.000001)
+          assertBool (show (lo, hi)) (abs (hi - (2 + half)) < 0.000001)
+        Nothing -> assertFailure "expected a Welch interval"
+  , testCase "mean interval handles missing and constant samples" $ do
+      assertEqual "old baselines do not invent variance" Nothing (perfMeanInterval "duration" KM.empty (sample 1 1 10))
+      assertEqual "one sample cannot estimate variance" Nothing (perfMeanInterval "duration" (sample 1 1 10) (sample 1 0 1))
+      assertEqual "negative variance is invalid" Nothing (perfMeanInterval "duration" (sample 1 (-1) 10) (sample 1 1 10))
+      assertEqual "constant samples have zero estimated uncertainty" (Just (2, 2))
+        (perfMeanInterval "duration" (sample 1 0 10) (sample 3 0 10))
+      assertEqual "zero baseline still supports an absolute interval" (Just (1, 1))
+        (perfMeanInterval "duration" (sample 0 0 10) (sample 1 0 10))
+  , testCase "uncertain mean changes are not colored as regressions" $ do
+      let old = sample 10 10 5
+          res = (result (sample 11 10 5)) { trNumIterations = 5 }
+          rendered = unlines (renderPerf 79 True (Just old) res)
+      assertBool rendered ("mean delta (95% CI):" `isInfixOf` rendered)
+      assertBool rendered (not ("\ESC[91m" `isInfixOf` rendered))
+  , testCase "each mean comparison uses its own variance" $ do
+      let old = sample 10 0 10 `KM.union` KM.fromList
+            [("mem_usage_delta_avg", Aeson.Number 1000), ("stdev_mem_usage_delta", Aeson.Number 1000)]
+          new = sample 12 0 10 `KM.union` KM.fromList
+            [("mem_usage_delta_avg", Aeson.Number 1100), ("stdev_mem_usage_delta", Aeson.Number 1000)]
+          rows = renderPerf 120 True (Just old) ((result new) { trNumIterations = 10 })
+      assertBool (unlines rows) (maybe False (isInfixOf "\ESC[91m+20.0%") (find ("time excl. GC" `isInfixOf`) rows))
+      assertBool (unlines rows) (maybe False (isInfixOf "\ESC[2m+10.0%") (find ("allocated" `isInfixOf`) rows))
+      case perfMeanInterval "mem_usage_delta" old new of
+        Just (lo, hi) -> assertBool (show (lo, hi)) (lo < 0 && hi > 0 && abs (lo + hi - 200) < 0.000001)
+        Nothing -> assertFailure "expected an allocation mean interval"
+  , testCase "performance table groups timings and scales signed memory values" $ do
+      let old = KM.fromList [("avg_duration", Aeson.Number 10), ("non_gc_mem_usage_delta_avg", Aeson.Number (-4096))]
+          rows = renderPerf 120 False (Just old) tableResult
+          timing = find ("time excl. GC" `isInfixOf`) rows
+          memory = find ("non-GC change" `isInfixOf`) rows
+      assertEqual "timing distribution and mean comparison"
+        (Just ["time", "excl.", "GC", "12.0ms", "±", "1.00ms", "10.0ms", "…", "14.0ms", "1", "(10%)", "+20.0%"])
+        (words <$> timing)
+      assertEqual "signed memory uses the magnitude for its unit"
+        (Just ["non-GC", "change", "-2.05KB", "—", "—", "+50.0%"])
+        (words <$> memory)
+      assertBool (unlines rows) ("  process peak RSS: 12.0MB" `elem` rows)
+      assertBool "no ANSI escapes when color is disabled" (all (not . isInfixOf "\ESC[") rows)
+      assertBool "the colored header keeps its full label"
+        ("measurement" `isInfixOf` head (renderPerf 79 True (Just old) tableResult))
+  , testCase "each measurement row shows its own distribution" $ do
+      let rows = renderPerf 120 False Nothing fullTableResult
+      forM_
+        [ ("wall time", ["wall", "time", "12.0ms", "±", "2.00ms", "8.00ms", "…", "16.0ms", "0", "(0%)"])
+        , ("GC time", ["GC", "time", "0.00ms", "±", "0.00ms", "0.00ms", "…", "0.00ms", "0", "(0%)"])
+        , ("allocated", ["allocated", "1.54KB", "±", "128B", "1.02KB", "…", "2.05KB", "2", "(20%)"])
+        , ("non-GC change", ["non-GC", "change", "-2.05KB", "±", "1.02KB", "-4.10KB", "…", "0.00B", "3", "(30%)"])
+        ] $ \(label, expected) ->
+          assertEqual label (Just expected) (words <$> find (label `isInfixOf`) rows)
+  , testCase "JSON retains distributions in current and baseline measurements" $ do
+      case trRaw fullTableResult of
+        Aeson.Object obj -> case perfJson (Just obj) fullTableResult of
+          Just (Aeson.Object report) -> forM_ ["measurements", "baseline"] $ \key ->
+            assertEqual (show key) (Just (Aeson.Object obj)) (KM.lookup key report)
+          _ -> assertFailure "expected a performance report"
+        _ -> assertFailure "expected measurements"
+  , testCase "small spreads and range endpoints keep their precision" $ do
+      let obj = sample 1 0.001 10 `KM.union` KM.fromList [("min_duration", Aeson.toJSON (0.001 :: Double)), ("max_duration", Aeson.Number 1)]
+          rendered = unlines (renderPerf 79 False Nothing (result obj))
+      assertBool rendered ("1.00ms ± 1.00µs" `isInfixOf` unwords (words rendered))
+      assertBool rendered ("1.00µs … 1.00ms" `isInfixOf` unwords (words rendered))
+  , testCase "performance table resizes without changing rows or hiding the mean delta" $ do
+      let old = Just (sample 10 1 10)
+          full = renderPerf 79 False old tableResult
+          narrow = renderPerf 39 False old tableResult
+      assertEqual "stable row count" (length full) (length narrow)
+      assertBool (unlines narrow) (not ("outliers" `isInfixOf` head narrow))
+      assertBool (unlines narrow) ("delta" `isInfixOf` head narrow)
+      assertBool (unlines narrow) (any (\line -> "12.0ms" `isInfixOf` line && "+20.0%" `isInfixOf` line) narrow)
+      assertBool (unlines narrow) (not ("σ" `isInfixOf` head narrow))
+      forM_ [tableResult, fullTableResult] $ \res ->
+        forM_ [1, 20, 39, 79, 100, 119, 160] $ \cols -> do
+          let plain = renderPerf cols False old res
+              colored = renderPerf cols True old res
+          assertBool (show cols ++ ": " ++ unlines colored) (all ((<= cols) . termVisibleLength) colored)
+          assertEqual "color does not change column alignment" (map termVisibleLength plain) (map termVisibleLength colored)
+  , testCase "columns and separators stay aligned across benchmark units" $ do
+      let old = Just (sample 10 1 10)
+          tiny = (result (sample 0.000001 0.000000001 10 `KM.union` KM.fromList
+            [("min_duration", Aeson.toJSON (0.000000001 :: Double)), ("max_duration", Aeson.Number 1)])) { trNumIterations = 10 }
+          huge = (result (sample 1e300 1e200 10 `KM.union` KM.fromList
+            [ ("min_duration", Aeson.toJSON (-1e300 :: Double)), ("max_duration", Aeson.toJSON (1e300 :: Double))
+            , ("outlier_count", Aeson.Number 2000000000)
+            ])) { trNumIterations = 2000000000 }
+          timing rows = maybe "" id (find ("time excl. GC" `isInfixOf`) rows)
+      forM_ [79, 100, 119, 160] $ \cols -> do
+        let reference = renderPerf cols False old fullTableResult
+            separators s = [elemIndices '±' s, elemIndices '…' s]
+        forM_ [tiny, huge, tableResult, fullTableResult] $ \res ->
+          forM_ [Nothing, old] $ \baseline -> do
+            let rows = renderPerf cols False baseline res
+            assertEqual "baseline availability does not shift the header"
+              (head (renderPerf cols False Nothing fullTableResult))
+              (take (length (head (renderPerf cols False Nothing fullTableResult))) (head rows))
+            assertEqual "separators do not move when units or magnitudes change"
+              (separators (timing reference)) (separators (timing rows))
+            assertBool (unlines rows) (all ((<= cols) . termVisibleLength) rows)
+      assertBool "default report leaves room between columns"
+        (termVisibleLength (head (renderPerf maxBound False old fullTableResult)) >= 110)
+  , testCase "supported mean changes have aligned icons without ANSI color" $ do
+      let old = sample 10 0 10
+          rowsFor mean sd color = renderPerf 119 color (Just old)
+            ((result (sample mean sd 10)) { trNumIterations = 10 })
+          timing rows = maybe "" id (find ("time excl. GC" `isInfixOf`) rows)
+          better = timing (rowsFor 8 0 False)
+          worse = timing (rowsFor 12 0 False)
+          uncertain = timing (rowsFor 11 10 False)
+      assertBool better ("-20.0% ⚡" `isSuffixOf` better)
+      assertBool worse ("+20.0% 💩" `isSuffixOf` worse)
+      assertBool uncertain (not (any (`isInfixOf` uncertain) ["⚡", "💩"]))
+      assertEqual "icons share one slot" (elemIndices '⚡' better) (elemIndices '💩' worse)
+      assertEqual "neutral comparisons keep the icon space" (termVisibleLength better) (termVisibleLength uncertain)
+      assertEqual "color keeps the same width" (termVisibleLength better) (termVisibleLength (timing (rowsFor 8 0 True)))
+  , testCase "terminal fitting counts complete two-cell icons" $ do
+      forM_ ["⚡", "💩"] $ \icon -> do
+        assertEqual "two terminal cells" 2 (termVisibleLength icon)
+        assertEqual "do not draw half an icon" "" (termFitAnsiRight 1 icon)
+        assertEqual "a complete icon fits" icon (termFitAnsiRight 2 (icon ++ "x"))
+        assertEqual "one remaining cell cannot fit an icon" "x" (termFitAnsiRight 2 ("x" ++ icon))
+        assertEqual "icons count toward wrapping" 2 (termRenderedRows 3 (icon ++ icon))
+        let colored = "\ESC[92m" ++ icon ++ "x\ESC[0m"
+        assertEqual "ANSI does not count" 3 (termVisibleLength colored)
+        assertEqual "colored clipping preserves display width" 2 (termVisibleLength (termFitAnsiRight 2 colored))
+      assertEqual "combining marks stay with the final character" "e\x0301" (termFitAnsiRight 1 "e\x0301x")
+  , testCase "older measurements do not invent a spread or range" $ do
+      let rows = renderPerf 120 False Nothing (result (KM.singleton "avg_duration" (Aeson.Number 1)))
+      assertEqual "only the known mean is shown" (Just ["time", "excl.", "GC", "1.00ms", "—", "—"])
+        (words <$> find ("time excl. GC" `isInfixOf`) rows)
   , testCase "missing and zero baselines have defined output" $ do
       let render :: Maybe Aeson.Object -> Double -> String
-          render old value = unlines $ formatTestPerfLines False old
+          render old value = unlines $ renderPerf 79 False old
             (result (KM.singleton "avg_duration" (Aeson.toJSON value)))
       assertBool "no baseline has no delta" (not ("%" `isInfixOf` render Nothing 2))
       assertBool "missing metric has no delta" (not ("%" `isInfixOf` render (Just KM.empty) 2))
       assertBool "zero to zero is unchanged"
-        ("(+0.00%)" `isInfixOf` render (Just (KM.singleton "avg_duration" (Aeson.Number 0))) 0)
+        ("+0.0%" `isInfixOf` render (Just (KM.singleton "avg_duration" (Aeson.Number 0))) 0)
       assertBool "zero to nonzero has no percentage"
-        ("(from 0; % n/a)" `isInfixOf` render (Just (KM.singleton "avg_duration" (Aeson.Number 0))) 2)
+        ("from 0" `isInfixOf` render (Just (KM.singleton "avg_duration" (Aeson.Number 0))) 2)
   , testCase "failed and incomplete runs have no performance comparison" $ do
       let res = result (KM.singleton "avg_duration" (Aeson.Number 10))
       forM_ [res { trComplete = False }, res { trSuccess = Just False }, res { trSkipped = True },
              res { trException = Just "error" }, res { trNumIterations = 0 }, res { trSnapshotUpdated = True }] $ \invalid ->
-        assertEqual "no performance lines" [] (formatTestPerfLines False Nothing invalid)
+        assertEqual "no performance lines" [] (renderPerf 79 False Nothing invalid)
   , testCase "recording runs fresh tests and preserves unselected measurements" $
       withSystemTempDirectory "acton-perf-record" $ \proj -> do
         acton <- canonicalizePath "../../dist/bin/acton"
@@ -89,23 +228,34 @@ perfTests = testGroup "performance baselines"
             tests = M.findWithDefault M.empty "perf_record.sample" saved
         BL.writeFile baseline (Aeson.encode saved)
         assertEqual "two measured tests" 2 (M.size tests)
+        forM_ tests $ \raw -> case raw of
+          Aeson.Object obj -> do
+            forM_ distributionKeys $ \key -> assertBool (show key ++ " missing from recording") (KM.member key obj)
+            case KM.lookup "peak_rss" obj of
+              Nothing -> return ()
+              Just (Aeson.Number rss) -> assertBool "peak RSS is positive when available" (rss > 0)
+              Just _ -> assertFailure "peak RSS must be a number"
+          _ -> assertFailure "expected recorded measurements"
         bytes <- BL.readFile baseline
         out <- runOK ["--name", "first"]
-        assertBool out ("Mean:" `isInfixOf` out && "%" `isInfixOf` out)
-        assertBool out ("Allocated / run:" `isInfixOf` out)
+        assertBool out ("mean ± σ" `isInfixOf` unwords (words out) && "%" `isInfixOf` out)
+        assertBool out ("allocated" `isInfixOf` out)
         assertEqual "comparison leaves the baseline intact" bytes =<< BL.readFile baseline
         ttyOut <- runOK ["--tty", "--name", "first"]
-        assertBool ttyOut ("Mean:" `isInfixOf` ttyOut && "%" `isInfixOf` ttyOut)
+        assertBool ttyOut ("mean ± σ" `isInfixOf` unwords (words ttyOut) && "%" `isInfixOf` ttyOut)
         assertEqual "terminal comparison leaves the baseline intact" bytes =<< BL.readFile baseline
         json <- runOK ["--json", "--name", "first"]
         assertBool json ("\"cached\":false" `isInfixOf` json)
+        forM_ ["performance", "median_duration", "stdev_duration", "outlier_count", "avg_wall_duration", "avg_gc_duration", "mean_difference_ci95_ms"] $ \key ->
+          assertBool (key ++ " missing from " ++ json) (("\"" ++ key ++ "\"") `isInfixOf` json)
+        forM_ distributionKeys $ \key -> assertBool (show key ++ " missing from " ++ json) (show key `isInfixOf` json)
         -- Set a deterministic reference and check that --record compares with
         -- the old value before replacing only the selected measurement.
         let reference = M.adjust (M.adjust setMean "_test_first_wrapper")
               "perf_record.sample" saved
         BL.writeFile baseline (Aeson.encode reference)
         updatedOut <- runOK ["--record", "--name", "first"]
-        assertBool updatedOut ("-100.00%" `isInfixOf` updatedOut)
+        assertBool updatedOut ("-100.0%" `isInfixOf` updatedOut)
         updated <- readBaseline
         let updatedTests = M.findWithDefault M.empty "perf_record.sample" updated
         assertEqual "unselected measurement survives recording"
@@ -124,7 +274,7 @@ perfTests = testGroup "performance baselines"
             failedReference = M.adjust (M.adjust invalidate "_test_first_wrapper") "perf_record.sample" updated
         BL.writeFile baseline (Aeson.encode failedReference)
         invalidOut <- runOK ["--name", "first"]
-        assertBool invalidOut ("Mean:" `isInfixOf` invalidOut && not ("%" `isInfixOf` invalidOut))
+        assertBool invalidOut ("mean ± σ" `isInfixOf` unwords (words invalidOut) && not ("delta" `isInfixOf` invalidOut))
         BL.writeFile baseline "{broken"
         (badCode, _, badErr) <- run ["--record", "--name", "first"]
         assertBool badErr (badCode /= ExitSuccess && "Cannot read performance baseline" `isInfixOf` badErr)
@@ -165,3 +315,59 @@ result obj = TestResult
   , trSnapshotUpdated = False
   , trCached = False
   }
+
+sample :: Double -> Double -> Int -> Aeson.Object
+sample mean sd n = KM.fromList
+  [ ("avg_duration", Aeson.toJSON mean)
+  , ("stdev_duration", Aeson.toJSON sd)
+  , ("num_iterations", Aeson.toJSON n)
+  ]
+
+tableResult :: TestResult
+tableResult = (result (sample 12 1 10 `KM.union` KM.fromList
+  [ ("min_duration", Aeson.Number 10)
+  , ("median_duration", Aeson.Number 12)
+  , ("max_duration", Aeson.Number 14)
+  , ("outlier_count", Aeson.Number 1)
+  , ("avg_wall_duration", Aeson.Number 12)
+  , ("avg_gc_duration", Aeson.Number 0)
+  , ("mem_usage_delta_avg", Aeson.Number 1536)
+  , ("non_gc_mem_usage_delta_avg", Aeson.Number (-2048))
+  , ("peak_rss", Aeson.Number 12000000)
+  ])) { trNumIterations = 10 }
+
+fullTableResult :: TestResult
+fullTableResult = tableResult { trRaw = case trRaw tableResult of
+    Aeson.Object obj -> Aeson.Object (obj `KM.union` KM.fromList
+      [ ("stdev_wall_duration", Aeson.Number 2)
+      , ("min_wall_duration", Aeson.Number 8)
+      , ("max_wall_duration", Aeson.Number 16)
+      , ("outlier_count_wall_duration", Aeson.Number 0)
+      , ("stdev_gc_duration", Aeson.Number 0)
+      , ("min_gc_duration", Aeson.Number 0)
+      , ("max_gc_duration", Aeson.Number 0)
+      , ("outlier_count_gc_duration", Aeson.Number 0)
+      , ("stdev_mem_usage_delta", Aeson.Number 128)
+      , ("min_mem_usage_delta", Aeson.Number 1024)
+      , ("max_mem_usage_delta", Aeson.Number 2048)
+      , ("median_mem_usage_delta", Aeson.Number 1536)
+      , ("q1_mem_usage_delta", Aeson.Number 1408)
+      , ("q3_mem_usage_delta", Aeson.Number 1664)
+      , ("outlier_count_mem_usage_delta", Aeson.Number 2)
+      , ("stdev_non_gc_mem_usage_delta", Aeson.Number 1024)
+      , ("min_non_gc_mem_usage_delta", Aeson.Number (-4096))
+      , ("max_non_gc_mem_usage_delta", Aeson.Number 0)
+      , ("outlier_count_non_gc_mem_usage_delta", Aeson.Number 3)
+      ])
+    raw -> raw
+  }
+
+distributionKeys :: [Aeson.Key]
+distributionKeys =
+  [ stat <> "_" <> metric
+  | metric <- ["wall_duration", "gc_duration", "mem_usage_delta", "non_gc_mem_usage_delta"]
+  , stat <- ["min", "max", "median", "q1", "q3", "stdev", "outlier_count"]
+  ]
+
+renderPerf :: Int -> Bool -> Maybe Aeson.Object -> TestResult -> [String]
+renderPerf cols useColor baseline res = map ($ cols) (formatTestPerfLines useColor baseline res)

--- a/compiler/acton/PerfTests.hs
+++ b/compiler/acton/PerfTests.hs
@@ -9,6 +9,7 @@ import Data.List (isInfixOf, isSuffixOf, find, elemIndices)
 import TerminalSize (termVisibleLength, termFitAnsiRight, termRenderedRows)
 import qualified Data.Map as M
 import System.Directory
+import System.Environment (getEnvironment)
 import System.Exit
 import System.FilePath
 import System.IO.Temp (withSystemTempDirectory)
@@ -19,7 +20,7 @@ import Test.Tasty.HUnit
 import qualified Acton.Fingerprint as Fingerprint
 import Acton.Testing (TestResult(..))
 import TestFormat (formatTestPerfLines)
-import TestPerf (perfMeanInterval, perfJson)
+import TestPerf (perfComparable, perfMeanInterval, perfJson)
 
 perfTests :: TestTree
 perfTests = testGroup "performance baselines"
@@ -94,6 +95,39 @@ perfTests = testGroup "performance baselines"
             assertEqual (show key) (Just (Aeson.Object obj)) (KM.lookup key report)
           _ -> assertFailure "expected a performance report"
         _ -> assertFailure "expected measurements"
+  , testCase "CPU rows scale counts and keep IPC comparisons neutral" $ do
+      let old = counterSample 1000000 1
+          new = counterSample 2000000 2
+          rows = renderPerf 119 True (Just old) ((result new) { trNumIterations = 10 })
+          instructions = maybe "" id (find ("instructions" `isInfixOf`) rows)
+          ipc = maybe "" id (find ("IPC" `isInfixOf`) rows)
+      assertBool instructions ("2.00" `isInfixOf` instructions && "M" `isInfixOf` instructions)
+      assertBool instructions (not ("MB" `isInfixOf` instructions))
+      assertBool instructions ("💩" `isInfixOf` instructions)
+      assertBool ipc ("+100.0%" `isInfixOf` ipc && not (any (`isInfixOf` ipc) ["⚡", "💩", "ratio", "\ESC[91m"]))
+      forM_ [39, 79, 119, 160] $ \cols ->
+        assertBool (show cols) (all ((<= cols) . termVisibleLength) (renderPerf cols True (Just old) (result new)))
+      case perfJson (Just old) (result new) of
+        Just (Aeson.Object report) -> do
+          assertEqual "measurements retain counters and metadata" (Just (Aeson.Object new)) (KM.lookup "measurements" report)
+          assertEqual "baseline retains counters and metadata" (Just (Aeson.Object old)) (KM.lookup "baseline" report)
+        _ -> assertFailure "expected a counter report"
+  , testCase "different counter scope or machine cannot produce a performance delta" $ do
+      let old = counterSample 1000000 1
+          new = counterSample 2000000 2
+          alter key value = KM.insert "counter_info" (case KM.lookup "counter_info" old of
+            Just (Aeson.Object info) -> Aeson.Object (KM.insert key (Aeson.String value) info)
+            _ -> Aeson.Null) old
+      assertBool "matching counters can compare" (perfComparable "instructions" old new)
+      assertBool "hardware permissions do not change CPU-time accounting"
+        (perfComparable "cpu_user" (alter "scope" "process:user") new)
+      forM_ [alter "scope" "process:user", alter "cpu" "another CPU", alter "version" "2", KM.delete "counter_info" old] $ \baseline -> do
+        assertEqual "no confidence interval for incomparable counters" Nothing (perfMeanInterval "instructions" baseline new)
+        let rows = renderPerf 119 False (Just baseline) (result new)
+            line = maybe "" id (find ("instructions" `isInfixOf`) rows)
+        assertBool line (not ("+100.0%" `isInfixOf` line))
+        assertBool line ("2.00M" `isInfixOf` line)
+        assertBool "legacy timing remains comparable" (perfComparable "duration" baseline new)
   , testCase "small spreads and range endpoints keep their precision" $ do
       let obj = sample 1 0.001 10 `KM.union` KM.fromList [("min_duration", Aeson.toJSON (0.001 :: Double)), ("max_duration", Aeson.Number 1)]
           rendered = unlines (renderPerf 79 False Nothing (result obj))
@@ -205,6 +239,7 @@ perfTests = testGroup "performance baselines"
         writeFile (proj </> "Build.act") $ unlines ["name = " ++ show name, "fingerprint = " ++ fp]
         writeFile (proj </> "src/sample.act") $ unlines
           [ "import testing"
+          , "import acton.rts"
           , ""
           , "actor _test_first(t: testing.AsyncT):"
           , "    t.success()"
@@ -220,7 +255,23 @@ perfTests = testGroup "performance baselines"
           , ""
           , "actor _test_slow(t: testing.AsyncT):"
           , "    after 3.5: t.success()"
+          , ""
+          , "actor _test_counter_activation(t: testing.EnvT):"
+          , "    assert t.env.getenv(\"ACTON_TEST_PERF\") is None"
+          , "    info = acton.rts.perf_info(t.env.syscap)"
+          , "    if \"perf\" in t.env.argv:"
+          , "        assert info[\"status\"] != \"not enabled at process start\""
+          , "    else:"
+          , "        assert info[\"status\"] == \"not enabled at process start\""
+          , "        assert acton.rts.perf_snapshot(t.env.syscap).instructions is None"
+          , "    t.success()"
           ]
+        _ <- runOK ["--name", "counter_activation"]
+        environment <- getEnvironment
+        (ordinaryCode, ordinaryOut, ordinaryErr) <- readCreateProcessWithExitCode
+          (proc acton ["test", "--iter", "1", "--name", "counter_activation", "--no-cache"])
+            { cwd = Just proj, env = Just (("ACTON_TEST_PERF", "1") : filter ((/= "ACTON_TEST_PERF") . fst) environment) } ""
+        assertEqual (ordinaryOut ++ ordinaryErr) ExitSuccess ordinaryCode
         _ <- runOK ["--record", "--name", "first|second"]
         saved0 <- readBaseline
         -- The old writer included null entries when a test process crashed.
@@ -231,6 +282,15 @@ perfTests = testGroup "performance baselines"
         forM_ tests $ \raw -> case raw of
           Aeson.Object obj -> do
             forM_ distributionKeys $ \key -> assertBool (show key ++ " missing from recording") (KM.member key obj)
+            case KM.lookup "counter_info" obj of
+              Just (Aeson.Object info) -> do
+                assertBool "performance counters activated before runtime startup"
+                  (KM.lookup "status" info /= Just (Aeson.String "not enabled at process start"))
+                when (KM.lookup "status" info == Just (Aeson.String "available")) $
+                  forM_ ["avg_instructions", "avg_cycles", "avg_ipc"] $ \key -> case KM.lookup key obj of
+                    Just (Aeson.Number n) -> assertBool (show key) (n > 0)
+                    _ -> assertFailure (show key ++ " missing from available hardware counters")
+              _ -> assertFailure "missing counter metadata"
             case KM.lookup "peak_rss" obj of
               Nothing -> return ()
               Just (Aeson.Number rss) -> assertBool "peak RSS is positive when available" (rss > 0)
@@ -246,7 +306,7 @@ perfTests = testGroup "performance baselines"
         assertEqual "terminal comparison leaves the baseline intact" bytes =<< BL.readFile baseline
         json <- runOK ["--json", "--name", "first"]
         assertBool json ("\"cached\":false" `isInfixOf` json)
-        forM_ ["performance", "median_duration", "stdev_duration", "outlier_count", "avg_wall_duration", "avg_gc_duration", "mean_difference_ci95_ms"] $ \key ->
+        forM_ ["performance", "median_duration", "stdev_duration", "outlier_count", "avg_wall_duration", "avg_gc_duration", "mean_difference_ci95_ms", "counter_info", "avg_cpu_user", "avg_cpu_system"] $ \key ->
           assertBool (key ++ " missing from " ++ json) (("\"" ++ key ++ "\"") `isInfixOf` json)
         forM_ distributionKeys $ \key -> assertBool (show key ++ " missing from " ++ json) (show key `isInfixOf` json)
         -- Set a deterministic reference and check that --record compares with
@@ -365,8 +425,23 @@ fullTableResult = tableResult { trRaw = case trRaw tableResult of
 distributionKeys :: [Aeson.Key]
 distributionKeys =
   [ stat <> "_" <> metric
-  | metric <- ["wall_duration", "gc_duration", "mem_usage_delta", "non_gc_mem_usage_delta"]
+  | metric <- ["wall_duration", "gc_duration", "mem_usage_delta", "non_gc_mem_usage_delta", "cpu_user", "cpu_system"]
   , stat <- ["min", "max", "median", "q1", "q3", "stdev", "outlier_count"]
+  ]
+
+counterSample :: Double -> Double -> Aeson.Object
+counterSample instructions ipc = KM.fromList
+  [ ("avg_instructions", Aeson.toJSON instructions)
+  , ("stdev_instructions", Aeson.Number 0)
+  , ("avg_ipc", Aeson.toJSON ipc)
+  , ("stdev_ipc", Aeson.Number 0)
+  , ("num_iterations", Aeson.Number 10)
+  , ("counter_info", Aeson.object
+      [ "version" Aeson..= ("1" :: String), "backend" Aeson..= ("perf_event_open" :: String)
+      , "scope" Aeson..= ("process:user+kernel" :: String), "os" Aeson..= ("Linux" :: String)
+      , "release" Aeson..= ("6.1" :: String), "arch" Aeson..= ("x86_64" :: String)
+      , "cpu" Aeson..= ("test CPU" :: String), "status" Aeson..= ("available" :: String)
+      ])
   ]
 
 renderPerf :: Int -> Bool -> Maybe Aeson.Object -> TestResult -> [String]

--- a/compiler/acton/PerfTests.hs
+++ b/compiler/acton/PerfTests.hs
@@ -1,0 +1,167 @@
+{-# LANGUAGE OverloadedStrings #-}
+module PerfTests (perfTests) where
+
+import Control.Monad
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KM
+import qualified Data.ByteString.Lazy as BL
+import Data.List (isInfixOf)
+import qualified Data.Map as M
+import System.Directory
+import System.Exit
+import System.FilePath
+import System.IO.Temp (withSystemTempDirectory)
+import System.Process
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import qualified Acton.Fingerprint as Fingerprint
+import Acton.Testing (TestResult(..))
+import TestFormat (formatTestPerfLines)
+
+perfTests :: TestTree
+perfTests = testGroup "performance baselines"
+  [ testCase "timing and allocation changes use the recorded measurement" $ do
+      let old = KM.fromList [("avg_duration", Aeson.Number 10), ("mem_usage_delta_avg", Aeson.Number 100)]
+          new = KM.fromList [("avg_duration", Aeson.Number 12), ("mem_usage_delta_avg", Aeson.Number 50)]
+          rendered = unlines (formatTestPerfLines False (Just old) (result new))
+      assertBool rendered ("12.000 ms (+20.00%)" `isInfixOf` rendered)
+      assertBool rendered ("50 B (-50.00%)" `isInfixOf` rendered)
+  , testCase "missing and zero baselines have defined output" $ do
+      let render :: Maybe Aeson.Object -> Double -> String
+          render old value = unlines $ formatTestPerfLines False old
+            (result (KM.singleton "avg_duration" (Aeson.toJSON value)))
+      assertBool "no baseline has no delta" (not ("%" `isInfixOf` render Nothing 2))
+      assertBool "missing metric has no delta" (not ("%" `isInfixOf` render (Just KM.empty) 2))
+      assertBool "zero to zero is unchanged"
+        ("(+0.00%)" `isInfixOf` render (Just (KM.singleton "avg_duration" (Aeson.Number 0))) 0)
+      assertBool "zero to nonzero has no percentage"
+        ("(from 0; % n/a)" `isInfixOf` render (Just (KM.singleton "avg_duration" (Aeson.Number 0))) 2)
+  , testCase "failed and incomplete runs have no performance comparison" $ do
+      let res = result (KM.singleton "avg_duration" (Aeson.Number 10))
+      forM_ [res { trComplete = False }, res { trSuccess = Just False }, res { trSkipped = True },
+             res { trException = Just "error" }, res { trNumIterations = 0 }, res { trSnapshotUpdated = True }] $ \invalid ->
+        assertEqual "no performance lines" [] (formatTestPerfLines False Nothing invalid)
+  , testCase "recording runs fresh tests and preserves unselected measurements" $
+      withSystemTempDirectory "acton-perf-record" $ \proj -> do
+        acton <- canonicalizePath "../../dist/bin/acton"
+        let name = "perf_record"
+            fp = Fingerprint.formatFingerprint
+              (Fingerprint.updateFingerprintPrefix (Fingerprint.fingerprintPrefixForName name) 1)
+            baseline = proj </> "perf_data"
+            run args = readCreateProcessWithExitCode
+              (proc acton (["test", "perf", "--iter", "2", "--color", "never"] ++ args)) { cwd = Just proj } ""
+            runOK args = do
+              (code, out, err) <- run args
+              assertEqual (unwords args ++ "\n" ++ out ++ err) ExitSuccess code
+              return out
+            readBaseline = do
+              decoded <- Aeson.eitherDecodeFileStrict baseline
+              case decoded of
+                Left err -> assertFailure err >> return M.empty
+                Right saved -> return (saved :: M.Map String (M.Map String Aeson.Value))
+            setMean (Aeson.Object obj) = Aeson.Object (KM.insert "avg_duration" (Aeson.Number 1000000000) obj)
+            setMean raw = raw
+        createDirectoryIfMissing True (proj </> "src")
+        writeFile (proj </> "Build.act") $ unlines ["name = " ++ show name, "fingerprint = " ++ fp]
+        writeFile (proj </> "src/sample.act") $ unlines
+          [ "import testing"
+          , ""
+          , "actor _test_first(t: testing.AsyncT):"
+          , "    t.success()"
+          , ""
+          , "actor _test_second(t: testing.AsyncT):"
+          , "    t.success()"
+          , ""
+          , "actor _test_failed(t: testing.AsyncT):"
+          , "    t.failure(ValueError(\"expected failure\"))"
+          , ""
+          , "actor _test_skipped(t: testing.AsyncT):"
+          , "    t.skip(\"expected skip\")"
+          , ""
+          , "actor _test_slow(t: testing.AsyncT):"
+          , "    after 3.5: t.success()"
+          ]
+        _ <- runOK ["--record", "--name", "first|second"]
+        saved0 <- readBaseline
+        -- The old writer included null entries when a test process crashed.
+        let saved = M.insert "missing" (M.singleton "_test_crashed" Aeson.Null) saved0
+            tests = M.findWithDefault M.empty "perf_record.sample" saved
+        BL.writeFile baseline (Aeson.encode saved)
+        assertEqual "two measured tests" 2 (M.size tests)
+        bytes <- BL.readFile baseline
+        out <- runOK ["--name", "first"]
+        assertBool out ("Mean:" `isInfixOf` out && "%" `isInfixOf` out)
+        assertBool out ("Allocated / run:" `isInfixOf` out)
+        assertEqual "comparison leaves the baseline intact" bytes =<< BL.readFile baseline
+        ttyOut <- runOK ["--tty", "--name", "first"]
+        assertBool ttyOut ("Mean:" `isInfixOf` ttyOut && "%" `isInfixOf` ttyOut)
+        assertEqual "terminal comparison leaves the baseline intact" bytes =<< BL.readFile baseline
+        json <- runOK ["--json", "--name", "first"]
+        assertBool json ("\"cached\":false" `isInfixOf` json)
+        -- Set a deterministic reference and check that --record compares with
+        -- the old value before replacing only the selected measurement.
+        let reference = M.adjust (M.adjust setMean "_test_first_wrapper")
+              "perf_record.sample" saved
+        BL.writeFile baseline (Aeson.encode reference)
+        updatedOut <- runOK ["--record", "--name", "first"]
+        assertBool updatedOut ("-100.00%" `isInfixOf` updatedOut)
+        updated <- readBaseline
+        let updatedTests = M.findWithDefault M.empty "perf_record.sample" updated
+        assertEqual "unselected measurement survives recording"
+          (M.lookup "_test_second_wrapper" tests) (M.lookup "_test_second_wrapper" updatedTests)
+        assertEqual "recording cached source must not empty the baseline" 2 (M.size updatedTests)
+        assertEqual "unavailable old measurements survive recording"
+          (M.lookup "missing" saved) (M.lookup "missing" updated)
+        updatedBytes <- BL.readFile baseline
+        (failedCode, _, _) <- run ["--record", "--name", "failed"]
+        assertBool "failing test exits unsuccessfully" (failedCode /= ExitSuccess)
+        _ <- runOK ["--record", "--name", "skipped"]
+        _ <- runOK ["--record", "--name", "absent"]
+        assertEqual "failed, skipped and empty selections preserve the baseline" updatedBytes =<< BL.readFile baseline
+        let invalidate (Aeson.Object obj) = Aeson.Object (KM.insert "success" (Aeson.Bool False) obj)
+            invalidate raw = raw
+            failedReference = M.adjust (M.adjust invalidate "_test_first_wrapper") "perf_record.sample" updated
+        BL.writeFile baseline (Aeson.encode failedReference)
+        invalidOut <- runOK ["--name", "first"]
+        assertBool invalidOut ("Mean:" `isInfixOf` invalidOut && not ("%" `isInfixOf` invalidOut))
+        BL.writeFile baseline "{broken"
+        (badCode, _, badErr) <- run ["--record", "--name", "first"]
+        assertBool badErr (badCode /= ExitSuccess && "Cannot read performance baseline" `isInfixOf` badErr)
+        assertEqual "malformed baseline is not overwritten" "{broken" =<< BL.readFile baseline
+        removeFile baseline
+        -- Sampling limits are checked between iterations. A slow iteration
+        -- must be allowed to finish beyond the former three-second watchdog.
+        (slowCode, slowOut, slowErr) <- readCreateProcessWithExitCode
+          (proc acton ["test", "perf", "--min-iter", "1", "--max-iter", "1", "--name", "slow", "--json"])
+            { cwd = Just proj } ""
+        assertEqual (slowOut ++ slowErr) ExitSuccess slowCode
+  , testCase "record requires performance mode" $ do
+      acton <- canonicalizePath "../../dist/bin/acton"
+      forM_ [[], ["stress"], ["list"]] $ \mode -> do
+        (code, _, err) <- readCreateProcessWithExitCode (proc acton (["test"] ++ mode ++ ["--record"])) ""
+        assertBool err (code /= ExitSuccess && "--record requires acton test perf" `isInfixOf` err)
+  ]
+
+result :: Aeson.Object -> TestResult
+result obj = TestResult
+  { trModule = "sample"
+  , trName = "_test_sample"
+  , trComplete = True
+  , trSuccess = Just True
+  , trSkipped = False
+  , trSkipReason = Nothing
+  , trException = Nothing
+  , trOutput = Nothing
+  , trStdOut = Nothing
+  , trStdErr = Nothing
+  , trFlaky = False
+  , trNumSkipped = 0
+  , trNumFailures = 0
+  , trNumErrors = 0
+  , trNumIterations = 3
+  , trTestDuration = 100
+  , trRaw = Aeson.Object obj
+  , trSnapshotUpdated = False
+  , trCached = False
+  }

--- a/compiler/acton/TerminalSize.hs
+++ b/compiler/acton/TerminalSize.hs
@@ -16,6 +16,7 @@ module TerminalSize
 
 import Control.Exception (SomeException, try)
 import Control.Monad (when)
+import Data.Char.WCWidth (wcwidth)
 import Data.IORef
 import Data.List (isInfixOf)
 import Foreign
@@ -127,7 +128,7 @@ termVisibleLength = go 0
   where
     go acc [] = acc
     go acc ('\ESC':'[':xs) = go acc (dropAnsi xs)
-    go acc (_:xs) = go (acc + 1) xs
+    go acc (x:xs) = go (acc + max 0 (wcwidth x)) xs
 
 termFitAnsiRight :: Int -> String -> String
 termFitAnsiRight width s
@@ -138,12 +139,13 @@ termFitAnsiRight width s
       in if "\ESC[" `isInfixOf` trimmed then trimmed ++ "\ESC[0m" else trimmed
   where
     go _ [] = []
-    go n _
-      | n <= 0 = []
     go n ('\ESC':'[':xs) =
       let (esc, rest) = spanAnsi xs
       in '\ESC' : '[' : esc ++ go n rest
-    go n (x:xs) = x : go (n - 1) xs
+    go n (x:xs)
+      | cells > n = []
+      | otherwise = x : go (n - cells) xs
+      where cells = max 0 (wcwidth x)
 
 termFitPlainRight :: Int -> String -> String
 termFitPlainRight width s

--- a/compiler/acton/TestFormat.hs
+++ b/compiler/acton/TestFormat.hs
@@ -176,33 +176,34 @@ formatTestPerfLines useColor baseline res =
     dim = paint "\ESC[2m"
     missing = dim "—"
     interval metric obj = baseline >>= (\old -> perfMeanInterval metric old obj)
-    change obj key value =
-      let metric = lookup key [(perfStatKey m "avg", m) | (m, _, _) <- perfMetrics]
-          direction = case metric >>= (\m -> if m == "ipc" then Nothing else interval m obj) of
-            Just (lo, _) | lo > 0 -> Just ("💩", "\ESC[91m")
-            Just (_, hi) | hi < 0 -> Just ("⚡", "\ESC[92m")
-            _ -> Nothing
-          comparison icon color s
-            | isJust metric = padLeft 11 (paint color s) ++ " "
-                ++ (if null icon then "  " else paint (if icon == "⚡" then testColorYellow else color) icon)
-            | otherwise = paint color s
-          neutral = comparison "" "\ESC[2m"
-          previous old = if maybe True (\m -> perfComparable m old obj) metric
-            then perfNumber old key else Nothing
-      in case baseline >>= previous of
-        Just 0 | value == 0 -> neutral "+0.0%"
-        Just 0 -> neutral "from 0"
-        Just old ->
-          let pct = (value - old) / abs old * 100
-              percent = fitNumber 11
-                [printf "%+.1f%%" pct, printf "%+.2e%%" pct, printf "%+.0e%%" pct]
-          in if isNaN pct || isInfinite pct
-               then neutral "n/a"
-               else case direction of
-                 Just (icon, color) -> comparison icon color percent
-                 Nothing | isJust metric -> neutral percent
-                 _ -> paint (if pct > 0 then "\ESC[91m" else if pct < 0 then "\ESC[92m" else "\ESC[2m") percent
-        Nothing -> neutral "—"
+    percentage previous value = case previous of
+      Nothing -> (Nothing, "—")
+      Just 0 -> (Nothing, if value == 0 then "+0.0%" else "from 0")
+      Just old ->
+        let pct = (value - old) / abs old * 100
+        in if isNaN pct || isInfinite pct then (Nothing, "n/a")
+           else (Just pct, fitNumber 11 [printf "%+.1f%%" pct, printf "%+.2e%%" pct, printf "%+.0e%%" pct])
+    meanChange obj metric value =
+      let previous = do
+            old <- baseline
+            if perfComparable metric old obj then perfNumber old (perfStatKey metric "avg") else Nothing
+          (pct, text) = percentage previous value
+          bounds = if metric == "ipc" then Nothing else interval metric obj
+          (icon, color) = case (pct, bounds) of
+            (Just _, Just (lo, _)) | lo > 0 -> ("💩", "\ESC[91m")
+            (Just _, Just (_, hi)) | hi < 0 -> ("⚡", "\ESC[92m")
+            _ -> ("", "\ESC[2m")
+      in padLeft 11 (paint color text) ++ " "
+          ++ (if null icon then "  " else paint (if icon == "⚡" then testColorYellow else color) icon)
+    footerChange key value = case baseline >>= (\old -> perfNumber old key) of
+      Nothing -> ""
+      Just old ->
+        let (pct, text) = percentage (Just old) value
+            color = case pct of
+              Just p | p > 0 -> "\ESC[91m"
+              Just p | p < 0 -> "\ESC[92m"
+              _ -> "\ESC[2m"
+        in " (" ++ paint color text ++ ")"
     fitNumber width choices = fromMaybe (last choices) (listToMaybe [s | s <- choices, length s <= width])
     padLeft width s = replicate (max 0 (width - termVisibleLength s)) ' ' ++ s
     padRight width s = s ++ replicate (max 0 (width - termVisibleLength s)) ' '
@@ -233,7 +234,7 @@ formatTestPerfLines useColor baseline res =
                     count = fitNumber 14 [printf "%.0f (%.0f%%)" n pct, printf "%.1e (%.0f%%)" n pct]
                 in paint (if pct >= 10 then testColorYellow else "\ESC[2m") count
               _ -> missing
-        in [label, mean, range, outliers, change obj (perfStatKey metric "avg") value]
+        in [label, mean, range, outliers, meanChange obj metric value]
     table obj =
       let headings numberWidth showSpread =
             let title color = padLeft (numberWidth + 2) . paint color
@@ -273,15 +274,9 @@ formatTestPerfLines useColor baseline res =
       in map render rows
     footers obj = map (\line cols -> termFitAnsiRight cols line) $ catMaybes
       [ do value <- perfNumber obj "median_duration"
-           let delta = case baseline >>= (\old -> perfNumber old "median_duration") of
-                 Just _ -> " (" ++ change obj "median_duration" value ++ ")"
-                 Nothing -> ""
-           return ("  median: " ++ single "" "ms" value ++ delta)
+           return ("  median: " ++ single "" "ms" value ++ footerChange "median_duration" value)
       , do value <- perfNumber obj "peak_rss"
-           let delta = case baseline >>= (\old -> perfNumber old "peak_rss") of
-                 Just _ -> " (" ++ change obj "peak_rss" value ++ ")"
-                 Nothing -> ""
-           return ("  process peak RSS: " ++ single "" "B" value ++ delta)
+           return ("  process peak RSS: " ++ single "" "B" value ++ footerChange "peak_rss" value)
       , do (lo, hi) <- interval "duration" obj
            return ("  mean delta (95% CI): " ++ pair "ms" " … " ("", "") lo hi)
       , do info <- perfCounterInfo obj

--- a/compiler/acton/TestFormat.hs
+++ b/compiler/acton/TestFormat.hs
@@ -6,6 +6,8 @@ module TestFormat
   , formatTestFinalLineRenderer
   , formatTestLiveLineRenderer
   , formatTestDetailLines
+  , formatTestPerfLines
+  , testPerfData
   , testColorApply
   , testColorBold
   , testColorRed
@@ -160,6 +162,48 @@ fitTestDisplay width display
   | length display <= width = display
   | width <= 3 = take width display
   | otherwise = termFitPlainRight (width - 3) display ++ "..."
+
+-- | Only complete, successful measurements can be recorded or compared.
+testPerfData :: TestResult -> Maybe Aeson.Object
+testPerfData res
+  | not (trComplete res) || trSuccess res /= Just True || isJust (trException res)
+    || trSkipped res || trCached res || trSnapshotUpdated res || trNumIterations res <= 0 = Nothing
+  | otherwise = case trRaw res of
+      Aeson.Object obj -> Just obj
+      _ -> Nothing
+
+-- | Format the per-iteration measurements, with changes from a recorded run.
+formatTestPerfLines :: Bool -> Maybe Aeson.Object -> TestResult -> [String]
+formatTestPerfLines useColor baseline res =
+    case testPerfData res of
+      Just obj -> catMaybes
+        [ metric obj "min_duration" "Min" "ms"
+        , metric obj "avg_duration" "Mean" "ms"
+        , metric obj "max_duration" "Max" "ms"
+        , metric obj "mem_usage_delta_avg" "Allocated / run" "B"
+        , metric obj "non_gc_mem_usage_delta_avg" "Non-GC change / run" "B"
+        ]
+      Nothing -> []
+  where
+    number :: Aeson.Object -> String -> Maybe Double
+    number obj key = do
+      value <- AesonKM.lookup (AesonKey.fromString key) obj >>= AesonTypes.parseMaybe Aeson.parseJSON
+      if isNaN value || isInfinite value then Nothing else Just value
+    metric :: Aeson.Object -> String -> String -> String -> Maybe String
+    metric obj key label unit = do
+      value <- number obj key
+      let previous = baseline >>= (\old -> number old key)
+          amount :: String
+          amount = if unit == "ms" then printf "%.3f ms" value else printf "%.0f B" value
+          change = case previous of
+            Just old | old /= 0 ->
+              let pct = (value - old) / abs old * 100 :: Double
+                  color = if pct > 0 then testColorRed else if pct < 0 then testColorGreen else testColorReset
+              in " (" ++ testColorApply useColor [color] (printf "%+.2f%%" pct) ++ ")"
+            Just 0 | value == 0 -> " (+0.00%)"
+            Just 0 -> " (from 0; % n/a)"
+            _ -> ""
+      return (printf "      %-20s %s%s" (label ++ ":") amount change)
 
 -- | Format a single test result line with alignment and timing.
 formatTestLineWith :: Bool -> (TestResult -> String) -> Double -> Int -> String -> TestResult -> String

--- a/compiler/acton/TestFormat.hs
+++ b/compiler/acton/TestFormat.hs
@@ -21,6 +21,7 @@ import Data.Char (isSpace)
 import Data.List (foldl', isPrefixOf, isInfixOf, intercalate)
 import Data.Maybe (catMaybes, fromMaybe, isJust, listToMaybe, mapMaybe)
 import qualified Data.Map as M
+import qualified Data.Text as T
 import TerminalSize (termFitAnsiRight, termFitPlainRight, termVisibleLength)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Types as AesonTypes
@@ -177,7 +178,7 @@ formatTestPerfLines useColor baseline res =
     interval metric obj = baseline >>= (\old -> perfMeanInterval metric old obj)
     change obj key value =
       let metric = lookup key [(perfStatKey m "avg", m) | (m, _, _) <- perfMetrics]
-          direction = case metric >>= (\m -> interval m obj) of
+          direction = case metric >>= (\m -> if m == "ipc" then Nothing else interval m obj) of
             Just (lo, _) | lo > 0 -> Just ("💩", "\ESC[91m")
             Just (_, hi) | hi < 0 -> Just ("⚡", "\ESC[92m")
             _ -> Nothing
@@ -186,7 +187,9 @@ formatTestPerfLines useColor baseline res =
                 ++ (if null icon then "  " else paint (if icon == "⚡" then testColorYellow else color) icon)
             | otherwise = paint color s
           neutral = comparison "" "\ESC[2m"
-      in case baseline >>= (\old -> perfNumber old key) of
+          previous old = if maybe True (\m -> perfComparable m old obj) metric
+            then perfNumber old key else Nothing
+      in case baseline >>= previous of
         Just 0 | value == 0 -> neutral "+0.0%"
         Just 0 -> neutral "from 0"
         Just old ->
@@ -281,8 +284,31 @@ formatTestPerfLines useColor baseline res =
            return ("  process peak RSS: " ++ single "" "B" value ++ delta)
       , do (lo, hi) <- interval "duration" obj
            return ("  mean delta (95% CI): " ++ pair "ms" " … " ("", "") lo hi)
+      , do info <- perfCounterInfo obj
+           let scope = case counterText info "scope" of
+                 Just "process:user" -> "user only"
+                 _ -> "user + kernel"
+               hardware = if counterText info "status" == Just "available" then "; hardware: " ++ scope else ""
+           return ("  CPU measurements: all process threads, including GC" ++ hardware)
+      , do info <- perfCounterInfo obj
+           status <- counterText info "status"
+           if status == "available" then Nothing
+             else Just ("  hardware counters unavailable: " ++ status)
+      , do old <- baseline
+           _ <- perfNumber old "avg_cpu_user"
+           _ <- perfNumber obj "avg_cpu_user"
+           if perfComparable "cpu_user" old obj then Nothing
+             else Just "  CPU deltas unavailable: baseline machine differs or is unknown"
+      , do old <- baseline
+           _ <- perfNumber old "avg_instructions"
+           _ <- perfNumber obj "avg_instructions"
+           if perfComparable "instructions" old obj then Nothing
+             else Just "  hardware deltas unavailable: baseline machine or counter scope differs or is unknown"
       , Just ("  total: " ++ single "" "ms" (trTestDuration res) ++ printf " (%.1f runs/s)" (testsPerSecond (trNumIterations res) (trTestDuration res)))
       ] ++ [""]
+    counterText info key = case AesonKM.lookup (AesonKey.fromString key) info of
+      Just (Aeson.String s) -> Just (T.unpack s)
+      _ -> Nothing
 
 -- Scale each quantity with decimal prefixes, including signed memory changes.
 -- A small spread keeps its own unit instead of rounding to zero beside a mean.
@@ -291,10 +317,15 @@ perfScale unit value =
     fromMaybe fallback (listToMaybe [entry | entry@(scale, _) <- scales, magnitude >= scale])
   where
     magnitude = abs value
-    scales = if unit == "ms"
-      then [(1e6, "ks"), (1e3, "s"), (1, "ms"), (1e-3, "µs"), (1e-6, "ns")]
-      else [(1e12, "TB"), (1e9, "GB"), (1e6, "MB"), (1e3, "KB"), (1, "B")]
-    fallback = if unit == "ms" && magnitude > 0 then (1e-6, "ns") else (1, unit)
+    scales = case unit of
+      "ms" -> [(1e6, "ks"), (1e3, "s"), (1, "ms"), (1e-3, "µs"), (1e-6, "ns")]
+      "count" -> [(1e12, "T"), (1e9, "G"), (1e6, "M"), (1e3, "K"), (1, "")]
+      "ratio" -> [(1, "")]
+      _ -> [(1e12, "TB"), (1e9, "GB"), (1e6, "MB"), (1e3, "KB"), (1, "B")]
+    fallback
+      | unit == "ms" && magnitude > 0 = (1e-6, "ns")
+      | unit `elem` ["count", "ratio"] = (1, "")
+      | otherwise = (1, unit)
 
 perfDigits :: Double -> String
 perfDigits value

--- a/compiler/acton/TestFormat.hs
+++ b/compiler/acton/TestFormat.hs
@@ -7,7 +7,6 @@ module TestFormat
   , formatTestLiveLineRenderer
   , formatTestDetailLines
   , formatTestPerfLines
-  , testPerfData
   , testColorApply
   , testColorBold
   , testColorRed
@@ -17,11 +16,12 @@ module TestFormat
   ) where
 
 import Acton.Testing (TestResult(..))
+import TestPerf
 import Data.Char (isSpace)
 import Data.List (foldl', isPrefixOf, isInfixOf, intercalate)
 import Data.Maybe (catMaybes, fromMaybe, isJust, listToMaybe, mapMaybe)
 import qualified Data.Map as M
-import TerminalSize (termFitPlainRight, termVisibleLength)
+import TerminalSize (termFitAnsiRight, termFitPlainRight, termVisibleLength)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Types as AesonTypes
 import qualified Data.Aeson.Key as AesonKey
@@ -163,47 +163,146 @@ fitTestDisplay width display
   | width <= 3 = take width display
   | otherwise = termFitPlainRight (width - 3) display ++ "..."
 
--- | Only complete, successful measurements can be recorded or compared.
-testPerfData :: TestResult -> Maybe Aeson.Object
-testPerfData res
-  | not (trComplete res) || trSuccess res /= Just True || isJust (trException res)
-    || trSkipped res || trCached res || trSnapshotUpdated res || trNumIterations res <= 0 = Nothing
-  | otherwise = case trRaw res of
-      Aeson.Object obj -> Just obj
-      _ -> Nothing
-
--- | Format the per-iteration measurements, with changes from a recorded run.
-formatTestPerfLines :: Bool -> Maybe Aeson.Object -> TestResult -> [String]
+-- | Render a performance table. Keep the row count stable when the terminal
+-- resizes, dropping outliers, range and spread before the mean and comparison.
+formatTestPerfLines :: Bool -> Maybe Aeson.Object -> TestResult -> [Int -> String]
 formatTestPerfLines useColor baseline res =
     case testPerfData res of
-      Just obj -> catMaybes
-        [ metric obj "min_duration" "Min" "ms"
-        , metric obj "avg_duration" "Mean" "ms"
-        , metric obj "max_duration" "Max" "ms"
-        , metric obj "mem_usage_delta_avg" "Allocated / run" "B"
-        , metric obj "non_gc_mem_usage_delta_avg" "Non-GC change / run" "B"
-        ]
+      Just obj -> table obj ++ footers obj
       Nothing -> []
   where
-    number :: Aeson.Object -> String -> Maybe Double
-    number obj key = do
-      value <- AesonKM.lookup (AesonKey.fromString key) obj >>= AesonTypes.parseMaybe Aeson.parseJSON
-      if isNaN value || isInfinite value then Nothing else Just value
-    metric :: Aeson.Object -> String -> String -> String -> Maybe String
-    metric obj key label unit = do
-      value <- number obj key
-      let previous = baseline >>= (\old -> number old key)
-          amount :: String
-          amount = if unit == "ms" then printf "%.3f ms" value else printf "%.0f B" value
-          change = case previous of
-            Just old | old /= 0 ->
-              let pct = (value - old) / abs old * 100 :: Double
-                  color = if pct > 0 then testColorRed else if pct < 0 then testColorGreen else testColorReset
-              in " (" ++ testColorApply useColor [color] (printf "%+.2f%%" pct) ++ ")"
-            Just 0 | value == 0 -> " (+0.00%)"
-            Just 0 -> " (from 0; % n/a)"
-            _ -> ""
-      return (printf "      %-20s %s%s" (label ++ ":") amount change)
+    paint color = testColorApply (useColor && not (null color)) [color]
+    dim = paint "\ESC[2m"
+    missing = dim "—"
+    interval metric obj = baseline >>= (\old -> perfMeanInterval metric old obj)
+    change obj key value =
+      let metric = lookup key [(perfStatKey m "avg", m) | (m, _, _) <- perfMetrics]
+          direction = case metric >>= (\m -> interval m obj) of
+            Just (lo, _) | lo > 0 -> Just ("💩", "\ESC[91m")
+            Just (_, hi) | hi < 0 -> Just ("⚡", "\ESC[92m")
+            _ -> Nothing
+          comparison icon color s
+            | isJust metric = padLeft 11 (paint color s) ++ " "
+                ++ (if null icon then "  " else paint (if icon == "⚡" then testColorYellow else color) icon)
+            | otherwise = paint color s
+          neutral = comparison "" "\ESC[2m"
+      in case baseline >>= (\old -> perfNumber old key) of
+        Just 0 | value == 0 -> neutral "+0.0%"
+        Just 0 -> neutral "from 0"
+        Just old ->
+          let pct = (value - old) / abs old * 100
+              percent = fitNumber 11
+                [printf "%+.1f%%" pct, printf "%+.2e%%" pct, printf "%+.0e%%" pct]
+          in if isNaN pct || isInfinite pct
+               then neutral "n/a"
+               else case direction of
+                 Just (icon, color) -> comparison icon color percent
+                 Nothing | isJust metric -> neutral percent
+                 _ -> paint (if pct > 0 then "\ESC[91m" else if pct < 0 then "\ESC[92m" else "\ESC[2m") percent
+        Nothing -> neutral "—"
+    fitNumber width choices = fromMaybe (last choices) (listToMaybe [s | s <- choices, length s <= width])
+    padLeft width s = replicate (max 0 (width - termVisibleLength s)) ' ' ++ s
+    padRight width s = s ++ replicate (max 0 (width - termVisibleLength s)) ' '
+    single color unit value =
+      let (scale, suffix) = perfScale unit value
+      in paint color (perfDigits (value / scale)) ++ dim suffix
+    pair unit separator (colorA, colorB) a b =
+      single colorA unit a ++ separator ++ single colorB unit b
+    quantity width color unit value =
+      let (scale, suffix) = perfScale unit value
+          scaled = value / scale
+          digits = fitNumber width [perfDigits scaled, printf "%.1e" scaled, printf "%.0e" scaled]
+      in padLeft width (paint color digits) ++ padRight 2 (dim suffix)
+    row obj (metric, label, unit) = do
+      value <- perfNumber obj (perfStatKey metric "avg")
+      return $ \numberWidth showSpread ->
+        let q = quantity numberWidth
+            meanValue = q "\ESC[92m" unit value
+            mean = if not showSpread then meanValue else case perfNumber obj (perfStatKey metric "stdev") of
+              Just sd | sd >= 0 && trNumIterations res > 1 -> meanValue ++ " ± " ++ q testColorGreen unit sd
+              _ -> padRight (2 * (numberWidth + 2) + 3) meanValue
+            range = case (perfNumber obj (perfStatKey metric "min"), perfNumber obj (perfStatKey metric "max")) of
+              (Just lo, Just hi) -> q "\ESC[36m" unit lo ++ " … " ++ q "\ESC[35m" unit hi
+              _ -> padLeft (numberWidth + 2) missing
+            outliers = case perfNumber obj (perfStatKey metric "outlier_count") of
+              Just n ->
+                let pct = n / fromIntegral (trNumIterations res) * 100
+                    count = fitNumber 14 [printf "%.0f (%.0f%%)" n pct, printf "%.1e (%.0f%%)" n pct]
+                in paint (if pct >= 10 then testColorYellow else "\ESC[2m") count
+              _ -> missing
+        in [label, mean, range, outliers, change obj (perfStatKey metric "avg") value]
+    table obj =
+      let headings numberWidth showSpread =
+            let title color = padLeft (numberWidth + 2) . paint color
+                mean = title "\ESC[92m" "mean"
+            in [ paint testColorBold "measurement"
+               , mean ++ if showSpread then " ± " ++ title testColorGreen "σ" else ""
+               , title "\ESC[36m" "min" ++ " … " ++ title "\ESC[35m" "max"
+               , paint testColorYellow "outliers"
+               , paint testColorBold "delta" ++ "   "
+               ]
+          rows = headings : mapMaybe (row obj) perfMetrics
+          -- Choose widths only from the viewport, so benchmarks stay aligned.
+          -- Reserve comparison space even when this test has no baseline.
+          layouts = [ (16, 10, 4, [0,1,2,3,4], True)
+                    , (13, 7, 2, [0,1,2,3,4], True)
+                    , (13, 7, 2, [0,1,2,4], True)
+                    , (13, 7, 2, [0,1,4], True)
+                    , (13, 7, 1, [0,1,4], False)
+                    ]
+          widths (labelWidth, numberWidth, _, _, showSpread) =
+            let q = numberWidth + 2
+            in [labelWidth, if showSpread then 2 * q + 3 else q, 2 * q + 3, 14, 14]
+          width layout@(_, _, gap, indexes, _) = 2 + sum [widths layout !! i | i <- indexes] + gap * (length indexes - 1)
+          render cells cols =
+            let layout@(labelWidth, numberWidth, gap, indexes, showSpread) =
+                  fromMaybe (last layouts) (listToMaybe [l | l <- layouts, width l <= cols])
+                columnWidths = widths layout
+                values = cells numberWidth showSpread
+                cell i =
+                  let w = if i == 0 then max 1 (labelWidth - max 0 (width layout - cols)) else columnWidths !! i
+                      s = values !! i
+                  in if i == 0 then padRight w (termFitAnsiRight w s)
+                     else if i == 1 || i == 2 then padRight w s
+                     else padLeft w s
+                shown = [i | i <- indexes, i /= 4 || isJust baseline]
+            in termFitAnsiRight cols ("  " ++ intercalate (replicate gap ' ') (map cell shown))
+      in map render rows
+    footers obj = map (\line cols -> termFitAnsiRight cols line) $ catMaybes
+      [ do value <- perfNumber obj "median_duration"
+           let delta = case baseline >>= (\old -> perfNumber old "median_duration") of
+                 Just _ -> " (" ++ change obj "median_duration" value ++ ")"
+                 Nothing -> ""
+           return ("  median: " ++ single "" "ms" value ++ delta)
+      , do value <- perfNumber obj "peak_rss"
+           let delta = case baseline >>= (\old -> perfNumber old "peak_rss") of
+                 Just _ -> " (" ++ change obj "peak_rss" value ++ ")"
+                 Nothing -> ""
+           return ("  process peak RSS: " ++ single "" "B" value ++ delta)
+      , do (lo, hi) <- interval "duration" obj
+           return ("  mean delta (95% CI): " ++ pair "ms" " … " ("", "") lo hi)
+      , Just ("  total: " ++ single "" "ms" (trTestDuration res) ++ printf " (%.1f runs/s)" (testsPerSecond (trNumIterations res) (trTestDuration res)))
+      ] ++ [""]
+
+-- Scale each quantity with decimal prefixes, including signed memory changes.
+-- A small spread keeps its own unit instead of rounding to zero beside a mean.
+perfScale :: String -> Double -> (Double, String)
+perfScale unit value =
+    fromMaybe fallback (listToMaybe [entry | entry@(scale, _) <- scales, magnitude >= scale])
+  where
+    magnitude = abs value
+    scales = if unit == "ms"
+      then [(1e6, "ks"), (1e3, "s"), (1, "ms"), (1e-3, "µs"), (1e-6, "ns")]
+      else [(1e12, "TB"), (1e9, "GB"), (1e6, "MB"), (1e3, "KB"), (1, "B")]
+    fallback = if unit == "ms" && magnitude > 0 then (1e-6, "ns") else (1, unit)
+
+perfDigits :: Double -> String
+perfDigits value
+  | abs value >= 10000 = printf "%.2e" value
+  | value /= 0 && abs value < 1 = printf "%.2e" value
+  | abs value >= 100 = printf "%.0f" value
+  | abs value >= 10 = printf "%.1f" value
+  | otherwise = printf "%.2f" value
 
 -- | Format a single test result line with alignment and timing.
 formatTestLineWith :: Bool -> (TestResult -> String) -> Double -> Int -> String -> TestResult -> String
@@ -318,9 +417,13 @@ formatTestLineFitted useColor statusFn expectedDurationMs nameWidth width displa
       | width >= length statusPlain = statusRendered
       | otherwise = fitTestDisplay width display
 
-formatTestFinalLineRenderer :: Bool -> Double -> Int -> String -> TestResult -> Int -> String
-formatTestFinalLineRenderer useColor expectedDurationMs nameWidth display res cols =
-    formatTestLineFitted useColor formatTestStatus expectedDurationMs nameWidth cols display res
+formatTestFinalLineRenderer :: Bool -> Bool -> Double -> Int -> String -> TestResult -> Int -> String
+formatTestFinalLineRenderer useColor perfMode expectedDurationMs nameWidth display res cols
+  | perfMode && isJust (testPerfData res) =
+      termFitAnsiRight cols (testColorApply useColor [testColorBold] "Benchmark"
+        ++ testColorApply useColor ["\ESC[2m"] (printf " (%d runs)" (trNumIterations res))
+        ++ ": " ++ display)
+  | otherwise = formatTestLineFitted useColor formatTestStatus expectedDurationMs nameWidth cols display res
 
 formatTestLiveLineRenderer :: Bool -> Double -> Int -> String -> TestResult -> Int -> String
 formatTestLiveLineRenderer useColor expectedDurationMs nameWidth display res cols =

--- a/compiler/acton/TestPerf.hs
+++ b/compiler/acton/TestPerf.hs
@@ -3,6 +3,8 @@ module TestPerf
   , perfNumber
   , perfMetrics
   , perfStatKey
+  , perfCounterInfo
+  , perfComparable
   , perfMeanInterval
   , perfJson
   ) where
@@ -39,6 +41,11 @@ perfMetrics =
     [ ("duration", "time excl. GC", "ms")
     , ("wall_duration", "wall time", "ms")
     , ("gc_duration", "GC time", "ms")
+    , ("cpu_user", "CPU user", "ms")
+    , ("cpu_system", "CPU system", "ms")
+    , ("instructions", "instructions", "count")
+    , ("cycles", "cycles", "count")
+    , ("ipc", "IPC", "ratio")
     , ("mem_usage_delta", "allocated", "B")
     , ("non_gc_mem_usage_delta", "non-GC change", "B")
     ]
@@ -50,10 +57,31 @@ perfStatKey metric "avg"
   | metric `elem` ["mem_usage_delta", "non_gc_mem_usage_delta"] = metric ++ "_avg"
 perfStatKey metric stat = stat ++ "_" ++ metric
 
+perfCounterInfo :: Aeson.Object -> Maybe Aeson.Object
+perfCounterInfo obj = case AesonKM.lookup (AesonKey.fromString "counter_info") obj of
+    Just (Aeson.Object info) -> Just info
+    _ -> Nothing
+
+-- Counter deltas only make sense for the same machine and accounting scope.
+-- Legacy recordings can still be compared using their original metrics.
+perfComparable :: String -> Aeson.Object -> Aeson.Object -> Bool
+perfComparable metric old new
+  | metric `notElem` ["cpu_user", "cpu_system", "instructions", "cycles", "ipc"] = True
+  | otherwise = case (perfCounterInfo old, perfCounterInfo new) of
+      (Just a, Just b) -> all (matches a b) keys
+      _ -> False
+  where
+    keys = ["version", "os", "release", "arch", "cpu"] ++
+      if metric `elem` ["cpu_user", "cpu_system"] then [] else ["backend", "scope"]
+    matches a b key = case AesonKM.lookup (AesonKey.fromString key) a of
+      Just value@(Aeson.String s) | s /= mempty -> AesonKM.lookup (AesonKey.fromString key) b == Just value
+      _ -> False
+
 -- | Approximate 95% Welch interval for a mean difference, in the metric's units.
 -- The sample model assumes independent iterations; process drift is not covered.
 perfMeanInterval :: String -> Aeson.Object -> Aeson.Object -> Maybe (Double, Double)
 perfMeanInterval metric old new = do
+    guard (perfComparable metric old new)
     (mean0, s0, n0) <- sample old
     (mean1, s1, n1) <- sample new
     let v0 = s0 * s0 / n0
@@ -101,7 +129,7 @@ perfJson baseline res = do
       , AesonKey.fromString "mean_difference_ci95_ms" Aeson..= fmap bounds interval
       ]
   where
-    keys = ["peak_rss", "num_iterations"] ++
+    keys = ["peak_rss", "num_iterations", "counter_info"] ++
       [ perfStatKey metric stat
       | (metric, _, _) <- perfMetrics
       , stat <- ["avg", "min", "max", "median", "q1", "q3", "stdev", "outlier_count"]

--- a/compiler/acton/TestPerf.hs
+++ b/compiler/acton/TestPerf.hs
@@ -1,0 +1,113 @@
+module TestPerf
+  ( testPerfData
+  , perfNumber
+  , perfMetrics
+  , perfStatKey
+  , perfMeanInterval
+  , perfJson
+  ) where
+
+import Acton.Testing (TestResult(..))
+import Control.Monad (guard)
+import Data.Maybe (isJust)
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Types as AesonTypes
+import qualified Data.Aeson.Key as AesonKey
+import qualified Data.Aeson.KeyMap as AesonKM
+
+-- | Only complete, successful measurements can be recorded or compared.
+testPerfData :: TestResult -> Maybe Aeson.Object
+testPerfData res
+  | not (trComplete res) || trSuccess res /= Just True || isJust (trException res)
+    || trSkipped res || trCached res || trSnapshotUpdated res || trNumIterations res <= 0 = Nothing
+  | otherwise = case trRaw res of
+      Aeson.Object obj -> Just obj
+      _ -> Nothing
+
+perfNumber :: Aeson.Object -> String -> Maybe Double
+perfNumber obj key = do
+    value <- AesonKM.lookup (AesonKey.fromString key) obj >>= AesonTypes.parseMaybe Aeson.parseJSON
+    guard (finite value)
+    return value
+
+finite :: Double -> Bool
+finite x = not (isNaN x || isInfinite x)
+
+-- | Sample series, display labels and base units shared by the table and JSON.
+perfMetrics :: [(String, String, String)]
+perfMetrics =
+    [ ("duration", "time excl. GC", "ms")
+    , ("wall_duration", "wall time", "ms")
+    , ("gc_duration", "GC time", "ms")
+    , ("mem_usage_delta", "allocated", "B")
+    , ("non_gc_mem_usage_delta", "non-GC change", "B")
+    ]
+
+-- Preserve the original mean and duration outlier keys in saved measurements.
+perfStatKey :: String -> String -> String
+perfStatKey "duration" "outlier_count" = "outlier_count"
+perfStatKey metric "avg"
+  | metric `elem` ["mem_usage_delta", "non_gc_mem_usage_delta"] = metric ++ "_avg"
+perfStatKey metric stat = stat ++ "_" ++ metric
+
+-- | Approximate 95% Welch interval for a mean difference, in the metric's units.
+-- The sample model assumes independent iterations; process drift is not covered.
+perfMeanInterval :: String -> Aeson.Object -> Aeson.Object -> Maybe (Double, Double)
+perfMeanInterval metric old new = do
+    (mean0, s0, n0) <- sample old
+    (mean1, s1, n1) <- sample new
+    let v0 = s0 * s0 / n0
+        v1 = s1 * s1 / n1
+        variance = v0 + v1
+        difference = mean1 - mean0
+    guard (finite variance && finite difference)
+    half <- if variance == 0
+      then return 0
+      else do
+        let df = variance * variance / (v0 * v0 / (n0 - 1) + v1 * v1 / (n1 - 1))
+        guard (finite df && df >= 1)
+        return (critical95 df * sqrt variance)
+    let lo = difference - half
+        hi = difference + half
+    guard (finite lo && finite hi)
+    return (lo, hi)
+  where
+    sample obj = do
+      mean <- perfNumber obj (perfStatKey metric "avg")
+      s <- perfNumber obj (perfStatKey metric "stdev")
+      n <- perfNumber obj "num_iterations"
+      guard (s >= 0 && n >= 2 && n == fromInteger (floor n))
+      return (mean, s, n)
+
+-- Two-sided Student t critical values, rounded up. Use the next lower
+-- tabulated degrees of freedom to keep the interval conservative.
+critical95 :: Double -> Double
+critical95 df = last [score | (n, score) <- table, n <= max 1 df]
+  where
+    table = zip [1..30]
+      [ 12.707, 4.303, 3.183, 2.777, 2.571, 2.447, 2.365, 2.307, 2.263, 2.229
+      , 2.201, 2.179, 2.161, 2.145, 2.132, 2.120, 2.110, 2.101, 2.094, 2.086
+      , 2.080, 2.074, 2.069, 2.064, 2.060, 2.056, 2.052, 2.049, 2.046, 2.043
+      ] ++ [(40, 2.022), (60, 2.001), (120, 1.980)]
+
+-- | Keep the machine report compact and use the same quantities as the UI.
+perfJson :: Maybe Aeson.Object -> TestResult -> Maybe Aeson.Value
+perfJson baseline res = do
+    obj <- testPerfData res
+    let interval = baseline >>= (\old -> perfMeanInterval "duration" old obj)
+    return $ Aeson.object
+      [ AesonKey.fromString "measurements" Aeson..= measurements obj
+      , AesonKey.fromString "baseline" Aeson..= fmap measurements baseline
+      , AesonKey.fromString "mean_difference_ci95_ms" Aeson..= fmap bounds interval
+      ]
+  where
+    keys = ["peak_rss", "num_iterations"] ++
+      [ perfStatKey metric stat
+      | (metric, _, _) <- perfMetrics
+      , stat <- ["avg", "min", "max", "median", "q1", "q3", "stdev", "outlier_count"]
+      ]
+    measurements = Aeson.Object . AesonKM.filterWithKey (\key _ -> AesonKey.toString key `elem` keys)
+    bounds (lo, hi) = Aeson.object
+      [ AesonKey.fromString "lower" Aeson..= lo
+      , AesonKey.fromString "upper" Aeson..= hi
+      ]

--- a/compiler/acton/TestRunner.hs
+++ b/compiler/acton/TestRunner.hs
@@ -11,6 +11,7 @@ import Acton.Compile
 import qualified Acton.Syntax as A
 import qualified Acton.SourceProvider as Source
 import qualified InterfaceFiles
+import qualified FileUtil
 import TestFormat
 import TestUI
 import Control.Concurrent.Async
@@ -39,7 +40,7 @@ import qualified Data.ByteString.Lazy as BL
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import Data.Time.Clock (UTCTime)
-import Control.Exception (SomeException, SomeAsyncException, AsyncException(..), displayException, evaluate, mask, onException, try, fromException, throwIO, finally)
+import Control.Exception (IOException, SomeException, SomeAsyncException, AsyncException(..), displayException, evaluate, mask, onException, try, fromException, throwIO, finally)
 import TerminalSize (termFitAnsiRight)
 import qualified Text.Regex.TDFA as TDFA
 import Data.Version (showVersion)
@@ -227,7 +228,13 @@ runProjectTests useColorOut gopts opts paths topts mode modules maxParallel = do
             nameWidth = max 20 (maxNameLen + 5)
             runContext = mkRunContext opts topts mode
             ctxHash = contextHashBytes runContext
-            useCache = not (C.testNoCache topts) && mode /= TestModeStress
+            useCache = not (C.testNoCache topts) && mode == TestModeRun
+        perfData <- if mode == TestModePerf then readPerfData paths else return M.empty
+        let detailLines res =
+              formatTestDetailLines useColorOut (C.testShowLog topts) res ++
+              if mode == TestModePerf
+                then formatTestPerfLines useColorOut (lookupPerfData perfData res) res
+                else []
         cache <-
           if useCache
             then readTestCache (testCachePath paths) runContext
@@ -261,12 +268,13 @@ runProjectTests useColorOut gopts opts paths topts mode modules maxParallel = do
             else return cachedResults1
         let showCached = C.testShowCached topts
         when (not emitJson && not useCache) $
-          if mode == TestModeStress
-            then putStrLn "Skipping test result cache in stress mode; running all selected tests"
-            else putStrLn "Skipping test result cache (--no-cache); running all selected tests"
+          case mode of
+            TestModePerf -> putStrLn "Skipping test result cache in perf mode; running all selected tests"
+            TestModeStress -> putStrLn "Skipping test result cache in stress mode; running all selected tests"
+            _ -> putStrLn "Skipping test result cache (--no-cache); running all selected tests"
         when (not emitJson && showCached && not (null cachedResults)) $
           putStrLn ("Using cached results for " ++ show (length cachedResults) ++ " tests")
-        ui <- initTestProgressUI gopts nameWidth (C.testShowLog topts) useColorOut
+        ui <- initTestProgressUI gopts nameWidth useColorOut
         let totalTests = length specs
         progressDoneRef <- newIORef 0
         workers <- newIORef []
@@ -294,11 +302,10 @@ runProjectTests useColorOut gopts opts paths topts mode modules maxParallel = do
                   display = tsDisplay spec
                   modDisplay = displayModName paths (tsModule spec)
                   useColorLine = tpuUseColor ui
-                  showLog = tpuShowLog ui
               case M.lookup key cachedMap of
                 Just cachedRes -> do
                   let line = formatTestFinalLineRenderer useColorLine expectedDurationMs nameWidth display cachedRes
-                      details = formatTestDetailLines useColorLine showLog cachedRes
+                      details = detailLines cachedRes
                   if shouldShowCached cachedRes
                     then do
                       ok <- testUiAppendFinal ui key modDisplay line
@@ -342,7 +349,7 @@ runProjectTests useColorOut gopts opts paths topts mode modules maxParallel = do
                       if not started
                         then return Nothing
                         else do
-                          callbacks <- testProgressCallbacks ui eventChan key display expectedDurationMs
+                          callbacks <- testProgressCallbacks ui eventChan key display expectedDurationMs detailLines
                           mask $ \unmask -> do
                             worker <- async $ unmask $ mask $ \restore -> do
                               resE <- try (restore (runModuleTestStreaming opts paths topts mode (tsModule spec) (tsName spec)
@@ -401,7 +408,7 @@ runProjectTests useColorOut gopts opts paths topts mode modules maxParallel = do
                 then filter (\r -> not (trCached r) || trSnapshotUpdated r) results
                 else filter (not . trCached) results
         when (C.testRecord topts) $
-          writePerfData paths resultsRun
+          writePerfData paths perfData resultsRun
         let cacheEntries' = foldl' (updateTestCacheEntry testHashInfos) cacheEntries resultsRun
             newCache = TestCache
               { tcVersion = testCacheVersion
@@ -417,7 +424,7 @@ runProjectTests useColorOut gopts opts paths topts mode modules maxParallel = do
             return (testExitCode results)
           else do
             when (not (tpuEnabled ui)) $
-              printTestResultsOrdered paths (tpuUseColor ui) (tpuShowLog ui) showCached nameWidth specs results
+              printTestResultsOrdered paths (tpuUseColor ui) showCached nameWidth detailLines specs results
             _ <- printTestSummary (tpuUseColor ui) (timeEnd - timeStart) showCached results
             testUiProgressClear ui
             return (testExitCode results)
@@ -775,15 +782,13 @@ runModuleTestStreaming opts paths topts mode modName testName allowLive callback
         _ ->
           Aeson.object [AesonKey.fromString "interrupted" Aeson..= True]
 
-testProgressCallbacks :: TestProgressUI -> Chan TestEvent -> TestKey -> String -> Double -> IO TestProgressCallbacks
-testProgressCallbacks ui eventChan key display expectedDurationMs = do
+testProgressCallbacks :: TestProgressUI -> Chan TestEvent -> TestKey -> String -> Double -> (TestResult -> [String]) -> IO TestProgressCallbacks
+testProgressCallbacks ui eventChan key display expectedDurationMs detailLines = do
     workerKeysRef <- newIORef M.empty
     let nameWidth = tpuNameWidth ui
         useColorOut = tpuUseColor ui
-        showLog = tpuShowLog ui
         liveLine res = formatTestLiveLineRenderer useColorOut expectedDurationMs nameWidth display res
         finalLine res = formatTestFinalLineRenderer useColorOut expectedDurationMs nameWidth display res
-        detailLines res = formatTestDetailLines useColorOut showLog res
         workerLine done durationMs laneSpec row cols =
           let role = if swrSync row then "sync" else "drift"
               phase =
@@ -1205,8 +1210,8 @@ printTestSummary useColor elapsed showCached results = do
             then return 1
             else return 0
 
-printTestResultsOrdered :: Paths -> Bool -> Bool -> Bool -> Int -> [TestSpec] -> [TestResult] -> IO ()
-printTestResultsOrdered paths useColor showLog showCached nameWidth specs results = do
+printTestResultsOrdered :: Paths -> Bool -> Bool -> Int -> (TestResult -> [String]) -> [TestSpec] -> [TestResult] -> IO ()
+printTestResultsOrdered paths useColor showCached nameWidth detailLines specs results = do
     let resMap = M.fromList [ (TestKey (trModule res) (trName res), res) | res <- results ]
         isOk res = trSuccess res == Just True && trException res == Nothing && not (trSkipped res)
         shouldShow res = not (trCached res) || showCached || not (isOk res) || trSnapshotUpdated res
@@ -1229,7 +1234,7 @@ printTestResultsOrdered paths useColor showLog showCached nameWidth specs result
                         putStrLn (moduleHeaderLine (displayModName paths modName))
                         return (Set.insert modName printedMods)
                   putStrLn (formatLine spec res)
-                  mapM_ putStrLn (formatTestDetailLines useColor showLog res)
+                  mapM_ putStrLn (detailLines res)
                   mapM_ putStrLn (formatStressWorkerFinalLines useColor res)
                   go printedMods' True rest
     go Set.empty False specs
@@ -1358,22 +1363,43 @@ markSnapshotUpdated res = res
   , trNumErrors = 0
   }
 
--- | Write perf data JSON for the current test run.
-writePerfData :: Paths -> [TestResult] -> IO ()
-writePerfData paths results = do
-    let addTest acc res =
-          let modKey = AesonKey.fromString (trModule res)
-              testKey = AesonKey.fromString (trName res)
-              entry = case AesonKM.lookup modKey acc of
-                        Just (Aeson.Object obj) -> obj
-                        _ -> AesonKM.empty
-              entry' = AesonKM.insert testKey (trRaw res) entry
-              acc' = AesonKM.insert modKey (Aeson.Object entry') acc
-          in acc'
-        modulesObj = foldl' addTest AesonKM.empty results
-        outVal = Aeson.Object modulesObj
-        outPath = joinPath [projPath paths, "perf_data"]
-    BL.writeFile outPath (Aeson.encode outVal)
+type PerfData = M.Map String (M.Map String Aeson.Value)
+
+-- | Read the baseline before running tests, including when updating it.
+readPerfData :: Paths -> IO PerfData
+readPerfData paths = do
+    let path = projPath paths </> "perf_data"
+    exists <- doesPathExist path
+    if not exists
+      then return M.empty
+      else do
+        result <- try (Aeson.eitherDecodeFileStrict path) :: IO (Either IOException (Either String PerfData))
+        case result of
+          Right (Right baseline) -> return baseline
+          Right (Left err) -> printErrorAndExit ("Cannot read performance baseline " ++ path ++ ": " ++ err)
+          Left err -> printErrorAndExit ("Cannot read performance baseline " ++ path ++ ": " ++ displayException err)
+
+lookupPerfData :: PerfData -> TestResult -> Maybe Aeson.Object
+lookupPerfData baseline res = do
+    tests <- M.lookup (trModule res) baseline
+    raw <- M.lookup (trName res) tests
+    old <- AesonTypes.parseMaybe parseTestInfoValue raw
+    testPerfData old
+
+-- | Update successful measurements without discarding unselected or failed tests.
+writePerfData :: Paths -> PerfData -> [TestResult] -> IO ()
+writePerfData paths baseline results = do
+    let measurements =
+          [ (res, obj)
+          | res <- results
+          , Just obj <- [testPerfData res]
+          ]
+        addTest acc (res, obj) =
+          M.insertWith M.union (trModule res) (M.singleton (trName res) (Aeson.Object obj)) acc
+        updated = foldl' addTest baseline measurements
+    unless (null measurements) $
+      FileUtil.writeFile (projPath paths </> "perf_data")
+        (T.unpack (TE.decodeUtf8 (BL.toStrict (Aeson.encode updated))))
 
 -- | Run a process and stream stderr lines to a callback while capturing output.
 readProcessWithExitCodeStreaming :: CreateProcess -> (String -> IO ()) -> IO (ExitCode, String, String)

--- a/compiler/acton/TestRunner.hs
+++ b/compiler/acton/TestRunner.hs
@@ -13,6 +13,7 @@ import qualified Acton.SourceProvider as Source
 import qualified InterfaceFiles
 import qualified FileUtil
 import TestFormat
+import TestPerf
 import TestUI
 import Control.Concurrent.Async
 import Control.Concurrent.Chan (Chan, newChan, readChan, writeChan)
@@ -218,7 +219,7 @@ runProjectTests useColorOut gopts opts paths topts mode modules maxParallel = do
         if emitJson
           then do
             timeEnd <- getTime Monotonic
-            outputJsonReport paths (timeEnd - timeStart) []
+            outputJsonReport paths mode M.empty (timeEnd - timeStart) []
             return 0
           else do
             putStrLn "Nothing to test"
@@ -231,7 +232,7 @@ runProjectTests useColorOut gopts opts paths topts mode modules maxParallel = do
             useCache = not (C.testNoCache topts) && mode == TestModeRun
         perfData <- if mode == TestModePerf then readPerfData paths else return M.empty
         let detailLines res =
-              formatTestDetailLines useColorOut (C.testShowLog topts) res ++
+              map staticLine (formatTestDetailLines useColorOut (C.testShowLog topts) res) ++
               if mode == TestModePerf
                 then formatTestPerfLines useColorOut (lookupPerfData perfData res) res
                 else []
@@ -304,7 +305,7 @@ runProjectTests useColorOut gopts opts paths topts mode modules maxParallel = do
                   useColorLine = tpuUseColor ui
               case M.lookup key cachedMap of
                 Just cachedRes -> do
-                  let line = formatTestFinalLineRenderer useColorLine expectedDurationMs nameWidth display cachedRes
+                  let line = formatTestFinalLineRenderer useColorLine (mode == TestModePerf) expectedDurationMs nameWidth display cachedRes
                       details = detailLines cachedRes
                   if shouldShowCached cachedRes
                     then do
@@ -349,7 +350,7 @@ runProjectTests useColorOut gopts opts paths topts mode modules maxParallel = do
                       if not started
                         then return Nothing
                         else do
-                          callbacks <- testProgressCallbacks ui eventChan key display expectedDurationMs detailLines
+                          callbacks <- testProgressCallbacks ui eventChan key display (mode == TestModePerf) expectedDurationMs detailLines
                           mask $ \unmask -> do
                             worker <- async $ unmask $ mask $ \restore -> do
                               resE <- try (restore (runModuleTestStreaming opts paths topts mode (tsModule spec) (tsName spec)
@@ -419,12 +420,12 @@ runProjectTests useColorOut gopts opts paths topts mode modules maxParallel = do
           writeTestCache (testCachePath paths) newCache
         if emitJson
           then do
-            outputJsonReport paths (timeEnd - timeStart) results
+            outputJsonReport paths mode perfData (timeEnd - timeStart) results
             testUiProgressClear ui
             return (testExitCode results)
           else do
             when (not (tpuEnabled ui)) $
-              printTestResultsOrdered paths (tpuUseColor ui) showCached nameWidth detailLines specs results
+              printTestResultsOrdered paths (tpuUseColor ui) (mode == TestModePerf) showCached nameWidth detailLines specs results
             _ <- printTestSummary (tpuUseColor ui) (timeEnd - timeStart) showCached results
             testUiProgressClear ui
             return (testExitCode results)
@@ -443,8 +444,8 @@ testExitCode results =
         errors = length [ r | r <- results, trSuccess r == Nothing ]
     in if errors > 0 then 2 else if failures > 0 then 1 else 0
 
-outputJsonReport :: Paths -> TimeSpec -> [TestResult] -> IO ()
-outputJsonReport paths elapsed results = do
+outputJsonReport :: Paths -> TestMode -> PerfData -> TimeSpec -> [TestResult] -> IO ()
+outputJsonReport paths mode baseline elapsed results = do
     let total = length results
         failures = length [ r | r <- results, trSuccess r == Just False ]
         errors = length [ r | r <- results, trSuccess r == Nothing ]
@@ -472,7 +473,7 @@ outputJsonReport paths elapsed results = do
               includeOutput = not (isOk res)
               name = displayTestName (trName res)
               combinedOutput = if includeOutput then formatCombinedOutput (trStdOut res) (trStdErr res) else Nothing
-          in Aeson.object
+          in Aeson.object $
                [ AesonKey.fromString "module" Aeson..= displayModName paths (trModule res)
                , AesonKey.fromString "name" Aeson..= name
                , AesonKey.fromString "raw_name" Aeson..= trName res
@@ -485,6 +486,9 @@ outputJsonReport paths elapsed results = do
                , AesonKey.fromString "skip_reason" Aeson..= trSkipReason res
                , AesonKey.fromString "exception" Aeson..= trException res
                , AesonKey.fromString "output" Aeson..= combinedOutput
+               ] ++
+               [ AesonKey.fromString "performance" Aeson..= perfJson (lookupPerfData baseline res) res
+               | mode == TestModePerf
                ]
         report = Aeson.object
           [ AesonKey.fromString "summary" Aeson..= Aeson.object
@@ -782,13 +786,13 @@ runModuleTestStreaming opts paths topts mode modName testName allowLive callback
         _ ->
           Aeson.object [AesonKey.fromString "interrupted" Aeson..= True]
 
-testProgressCallbacks :: TestProgressUI -> Chan TestEvent -> TestKey -> String -> Double -> (TestResult -> [String]) -> IO TestProgressCallbacks
-testProgressCallbacks ui eventChan key display expectedDurationMs detailLines = do
+testProgressCallbacks :: TestProgressUI -> Chan TestEvent -> TestKey -> String -> Bool -> Double -> (TestResult -> [TestLine]) -> IO TestProgressCallbacks
+testProgressCallbacks ui eventChan key display perfMode expectedDurationMs detailLines = do
     workerKeysRef <- newIORef M.empty
     let nameWidth = tpuNameWidth ui
         useColorOut = tpuUseColor ui
         liveLine res = formatTestLiveLineRenderer useColorOut expectedDurationMs nameWidth display res
-        finalLine res = formatTestFinalLineRenderer useColorOut expectedDurationMs nameWidth display res
+        finalLine res = formatTestFinalLineRenderer useColorOut perfMode expectedDurationMs nameWidth display res
         workerLine done durationMs laneSpec row cols =
           let role = if swrSync row then "sync" else "drift"
               phase =
@@ -1210,13 +1214,13 @@ printTestSummary useColor elapsed showCached results = do
             then return 1
             else return 0
 
-printTestResultsOrdered :: Paths -> Bool -> Bool -> Int -> (TestResult -> [String]) -> [TestSpec] -> [TestResult] -> IO ()
-printTestResultsOrdered paths useColor showCached nameWidth detailLines specs results = do
+printTestResultsOrdered :: Paths -> Bool -> Bool -> Bool -> Int -> (TestResult -> [TestLine]) -> [TestSpec] -> [TestResult] -> IO ()
+printTestResultsOrdered paths useColor perfMode showCached nameWidth detailLines specs results = do
     let resMap = M.fromList [ (TestKey (trModule res) (trName res), res) | res <- results ]
         isOk res = trSuccess res == Just True && trException res == Nothing && not (trSkipped res)
         shouldShow res = not (trCached res) || showCached || not (isOk res) || trSnapshotUpdated res
         formatLine spec res =
-          formatTestLineWith useColor formatTestStatus (trTestDuration res) nameWidth (tsDisplay spec) res
+          formatTestFinalLineRenderer useColor perfMode (trTestDuration res) nameWidth (tsDisplay spec) res maxBound
     let go _ _ [] = return ()
         go printedMods printedAny (spec:rest) =
           case M.lookup (TestKey (tsModule spec) (tsName spec)) resMap of
@@ -1234,7 +1238,7 @@ printTestResultsOrdered paths useColor showCached nameWidth detailLines specs re
                         putStrLn (moduleHeaderLine (displayModName paths modName))
                         return (Set.insert modName printedMods)
                   putStrLn (formatLine spec res)
-                  mapM_ putStrLn (detailLines res)
+                  mapM_ (putStrLn . ($ maxBound)) (detailLines res)
                   mapM_ putStrLn (formatStressWorkerFinalLines useColor res)
                   go printedMods' True rest
     go Set.empty False specs

--- a/compiler/acton/TestRunner.hs
+++ b/compiler/acton/TestRunner.hs
@@ -28,6 +28,7 @@ import qualified Data.Set as Set
 import System.Clock
 import System.Directory
 import System.Exit
+import System.Environment (getEnvironment)
 import System.FilePath ((</>), (<.>), joinPath)
 import System.IO (hClose, hGetContents, hGetLine, hIsEOF)
 import System.Process
@@ -653,6 +654,7 @@ runModuleTestStreaming :: C.CompileOptions
                        -> TestProgressCallbacks
                        -> IO TestResult
 runModuleTestStreaming opts paths topts mode modName testName allowLive callbacks = do
+    environment <- getEnvironment
     let binPath = testBinaryPath opts paths modName
         modeArgs =
           case mode of
@@ -681,6 +683,8 @@ runModuleTestStreaming opts paths topts mode modName testName allowLive callback
                           Nothing -> addStdErr line
     let procSpec = (proc binPath cmd)
           { cwd = Just (projPath paths)
+          , env = Just ((if mode == TestModePerf then [("ACTON_TEST_PERF", "1")] else [])
+              ++ filter ((/= "ACTON_TEST_PERF") . fst) environment)
           , create_group = C.watch opts
           , delegate_ctlc = not (C.watch opts)
           }

--- a/compiler/acton/TestRunner.hs
+++ b/compiler/acton/TestRunner.hs
@@ -275,160 +275,158 @@ runProjectTests useColorOut gopts opts paths topts mode modules maxParallel = do
             _ -> putStrLn "Skipping test result cache (--no-cache); running all selected tests"
         when (not emitJson && showCached && not (null cachedResults)) $
           putStrLn ("Using cached results for " ++ show (length cachedResults) ++ " tests")
-        ui <- initTestProgressUI gopts nameWidth useColorOut
-        let totalTests = length specs
-        progressDoneRef <- newIORef 0
-        workers <- newIORef []
-        let (effectiveMinTime, effectiveMaxTime) = effectiveTestTiming mode topts
-            expectedDurationMs =
-              fromIntegral
-                (if effectiveMaxTime > 0
-                   then effectiveMaxTime
-                   else effectiveMinTime)
-        let progressStep = do
-              done <- atomicModifyIORef' progressDoneRef (\x -> let x' = x + 1 in (x', x'))
-              let pct =
-                    if totalTests <= 0
-                      then 100
-                      else min 100 ((done * 100) `div` totalTests)
-              testUiProgressPercent ui pct
-        testUiProgressPercent ui 0
-        eventChan <- newChan
-        let cachedMap = M.fromList [ (TestKey (trModule res) (trName res), res) | res <- cachedResults ]
-            shouldShowCached res =
-              let ok = trSuccess res == Just True && trException res == Nothing && not (trSkipped res)
-              in showCached || not ok || trSnapshotUpdated res
-            startSpec spec running results = do
-              let key = TestKey (tsModule spec) (tsName spec)
-                  display = tsDisplay spec
-                  modDisplay = displayModName paths (tsModule spec)
-                  useColorLine = tpuUseColor ui
-              case M.lookup key cachedMap of
-                Just cachedRes -> do
-                  let line = formatTestFinalLineRenderer useColorLine (mode == TestModePerf) expectedDurationMs nameWidth display cachedRes
-                      details = detailLines cachedRes
-                  if shouldShowCached cachedRes
-                    then do
-                      ok <- testUiAppendFinal ui key modDisplay line
-                      if not ok
-                        then return Nothing
-                        else do
-                          inserted <- testUiInsertDetails ui key details
-                          unless inserted $ queuePendingDetails ui key details
-                          progressStep
-                          return (Just (running, cachedRes : results))
-                    else do
-                      progressStep
-                      return (Just (running, cachedRes : results))
-                Nothing -> do
-                  if running >= maxParallel
-                    then return Nothing
-                    else do
-                      let initRes = TestResult
-                            { trModule = tsModule spec
-                            , trName = tsName spec
-                            , trComplete = False
-                            , trSuccess = Nothing
-                            , trSkipped = False
-                            , trSkipReason = Nothing
-                            , trException = Nothing
-                            , trOutput = Nothing
-                            , trStdOut = Nothing
-                            , trStdErr = Nothing
-                            , trFlaky = False
-                            , trNumSkipped = 0
-                            , trNumFailures = 0
-                            , trNumErrors = 0
-                            , trNumIterations = 0
-                            , trTestDuration = 0
-                            , trRaw = Aeson.Null
-                            , trSnapshotUpdated = False
-                            , trCached = False
-                            }
-                          initLine = formatTestLiveLineRenderer useColorLine expectedDurationMs nameWidth display initRes
-                      started <- testUiStart ui key modDisplay initLine
-                      if not started
-                        then return Nothing
-                        else do
-                          callbacks <- testProgressCallbacks ui eventChan key display (mode == TestModePerf) expectedDurationMs detailLines
-                          mask $ \unmask -> do
-                            worker <- async $ unmask $ mask $ \restore -> do
-                              resE <- try (restore (runModuleTestStreaming opts paths topts mode (tsModule spec) (tsName spec)
-                                                     (tpuEnabled ui) callbacks))
-                                        :: IO (Either SomeException TestResult)
-                              case resE of
-                                Right res ->
-                                  writeChan eventChan (TestEventDone res)
-                                Left ex -> do
-                                  let res = initRes
-                                        { trComplete = True
-                                        , trException = Just ("Test runner exception: " ++ displayException ex)
-                                        , trNumErrors = 1
-                                        }
-                                  finishE <- try (restore (tpcOnDone callbacks res >> tpcOnFinal callbacks res))
-                                               :: IO (Either SomeException ())
-                                  writeChan eventChan (TestEventDone res)
-                                  case finishE of
-                                    Left finishEx | isJust (fromException finishEx :: Maybe SomeAsyncException) -> throwIO finishEx
-                                    _ -> return ()
-                                  when (isJust (fromException ex :: Maybe SomeAsyncException)) $
-                                    throwIO ex
-                            atomicModifyIORef' workers (\ws -> (worker : ws, ()))
-                          return (Just (running + 1, results))
-            startAvailable pending running results = do
-              case pending of
-                [] -> return ([], running, results)
-                (spec:rest) -> do
-                  mnext <- startSpec spec running results
-                  case mnext of
-                    Nothing -> return (pending, running, results)
-                    Just (running', results') -> startAvailable rest running' results'
-            loop pending running results = do
-              flushPendingDetails ui
-              (pending', running', results') <- startAvailable pending running results
-              if null pending' && running' == 0
-                then do
-                  flushPendingDetails ui
-                  return results'
-                else do
-                  evt <- readChan eventChan
-                  case evt of
-                    TestEventDone res -> do
-                      progressStep
-                      let pending'' =
-                            if testResultInterrupted res
-                              then []
-                              else pending'
-                      loop pending'' (running' - 1) (res : results')
-                    TestEventRoom -> loop pending' running' results'
-        results <- loop specs 0 [] `finally` (readIORef workers >>= mapConcurrently_ cancel)
-        timeEnd <- getTime Monotonic
-        writeSnapshotOutputs paths results
-        let resultsRun =
-              if C.testSnapshotUpdate topts
-                then filter (\r -> not (trCached r) || trSnapshotUpdated r) results
-                else filter (not . trCached) results
-        when (C.testRecord topts) $
-          writePerfData paths perfData resultsRun
-        let cacheEntries' = foldl' (updateTestCacheEntry testHashInfos) cacheEntries resultsRun
-            newCache = TestCache
-              { tcVersion = testCacheVersion
-              , tcContext = runContext
-              , tcTests = cacheEntries'
-              }
-        when useCache $
-          writeTestCache (testCachePath paths) newCache
-        if emitJson
-          then do
-            outputJsonReport paths mode perfData (timeEnd - timeStart) results
-            testUiProgressClear ui
-            return (testExitCode results)
-          else do
-            when (not (tpuEnabled ui)) $
-              printTestResultsOrdered paths (tpuUseColor ui) (mode == TestModePerf) showCached nameWidth detailLines specs results
-            _ <- printTestSummary (tpuUseColor ui) (timeEnd - timeStart) showCached results
-            testUiProgressClear ui
-            return (testExitCode results)
+        withTestProgressUI gopts nameWidth useColorOut $ \ui -> do
+          let totalTests = length specs
+          progressDoneRef <- newIORef 0
+          workers <- newIORef []
+          let (effectiveMinTime, effectiveMaxTime) = effectiveTestTiming mode topts
+              expectedDurationMs =
+                fromIntegral
+                  (if effectiveMaxTime > 0
+                     then effectiveMaxTime
+                     else effectiveMinTime)
+          let progressStep = do
+                done <- atomicModifyIORef' progressDoneRef (\x -> let x' = x + 1 in (x', x'))
+                let pct =
+                      if totalTests <= 0
+                        then 100
+                        else min 100 ((done * 100) `div` totalTests)
+                testUiProgressPercent ui pct
+          testUiProgressPercent ui 0
+          eventChan <- newChan
+          let cachedMap = M.fromList [ (TestKey (trModule res) (trName res), res) | res <- cachedResults ]
+              shouldShowCached res =
+                let ok = trSuccess res == Just True && trException res == Nothing && not (trSkipped res)
+                in showCached || not ok || trSnapshotUpdated res
+              startSpec spec running results = do
+                let key = TestKey (tsModule spec) (tsName spec)
+                    display = tsDisplay spec
+                    modDisplay = displayModName paths (tsModule spec)
+                    useColorLine = tpuUseColor ui
+                case M.lookup key cachedMap of
+                  Just cachedRes -> do
+                    let line = formatTestFinalLineRenderer useColorLine (mode == TestModePerf) expectedDurationMs nameWidth display cachedRes
+                        details = detailLines cachedRes
+                    if shouldShowCached cachedRes
+                      then do
+                        ok <- testUiAppendFinal ui key modDisplay line
+                        if not ok
+                          then return Nothing
+                          else do
+                            inserted <- testUiInsertDetails ui key details
+                            unless inserted $ queuePendingDetails ui key details
+                            progressStep
+                            return (Just (running, cachedRes : results))
+                      else do
+                        progressStep
+                        return (Just (running, cachedRes : results))
+                  Nothing -> do
+                    if running >= maxParallel
+                      then return Nothing
+                      else do
+                        let initRes = TestResult
+                              { trModule = tsModule spec
+                              , trName = tsName spec
+                              , trComplete = False
+                              , trSuccess = Nothing
+                              , trSkipped = False
+                              , trSkipReason = Nothing
+                              , trException = Nothing
+                              , trOutput = Nothing
+                              , trStdOut = Nothing
+                              , trStdErr = Nothing
+                              , trFlaky = False
+                              , trNumSkipped = 0
+                              , trNumFailures = 0
+                              , trNumErrors = 0
+                              , trNumIterations = 0
+                              , trTestDuration = 0
+                              , trRaw = Aeson.Null
+                              , trSnapshotUpdated = False
+                              , trCached = False
+                              }
+                            initLine = formatTestLiveLineRenderer useColorLine expectedDurationMs nameWidth display initRes
+                        started <- testUiStart ui key modDisplay initLine
+                        if not started
+                          then return Nothing
+                          else do
+                            callbacks <- testProgressCallbacks ui eventChan key display (mode == TestModePerf) expectedDurationMs detailLines
+                            mask $ \unmask -> do
+                              worker <- async $ unmask $ mask $ \restore -> do
+                                resE <- try (restore (runModuleTestStreaming opts paths topts mode (tsModule spec) (tsName spec)
+                                                       (tpuEnabled ui) callbacks))
+                                          :: IO (Either SomeException TestResult)
+                                case resE of
+                                  Right res ->
+                                    writeChan eventChan (TestEventDone res)
+                                  Left ex -> do
+                                    let res = initRes
+                                          { trComplete = True
+                                          , trException = Just ("Test runner exception: " ++ displayException ex)
+                                          , trNumErrors = 1
+                                          }
+                                    finishE <- try (restore (tpcOnDone callbacks res >> tpcOnFinal callbacks res))
+                                                 :: IO (Either SomeException ())
+                                    writeChan eventChan (TestEventDone res)
+                                    case finishE of
+                                      Left finishEx | isJust (fromException finishEx :: Maybe SomeAsyncException) -> throwIO finishEx
+                                      _ -> return ()
+                                    when (isJust (fromException ex :: Maybe SomeAsyncException)) $
+                                      throwIO ex
+                              atomicModifyIORef' workers (\ws -> (worker : ws, ()))
+                            return (Just (running + 1, results))
+              startAvailable pending running results = do
+                case pending of
+                  [] -> return ([], running, results)
+                  (spec:rest) -> do
+                    mnext <- startSpec spec running results
+                    case mnext of
+                      Nothing -> return (pending, running, results)
+                      Just (running', results') -> startAvailable rest running' results'
+              loop pending running results = do
+                flushPendingDetails ui
+                (pending', running', results') <- startAvailable pending running results
+                if null pending' && running' == 0
+                  then do
+                    flushPendingDetails ui
+                    return results'
+                  else do
+                    evt <- readChan eventChan
+                    case evt of
+                      TestEventDone res -> do
+                        progressStep
+                        let pending'' =
+                              if testResultInterrupted res
+                                then []
+                                else pending'
+                        loop pending'' (running' - 1) (res : results')
+                      TestEventRoom -> loop pending' running' results'
+          results <- loop specs 0 [] `finally` (readIORef workers >>= mapConcurrently_ cancel)
+          timeEnd <- getTime Monotonic
+          writeSnapshotOutputs paths results
+          let resultsRun =
+                if C.testSnapshotUpdate topts
+                  then filter (\r -> not (trCached r) || trSnapshotUpdated r) results
+                  else filter (not . trCached) results
+          when (C.testRecord topts) $
+            writePerfData paths perfData resultsRun
+          let cacheEntries' = foldl' (updateTestCacheEntry testHashInfos) cacheEntries resultsRun
+              newCache = TestCache
+                { tcVersion = testCacheVersion
+                , tcContext = runContext
+                , tcTests = cacheEntries'
+                }
+          when useCache $
+            writeTestCache (testCachePath paths) newCache
+          if emitJson
+            then do
+              outputJsonReport paths mode perfData (timeEnd - timeStart) results
+              return (testExitCode results)
+            else do
+              when (not (tpuEnabled ui)) $
+                printTestResultsOrdered paths (tpuUseColor ui) (mode == TestModePerf) showCached nameWidth detailLines specs results
+              _ <- printTestSummary (tpuUseColor ui) (timeEnd - timeStart) showCached results
+              return (testExitCode results)
   where
     mkRunContext opts' topts' mode' = TestRunContext
       { trcCompilerVersion = getVer

--- a/compiler/acton/TestUI.hs
+++ b/compiler/acton/TestUI.hs
@@ -1,6 +1,8 @@
 module TestUI
   ( TestKey(..)
+  , TestLine
   , TestProgressUI(..)
+  , staticLine
   , initTestProgressUI
   , testUiStart
   , testUiAppendFinal
@@ -45,7 +47,7 @@ data TestProgressUI = TestProgressUI
   , tpuLiveSetRef :: IORef (Set.Set TestKey)
   , tpuLiveLineRef :: IORef (M.Map TestKey TestLine)
   , tpuPrintedModulesRef :: IORef (Set.Set String)
-  , tpuPendingDetailsRef :: IORef (M.Map TestKey [String])
+  , tpuPendingDetailsRef :: IORef (M.Map TestKey [TestLine])
   , tpuSpinnerRef :: IORef Int
   , tpuTickerThreadRef :: IORef (Maybe ThreadId)
   , tpuTermProgress :: TermProgress
@@ -435,17 +437,16 @@ canInsertLinesUnlocked ui insertIdx n
                 total <- readIORef (tpuTotalLinesRef ui)
                 return ((total + n - minimum idxs) < rows)
 
-insertLinesAfterUnlocked :: TestProgressUI -> Int -> [String] -> IO Bool
-insertLinesAfterUnlocked ui idx lines = do
-    let n = length lines
+insertLinesAfterUnlocked :: TestProgressUI -> Int -> [TestLine] -> IO Bool
+insertLinesAfterUnlocked ui idx lineFns = do
+    let n = length lineFns
     if n <= 0
       then return True
       else do
         (rows, cols) <- currentViewportUnlocked ui
         total <- readIORef (tpuTotalLinesRef ui)
         liveSet <- readIORef (tpuLiveSetRef ui)
-        let lineFns = map staticLine lines
-            rendered = map ($ safeLiveWidth cols) lineFns
+        let rendered = map ($ safeLiveWidth cols) lineFns
             startIdx = idx + 1
             offsetNew = (total + n) - startIdx
             visibleOk =
@@ -488,7 +489,7 @@ rerenderFromUnlocked ui startIdx oldTotal = do
           putStr "\n"
         hFlush stdout
 
-testUiInsertDetails :: TestProgressUI -> TestKey -> [String] -> IO Bool
+testUiInsertDetails :: TestProgressUI -> TestKey -> [TestLine] -> IO Bool
 testUiInsertDetails ui key lines = withTestProgressLock ui $ do
     if null lines
       then return True
@@ -501,7 +502,7 @@ testUiInsertDetails ui key lines = withTestProgressLock ui $ do
             Nothing -> return False
             Just idx -> insertLinesAfterUnlocked ui idx lines
 
-queuePendingDetails :: TestProgressUI -> TestKey -> [String] -> IO ()
+queuePendingDetails :: TestProgressUI -> TestKey -> [TestLine] -> IO ()
 queuePendingDetails ui key lines = withTestProgressLock ui $ do
     unless (null lines) $
       modifyIORef' (tpuPendingDetailsRef ui) (M.insert key lines)

--- a/compiler/acton/TestUI.hs
+++ b/compiler/acton/TestUI.hs
@@ -3,7 +3,7 @@ module TestUI
   , TestLine
   , TestProgressUI(..)
   , staticLine
-  , initTestProgressUI
+  , withTestProgressUI
   , testUiStart
   , testUiAppendFinal
   , testUiUpdateLive
@@ -11,7 +11,6 @@ module TestUI
   , testUiUpdateFinal
   , testUiInsertDetails
   , testUiProgressPercent
-  , testUiProgressClear
   , queuePendingDetails
   , flushPendingDetails
   , moduleHeaderLine
@@ -20,6 +19,7 @@ module TestUI
 import qualified Acton.CommandLineParser as C
 import Control.Concurrent (ThreadId, forkIO, killThread, myThreadId, threadDelay)
 import Control.Concurrent.MVar
+import Control.Exception (bracket, finally, mask)
 import Control.Monad
 import Data.IORef
 import qualified Data.List
@@ -56,6 +56,15 @@ data TestProgressUI = TestProgressUI
   , tpuNameWidth :: Int
   , tpuUseColor :: Bool
   }
+
+withTestProgressUI :: C.GlobalOptions -> Int -> Bool -> (TestProgressUI -> IO a) -> IO a
+withTestProgressUI gopts nameWidth useColorOut action =
+    bracket (initTestProgressUI gopts nameWidth useColorOut) release $ \ui -> do
+      when (tpuEnabled ui) $ putStr "\ESC[?25l" >> hFlush stdout
+      action ui
+  where
+    release ui = (stopTestTicker ui >> testUiProgressClear ui) `finally`
+      when (tpuEnabled ui) (putStr "\ESC[?25h" >> hFlush stdout)
 
 initTestProgressUI :: C.GlobalOptions -> Int -> Bool -> IO TestProgressUI
 initTestProgressUI gopts nameWidth useColorOut = do
@@ -152,8 +161,8 @@ startTestTicker ui =
       m <- readIORef (tpuTickerThreadRef ui)
       case m of
         Just _ -> return ()
-        Nothing -> do
-          tid <- forkIO (testTickerLoop ui)
+        Nothing -> mask $ \restore -> do
+          tid <- forkIO (restore (testTickerLoop ui))
           writeIORef (tpuTickerThreadRef ui) (Just tid)
 
 stopTestTicker :: TestProgressUI -> IO ()
@@ -172,9 +181,9 @@ testTickerLoop ui = do
               then return False
               else do
                 (_, cols) <- ensureViewportUnlocked ui
-                when (testSpinnerEnabled cols) $ do
+                when (testSpinnerEnabled cols) $
                   modifyIORef' (tpuSpinnerRef ui) (+ 1)
-                  refreshTestSpinnersUnlocked ui cols
+                refreshTestLinesUnlocked ui cols
                 termProgressHeartbeat (tpuTermProgress ui)
                 return True
           when keep loop
@@ -237,8 +246,8 @@ rerenderVisibleUnlocked ui rowsBefore rowsAfter cols = do
       hFlush stdout
     writeIORef (tpuLinesRef ui) renderedAll
 
-refreshTestSpinnersUnlocked :: TestProgressUI -> Int -> IO ()
-refreshTestSpinnersUnlocked ui cols = do
+refreshTestLinesUnlocked :: TestProgressUI -> Int -> IO ()
+refreshTestLinesUnlocked ui cols = do
     idxMap <- readIORef (tpuLineIndexRef ui)
     liveLines <- readIORef (tpuLiveLineRef ui)
     forM_ (M.toList liveLines) $ \(key, lineFn) ->
@@ -359,29 +368,30 @@ updateLineAtUnlocked ui idx lineFn = do
 updateLineAtUnlockedWithCols :: TestProgressUI -> Int -> Int -> TestLine -> IO ()
 updateLineAtUnlockedWithCols ui cols idx lineFn = do
     rendered <- renderIndexedLineWithColsUnlocked ui cols idx lineFn
+    previous <- readIORef (tpuLinesRef ui)
+    let old = case drop idx previous of
+          line:_ -> Just line
+          _ -> Nothing
+        update = case (old, rendered) of
+          (Just (' ':_:' ':rest), ' ':spinner:' ':rest') | rest == rest' -> "\r " ++ [spinner]
+          _ -> "\r" ++ rendered ++ case old of
+            Just line | termVisibleLength line > termVisibleLength rendered -> "\ESC[K"
+            _ -> ""
+    -- Keep the renderer even if it produces the same text at the current width.
     modifyIORef' (tpuLineRenderRef ui) (updateLineListAt idx lineFn)
     modifyIORef' (tpuLinesRef ui) (updateLineListAt idx rendered)
     total <- readIORef (tpuTotalLinesRef ui)
     (rows, _) <- currentViewportUnlocked ui
     let offset = total - idx
-    when (offset > 0 && (rows <= 0 || offset < rows)) $ do
-      putStr ("\ESC[" ++ show offset ++ "A")
-      putStr "\r\ESC[2K"
-      putStr rendered
-      putStr ("\ESC[" ++ show offset ++ "B")
-      putStr "\r"
+    when (old /= Just rendered && offset > 0 && (rows <= 0 || offset < rows)) $ do
+      putStr ("\ESC[" ++ show offset ++ "A" ++ update ++ "\ESC[" ++ show offset ++ "B\r")
       hFlush stdout
 
 testUiUpdateLive :: TestProgressUI -> TestKey -> TestLine -> IO ()
 testUiUpdateLive ui key lineFn = withTestProgressLock ui $ do
-    when (tpuEnabled ui) $ do
-      void (ensureViewportUnlocked ui)
-      idxMap <- readIORef (tpuLineIndexRef ui)
-      case M.lookup key idxMap of
-        Nothing -> return ()
-        Just idx -> do
-          modifyIORef' (tpuLiveLineRef ui) (M.insert key lineFn)
-          updateLineAtUnlocked ui idx lineFn
+    -- Coalesce result updates with spinner ticks; final results paint at once.
+    when (tpuEnabled ui) $
+      modifyIORef' (tpuLiveLineRef ui) (M.adjust (const lineFn) key)
 
 testUiFinalize :: TestProgressUI -> TestKey -> TestLine -> IO Bool
 testUiFinalize ui key lineFn = withTestProgressLock ui $ do

--- a/compiler/acton/TestUI.hs
+++ b/compiler/acton/TestUI.hs
@@ -53,11 +53,10 @@ data TestProgressUI = TestProgressUI
   , tpuLock :: MVar ()
   , tpuNameWidth :: Int
   , tpuUseColor :: Bool
-  , tpuShowLog :: Bool
   }
 
-initTestProgressUI :: C.GlobalOptions -> Int -> Bool -> Bool -> IO TestProgressUI
-initTestProgressUI gopts nameWidth showLog useColorOut = do
+initTestProgressUI :: C.GlobalOptions -> Int -> Bool -> IO TestProgressUI
+initTestProgressUI gopts nameWidth useColorOut = do
     tty <- hIsTerminalDevice stdout
     let enabled = (tty || C.tty gopts) && not (C.quiet gopts)
     totalLinesRef <- newIORef 0
@@ -92,7 +91,6 @@ initTestProgressUI gopts nameWidth showLog useColorOut = do
       , tpuLock = lock
       , tpuNameWidth = nameWidth
       , tpuUseColor = useColorOut
-      , tpuShowLog = showLog
       }
 
 withTestProgressLock :: TestProgressUI -> IO a -> IO a

--- a/compiler/acton/WatchTests.hs
+++ b/compiler/acton/WatchTests.hs
@@ -5,7 +5,7 @@ import Control.Concurrent (threadDelay)
 import Control.Exception (IOException, catch, finally, mask)
 import Control.Monad
 import qualified Data.ByteString.Char8 as BS
-import Data.List (isInfixOf)
+import Data.List (isInfixOf, isPrefixOf, isSuffixOf, tails)
 import Data.Maybe (isJust)
 import System.Directory
 import System.Exit
@@ -53,7 +53,7 @@ watchProcessTests = testGroup "watch subprocesses"
   , testCase "stopping test watch stops test descendants" $
       withProcessProject $ \acton proj system -> do
         writeExecutable (proj </> "out/bin/.test_main") (childProcess True ++ waitingParent)
-        withActon acton proj ["test", "--watch", "--no-cache", "--syspath", system] $ \ph _ _ -> do
+        withActon acton proj ["test", "--watch", "--tty", "--no-cache", "--syspath", system] $ \ph _ output -> do
           child <- awaitPid proj "child.pid"
           leader <- awaitPid proj "leader.pid"
           terminateProcess ph
@@ -61,6 +61,7 @@ watchProcessTests = testGroup "watch subprocesses"
           assertEqual "watch should handle TERM" (ExitFailure 143) code
           assertStopped "test leader" leader
           assertStopped "test descendant" child
+          assertCursorRestored =<< output
   , testGroup "successful test exit stops descendants"
       [ testCase pipes $ withProcessProject $ \acton proj system -> do
           writeExecutable (proj </> "out/bin/.test_main")
@@ -135,13 +136,54 @@ watchProcessTests = testGroup "watch subprocesses"
           , "echo $$ > leader.pid"
           , "while :; do sleep 1; done"
           ]
-        withActon acton proj ["test", "stress", "--syspath", system] $ \ph group output -> do
+        withActon acton proj ["test", "stress", "--tty", "--syspath", system] $ \ph group output -> do
           _ <- awaitPid proj "leader.pid"
           signalProcessGroup sigINT group
           code <- await "interrupted stress exit" (getProcessExitCode ph)
           logText <- output
           assertEqual logText ExitSuccess code
           assertBool logText ("Stress run interrupted by user; showing partial results collected so far." `isInfixOf` logText)
+          assertCursorRestored logText
+  , testCase "live updates keep the cursor hidden and avoid repainting unchanged rows" $
+      withProcessProject $ \acton proj system -> do
+        writeExecutable (proj </> "out/bin/.test_main")
+          [ testInfo False
+          , "sleep 0.3"
+          , testInfo False
+          , "sleep 0.3"
+          , testInfo True
+          ]
+        withActon acton proj ["test", "--tty", "--no-cache", "--color", "never", "--syspath", system] $ \ph _ output -> do
+          code <- await "test exit" (getProcessExitCode ph)
+          logText <- output
+          assertEqual logText ExitSuccess code
+          assertCursorRestored logText
+          assertBool "cursor restoration is the last terminal operation" ("\ESC[?25h" `isSuffixOf` logText)
+          let liveOutput = dropWhile (not . isPrefixOf "\ESC[?25l") (tails (testOutput logText))
+              updates = case liveOutput of
+                text:_ -> text
+                [] -> ""
+          assertBool updates (count "ready:" updates <= 3)
+          assertBool "spinner updates move directly to column two" ("\ESC[1A\r " `isInfixOf` updates)
+          assertBool "live updates do not erase the row before writing it" (not ("\ESC[2K" `isInfixOf` updates))
+  , testGroup "non-interactive test reports do not change cursor visibility"
+      [ testCase label $ withProcessProject $ \acton proj system -> do
+          writeExecutable (proj </> "out/bin/.test_main") [testInfo True]
+          withActon acton proj (["test", "--no-cache", "--syspath", system] ++ args) $ \ph _ output -> do
+            code <- await "test exit" (getProcessExitCode ph)
+            logText <- output
+            assertEqual logText ExitSuccess code
+            assertBool logText (not ("\ESC[?25" `isInfixOf` logText))
+      | (label, args) <- [("redirected", []), ("quiet", ["--tty", "--quiet"]), ("JSON", ["--tty", "--json"])]
+      ]
+  , testCase "a failed test process restores the cursor" $
+      withProcessProject $ \acton proj system -> do
+        writeExecutable (proj </> "out/bin/.test_main") ["exit 1"]
+        withActon acton proj ["test", "--tty", "--no-cache", "--syspath", system] $ \ph _ output -> do
+          code <- await "failed test exit" (getProcessExitCode ph)
+          logText <- output
+          assertBool logText (code /= ExitSuccess)
+          assertCursorRestored logText
   ]
   where
     -- Inherited child pipes prevent EOF after the leader exits; redirected
@@ -154,6 +196,17 @@ watchProcessTests = testGroup "watch subprocesses"
       ]
     waitingParent = ["trap '' TERM", "while :; do sleep 1; done"]
     testInfo = moduleTestInfo "main"
+    count needle = length . filter (isPrefixOf needle) . tails
+    testOutput logText = case dropWhile (not . isPrefixOf "Skipping test result cache") (tails logText) of
+      text:_ -> text
+      _ -> logText
+    assertCursorRestored output = do
+      let logText = testOutput output
+      assertEqual "cursor is hidden once" 1 (count "\ESC[?25l" logText)
+      assertEqual "cursor is restored once" 1 (count "\ESC[?25h" logText)
+      assertBool "hide precedes restore"
+        (length (dropWhile (not . isPrefixOf "\ESC[?25l") (tails logText)) >
+         length (dropWhile (not . isPrefixOf "\ESC[?25h") (tails logText)))
     moduleTestInfo modName complete = "echo '{\"test_info\":{\"definition\":{\"module\":\"" ++ modName ++ "\",\"name\":\"_test_ready\"},\"complete\":" ++
       (if complete then "true" else "false") ++ ",\"success\":true,\"num_iterations\":1}}' >&2"
     awaitFile path = await path $ do

--- a/compiler/acton/package.yaml.in
+++ b/compiler/acton/package.yaml.in
@@ -58,6 +58,7 @@ dependencies:
   - timeit
   - unix
   - unordered-containers
+  - wcwidth
   - regex-tdfa
   
 executables:
@@ -74,6 +75,7 @@ executables:
       - TerminalSize
       - ZigProgress
       - TestFormat
+      - TestPerf
       - TestRunner
       - TestUI
     ghc-options:

--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -33,6 +33,7 @@ import qualified Options.Applicative as OA
 import qualified Paths_acton
 import qualified Repl
 import qualified WatchTests
+import qualified PerfTests
 import qualified TestGolden
 
 -- The default is to build and run each test program with the expectation that
@@ -76,6 +77,7 @@ main = do
       , typeErrorAutoTests
       , parseFlagTests
       , WatchTests.watchProcessTests
+      , PerfTests.perfTests
       , crossCompileTests
       , pkgCliTests
       ]

--- a/compiler/lib/src/Acton/CommandLineParser.hs
+++ b/compiler/lib/src/Acton/CommandLineParser.hs
@@ -517,7 +517,7 @@ testOptions = mkTestOptions
     <*> switch (long "show-cached"   <> help "Show cached test results")
     <*> switch (long "no-cache"      <> help "Always run tests instead of reusing cached results")
     <*> switch (long "json"          <> help "Output final test results as JSON")
-    <*> switch (long "record"        <> help "Record test performance results")
+    <*> switch (long "record"        <> help "Update the performance baseline in perf_data (perf mode)")
     <*> switch (long "snapshot-update" <> long "golden-update" <> long "accept" <> help "Accept current test output as expected snapshot values")
     <*> option auto (long "iter"     <> metavar "N" <> value (-1) <> help "Number of iterations to run a test")
     <*> optional (option auto (long "max-iter" <> metavar "N" <> help "Maximum number of iterations to run a test (mode defaults when omitted)"))

--- a/docs/acton-guide/src/testing/perf_record.md
+++ b/docs/acton-guide/src/testing/perf_record.md
@@ -10,11 +10,11 @@ acton test perf --release --record
 acton test perf --release
 ```
 
-Each measured test shows timing statistics, allocation volume, estimated non-GC
+Each measured test shows timing statistics, CPU measurements, allocation volume, estimated non-GC
 memory change and process peak RSS. If the baseline contains a successful
 measurement of that test, the delta column shows each row's mean percentage
 change. The median and peak RSS comparisons appear below the table.
-Positive values mean more time or memory; negative values mean
+Positive values mean a higher measured value; negative values mean
 less. A change from zero to a nonzero value has no defined percentage and is
 shown as `from 0`.
 
@@ -44,6 +44,7 @@ an increase; negative bounds indicate a decrease. Each table row's mean percenta
 change is colored only when its own interval excludes zero. The same check adds
 ⚡ after the delta for an improvement or 💩 for a regression, including when
 color is disabled.
+IPC comparisons stay neutral: higher IPC alone does not establish an improvement.
 Older recordings without a standard deviation still show a percentage, with
 neutral coloring.
 The median and process peak RSS colors show direction without an uncertainty
@@ -69,5 +70,12 @@ particular, keep `--release` consistent between runs. The baseline matches tests
 by their stored module and test names; renamed tests or recordings using older
 module names need a new recording. Remove `perf_data` to start a new baseline
 without retaining old entries. `--record` is only supported in performance mode.
+
+CPU measurements also check the recorded CPU model, architecture and OS version.
+Hardware counts additionally check the backend and accounting scope. Deltas are
+omitted when the relevant metadata differs or is missing. For example, user-only
+Linux counts cannot be compared against user-plus-kernel counts, while CPU-time
+comparisons remain available. Older recordings still provide their original
+timing and memory comparisons; record again to establish a CPU baseline.
 
 See [Performance testing](performance.md) for the meaning of each measurement.

--- a/docs/acton-guide/src/testing/perf_record.md
+++ b/docs/acton-guide/src/testing/perf_record.md
@@ -10,24 +10,49 @@ acton test perf --release --record
 acton test perf --release
 ```
 
-Each measured test shows its minimum, mean and maximum iteration time, average
-allocated bytes, and estimated non-GC memory change. If the baseline contains a
-successful measurement of that test, each available metric also shows its
-percentage change. Positive values mean more time or memory; negative values mean
+Each measured test shows timing statistics, allocation volume, estimated non-GC
+memory change and process peak RSS. If the baseline contains a successful
+measurement of that test, the delta column shows each row's mean percentage
+change. The median and peak RSS comparisons appear below the table.
+Positive values mean more time or memory; negative values mean
 less. A change from zero to a nonzero value has no defined percentage and is
-shown as `from 0; % n/a`.
+shown as `from 0`.
 
 For example:
 
 ```text
 Tests - module sample:
-   sample:          OK             :    3 runs in 9.542ms @  314.4/s
-      Min:                 0.107 ms (+94.55%)
-      Mean:                0.126 ms (+40.00%)
-      Max:                 0.158 ms (+6.76%)
-      Allocated / run:     30101 B (+3.83%)
-      Non-GC change / run: 61440 B (-11.76%)
+Benchmark (3 runs): sample
+  measurement                 mean ±            σ             min …          max          outliers             delta
+  time excl. GC              126µs ±       27.9µs           107µs …        158µs            0 (0%)            +40.0%
+  wall time                  126µs ±       27.9µs           107µs …        158µs            0 (0%)                 —
+  GC time                   0.00ms ±       0.00ms          0.00ms …       0.00ms            0 (0%)                 —
+  allocated                 30.1KB ±       64.0B           30.0KB …       30.1KB            0 (0%)             +3.8%
+  non-GC change             61.4KB ±       4.10KB          57.3KB …       65.5KB            0 (0%)            -11.8%
+  median: 113µs
+  process peak RSS: 12.4MB
+  total: 9.54ms (314.4 runs/s)
 ```
+
+Old recordings still provide comparisons for the quantities they contain, as
+in this example. Record again to save the additional statistics.
+
+When both runs have at least two samples and include standard deviations, the
+report adds an approximate 95% Welch confidence interval for the difference in
+mean iteration time, with units shown beside each bound. Positive bounds indicate
+an increase; negative bounds indicate a decrease. Each table row's mean percentage
+change is colored only when its own interval excludes zero. The same check adds
+⚡ after the delta for an improvement or 💩 for a regression, including when
+color is disabled.
+Older recordings without a standard deviation still show a percentage, with
+neutral coloring.
+The median and process peak RSS colors show direction without an uncertainty
+estimate.
+
+The interval allows different sample counts and variances. It assumes independent
+iterations and cannot account for correlations within a process, machine load or
+changes between runs. Treat it as a guide to measured variability and repeat
+benchmarks before attributing small changes to code.
 
 Performance tests always run afresh, even when their source code is unchanged.
 Compilation still reuses unchanged build artifacts.

--- a/docs/acton-guide/src/testing/perf_record.md
+++ b/docs/acton-guide/src/testing/perf_record.md
@@ -1,46 +1,48 @@
 # Performance comparisons
 
-When running in `performance mode` you can record a snapshot of performance using `acton test perf --record`. A `perf_data` file is written to disk with the stored performance data. Subsequent test runs will read this file and show a comparison. The difference is displayed as a percentage increase or decrease in time.
+Record a baseline with `acton test perf --record`. This writes measurements to
+`perf_data` in the project directory. Later performance runs compare with that
+file without changing it:
 
-Source:
-```python
-import testing
-
-def _test_simple():
-    a = 0
-    for i in range(99999):
-        a += i
-```
-
-Run:
 ```sh
-acton test perf --record
-acton test perf
+acton test perf --release --record
+# Make a change, then measure it against the baseline.
+acton test perf --release
 ```
 
-Output:
-```sh
-Building project in /home/user/foo
-  Compiling example.act for release
-   Finished compilation in   0.017 s
-  Final compilation step
-   Finished final compilation step in   0.452 s
+Each measured test shows its minimum, mean and maximum iteration time, average
+allocated bytes, and estimated non-GC memory change. If the baseline contains a
+successful measurement of that test, each available metric also shows its
+percentage change. Positive values mean more time or memory; negative values mean
+less. A change from zero to a nonzero value has no defined percentage and is
+shown as `from 0; % n/a`.
 
-Tests - module example:
-  simple:                OK:  3.25ms            Avg:  4.16ms             7.38ms             122 runs in 1006.002ms
+For example:
 
-All 1 tests passed (1.565s)
-
-Building project in /home/user/foo
-  Compiling example.act for release
-   Already up to date, in    0.000 s
-  Final compilation step
-   Finished final compilation step in   0.116 s
-
-Tests - module example:
-  simple:                OK:  3.23ms -0.50%     Avg:  4.17ms +0.19%      6.35ms -13.91%     119 runs in 1001.375ms
-
-All 1 tests passed (1.215s)
-
+```text
+Tests - module sample:
+   sample:          OK             :    3 runs in 9.542ms @  314.4/s
+      Min:                 0.107 ms (+94.55%)
+      Mean:                0.126 ms (+40.00%)
+      Max:                 0.158 ms (+6.76%)
+      Allocated / run:     30101 B (+3.83%)
+      Non-GC change / run: 61440 B (-11.76%)
 ```
-(note that the output is rather wide, scroll horizontally to see the full output)
+
+Performance tests always run afresh, even when their source code is unchanged.
+Compilation still reuses unchanged build artifacts.
+
+Use `--record` again to update the baseline. The run compares against the previous
+values before replacing them. Filters such as `--module` and `--name` update only
+the selected successful tests; other measurements remain in the file. Failed,
+skipped and incomplete tests do not replace saved measurements. If no test
+produces a successful measurement, the file is left untouched. Invalid JSON is
+reported as an error so that a damaged baseline is not silently overwritten.
+
+Use the same machine and build options for comparable measurements. In
+particular, keep `--release` consistent between runs. The baseline matches tests
+by their stored module and test names; renamed tests or recordings using older
+module names need a new recording. Remove `perf_data` to start a new baseline
+without retaining old entries. `--record` is only supported in performance mode.
+
+See [Performance testing](performance.md) for the meaning of each measurement.

--- a/docs/acton-guide/src/testing/performance.md
+++ b/docs/acton-guide/src/testing/performance.md
@@ -51,6 +51,17 @@ The result includes:
 - **Wall time, GC time:** unadjusted wall time and measured full GC
   time within an iteration. The GC counter has millisecond resolution. These
   exclude the forced collections between iterations.
+- **CPU user, CPU system:** CPU time spent in user code and the kernel across
+  all threads in the test process. Unlike wall time, this excludes time waiting
+  to be scheduled and can exceed wall time when threads work in parallel.
+- **Instructions, cycles:** hardware counts across all threads in the test
+  process. Counts use decimal prefixes: K is one thousand and M is one million.
+  These include GC and runtime work during the measurement, as do CPU times.
+  They exclude child processes and the forced collections between iterations.
+- **IPC:** instructions divided by cycles for each iteration. The table
+  summarizes these per-iteration ratios. A higher IPC does not necessarily mean
+  a faster program, so its comparison has neutral coloring and no improvement
+  or regression icon.
 - **Allocated:** average bytes reported by the GC allocation counter
   during an iteration. This measures allocation volume, not peak memory usage.
 - **Non-GC change:** estimated average change per iteration in resident memory outside
@@ -73,6 +84,22 @@ Very short tests are sensitive to measurement overhead and scheduling noise.
 Prefer workloads lasting at least a few milliseconds and repeat measurements
 before drawing conclusions from small percentage changes.
 
+CPU counters bracket each iteration, including a small amount of harness and
+counter-reading work. They do not isolate instructions spent on GC from other
+work. Wall time, CPU time and instruction counts provide different views of the
+same run; counters help explain variation but do not remove it.
+
+Linux uses `perf_event_open`, with thread inheritance requiring Linux 5.13 or
+later and matching build headers. It first requests user and kernel events,
+then tries user-only events if permissions prevent kernel counting. The report
+states which scope was collected. macOS uses the kernel's process instruction
+and cycle accounting through `proc_pid_rusage`, where the OS and hardware support
+it. Hardware counters are optional: denied permissions, unsupported hardware,
+failed reads or incomplete counter coverage omit those rows with an explanation.
+CPU times remain available independently. Linux samples with multiplexed events
+are omitted rather than scaled; a row is reported only when every iteration has
+a valid sample.
+
 `--json` includes a `performance` object for each successful test. Its
 `measurements` contain the displayed quantities, iteration count, median and
 quartiles for every row. For example, `stdev_wall_duration`,
@@ -84,6 +111,12 @@ or `null` when no baseline matches. `mean_difference_ci95_ms` contains the
 comparison interval's `lower` and `upper` bounds for time excluding GC, or `null`
 when the necessary statistics are unavailable. Failed or skipped tests have
 `performance: null`.
+
+CPU durations are also in milliseconds. Instruction and cycle values are raw
+counts; IPC is a unitless ratio. For example, `avg_instructions`, `stdev_cycles`
+and `median_ipc` follow the same statistics naming scheme. `counter_info` records
+the backend, accounting scope, availability, CPU model, architecture and OS
+version. Missing counters are absent, while a measured zero remains zero.
 
 See [Performance comparisons](perf_record.md) to record a baseline and compare
 later runs, or [Stress testing](stress.md) for concurrency-focused tests.

--- a/docs/acton-guide/src/testing/performance.md
+++ b/docs/acton-guide/src/testing/performance.md
@@ -1,38 +1,51 @@
 # Performance testing
 
-It is also possible to run tests in a *performance mode*, which uses the same basic test definitions (so you can run your tests both as logic test and for performance purposes) but alters the way in which the tests are run. In performance mode, only a single test will be run at a time unlike the normal mode in which many tests are typically run concurrently.
+Performance mode uses the same test definitions as ordinary testing, but runs one
+test at a time and always takes fresh measurements. Tests run serially even when
+`--jobs` allows parallel compilation.
 
-To get good numbers in performance mode, it's good if test functions run for at least a couple of milliseconds. With very short tests, very small differences lead to very large percentage differences.
-
-Source:
 ```python
 import testing
 
-def _test_simple():
+actor _test_simple(t: testing.AsyncT):
     a = 0
     for i in range(99999):
         a += i
+    assert a == 4999850001
+    t.success()
 ```
 
-Run:
 ```sh
-acton test perf
+acton test perf --release
 ```
 
-Output:
-```sh
-Building project in /home/user/foo
-  Compiling example.act for release
-   Finished compilation in   0.016 s
-  Final compilation step
-   Finished final compilation step in   0.451 s
+Use `--release` to measure optimized code. Without an explicit optimization
+option, the normal Debug build default applies. For more samples, increase the
+minimum duration, for example `--min-time 5000` for five seconds per test, or use
+`--iter` to select a fixed number of iterations.
 
-Tests - module example:
-  simple:                OK:  3.21ms            Avg:  4.20ms             5.11ms             106 runs in 1005.261ms
+Sampling limits are checked between iterations. A separate watchdog allows at
+least five minutes for a slow or hung performance test, so a long iteration can
+finish even when the sampling target is shorter. Longer configured run limits
+extend the watchdog; `--max-time 0` disables it.
 
-All 1 tests passed (1.571s)
+The result includes:
 
-```
-(note that the output is rather wide, scroll horizontally to see the full output)
+- **Min, Mean, Max:** minimum, average and maximum wall time per test iteration,
+  with measured garbage collection time subtracted. These include waiting within
+  asynchronous tests.
+- **Allocated / run:** average bytes reported by the GC allocation counter
+  during an iteration. This measures allocation volume, not peak memory usage.
+- **Non-GC change / run:** estimated average change in resident memory outside
+  the GC heap. This subtracts GC memory usage from RSS before and after the
+  iteration, with collections around the test. It is noisy and can be negative.
+- **Runs, total time, runs/second:** elapsed time and throughput for the whole
+  test loop, including harness and collection overhead. This differs from the
+  per-iteration times above.
 
-See [Stress testing](stress.md) for concurrency-focused stress runs.
+Very short tests are sensitive to measurement overhead and scheduling noise.
+Prefer workloads lasting at least a few milliseconds and repeat measurements
+before drawing conclusions from small percentage changes.
+
+See [Performance comparisons](perf_record.md) to record a baseline and compare
+later runs, or [Stress testing](stress.md) for concurrency-focused tests.

--- a/docs/acton-guide/src/testing/performance.md
+++ b/docs/acton-guide/src/testing/performance.md
@@ -29,16 +29,42 @@ least five minutes for a slow or hung performance test, so a long iteration can
 finish even when the sampling target is shorter. Longer configured run limits
 extend the watchdog; `--max-time 0` disables it.
 
+Each benchmark has a table with `mean ± σ`, `min … max`, outliers and an optional
+baseline delta. Time and memory values use compact units such as µs, ms, KB and
+MB; memory prefixes are decimal (1 KB = 1000 bytes). Numeric and unit fields have
+fixed widths, so columns stay aligned across benchmarks. The default report is
+116 columns wide. Smaller terminals use compact layouts, omitting outliers,
+then the range, then the standard deviation to preserve the mean and delta.
+A dash means that statistic was not collected.
+
+Each row summarizes its own per-iteration samples. Wall time combines the time
+excluding GC and the GC time from the same iteration before calculating its
+distribution. Memory averages and quartiles can contain fractions of a byte.
+
 The result includes:
 
-- **Min, Mean, Max:** minimum, average and maximum wall time per test iteration,
-  with measured garbage collection time subtracted. These include waiting within
-  asynchronous tests.
-- **Allocated / run:** average bytes reported by the GC allocation counter
+- **Time excl. GC:** wall time per test iteration with measured full
+  garbage collection time subtracted. These include waiting within asynchronous
+  tests. The row shows the mean and range; the median appears below the table.
+- **σ:** sample standard deviation of the row's measurements. Requires at least
+  two iterations; a constant measurement has zero deviation.
+- **Wall time, GC time:** unadjusted wall time and measured full GC
+  time within an iteration. The GC counter has millisecond resolution. These
+  exclude the forced collections between iterations.
+- **Allocated:** average bytes reported by the GC allocation counter
   during an iteration. This measures allocation volume, not peak memory usage.
-- **Non-GC change / run:** estimated average change in resident memory outside
+- **Non-GC change:** estimated average change per iteration in resident memory outside
   the GC heap. This subtracts GC memory usage from RSS before and after the
   iteration, with collections around the test. It is noisy and can be negative.
+- **Process peak RSS:** peak resident memory for the test process, below the table.
+  This includes startup, the runtime, all threads, the test harness and all
+  iterations. It is recorded before computing the final statistics and is
+  omitted on platforms where it is unavailable.
+- **Outliers:** iterations outside the range from Q1 minus 1.5 times the
+  interquartile range to Q3 plus 1.5 times that range. Quartiles use linear
+  interpolation between sorted samples. Outliers remain in all statistics;
+  they are counted separately for each row. When most GC samples are zero,
+  nonzero collections can all count as outliers.
 - **Runs, total time, runs/second:** elapsed time and throughput for the whole
   test loop, including harness and collection overhead. This differs from the
   per-iteration times above.
@@ -46,6 +72,18 @@ The result includes:
 Very short tests are sensitive to measurement overhead and scheduling noise.
 Prefer workloads lasting at least a few milliseconds and repeat measurements
 before drawing conclusions from small percentage changes.
+
+`--json` includes a `performance` object for each successful test. Its
+`measurements` contain the displayed quantities, iteration count, median and
+quartiles for every row. For example, `stdev_wall_duration`,
+`q1_mem_usage_delta` and `outlier_count_gc_duration` describe wall time spread,
+the first allocation quartile and GC outliers. The time excluding GC retains
+its original `outlier_count` key. Durations are in milliseconds and memory
+quantities are in bytes. `baseline` contains the available reference quantities,
+or `null` when no baseline matches. `mean_difference_ci95_ms` contains the
+comparison interval's `lower` and `upper` bounds for time excluding GC, or `null`
+when the necessary statistics are unavailable. Failed or skipped tests have
+`performance: null`.
 
 See [Performance comparisons](perf_record.md) to record a baseline and compare
 later runs, or [Stress testing](stress.md) for concurrency-focused tests.

--- a/test/stdlib_tests/src/test_testing_perf.act
+++ b/test/stdlib_tests/src/test_testing_perf.act
@@ -1,0 +1,156 @@
+import math
+import testing
+
+
+def measurements(samples: list[float], gc: float=0.0) -> testing.TestInfo:
+    info = testing.TestInfo(testing.Test("sample", "", "perf"))
+    for sample in samples:
+        info.update(True, testing.TestResult(True, None, None, sample, 0, 0, gc_duration=gc))
+    return info
+
+
+def number(stats: dict[str, value], key: str) -> float:
+    v = stats[key]
+    if isinstance(v, float):
+        return v
+    if isinstance(v, int):
+        return float(v)
+    raise ValueError("Expected a numeric statistic")
+
+
+def _test_empty_and_single_sample(t: testing.SyncT):
+    assert len(measurements([]).performance()) == 0
+    info = measurements([4.0], gc=0.25)
+    stats = info.performance()
+    assert number(stats, "median_duration") == 4.0
+    assert number(stats, "q1_duration") == 4.0
+    assert number(stats, "q3_duration") == 4.0
+    assert number(stats, "outlier_count") == 0.0
+    assert "stdev_duration" not in stats
+    assert number(stats, "avg_gc_duration") == 0.25
+    assert number(stats, "avg_wall_duration") == 4.25
+    for stem, expected in [("duration", 4.0), ("wall_duration", 4.25), ("gc_duration", 0.25),
+                           ("mem_usage_delta", 0.0), ("non_gc_mem_usage_delta", 0.0)]:
+        for stat in ["min", "max", "median", "q1", "q3"]:
+            assert number(stats, stat + "_" + stem) == expected
+        assert "stdev_" + stem not in stats
+        outlier_key = "outlier_count" if stem == "duration" else "outlier_count_" + stem
+        assert number(stats, outlier_key) == 0.0
+
+
+def _test_odd_samples(t: testing.SyncT):
+    stats = measurements([5.0, 2.0, 4.0, 1.0, 3.0]).performance()
+    assert number(stats, "median_duration") == 3.0
+    assert number(stats, "q1_duration") == 2.0
+    assert number(stats, "q3_duration") == 4.0
+    assert abs(number(stats, "stdev_duration") - math.sqrt(2.5)) < 0.000000001
+
+
+def _test_even_samples(t: testing.SyncT):
+    stats = measurements([4.0, 2.0, 1.0, 3.0]).performance()
+    assert number(stats, "median_duration") == 2.5
+    assert number(stats, "q1_duration") == 1.75
+    assert number(stats, "q3_duration") == 3.25
+    assert abs(number(stats, "stdev_duration") - math.sqrt(5.0 / 3.0)) < 0.000000001
+
+
+def _test_outliers_are_retained(t: testing.SyncT):
+    info = measurements([1.0, 1.0, 1.0, 1.0, 100.0])
+    stats = info.performance()
+    assert number(stats, "outlier_count") == 1.0
+    assert number(stats, "median_duration") == 1.0
+    assert info.avg_duration == 20.8
+    assert abs(number(stats, "stdev_duration") - math.sqrt(1960.2)) < 0.000000001
+    assert len(info.results) == 5
+
+
+def _test_wall_time_uses_paired_samples(t: testing.SyncT):
+    info = testing.TestInfo(testing.Test("sample", "", "perf"))
+    info.update(True, testing.TestResult(True, None, None, 1.0, 0, 0, gc_duration=3.0))
+    info.update(True, testing.TestResult(True, None, None, 3.0, 0, 0, gc_duration=1.0))
+    stats = info.performance()
+    assert number(stats, "avg_wall_duration") == 4.0
+    assert number(stats, "min_wall_duration") == 4.0
+    assert number(stats, "max_wall_duration") == 4.0
+    assert number(stats, "stdev_wall_duration") == 0.0
+    assert number(stats, "avg_gc_duration") == 2.0
+    assert number(stats, "min_gc_duration") == 1.0
+    assert number(stats, "max_gc_duration") == 3.0
+    assert abs(number(stats, "stdev_gc_duration") - math.sqrt(2.0)) < 0.000000001
+
+
+def _test_memory_statistics_preserve_fractional_and_signed_values(t: testing.SyncT):
+    info = testing.TestInfo(testing.Test("sample", "", "perf"))
+    for allocated, non_gc in [(0, -1), (1, 0), (1, 0)]:
+        info.update(True, testing.TestResult(True, None, None, 1.0, allocated, non_gc))
+    stats = info.performance()
+    assert abs(info.mem_usage_delta_avg - 2.0 / 3.0) < 0.000000001
+    assert abs(info.non_gc_mem_usage_delta_avg + 1.0 / 3.0) < 0.000000001
+    assert abs(number(stats, "mem_usage_delta_avg") - 2.0 / 3.0) < 0.000000001
+    assert abs(number(stats, "non_gc_mem_usage_delta_avg") + 1.0 / 3.0) < 0.000000001
+    for stem in ["mem_usage_delta", "non_gc_mem_usage_delta"]:
+        assert abs(number(stats, "stdev_" + stem) - math.sqrt(1.0 / 3.0)) < 0.000000001
+        assert number(stats, "outlier_count_" + stem) == 0.0
+    assert number(stats, "min_mem_usage_delta") == 0.0
+    assert number(stats, "max_mem_usage_delta") == 1.0
+    assert number(stats, "median_mem_usage_delta") == 1.0
+    assert number(stats, "q1_mem_usage_delta") == 0.5
+    assert number(stats, "q3_mem_usage_delta") == 1.0
+    assert number(stats, "min_non_gc_mem_usage_delta") == -1.0
+    assert number(stats, "max_non_gc_mem_usage_delta") == 0.0
+    assert number(stats, "median_non_gc_mem_usage_delta") == 0.0
+    assert number(stats, "q1_non_gc_mem_usage_delta") == -0.5
+    assert number(stats, "q3_non_gc_mem_usage_delta") == 0.0
+    for data in [info.to_json(), info.to_json(include_perf=True)]:
+        restored = testing.TestInfo.from_json(data)
+        assert abs(restored.mem_usage_delta_avg - 2.0 / 3.0) < 0.000000001
+        assert abs(restored.non_gc_mem_usage_delta_avg + 1.0 / 3.0) < 0.000000001
+    legacy = info.to_json()
+    legacy["mem_usage_delta_avg"] = 100
+    legacy["non_gc_mem_usage_delta_avg"] = -10
+    restored = testing.TestInfo.from_json(legacy)
+    assert restored.mem_usage_delta_avg == 100.0
+    assert restored.non_gc_mem_usage_delta_avg == -10.0
+
+
+def _test_sparse_gc_and_memory_outliers_are_retained(t: testing.SyncT):
+    info = testing.TestInfo(testing.Test("sample", "", "perf"))
+    for gc in [0.0, 0.0, 0.0, 0.0, 100.0]:
+        info.update(True, testing.TestResult(True, None, None, 1.0, int(gc), -int(gc), gc_duration=gc))
+    stats = info.performance()
+    assert number(stats, "outlier_count") == 0.0
+    for stem in ["wall_duration", "gc_duration", "mem_usage_delta", "non_gc_mem_usage_delta"]:
+        assert number(stats, "outlier_count_" + stem) == 1.0
+        assert abs(number(stats, "stdev_" + stem) - math.sqrt(2000.0)) < 0.000000001
+    assert number(stats, "avg_wall_duration") == 21.0
+    assert number(stats, "avg_gc_duration") == 20.0
+    assert number(stats, "q1_gc_duration") == 0.0
+    assert number(stats, "q3_gc_duration") == 0.0
+    assert number(stats, "mem_usage_delta_avg") == 20.0
+    assert number(stats, "non_gc_mem_usage_delta_avg") == -20.0
+    assert len(info.results) == 5
+
+
+def _test_summary_serialization(t: testing.SyncT):
+    info = measurements([1.0, 3.0], gc=0.5)
+    live = info.to_json()
+    final = info.to_json(include_perf=True)
+    assert "median_duration" not in live
+    assert "median_duration" in final
+    assert "stdev_duration" in final
+    assert "avg_wall_duration" in final
+    for stem in ["wall_duration", "gc_duration", "mem_usage_delta", "non_gc_mem_usage_delta"]:
+        for stat in ["min", "max", "median", "q1", "q3", "stdev", "outlier_count"]:
+            assert stat + "_" + stem not in live
+            assert stat + "_" + stem in final
+    results = final["results"]
+    if isinstance(results, list):
+        assert len(results) == 0
+    else:
+        raise AssertionError("Expected a list of results")
+    sample = info.results[0]
+    restored = testing.TestResult.from_json(sample.to_json())
+    assert restored.gc_duration == 0.5
+    old = sample.to_json()
+    del old["gc_duration"]
+    assert testing.TestResult.from_json(old).gc_duration == 0.0

--- a/test/stdlib_tests/src/test_testing_perf.act
+++ b/test/stdlib_tests/src/test_testing_perf.act
@@ -154,3 +154,74 @@ def _test_summary_serialization(t: testing.SyncT):
     old = sample.to_json()
     del old["gc_duration"]
     assert testing.TestResult.from_json(old).gc_duration == 0.0
+
+
+def snapshot(count: ?u64, cycles: ?u64, enabled: u64, running: u64, user: ?u64=None, system: ?u64=None):
+    return (user_ns=user, system_ns=system, instructions=count, cycles=cycles,
+            instructions_enabled=enabled, instructions_running=running,
+            cycles_enabled=enabled, cycles_running=running)
+
+
+def _test_counter_deltas_preserve_integer_precision(t: testing.SyncT):
+    # Lifetime counts may exceed the exact integer range of a double.
+    start = 2**54
+    before = snapshot(u64(start), u64(start), u64(10), u64(10), u64(1000), u64(0))
+    end = snapshot(u64(start+3), u64(start+2), u64(20), u64(20), u64(2001000), u64(0))
+    counters = testing.perf_delta(before, end)
+    assert counters == {"instructions": 3.0, "cycles": 2.0, "ipc": 1.5, "cpu_user": 2.0, "cpu_system": 0.0}
+    huge: u64 = 0xffffffffffffffff
+    before = snapshot(u64(0), u64(0), u64(0), u64(0))
+    end = snapshot(huge, huge, u64(10), u64(10))
+    counters = testing.perf_delta(before, end)
+    assert counters["instructions"] == float(huge)
+    assert counters["cycles"] == float(huge)
+    assert counters["ipc"] == 1.0
+
+
+def _test_unavailable_and_incomplete_counters_are_omitted(t: testing.SyncT):
+    before = snapshot(u64(100), u64(100), u64(10), u64(10), u64(1000), u64(0))
+    for end in [snapshot(None, None, u64(20), u64(20)),
+                  snapshot(u64(99), u64(200), u64(20), u64(20)),
+                  snapshot(u64(200), u64(99), u64(20), u64(20)),
+                  snapshot(u64(200), u64(200), u64(20), u64(19)),
+                  snapshot(u64(200), u64(200), u64(20), u64(10)),
+                  snapshot(u64(200), u64(200), u64(9), u64(20))]:
+        assert testing.perf_delta(before, end) == {}
+    end = snapshot(u64(200), u64(100), u64(20), u64(20), u64(999), u64(0))
+    counters = testing.perf_delta(before, end)
+    assert "cpu_user" not in counters
+    assert "ipc" not in counters
+    assert counters["cycles"] == 0.0
+    assert counters["cpu_system"] == 0.0
+
+
+def _test_counter_distributions_and_serialization(t: testing.SyncT):
+    info = testing.TestInfo(testing.Test("sample", "", "perf"), counter_info={"status": "available", "scope": "process:user"})
+    # IPC averages paired ratios: mean(1/2, 3/3), not mean(1,3)/mean(2,3).
+    for instructions, cycles in [(1.0, 2.0), (3.0, 3.0)]:
+        counters = {"instructions": instructions, "cycles": cycles, "ipc": instructions/cycles, "cpu_user": 1.0, "cpu_system": 0.0}
+        sample = testing.TestResult(True, None, None, 1.0, 0, 0, counters=counters)
+        assert testing.TestResult.from_json(sample.to_json()).counters == counters
+        legacy = sample.to_json()
+        del legacy["counters"]
+        assert testing.TestResult.from_json(legacy).counters is None
+        info.update(True, sample)
+    stats = info.performance()
+    assert number(stats, "avg_ipc") == 0.75
+    assert number(stats, "min_ipc") == 0.5
+    assert number(stats, "max_ipc") == 1.0
+    assert number(stats, "avg_instructions") == 2.0
+    for metric in ["cpu_user", "cpu_system", "instructions", "cycles", "ipc"]:
+        for stat in ["avg", "min", "max", "median", "q1", "q3", "stdev", "outlier_count"]:
+            assert stat + "_" + metric in stats
+    data = info.to_json(include_perf=True)
+    assert testing.TestInfo.from_json(data).counter_info == info.counter_info
+    # A partial series cannot use the full iteration count in comparisons.
+    info.update(True, testing.TestResult(True, None, None, 1.0, 0, 0, counters={"cpu_user": 1.0, "cpu_system": 0.0}))
+    stats = info.performance()
+    assert "avg_instructions" not in stats
+    assert "avg_cycles" not in stats
+    assert "avg_ipc" not in stats
+    assert number(stats, "avg_cpu_system") == 0.0
+    restored = testing.TestInfo.from_json(info.to_json(include_perf=True))
+    assert restored.counter_info["status"] == "incomplete or multiplexed counter samples"


### PR DESCRIPTION
Restore recorded baseline comparisons in acton test perf. Run benchmarks serially with a timeout of at least five minutes. Show timing, GC and memory distributions with comparison markers in an aligned report that flickers less.

Add process CPU time and optional instructions, cycles and IPC measurements on Linux and macOS. Include all runtime threads and GC within each iteration. Preserve older recordings and omit unavailable or incomplete counter measurements.
