### PR TITLE
Short-circuit builtin equality for aliases

### DIFF
--- a/base/builtin/bigint.c
+++ b/base/builtin/bigint.c
@@ -623,10 +623,14 @@ B_float B_DivD_bigintD___truediv__ (B_DivD_bigint wit, B_bigint a, B_bigint b) {
 // B_OrdD_bigint  ////////////////////////////////////////////////////////////////////////////////////////
 
 bool B_OrdD_bigintD___eq__ (B_OrdD_bigint wit, B_bigint a, B_bigint b) {
+    if (a == b)
+        return true;
     return zz_equal(&a->val,&b->val);
 }
 
 bool B_OrdD_bigintD___ne__ (B_OrdD_bigint wit, B_bigint a, B_bigint b) {
+    if (a == b)
+        return false;
     return !zz_equal(&a->val,&b->val);
 }
 

--- a/base/builtin/builtin_functions.c
+++ b/base/builtin/builtin_functions.c
@@ -469,6 +469,8 @@ $EqOpt $EqOptG_new(B_Eq W_Eq$A) {
 // the same offsets in the Eq, Ord and Hashable witness class structs.
 
 static bool $tupleWitD___eq__(B_tuple wits, $WORD a, $WORD b) {
+    if (a == b)
+        return true;
     B_tuple ta = (B_tuple)a;
     B_tuple tb = (B_tuple)b;
     for (int i = 0; i < wits->size; i++) {

--- a/base/builtin/dict.c
+++ b/base/builtin/dict.c
@@ -369,6 +369,8 @@ bool B_dictrel(bool directfalse,B_OrdD_dict w, B_dict a, B_dict b) {
 }
 
 bool B_OrdD_dictD___eq__ (B_OrdD_dict w, B_dict a, B_dict b) {
+    if (a == b)
+        return true;
     return B_dictrel(a->numelements != b->numelements,w,a,b);
 }
 

--- a/base/builtin/list.c
+++ b/base/builtin/list.c
@@ -240,6 +240,8 @@ int64_t B_listD_count(B_list self, B_Eq W_EqD_B, $WORD val) {
 // B_OrdD_list ////////////////////////////////////////////////////////
 
 bool B_OrdD_listD___eq__ (B_OrdD_list w, B_list a, B_list b) {
+    if (a == b)
+        return true;
     if (a->length != b->length) return false;
     B_Ord w2 = w->W_OrdD_AD_OrdD_list;
     for (int i = 0; i<a->length; i++) {

--- a/base/builtin/str.c
+++ b/base/builtin/str.c
@@ -1574,10 +1574,14 @@ B_str B_strD_zfill(B_str s, int64_t width) {
 // Thus they do not in general reflect locale-dependent order conventions.
 
 bool B_OrdD_strD___eq__ (B_OrdD_str wit, B_str a, B_str b) {
+    if (a == b)
+        return true;
     return strcmp((char *)a->str,(char *)b->str) == 0;
 }
 
 bool B_OrdD_strD___ne__ (B_OrdD_str wit, B_str a, B_str b) {
+    if (a == b)
+        return false;
     return strcmp((char *)a->str,(char *)b->str) != 0;
 }
 
@@ -2587,10 +2591,14 @@ B_bytearray B_bytearrayD_zfill(B_bytearray s, int64_t width) {
 
 
 bool B_OrdD_bytearrayD___eq__ (B_OrdD_bytearray wit, B_bytearray a, B_bytearray b) {
+    if (a == b)
+        return true;
     return strcmp((char *)a->str,(char *)b->str)==0;
 }
 
 bool B_OrdD_bytearrayD___ne__ (B_OrdD_bytearray wit, B_bytearray a, B_bytearray b) {
+    if (a == b)
+        return false;
     return strcmp((char *)a->str,(char *)b->str)!=0;
 }
 
@@ -3697,6 +3705,8 @@ B_bytes B_bytesD_zfill(B_bytes s, int64_t width) {
 
 
 bool B_OrdD_bytesD___eq__ (B_OrdD_bytes wit, B_bytes a, B_bytes b) {
+    if (a == b)
+        return true;
     if (a->nbytes != b->nbytes)
         return false;
     for (int i=0; i < a->nbytes; i++)

--- a/test/builtins_auto/eq_identity_fast_path.act
+++ b/test/builtins_auto/eq_identity_fast_path.act
@@ -1,0 +1,79 @@
+def test_reflexive_builtin_aliases():
+    s = "abcdefghij" * 1000
+    s_alias = s
+    if not (s_alias == s) or s_alias != s:
+        raise ValueError("str alias comparison failed")
+
+    bs = b"abcdefghij" * 1000
+    bs_alias = bs
+    if not (bs_alias == bs) or bs_alias != bs:
+        raise ValueError("bytes alias comparison failed")
+
+    ba = bytearray(bs)
+    ba_alias = ba
+    if not (ba_alias == ba) or ba_alias != ba:
+        raise ValueError("bytearray alias comparison failed")
+
+    n: bigint = 10**1000
+    n_alias = n
+    if not (n_alias == n) or n_alias != n:
+        raise ValueError("bigint alias comparison failed")
+
+
+def test_distinct_equal_builtins():
+    s1 = "abcdefghij" * 1000
+    s2 = "abcdefghij" * 1000
+    if not (s1 == s2) or s1 != s2:
+        raise ValueError("distinct equal str comparison failed")
+
+    bs1 = b"abcdefghij" * 1000
+    bs2 = b"abcdefghij" * 1000
+    if not (bs1 == bs2) or bs1 != bs2:
+        raise ValueError("distinct equal bytes comparison failed")
+
+    ba1 = bytearray(b"abcdefghij")
+    ba2 = bytearray(b"abcdefghij")
+    if not (ba1 == ba2) or ba1 != ba2:
+        raise ValueError("distinct equal bytearray comparison failed")
+
+    n1 = bigint("1" * 1000)
+    n2 = bigint("1" * 1000)
+    if not (n1 == n2) or n1 != n2:
+        raise ValueError("distinct equal bigint comparison failed")
+
+
+def test_container_reflexivity_and_numeric_exceptions():
+    n = float("nan")
+    if n == n:
+        raise ValueError("float NaN became reflexive")
+
+    c = complex.from_real_imag(n, 0.0)
+    if c == c:
+        raise ValueError("complex NaN became reflexive")
+
+    ns = [n]
+    if not (ns == ns) or ns != ns:
+        raise ValueError("list alias comparison is not reflexive")
+
+    nt = (n,)
+    if not (nt == nt) or nt != nt:
+        raise ValueError("tuple alias comparison is not reflexive")
+
+    nd = {"nan": n}
+    if not (nd == nd) or nd != nd:
+        raise ValueError("dict alias comparison is not reflexive")
+
+    sn = {n}
+    if not (sn == sn) or sn != sn:
+        raise ValueError("set alias comparison is not reflexive")
+
+
+actor main(env):
+    try:
+        test_reflexive_builtin_aliases()
+        test_distinct_equal_builtins()
+        test_container_reflexivity_and_numeric_exceptions()
+        env.exit(0)
+    except Exception as e:
+        print(e)
+        env.exit(1)


### PR DESCRIPTION
Comparing an object with itself can traverse its entire contents. Add pointer-identity shortcuts for str, bytes, bytearray, bigint, list, dict and tuple equality and inequality.

Container aliases now compare equal even when they contain NaN, matching the existing set behavior. Direct float and complex comparisons retain their IEEE NaN behavior.
