### PR TITLE
Use elapsed time for macOS GC measurements

### DIFF
--- a/deps/libgc/build.zig
+++ b/deps/libgc/build.zig
@@ -174,6 +174,12 @@ pub fn build(b: *std.Build) void {
         "typd_mlc.c",
     }) catch unreachable;
 
+    // Use elapsed time for GC measurements. The fallback clock() counts CPU
+    // time across parallel marker threads, which can exceed wall time.
+    if (t.os.tag == .macos) {
+        flags.append("-D HAVE_CLOCK_GETTIME") catch unreachable;
+    }
+
     if (enable_threads) {
         flags.append("-D GC_THREADS") catch unreachable;
         if (enable_parallel_mark) {


### PR DESCRIPTION
The GC clock on macOS falls back to process CPU time, which includes parallel collector threads. Subtracting that value from elapsed wall time can produce negative performance test durations.

Enable clock_gettime so GC measurements use monotonic elapsed time.
