### PR TITLE
Drain queued writes before TCP listen close

### DIFF
--- a/base/src/net.ext.c
+++ b/base/src/net.ext.c
@@ -1095,6 +1095,15 @@ $R netQ_TCPListenConnectionD_writeG_local (netQ_TCPListenConnection self, $Cont 
     return $R_CONT(c$cont, B_None);
 }
 
+static void listen_conn_after_shutdown(uv_shutdown_t *req, int status) {
+    log_debug("TCP listen connection shutdown complete, closing handle");
+    if (status < 0 && status != UV_ECANCELED)
+        log_warn("Error in TCP listen connection shutdown: %s", uv_strerror(status));
+    uv_handle_t *handle = (uv_handle_t *)req->handle;
+    if (uv_is_closing(handle) == 0)
+        uv_close(handle, NULL);
+}
+
 $R netQ_TCPListenConnectionD_closeG_local (netQ_TCPListenConnection self, $Cont c$cont) {
     log_debug("Closing TCP connection, affinity=%d", self->$affinity);
     uv_stream_t *client = (uv_stream_t *)(intptr_t)self->client;
@@ -1102,12 +1111,17 @@ $R netQ_TCPListenConnectionD_closeG_local (netQ_TCPListenConnection self, $Cont 
     if ((intptr_t)client == -1)
         return $R_CONT(c$cont, B_None);
 
-    // TODO: shouldn't we call uv_shutdown() first? uv_read_stop() is not needed I think
+    self->client = -1LL;
     uv_read_stop(client);
-    if (uv_is_closing((uv_handle_t *)client) == 0) {
+    if (uv_is_closing((uv_handle_t *)client))
+        return $R_CONT(c$cont, B_None);
+
+    uv_shutdown_t *req = (uv_shutdown_t *)acton_malloc(sizeof(uv_shutdown_t));
+    int r = uv_shutdown(req, client, listen_conn_after_shutdown);
+    if (r < 0) {
+        log_debug("TCP listen connection shutdown failed, closing handle: %s", uv_strerror(r));
         uv_close((uv_handle_t *)client, NULL);
     }
-    self->client = -1LL;
     return $R_CONT(c$cont, B_None);
 }
 

--- a/test/stdlib_tests/src/test_net_tcp.act
+++ b/test/stdlib_tests/src/test_net_tcp.act
@@ -4,13 +4,13 @@ import random
 import re
 import testing
 
-actor test_tcp_client_side_close(report_result, env, log_handler: logging.Handler):
-    log = logging.Logger(log_handler)
+actor _test_TCPClientSideClose(t: testing.EnvT):
+    log = logging.Logger(t.log_handler)
     test_payload = b"Stay a while and listen."
     address = "127.0.0.1"
     var retries = 10
     var port = random.randint(10000, 40000)
-    tcp_cap = net.TCPCap(net.NetCap(env.cap))
+    tcp_cap = net.TCPCap(net.NetCap(t.env.cap))
 
     var recv_buf: list[bytes] = []
 
@@ -21,17 +21,17 @@ actor test_tcp_client_side_close(report_result, env, log_handler: logging.Handle
 
     def on_server_error(s, errmsg):
         log.error(errmsg)
-        report_result(False, AssertionError("server error: " + errmsg))
+        t.failure(AssertionError("server error: " + errmsg))
 
     def on_server_remote_close(s):
         try:
             testing.assertEqual(test_payload, bytes([]).join(recv_buf), "Did not receive expected data before remote close event")
         except AssertionError as ex:
-            report_result(False, ex)
+            t.failure(ex)
         except Exception as ex:
-            report_result(None, ex)
+            t.error(ex)
         else:
-            report_result(True, None)
+            t.success()
 
     def on_listen(l, error):
         if error is not None:
@@ -42,7 +42,7 @@ actor test_tcp_client_side_close(report_result, env, log_handler: logging.Handle
                     _start()
                     return
             log.error(error)
-            report_result(False, AssertionError("listen error: " + error))
+            t.failure(AssertionError("listen error: " + error))
         else:
             _connect_client()
 
@@ -69,16 +69,12 @@ actor test_tcp_client_side_close(report_result, env, log_handler: logging.Handle
         server = net.TCPListener(net.TCPListenCap(tcp_cap), address, port, on_listen, on_listen_accept)
     _start()
 
-def _test_tcp_client_side_close(report_result: action(?bool, ?Exception) -> None , env: Env, log_handler: logging.Handler):
-    test_tcp_client_side_close(report_result, env, log_handler)
-
-actor test_tcp_server_side_close(report_result, env, log_handler: logging.Handler):
-    log = logging.Logger(log_handler)
-    test_payload = b"Stay a while and listen."
+actor test_tcp_server_side_close(t: testing.EnvT, test_payload: bytes):
+    log = logging.Logger(t.log_handler)
     address = "127.0.0.1"
     var retries = 10
     var port = random.randint(10000, 40000)
-    tcp_cap = net.TCPCap(net.NetCap(env.cap))
+    tcp_cap = net.TCPCap(net.NetCap(t.env.cap))
 
     recv_buf: list[bytes] = []
 
@@ -89,7 +85,7 @@ actor test_tcp_server_side_close(report_result, env, log_handler: logging.Handle
 
     def on_server_error(s, errmsg):
         log.error(errmsg)
-        report_result(False, AssertionError("server error: " + errmsg))
+        t.failure(AssertionError("server error: " + errmsg))
 
     def on_listen(l, error):
         if error is not None:
@@ -100,7 +96,7 @@ actor test_tcp_server_side_close(report_result, env, log_handler: logging.Handle
                     log.info("address already in use, retrying...")
                     return
             log.error(error)
-            report_result(False, AssertionError("listen error: " + error))
+            t.failure(AssertionError("listen error: " + error))
         else:
             _connect_client()
 
@@ -127,13 +123,14 @@ actor test_tcp_server_side_close(report_result, env, log_handler: logging.Handle
         if client is not None and client is c:
             try:
                 recv = bytes([]).join(recv_buf)
-                testing.assertEqual(test_payload, recv, "Did not receive expected data '%s' before remote close event, got '%s', retry: %d" % (str(test_payload), str(recv), retries))
+                testing.assertEqual(len(test_payload), len(recv), "Did not receive expected %d bytes before remote close event, got %d bytes, retry: %d" % (len(test_payload), len(recv), retries))
+                testing.assertEqual(test_payload, recv, "Received data differs from the data the server wrote", print_vals=False, print_diff=False)
             except AssertionError as ex:
-                report_result(False, ex)
+                t.failure(ex)
             except Exception as ex:
-                report_result(None, ex)
+                t.error(ex)
             else:
-                report_result(True, None)
+                t.success()
 
     def _start():
         retries -= 1
@@ -141,5 +138,16 @@ actor test_tcp_server_side_close(report_result, env, log_handler: logging.Handle
         server = net.TCPListener(net.TCPListenCap(tcp_cap), address, port, on_listen, on_listen_accept)
     _start()
 
-def _test_tcp_server_side_close(report_result: action(?bool, ?Exception) -> None , env: Env, log_handler: logging.Handler):
-    test_tcp_server_side_close(report_result, env, log_handler)
+actor _test_TCPServerSideClose(t: testing.EnvT):
+    test_tcp_server_side_close(t, b"Stay a while and listen.")
+
+actor _test_TCPServerSideCloseLargePayload(t: testing.EnvT):
+    """Server-side close delivers a payload larger than the socket send buffer
+
+    The server writes 4 MB and closes the connection in the same step. The
+    write is asynchronous. The data that does not fit in the socket send
+    buffer stays in the stream write queue. close() must drain that queue
+    before it closes the handle, or the client receives a truncated payload.
+    http.Listener closes this way on Connection: close and for HTTP/1.0.
+    """
+    test_tcp_server_side_close(t, ("x" * 4000000).encode())


### PR DESCRIPTION
TCPListenConnection.close() calls uv_shutdown() on the stream before it closes the handle. The shutdown completes after libuv sends every write in the stream write queue. The shutdown callback then closes the handle. TCPConnection.close() already uses the same sequence.

Add a stdlib test in test_net_tcp where the server writes a 4 MB payload and closes the connection in the same step (very similar to the HTTP server where the client sends Connection: close).