### PR TITLE
Add calibrated performance test loops

### DIFF
--- a/.github/workflows/test-app.yml
+++ b/.github/workflows/test-app.yml
@@ -28,8 +28,8 @@ jobs:
           repository: ${{ inputs.repo_url }}
           path: app
       - name: "Compile acton program"
-        run: |
-          cd app
-          acton build
-          acton test
-          acton test perf
+        working-directory: app
+        run: acton build
+      - name: "Run tests"
+        working-directory: app
+        run: acton test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -973,10 +973,14 @@ jobs:
       - name: "Run perf tests and record"
         run: |
           acton version
-          cd test/stdlib_tests
-          acton test perf --record
-          cd ../perf
-          acton test perf --record
+          rm -f test/perf/perf_data
+          perf_help="$(acton test perf --help)"
+          if ! grep -q -- '--scale' <<< "$perf_help"; then
+            echo "The APT compiler predates performance loops. Running the new compiler's benchmarks without a baseline." | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          cd test/perf
+          acton test perf --time 1s --record
       - name: "Download .deb files"
         uses: actions/download-artifact@v8
         with:
@@ -985,14 +989,14 @@ jobs:
         run: |
           sudo dpkg -i ./deb/acton_*.deb
           acton version
+      - name: "Run stdlib tests in ReleaseFast"
+        working-directory: test/stdlib_tests
+        run: acton test --optimize ReleaseFast --iter 1 --no-cache
       - name: "Run perf tests to compare"
         run: |
-          cd test/stdlib_tests
+          cd test/perf
           rm -rf out
-          acton test perf
-          cd ../perf
-          rm -rf out
-          acton test perf
+          acton test perf --time 1s
 
   test-app-sorespo:
     strategy:

--- a/base/src/testing.act
+++ b/base/src/testing.act
@@ -327,10 +327,137 @@ class SkipTest(AssertionError):
 class AbortTest(Exception):
     pass
 
+class PerfLoop(Iterator[int]):
+    """One invocation's loop. Native __next__ brackets batches; policy lives here.
+
+    Phases: 0 ordinary, 1 calibration, 2 warmup, 3 measurement.
+    """
+    calibration: list[dict[str, value]]
+    _state: u64
+    _last_wall_ns: u64
+    _start_wall_ns: u64
+    _start_gc_ms: u64
+    _start_alloc: u64
+    _start_user_ns: u64
+    _start_system_ns: u64
+    _start_instructions: u64
+    _start_cycles: u64
+    _start_instructions_enabled: u64
+    _start_instructions_running: u64
+    _start_cycles_enabled: u64
+    _start_cycles_running: u64
+    _wall_ns: u64
+    _gc_ns: u64
+    _allocated_bytes: u64
+    _user_ns: u64
+    _system_ns: u64
+    _instructions: u64
+    _cycles: u64
+    _batch_left: u64
+    _batch_size: u64
+    _yield_scale: ?int
+    _report_result: ?action(?bool, ?Exception, ?str) -> None
+
+    def __init__(self, phase: int=0, scale: int=1, budget_ms: float=0.0, remaining_ms: float=0.0, target_ms: float=0.0):
+        self._phase = phase
+        self.scale = scale
+        self.iterations = 0
+        self._budget_ms = budget_ms
+        self._remaining_ms = remaining_ms
+        self._target_ms = target_ms
+        self._previous_wall_ms = 0.0
+        self._sw = time.Stopwatch()
+        self.calibration = []
+        self._state = 0
+        self._last_wall_ns = 0
+        self._start_wall_ns = 0
+        self._start_gc_ms = 0
+        self._start_alloc = 0
+        self._start_user_ns = 0
+        self._start_system_ns = 0
+        self._start_instructions = 0
+        self._start_cycles = 0
+        self._start_instructions_enabled = 0
+        self._start_instructions_running = 0
+        self._start_cycles_enabled = 0
+        self._start_cycles_running = 0
+        self._wall_ns = 0
+        self._gc_ns = 0
+        self._allocated_bytes = 0
+        self._user_ns = 0
+        self._system_ns = 0
+        self._instructions = 0
+        self._cycles = 0
+        self._batch_left = 0
+        self._batch_size = 1
+        self._yield_scale = None
+        self._report_result = None
+        self._start_cpu_valid = False
+        self._start_hardware_valid = False
+        self._cpu_valid = True
+        self._hardware_valid = True
+
+    def claim(self) -> PerfLoop:
+        NotImplemented
+
+    def __next__(self) -> int:
+        NotImplemented
+
+    def close(self) -> None:
+        NotImplemented
+
+    action def _report(self, success: ?bool, exception: ?Exception, output: ?str) -> None:
+        NotImplemented
+
+    def status(self) -> int:
+        """0 unused, 1 unfinished, 2 exhausted, 3 invalid."""
+        NotImplemented
+
+    mut def _advance(self, completed: int) -> ?int:
+        self.iterations += completed
+        if self._phase == 0:
+            return 1 if self.iterations == 0 else None
+        elapsed = self._sw.elapsed().to_float() * 1000.0
+        if completed == 0:
+            # Setup uses the total budget, but a run may finish its first body
+            # after its individual slice expires.
+            return self.scale if elapsed < self._remaining_ms else None
+        if self._phase == 1:
+            wall_ms = float(self._last_wall_ns) / 1000000.0
+            self.calibration.append({"scale": self.scale, "wall_ms": wall_ms})
+            if wall_ms >= self._target_ms or elapsed >= self._budget_ms or self.scale >= 2**30:
+                # Doubling the input can overshoot badly for nonlinear workloads.
+                if self.iterations > 1 and abs(self._previous_wall_ms - self._target_ms) <= abs(wall_ms - self._target_ms):
+                    self.scale //= 2
+                return None
+            self._previous_wall_ms = wall_ms
+            self.scale *= 2
+        elif elapsed >= self._budget_ms:
+            return None
+        return self.scale
+
+    def counters(self) -> dict[str, float]:
+        counts: dict[str, float] = {}
+        n = float(self.iterations)
+        if self._cpu_valid:
+            counts["cpu_user"] = float(self._user_ns) / 1000000.0 / n
+            counts["cpu_system"] = float(self._system_ns) / 1000000.0 / n
+        if self._hardware_valid:
+            counts["instructions"] = float(self._instructions) / n
+            counts["cycles"] = float(self._cycles) / n
+            if self._cycles > 0:
+                counts["ipc"] = float(self._instructions) / float(self._cycles)
+        return counts
+
 class SyncT(value):
-    def __init__(self, log_handler: logging.Handler, tags: set[str]):
+    def __init__(self, log_handler: logging.Handler, tags: set[str], loop: ?PerfLoop=None):
         self.log_handler = log_handler
         self.tags = tags
+        self._loop = loop if loop is not None else PerfLoop()
+
+    def loop(self) -> Iterator[int]:
+        """Measure this loop's bodies, yielding the workload scale each time."""
+        return self._loop.claim()
 
     def skip(self, reason: ?str="Skipped"):
         raise SkipTest(reason)
@@ -340,10 +467,15 @@ class SyncT(value):
             self.skip(f"Missing required capability '{tag}' (enable with --tag {tag})")
 
 class AsyncT(value):
-    def __init__(self, report_result: action(?bool, ?Exception, ?str) -> None, log_handler: logging.Handler, tags: set[str]):
+    def __init__(self, report_result: action(?bool, ?Exception, ?str) -> None, log_handler: logging.Handler, tags: set[str], loop: ?PerfLoop=None):
         self.report_result = report_result
         self.log_handler = log_handler
         self.tags = tags
+        self._loop = loop if loop is not None else PerfLoop()
+
+    def loop(self) -> Iterator[int]:
+        """Measure this loop's bodies, yielding the workload scale each time."""
+        return self._loop.claim()
 
     def success(self, output: ?str=None):
         self.report_result(True, None, output)
@@ -363,11 +495,16 @@ class AsyncT(value):
             self.skip(f"Missing required capability '{tag}' (enable with --tag {tag})")
 
 class EnvT(value):
-    def __init__(self, report_result: action(?bool, ?Exception, ?str) -> None, env: Env, log_handler: logging.Handler, tags: set[str]):
+    def __init__(self, report_result: action(?bool, ?Exception, ?str) -> None, env: Env, log_handler: logging.Handler, tags: set[str], loop: ?PerfLoop=None):
         self.report_result = report_result
         self.env = env
         self.log_handler = log_handler
         self.tags = tags
+        self._loop = loop if loop is not None else PerfLoop()
+
+    def loop(self) -> Iterator[int]:
+        """Measure this loop's bodies, yielding the workload scale each time."""
+        return self._loop.claim()
 
     def success(self, output: ?str=None):
         self.report_result(True, None, output)
@@ -408,17 +545,17 @@ class Test(object):
             n = n[:-8]
         return n
 
-    def run(self, report_result: action(?bool, ?Exception, ?str) -> None, env: Env, log_handler: logging.Handler, tags: set[str]):
+    def run(self, report_result: action(?bool, ?Exception, ?str) -> None, env: Env, log_handler: logging.Handler, tags: set[str], loop: ?PerfLoop=None):
         if isinstance(self, UnitTest):
             self.run_test(report_result, env, log_handler, tags)
         elif isinstance(self, SimpleSyncTest):
             self.run_test(report_result, env, log_handler, tags)
         elif isinstance(self, SyncTest):
-            self.run_test(report_result, env, log_handler, tags)
+            self.run_test(report_result, env, log_handler, tags, loop)
         elif isinstance(self, AsyncTest):
-            self.run_test(report_result, env, log_handler, tags)
+            self.run_test(report_result, env, log_handler, tags, loop)
         elif isinstance(self, EnvTest):
-            self.run_test(report_result, env, log_handler, tags)
+            self.run_test(report_result, env, log_handler, tags, loop)
         else:
             raise ValueError("Test: Invalid test type")
 
@@ -526,12 +663,12 @@ class SyncTest(Test):
         self.desc = desc
         self.module = module
 
-    def run_test(self, report_result: action(?bool, ?Exception, ?str) -> None, env: Env, log_handler: logging.Handler, tags: set[str]):
+    def run_test(self, report_result: action(?bool, ?Exception, ?str) -> None, env: Env, log_handler: logging.Handler, tags: set[str], loop: ?PerfLoop=None):
         output = None
         success = None
         exception = None
         try:
-            output = self.fn(SyncT(log_handler, tags))
+            output = self.fn(SyncT(log_handler, tags, loop))
             success = True
             exception = None
         except SkipTest as e:
@@ -552,9 +689,9 @@ class AsyncTest(Test):
         self.desc = desc
         self.module = module
 
-    def run_test(self, report_result: action(?bool, ?Exception, ?str) -> None, env: Env, log_handler: logging.Handler, tags: set[str]):
+    def run_test(self, report_result: action(?bool, ?Exception, ?str) -> None, env: Env, log_handler: logging.Handler, tags: set[str], loop: ?PerfLoop=None):
         try:
-            self.fn(AsyncT(report_result, log_handler, tags))
+            self.fn(AsyncT(report_result, log_handler, tags, loop))
         except AbortTest:
             pass
 
@@ -565,9 +702,9 @@ class EnvTest(Test):
         self.desc = desc
         self.module = module
 
-    def run_test(self, report_result: action(?bool, ?Exception, ?str) -> None, env: Env, log_handler: logging.Handler, tags: set[str]):
+    def run_test(self, report_result: action(?bool, ?Exception, ?str) -> None, env: Env, log_handler: logging.Handler, tags: set[str], loop: ?PerfLoop=None):
         try:
-            self.fn(EnvT(report_result, env, log_handler, tags))
+            self.fn(EnvT(report_result, env, log_handler, tags, loop))
         except AbortTest:
             pass
 
@@ -606,7 +743,8 @@ class TestResult(object):
                  skipped: bool=False,
                  skip_reason: ?str=None,
                  gc_duration: float=0.0,
-                 counters: ?dict[str, float]=None):
+                 counters: ?dict[str, float]=None,
+                 loop_iterations: int=1):
         self.success = success
         self.skipped = skipped
         self.skip_reason = skip_reason
@@ -617,6 +755,7 @@ class TestResult(object):
         self.mem_usage_delta = mem_usage_delta
         self.non_gc_mem_usage_delta = non_gc_mem_usage_delta
         self.counters = counters
+        self.loop_iterations = loop_iterations
 
     def to_json(self):
         data = {
@@ -627,6 +766,7 @@ class TestResult(object):
             "output": self.output,
             "duration": self.duration,
             "gc_duration": self.gc_duration,
+            "loop_iterations": self.loop_iterations,
             "mem_usage_delta": self.mem_usage_delta,
             "non_gc_mem_usage_delta": self.non_gc_mem_usage_delta,
         }
@@ -656,6 +796,7 @@ class TestResult(object):
         gc_duration = data["gc_duration"] if "gc_duration" in data else 0.0
         mem_usage_delta = data["mem_usage_delta"]
         non_gc_mem_usage_delta = data["non_gc_mem_usage_delta"]
+        loop_iterations = data["loop_iterations"] if "loop_iterations" in data else 1
         counters: ?dict[str, float] = None
         if "counters" in data:
             raw_counters = data["counters"]
@@ -678,8 +819,9 @@ class TestResult(object):
             and isinstance(gc_duration, float)
             and isinstance(mem_usage_delta, int)
             and isinstance(non_gc_mem_usage_delta, int)
+            and isinstance(loop_iterations, int) and loop_iterations > 0
             ):
-            return TestResult(success, exception, output, duration, mem_usage_delta, non_gc_mem_usage_delta, skipped, skip_reason, gc_duration, counters)
+            return TestResult(success, exception, output, duration, mem_usage_delta, non_gc_mem_usage_delta, skipped, skip_reason, gc_duration, counters, loop_iterations)
         raise ValueError("Invalid TestResult JSON")
 
 
@@ -800,7 +942,7 @@ class TestInfo(object):
             self.max_duration = result.duration
             self.total_duration = result.duration
             self.avg_duration = result.duration
-            self.mem_usage_delta_avg = float(result.mem_usage_delta)
+            self.mem_usage_delta_avg = (float(result.mem_usage_delta) / float(result.loop_iterations))
             self.non_gc_mem_usage_delta_avg = float(result.non_gc_mem_usage_delta)
             self.non_gc_mem_inc_count = 1 if result.non_gc_mem_usage_delta > 0 else 0
         else:
@@ -810,7 +952,7 @@ class TestInfo(object):
                 self.max_duration = result.duration
             self.total_duration += result.duration
             self.avg_duration = self.total_duration / float(self.num_iterations)
-            self.mem_usage_delta_avg = (self.mem_usage_delta_avg * float(prev_iterations) + float(result.mem_usage_delta)) / float(self.num_iterations)
+            self.mem_usage_delta_avg = (self.mem_usage_delta_avg * float(prev_iterations) + (float(result.mem_usage_delta) / float(result.loop_iterations))) / float(self.num_iterations)
             self.non_gc_mem_usage_delta_avg = (self.non_gc_mem_usage_delta_avg * float(prev_iterations) + float(result.non_gc_mem_usage_delta)) / float(self.num_iterations)
             if result.non_gc_mem_usage_delta > 0:
                 self.non_gc_mem_inc_count += 1
@@ -896,7 +1038,7 @@ class TestInfo(object):
         stats: dict[str, value] = summarize("duration", "avg_duration", [r.duration for r in self.results])
         stats.update(summarize("wall_duration", "avg_wall_duration", [r.duration + r.gc_duration for r in self.results]).items())
         stats.update(summarize("gc_duration", "avg_gc_duration", [r.gc_duration for r in self.results]).items())
-        stats.update(summarize("mem_usage_delta", "mem_usage_delta_avg", [float(r.mem_usage_delta) for r in self.results]).items())
+        stats.update(summarize("mem_usage_delta", "mem_usage_delta_avg", [(float(r.mem_usage_delta) / float(r.loop_iterations)) for r in self.results]).items())
         stats.update(summarize("non_gc_mem_usage_delta", "non_gc_mem_usage_delta_avg", [float(r.non_gc_mem_usage_delta) for r in self.results]).items())
         for metric in ["cpu_user", "cpu_system", "instructions", "cycles", "ipc"]:
             samples: list[float] = []
@@ -1081,6 +1223,8 @@ class TestRunnerConfig(object):
     stress_workers: int
     output_enabled: bool
     tags: set[str]
+    time_ms: int
+    scale: int
 
     def __init__(self, perf_mode: bool, stress_mode: bool, args):
         def split_tags(tag_args: list[str]) -> set[str]:
@@ -1104,10 +1248,62 @@ class TestRunnerConfig(object):
         raw_max_time = args.get_int("max-time")
         if raw_max_time <= 0:
             self.max_time = 0.0
+        elif perf_mode:
+            self.max_time = float(raw_max_time) / 1000.0
         else:
             self.max_time = max([float(raw_max_time) / 1000.0, self.min_time])
         self.stress_workers = max([0, args.get_int("stress-workers")])
         self.tags = split_tags(args.get_strlist("tag"))
+        self.time_ms = args.get_int("time")
+        self.scale = args.get_int("scale")
+        if perf_mode and (self.time_ms <= 0 or self.scale < 0):
+            raise ValueError("Performance time must be positive and scale must be non-negative")
+
+class PerfRun(object):
+    """Calibrate once, then collect fresh invocations within one elapsed budget."""
+    calibration: list[dict[str, value]]
+
+    def __init__(self, time_ms: int, scale: int=0):
+        self.time_ms = time_ms
+        self.scale = max([1, scale])
+        self.loop = False
+        self.phase = "calibrate" if scale == 0 else "warmup"
+        self.warmup_duration_ms = 0.0
+        self.measurement_ms = 0.0
+        self.loop_iterations = 0
+        self.calibration = []
+        self._sw = time.Stopwatch()
+
+    def remaining_ms(self) -> float:
+        return max([0.0, float(self.time_ms) - self._sw.elapsed().to_float() * 1000.0])
+
+    def next_loop(self, samples: int) -> PerfLoop:
+        remaining = self.remaining_ms()
+        if self.phase == "calibrate":
+            return PerfLoop(1, self.scale, min([remaining, float(self.time_ms) / 3.0]), remaining, float(self.time_ms) / 10.0)
+        if self.phase == "warmup":
+            return PerfLoop(2, self.scale, min([remaining, float(self.time_ms) / 10.0]), remaining)
+        return PerfLoop(3, self.scale, remaining / float(max([1, 4 - samples])), remaining)
+
+    def observe(self, loop: PerfLoop, elapsed_ms: float, wall_ms: float) -> bool:
+        """Preparation never contributes a statistical sample."""
+        if self.phase == "calibrate":
+            self.scale = loop.scale if self.loop else 1
+            self.calibration = loop.calibration
+            self.phase = "warmup"
+            if not self.loop:
+                self.warmup_duration_ms = elapsed_ms
+                if elapsed_ms >= float(self.time_ms) / 10.0:
+                    self.phase = "measure"
+        elif self.phase == "warmup":
+            self.warmup_duration_ms = elapsed_ms
+            if self.warmup_duration_ms >= float(self.time_ms) / 10.0:
+                self.phase = "measure"
+        else:
+            self.measurement_ms += wall_ms
+            self.loop_iterations += loop.iterations if self.loop else 0
+            return True
+        return False
 
 class TimeoutError(Exception):
     pass
@@ -1154,6 +1350,10 @@ actor TestExecutor(syscap, config, t: Test, report_complete, report_progress, en
     var progress_report_sw = time.Stopwatch()
     var test_info = None
     var iteration = 0
+    var invocation = 0
+    var accepting_result = False
+    perf_run = PerfRun(config.time_ms, config.scale) if config.perf_mode else None
+    perf_phase_sw = time.Stopwatch()
     var stress_drift_rank = max([0, executor_id - stress_nodrift_workers])
     var stress_drift_workers = max([1, stress_workers - stress_nodrift_workers])
     var stress_last_drift_us = 0
@@ -1305,7 +1505,50 @@ actor TestExecutor(syscap, config, t: Test, report_complete, report_progress, en
         legacy_path = file.join_path([fs.cwd(), "test", "golden", module, test])
         return _read_expected(legacy_path)
 
-    action def _report_result(test: Test, sw, non_gc_mem_usage_before, gc_total_bytes_start, gc_time_start, counter_start, success: ?bool, exception: ?Exception, val: ?str):
+    def _emit_result(complete: bool):
+        measurement_duration_ms = perf_phase_sw.elapsed().to_float() * 1000.0
+        elapsed_ms = test_sw.elapsed().to_float() * 1000.0
+        if test_info is not None and config.output_enabled:
+            peak_rss = acton.rts.get_peak_rss(syscap) if config.perf_mode and complete else None
+            payload = test_info.to_json(include_perf=config.perf_mode and complete)
+            if peak_rss is not None:
+                payload["peak_rss"] = int(peak_rss)
+            if perf_run is not None:
+                payload["test_duration"] = elapsed_ms
+                payload["perf_phase"] = perf_run.phase
+                payload["loop_iterations"] = perf_run.loop_iterations
+                payload["perf_info"] = {
+                    "version": "3",
+                    "scale": perf_run.scale,
+                    "loop": perf_run.loop,
+                    "time_budget_ms": config.time_ms,
+                    "warmup_duration_ms": perf_run.warmup_duration_ms,
+                    "measurement_ms": perf_run.measurement_ms,
+                    "measurement_duration_ms": measurement_duration_ms if perf_run.phase == "measure" else 0.0,
+                    "calibration": perf_run.calibration,
+                    "workers": env.nr_wthreads,
+                    "gc": "natural",
+                }
+            print("\n" + json.encode({"test_info": payload}), err=True)
+        last_report.reset()
+
+    def _finish_budget():
+        if test_info is not None:
+            test_info.complete = True
+            test_info.test_duration = test_sw.elapsed().to_float() * 1000.0
+            if iteration == 0:
+                test_info.success = False
+                test_info.exception = "Performance time budget exhausted during preparation; increase --time"
+                test_info.num_failures = 1
+        _emit_result(True)
+        report_complete(executor_id, t, test_info)
+
+    action def _report_result(test: Test, invocation_id: int, loop: PerfLoop, sw, non_gc_mem_usage_before, gc_total_bytes_start, gc_time_start, counter_start, success: ?bool, exception: ?Exception, val: ?str):
+        # The executor accepts exactly one completion for the active invocation.
+        # Late callbacks cannot update a subsequent invocation's measurements.
+        if invocation_id != invocation or not accepting_result:
+            return
+        accepting_result = False
         full_dur = sw.elapsed().to_float() * 1000.0
         gc_time_end = acton.rts.get_gc_time(syscap).total
         gc_dur = float(gc_time_end - gc_time_start)
@@ -1314,16 +1557,19 @@ actor TestExecutor(syscap, config, t: Test, report_complete, report_progress, en
         mem_usage_delta = gc_total_bytes_end - gc_total_bytes_start
         counters = perf_delta(counter_start, acton.rts.perf_snapshot(syscap)) if counter_start is not None else None
         test_dur = test_sw.elapsed().to_float()
+        # Snapshot comparison is correctness work, outside the measured interval.
+        if val is not None:
+            exp_val = get_expected(test.module, test.display_name())
+            if exp_val is None or exp_val is not None and val != exp_val:
+                success = False
+                exception = NotEqualError(val, exp_val, "Test output does not match expected snapshot value.", diff_str=f"{term.normal}{diff.diff(str(exp_val), val, color=True)}", print_vals=False)
         if config.stress_mode and not config.perf_mode:
             _update_stress_timing_estimate(testiter_dur)
             if stress_calibrating:
                 stress_calib_samples += 1
                 if stress_calib_samples >= stress_calib_target_samples:
                     _finalize_stress_calibration()
-        if config.perf_mode:
-            acton.rts.gc(syscap)
-            acton.rts.gc(syscap)
-        non_gc_mem_usage_after = int(acton.rts.get_rss(syscap) - acton.rts.get_mem_usage(syscap))
+        non_gc_mem_usage_after = 0 if config.perf_mode else int(acton.rts.get_rss(syscap) - acton.rts.get_mem_usage(syscap))
         non_gc_mem_usage_delta = non_gc_mem_usage_after - non_gc_mem_usage_before
         #print(f"non-GC memory before: {non_gc_mem_usage_before}  after: {non_gc_mem_usage_after}  delta: {non_gc_mem_usage_delta}")
 
@@ -1336,11 +1582,70 @@ actor TestExecutor(syscap, config, t: Test, report_complete, report_progress, en
             success = True
             exception = None
 
+        loop_status = loop.status()
+        if success == True and exception is None and not skipped and loop_status in [1, 3]:
+            success = False
+            exception = ValueError("Benchmark loop must run to exhaustion")
+        if perf_run is not None:
+            if invocation == 1:
+                perf_run.loop = loop_status != 0
+                if not perf_run.loop:
+                    perf_run.scale = 1
+            elif success == True and exception is None and not skipped and (loop_status != 0) != perf_run.loop:
+                success = False
+                exception = ValueError("Call t.loop() consistently in every invocation")
+            if success == True and exception is None and not skipped and loop_status == 2 and loop.iterations == 0:
+                _finish_budget()
+                return
+
+        complete = config.perf_mode and (success != True or exception is not None)
+        if perf_run is not None and not complete and not skipped:
+            phase = perf_run.phase
+            wall_ms = float(loop._wall_ns) / 1000000.0 if perf_run.loop else full_dur
+            measured = perf_run.observe(loop, perf_phase_sw.elapsed().to_float() * 1000.0, wall_ms)
+            if phase != perf_run.phase and (perf_run.loop or perf_run.phase == "measure"):
+                perf_phase_sw.reset()
+            if not measured:
+                if perf_run.remaining_ms() > 0.0:
+                    if last_report.elapsed().to_float() > 0.05:
+                        _emit_result(False)
+                    after 0: _run_fn(test)
+                    return
+                success = False
+                exception = ValueError("Performance time budget exhausted during preparation; increase --time")
+                complete = True
+
+        if perf_run is not None and (complete or skipped):
+            # Failed or skipped invocations are outcomes, never timing samples.
+            if test_info is not None:
+                test_info.complete = True
+                test_info.success = success
+                test_info.skipped = skipped
+                test_info.skip_reason = skip_reason
+                test_info.exception = str(exception) if exception is not None else None
+                test_info.output = val
+                test_info.test_duration = test_dur * 1000.0
+                test_info.num_skipped += 1 if skipped else 0
+                test_info.num_failures += 1 if success == False else 0
+                test_info.num_errors += 1 if success is None else 0
+            _emit_result(True)
+            report_complete(executor_id, t, test_info)
+            return
+
+        loop_iterations = 1
+        if perf_run is not None and perf_run.loop:
+            loop_iterations = loop.iterations
+            gc_dur = float(loop._gc_ns) / 1000000.0 / float(loop_iterations)
+            testiter_dur = float(loop._wall_ns) / 1000000.0 / float(loop_iterations) - gc_dur
+            mem_usage_delta = int(loop._allocated_bytes)
+            counters = loop.counters()
+
         completed_iterations = iteration + 1
-        complete = False
         if skipped:
             complete = True
-        if config.stress_mode:
+        if perf_run is not None:
+            complete = perf_run.remaining_ms() <= 0.0 or (perf_run.loop and completed_iterations >= 4)
+        elif config.stress_mode:
             if config.max_time > 0.0 and test_dur > config.max_time:
                 complete = True
             if config.max_iter > 0 and completed_iterations >= config.max_iter:
@@ -1355,19 +1660,12 @@ actor TestExecutor(syscap, config, t: Test, report_complete, report_progress, en
 
         if test_info is not None:
             exc = str(exception) if exception is not None else None
-            test_info.update(complete, TestResult(success, exc, val, testiter_dur, mem_usage_delta, non_gc_mem_usage_delta, skipped=skipped, skip_reason=skip_reason, gc_duration=gc_dur, counters=counters), test_dur*1000.0)
+            test_info.update(complete, TestResult(success, exc, val, testiter_dur, mem_usage_delta, non_gc_mem_usage_delta, skipped=skipped, skip_reason=skip_reason, gc_duration=gc_dur, counters=counters, loop_iterations=loop_iterations), test_dur*1000.0)
             if config.stress_mode and not config.perf_mode and executor_id >= stress_nodrift_workers:
                 _maybe_refine_stress_phase(test_info.num_iterations)
         iteration = completed_iterations
         if last_report.elapsed().to_float() > 0.05 or complete:
-            if test_info is not None and config.output_enabled:
-                # Capture the process peak before allocating the final summary.
-                peak_rss = acton.rts.get_peak_rss(syscap) if config.perf_mode and complete else None
-                payload = test_info.to_json(include_perf=config.perf_mode and complete)
-                if peak_rss is not None:
-                    payload["peak_rss"] = int(peak_rss)
-                print("\n" + json.encode({"test_info": payload}), err=True)
-            last_report.reset()
+            _emit_result(complete)
         if config.stress_mode and (iteration == 1 or iteration % 32 == 0 or progress_report_sw.elapsed().to_float() > 0.08 or complete):
             report_progress(executor_id,
                             iteration,
@@ -1386,42 +1684,43 @@ actor TestExecutor(syscap, config, t: Test, report_complete, report_progress, en
             report_complete(executor_id, t, test_info)
 
     def _run_fn(t: Test):
+        if perf_run is not None and perf_run.remaining_ms() <= 0.0:
+            _finish_budget()
+            return
         _stress_drift_delay()
-        print("\n== Running test, iteration:", iteration)
-        print("\n== Running test, iteration:", iteration, err=True)
-        # Run GC to get accurate memory usage
-        if config.perf_mode:
-            acton.rts.gc(syscap)
-            acton.rts.gc(syscap)
-        non_gc_mem_usage_before = int(acton.rts.get_rss(syscap) - acton.rts.get_mem_usage(syscap))
+        invocation += 1
+        invocation_id = invocation
+        accepting_result = True
+        print("\n== Running test, iteration:", invocation_id)
+        print("\n== Running test, iteration:", invocation_id, err=True)
+        non_gc_mem_usage_before = 0 if config.perf_mode else int(acton.rts.get_rss(syscap) - acton.rts.get_mem_usage(syscap))
+        loop = perf_run.next_loop(iteration) if perf_run is not None else PerfLoop()
         counter_start = acton.rts.perf_snapshot(syscap) if config.perf_mode else None
         gc_total_bytes_start = int(acton.rts.get_gc_total_bytes(syscap))
         gc_time_start = acton.rts.get_gc_time(syscap).total
         sw = time.Stopwatch()
 
         def repres(s: ?bool, e: ?Exception, val: ?str) -> None:
-            # Compare expected snapshot value
-            if val is not None:
-                exp_val = get_expected(t.module, t.display_name())
-                if exp_val is None or exp_val is not None and val != exp_val:
-                    exc = NotEqualError(val, exp_val, f"Test output does not match expected snapshot value.", diff_str=f"{term.normal}{diff.diff(str(exp_val), val, color=True)}", print_vals=False)
-                    _report_result(t, sw, non_gc_mem_usage_before, gc_total_bytes_start, gc_time_start, counter_start, False, exc, val)
-                    return
-            _report_result(t, sw, non_gc_mem_usage_before, gc_total_bytes_start, gc_time_start, counter_start, s, e, val)
+            _report_result(t, invocation_id, loop, sw, non_gc_mem_usage_before, gc_total_bytes_start, gc_time_start, counter_start, s, e, val)
 
+        loop._report_result = repres
+        report = loop._report
         try:
-            t.run(repres, env, log_handler, config.tags)
+            t.run(report, env, log_handler, config.tags, loop)
         except SkipTest as e:
-            _report_result(t, sw, non_gc_mem_usage_before, gc_total_bytes_start, gc_time_start, counter_start, True, e, None)
+            report(True, e, None)
         except AssertionError as e:
-            _report_result(t, sw, non_gc_mem_usage_before, gc_total_bytes_start, gc_time_start, counter_start, False, e, None)
+            report(False, e, None)
         except Exception as e:
-            _report_result(t, sw, non_gc_mem_usage_before, gc_total_bytes_start, gc_time_start, counter_start, None, e, None)
+            report(None, e, None)
 
     def _run_test():
         """Get the next available test and run it"""
         test_sw = time.Stopwatch()
         test_info = TestInfo(t, counter_info=acton.rts.perf_info(syscap) if config.perf_mode else None)
+        perf_phase_sw.reset()
+        if perf_run is not None:
+            perf_run._sw.reset()
         _run_fn(t)
 
     after 0: _run_test()
@@ -1814,8 +2113,8 @@ actor test_runner(env: Env,
         test_timeout = 0.0
         if config.max_time > 0:
             test_timeout = max([config.max_time, 2.0]) + _stress_timeout_slack_s()
-            if config.perf_mode:
-                test_timeout = max([test_timeout, 300.0])
+        if config.perf_mode:
+            test_timeout = max([300.0, float(config.time_ms) / 1000.0 + 2.0])
 
         test_name = args.get_str("name")
         if test_name not in all_tests:
@@ -2105,6 +2404,8 @@ actor test_runner(env: Env,
         tp.add_option("min-iter", "int", default=3, help="Minumum number of iterations to run")
         tp.add_option("max-time", "int", default=1000, help="Maximum time to run a test in milliseconds (0 = no time limit)")
         tp.add_option("min-time", "int", default=50, help="Minimum time to run a test in milliseconds")
+        tp.add_option("time", "int", default=5000, help="Total performance budget in milliseconds")
+        tp.add_option("scale", "int", default=0, help="Performance workload scale (0 = calibrate)")
         tp.add_option("stress-workers", "int", default=0, help="Concurrent stress workers to run (0 = auto)")
         tp.add_option("tag", "strlist", default=[], help="Enable test capability tag")
         pp = tp.add_cmd("perf", "Performance benchmark tests", _run_perf_tests)

--- a/base/src/testing.ext.c
+++ b/base/src/testing.ext.c
@@ -1,0 +1,217 @@
+#include <uv.h>
+
+#include "rts/perf.h"
+
+enum {
+    TESTING_LOOP_CLAIMED = 1,
+    TESTING_LOOP_STARTED = 2,
+    TESTING_LOOP_EXHAUSTED = 4,
+    TESTING_LOOP_CLOSED = 8,
+    TESTING_LOOP_INVALID = 16,
+    TESTING_LOOP_BUSY = 32
+};
+
+void testingQ___ext_init__() {}
+
+static void testing_loop_invalid(testingQ_PerfLoop self, const char *message) {
+    uint64_t state = __atomic_load_n(&self->_state, __ATOMIC_ACQUIRE);
+    while (!(state & TESTING_LOOP_CLOSED) &&
+           !__atomic_compare_exchange_n(&self->_state, &state,
+                                        state | TESTING_LOOP_INVALID, false,
+                                        __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)) {}
+    $RAISE((B_BaseException)B_ValueErrorG_new(to$str((char *)message)));
+}
+
+testingQ_PerfLoop testingQ_PerfLoopD_claim(testingQ_PerfLoop self) {
+    uint64_t state = 0;
+    if (!__atomic_compare_exchange_n(&self->_state, &state,
+                                     TESTING_LOOP_CLAIMED, false,
+                                     __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE))
+        testing_loop_invalid(self, "Use t.loop() once per test invocation");
+    return self;
+}
+
+static void testing_loop_start(testingQ_PerfLoop self) {
+    if (self->_phase == 0)
+        return;
+    if (self->_phase != 3) {
+        self->_start_wall_ns = uv_hrtime();
+        return;
+    }
+    struct rts_perf_sample sample;
+    rts_perf_read(&sample);
+    self->_start_cpu_valid = sample.cpu_available;
+    self->_start_hardware_valid = sample.hardware_available;
+    self->_start_user_ns = sample.user_ns;
+    self->_start_system_ns = sample.system_ns;
+    self->_start_instructions = sample.instructions;
+    self->_start_cycles = sample.cycles;
+    self->_start_instructions_enabled = sample.instructions_enabled;
+    self->_start_instructions_running = sample.instructions_running;
+    self->_start_cycles_enabled = sample.cycles_enabled;
+    self->_start_cycles_running = sample.cycles_running;
+    self->_start_gc_ms = GC_get_full_gc_total_time();
+    self->_start_alloc = GC_get_total_bytes();
+    self->_start_wall_ns = uv_hrtime();
+}
+
+static bool testing_loop_covered(uint64_t start_enabled, uint64_t start_running,
+                                 uint64_t enabled, uint64_t running) {
+    return enabled >= start_enabled && running > start_running &&
+           enabled - start_enabled == running - start_running;
+}
+
+static bool testing_loop_end(testingQ_PerfLoop self) {
+    if (self->_phase == 0)
+        return true;
+    uint64_t wall_ns = uv_hrtime() - self->_start_wall_ns;
+    self->_last_wall_ns = wall_ns;
+    if (self->_phase != 3)
+        return true;
+    uint64_t allocated = GC_get_total_bytes();
+    uint64_t gc_ms = GC_get_full_gc_total_time();
+    struct rts_perf_sample sample;
+    rts_perf_read(&sample);
+    if (allocated < self->_start_alloc || gc_ms < self->_start_gc_ms)
+        return false;
+    self->_wall_ns += wall_ns;
+    self->_gc_ns += (gc_ms - self->_start_gc_ms) * 1000000;
+    self->_allocated_bytes += allocated - self->_start_alloc;
+    if (self->_start_cpu_valid && sample.cpu_available &&
+        sample.user_ns >= self->_start_user_ns &&
+        sample.system_ns >= self->_start_system_ns) {
+        self->_user_ns += sample.user_ns - self->_start_user_ns;
+        self->_system_ns += sample.system_ns - self->_start_system_ns;
+    } else {
+        self->_cpu_valid = false;
+    }
+    if (self->_start_hardware_valid && sample.hardware_available &&
+        sample.instructions >= self->_start_instructions &&
+        sample.cycles >= self->_start_cycles &&
+        testing_loop_covered(self->_start_instructions_enabled,
+                             self->_start_instructions_running,
+                             sample.instructions_enabled, sample.instructions_running) &&
+        testing_loop_covered(self->_start_cycles_enabled, self->_start_cycles_running,
+                             sample.cycles_enabled, sample.cycles_running)) {
+        self->_instructions += sample.instructions - self->_start_instructions;
+        self->_cycles += sample.cycles - self->_start_cycles;
+    } else {
+        self->_hardware_valid = false;
+    }
+    return true;
+}
+
+static void testing_loop_batch(testingQ_PerfLoop self, uint64_t completed) {
+    if (self->_phase < 2) {
+        self->_batch_size = 1;
+        return;
+    }
+    uint64_t duration = self->_last_wall_ns ? self->_last_wall_ns : 1;
+    uint64_t count = completed * 1000000 / duration;
+    if (count < 1)
+        count = 1;
+    if (count > completed * 4)
+        count = completed * 4;
+    if (count > 1048576)
+        count = 1048576;
+    self->_batch_size = count;
+}
+
+B_int testingQ_PerfLoopD___next__(testingQ_PerfLoop self) {
+    uint64_t state = __atomic_load_n(&self->_state, __ATOMIC_ACQUIRE);
+    for (;;) {
+        if (!(state & TESTING_LOOP_CLAIMED) ||
+            (state & (TESTING_LOOP_CLOSED | TESTING_LOOP_INVALID | TESTING_LOOP_BUSY))) {
+            testing_loop_invalid(self, "Cannot advance a closed or concurrent t.loop()");
+            return NULL;
+        }
+        if (state & TESTING_LOOP_EXHAUSTED) {
+            $RAISE((B_BaseException)B_StopIterationG_new(to$str("t.loop() exhausted")));
+            return NULL;
+        }
+        if (__atomic_compare_exchange_n(&self->_state, &state,
+                                         state | TESTING_LOOP_BUSY, false,
+                                         __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE))
+            break;
+    }
+    // Fast iterations reuse the scale box and do no timing or policy work.
+    if ((state & TESTING_LOOP_STARTED) && self->_batch_left > 0) {
+        self->_batch_left--;
+        B_int scale = self->_yield_scale;
+        __atomic_fetch_and(&self->_state, ~((uint64_t)TESTING_LOOP_BUSY), __ATOMIC_RELEASE);
+        return scale;
+    }
+
+    uint64_t completed = (state & TESTING_LOOP_STARTED) ? self->_batch_size : 0;
+    // $PUSH allocates its exception frame, so stop measurement before it.
+    bool counters_valid = completed ? testing_loop_end(self) : true;
+    B_int scale = NULL;
+    if ($PUSH()) {
+        if (!counters_valid)
+            testing_loop_invalid(self, "Runtime counters decreased during t.loop()");
+        if (completed)
+            testing_loop_batch(self, completed);
+        scale = testingQ_PerfLoopD__advance(self, (int64_t)completed);
+        uint64_t current = __atomic_load_n(&self->_state, __ATOMIC_ACQUIRE);
+        if (current & (TESTING_LOOP_CLOSED | TESTING_LOOP_INVALID))
+            testing_loop_invalid(self, "t.loop() completed while being advanced");
+        if (scale) {
+            self->_yield_scale = scale;
+            self->_batch_left = self->_batch_size - 1;
+            testing_loop_start(self);
+            __atomic_fetch_or(&self->_state, TESTING_LOOP_STARTED, __ATOMIC_RELEASE);
+        } else {
+            __atomic_fetch_or(&self->_state, TESTING_LOOP_EXHAUSTED, __ATOMIC_RELEASE);
+        }
+        $DROP();
+    } else {
+        B_BaseException exception = $POP();
+        __atomic_fetch_or(&self->_state, TESTING_LOOP_INVALID, __ATOMIC_RELAXED);
+        __atomic_fetch_and(&self->_state, ~((uint64_t)TESTING_LOOP_BUSY), __ATOMIC_RELEASE);
+        $RAISE(exception);
+        return NULL;
+    }
+    __atomic_fetch_and(&self->_state, ~((uint64_t)TESTING_LOOP_BUSY), __ATOMIC_RELEASE);
+    if (!scale)
+        $RAISE((B_BaseException)B_StopIterationG_new(to$str("t.loop() exhausted")));
+    return scale;
+}
+
+B_NoneType testingQ_PerfLoopD_close(testingQ_PerfLoop self) {
+    uint64_t state = __atomic_load_n(&self->_state, __ATOMIC_ACQUIRE);
+    for (;;) {
+        uint64_t closed = state | TESTING_LOOP_CLOSED;
+        if (state & TESTING_LOOP_BUSY)
+            closed |= TESTING_LOOP_INVALID;
+        if (__atomic_compare_exchange_n(&self->_state, &state, closed, false,
+                                         __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE))
+            break;
+    }
+    // Only boundary work holds BUSY. Workload bodies never hold this gate.
+    while (__atomic_load_n(&self->_state, __ATOMIC_ACQUIRE) & TESTING_LOOP_BUSY)
+        uv_sleep(0);
+    return B_None;
+}
+
+B_Msg testingQ_PerfLoopD__report(testingQ_PerfLoop self, B_bool success,
+                                B_Exception exception, B_str output) {
+    testingQ_PerfLoopD_close(self);
+    $action report = self->_report_result;
+    if (!report) {
+        testing_loop_invalid(self, "No test result callback for this loop");
+        return NULL;
+    }
+    return ((B_Msg (*)($action, B_bool, B_Exception, B_str))report->$class->__asyn__)
+        (report, success, exception, output);
+}
+
+int64_t testingQ_PerfLoopD_status(testingQ_PerfLoop self) {
+    uint64_t state = __atomic_load_n(&self->_state, __ATOMIC_ACQUIRE);
+    if (state & TESTING_LOOP_INVALID)
+        return 3;
+    if (state & TESTING_LOOP_EXHAUSTED)
+        return 2;
+    if (state & TESTING_LOOP_CLAIMED)
+        return 1;
+    return 0;
+}

--- a/compiler/acton/PerfTests.hs
+++ b/compiler/acton/PerfTests.hs
@@ -33,6 +33,7 @@ perfTests = testGroup "performance baselines"
       opts <- parsePerfOptions []
       assertEqual "release by default" C.ReleaseFast (C.optimize (C.testCompile opts))
       assertEqual "five seconds per benchmark" 5000 (C.testTime opts)
+      assertEqual "scale is calibrated by default" Nothing (C.testScale opts)
       explicit <- parsePerfOptions ["--optimize", "Debug", "--time", "250ms"]
       assertEqual "explicit debug remains available" C.Debug (C.optimize (C.testCompile explicit))
       assertEqual "milliseconds are accepted" 250 (C.testTime explicit)
@@ -42,10 +43,20 @@ perfTests = testGroup "performance baselines"
         case parseOptions ["test", "perf", "--time", duration] of
           O.Failure _ -> return ()
           _ -> assertFailure ("--time must reject " ++ duration)
-      forM_ ["--iter", "--min-iter", "--max-iter", "--min-time", "--max-time", "--warmup", "--scale"] $ \option ->
+      forM_ ["--iter", "--min-iter", "--max-iter", "--min-time", "--max-time", "--warmup"] $ \option ->
         case parseOptions ["test", "perf", option, "1"] of
           O.Failure _ -> return ()
           _ -> assertFailure ("perf must reject " ++ option)
+      forM_ [1, 50000, maxBound :: Int] $ \scale ->
+        assertEqual "positive workload scales are accepted" (Just scale) . C.testScale =<< parsePerfOptions ["--scale", show scale]
+      forM_ ["0", "-1", "1.5", show (toInteger (maxBound :: Int) + 1)] $ \scale ->
+        case parseOptions ["test", "perf", "--scale", scale] of
+          O.Failure _ -> return ()
+          _ -> assertFailure ("--scale must reject " ++ scale)
+      forM_ [[], ["stress"]] $ \mode ->
+        case parseOptions (["test"] ++ mode ++ ["--scale", "1"]) of
+          O.Failure _ -> return ()
+          _ -> assertFailure ("--scale must reject mode " ++ show mode)
       case parseOptions ["test"] of
         O.Success (C.CmdOpt _ (C.Test (C.TestRun normal))) -> assertEqual "ordinary tests keep debug" C.Debug (C.optimize (C.testCompile normal))
         _ -> assertFailure "ordinary test options failed to parse"
@@ -59,14 +70,14 @@ perfTests = testGroup "performance baselines"
         _ -> assertFailure "stress test limits failed to parse"
   , testCase "global options can appear throughout performance commands" $ do
       forM_
-        [ ["test", "--color", "never", "perf", "--time", "100ms", "--name", "sample"]
-        , ["test", "perf", "--color", "never", "--time", "100ms", "--name", "sample"]
-        , ["test", "perf", "--time", "100ms", "--color", "never", "--name", "sample"]
-        , ["test", "perf", "--time", "100ms", "--name", "sample", "--color", "never"]
+        [ ["test", "--color", "never", "perf", "--time", "100ms", "--scale", "7", "--name", "sample"]
+        , ["test", "perf", "--color", "never", "--time", "100ms", "--scale", "7", "--name", "sample"]
+        , ["test", "perf", "--time", "100ms", "--scale", "7", "--color", "never", "--name", "sample"]
+        , ["test", "perf", "--time", "100ms", "--scale", "7", "--name", "sample", "--color", "never"]
         ] $ \args -> case parseOptions args of
           O.Success (C.CmdOpt globals (C.Test (C.TestPerf opts))) -> do
             assertEqual (unwords args) C.Never (C.color globals)
-            assertEqual "performance options survive global options" (100, ["sample"]) (C.testTime opts, C.testNames opts)
+            assertEqual "performance options survive global options" (100, Just 7, ["sample"]) (C.testTime opts, C.testScale opts, C.testNames opts)
           O.Failure failure -> assertFailure (fst (O.renderFailure failure "acton"))
           _ -> assertFailure ("unexpected command: " ++ unwords args)
       case parseOptions ["test", "--quiet", "perf", "--time", "100ms", "--jobs", "2", "--name", "sample", "--no-progress", "--tag", "input"] of
@@ -80,13 +91,14 @@ perfTests = testGroup "performance baselines"
           assertEqual "stress options also mix with global options" (C.Never, 2, ["sample"]) (C.color globals, C.testIter opts, C.testNames opts)
         O.Failure failure -> assertFailure (fst (O.renderFailure failure "acton"))
         _ -> assertFailure "expected stress options"
-  , testCase "performance help exposes only the supported budget control" $
+  , testCase "performance help exposes time and workload scale controls" $
       case parseOptions ["test", "perf", "--help"] of
         O.Failure failure -> do
           let (text, code) = O.renderFailure failure "acton"
           assertEqual text ExitSuccess code
           assertBool text ("--time DURATION" `isInfixOf` unwords (words text))
-          assertBool text (not (any (`isInfixOf` text) ["--iter", "--min-time", "--max-time", "--warmup", "--scale"]))
+          assertBool text ("--scale N" `isInfixOf` unwords (words text))
+          assertBool text (not (any (`isInfixOf` text) ["--iter", "--min-time", "--max-time", "--warmup"]))
         _ -> assertFailure "expected performance help"
   , testCase "all metrics require the same complete performance identity" $ do
       let old = sample 10 0 10
@@ -382,6 +394,9 @@ perfTests = testGroup "performance baselines"
           , "actor _test_second(t: testing.AsyncT):"
           , "    t.success()"
           , ""
+          , "def _test_snapshot() -> str:"
+          , "    return \"snapshot value\""
+          , ""
           , "actor _test_failed(t: testing.AsyncT):"
           , "    t.failure(ValueError(\"expected failure\"))"
           , ""
@@ -472,6 +487,12 @@ perfTests = testGroup "performance baselines"
           ]
         _ <- runOK ["--name", "counter_activation"]
         environment <- getEnvironment
+        let runLoop budget expected args = do
+              (code, out, err) <- readCreateProcessWithExitCode
+                (proc acton (["test", "perf", "--time", budget, "--name", "looped", "--json"] ++ args))
+                  { cwd = Just proj, env = Just (("ACTON_PERF_EXPECT_SCALE", expected) : filter ((/= "ACTON_PERF_EXPECT_SCALE") . fst) environment) } ""
+              assertEqual (out ++ err) ExitSuccess code
+              singleJsonTest out >>= requireObject "performance"
         (ordinaryCode, ordinaryOut, ordinaryErr) <- readCreateProcessWithExitCode
           (proc acton ["test", "--iter", "1", "--name", "counter_activation", "--no-cache"])
             { cwd = Just proj, env = Just (("ACTON_TEST_PERF", "1") : filter ((/= "ACTON_TEST_PERF") . fst) environment) } ""
@@ -563,14 +584,25 @@ perfTests = testGroup "performance baselines"
         assertEqual "unavailable old measurements survive recording"
           (M.lookup "missing" saved) (M.lookup "missing" updated)
         updatedBytes <- BL.readFile baseline
-        (failedCode, failedOut, _) <- run ["--record", "--name", "failed", "--json"]
+        (failedCode, failedOut, _) <- run ["--record", "--name", "failed", "--json", "--scale", "50000"]
         assertBool "failing test exits unsuccessfully" (failedCode /= ExitSuccess)
         failed <- singleJsonTest failedOut
         assertEqual "an initial failure aborts before any measured sample" (Just (Aeson.Number 0)) (KM.lookup "iterations" failed)
         assertEqual "failed preparation produces no performance measurement" (Just Aeson.Null) (KM.lookup "performance" failed)
-        _ <- runOK ["--record", "--name", "skipped"]
+        assertBool "explicit scale preserves the original failure" ("expected failure" `isInfixOf` failedOut && not ("Explicit --scale" `isInfixOf` failedOut))
+        skippedOut <- runOK ["--record", "--name", "skipped", "--json", "--scale", "50000"]
+        skipped <- singleJsonTest skippedOut
+        assertEqual "explicit scale preserves skips" (Just (Aeson.Bool True)) (KM.lookup "skipped" skipped)
+        assertBool skippedOut ("expected skip" `isInfixOf` skippedOut && not ("Explicit --scale" `isInfixOf` skippedOut))
+        forM_ [("first", []), ("snapshot", ["--accept"])] $ \(test, args) -> do
+          (noLoopCode, noLoopOut, noLoopErr) <- run (["--record", "--name", test, "--json", "--scale", "50000"] ++ args)
+          assertBool (noLoopOut ++ noLoopErr) (noLoopCode /= ExitSuccess)
+          noLoop <- singleJsonTest noLoopOut
+          assertEqual "scale rejection stays failed after snapshot acceptance" (Just (Aeson.String "FAIL")) (KM.lookup "status" noLoop)
+          assertEqual "explicit scale on a whole invocation has no performance report" (Just Aeson.Null) (KM.lookup "performance" noLoop)
+          assertBool noLoopOut ("Explicit --scale requires a test that uses t.loop()" `isInfixOf` noLoopOut)
         _ <- runOK ["--record", "--name", "absent"]
-        assertEqual "failed, skipped and empty selections preserve the baseline" updatedBytes =<< BL.readFile baseline
+        assertEqual "failed, skipped, incompatible and empty selections preserve the baseline" updatedBytes =<< BL.readFile baseline
         let invalidate (Aeson.Object obj) = Aeson.Object (KM.insert "success" (Aeson.Bool False) obj)
             invalidate raw = raw
             failedReference = M.adjust (M.adjust invalidate "_test_first_wrapper") "perf_record.sample" updated
@@ -593,23 +625,25 @@ perfTests = testGroup "performance baselines"
         duration <- requireNumber "duration_ms" slow
         assertBool "the slow invocation completed past the former watchdog" (duration >= 3000)
         assertBool slowOut (not ("TimeoutError" `isInfixOf` slowOut))
-        loopedOut <- runOK ["--record", "--name", "looped", "--json", "--tag", "beta, alpha", "--tag", "alpha"]
-        looped <- singleJsonTest loopedOut >>= requireObject "performance" >>= requireObject "measurements"
+        looped <- runLoop "100ms" "50000" ["--record", "--scale", "50000", "--tag", "beta, alpha", "--tag", "alpha"] >>= requireObject "measurements"
         loopedInfo <- requireObject "perf_info" looped
         assertEqual "author opted into loop measurement" (Just (Aeson.Bool True)) (KM.lookup "loop" loopedInfo)
-        scale <- requireNumber "scale" loopedInfo
-        assertBool "calibration chooses a positive scale" (scale >= 1)
+        assertEqual "explicit scale reaches every yield without a baseline" (Just (Aeson.Number 50000)) (KM.lookup "scale" loopedInfo)
+        assertEqual "explicit scale skips calibration" (Just (Aeson.toJSON ([] :: [Aeson.Value]))) (KM.lookup "calibration" loopedInfo)
+        assertEqual "explicit scale retains the requested time budget" (Just (Aeson.Number 100)) (KM.lookup "time_budget_ms" loopedInfo)
+        warmup <- requireNumber "warmup_duration_ms" loopedInfo
+        assertBool "explicit scale retains warmup" (warmup > 0)
         samples <- requireNumber "num_iterations" looped
         bodies <- requireNumber "loop_iterations" looped
         assertBool "loop samples are complete invocation averages" (samples >= 1 && samples <= 4)
         assertBool "loop bodies are counted separately from statistical samples" (bodies >= samples)
-        case KM.lookup "calibration" loopedInfo of
-          Just (Aeson.Array _) -> return ()
-          _ -> assertFailure "missing calibration observations"
         assertEqual "tags match actual capability parsing" (Just (Aeson.toJSON (["alpha", "beta"] :: [String]))) (KM.lookup "tags" loopedInfo)
         helperOut <- runOK ["--name", "helper_workload", "--json"]
         helperInfo <- singleJsonTest helperOut >>= requireObject "performance" >>= requireObject "measurements" >>= requireObject "perf_info"
         assertEqual "a helper actor can exhaust the loop before reporting completion" (Just (Aeson.Bool True)) (KM.lookup "loop" helperInfo)
+        case KM.lookup "calibration" helperInfo of
+          Just (Aeson.Array observations) -> assertBool "automatic scale records calibration observations" (not (null observations))
+          _ -> assertFailure "missing calibration observations"
         lateOut <- runOK ["--name", "late_loop", "--json"]
         lateInfo <- singleJsonTest lateOut >>= requireObject "performance" >>= requireObject "measurements" >>= requireObject "perf_info"
         assertEqual "late loop requests and duplicate completions cannot change measurement identity"
@@ -633,7 +667,7 @@ perfTests = testGroup "performance baselines"
               assertBool "loop validation preserves the original failure"
                 (not ("Benchmark loop must run to exhaustion" `isInfixOf` out))
         (timedCode, timedOut, timedErr) <- readCreateProcessWithExitCode
-          (proc acton ["test", "perf", "--time", "200ms", "--name", "timed_body", "--json"])
+          (proc acton ["test", "perf", "--time", "1s", "--scale", "1", "--name", "timed_body", "--json"])
             { cwd = Just proj } ""
         assertEqual (timedOut ++ timedErr) ExitSuccess timedCode
         timed <- singleJsonTest timedOut >>= requireObject "performance" >>= requireObject "measurements"
@@ -647,22 +681,26 @@ perfTests = testGroup "performance baselines"
         -- Machines without a usable identity intentionally cannot reuse a
         -- recording. The pure tests above cover that contract independently.
         when (hasMachine loopedInfo) $ do
-          recorded <- readBaseline
-          let setScale (Aeson.Object obj) = Aeson.Object (changeIdentity "scale" (Aeson.Number 7) obj)
-              setScale raw = raw
-              fixed = M.adjust (M.adjust setScale "_test_looped_wrapper") "perf_record.sample" recorded
-          BL.writeFile baseline (Aeson.encode fixed)
-          (reuseCode, reuseOut, reuseErr) <- readCreateProcessWithExitCode
-            (proc acton ["test", "perf", "--time", "200ms", "--name", "looped", "--json", "--tag", "alpha,beta"])
-              { cwd = Just proj, env = Just (("ACTON_PERF_EXPECT_SCALE", "7") : filter ((/= "ACTON_PERF_EXPECT_SCALE") . fst) environment) } ""
-          assertEqual (reuseOut ++ reuseErr) ExitSuccess reuseCode
-          reused <- singleJsonTest reuseOut >>= requireObject "performance"
-          assertEqual "different time budgets remain comparable" (Just Aeson.Null) (KM.lookup "comparison_unavailable_reason" reused)
+          fixed <- BL.readFile baseline
+          same <- runLoop "200ms" "50000" ["--scale", "50000", "--tag", "alpha,beta"]
+          assertEqual "the same explicit scale remains comparable across budgets" (Just Aeson.Null) (KM.lookup "comparison_unavailable_reason" same)
+          sameInfo <- requireObject "measurements" same >>= requireObject "perf_info"
+          assertEqual "the new budget is retained as provenance" (Just (Aeson.Number 200)) (KM.lookup "time_budget_ms" sameInfo)
+          different <- runLoop "200ms" "25000" ["--scale", "25000", "--tag", "alpha,beta"]
+          assertEqual "explicit scale overrides the recorded scale" (Just (Aeson.String "workload scale differs")) (KM.lookup "comparison_unavailable_reason" different)
+          assertEqual "different workloads have no confidence interval" (Just Aeson.Null) (KM.lookup "mean_difference_ci95_ms" different)
+          differentInfo <- requireObject "measurements" different >>= requireObject "perf_info"
+          assertEqual "the requested workload is measured" (Just (Aeson.Number 25000)) (KM.lookup "scale" differentInfo)
+          assertEqual "comparison leaves the baseline intact" fixed =<< BL.readFile baseline
+          _ <- runLoop "200ms" "25000" ["--record", "--scale", "25000", "--tag", "alpha,beta"]
+          replaced <- BL.readFile baseline
+          assertBool "recording replaces the workload scale" (replaced /= fixed)
+          reused <- runLoop "100ms" "25000" ["--tag", "alpha,beta"]
+          assertEqual "the replacement baseline is comparable by default" (Just Aeson.Null) (KM.lookup "comparison_unavailable_reason" reused)
           reusedInfo <- requireObject "measurements" reused >>= requireObject "perf_info"
-          assertEqual "recorded scale reaches every loop body" (Just (Aeson.Number 7)) (KM.lookup "scale" reusedInfo)
+          assertEqual "recorded scale reaches every loop body" (Just (Aeson.Number 25000)) (KM.lookup "scale" reusedInfo)
           assertEqual "reused scale skips calibration" (Just (Aeson.toJSON ([] :: [Aeson.Value]))) (KM.lookup "calibration" reusedInfo)
-          assertEqual "the new budget is retained as provenance" (Just (Aeson.Number 200)) (KM.lookup "time_budget_ms" reusedInfo)
-          assertEqual "comparison leaves the seeded baseline intact" (Aeson.encode fixed) =<< BL.readFile baseline
+          assertEqual "default reuse leaves the new baseline intact" replaced =<< BL.readFile baseline
   , testCase "record requires performance mode" $ do
       acton <- canonicalizePath "../../dist/bin/acton"
       forM_ [[], ["stress"], ["list"]] $ \mode -> do

--- a/compiler/acton/PerfTests.hs
+++ b/compiler/acton/PerfTests.hs
@@ -2,9 +2,14 @@
 module PerfTests (perfTests) where
 
 import Control.Monad
+import qualified Acton.CommandLineParser as C
+import qualified Options.Applicative as O
 import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Types as AesonTypes
+import qualified Data.Aeson.Key as AesonKey
 import qualified Data.Aeson.KeyMap as KM
 import qualified Data.ByteString.Lazy as BL
+import qualified Data.ByteString.Lazy.Char8 as BL8
 import Data.List (isInfixOf, isSuffixOf, find, elemIndices)
 import TerminalSize (termVisibleLength, termFitAnsiRight, termRenderedRows)
 import qualified Data.Map as M
@@ -20,13 +25,139 @@ import Test.Tasty.HUnit
 import qualified Acton.Fingerprint as Fingerprint
 import Acton.Testing (TestResult(..))
 import TestFormat (formatTestPerfLines)
-import TestPerf (perfComparable, perfMeanInterval, perfJson)
+import TestPerf (perfComparable, perfComparisonReason, perfBaselineScale, perfMeanInterval, perfJson)
 
 perfTests :: TestTree
 perfTests = testGroup "performance baselines"
-  [ testCase "timing and allocation changes use the recorded measurement" $ do
-      let old = KM.fromList [("avg_duration", Aeson.Number 10), ("mem_usage_delta_avg", Aeson.Number 100)]
-          new = KM.fromList [("avg_duration", Aeson.Number 12), ("mem_usage_delta_avg", Aeson.Number 50)]
+  [ testCase "performance defaults use release and one total time budget" $ do
+      opts <- parsePerfOptions []
+      assertEqual "release by default" C.ReleaseFast (C.optimize (C.testCompile opts))
+      assertEqual "five seconds per benchmark" 5000 (C.testTime opts)
+      explicit <- parsePerfOptions ["--optimize", "Debug", "--time", "250ms"]
+      assertEqual "explicit debug remains available" C.Debug (C.optimize (C.testCompile explicit))
+      assertEqual "milliseconds are accepted" 250 (C.testTime explicit)
+      forM_ [("5s", 5000), ("1.5s", 1500), ("0.001s", 1)] $ \(duration, expected) ->
+        assertEqual duration expected . C.testTime =<< parsePerfOptions ["--time", duration]
+      forM_ ["0ms", "-1s", "0.1ms", "100", "1m", "1e100s", "NaNs"] $ \duration ->
+        case parseOptions ["test", "perf", "--time", duration] of
+          O.Failure _ -> return ()
+          _ -> assertFailure ("--time must reject " ++ duration)
+      forM_ ["--iter", "--min-iter", "--max-iter", "--min-time", "--max-time", "--warmup", "--scale"] $ \option ->
+        case parseOptions ["test", "perf", option, "1"] of
+          O.Failure _ -> return ()
+          _ -> assertFailure ("perf must reject " ++ option)
+      case parseOptions ["test"] of
+        O.Success (C.CmdOpt _ (C.Test (C.TestRun normal))) -> assertEqual "ordinary tests keep debug" C.Debug (C.optimize (C.testCompile normal))
+        _ -> assertFailure "ordinary test options failed to parse"
+      case parseOptions ["test", "--iter", "2", "--min-time", "10"] of
+        O.Success (C.CmdOpt _ (C.Test (C.TestRun normal))) ->
+          assertEqual "ordinary test limits remain available" (2, 10) (C.testIter normal, C.testMinTime normal)
+        _ -> assertFailure "ordinary test limits failed to parse"
+      case parseOptions ["test", "stress", "--max-iter", "9", "--max-time", "20", "--stress-workers", "3"] of
+        O.Success (C.CmdOpt _ (C.Test (C.TestStress stress))) ->
+          assertEqual "stress test limits remain available" (9, 20, 3) (C.testMaxIter stress, C.testMaxTime stress, C.testStressWorkers stress)
+        _ -> assertFailure "stress test limits failed to parse"
+  , testCase "global options can appear throughout performance commands" $ do
+      forM_
+        [ ["test", "--color", "never", "perf", "--time", "100ms", "--name", "sample"]
+        , ["test", "perf", "--color", "never", "--time", "100ms", "--name", "sample"]
+        , ["test", "perf", "--time", "100ms", "--color", "never", "--name", "sample"]
+        , ["test", "perf", "--time", "100ms", "--name", "sample", "--color", "never"]
+        ] $ \args -> case parseOptions args of
+          O.Success (C.CmdOpt globals (C.Test (C.TestPerf opts))) -> do
+            assertEqual (unwords args) C.Never (C.color globals)
+            assertEqual "performance options survive global options" (100, ["sample"]) (C.testTime opts, C.testNames opts)
+          O.Failure failure -> assertFailure (fst (O.renderFailure failure "acton"))
+          _ -> assertFailure ("unexpected command: " ++ unwords args)
+      case parseOptions ["test", "--quiet", "perf", "--time", "100ms", "--jobs", "2", "--name", "sample", "--no-progress", "--tag", "input"] of
+        O.Success (C.CmdOpt globals (C.Test (C.TestPerf opts))) -> do
+          assertEqual "several global options retain their values" (True, 2, True) (C.quiet globals, C.jobs globals, C.noProgress globals)
+          assertEqual "leaf parsing resumes after every global option" ["input"] (C.testTags opts)
+        O.Failure failure -> assertFailure (fst (O.renderFailure failure "acton"))
+        _ -> assertFailure "expected performance options"
+      case parseOptions ["test", "stress", "--iter", "2", "--color", "never", "--name", "sample"] of
+        O.Success (C.CmdOpt globals (C.Test (C.TestStress opts))) ->
+          assertEqual "stress options also mix with global options" (C.Never, 2, ["sample"]) (C.color globals, C.testIter opts, C.testNames opts)
+        O.Failure failure -> assertFailure (fst (O.renderFailure failure "acton"))
+        _ -> assertFailure "expected stress options"
+  , testCase "performance help exposes only the supported budget control" $
+      case parseOptions ["test", "perf", "--help"] of
+        O.Failure failure -> do
+          let (text, code) = O.renderFailure failure "acton"
+          assertEqual text ExitSuccess code
+          assertBool text ("--time DURATION" `isInfixOf` unwords (words text))
+          assertBool text (not (any (`isInfixOf` text) ["--iter", "--min-time", "--max-time", "--warmup", "--scale"]))
+        _ -> assertFailure "expected performance help"
+  , testCase "all metrics require the same complete performance identity" $ do
+      let old = sample 10 0 10
+          new = sample 12 0 10
+          changed key value = changeIdentity key value old
+          incompatible =
+            [ ("machine", Aeson.String "another machine")
+            , ("machine", Aeson.Null)
+            , ("version", Aeson.String "1")
+            , ("build", Aeson.String "ReleaseFast")
+            , ("tags", Aeson.toJSON (["different"] :: [String]))
+            , ("gc", Aeson.String "forced")
+            , ("scale", Aeson.Number 8)
+            , ("loop", Aeson.Bool False)
+            , ("workers", Aeson.Number 2)
+            ]
+      forM_ incompatible $ \(key, value) -> forM_ ["wall_duration", "gc_duration", "cpu_user", "mem_usage_delta", "peak_rss", "median_wall_duration", "instructions"] $ \metric -> do
+        assertBool (show key ++ " " ++ metric) (not (perfComparable metric (changed key value) new))
+        assertBool "the rejected comparison has a reason" (perfComparisonReason metric (changed key value) new /= Nothing)
+      forM_ (KM.keys identity) $ \key ->
+        let missing = KM.insert "perf_info" (Aeson.Object (KM.delete key identity)) old
+        in assertBool (show key) (not (perfComparable "wall_duration" missing new))
+      assertBool "old recordings require a new identity" (not (perfComparable "wall_duration" (KM.delete "perf_info" old) new))
+      build <- requireObject "build" identity
+      forM_ ["no_threads", "db", "no_dbp"] $ \key -> do
+        assertBool (show key ++ " changes the runtime condition")
+          (not (perfComparable "wall_duration" (changeIdentity "build" (Aeson.Object (KM.insert key (Aeson.Bool True) build)) old) new))
+        assertBool (show key ++ " must be recorded")
+          (not (perfComparable "wall_duration" (changeIdentity "build" (Aeson.Object (KM.delete key build)) old) new))
+      let longer = changeIdentity "measurement_ms" (Aeson.Number 9000)
+            (changeIdentity "measurement_duration_ms" (Aeson.Number 9500)
+              (changeIdentity "time_budget_ms" (Aeson.Number 10000) (sample 12 0 20)))
+      assertBool "time budgets, realized durations and sample counts are not identity" (perfComparable "wall_duration" old longer)
+      let footerOld = old `KM.union` KM.fromList [("median_wall_duration", Aeson.Number 10), ("peak_rss", Aeson.Number 100)]
+          footerNew = new `KM.union` KM.fromList [("median_wall_duration", Aeson.Number 12), ("peak_rss", Aeson.Number 200)]
+          text = unlines (renderPerf 119 False (Just (changeIdentity "machine" Aeson.Null footerOld)) (result footerNew))
+      assertBool text ("comparison unavailable: machine identity is unavailable" `isInfixOf` text)
+      assertBool "footer values cannot bypass identity checks" (not (any (`isInfixOf` text) ["+20.0%", "+100.0%", "⚡", "💩"]))
+      case perfJson (Just (KM.delete "perf_info" old)) (result new) of
+        Just (Aeson.Object report) -> do
+          assertEqual "no legacy confidence interval" (Just Aeson.Null) (KM.lookup "mean_difference_ci95_ms" report)
+          assertBool "JSON explains eligibility" (KM.lookup "comparison_unavailable_reason" report /= Just Aeson.Null)
+        _ -> assertFailure "expected comparison metadata"
+  , testCase "performance baselines accept zero runtime workers" $ do
+      build <- requireObject "build" identity
+      let noThreads = changeIdentity "build" (Aeson.Object (KM.insert "no_threads" (Aeson.Bool True) build))
+            . changeIdentity "workers" (Aeson.Number 0)
+          old = noThreads (sample 10 0 10)
+          new = noThreads (sample 12 0 10)
+          rendered = unlines (renderPerf 119 False (Just old) (result new))
+      assertEqual "matching runtimes without threads are comparable" Nothing (perfComparisonReason "wall_duration" old new)
+      assertEqual "zero workers retain the mean interval" (Just (2, 2)) (perfMeanInterval "wall_duration" old new)
+      assertBool rendered ("+20.0%" `isInfixOf` rendered)
+      assertEqual "worker counts must still match" (Just "runtime worker count differs")
+        (perfComparisonReason "wall_duration" old (changeIdentity "workers" (Aeson.Number 1) new))
+      forM_ [("workers", [-1, 0.5]), ("scale", [0, -1, 0.5])] $ \(key, invalid) ->
+        forM_ invalid $ \n ->
+          assertBool (show (key, n)) (not (perfComparable "wall_duration"
+            (changeIdentity key (Aeson.Number n) old) (changeIdentity key (Aeson.Number n) new)))
+  , testCase "recorded scale is reused only for known compatible loops" $ do
+      let old = sample 10 0 10
+      assertEqual "reuse the recorded workload" (Just 7) (perfBaselineScale old identity)
+      forM_ [changeIdentity "machine" Aeson.Null old, changeIdentity "scale" (Aeson.Number 0) old,
+             changeIdentity "loop" (Aeson.Bool False) old, changeIdentity "version" (Aeson.String "2") old,
+             KM.delete "perf_info" old] $ \baseline ->
+        assertEqual "cannot reuse a missing or incompatible scale" Nothing (perfBaselineScale baseline identity)
+      assertEqual "worker count is checked after execution" (Just 7)
+        (perfBaselineScale (changeIdentity "workers" (Aeson.Number 2) old) identity)
+  , testCase "timing and allocation changes use the recorded measurement" $ do
+      let old = identified $ KM.fromList [("avg_wall_duration", Aeson.Number 10), ("mem_usage_delta_avg", Aeson.Number 100)]
+          new = identified $ KM.fromList [("avg_wall_duration", Aeson.Number 12), ("mem_usage_delta_avg", Aeson.Number 50)]
           rendered = unlines (renderPerf 79 False (Just old) (result new))
       assertBool rendered ("+20.0%" `isInfixOf` rendered)
       assertBool rendered ("-50.0%" `isInfixOf` rendered)
@@ -34,24 +165,24 @@ perfTests = testGroup "performance baselines"
       let old = sample 8 4 5
           new = sample 10 1 20
           half = 2.777 * sqrt 3.25
-      case perfMeanInterval "duration" old new of
+      case perfMeanInterval "wall_duration" old new of
         Just (lo, hi) -> do
           assertBool (show (lo, hi)) (abs (lo - (2 - half)) < 0.000001)
           assertBool (show (lo, hi)) (abs (hi - (2 + half)) < 0.000001)
         Nothing -> assertFailure "expected a Welch interval"
   , testCase "mean interval handles missing and constant samples" $ do
-      assertEqual "old baselines do not invent variance" Nothing (perfMeanInterval "duration" KM.empty (sample 1 1 10))
-      assertEqual "one sample cannot estimate variance" Nothing (perfMeanInterval "duration" (sample 1 1 10) (sample 1 0 1))
-      assertEqual "negative variance is invalid" Nothing (perfMeanInterval "duration" (sample 1 (-1) 10) (sample 1 1 10))
+      assertEqual "old baselines do not invent variance" Nothing (perfMeanInterval "wall_duration" KM.empty (sample 1 1 10))
+      assertEqual "one sample cannot estimate variance" Nothing (perfMeanInterval "wall_duration" (sample 1 1 10) (sample 1 0 1))
+      assertEqual "negative variance is invalid" Nothing (perfMeanInterval "wall_duration" (sample 1 (-1) 10) (sample 1 1 10))
       assertEqual "constant samples have zero estimated uncertainty" (Just (2, 2))
-        (perfMeanInterval "duration" (sample 1 0 10) (sample 3 0 10))
+        (perfMeanInterval "wall_duration" (sample 1 0 10) (sample 3 0 10))
       assertEqual "zero baseline still supports an absolute interval" (Just (1, 1))
-        (perfMeanInterval "duration" (sample 0 0 10) (sample 1 0 10))
+        (perfMeanInterval "wall_duration" (sample 0 0 10) (sample 1 0 10))
   , testCase "uncertain mean changes are not colored as regressions" $ do
       let old = sample 10 10 5
           res = (result (sample 11 10 5)) { trNumIterations = 5 }
           rendered = unlines (renderPerf 79 True (Just old) res)
-      assertBool rendered ("mean delta (95% CI):" `isInfixOf` rendered)
+      assertBool rendered ("wall mean delta (approx. 95% CI):" `isInfixOf` rendered)
       assertBool rendered (not ("\ESC[91m" `isInfixOf` rendered))
   , testCase "each mean comparison uses its own variance" $ do
       let old = sample 10 0 10 `KM.union` KM.fromList
@@ -59,23 +190,23 @@ perfTests = testGroup "performance baselines"
           new = sample 12 0 10 `KM.union` KM.fromList
             [("mem_usage_delta_avg", Aeson.Number 1100), ("stdev_mem_usage_delta", Aeson.Number 1000)]
           rows = renderPerf 120 True (Just old) ((result new) { trNumIterations = 10 })
-      assertBool (unlines rows) (maybe False (isInfixOf "\ESC[91m+20.0%") (find ("time excl. GC" `isInfixOf`) rows))
+      assertBool (unlines rows) (maybe False (isInfixOf "\ESC[91m+20.0%") (find ("wall time" `isInfixOf`) rows))
       assertBool (unlines rows) (maybe False (isInfixOf "\ESC[2m+10.0%") (find ("allocated" `isInfixOf`) rows))
       case perfMeanInterval "mem_usage_delta" old new of
         Just (lo, hi) -> assertBool (show (lo, hi)) (lo < 0 && hi > 0 && abs (lo + hi - 200) < 0.000001)
         Nothing -> assertFailure "expected an allocation mean interval"
-  , testCase "performance table groups timings and scales signed memory values" $ do
-      let old = KM.fromList [("avg_duration", Aeson.Number 10), ("non_gc_mem_usage_delta_avg", Aeson.Number (-4096))]
+  , testCase "performance table headlines natural wall time and omits non-GC memory" $ do
+      let old = KM.insert "peak_rss" (Aeson.Number 24000000) (sample 10 0 10)
           rows = renderPerf 120 False (Just old) tableResult
-          timing = find ("time excl. GC" `isInfixOf`) rows
-          memory = find ("non-GC change" `isInfixOf`) rows
-      assertEqual "timing distribution and mean comparison"
-        (Just ["time", "excl.", "GC", "12.0ms", "±", "1.00ms", "10.0ms", "…", "14.0ms", "1", "(10%)", "+20.0%"])
+          timing = find ("wall time" `isInfixOf`) rows
+      assertEqual "wall distribution and mean comparison"
+        (Just ["wall", "time", "12.0ms", "±", "1.00ms", "10.0ms", "…", "14.0ms", "1", "(10%)", "+20.0%", "💩"])
         (words <$> timing)
-      assertEqual "signed memory uses the magnitude for its unit"
-        (Just ["non-GC", "change", "-2.05KB", "—", "—", "+50.0%"])
-        (words <$> memory)
-      assertBool (unlines rows) ("  process peak RSS: 12.0MB" `elem` rows)
+      assertBool (unlines rows) (not (any (\label -> any (label `isInfixOf`) rows) ["time excl. GC", "non-GC change"]))
+      forM_ [False, True] $ \color ->
+        assertEqual "process peak RSS has no baseline delta or comparison color"
+          (Just ("  process peak RSS: 12.0" ++ if color then "\ESC[2mMB\ESC[0m" else "MB"))
+          (find ("process peak RSS:" `isInfixOf`) (renderPerf 120 color (Just old) tableResult))
       assertBool "no ANSI escapes when color is disabled" (all (not . isInfixOf "\ESC[") rows)
       assertBool "the colored header keeps its full label"
         ("measurement" `isInfixOf` head (renderPerf 79 True (Just old) tableResult))
@@ -85,14 +216,14 @@ perfTests = testGroup "performance baselines"
         [ ("wall time", ["wall", "time", "12.0ms", "±", "2.00ms", "8.00ms", "…", "16.0ms", "0", "(0%)"])
         , ("GC time", ["GC", "time", "0.00ms", "±", "0.00ms", "0.00ms", "…", "0.00ms", "0", "(0%)"])
         , ("allocated", ["allocated", "1.54KB", "±", "128B", "1.02KB", "…", "2.05KB", "2", "(20%)"])
-        , ("non-GC change", ["non-GC", "change", "-2.05KB", "±", "1.02KB", "-4.10KB", "…", "0.00B", "3", "(30%)"])
         ] $ \(label, expected) ->
           assertEqual label (Just expected) (words <$> find (label `isInfixOf`) rows)
   , testCase "JSON retains distributions in current and baseline measurements" $ do
       case trRaw fullTableResult of
         Aeson.Object obj -> case perfJson (Just obj) fullTableResult of
           Just (Aeson.Object report) -> forM_ ["measurements", "baseline"] $ \key ->
-            assertEqual (show key) (Just (Aeson.Object obj)) (KM.lookup key report)
+            let measured = KM.filterWithKey (\name _ -> not ("non_gc_mem_usage_delta" `isInfixOf` AesonKey.toString name)) obj
+            in assertEqual (show key ++ " omits the unmeasured legacy non-GC estimate") (Just (Aeson.Object measured)) (KM.lookup key report)
           _ -> assertFailure "expected a performance report"
         _ -> assertFailure "expected measurements"
   , testCase "CPU rows scale counts and keep IPC comparisons neutral" $ do
@@ -121,15 +252,15 @@ perfTests = testGroup "performance baselines"
       assertBool "matching counters can compare" (perfComparable "instructions" old new)
       assertBool "hardware permissions do not change CPU-time accounting"
         (perfComparable "cpu_user" (alter "scope" "process:user") new)
-      forM_ [alter "scope" "process:user", alter "cpu" "another CPU", alter "version" "2", KM.delete "counter_info" old] $ \baseline -> do
+      forM_ [alter "scope" "process:user", alter "version" "2", KM.delete "counter_info" old] $ \baseline -> do
         assertEqual "no confidence interval for incomparable counters" Nothing (perfMeanInterval "instructions" baseline new)
         let rows = renderPerf 119 False (Just baseline) (result new)
             line = maybe "" id (find ("instructions" `isInfixOf`) rows)
         assertBool line (not ("+100.0%" `isInfixOf` line))
         assertBool line ("2.00M" `isInfixOf` line)
-        assertBool "legacy timing remains comparable" (perfComparable "duration" baseline new)
+        assertBool "hardware scope does not invalidate wall time" (perfComparable "wall_duration" baseline new)
   , testCase "small spreads and range endpoints keep their precision" $ do
-      let obj = sample 1 0.001 10 `KM.union` KM.fromList [("min_duration", Aeson.toJSON (0.001 :: Double)), ("max_duration", Aeson.Number 1)]
+      let obj = sample 1 0.001 10 `KM.union` KM.fromList [("min_wall_duration", Aeson.toJSON (0.001 :: Double)), ("max_wall_duration", Aeson.Number 1)]
           rendered = unlines (renderPerf 79 False Nothing (result obj))
       assertBool rendered ("1.00ms ± 1.00µs" `isInfixOf` unwords (words rendered))
       assertBool rendered ("1.00µs … 1.00ms" `isInfixOf` unwords (words rendered))
@@ -151,12 +282,12 @@ perfTests = testGroup "performance baselines"
   , testCase "columns and separators stay aligned across benchmark units" $ do
       let old = Just (sample 10 1 10)
           tiny = (result (sample 0.000001 0.000000001 10 `KM.union` KM.fromList
-            [("min_duration", Aeson.toJSON (0.000000001 :: Double)), ("max_duration", Aeson.Number 1)])) { trNumIterations = 10 }
+            [("min_wall_duration", Aeson.toJSON (0.000000001 :: Double)), ("max_wall_duration", Aeson.Number 1)])) { trNumIterations = 10 }
           huge = (result (sample 1e300 1e200 10 `KM.union` KM.fromList
-            [ ("min_duration", Aeson.toJSON (-1e300 :: Double)), ("max_duration", Aeson.toJSON (1e300 :: Double))
-            , ("outlier_count", Aeson.Number 2000000000)
+            [ ("min_wall_duration", Aeson.toJSON (-1e300 :: Double)), ("max_wall_duration", Aeson.toJSON (1e300 :: Double))
+            , ("outlier_count_wall_duration", Aeson.Number 2000000000)
             ])) { trNumIterations = 2000000000 }
-          timing rows = maybe "" id (find ("time excl. GC" `isInfixOf`) rows)
+          timing rows = maybe "" id (find ("wall time" `isInfixOf`) rows)
       forM_ [79, 100, 119, 160] $ \cols -> do
         let reference = renderPerf cols False old fullTableResult
             separators s = [elemIndices '±' s, elemIndices '…' s]
@@ -175,7 +306,7 @@ perfTests = testGroup "performance baselines"
       let old = sample 10 0 10
           rowsFor mean sd color = renderPerf 119 color (Just old)
             ((result (sample mean sd 10)) { trNumIterations = 10 })
-          timing rows = maybe "" id (find ("time excl. GC" `isInfixOf`) rows)
+          timing rows = maybe "" id (find ("wall time" `isInfixOf`) rows)
           better = timing (rowsFor 8 0 False)
           worse = timing (rowsFor 12 0 False)
           uncertain = timing (rowsFor 11 10 False)
@@ -197,21 +328,21 @@ perfTests = testGroup "performance baselines"
         assertEqual "colored clipping preserves display width" 2 (termVisibleLength (termFitAnsiRight 2 colored))
       assertEqual "combining marks stay with the final character" "e\x0301" (termFitAnsiRight 1 "e\x0301x")
   , testCase "older measurements do not invent a spread or range" $ do
-      let rows = renderPerf 120 False Nothing (result (KM.singleton "avg_duration" (Aeson.Number 1)))
-      assertEqual "only the known mean is shown" (Just ["time", "excl.", "GC", "1.00ms", "—", "—"])
-        (words <$> find ("time excl. GC" `isInfixOf`) rows)
+      let rows = renderPerf 120 False Nothing (result (KM.singleton "avg_wall_duration" (Aeson.Number 1)))
+      assertEqual "only the known mean is shown" (Just ["wall", "time", "1.00ms", "—", "—"])
+        (words <$> find ("wall time" `isInfixOf`) rows)
   , testCase "missing and zero baselines have defined output" $ do
       let render :: Maybe Aeson.Object -> Double -> String
           render old value = unlines $ renderPerf 79 False old
-            (result (KM.singleton "avg_duration" (Aeson.toJSON value)))
+            (result (identified (KM.singleton "avg_wall_duration" (Aeson.toJSON value))))
       assertBool "no baseline has no delta" (not ("%" `isInfixOf` render Nothing 2))
       assertBool "missing metric has no delta" (not ("%" `isInfixOf` render (Just KM.empty) 2))
       assertBool "zero to zero is unchanged"
-        ("+0.0%" `isInfixOf` render (Just (KM.singleton "avg_duration" (Aeson.Number 0))) 0)
+        ("+0.0%" `isInfixOf` render (Just (identified (KM.singleton "avg_wall_duration" (Aeson.Number 0)))) 0)
       assertBool "zero to nonzero has no percentage"
-        ("from 0" `isInfixOf` render (Just (KM.singleton "avg_duration" (Aeson.Number 0))) 2)
+        ("from 0" `isInfixOf` render (Just (identified (KM.singleton "avg_wall_duration" (Aeson.Number 0)))) 2)
   , testCase "failed and incomplete runs have no performance comparison" $ do
-      let res = result (KM.singleton "avg_duration" (Aeson.Number 10))
+      let res = result (KM.singleton "avg_wall_duration" (Aeson.Number 10))
       forM_ [res { trComplete = False }, res { trSuccess = Just False }, res { trSkipped = True },
              res { trException = Just "error" }, res { trNumIterations = 0 }, res { trSnapshotUpdated = True }] $ \invalid ->
         assertEqual "no performance lines" [] (renderPerf 79 False Nothing invalid)
@@ -223,7 +354,7 @@ perfTests = testGroup "performance baselines"
               (Fingerprint.updateFingerprintPrefix (Fingerprint.fingerprintPrefixForName name) 1)
             baseline = proj </> "perf_data"
             run args = readCreateProcessWithExitCode
-              (proc acton (["test", "perf", "--iter", "2", "--color", "never"] ++ args)) { cwd = Just proj } ""
+              (proc acton (["test", "perf", "--time", "100ms", "--color", "never"] ++ args)) { cwd = Just proj } ""
             runOK args = do
               (code, out, err) <- run args
               assertEqual (unwords args ++ "\n" ++ out ++ err) ExitSuccess code
@@ -233,13 +364,17 @@ perfTests = testGroup "performance baselines"
               case decoded of
                 Left err -> assertFailure err >> return M.empty
                 Right saved -> return (saved :: M.Map String (M.Map String Aeson.Value))
-            setMean (Aeson.Object obj) = Aeson.Object (KM.insert "avg_duration" (Aeson.Number 1000000000) obj)
+            setMean (Aeson.Object obj) = Aeson.Object (KM.insert "avg_wall_duration" (Aeson.Number 1000000000) obj)
             setMean raw = raw
+            hasMachine info = case KM.lookup "machine" info of
+              Just (Aeson.String value) -> value /= mempty
+              _ -> False
         createDirectoryIfMissing True (proj </> "src")
         writeFile (proj </> "Build.act") $ unlines ["name = " ++ show name, "fingerprint = " ++ fp]
         writeFile (proj </> "src/sample.act") $ unlines
           [ "import testing"
           , "import acton.rts"
+          , "import time"
           , ""
           , "actor _test_first(t: testing.AsyncT):"
           , "    t.success()"
@@ -255,6 +390,75 @@ perfTests = testGroup "performance baselines"
           , ""
           , "actor _test_slow(t: testing.AsyncT):"
           , "    after 3.5: t.success()"
+          , ""
+          , "actor _test_looped(t: testing.EnvT):"
+          , "    expected_scale = t.env.getenv(\"ACTON_PERF_EXPECT_SCALE\")"
+          , "    for scale in t.loop():"
+          , "        assert scale > 0"
+          , "        if expected_scale is not None:"
+          , "            assert scale == int(expected_scale)"
+          , "    t.success()"
+          , ""
+          , "actor LoopWorker(t: testing.AsyncT):"
+          , "    for scale in t.loop():"
+          , "        assert scale > 0"
+          , "    t.success()"
+          , ""
+          , "actor _test_helper_workload(t: testing.AsyncT):"
+          , "    LoopWorker(t)"
+          , ""
+          , "actor _test_complete_before_loop(t: testing.AsyncT):"
+          , "    iterator = t.loop()"
+          , "    t.report_result(True, None, None)"
+          , "    try:"
+          , "        list(iterator)"
+          , "    except ValueError:"
+          , "        pass"
+          , ""
+          , "actor _test_late_loop(t: testing.AsyncT):"
+          , "    t.success()"
+          , "    try:"
+          , "        t.loop()"
+          , "    except ValueError:"
+          , "        pass"
+          , "    t.success()"
+          , ""
+          , "def _test_break_loop(t: testing.SyncT):"
+          , "    for scale in t.loop():"
+          , "        break"
+          , ""
+          , "def _test_return_loop(t: testing.SyncT):"
+          , "    for scale in t.loop():"
+          , "        return"
+          , ""
+          , "def _test_body_stop(t: testing.SyncT):"
+          , "    for scale in t.loop():"
+          , "        raise StopIteration(\"body stopped\")"
+          , ""
+          , "def _test_repeat_loop(t: testing.SyncT):"
+          , "    t.loop()"
+          , "    for scale in t.loop():"
+          , "        pass"
+          , ""
+          , "def _test_loop_failure(t: testing.SyncT):"
+          , "    for scale in t.loop():"
+          , "        raise ValueError(\"original body failure\")"
+          , ""
+          , "actor _test_inconsistent_loop(t: testing.EnvT):"
+          , "    if t.env.getenv(\"ACTON_PERF_TEST_LOOP_SEEN\") is None:"
+          , "        t.env.setenv(\"ACTON_PERF_TEST_LOOP_SEEN\", \"1\")"
+          , "        for scale in t.loop():"
+          , "            assert scale > 0"
+          , "    t.success()"
+          , ""
+          , "actor _test_timed_body(t: testing.EnvT):"
+          , "    acton.rts.sleep(t.env.syscap, 0.02)"
+          , "    for scale in t.loop():"
+          , "        start = time.monotonic().unix_ns()"
+          , "        while time.monotonic().unix_ns() - start < 1000000:"
+          , "            pass"
+          , "    acton.rts.sleep(t.env.syscap, 0.02)"
+          , "    t.success()"
           , ""
           , "actor _test_counter_activation(t: testing.EnvT):"
           , "    assert t.env.getenv(\"ACTON_TEST_PERF\") is None"
@@ -281,6 +485,18 @@ perfTests = testGroup "performance baselines"
         assertEqual "two measured tests" 2 (M.size tests)
         forM_ tests $ \raw -> case raw of
           Aeson.Object obj -> do
+            samples <- requireNumber "num_iterations" obj
+            assertBool "ordinary workloads retain complete measured invocations" (samples >= 1)
+            info <- requireObject "perf_info" obj
+            assertEqual "measurement version is recorded" (Just (Aeson.String "3")) (KM.lookup "version" info)
+            assertEqual "the total requested budget is recorded" (Just (Aeson.Number 100)) (KM.lookup "time_budget_ms" info)
+            assertEqual "ordinary workloads keep scale one" (Just (Aeson.Number 1)) (KM.lookup "scale" info)
+            assertEqual "ordinary workloads measure complete invocations" (Just (Aeson.Bool False)) (KM.lookup "loop" info)
+            assertEqual "GC remains natural" (Just (Aeson.String "natural")) (KM.lookup "gc" info)
+            warmup <- requireNumber "warmup_duration_ms" info
+            assertBool "warmup completed before measurement" (warmup > 0)
+            build <- requireObject "build" info
+            assertEqual "effective release mode is recorded" (Just (Aeson.String "ReleaseFast")) (KM.lookup "optimize" build)
             forM_ distributionKeys $ \key -> assertBool (show key ++ " missing from recording") (KM.member key obj)
             case KM.lookup "counter_info" obj of
               Just (Aeson.Object info) -> do
@@ -296,26 +512,49 @@ perfTests = testGroup "performance baselines"
               Just (Aeson.Number rss) -> assertBool "peak RSS is positive when available" (rss > 0)
               Just _ -> assertFailure "peak RSS must be a number"
           _ -> assertFailure "expected recorded measurements"
+        firstInfo <- case M.lookup "_test_first_wrapper" tests of
+          Just (Aeson.Object obj) -> requireObject "perf_info" obj
+          _ -> assertFailure "missing first recording" >> fail "missing recording"
+        let canCompare = hasMachine firstInfo
+            assertComparison text = do
+              assertBool text ("mean ± σ" `isInfixOf` unwords (words text))
+              let signedPercentage token = case dropWhile (== '(') token of
+                    sign : rest -> sign `elem` ['+', '-'] && '%' `elem` rest
+                    _ -> False
+                  hasDelta = any signedPercentage (words text) || "from 0" `isInfixOf` text
+              if canCompare
+                then assertBool text hasDelta
+                else do
+                  assertBool text ("comparison unavailable: machine identity is unavailable" `isInfixOf` text)
+                  assertBool "unknown identity cannot show a delta or confidence interval"
+                    (not (hasDelta || any (`isInfixOf` text) ["wall mean delta", "⚡", "💩"]))
         bytes <- BL.readFile baseline
         out <- runOK ["--name", "first"]
-        assertBool out ("mean ± σ" `isInfixOf` unwords (words out) && "%" `isInfixOf` out)
+        assertComparison out
         assertBool out ("allocated" `isInfixOf` out)
         assertEqual "comparison leaves the baseline intact" bytes =<< BL.readFile baseline
         ttyOut <- runOK ["--tty", "--name", "first"]
-        assertBool ttyOut ("mean ± σ" `isInfixOf` unwords (words ttyOut) && "%" `isInfixOf` ttyOut)
+        assertComparison ttyOut
         assertEqual "terminal comparison leaves the baseline intact" bytes =<< BL.readFile baseline
         json <- runOK ["--json", "--name", "first"]
         assertBool json ("\"cached\":false" `isInfixOf` json)
-        forM_ ["performance", "median_duration", "stdev_duration", "outlier_count", "avg_wall_duration", "avg_gc_duration", "mean_difference_ci95_ms", "counter_info", "avg_cpu_user", "avg_cpu_system"] $ \key ->
+        forM_ ["performance", "median_wall_duration", "stdev_wall_duration", "outlier_count_wall_duration", "avg_wall_duration", "avg_gc_duration", "mean_difference_ci95_ms", "counter_info", "avg_cpu_user", "avg_cpu_system", "loop_iterations"] $ \key ->
           assertBool (key ++ " missing from " ++ json) (("\"" ++ key ++ "\"") `isInfixOf` json)
         forM_ distributionKeys $ \key -> assertBool (show key ++ " missing from " ++ json) (show key `isInfixOf` json)
+        performance <- singleJsonTest json >>= requireObject "performance"
+        assertEqual "JSON reports whether the machine can be compared"
+          (Just (if canCompare then Aeson.Null else Aeson.String "machine identity is unavailable"))
+          (KM.lookup "comparison_unavailable_reason" performance)
+        unless canCompare $
+          assertEqual "unknown identity has no confidence interval" (Just Aeson.Null) (KM.lookup "mean_difference_ci95_ms" performance)
         -- Set a deterministic reference and check that --record compares with
         -- the old value before replacing only the selected measurement.
         let reference = M.adjust (M.adjust setMean "_test_first_wrapper")
               "perf_record.sample" saved
         BL.writeFile baseline (Aeson.encode reference)
         updatedOut <- runOK ["--record", "--name", "first"]
-        assertBool updatedOut ("-100.0%" `isInfixOf` updatedOut)
+        assertComparison updatedOut
+        when canCompare $ assertBool updatedOut ("-100.0%" `isInfixOf` updatedOut)
         updated <- readBaseline
         let updatedTests = M.findWithDefault M.empty "perf_record.sample" updated
         assertEqual "unselected measurement survives recording"
@@ -324,8 +563,11 @@ perfTests = testGroup "performance baselines"
         assertEqual "unavailable old measurements survive recording"
           (M.lookup "missing" saved) (M.lookup "missing" updated)
         updatedBytes <- BL.readFile baseline
-        (failedCode, _, _) <- run ["--record", "--name", "failed"]
+        (failedCode, failedOut, _) <- run ["--record", "--name", "failed", "--json"]
         assertBool "failing test exits unsuccessfully" (failedCode /= ExitSuccess)
+        failed <- singleJsonTest failedOut
+        assertEqual "an initial failure aborts before any measured sample" (Just (Aeson.Number 0)) (KM.lookup "iterations" failed)
+        assertEqual "failed preparation produces no performance measurement" (Just Aeson.Null) (KM.lookup "performance" failed)
         _ <- runOK ["--record", "--name", "skipped"]
         _ <- runOK ["--record", "--name", "absent"]
         assertEqual "failed, skipped and empty selections preserve the baseline" updatedBytes =<< BL.readFile baseline
@@ -340,18 +582,147 @@ perfTests = testGroup "performance baselines"
         assertBool badErr (badCode /= ExitSuccess && "Cannot read performance baseline" `isInfixOf` badErr)
         assertEqual "malformed baseline is not overwritten" "{broken" =<< BL.readFile baseline
         removeFile baseline
-        -- Sampling limits are checked between iterations. A slow iteration
-        -- must be allowed to finish beyond the former three-second watchdog.
-        (slowCode, slowOut, slowErr) <- readCreateProcessWithExitCode
-          (proc acton ["test", "perf", "--min-iter", "1", "--max-iter", "1", "--name", "slow", "--json"])
+        -- A complete invocation may exceed the requested budget. It must be
+        -- allowed to finish beyond the former three-second watchdog, but a
+        -- run with no time left for measurement is not a successful benchmark.
+        (slowCode, slowOut, slowErr) <- run ["--name", "slow", "--json"]
+        assertBool (slowOut ++ slowErr) (slowCode /= ExitSuccess)
+        slow <- singleJsonTest slowOut
+        assertEqual "exhausting preparation leaves no measured samples" (Just (Aeson.Number 0)) (KM.lookup "iterations" slow)
+        assertEqual "exhausted preparation produces no measurement" (Just Aeson.Null) (KM.lookup "performance" slow)
+        duration <- requireNumber "duration_ms" slow
+        assertBool "the slow invocation completed past the former watchdog" (duration >= 3000)
+        assertBool slowOut (not ("TimeoutError" `isInfixOf` slowOut))
+        loopedOut <- runOK ["--record", "--name", "looped", "--json", "--tag", "beta, alpha", "--tag", "alpha"]
+        looped <- singleJsonTest loopedOut >>= requireObject "performance" >>= requireObject "measurements"
+        loopedInfo <- requireObject "perf_info" looped
+        assertEqual "author opted into loop measurement" (Just (Aeson.Bool True)) (KM.lookup "loop" loopedInfo)
+        scale <- requireNumber "scale" loopedInfo
+        assertBool "calibration chooses a positive scale" (scale >= 1)
+        samples <- requireNumber "num_iterations" looped
+        bodies <- requireNumber "loop_iterations" looped
+        assertBool "loop samples are complete invocation averages" (samples >= 1 && samples <= 4)
+        assertBool "loop bodies are counted separately from statistical samples" (bodies >= samples)
+        case KM.lookup "calibration" loopedInfo of
+          Just (Aeson.Array _) -> return ()
+          _ -> assertFailure "missing calibration observations"
+        assertEqual "tags match actual capability parsing" (Just (Aeson.toJSON (["alpha", "beta"] :: [String]))) (KM.lookup "tags" loopedInfo)
+        helperOut <- runOK ["--name", "helper_workload", "--json"]
+        helperInfo <- singleJsonTest helperOut >>= requireObject "performance" >>= requireObject "measurements" >>= requireObject "perf_info"
+        assertEqual "a helper actor can exhaust the loop before reporting completion" (Just (Aeson.Bool True)) (KM.lookup "loop" helperInfo)
+        lateOut <- runOK ["--name", "late_loop", "--json"]
+        lateInfo <- singleJsonTest lateOut >>= requireObject "performance" >>= requireObject "measurements" >>= requireObject "perf_info"
+        assertEqual "late loop requests and duplicate completions cannot change measurement identity"
+          (Just (Aeson.Bool False)) (KM.lookup "loop" lateInfo)
+        forM_
+          [ ("complete_before_loop", "Benchmark loop must run to exhaustion")
+          , ("break_loop", "Benchmark loop must run to exhaustion")
+          , ("return_loop", "Benchmark loop must run to exhaustion")
+          , ("body_stop", "Benchmark loop must run to exhaustion")
+          , ("repeat_loop", "Use t.loop() once per test invocation")
+          , ("loop_failure", "original body failure")
+          , ("inconsistent_loop", "Call t.loop() consistently in every invocation")
+          ] $ \(test, message) -> do
+            (code, out, err) <- run ["--name", test, "--json"]
+            assertBool (test ++ "\n" ++ out ++ err) (code /= ExitSuccess)
+            invalid <- singleJsonTest out
+            assertEqual (test ++ " fails before measurement") (Just (Aeson.Number 0)) (KM.lookup "iterations" invalid)
+            assertEqual (test ++ " cannot produce a performance report") (Just Aeson.Null) (KM.lookup "performance" invalid)
+            assertBool out (message `isInfixOf` out)
+            when (test == "loop_failure") $
+              assertBool "loop validation preserves the original failure"
+                (not ("Benchmark loop must run to exhaustion" `isInfixOf` out))
+        (timedCode, timedOut, timedErr) <- readCreateProcessWithExitCode
+          (proc acton ["test", "perf", "--time", "200ms", "--name", "timed_body", "--json"])
             { cwd = Just proj } ""
-        assertEqual (slowOut ++ slowErr) ExitSuccess slowCode
+        assertEqual (timedOut ++ timedErr) ExitSuccess timedCode
+        timed <- singleJsonTest timedOut >>= requireObject "performance" >>= requireObject "measurements"
+        timedInfo <- requireObject "perf_info" timed
+        mean <- requireNumber "avg_wall_duration" timed
+        assertBool "body time is normalized per loop iteration" (mean >= 0.5 && mean < 15)
+        work <- requireNumber "measurement_ms" timedInfo
+        elapsed <- requireNumber "measurement_duration_ms" timedInfo
+        runs <- requireNumber "num_iterations" timed
+        assertBool ("setup and teardown are outside measured body time: " ++ show (elapsed, work, runs)) (elapsed - work >= 35 * runs)
+        -- Machines without a usable identity intentionally cannot reuse a
+        -- recording. The pure tests above cover that contract independently.
+        when (hasMachine loopedInfo) $ do
+          recorded <- readBaseline
+          let setScale (Aeson.Object obj) = Aeson.Object (changeIdentity "scale" (Aeson.Number 7) obj)
+              setScale raw = raw
+              fixed = M.adjust (M.adjust setScale "_test_looped_wrapper") "perf_record.sample" recorded
+          BL.writeFile baseline (Aeson.encode fixed)
+          (reuseCode, reuseOut, reuseErr) <- readCreateProcessWithExitCode
+            (proc acton ["test", "perf", "--time", "200ms", "--name", "looped", "--json", "--tag", "alpha,beta"])
+              { cwd = Just proj, env = Just (("ACTON_PERF_EXPECT_SCALE", "7") : filter ((/= "ACTON_PERF_EXPECT_SCALE") . fst) environment) } ""
+          assertEqual (reuseOut ++ reuseErr) ExitSuccess reuseCode
+          reused <- singleJsonTest reuseOut >>= requireObject "performance"
+          assertEqual "different time budgets remain comparable" (Just Aeson.Null) (KM.lookup "comparison_unavailable_reason" reused)
+          reusedInfo <- requireObject "measurements" reused >>= requireObject "perf_info"
+          assertEqual "recorded scale reaches every loop body" (Just (Aeson.Number 7)) (KM.lookup "scale" reusedInfo)
+          assertEqual "reused scale skips calibration" (Just (Aeson.toJSON ([] :: [Aeson.Value]))) (KM.lookup "calibration" reusedInfo)
+          assertEqual "the new budget is retained as provenance" (Just (Aeson.Number 200)) (KM.lookup "time_budget_ms" reusedInfo)
+          assertEqual "comparison leaves the seeded baseline intact" (Aeson.encode fixed) =<< BL.readFile baseline
   , testCase "record requires performance mode" $ do
       acton <- canonicalizePath "../../dist/bin/acton"
       forM_ [[], ["stress"], ["list"]] $ \mode -> do
         (code, _, err) <- readCreateProcessWithExitCode (proc acton (["test"] ++ mode ++ ["--record"])) ""
         assertBool err (code /= ExitSuccess && "--record requires acton test perf" `isInfixOf` err)
   ]
+
+parseOptions :: [String] -> O.ParserResult C.CmdLineOptions
+parseOptions = O.execParserPure C.cmdLinePrefs (O.info (C.cmdLineParser O.<**> O.helper) mempty)
+
+parsePerfOptions :: [String] -> IO C.TestOptions
+parsePerfOptions args = case parseOptions (["test", "perf"] ++ args) of
+    O.Success (C.CmdOpt _ (C.Test (C.TestPerf opts))) -> return opts
+    O.Failure failure -> assertFailure (fst (O.renderFailure failure "acton")) >> fail "invalid options"
+    _ -> assertFailure "expected performance options" >> fail "invalid command"
+
+singleJsonTest :: String -> IO Aeson.Object
+singleJsonTest out = case Aeson.eitherDecode (BL8.pack out) >>= AesonTypes.parseEither parser of
+    Right obj -> return obj
+    Left err -> assertFailure (err ++ "\n" ++ out) >> fail "invalid test report"
+  where
+    parser = Aeson.withObject "test report" $ \report -> do
+      tests <- report Aeson..: "tests"
+      case tests of
+        [Aeson.Object obj] -> return obj
+        _ -> fail "expected one test"
+
+requireObject :: Aeson.Key -> Aeson.Object -> IO Aeson.Object
+requireObject key obj = case KM.lookup key obj of
+    Just (Aeson.Object value) -> return value
+    _ -> assertFailure ("missing object " ++ show key ++ " in " ++ show obj) >> fail "missing object"
+
+requireNumber :: Aeson.Key -> Aeson.Object -> IO Double
+requireNumber key obj = case KM.lookup key obj of
+    Just (Aeson.Number value) -> return (realToFrac value)
+    _ -> assertFailure ("missing number " ++ show key ++ " in " ++ show obj) >> fail "missing number"
+
+identity :: Aeson.Object
+identity = KM.fromList
+  [ ("version", Aeson.String "3")
+  , ("machine", Aeson.String "same machine")
+  , ("scale", Aeson.Number 7)
+  , ("loop", Aeson.Bool True)
+  , ("workers", Aeson.Number 4)
+  , ("gc", Aeson.String "natural")
+  , ("tags", Aeson.toJSON ([] :: [String]))
+  , ("build", Aeson.object
+      [ "optimize" Aeson..= ("ReleaseFast" :: String), "target" Aeson..= ("aarch64-macos-none" :: String)
+      , "cpu" Aeson..= ("" :: String), "no_threads" Aeson..= False
+      , "db" Aeson..= False, "no_dbp" Aeson..= False
+      ])
+  ]
+
+identified :: Aeson.Object -> Aeson.Object
+identified = KM.insert "perf_info" (Aeson.Object identity)
+
+changeIdentity :: Aeson.Key -> Aeson.Value -> Aeson.Object -> Aeson.Object
+changeIdentity key value obj = KM.insert "perf_info" (case KM.lookup "perf_info" obj of
+    Just (Aeson.Object info) -> Aeson.Object (KM.insert key value info)
+    _ -> Aeson.Null) obj
 
 result :: Aeson.Object -> TestResult
 result obj = TestResult
@@ -369,7 +740,9 @@ result obj = TestResult
   , trNumSkipped = 0
   , trNumFailures = 0
   , trNumErrors = 0
-  , trNumIterations = 3
+  , trNumIterations = case KM.lookup "num_iterations" obj of
+      Just (Aeson.Number n) -> floor n
+      _ -> 3
   , trTestDuration = 100
   , trRaw = Aeson.Object obj
   , trSnapshotUpdated = False
@@ -377,18 +750,18 @@ result obj = TestResult
   }
 
 sample :: Double -> Double -> Int -> Aeson.Object
-sample mean sd n = KM.fromList
-  [ ("avg_duration", Aeson.toJSON mean)
-  , ("stdev_duration", Aeson.toJSON sd)
+sample mean sd n = identified $ KM.fromList
+  [ ("avg_wall_duration", Aeson.toJSON mean)
+  , ("stdev_wall_duration", Aeson.toJSON sd)
   , ("num_iterations", Aeson.toJSON n)
   ]
 
 tableResult :: TestResult
 tableResult = (result (sample 12 1 10 `KM.union` KM.fromList
-  [ ("min_duration", Aeson.Number 10)
-  , ("median_duration", Aeson.Number 12)
-  , ("max_duration", Aeson.Number 14)
-  , ("outlier_count", Aeson.Number 1)
+  [ ("min_wall_duration", Aeson.Number 10)
+  , ("median_wall_duration", Aeson.Number 12)
+  , ("max_wall_duration", Aeson.Number 14)
+  , ("outlier_count_wall_duration", Aeson.Number 1)
   , ("avg_wall_duration", Aeson.Number 12)
   , ("avg_gc_duration", Aeson.Number 0)
   , ("mem_usage_delta_avg", Aeson.Number 1536)
@@ -398,7 +771,7 @@ tableResult = (result (sample 12 1 10 `KM.union` KM.fromList
 
 fullTableResult :: TestResult
 fullTableResult = tableResult { trRaw = case trRaw tableResult of
-    Aeson.Object obj -> Aeson.Object (obj `KM.union` KM.fromList
+    Aeson.Object obj -> Aeson.Object (KM.fromList
       [ ("stdev_wall_duration", Aeson.Number 2)
       , ("min_wall_duration", Aeson.Number 8)
       , ("max_wall_duration", Aeson.Number 16)
@@ -418,19 +791,19 @@ fullTableResult = tableResult { trRaw = case trRaw tableResult of
       , ("min_non_gc_mem_usage_delta", Aeson.Number (-4096))
       , ("max_non_gc_mem_usage_delta", Aeson.Number 0)
       , ("outlier_count_non_gc_mem_usage_delta", Aeson.Number 3)
-      ])
+      ] `KM.union` obj)
     raw -> raw
   }
 
 distributionKeys :: [Aeson.Key]
 distributionKeys =
   [ stat <> "_" <> metric
-  | metric <- ["wall_duration", "gc_duration", "mem_usage_delta", "non_gc_mem_usage_delta", "cpu_user", "cpu_system"]
+  | metric <- ["wall_duration", "gc_duration", "mem_usage_delta", "cpu_user", "cpu_system"]
   , stat <- ["min", "max", "median", "q1", "q3", "stdev", "outlier_count"]
   ]
 
 counterSample :: Double -> Double -> Aeson.Object
-counterSample instructions ipc = KM.fromList
+counterSample instructions ipc = identified $ KM.fromList
   [ ("avg_instructions", Aeson.toJSON instructions)
   , ("stdev_instructions", Aeson.Number 0)
   , ("avg_ipc", Aeson.toJSON ipc)

--- a/compiler/acton/TestFormat.hs
+++ b/compiler/acton/TestFormat.hs
@@ -17,8 +17,9 @@ module TestFormat
 
 import Acton.Testing (TestResult(..))
 import TestPerf
+import TestOutput (testOutputMeaningful, splitTestOutput)
 import Data.Char (isSpace)
-import Data.List (foldl', isPrefixOf, isInfixOf, intercalate)
+import Data.List (foldl', isPrefixOf, intercalate)
 import Data.Maybe (catMaybes, fromMaybe, isJust, listToMaybe, mapMaybe)
 import qualified Data.Map as M
 import qualified Data.Text as T
@@ -566,25 +567,6 @@ formatTestDetailLines useColor showLog res =
               else []
           body = map ("    " ++) (lines chunk)
       in header ++ body ++ [""]
-    testOutputMeaningful msgs =
-      any (\line -> not (all isSpace line) && not ("== Running test," `isPrefixOf` line)) (lines msgs)
-    splitTestOutput buf =
-      let ls = lines buf
-          isMarker line = "== Running test, iteration:" `isInfixOf` stripAnsi (trim line)
-          step (chunks, current, seenMarker) line
-            | isMarker line =
-                if seenMarker
-                  then (chunks ++ [trim current], "", True)
-                  else (chunks, "", True)
-            | otherwise =
-                let current' = if null current then line else current ++ "\n" ++ line
-                in (chunks, current', seenMarker)
-          (chunks0, current0, seenMarker) = foldl' step ([], "", False) ls
-          chunks1 =
-            if seenMarker
-              then chunks0 ++ [trim current0]
-              else if null (trim buf) then [] else [trim buf]
-      in chunks1
     renderIterationOutput out err =
       let out' = trim out
           err' = trim err
@@ -611,10 +593,3 @@ formatTestDetailLines useColor showLog res =
     trim s =
       let dropEnd = reverse . dropWhile isSpace . reverse
       in dropWhile isSpace (dropEnd s)
-    stripAnsi [] = []
-    stripAnsi ('\ESC':'[':xs) = stripAnsi (dropAnsi xs)
-    stripAnsi (x:xs) = x : stripAnsi xs
-    dropAnsi [] = []
-    dropAnsi (c:cs)
-      | c == 'm' = cs
-      | otherwise = dropAnsi cs

--- a/compiler/acton/TestFormat.hs
+++ b/compiler/acton/TestFormat.hs
@@ -195,7 +195,7 @@ formatTestPerfLines useColor baseline res =
             _ -> ("", "\ESC[2m")
       in padLeft 11 (paint color text) ++ " "
           ++ (if null icon then "  " else paint (if icon == "⚡" then testColorYellow else color) icon)
-    footerChange key value = case baseline >>= (\old -> perfNumber old key) of
+    footerChange obj key value = case baseline >>= (\old -> if perfComparable key old obj then perfNumber old key else Nothing) of
       Nothing -> ""
       Just old ->
         let (pct, text) = percentage (Just old) value
@@ -273,12 +273,47 @@ formatTestPerfLines useColor baseline res =
             in termFitAnsiRight cols ("  " ++ intercalate (replicate gap ' ') (map cell shown))
       in map render rows
     footers obj = map (\line cols -> termFitAnsiRight cols line) $ catMaybes
-      [ do value <- perfNumber obj "median_duration"
-           return ("  median: " ++ single "" "ms" value ++ footerChange "median_duration" value)
+      [ do info <- perfInfo obj
+           workers <- perfNumber info "workers"
+           scope <- if AesonKM.lookup (AesonKey.fromString "loop") info == Just (Aeson.Bool True)
+             then do scale <- perfNumber info "scale"
+                     iterations <- perfNumber obj "loop_iterations"
+                     return (printf "per loop iteration at scale %.0f; %d runs; %.0f loop iterations" scale (trNumIterations res) iterations)
+             else return (printf "whole invocation; %d runs" (trNumIterations res))
+           return ("  " ++ scope ++ printf "; %.0f runtime workers" workers)
+      , do info <- perfInfo obj
+           raw <- AesonKM.lookup (AesonKey.fromString "calibration") info
+           points <- AesonTypes.parseMaybe Aeson.parseJSON raw :: Maybe [Aeson.Object]
+           let point obj = do
+                 scale <- perfNumber obj "scale"
+                 duration <- perfNumber obj "wall_ms"
+                 return (printf "%.0f:" scale ++ single "" "ms" duration)
+               observed = mapMaybe point points
+               shown = if length observed > 4
+                 then take 2 observed ++ ["…"] ++ drop (length observed - 2) observed
+                 else observed
+           if null observed then Nothing
+             else Just ("  calibration: " ++ intercalate "; " shown)
+      , if trNumIterations res < 4
+             then Just "  limited samples: use a larger --time budget for more complete runs"
+             else Nothing
+      , do info <- perfInfo obj
+           duration <- perfNumber info "warmup_duration_ms"
+           return ("  warmup: " ++ single "" "ms" duration ++ " (excluded)")
+      , do info <- perfInfo obj
+           duration <- perfNumber info "measurement_duration_ms"
+           measured <- perfNumber info "measurement_ms"
+           return ("  measurement: " ++ single "" "ms" measured ++ " timed, " ++ single "" "ms" duration ++ " elapsed including setup and teardown")
+      , do value <- perfNumber obj "median_wall_duration"
+           return ("  wall median: " ++ single "" "ms" value ++ footerChange obj "median_wall_duration" value)
       , do value <- perfNumber obj "peak_rss"
-           return ("  process peak RSS: " ++ single "" "B" value ++ footerChange "peak_rss" value)
-      , do (lo, hi) <- interval "duration" obj
-           return ("  mean delta (95% CI): " ++ pair "ms" " … " ("", "") lo hi)
+           return ("  process peak RSS: " ++ single "" "B" value)
+      , do (lo, hi) <- interval "wall_duration" obj
+           return ("  wall mean delta (approx. 95% CI): " ++ pair "ms" " … " ("", "") lo hi)
+      , do reason <- case baseline of
+             Nothing -> Just "no recorded baseline"
+             Just old -> perfComparisonReason "wall_duration" old obj
+           return ("  comparison unavailable: " ++ reason)
       , do info <- perfCounterInfo obj
            let scope = case counterText info "scope" of
                  Just "process:user" -> "user only"
@@ -290,16 +325,15 @@ formatTestPerfLines useColor baseline res =
            if status == "available" then Nothing
              else Just ("  hardware counters unavailable: " ++ status)
       , do old <- baseline
-           _ <- perfNumber old "avg_cpu_user"
-           _ <- perfNumber obj "avg_cpu_user"
-           if perfComparable "cpu_user" old obj then Nothing
-             else Just "  CPU deltas unavailable: baseline machine differs or is unknown"
-      , do old <- baseline
            _ <- perfNumber old "avg_instructions"
            _ <- perfNumber obj "avg_instructions"
-           if perfComparable "instructions" old obj then Nothing
-             else Just "  hardware deltas unavailable: baseline machine or counter scope differs or is unknown"
-      , Just ("  total: " ++ single "" "ms" (trTestDuration res) ++ printf " (%.1f runs/s)" (testsPerSecond (trNumIterations res) (trTestDuration res)))
+           reason <- perfComparisonReason "instructions" old obj
+           if perfComparable "wall_duration" old obj
+             then Just ("  hardware deltas unavailable: " ++ reason)
+             else Nothing
+      , Just ("  total: " ++ single "" "ms" (trTestDuration res) ++ case perfInfo obj >>= (\info -> perfNumber info "time_budget_ms") of
+           Just budget -> " / " ++ single "" "ms" budget ++ " budget"
+           Nothing -> "")
       ] ++ [""]
     counterText info key = case AesonKM.lookup (AesonKey.fromString key) info of
       Just (Aeson.String s) -> Just (T.unpack s)
@@ -336,7 +370,9 @@ formatTestLineWith useColor statusFn expectedDurationMs nameWidth display res =
     let prefix0 = "   " ++ display ++ ": "
         padding = replicate (max 0 (nameWidth - length prefix0)) ' '
         statusRaw = statusFn res
-        runs = printf "%4d runs in %s @ %6.1f/s" (trNumIterations res) (formatMillisPadded expectedDurationMs (trTestDuration res)) (testsPerSecond (trNumIterations res) (trTestDuration res))
+        runs = case perfPhase res of
+          Just phase -> phase ++ printf ": %d measured samples, %s elapsed" (trNumIterations res) (formatSecondsCompact (trTestDuration res))
+          Nothing -> printf "%4d runs in %s @ %6.1f/s" (trNumIterations res) (formatMillisPadded expectedDurationMs (trTestDuration res)) (testsPerSecond (trNumIterations res) (trTestDuration res))
         statusPart = colorizeStatusPart useColor (trCached res) statusRaw runs
         stressPart =
           case stressWorkerOverview res of
@@ -410,8 +446,8 @@ formatTestLineFitted useColor statusFn expectedDurationMs nameWidth width displa
     (statusPlain, statusRendered) = renderStatusToken useColor (trCached res) statusRaw
     (statusFieldPlain, statusFieldRendered) = renderStatusField useColor (trCached res) statusRaw
     duration = formatSecondsCompactPadded expectedDurationMs (trTestDuration res)
-    summaryFull = show (trNumIterations res) ++ " runs " ++ duration
-    summaryCompact = show (trNumIterations res) ++ "r " ++ duration
+    summaryFull = maybe "" (++ " ") (perfPhase res) ++ show (trNumIterations res) ++ " runs " ++ duration
+    summaryCompact = maybe "" (++ " ") (perfPhase res) ++ show (trNumIterations res) ++ "r " ++ duration
     summaries = [Just summaryFull, Just summaryCompact, Nothing]
     legacyRendered = formatTestLineWith useColor statusFn expectedDurationMs nameWidth display res
     legacyLine
@@ -454,6 +490,15 @@ formatTestFinalLineRenderer useColor perfMode expectedDurationMs nameWidth displ
 formatTestLiveLineRenderer :: Bool -> Double -> Int -> String -> TestResult -> Int -> String
 formatTestLiveLineRenderer useColor expectedDurationMs nameWidth display res cols =
     formatTestLineFitted useColor formatTestStatusLive expectedDurationMs nameWidth cols display res
+
+perfPhase :: TestResult -> Maybe String
+perfPhase res
+  | trComplete res = Nothing
+  | otherwise = case trRaw res of
+      Aeson.Object obj -> case AesonKM.lookup (AesonKey.fromString "perf_phase") obj of
+        Just (Aeson.String phase) -> Just (T.unpack phase)
+        _ -> Nothing
+      _ -> Nothing
 
 formatTestDetailLines :: Bool -> Bool -> TestResult -> [String]
 formatTestDetailLines useColor showLog res =

--- a/compiler/acton/TestOutput.hs
+++ b/compiler/acton/TestOutput.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE OverloadedStrings #-}
+module TestOutput
+  ( TestOutput
+  , emptyTestOutput
+  , appendTestOutput
+  , finishTestOutput
+  , testOutputMeaningful
+  , splitTestOutput
+  ) where
+
+import Data.List (foldl')
+import qualified Data.Text as T
+
+-- Keep only nonempty frames. Marker ordinals, rather than invocation IDs,
+-- preserve stream alignment when stress workers restart their numbering.
+data TestOutput = TestOutput !Int ![T.Text] ![(Int, T.Text)]
+
+emptyTestOutput :: TestOutput
+emptyTestOutput = TestOutput 0 [] []
+
+appendTestOutput :: T.Text -> TestOutput -> TestOutput
+appendTestOutput line output@(TestOutput ordinal current frames)
+  | isMarker line = TestOutput (ordinal + 1) [] (saveFrame output)
+  | null current && T.null (T.strip line) = output
+  | otherwise = TestOutput ordinal (line : current) frames
+
+saveFrame :: TestOutput -> [(Int, T.Text)]
+saveFrame (TestOutput ordinal current frames)
+  | T.null body = frames
+  | otherwise = (ordinal, body) : frames
+  where body = T.strip (T.unlines (reverse current))
+
+-- Emit aligned frames in the existing cached log format. An empty counterpart
+-- is needed when only one stream has output; entirely empty iterations vanish.
+finishTestOutput :: TestOutput -> TestOutput -> (String, String)
+finishTestOutput out err =
+    let frames = merge (reverse (saveFrame out)) (reverse (saveFrame err))
+        render select = T.unpack (T.concat [marker <> T.pack (show n) <> "\n" <> select o e <> "\n" | (n, o, e) <- frames])
+    in (render const, render (flip const))
+  where
+    merge [] es = [(n, "", e) | (n, e) <- es]
+    merge os [] = [(n, o, "") | (n, o) <- os]
+    merge os@((n, o):os') es@((m, e):es')
+      | n < m = (n, o, "") : merge os' es
+      | n > m = (m, "", e) : merge os es'
+      | otherwise = (n, o, e) : merge os' es'
+
+marker :: T.Text
+marker = "== Running test, iteration: "
+
+isMarker :: T.Text -> Bool
+isMarker line =
+    case T.stripPrefix marker (T.strip line) of
+      Just number -> not (T.null number) && T.all (\c -> c >= '0' && c <= '9') number
+      Nothing -> False
+
+testOutputMeaningful :: String -> Bool
+testOutputMeaningful = any (\line -> not (T.null (T.strip line)) && not (isMarker line)) . T.lines . T.pack
+
+-- Both human and JSON reports must split the cached streams identically,
+-- including empty counterparts used to align stdout with stderr.
+splitTestOutput :: String -> [String]
+splitTestOutput buf =
+    let step (frames, current, seen) line
+          | isMarker line = (if seen then body current : frames else frames, [], True)
+          | otherwise = (frames, line : current, seen)
+        body = T.unpack . T.strip . T.unlines . reverse
+        (frames, current, seen) = foldl' step ([], [], False) (T.lines (T.pack buf))
+    in if seen
+         then reverse (body current : frames)
+         else if null (body current) then [] else [body current]

--- a/compiler/acton/TestOutputTests.hs
+++ b/compiler/acton/TestOutputTests.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE OverloadedStrings #-}
+module TestOutputTests (testOutputTests) where
+
+import Data.List (foldl')
+import qualified Data.Text as T
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import TestOutput
+
+testOutputTests :: TestTree
+testOutputTests = testGroup "test output capture"
+  [ testCase "quiet iterations leave no captured logs" $ do
+      let quiet = capture (concat (replicate 100000 ["", marker, "  "]))
+      assertEqual "neither stream retains iteration markers" ("", "") (finishTestOutput quiet quiet)
+  , testCase "sparse streams retain iteration pairing and repeated output" $ do
+      let out = capture [marker, "first", marker, marker, marker, "both", marker, "both"]
+          err = capture [marker, marker, "second", marker, marker, "error", marker, "error"]
+      assertEqual "only jointly empty iterations disappear"
+        [("first", ""), ("", "second"), ("both", "error"), ("both", "error")]
+        (pairs (finishTestOutput out err))
+  , testCase "preamble and unfinished final frames survive" $ do
+      let out = capture ["startup", marker, "last line without newline"]
+          err = capture [marker, "{\"unrelated\":true}"]
+      assertEqual "diagnostics before the first invocation stay separate"
+        [("startup", ""), ("last line without newline", "{\"unrelated\":true}")]
+        (pairs (finishTestOutput out err))
+  , testCase "marker-like payload and internal whitespace survive" $ do
+      let payload = "trace: == Running test, iteration: 12\n\n  λ\n== Running test, iteration: unknown"
+          out = capture (marker : T.lines payload)
+          err = capture [marker]
+          (outText, errText) = finishTestOutput out err
+      assertBool "marker-like text is meaningful" (testOutputMeaningful (T.unpack payload))
+      assertBool "an empty counterpart is not meaningful" (not (testOutputMeaningful errText))
+      assertEqual "payload survives capture and reporting" [T.unpack payload] (splitTestOutput outText)
+  , testCase "cached logs retain empty frames for pairing" $ do
+      assertEqual "old cached streams split without dropping empty frames"
+        ["", "second", ""] (splitTestOutput (T.unpack (T.unlines [marker, marker, "second", marker])))
+  ]
+  where
+    -- Deliberately repeat the printed invocation ID, as stress workers do.
+    marker = "== Running test, iteration: 1"
+    capture = foldl' (flip appendTestOutput) emptyTestOutput
+    pairs (out, err) = zip (splitTestOutput out) (splitTestOutput err)

--- a/compiler/acton/TestPerf.hs
+++ b/compiler/acton/TestPerf.hs
@@ -3,7 +3,10 @@ module TestPerf
   , perfNumber
   , perfMetrics
   , perfStatKey
+  , perfInfo
   , perfCounterInfo
+  , perfComparisonReason
+  , perfBaselineScale
   , perfComparable
   , perfMeanInterval
   , perfJson
@@ -12,6 +15,7 @@ module TestPerf
 import Acton.Testing (TestResult(..))
 import Control.Monad (guard)
 import Data.Maybe (isJust)
+import Data.List (find)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Types as AesonTypes
 import qualified Data.Aeson.Key as AesonKey
@@ -38,16 +42,14 @@ finite x = not (isNaN x || isInfinite x)
 -- | Sample series, display labels and base units shared by the table and JSON.
 perfMetrics :: [(String, String, String)]
 perfMetrics =
-    [ ("duration", "time excl. GC", "ms")
-    , ("wall_duration", "wall time", "ms")
-    , ("gc_duration", "GC time", "ms")
+    [ ("wall_duration", "wall time", "ms")
     , ("cpu_user", "CPU user", "ms")
     , ("cpu_system", "CPU system", "ms")
     , ("instructions", "instructions", "count")
     , ("cycles", "cycles", "count")
     , ("ipc", "IPC", "ratio")
     , ("mem_usage_delta", "allocated", "B")
-    , ("non_gc_mem_usage_delta", "non-GC change", "B")
+    , ("gc_duration", "GC time", "ms")
     ]
 
 -- Preserve the original mean and duration outlier keys in saved measurements.
@@ -57,25 +59,84 @@ perfStatKey metric "avg"
   | metric `elem` ["mem_usage_delta", "non_gc_mem_usage_delta"] = metric ++ "_avg"
 perfStatKey metric stat = stat ++ "_" ++ metric
 
+perfInfo :: Aeson.Object -> Maybe Aeson.Object
+perfInfo = objectField "perf_info"
+
 perfCounterInfo :: Aeson.Object -> Maybe Aeson.Object
-perfCounterInfo obj = case AesonKM.lookup (AesonKey.fromString "counter_info") obj of
+perfCounterInfo = objectField "counter_info"
+
+objectField :: String -> Aeson.Object -> Maybe Aeson.Object
+objectField key obj = case AesonKM.lookup (AesonKey.fromString key) obj of
     Just (Aeson.Object info) -> Just info
     _ -> Nothing
 
--- Counter deltas only make sense for the same machine and accounting scope.
--- Legacy recordings can still be compared using their original metrics.
+-- Every delta needs the same workload and machine. Counter accounting scope
+-- is an additional constraint for hardware measurements only.
 perfComparable :: String -> Aeson.Object -> Aeson.Object -> Bool
-perfComparable metric old new
-  | metric `notElem` ["cpu_user", "cpu_system", "instructions", "cycles", "ipc"] = True
-  | otherwise = case (perfCounterInfo old, perfCounterInfo new) of
-      (Just a, Just b) -> all (matches a b) keys
-      _ -> False
+perfComparable metric old new = not (isJust (perfComparisonReason metric old new))
+
+perfComparisonReason :: String -> Aeson.Object -> Aeson.Object -> Maybe String
+perfComparisonReason metric old new = case (perfInfo old, perfInfo new) of
+    (Nothing, _) -> Just "baseline has no performance identity; record a new baseline"
+    (_, Nothing) -> Just "current performance identity is unavailable"
+    (Just a, Just b) -> case metadataReason (hostKeys ++ ["scale", "loop", "workers"]) a b of
+      Just reason -> Just reason
+      Nothing
+        | metric `elem` ["instructions", "cycles", "ipc"] -> case (perfCounterInfo old, perfCounterInfo new) of
+            (Just ca, Just cb) -> metadataReason ["version", "backend", "scope"] ca cb
+            _ -> Just "hardware counter scope is unavailable"
+        | otherwise -> Nothing
+
+-- Select the recorded workload scale before launching the process. The completed
+-- run must still pass the actual worker-count and loop checks above.
+perfBaselineScale :: Aeson.Object -> Aeson.Object -> Maybe Int
+perfBaselineScale baseline currentInfo = do
+    old <- perfInfo baseline
+    guard (not (isJust (metadataReason hostKeys old currentInfo)))
+    guard (AesonKM.lookup (AesonKey.fromString "loop") old == Just (Aeson.Bool True))
+    value <- AesonKM.lookup (AesonKey.fromString "scale") old >>= AesonTypes.parseMaybe Aeson.parseJSON
+    guard (value > 0)
+    return value
+
+hostKeys :: [String]
+hostKeys = ["machine", "version", "build", "tags", "gc"]
+
+metadataReason :: [String] -> Aeson.Object -> Aeson.Object -> Maybe String
+metadataReason keys old new = do
+    key <- find (not . matches) keys
+    return (label key ++ if valid key old && valid key new then " differs" else " is unavailable")
   where
-    keys = ["version", "os", "release", "arch", "cpu"] ++
-      if metric `elem` ["cpu_user", "cpu_system"] then [] else ["backend", "scope"]
-    matches a b key = case AesonKM.lookup (AesonKey.fromString key) a of
-      Just value@(Aeson.String s) | s /= mempty -> AesonKM.lookup (AesonKey.fromString key) b == Just value
-      _ -> False
+    value obj key = AesonKM.lookup (AesonKey.fromString key) obj
+    matches key = valid key old && valid key new && value old key == value new key
+    valid key obj = case key of
+      "build" -> case value obj key of
+        Just (Aeson.Object build) -> all (\k -> case value build k of
+            Just (Aeson.String s) -> k == "cpu" || s /= mempty
+            _ -> False) ["optimize", "target", "cpu"]
+          && all (\k -> case value build k of
+               Just (Aeson.Bool _) -> True
+               _ -> False) ["no_threads", "db", "no_dbp"]
+        _ -> False
+      "tags" -> isJust (value obj key >>= (AesonTypes.parseMaybe Aeson.parseJSON :: Aeson.Value -> Maybe [String]))
+      "loop" -> case value obj key of
+        Just (Aeson.Bool _) -> True
+        _ -> False
+      _ | key `elem` ["scale", "workers"] -> case perfNumber obj key of
+            Just n -> n >= (if key == "workers" then 0 else 1) && n == fromInteger (floor n)
+            _ -> False
+        | otherwise -> case value obj key of
+            Just (Aeson.String s) -> s /= mempty
+            _ -> False
+    label key = case key of
+      "machine" -> "machine identity"
+      "version" -> "measurement version"
+      "build" -> "build mode"
+      "tags" -> "input tags"
+      "gc" -> "GC policy"
+      "scale" -> "workload scale"
+      "loop" -> "measurement loop usage"
+      "workers" -> "runtime worker count"
+      _ -> "hardware counter " ++ key
 
 -- | Approximate 95% Welch interval for a mean difference, in the metric's units.
 -- The sample model assumes independent iterations; process drift is not covered.
@@ -122,16 +183,20 @@ critical95 df = last [score | (n, score) <- table, n <= max 1 df]
 perfJson :: Maybe Aeson.Object -> TestResult -> Maybe Aeson.Value
 perfJson baseline res = do
     obj <- testPerfData res
-    let interval = baseline >>= (\old -> perfMeanInterval "duration" old obj)
+    let interval = baseline >>= (\old -> perfMeanInterval "wall_duration" old obj)
+        reason = case baseline of
+          Nothing -> Just "no recorded baseline"
+          Just old -> perfComparisonReason "wall_duration" old obj
     return $ Aeson.object
       [ AesonKey.fromString "measurements" Aeson..= measurements obj
       , AesonKey.fromString "baseline" Aeson..= fmap measurements baseline
       , AesonKey.fromString "mean_difference_ci95_ms" Aeson..= fmap bounds interval
+      , AesonKey.fromString "comparison_unavailable_reason" Aeson..= reason
       ]
   where
-    keys = ["peak_rss", "num_iterations", "counter_info"] ++
+    keys = ["peak_rss", "num_iterations", "loop_iterations", "perf_info", "counter_info"] ++
       [ perfStatKey metric stat
-      | (metric, _, _) <- perfMetrics
+      | metric <- [m | (m, _, _) <- perfMetrics] ++ ["duration"]
       , stat <- ["avg", "min", "max", "median", "q1", "q3", "stdev", "outlier_count"]
       ]
     measurements = Aeson.Object . AesonKM.filterWithKey (\key _ -> AesonKey.toString key `elem` keys)

--- a/compiler/acton/TestRunner.hs
+++ b/compiler/acton/TestRunner.hs
@@ -13,6 +13,7 @@ import qualified Acton.SourceProvider as Source
 import qualified InterfaceFiles
 import qualified FileUtil
 import TestFormat
+import TestOutput
 import TestPerf
 import TestUI
 import Control.Applicative ((<|>))
@@ -32,7 +33,7 @@ import System.Exit
 import System.Environment (getEnvironment)
 import qualified System.Info as System
 import System.FilePath ((</>), (<.>), joinPath)
-import System.IO (hClose, hGetContents, hGetLine, hIsEOF)
+import System.IO (hClose, hIsEOF)
 import System.Process
 import ProcessUtil (stopProcessGroup)
 import Text.Printf
@@ -45,6 +46,7 @@ import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Base16 as Base16
 import qualified Crypto.Hash.SHA256 as SHA256
 import qualified Data.Text as T
+import qualified Data.Text.IO as TIO
 import qualified Data.Text.Encoding as TE
 import Data.Time.Clock (UTCTime)
 import Control.Exception (IOException, SomeException, SomeAsyncException, AsyncException(..), displayException, evaluate, mask, onException, try, fromException, throwIO, finally)
@@ -521,29 +523,6 @@ renderChunk multi (chunk, count) =
 stripTrailingBlanks :: [String] -> [String]
 stripTrailingBlanks = reverse . dropWhile null . reverse
 
-testOutputMeaningful :: String -> Bool
-testOutputMeaningful msgs =
-    any (\line -> not (all isSpace line) && not ("== Running test," `isPrefixOf` line)) (lines msgs)
-
-splitTestOutput :: String -> [String]
-splitTestOutput buf =
-    let ls = lines buf
-        isMarker line = "== Running test, iteration:" `isInfixOf` stripAnsi (trim line)
-        step (chunks, current, seenMarker) line
-          | isMarker line =
-              if seenMarker
-                then (chunks ++ [trim current], "", True)
-                else (chunks, "", True)
-          | otherwise =
-              let current' = if null current then line else current ++ "\n" ++ line
-              in (chunks, current', seenMarker)
-        (chunks0, current0, seenMarker) = foldl' step ([], "", False) ls
-        chunks1 =
-          if seenMarker
-            then chunks0 ++ [trim current0]
-            else if null (trim buf) then [] else [trim buf]
-    in chunks1
-
 renderIterationOutput :: String -> String -> String
 renderIterationOutput out err =
     let out' = trim out
@@ -576,17 +555,6 @@ trim :: String -> String
 trim s =
     let dropEnd = reverse . dropWhile isSpace . reverse
     in dropWhile isSpace (dropEnd s)
-
-stripAnsi :: String -> String
-stripAnsi [] = []
-stripAnsi ('\ESC':'[':xs) = stripAnsi (dropAnsi xs)
-stripAnsi (x:xs) = x : stripAnsi xs
-
-dropAnsi :: String -> String
-dropAnsi [] = []
-dropAnsi (c:cs)
-  | c == 'm' = cs
-  | otherwise = dropAnsi cs
 
 -- | Filter module names based on CLI-provided allow lists.
 filterModules :: [String] -> [String] -> [String]
@@ -672,12 +640,16 @@ runModuleTestStreaming opts paths topts mode perfHostInfo baselineScale modName 
             _ -> []
         cmd = ["test", testName] ++ modeArgs ++ testCmdArgs mode topts
           ++ maybe [] (\scale -> ["--scale", show scale]) (C.testScale topts <|> baselineScale)
-    updatesRef <- newIORef []
+    resultRef <- newIORef Nothing
     lineDoneRef <- newIORef False
-    stdErrRef <- newIORef []
+    stdOutRef <- newIORef emptyTestOutput
+    stdErrRef <- newIORef emptyTestOutput
     let onUpdate raw = do
           let res = validateScale (annotatePerfResult perfHostInfo raw)
-          modifyIORef' updatesRef (\xs -> xs ++ [res])
+          modifyIORef' resultRef $ \previous ->
+            case previous of
+              Just old | trComplete old && not (trComplete res) -> previous
+              _ -> Just res
           done <- readIORef lineDoneRef
           when (not done && allowLive) $ do
             if trComplete res
@@ -685,7 +657,8 @@ runModuleTestStreaming opts paths topts mode perfHostInfo baselineScale modName 
                 tpcOnDone callbacks res
                 writeIORef lineDoneRef True
               else tpcOnLive callbacks res
-        addStdErr line = modifyIORef' stdErrRef (line :)
+        onOutLine line = modifyIORef' stdOutRef (appendTestOutput line)
+        addStdErr line = modifyIORef' stdErrRef (appendTestOutput line)
         onErrLine line =
           case parseJsonLine line of
             Nothing -> addStdErr line
@@ -699,20 +672,20 @@ runModuleTestStreaming opts paths topts mode perfHostInfo baselineScale modName 
           , create_group = C.watch opts
           , delegate_ctlc = not (C.watch opts)
           }
-    procRes <- try (readProcessWithExitCodeStreaming procSpec onErrLine) :: IO (Either SomeException (ExitCode, String, String))
-    (exitCode, out, _err, interruptedByUser) <-
+    procRes <- try (readProcessWithExitCodeStreaming procSpec onOutLine onErrLine) :: IO (Either SomeException ExitCode)
+    (exitCode, interruptedByUser) <-
       case procRes of
-        Right (code, outTxt, errTxt) ->
-          return (code, outTxt, errTxt, False)
+        Right code ->
+          return (code, False)
         Left ex ->
           case fromException ex of
             Just UserInterrupt ->
-              return (ExitFailure (-2), "", "", True)
+              return (ExitFailure (-2), True)
             _ -> throwIO ex
-    infos <- readIORef updatesRef
-    stdErrLines <- reverse <$> readIORef stdErrRef
-    let stdErrText = unlines stdErrLines
-    let final = pickFinalTestInfo infos
+    final <- readIORef resultRef
+    stdOut <- readIORef stdOutRef
+    stdErr <- readIORef stdErrRef
+    let (out, stdErrText) = finishTestOutput stdOut stdErr
         fallback = TestResult
           { trModule = modName
           , trName = testName
@@ -1115,12 +1088,12 @@ displayTestName name =
          else withoutPrefix
 
 -- | Parse a single JSON line emitted by test binaries.
-parseJsonLine :: String -> Maybe Aeson.Value
+parseJsonLine :: T.Text -> Maybe Aeson.Value
 parseJsonLine line =
-    let trimmed = dropWhile isSpace line
-    in if null trimmed
-         then Nothing
-         else Aeson.decodeStrict' (TE.encodeUtf8 (T.pack trimmed))
+    let trimmed = T.stripStart line
+    in case T.uncons trimmed of
+         Just ('{', _) -> Aeson.decodeStrict' (TE.encodeUtf8 trimmed)
+         _ -> Nothing
 
 -- | Extract test result payloads from JSON events.
 extractTestInfo :: [Aeson.Value] -> [TestResult]
@@ -1178,16 +1151,6 @@ parseTestInfoValue = Aeson.withObject "TestInfo" $ \o -> do
       , trSnapshotUpdated = False
       , trCached = False
       }
-
--- | Pick the final or last-seen TestResult from a stream.
-pickFinalTestInfo :: [TestResult] -> Maybe TestResult
-pickFinalTestInfo infos =
-    case reverse infos of
-      [] -> Nothing
-      xs ->
-        case listToMaybe [i | i <- xs, trComplete i] of
-          Just i -> Just i
-          Nothing -> Just (head xs)
 
 testResultInterrupted :: TestResult -> Bool
 testResultInterrupted res =
@@ -1476,9 +1439,9 @@ writePerfData paths baseline results = do
       FileUtil.writeFile (projPath paths </> "perf_data")
         (T.unpack (TE.decodeUtf8 (BL.toStrict (Aeson.encode updated))))
 
--- | Run a process and stream stderr lines to a callback while capturing output.
-readProcessWithExitCodeStreaming :: CreateProcess -> (String -> IO ()) -> IO (ExitCode, String, String)
-readProcessWithExitCodeStreaming cp onErrLine = mask $ \restore -> do
+-- | Drain both process streams through callbacks without retaining another copy.
+readProcessWithExitCodeStreaming :: CreateProcess -> (T.Text -> IO ()) -> (T.Text -> IO ()) -> IO ExitCode
+readProcessWithExitCodeStreaming cp onOutLine onErrLine = mask $ \restore -> do
     let cp' = cp { std_in = NoStream, std_out = CreatePipe, std_err = CreatePipe }
     withCreateProcess cp' $ \_ mOut mErr ph -> do
       pid <- getPid ph
@@ -1488,39 +1451,23 @@ readProcessWithExitCodeStreaming cp onErrLine = mask $ \restore -> do
             when owned $ do
               stopProcessGroup ph pid
               writeIORef groupOwned False
-          readStdout mH =
+          readLines onLine mH =
             case mH of
-              Nothing -> return ""
+              Nothing -> return ()
               Just h -> do
-                txt <- hGetContents h
-                _ <- evaluate (length txt)
+                let go = do
+                      eof <- hIsEOF h
+                      unless eof $ TIO.hGetLine h >>= onLine >> go
+                go
                 hClose h
-                return txt
-          readStderr mH =
-            case mH of
-              Nothing -> return ""
-              Just h -> do
-                txt <- readErrLines h
-                hClose h
-                return txt
-          readErrLines h = go []
-            where
-              go acc = do
-                eof <- hIsEOF h
-                if eof
-                  then return (unlines (reverse acc))
-                  else do
-                    line <- hGetLine h
-                    onErrLine line
-                    go (line : acc)
       let capture = restore $
-            withAsync (readStdout mOut) $ \outReader ->
-              withAsync (readStderr mErr) $ \errReader -> do
+            withAsync (readLines onOutLine mOut) $ \outReader ->
+              withAsync (readLines onErrLine mErr) $ \errReader -> do
                 code <- waitForProcess ph
                 when (create_group cp') stop
-                out <- wait outReader
-                err <- wait errReader
-                return (code, out, err)
+                wait outReader
+                wait errReader
+                return code
       if create_group cp'
         then capture `finally` stop
         else capture `onException` (terminateProcess ph >> void (waitForProcess ph))

--- a/compiler/acton/TestRunner.hs
+++ b/compiler/acton/TestRunner.hs
@@ -15,6 +15,7 @@ import qualified FileUtil
 import TestFormat
 import TestPerf
 import TestUI
+import Control.Applicative ((<|>))
 import Control.Concurrent.Async
 import Control.Concurrent.Chan (Chan, newChan, readChan, writeChan)
 import Control.Monad
@@ -670,12 +671,12 @@ runModuleTestStreaming opts paths topts mode perfHostInfo baselineScale modName 
             TestModeStress -> ["stress"]
             _ -> []
         cmd = ["test", testName] ++ modeArgs ++ testCmdArgs mode topts
-          ++ maybe [] (\scale -> ["--scale", show scale]) baselineScale
+          ++ maybe [] (\scale -> ["--scale", show scale]) (C.testScale topts <|> baselineScale)
     updatesRef <- newIORef []
     lineDoneRef <- newIORef False
     stdErrRef <- newIORef []
     let onUpdate raw = do
-          let res = annotatePerfResult perfHostInfo raw
+          let res = validateScale (annotatePerfResult perfHostInfo raw)
           modifyIORef' updatesRef (\xs -> xs ++ [res])
           done <- readIORef lineDoneRef
           when (not done && allowLive) $ do
@@ -757,10 +758,11 @@ runModuleTestStreaming opts paths topts mode perfHostInfo baselineScale modName 
                 ExitSuccess -> res1
                 ExitFailure code ->
                   res1 { trException = Just ("Test process exited with code " ++ show code) }
-    res' <-
+    updated <-
       if C.testSnapshotUpdate topts
         then applySnapshotUpdate paths res
         else return res
+    let res' = validateScale updated
     done <- readIORef lineDoneRef
     if done
       then tpcOnFinal callbacks res'
@@ -769,6 +771,18 @@ runModuleTestStreaming opts paths topts mode perfHostInfo baselineScale modName 
         tpcOnFinal callbacks res'
     return res'
   where
+    validateScale res
+      | isJust (C.testScale topts), trComplete res, trSuccess res == Just True
+      , not (trSkipped res), not (isJust (trException res))
+      , Aeson.Object obj <- trRaw res, Just info <- perfInfo obj
+      , AesonKM.lookup (AesonKey.fromString "loop") info == Just (Aeson.Bool False) =
+          res { trSuccess = Just False
+              , trException = Just "Explicit --scale requires a test that uses t.loop()"
+              , trNumFailures = trNumFailures res + 1
+              , trSnapshotUpdated = False
+              }
+      | otherwise = res
+
     isInterruptExitCode ExitSuccess = False
     isInterruptExitCode (ExitFailure code) = code == (-2) || code == 130
 

--- a/compiler/acton/TestRunner.hs
+++ b/compiler/acton/TestRunner.hs
@@ -19,7 +19,7 @@ import Control.Concurrent.Async
 import Control.Concurrent.Chan (Chan, newChan, readChan, writeChan)
 import Control.Monad
 import Data.IORef
-import Data.Char (isSpace)
+import Data.Char (isSpace, isHexDigit, toLower)
 import Data.List (isPrefixOf, isSuffixOf, foldl', isInfixOf, intercalate)
 import qualified Data.List
 import Data.Maybe (catMaybes, listToMaybe, isJust)
@@ -29,6 +29,7 @@ import System.Clock
 import System.Directory
 import System.Exit
 import System.Environment (getEnvironment)
+import qualified System.Info as System
 import System.FilePath ((</>), (<.>), joinPath)
 import System.IO (hClose, hGetContents, hGetLine, hIsEOF)
 import System.Process
@@ -39,6 +40,9 @@ import qualified Data.Aeson.Types as AesonTypes
 import qualified Data.Aeson.Key as AesonKey
 import qualified Data.Aeson.KeyMap as AesonKM
 import qualified Data.ByteString.Lazy as BL
+import qualified Data.ByteString.Char8 as BS
+import qualified Data.ByteString.Base16 as Base16
+import qualified Crypto.Hash.SHA256 as SHA256
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import Data.Time.Clock (UTCTime)
@@ -232,6 +236,7 @@ runProjectTests useColorOut gopts opts paths topts mode modules maxParallel = do
             ctxHash = contextHashBytes runContext
             useCache = not (C.testNoCache topts) && mode == TestModeRun
         perfData <- if mode == TestModePerf then readPerfData paths else return M.empty
+        perfHostInfo <- if mode == TestModePerf then readPerfHostInfo opts topts else return AesonKM.empty
         let detailLines res =
               map staticLine (formatTestDetailLines useColorOut (C.testShowLog topts) res) ++
               if mode == TestModePerf
@@ -352,9 +357,10 @@ runProjectTests useColorOut gopts opts paths topts mode modules maxParallel = do
                           then return Nothing
                           else do
                             callbacks <- testProgressCallbacks ui eventChan key display (mode == TestModePerf) expectedDurationMs detailLines
+                            let baselineScale = lookupPerfData perfData initRes >>= (\old -> perfBaselineScale old perfHostInfo)
                             mask $ \unmask -> do
                               worker <- async $ unmask $ mask $ \restore -> do
-                                resE <- try (restore (runModuleTestStreaming opts paths topts mode (tsModule spec) (tsName spec)
+                                resE <- try (restore (runModuleTestStreaming opts paths topts mode perfHostInfo baselineScale (tsModule spec) (tsName spec)
                                                        (tpuEnabled ui) callbacks))
                                           :: IO (Either SomeException TestResult)
                                 case resE of
@@ -648,12 +654,14 @@ runModuleTestStreaming :: C.CompileOptions
                        -> Paths
                        -> C.TestOptions
                        -> TestMode
+                       -> Aeson.Object
+                       -> Maybe Int
                        -> String
                        -> String
                        -> Bool
                        -> TestProgressCallbacks
                        -> IO TestResult
-runModuleTestStreaming opts paths topts mode modName testName allowLive callbacks = do
+runModuleTestStreaming opts paths topts mode perfHostInfo baselineScale modName testName allowLive callbacks = do
     environment <- getEnvironment
     let binPath = testBinaryPath opts paths modName
         modeArgs =
@@ -662,10 +670,12 @@ runModuleTestStreaming opts paths topts mode modName testName allowLive callback
             TestModeStress -> ["stress"]
             _ -> []
         cmd = ["test", testName] ++ modeArgs ++ testCmdArgs mode topts
+          ++ maybe [] (\scale -> ["--scale", show scale]) baselineScale
     updatesRef <- newIORef []
     lineDoneRef <- newIORef False
     stdErrRef <- newIORef []
-    let onUpdate res = do
+    let onUpdate raw = do
+          let res = annotatePerfResult perfHostInfo raw
           modifyIORef' updatesRef (\xs -> xs ++ [res])
           done <- readIORef lineDoneRef
           when (not done && allowLive) $ do
@@ -1030,14 +1040,11 @@ testsPerSecond iterations durationMs
   | otherwise = (fromIntegral iterations * 1000.0) / durationMs
 
 effectiveTestTiming :: TestMode -> C.TestOptions -> (Int, Int)
+effectiveTestTiming TestModePerf topts = (C.testTime topts, C.testTime topts)
 effectiveTestTiming mode topts =
     let rawMinTime = C.testMinTime topts
         minTime =
           case mode of
-            TestModePerf ->
-              if not (C.testMinTimeSet topts)
-                then 1000
-                else rawMinTime
             TestModeStress ->
               if not (C.testMinTimeSet topts)
                 then 1000
@@ -1047,7 +1054,6 @@ effectiveTestTiming mode topts =
         modeDefaultMaxTime =
           case mode of
             TestModeRun -> minTime
-            TestModePerf -> 1000
             TestModeStress -> 5000
             _ -> 1000
         maxTime
@@ -1058,7 +1064,9 @@ effectiveTestTiming mode topts =
 
 -- | Build test runner arguments from TestOptions limits.
 testCmdArgs :: TestMode -> C.TestOptions -> [String]
-testCmdArgs mode topts =
+testCmdArgs mode topts
+  | mode == TestModePerf = ["--time", show (C.testTime topts)] ++ tagArgs
+  | otherwise =
     let iter = C.testIter topts
         rawMaxIter = C.testMaxIter topts
         (minTime, maxTime) = effectiveTestTiming mode topts
@@ -1077,8 +1085,9 @@ testCmdArgs mode topts =
                  , "--max-time", show maxTime
                  , "--min-time", show minTime
                  ]
-        tagArgs = concatMap (\tag -> ["--tag", tag]) (C.testTags topts)
     in baseArgs ++ stressWorkerArgs ++ tagArgs
+  where
+    tagArgs = concatMap (\tag -> ["--tag", tag]) (C.testTags topts)
 
 -- | Normalize test names by stripping prefixes and wrappers.
 displayTestName :: String -> String
@@ -1370,6 +1379,52 @@ markSnapshotUpdated res = res
   }
 
 type PerfData = M.Map String (M.Map String Aeson.Value)
+
+-- Keep raw machine identifiers out of recordings. An unknown identity disables
+-- comparisons; a CPU model or OS version is not a machine identifier.
+readPerfHostInfo :: C.CompileOptions -> C.TestOptions -> IO Aeson.Object
+readPerfHostInfo opts topts = do
+    identity <- try readIdentity :: IO (Either IOException (Maybe String))
+    let machine = case identity of
+          Right (Just raw) -> Just (BS.unpack (Base16.encode (SHA256.hash (BS.pack ("acton-perf-machine-v1:" ++ raw)))))
+          _ -> Nothing
+    return $ AesonKM.fromList
+      [ (AesonKey.fromString "machine", Aeson.toJSON machine)
+      , (AesonKey.fromString "build", Aeson.object
+          [ AesonKey.fromString "optimize" Aeson..= show (C.optimize opts)
+          , AesonKey.fromString "target" Aeson..= C.target opts
+          , AesonKey.fromString "cpu" Aeson..= C.cpu opts
+          , AesonKey.fromString "no_threads" Aeson..= C.no_threads opts
+          , AesonKey.fromString "db" Aeson..= C.db opts
+          , AesonKey.fromString "no_dbp" Aeson..= C.no_dbp opts
+          ])
+      , (AesonKey.fromString "tags", Aeson.toJSON (Set.toAscList (Set.fromList tags)))
+      , (AesonKey.fromString "version", Aeson.toJSON ("3" :: String))
+      , (AesonKey.fromString "gc", Aeson.toJSON ("natural" :: String))
+      ]
+  where
+    tags = filter (not . null)
+      [ dropWhile isSpace (reverse (dropWhile isSpace (reverse tag)))
+      | raw <- C.testTags topts, tag <- splitOnChar ',' raw ]
+    readIdentity = case System.os of
+      "darwin" -> do
+        (code, out, _) <- readProcessWithExitCode "/usr/sbin/ioreg" ["-rd1", "-c", "IOPlatformExpertDevice"] ""
+        return $ if code /= ExitSuccess then Nothing else listToMaybe
+          [ raw | line <- lines out, (key, '=' : value) <- [break (== '=') line]
+                , "\"IOPlatformUUID\"" `isInfixOf` key, Just raw <- [normalize value] ]
+      "linux" -> normalize . BS.unpack <$> BS.readFile "/etc/machine-id"
+      _ -> return Nothing
+    normalize value =
+      let raw = map toLower (filter (\c -> not (isSpace c) && c /= '"' && c /= '-') value)
+      in if length raw == 32 && all isHexDigit raw && any (/= '0') raw
+           then Just raw else Nothing
+
+annotatePerfResult :: Aeson.Object -> TestResult -> TestResult
+annotatePerfResult host res = case trRaw res of
+    Aeson.Object obj | Just info <- perfInfo obj ->
+      let extra = AesonKM.filterWithKey (\key _ -> AesonKey.toString key `elem` ["machine", "build", "tags"]) host
+      in res { trRaw = Aeson.Object (AesonKM.insert (AesonKey.fromString "perf_info") (Aeson.Object (extra `AesonKM.union` info)) obj) }
+    _ -> res
 
 -- | Read the baseline before running tests, including when updating it.
 readPerfData :: Paths -> IO PerfData

--- a/compiler/acton/WatchTests.hs
+++ b/compiler/acton/WatchTests.hs
@@ -132,18 +132,52 @@ watchProcessTests = testGroup "watch subprocesses"
       withProcessProject $ \acton proj system -> do
         writeExecutable (proj </> "out/bin/.test_main")
           [ "trap 'exit 130' INT"
+          , "echo '== Running test, iteration: 1'"
+          , "echo '== Running test, iteration: 1' >&2"
           , testInfo False
+          , "printf 'stdout before interrupt'"
+          , "printf 'stderr before interrupt' >&2"
           , "echo $$ > leader.pid"
           , "while :; do sleep 1; done"
           ]
-        withActon acton proj ["test", "stress", "--tty", "--syspath", system] $ \ph group output -> do
+        withActon acton proj ["test", "stress", "--tty", "--show-log", "--syspath", system] $ \ph group output -> do
           _ <- awaitPid proj "leader.pid"
           signalProcessGroup sigINT group
           code <- await "interrupted stress exit" (getProcessExitCode ph)
           logText <- output
           assertEqual logText ExitSuccess code
           assertBool logText ("Stress run interrupted by user; showing partial results collected so far." `isInfixOf` logText)
+          assertBool logText ("stdout before interrupt" `isInfixOf` logText && "stderr before interrupt" `isInfixOf` logText)
           assertCursorRestored logText
+  , testCase "a final result survives later partial updates and output" $
+      withProcessProject $ \acton proj system -> do
+        writeExecutable (proj </> "out/bin/.test_main")
+          [ testInfo True
+          , "echo '{\"test_info\":{\"definition\":{\"module\":\"main\",\"name\":\"_test_ready\"},\"complete\":false,\"success\":false}}' >&2"
+          , "printf 'stdout after final result'"
+          , "printf 'stderr after final result' >&2"
+          ]
+        withActon acton proj ["test", "--no-cache", "--show-log", "--syspath", system] $ \ph _ output -> do
+          code <- await "test exit" (getProcessExitCode ph)
+          logText <- output
+          assertEqual logText ExitSuccess code
+          assertBool logText ("stdout after final result" `isInfixOf` logText && "stderr after final result" `isInfixOf` logText)
+  , testCase "a crashed test retains preamble and unterminated output" $
+      withProcessProject $ \acton proj system -> do
+        writeExecutable (proj </> "out/bin/.test_main")
+          [ "echo 'startup diagnostic' >&2"
+          , "echo '== Running test, iteration: 1'"
+          , "echo '== Running test, iteration: 1' >&2"
+          , "printf 'stdout before crash'"
+          , "printf 'stderr before crash' >&2"
+          , "exit 1"
+          ]
+        withActon acton proj ["test", "--no-cache", "--json", "--syspath", system] $ \ph _ output -> do
+          code <- await "failed test exit" (getProcessExitCode ph)
+          logText <- output
+          assertBool logText (code /= ExitSuccess)
+          forM_ ["startup diagnostic", "stdout before crash", "stderr before crash"] $ \message ->
+            assertBool logText (message `isInfixOf` logText)
   , testCase "live updates keep the cursor hidden and avoid repainting unchanged rows" $
       withProcessProject $ \acton proj system -> do
         writeExecutable (proj </> "out/bin/.test_main")

--- a/compiler/acton/package.yaml.in
+++ b/compiler/acton/package.yaml.in
@@ -75,6 +75,7 @@ executables:
       - TerminalSize
       - ZigProgress
       - TestFormat
+      - TestOutput
       - TestPerf
       - TestRunner
       - TestUI

--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -34,6 +34,7 @@ import qualified Paths_acton
 import qualified Repl
 import qualified WatchTests
 import qualified PerfTests
+import qualified TestOutputTests
 import qualified TestGolden
 
 -- The default is to build and run each test program with the expectation that
@@ -78,6 +79,7 @@ main = do
       , parseFlagTests
       , WatchTests.watchProcessTests
       , PerfTests.perfTests
+      , TestOutputTests.testOutputTests
       , crossCompileTests
       , pkgCliTests
       ]

--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -1648,7 +1648,7 @@ parseFlagTests =
     parserInfo = OA.info (C.cmdLineParser OA.<**> OA.helper) C.descr
 
     parseArgs args =
-      case OA.execParserPure OA.defaultPrefs parserInfo args of
+      case OA.execParserPure C.cmdLinePrefs parserInfo args of
         OA.Success result -> return result
         OA.Failure failure -> do
           let (msg, _) = OA.renderFailure failure "acton"
@@ -1667,7 +1667,7 @@ parseFlagTests =
           assertFailure ("expected build command for " ++ unwords args)
 
     renderParserHelp args =
-      case OA.execParserPure OA.defaultPrefs parserInfo args of
+      case OA.execParserPure C.cmdLinePrefs parserInfo args of
         OA.Failure failure -> pure (fst (OA.renderFailure failure "acton"))
         OA.Success _ -> assertFailure ("expected parser help for " ++ unwords args)
         OA.CompletionInvoked _ ->

--- a/compiler/lib/src/Acton/CommandLineParser.hs
+++ b/compiler/lib/src/Acton/CommandLineParser.hs
@@ -18,7 +18,11 @@ defTarget = "x86_64-linux-gnu.2.27"
 #endif
 
 parseCmdLine        :: IO CmdLineOptions
-parseCmdLine        = execParser (info (cmdLineParser <**> helper) descr)
+parseCmdLine        = customExecParser cmdLinePrefs (info (cmdLineParser <**> helper) descr)
+
+-- Keep global options available between options of nested commands.
+cmdLinePrefs :: ParserPrefs
+cmdLinePrefs = prefs subparserInline
 
 data CmdLineOptions = CompileOpt [String] GlobalOptions CompileOptions
                     | CmdOpt GlobalOptions Command
@@ -163,6 +167,7 @@ data TestOptions = TestOptions
     , testMinIter      :: Int
     , testMaxTime      :: Int
     , testMinTime      :: Int
+    , testTime         :: Int
     , testStressWorkers :: Int
     , testTags         :: [String]
     , testMaxIterSet   :: Bool
@@ -349,7 +354,10 @@ sigCompileOptions = mkSigCompileOptions
         , dep_overrides = depOverrides
         }
 
-compileOptions = CompileOptions
+compileOptions = compileOptionsWith optimizeOption
+
+compileOptionsWith :: Parser OptimizeMode -> Parser CompileOptions
+compileOptionsWith optimization = CompileOptions
         <$> switch (long "always-build" <> help "Show the result of parsing")
         <*> switch (long "ignore-compiler-version" <> help "Ignore acton version when checking .tydb freshness")
         <*> switch (long "db"           <> help "Enable DB backend")
@@ -370,7 +378,7 @@ compileOptions = CompileOptions
         <*> switch (long "cpedantic"    <> help "Pedantic C compilation with -Werror")
         <*> switch (long "dbg-no-lines" <> help "Disable emission of C #line directives (for debugging codegen)")
         <*> switch (long "no-dbp"      <> help "Disable deferred back passes")
-        <*> optimizeOption
+        <*> optimization
         <*> switch (long "only-build"   <> help "Only perform final build of .c files, do not compile .act files")
         <*> switch (long "skip-build"   <> help "Skip final bulid of .c files")
         <*> switch (long "watch"        <> help "Rebuild on file changes")
@@ -464,7 +472,10 @@ docOptions = DocOptions
         )
 
 optimizeOption :: Parser OptimizeMode
-optimizeOption = resolveOptimizeOption
+optimizeOption = fromMaybe Debug <$> requestedOptimizeOption
+
+requestedOptimizeOption :: Parser (Maybe OptimizeMode)
+requestedOptimizeOption = resolveOptimizeOption
     <$> optional releaseOption
     <*> optional
         (option optimizeReader
@@ -483,53 +494,41 @@ optimizeOption = resolveOptimizeOption
              <> internal
             )
 
-    resolveOptimizeOption _ (Just mode) = mode
-    resolveOptimizeOption (Just mode) _ = mode
-    resolveOptimizeOption Nothing Nothing = Debug
-
-data TestModeTag = ModeList | ModePerf | ModeStress deriving Show
+    resolveOptimizeOption _ (Just mode) = Just mode
+    resolveOptimizeOption release Nothing = release
 
 testCommand :: Parser TestCommand
 testCommand =
-    toCmd
-      <$> optional (argument testModeReader (metavar "MODE" <> help "list | perf | stress"))
-      <*> testOptions
-  where
-    toCmd mMode opts =
-      case mMode of
-        Just ModeList -> TestList opts
-        Just ModePerf -> TestPerf opts
-        Just ModeStress -> TestStress opts
-        Nothing -> TestRun opts
+    hsubparser
+      (  command "list" (info (TestList <$> testOptions False) (progDesc "List project tests"))
+      <> command "perf" (info (TestPerf <$> testOptions True) (progDesc "Measure test performance"))
+      <> command "stress" (info (TestStress <$> testOptions False) (progDesc "Run stress tests"))
+      )
+    <|> (TestRun <$> testOptions False)
 
-testModeReader :: ReadM TestModeTag
-testModeReader = eitherReader $ \s ->
-    case s of
-      "list" -> Right ModeList
-      "perf" -> Right ModePerf
-      "stress" -> Right ModeStress
-      _      -> Left "Expected 'list', 'perf' or 'stress'"
-
-testOptions :: Parser TestOptions
-testOptions = mkTestOptions
-    <$> compileOptions
+testOptions :: Bool -> Parser TestOptions
+testOptions perfMode = mkTestOptions
+    <$> compileOptionsWith (fromMaybe defaultOptimize <$> requestedOptimizeOption)
     <*> switch (long "show-log"      <> help "Show test log output")
     <*> switch (long "show-cached"   <> help "Show cached test results")
     <*> switch (long "no-cache"      <> help "Always run tests instead of reusing cached results")
     <*> switch (long "json"          <> help "Output final test results as JSON")
     <*> switch (long "record"        <> help "Update the performance baseline in perf_data (perf mode)")
     <*> switch (long "snapshot-update" <> long "golden-update" <> long "accept" <> help "Accept current test output as expected snapshot values")
-    <*> option auto (long "iter"     <> metavar "N" <> value (-1) <> help "Number of iterations to run a test")
-    <*> optional (option auto (long "max-iter" <> metavar "N" <> help "Maximum number of iterations to run a test (mode defaults when omitted)"))
-    <*> option auto (long "min-iter" <> metavar "N" <> value 3 <> help "Minimum number of iterations to run a test")
-    <*> optional (option auto (long "max-time" <> metavar "MS" <> help "Maximum time to run a test in milliseconds (0 = no time limit, mode defaults when omitted)"))
-    <*> optional (option auto (long "min-time" <> metavar "MS" <> help "Minimum time to run a test in milliseconds"))
-    <*> option auto (long "stress-workers" <> metavar "N" <> value 0 <> help "Concurrent stress workers to run in stress mode (0 = auto)")
+    <*> ordinary (-1) (option auto (long "iter" <> metavar "N" <> value (-1) <> help "Number of iterations to run a test"))
+    <*> ordinary Nothing (optional (option auto (long "max-iter" <> metavar "N" <> help "Maximum number of iterations to run a test (mode defaults when omitted)")))
+    <*> ordinary 3 (option auto (long "min-iter" <> metavar "N" <> value 3 <> help "Minimum number of iterations to run a test"))
+    <*> ordinary Nothing (optional (option auto (long "max-time" <> metavar "MS" <> help "Maximum time to run a test in milliseconds (0 = no time limit, mode defaults when omitted)")))
+    <*> ordinary Nothing (optional (option auto (long "min-time" <> metavar "MS" <> help "Minimum time to run a test in milliseconds")))
+    <*> (if perfMode then option durationReader (long "time" <> metavar "DURATION" <> value 5000 <> help "Total budget per benchmark, including calibration (e.g. 5s or 250ms; default: 5s)") else pure 5000)
+    <*> ordinary 0 (option auto (long "stress-workers" <> metavar "N" <> value 0 <> help "Concurrent stress workers to run in stress mode (0 = auto)"))
     <*> many (strOption (long "tag" <> metavar "TAG" <> help "Enable test capability TAG for testing.require()"))
     <*> many (strOption (long "module" <> metavar "MODULE" <> help "Filter on test module name"))
     <*> many (strOption (long "name" <> metavar "NAME" <> help "Filter on test name (regex, anchored; use .* for substrings)"))
   where
-    mkTestOptions testCompile testShowLog testShowCached testNoCache testJson testRecord testSnapshotUpdate testIter testMaxIterOpt testMinIter testMaxTimeOpt testMinTimeOpt testStressWorkers testTags testModules testNames =
+    defaultOptimize = if perfMode then ReleaseFast else Debug
+    ordinary fallback parser = if perfMode then pure fallback else parser
+    mkTestOptions testCompile testShowLog testShowCached testNoCache testJson testRecord testSnapshotUpdate testIter testMaxIterOpt testMinIter testMaxTimeOpt testMinTimeOpt testTime testStressWorkers testTags testModules testNames =
       TestOptions
         { testCompile = testCompile
         , testShowLog = testShowLog
@@ -543,6 +542,7 @@ testOptions = mkTestOptions
         , testMinIter = testMinIter
         , testMaxTime = fromMaybe 1000 testMaxTimeOpt
         , testMinTime = fromMaybe 50 testMinTimeOpt
+        , testTime = testTime
         , testStressWorkers = testStressWorkers
         , testTags = testTags
         , testMaxIterSet = isJust testMaxIterOpt
@@ -551,6 +551,23 @@ testOptions = mkTestOptions
         , testModules = testModules
         , testNames = testNames
         }
+
+durationReader :: ReadM Int
+durationReader = eitherReader $ \s -> case reads s :: [(Double, String)] of
+    [(number, unit)] ->
+      let milliseconds = case map toLower unit of
+            "ms" -> number
+            "s" -> number * 1000
+            _ -> 0
+      in if isNaN milliseconds || isInfinite milliseconds || milliseconds < 1
+           then Left expected
+           else let rounded = round milliseconds :: Integer
+                in if rounded > toInteger (maxBound :: Int)
+                     then Left "Duration is too large"
+                     else Right (fromInteger rounded)
+    _ -> Left expected
+  where
+    expected = "Expected a positive duration such as 5s or 250ms (minimum 1ms)"
 
 depOverrideReader :: ReadM (String,String)
 depOverrideReader = eitherReader $ \s ->

--- a/compiler/lib/src/Acton/CommandLineParser.hs
+++ b/compiler/lib/src/Acton/CommandLineParser.hs
@@ -168,6 +168,7 @@ data TestOptions = TestOptions
     , testMaxTime      :: Int
     , testMinTime      :: Int
     , testTime         :: Int
+    , testScale        :: Maybe Int
     , testStressWorkers :: Int
     , testTags         :: [String]
     , testMaxIterSet   :: Bool
@@ -521,6 +522,7 @@ testOptions perfMode = mkTestOptions
     <*> ordinary Nothing (optional (option auto (long "max-time" <> metavar "MS" <> help "Maximum time to run a test in milliseconds (0 = no time limit, mode defaults when omitted)")))
     <*> ordinary Nothing (optional (option auto (long "min-time" <> metavar "MS" <> help "Minimum time to run a test in milliseconds")))
     <*> (if perfMode then option durationReader (long "time" <> metavar "DURATION" <> value 5000 <> help "Total budget per benchmark, including calibration (e.g. 5s or 250ms; default: 5s)") else pure 5000)
+    <*> (if perfMode then optional (option scaleReader (long "scale" <> metavar "N" <> help "Use this positive workload scale for t.loop(), skipping calibration")) else pure Nothing)
     <*> ordinary 0 (option auto (long "stress-workers" <> metavar "N" <> value 0 <> help "Concurrent stress workers to run in stress mode (0 = auto)"))
     <*> many (strOption (long "tag" <> metavar "TAG" <> help "Enable test capability TAG for testing.require()"))
     <*> many (strOption (long "module" <> metavar "MODULE" <> help "Filter on test module name"))
@@ -528,7 +530,7 @@ testOptions perfMode = mkTestOptions
   where
     defaultOptimize = if perfMode then ReleaseFast else Debug
     ordinary fallback parser = if perfMode then pure fallback else parser
-    mkTestOptions testCompile testShowLog testShowCached testNoCache testJson testRecord testSnapshotUpdate testIter testMaxIterOpt testMinIter testMaxTimeOpt testMinTimeOpt testTime testStressWorkers testTags testModules testNames =
+    mkTestOptions testCompile testShowLog testShowCached testNoCache testJson testRecord testSnapshotUpdate testIter testMaxIterOpt testMinIter testMaxTimeOpt testMinTimeOpt testTime testScale testStressWorkers testTags testModules testNames =
       TestOptions
         { testCompile = testCompile
         , testShowLog = testShowLog
@@ -543,6 +545,7 @@ testOptions perfMode = mkTestOptions
         , testMaxTime = fromMaybe 1000 testMaxTimeOpt
         , testMinTime = fromMaybe 50 testMinTimeOpt
         , testTime = testTime
+        , testScale = testScale
         , testStressWorkers = testStressWorkers
         , testTags = testTags
         , testMaxIterSet = isJust testMaxIterOpt
@@ -551,6 +554,11 @@ testOptions perfMode = mkTestOptions
         , testModules = testModules
         , testNames = testNames
         }
+
+scaleReader :: ReadM Int
+scaleReader = eitherReader $ \s -> case reads s :: [(Integer, String)] of
+    [(n, "")] | n > 0 && n <= toInteger (maxBound :: Int) -> Right (fromInteger n)
+    _ -> Left "Expected a positive workload scale that fits in an integer"
 
 durationReader :: ReadM Int
 durationReader = eitherReader $ \s -> case reads s :: [(Double, String)] of

--- a/compiler/lib/src/Acton/Types.hs
+++ b/compiler/lib/src/Acton/Types.hs
@@ -2790,6 +2790,8 @@ testType (NDef (TSchema _ [] (TFun _ fx ppar kpar res)) _ _)
                                              (r, fx', [t], []) | t == envT   && validReturn r                     -> Just EnvTest
                                              -- Functions with keyword test parameters
                                              (r, fx', [], [t]) | t == syncT  && validReturn r                     -> Just SyncTest
+                                             (r, fx', [], [t]) | t == asyncT && validReturn r                     -> Just AsyncTest
+                                             (r, fx', [], [t]) | t == envT   && validReturn r                     -> Just EnvTest
                                              _                                                                    -> Nothing
     where validReturn r                 = r == tNone || r == TNone NoLoc || r == tStr
           syncT                         = tCon (TC (gname [name "testing"] (name "SyncT")) [])

--- a/compiler/lib/test/ActonSpec.hs
+++ b/compiler/lib/test/ActonSpec.hs
@@ -1853,6 +1853,24 @@ main = do
       testTypes env0 ["test_discovery"]
       testTypes env0 ["witness_forward"]
 
+      it "discovers functions with each testing context" $ do
+        let src = unlines
+              [ "import testing"
+              , "def _test_sync(t: testing.SyncT):"
+              , "    pass"
+              , "def _test_async(t: testing.AsyncT):"
+              , "    t.success()"
+              , "def _test_env(t: testing.EnvT):"
+              , "    t.success()"
+              ]
+            moduleName = S.modName ["context_test_discovery"]
+            sysTypesPath = ".." </> ".." </> "dist" </> "base" </> "out" </> "types"
+        parsed <- liftIO $ P.parseModule moduleName "<context_test_discovery>" src Nothing
+        env <- liftIO $ Acton.Env.mkEnv [sysTypesPath] env0 parsed
+        kchecked <- liftIO $ Acton.Kinds.check env parsed
+        (_, _, _, discovered) <- liftIO $ Acton.Types.reconstruct Nothing Nothing env kchecked Nothing
+        sort discovered `shouldBe` ["_test_async", "_test_env", "_test_sync"]
+
       testAttributesInitialization env0
 
       it "keeps generated names stable within unchanged defs" $ do

--- a/docs/acton-guide/src/testing.md
+++ b/docs/acton-guide/src/testing.md
@@ -48,6 +48,11 @@ When possible, strive to use unit tests rather than actor based tests and strive
 
 For snapshot-based assertions, see [Snapshot testing](testing/snapshot.md).
 
+Use `acton test perf` to measure tests with warmup and fresh performance
+measurements. Use `for scale in t.loop():` to measure a region while excluding
+setup and teardown; ordinary testing runs its body once at scale 1. See
+[Performance testing](testing/performance.md) for the lifecycle and examples.
+
 ## Cached test results
 
 The Acton test runner caches test results which means that repeated invokations of `acton test` might not actually (re)run tests. Cached failures and errors are still shown by default, so you never miss a failing test. Cached successes are hidden unless you pass `--show-cached`. Pass `--no-cache` to force all selected tests to run, even if cached results exist.

--- a/docs/acton-guide/src/testing/perf_record.md
+++ b/docs/acton-guide/src/testing/perf_record.md
@@ -5,55 +5,82 @@ Record a baseline with `acton test perf --record`. This writes measurements to
 file without changing it:
 
 ```sh
-acton test perf --release --record
+acton test perf --record
 # Make a change, then measure it against the baseline.
-acton test perf --release
+acton test perf
 ```
 
-Each measured test shows timing statistics, CPU measurements, allocation volume, estimated non-GC
-memory change and process peak RSS. If the baseline contains a successful
-measurement of that test, the delta column shows each row's mean percentage
-change. The median and peak RSS comparisons appear below the table.
+Each measured test shows wall time, CPU measurements, allocation volume and
+process peak RSS. If the baseline contains a successful, compatible measurement
+of that test, the delta column shows each row's mean percentage change. The wall
+median comparison appears below the table. Process peak RSS is shown without a
+delta because it includes calibration and warmup, which can differ between runs.
 Positive values mean a higher measured value; negative values mean
 less. A change from zero to a nonzero value has no defined percentage and is
 shown as `from 0`.
 
-For example:
+## Matching conditions
 
-```text
-Tests - module sample:
-Benchmark (3 runs): sample
-  measurement                 mean ±            σ             min …          max          outliers             delta
-  time excl. GC              126µs ±       27.9µs           107µs …        158µs            0 (0%)            +40.0%
-  wall time                  126µs ±       27.9µs           107µs …        158µs            0 (0%)                 —
-  GC time                   0.00ms ±       0.00ms          0.00ms …       0.00ms            0 (0%)                 —
-  allocated                 30.1KB ±       64.0B           30.0KB …       30.1KB            0 (0%)             +3.8%
-  non-GC change             61.4KB ±       4.10KB          57.3KB …       65.5KB            0 (0%)            -11.8%
-  median: 113µs
-  process peak RSS: 12.4MB
-  total: 9.54ms (314.4 runs/s)
-```
+Every comparison requires the same actual machine identity. Matching CPU models,
+architecture or OS version does not establish that two results came from the same
+machine. When identity is unavailable or different, the report shows the new
+measurement and explains why no delta is available. This applies to all metrics,
+including wall time, CPU time, allocation, hardware counts and the wall median.
 
-Old recordings still provide comparisons for the quantities they contain, as
-in this example. Record again to save the additional statistics.
+The test name, build settings, enabled capability tags, runtime worker count,
+scale, use of `t.loop()`, measurement version and GC policy must also match.
+Source code can change: that is what the comparison is intended to measure.
+The `--time` budget and number of measured runs can differ without invalidating
+an otherwise compatible comparison.
+Hardware counts additionally require the same backend and accounting scope;
+user-only counts cannot be compared with user-plus-kernel counts.
+
+Performance mode uses optimized builds by default. Keep explicit build options
+consistent between recording and comparison. Old recordings
+without machine identity or the required measurement metadata need to be recorded
+again before any deltas are shown.
+
+Same-machine comparisons can still be affected by other processes, thermal state
+and scheduling. Mandatory warmup does not remove those sources of variation.
+
+## Reusing scale
+
+For a test that uses `t.loop()`, a compatible baseline supplies the scale for
+the new run. The iterator yields that scale during warmup and measurement instead of
+calibrating a different workload. For example, after recording a list workload at
+scale 8, a slower version still processes the scale-8 input. It may complete fewer
+measured invocations or overrun the sampling target. It does not silently reduce
+the input to fit the target.
+
+A different scale is a distinct benchmark condition and prevents a delta against
+the old scale. Remove the recording to calibrate a fresh baseline. Dividing time
+by scale does not make different input sizes comparable, because workload costs
+can be nonlinear.
+
+## Reading uncertainty
 
 When both runs have at least two samples and include standard deviations, the
 report adds an approximate 95% Welch confidence interval for the difference in
-mean iteration time, with units shown beside each bound. Positive bounds indicate
-an increase; negative bounds indicate a decrease. Each table row's mean percentage
+mean time per loop body, or per invocation for tests without a loop, with units
+shown beside each bound. Positive bounds indicate an increase; negative bounds
+indicate a decrease. Each table row's mean percentage
 change is colored only when its own interval excludes zero. The same check adds
 ⚡ after the delta for an improvement or 💩 for a regression, including when
 color is disabled.
 IPC comparisons stay neutral: higher IPC alone does not establish an improvement.
-Older recordings without a standard deviation still show a percentage, with
-neutral coloring.
-The median and process peak RSS colors show direction without an uncertainty
-estimate.
+Compatible recordings without a standard deviation show a percentage with neutral
+coloring.
+The median's color shows direction without an uncertainty estimate.
 
-The interval allows different sample counts and variances. It assumes independent
-iterations and cannot account for correlations within a process, machine load or
-changes between runs. Treat it as a guide to measured variability and repeat
-benchmarks before attributing small changes to code.
+The interval allows different sample counts and variances. Each sample is one
+complete invocation's average, even if that invocation ran many loop bodies.
+It assumes independent samples and cannot account for correlations within a
+process, machine load or changes between runs. Treat it as a guide to measured
+variability and repeat benchmarks before attributing small changes to code.
+These samples come from one
+process per benchmark; they do not estimate variation between fresh processes.
+
+## Updating recordings
 
 Performance tests always run afresh, even when their source code is unchanged.
 Compilation still reuses unchanged build artifacts.
@@ -65,17 +92,9 @@ skipped and incomplete tests do not replace saved measurements. If no test
 produces a successful measurement, the file is left untouched. Invalid JSON is
 reported as an error so that a damaged baseline is not silently overwritten.
 
-Use the same machine and build options for comparable measurements. In
-particular, keep `--release` consistent between runs. The baseline matches tests
-by their stored module and test names; renamed tests or recordings using older
-module names need a new recording. Remove `perf_data` to start a new baseline
-without retaining old entries. `--record` is only supported in performance mode.
-
-CPU measurements also check the recorded CPU model, architecture and OS version.
-Hardware counts additionally check the backend and accounting scope. Deltas are
-omitted when the relevant metadata differs or is missing. For example, user-only
-Linux counts cannot be compared against user-plus-kernel counts, while CPU-time
-comparisons remain available. Older recordings still provide their original
-timing and memory comparisons; record again to establish a CPU baseline.
+The baseline matches tests by their stored module and test names; renamed tests
+or recordings using older module names need a new recording. Remove `perf_data`
+to start a new baseline without retaining old entries. `--record` is only
+supported in performance mode.
 
 See [Performance testing](performance.md) for the meaning of each measurement.

--- a/docs/acton-guide/src/testing/perf_record.md
+++ b/docs/acton-guide/src/testing/perf_record.md
@@ -52,10 +52,13 @@ scale 8, a slower version still processes the scale-8 input. It may complete few
 measured invocations or overrun the sampling target. It does not silently reduce
 the input to fit the target.
 
-A different scale is a distinct benchmark condition and prevents a delta against
-the old scale. Remove the recording to calibrate a fresh baseline. Dividing time
-by scale does not make different input sizes comparable, because workload costs
-can be nonlinear.
+Use `--scale N` to override the baseline with an exact positive integer. This
+skips calibration while preserving warmup and the independent `--time` budget.
+The same scale can still be compared with a compatible baseline; a different
+scale prevents a delta against the old scale. Use `--scale N --record` to record
+the chosen scale, or remove the recording to calibrate a fresh baseline.
+Dividing time by scale does not make different input sizes comparable, because
+workload costs can be nonlinear.
 
 ## Reading uncertainty
 

--- a/docs/acton-guide/src/testing/performance.md
+++ b/docs/acton-guide/src/testing/performance.md
@@ -1,33 +1,84 @@
 # Performance testing
 
-Performance mode uses the same test definitions as ordinary testing, but runs one
-test at a time and always takes fresh measurements. Tests run serially even when
-`--jobs` allows parallel compilation.
+Performance mode uses the same test definitions as ordinary testing, runs one
+benchmark process at a time, and always takes fresh measurements. It builds
+optimized code by default. Tests run serially even when `--jobs` allows parallel
+compilation; each test retains the application's runtime worker threads, so actor
+work can still run concurrently.
 
 ```python
 import testing
 
-actor _test_simple(t: testing.AsyncT):
-    a = 0
-    for i in range(99999):
-        a += i
-    assert a == 4999850001
-    t.success()
+def _test_sort(t: testing.SyncT):
+    source = list(range(1000, 0, -1))
+    result: ?list[int] = None
+    for scale in t.loop():
+        for i in range(scale):
+            result = sorted(source)
+    if result is not None:
+        assert result == list(range(1, 1001))
 ```
 
 ```sh
-acton test perf --release
+acton test perf
 ```
 
-Use `--release` to measure optimized code. Without an explicit optimization
-option, the normal Debug build default applies. For more samples, increase the
-minimum duration, for example `--min-time 5000` for five seconds per test, or use
-`--iter` to select a fixed number of iterations.
+The runner has a total budget of five seconds per benchmark, including
+calibration, warmup, setup and teardown. Use `--time` to change it:
 
-Sampling limits are checked between iterations. A separate watchdog allows at
-least five minutes for a slow or hung performance test, so a long iteration can
-finish even when the sampling target is shorter. Longer configured run limits
-extend the watchdog; `--max-time 0` disables it.
+```sh
+acton test perf --time 10s
+```
+
+Durations accept units such as `5s` and `250ms`. The budget is a target: the runner
+finishes a whole invocation, so slow work can overrun it. A separate watchdog
+allows at least five minutes for a slow test; longer budgets extend it.
+Compilation is outside the benchmark budget.
+
+## Choosing the measured work
+
+Use `for scale in t.loop():` on a `testing.SyncT`, `testing.AsyncT` or
+`testing.EnvT` context. The runner measures each loop body and excludes code before
+and after the loop from its timing and counter totals. In the example, building
+the input and checking the final result are excluded; sorting and allocating each
+sorted copy are measured. Ordinary testing runs the body once with scale 1.
+Tests without `t.loop()`, including tests without a context, measure their whole
+invocation.
+
+Scale is a positive integer whose meaning the author defines. The example sorts
+the same input `scale` times per body. It could instead control input size or the
+number of concurrent actors. Document that meaning. The runner tries increasing
+scales 1, 2, 4 and so on to find enough work for useful measurement. At the end of
+calibration, it chooses whichever of the last two scales ran closer to the target
+duration, then freezes that scale. A compatible baseline supplies its recorded
+scale instead.
+The calibration points show observed growth; they do not establish an algorithm's
+complexity. The terminal abbreviates long curves to the first and last two
+points; JSON retains every point. Time divided by scale is not generally
+comparable across scales.
+
+After preparation and warmup, a loop test aims for four complete measured
+invocations within the remaining budget. Each starts the test from the beginning,
+with fresh setup and teardown. Its loop repeats at the fixed scale while time
+remains. Tests without a loop repeat whole invocations until the budget ends.
+Expensive setup can leave fewer measured runs, or no measurement at all. In
+performance mode the loop may be empty if setup has already consumed its budget;
+teardown must handle that case. The report explains when there are no samples.
+Increase `--time` when needed.
+
+Use one `t.loop()` per invocation and allow it to finish normally in both ordinary
+and performance testing. An unfinished loop, including an early `break` or
+`return`, fails the test. For asynchronous work, wait for completion inside the
+body before the loop advances.
+Call `t.success()` after the loop and teardown have finished.
+
+The author owns input and reset behavior. Each loop body must perform the intended
+work again; repeatedly sorting an already sorted list measures a different
+workload. Setup allocations can still affect later GC, even though setup itself
+is excluded. Natural GC remains enabled throughout. Warmup does not guarantee
+stable caches, representative GC activity or freedom from scheduling noise.
+
+## Measurements
 
 Each benchmark has a table with `mean ± σ`, `min … max`, outliers and an optional
 baseline delta. Time and memory values use compact units such as µs, ms, KB and
@@ -37,54 +88,62 @@ fixed widths, so columns stay aligned across benchmarks. The default report is
 then the range, then the standard deviation to preserve the mean and delta.
 A dash means that statistic was not collected.
 
-Each row summarizes its own per-iteration samples. Wall time combines the time
-excluding GC and the GC time from the same iteration before calculating its
-distribution. Memory averages and quartiles can contain fractions of a byte.
+Each complete measured invocation contributes one statistical sample. For a loop
+test, that sample is the invocation's measured total divided by its completed
+loop bodies. The table summarizes those run averages, at the selected scale.
+For a test without a loop, each sample covers one whole invocation. Memory
+averages and quartiles can contain fractions of a byte.
 
 The result includes:
 
-- **Time excl. GC:** wall time per test iteration with measured full
-  garbage collection time subtracted. These include waiting within asynchronous
-  tests. The row shows the mean and range; the median appears below the table.
+- **Wall time:** the primary measurement, including natural GC and waiting within
+  the measured region.
 - **σ:** sample standard deviation of the row's measurements. Requires at least
-  two iterations; a constant measurement has zero deviation.
-- **Wall time, GC time:** unadjusted wall time and measured full GC
-  time within an iteration. The GC counter has millisecond resolution. These
-  exclude the forced collections between iterations.
+  two measured runs; a constant measurement has zero deviation.
+- **GC time:** measured full GC time within the measured region. The GC counter has
+  millisecond resolution. A zero can mean no collection occurred or that the
+  counter was too coarse to record it. There are no forced collections between
+  performance invocations.
 - **CPU user, CPU system:** CPU time spent in user code and the kernel across
   all threads in the test process. Unlike wall time, this excludes time waiting
   to be scheduled and can exceed wall time when threads work in parallel.
 - **Instructions, cycles:** hardware counts across all threads in the test
   process. Counts use decimal prefixes: K is one thousand and M is one million.
   These include GC and runtime work during the measurement, as do CPU times.
-  They exclude child processes and the forced collections between iterations.
-- **IPC:** instructions divided by cycles for each iteration. The table
-  summarizes these per-iteration ratios. A higher IPC does not necessarily mean
+  They exclude child processes.
+- **IPC:** total measured instructions divided by total measured cycles for each
+  run. The table summarizes these ratios. A higher IPC does not necessarily mean
   a faster program, so its comparison has neutral coloring and no improvement
   or regression icon.
 - **Allocated:** average bytes reported by the GC allocation counter
-  during an iteration. This measures allocation volume, not peak memory usage.
-- **Non-GC change:** estimated average change per iteration in resident memory outside
-  the GC heap. This subtracts GC memory usage from RSS before and after the
-  iteration, with collections around the test. It is noisy and can be negative.
+  in the measured region, averaged per loop body or whole invocation. This
+  measures allocation volume, not peak memory usage.
 - **Process peak RSS:** peak resident memory for the test process, below the table.
-  This includes startup, the runtime, all threads, the test harness and all
-  iterations. It is recorded before computing the final statistics and is
-  omitted on platforms where it is unavailable.
-- **Outliers:** iterations outside the range from Q1 minus 1.5 times the
+  This includes startup, the runtime, all threads, the test harness, calibration,
+  warmup and measurement. It is recorded before computing the final statistics
+  and is omitted on platforms where it is unavailable. RSS minus GC heap size
+  is not used as a performance or leak verdict. No baseline delta is shown,
+  because calibration and warmup can differ between runs.
+- **Outliers:** run averages outside the range from Q1 minus 1.5 times the
   interquartile range to Q3 plus 1.5 times that range. Quartiles use linear
   interpolation between sorted samples. Outliers remain in all statistics;
   they are counted separately for each row. When most GC samples are zero,
   nonzero collections can all count as outliers.
-- **Runs, total time, runs/second:** elapsed time and throughput for the whole
-  test loop, including harness and collection overhead. This differs from the
-  per-iteration times above.
+- **Scale, runs and loop iterations:** the fixed workload scale, complete measured
+  invocations and total completed bodies within those invocations. Many bodies in
+  one run still contribute only one statistical sample.
+- **Measured and elapsed time:** accumulated wall time inside measured regions,
+  and elapsed time across measured invocations including setup, teardown and
+  harness work. Both exclude calibration and warmup. Whole-run elapsed time
+  includes preparation.
 
 Very short tests are sensitive to measurement overhead and scheduling noise.
-Prefer workloads lasting at least a few milliseconds and repeat measurements
-before drawing conclusions from small percentage changes.
+Prefer workloads lasting at least a few milliseconds, using scale where useful,
+and repeat measurements before drawing conclusions from small percentage changes.
+Quartiles describe the run averages. They are not individual loop-body or request
+latency percentiles.
 
-CPU counters bracket each iteration, including a small amount of harness and
+CPU counters bracket each measured region, including a small amount of harness and
 counter-reading work. They do not isolate instructions spent on GC from other
 work. Wall time, CPU time and instruction counts provide different views of the
 same run; counters help explain variation but do not remove it.
@@ -97,26 +156,37 @@ and cycle accounting through `proc_pid_rusage`, where the OS and hardware suppor
 it. Hardware counters are optional: denied permissions, unsupported hardware,
 failed reads or incomplete counter coverage omit those rows with an explanation.
 CPU times remain available independently. Linux samples with multiplexed events
-are omitted rather than scaled; a row is reported only when every iteration has
+are omitted rather than scaled; a row is reported only when every measured run has
 a valid sample.
 
 `--json` includes a `performance` object for each successful test. Its
 `measurements` contain the displayed quantities, iteration count, median and
 quartiles for every row. For example, `stdev_wall_duration`,
 `q1_mem_usage_delta` and `outlier_count_gc_duration` describe wall time spread,
-the first allocation quartile and GC outliers. The time excluding GC retains
-its original `outlier_count` key. Durations are in milliseconds and memory
-quantities are in bytes. `baseline` contains the available reference quantities,
-or `null` when no baseline matches. `mean_difference_ci95_ms` contains the
-comparison interval's `lower` and `upper` bounds for time excluding GC, or `null`
-when the necessary statistics are unavailable. Failed or skipped tests have
-`performance: null`.
+the first allocation quartile and GC outliers. JSON also retains the earlier
+diagnostic fields for time excluding GC, including its `outlier_count` key.
+Durations are in milliseconds and memory quantities are in bytes. `baseline`
+contains saved reference quantities when available. `mean_difference_ci95_ms`
+contains the comparison interval's `lower` and `upper` bounds for wall time, or
+`null` when the conditions differ or the
+necessary statistics are unavailable. `comparison_unavailable_reason` explains
+missing or incompatible baselines. Failed or skipped tests have `performance: null`.
 
-CPU durations are also in milliseconds. Instruction and cycle values are raw
-counts; IPC is a unitless ratio. For example, `avg_instructions`, `stdev_cycles`
-and `median_ipc` follow the same statistics naming scheme. `counter_info` records
+CPU durations are also in milliseconds. Instruction and cycle values are counts
+per loop body or whole invocation; IPC is a unitless ratio. For example,
+`avg_instructions`, `stdev_cycles` and `median_ipc` follow the same statistics
+naming scheme. `counter_info` records
 the backend, accounting scope, availability, CPU model, architecture and OS
 version. Missing counters are absent, while a measured zero remains zero.
+
+The `perf_info` object records measurement version, machine and build identity,
+scale, whether `loop` was used, worker count and `time_budget_ms`.
+`measurement_ms` sums timed body wall time; `measurement_duration_ms` includes
+setup and teardown across the measured invocations. Both are in milliseconds and
+exclude warmup. At the top level of `measurements`, `loop_iterations` counts
+completed measured bodies and `num_iterations` counts complete invocation samples.
+`calibration` retains each observed `{scale, wall_ms}` point; these are sizing
+observations, separate from the measured samples.
 
 See [Performance comparisons](perf_record.md) to record a baseline and compare
 later runs, or [Stress testing](stress.md) for concurrency-focused tests.

--- a/docs/acton-guide/src/testing/performance.md
+++ b/docs/acton-guide/src/testing/performance.md
@@ -57,6 +57,17 @@ complexity. The terminal abbreviates long curves to the first and last two
 points; JSON retains every point. Time divided by scale is not generally
 comparable across scales.
 
+Use `--scale` to choose an exact positive integer for tests that use `t.loop()`:
+
+```sh
+acton test perf --scale 8 --time 10s
+```
+
+An explicit scale overrides the baseline's scale and skips calibration. Warmup
+still runs, and `--time` independently controls the total budget. Without
+`--scale`, the runner uses a compatible baseline's scale or calibrates one.
+Tests that do not call `t.loop()` reject an explicit `--scale`.
+
 After preparation and warmup, a loop test aims for four complete measured
 invocations within the remaining budget. Each starts the test from the beginning,
 with fresh setup and teardown. Its loop repeats at the fixed scale while time

--- a/test/perf/src/dct.act
+++ b/test/perf/src/dct.act
@@ -16,5 +16,13 @@ def dct_sum(l):
     return s
 
 
-def _test_dct():
-    r = dct_sum(500)
+def _test_dct(t: testing.SyncT):
+    # Scale the transform dimension: doubling it quadruples the work.
+    size = 0
+    result = 0.0
+    for scale in t.loop():
+        size = 32 * scale
+        result = dct_sum(float(size))
+    if size > 0:
+        # The zero-frequency row sums to size; the other rows sum to zero.
+        assert abs(result - float(size)) <= float(size) * 1e-8

--- a/test/perf/src/timers.act
+++ b/test/perf/src/timers.act
@@ -1,47 +1,44 @@
 import testing
 
 
-actor TimerBatch(t: testing.AsyncT, count: int, order: int):
+actor TimerBenchmark(t: testing.AsyncT, order: int):
+    iterations = t.loop()
+    var count = 0
     var received = 0
 
     def tick():
         received += 1
         if received == count:
+            run()
+
+    def run():
+        # Advance only after every callback, so each loop body includes enqueue,
+        # dequeue and delivery. The last timer also advances the logical clock.
+        try:
+            count = 1000 * next(iterations)
+        except StopIteration:
             t.success()
+            return
 
-    # after 0 bypasses the timer queue.
-    for i in range(count):
-        delay = 0.000001
-        if order > 0:
-            delay = float(i + 1) / 1000000.0
-        elif order < 0:
-            delay = float(count - i) / 1000000.0
-        after delay: tick()
+        received = 0
+        # Scale controls timer count; the deadline window stays at one millisecond.
+        # Keep delays at least one microsecond: after 0 bypasses the timer queue.
+        for i in range(count):
+            delay = 0.001
+            if order > 0:
+                delay = 0.000001 + 0.000999 * float(i) / float(count - 1)
+            elif order < 0:
+                delay = 0.000001 + 0.000999 * float(count - i - 1) / float(count - 1)
+            after delay: tick()
+
+    run()
 
 
-actor _test_equal_1000(t: testing.AsyncT):
-    TimerBatch(t, 1000, 0)
+actor _test_equal(t: testing.AsyncT):
+    TimerBenchmark(t, 0)
 
-actor _test_equal_4000(t: testing.AsyncT):
-    TimerBatch(t, 4000, 0)
+actor _test_increasing(t: testing.AsyncT):
+    TimerBenchmark(t, 1)
 
-actor _test_equal_16000(t: testing.AsyncT):
-    TimerBatch(t, 16000, 0)
-
-actor _test_increasing_1000(t: testing.AsyncT):
-    TimerBatch(t, 1000, 1)
-
-actor _test_increasing_4000(t: testing.AsyncT):
-    TimerBatch(t, 4000, 1)
-
-actor _test_increasing_16000(t: testing.AsyncT):
-    TimerBatch(t, 16000, 1)
-
-actor _test_decreasing_1000(t: testing.AsyncT):
-    TimerBatch(t, 1000, -1)
-
-actor _test_decreasing_4000(t: testing.AsyncT):
-    TimerBatch(t, 4000, -1)
-
-actor _test_decreasing_16000(t: testing.AsyncT):
-    TimerBatch(t, 16000, -1)
+actor _test_decreasing(t: testing.AsyncT):
+    TimerBenchmark(t, -1)

--- a/test/stdlib_tests/src/test_testing.act
+++ b/test/stdlib_tests/src/test_testing.act
@@ -55,6 +55,13 @@ def _test_async_snapshot(t: testing.AsyncT):
 def _test_env_snapshot(t: testing.EnvT):
     t.success("env snapshot")
 
+actor _test_DuplicateCompletion(t: testing.AsyncT):
+    # Only the first completion belongs to this invocation. The delayed one
+    # must not complete or fail a subsequent invocation of the same test.
+    t.success()
+    t.failure(AssertionError("duplicate completion"))
+    after 0.001: t.failure(AssertionError("late completion"))
+
 actor _test_AsyncRequireShortCircuit(t: testing.AsyncT):
     t.require("network")
     t.failure(AssertionError("should not run after require"))

--- a/test/stdlib_tests/src/test_testing_loop.act
+++ b/test/stdlib_tests/src/test_testing_loop.act
@@ -1,0 +1,63 @@
+import testing
+
+
+def loop_work(scale: int):
+    assert scale > 0
+    for i in range(scale):
+        assert i >= 0
+
+
+def _test_sync_function(t: testing.SyncT):
+    for scale in t.loop():
+        loop_work(scale)
+
+
+actor _test_sync_actor(t: testing.SyncT):
+    for scale in t.loop():
+        loop_work(scale)
+
+
+def _test_async_function(t: testing.AsyncT):
+    for scale in t.loop():
+        loop_work(scale)
+    t.success()
+
+
+actor LoopWorker():
+    def work(scale: int) -> int:
+        loop_work(scale)
+        return scale
+
+
+actor _test_async_actor(t: testing.AsyncT):
+    worker = LoopWorker()
+    for scale in t.loop():
+        result = await async worker.work(scale)
+        assert result == scale
+    t.success()
+
+
+def _test_env_function(t: testing.EnvT):
+    for scale in t.loop():
+        loop_work(scale)
+    t.success()
+
+
+actor _test_env_actor(t: testing.EnvT):
+    for scale in t.loop():
+        loop_work(scale)
+    t.success()
+
+
+def _test_context_defaults(t: testing.EnvT):
+    sync = testing.SyncT(t.log_handler, set())
+    asynchronous = testing.AsyncT(t.report_result, t.log_handler, set())
+    environment = testing.EnvT(t.report_result, t.env, t.log_handler, set())
+    assert list(sync.loop()) == [1]
+    assert list(asynchronous.loop()) == [1]
+    assert list(environment.loop()) == [1]
+    t.success()
+
+
+def _test_without_context():
+    loop_work(1)

--- a/test/stdlib_tests/src/test_testing_perf.act
+++ b/test/stdlib_tests/src/test_testing_perf.act
@@ -2,6 +2,95 @@ import math
 import testing
 
 
+def _test_calibration_doubles_the_workload(t: testing.SyncT):
+    loop = testing.PerfLoop(1, 1, 10000.0, 10000.0, 50.0)
+    assert loop._advance(0) == 1
+    for scale in [1, 2, 4]:
+        loop._last_wall_ns = u64(scale * 1000000)
+        assert loop._advance(1) == scale * 2
+    loop._last_wall_ns = u64(50000000)
+    assert loop._advance(1) is None
+    assert loop.scale == 8
+    assert loop.iterations == 4
+    assert len(loop.calibration) == 4
+    for i in range(4):
+        assert number(loop.calibration[i], "scale") == float(2**i)
+        assert number(loop.calibration[i], "wall_ms") == [1.0, 2.0, 4.0, 50.0][i]
+
+
+def _test_calibration_selects_nearer_scale(t: testing.SyncT):
+    for previous, current, expected in [(400, 1600, 1), (200, 600, 2), (300, 700, 1)]:
+        loop = testing.PerfLoop(1, 1, 10000.0, 10000.0, 500.0)
+        assert loop._advance(0) == 1
+        loop._last_wall_ns = u64(previous * 1000000)
+        assert loop._advance(1) == 2
+        loop._last_wall_ns = u64(current * 1000000)
+        assert loop._advance(1) is None
+        assert loop.scale == expected
+        assert number(loop.calibration[0], "wall_ms") == float(previous)
+        assert number(loop.calibration[1], "wall_ms") == float(current)
+        assert number(loop.calibration[1], "scale") == 2.0
+        run = testing.PerfRun(5000)
+        run.loop = True
+        assert not run.observe(loop, float(previous + current), 0.0)
+        assert run.next_loop(0).scale == expected
+
+    slow = testing.PerfLoop(1, 1, 10000.0, 10000.0, 500.0)
+    assert slow._advance(0) == 1
+    slow._last_wall_ns = u64(1600000000)
+    assert slow._advance(1) is None
+    assert slow.scale == 1
+
+
+def _test_loop_preserves_recorded_scale(t: testing.SyncT):
+    run = testing.PerfRun(5000, scale=37)
+    run.loop = True
+    assert run.phase == "warmup"
+    warmup = run.next_loop(0)
+    assert warmup.scale == 37
+    assert not run.observe(warmup, 500.0, 0.0)
+    assert run.phase == "measure"
+    sample = run.next_loop(0)
+    sample.iterations = 3
+    assert sample.scale == 37
+    assert run.observe(sample, 1000.0, 900.0)
+    assert run.scale == 37
+    assert run.measurement_ms == 900.0
+    assert run.loop_iterations == 3
+    assert len(run.calibration) == 0
+
+
+def _test_ordinary_loop_and_closed_context(t: testing.SyncT):
+    loop = testing.PerfLoop()
+    assert list(loop.claim()) == [1]
+    loop.close()
+    assert loop.status() == 2
+    try:
+        loop.claim()
+        assert False
+    except ValueError:
+        pass
+    assert loop.status() == 2
+    unused = testing.PerfLoop()
+    unused.close()
+    assert unused.status() == 0
+    unfinished = testing.PerfLoop()
+    assert next(unfinished.claim()) == 1
+    unfinished.close()
+    assert unfinished.status() == 1
+
+
+def _test_loop_memory_preserves_fractional_averages(t: testing.SyncT):
+    info = testing.TestInfo(testing.Test("sample", "", "perf"))
+    sample = testing.TestResult(True, None, None, 1.0, 3, 0, loop_iterations=2)
+    info.update(True, sample)
+    assert info.mem_usage_delta_avg == 1.5
+    assert number(info.performance(), "mem_usage_delta_avg") == 1.5
+    restored = testing.TestResult.from_json(sample.to_json())
+    assert restored.loop_iterations == 2
+    assert restored.mem_usage_delta == 3
+
+
 def measurements(samples: list[float], gc: float=0.0) -> testing.TestInfo:
     info = testing.TestInfo(testing.Test("sample", "", "perf"))
     for sample in samples:


### PR DESCRIPTION
Add warmup and calibrated t.loop() measurements with a configurable time budget and explicit --scale. Reuse recorded scales for comparisons, update the example benchmarks, and show peak RSS without a misleading delta.
