### PR TITLE
Benchmark builtin iteration with calibrated loops

### DIFF
--- a/test/perf/README.md
+++ b/test/perf/README.md
@@ -1,0 +1,86 @@
+# Builtin and collection benchmarks
+
+Run these modules with a compiler that supports `t.loop()` and workload scale:
+
+```sh
+acton test list --module builtin_functions --module collection_iterators
+acton test perf --module builtin_functions --module collection_iterators
+```
+
+Performance mode builds optimized code and runs one benchmark process at a time.
+`t.loop()` handles calibration, warmup and measurement. Ordinary `acton test`
+runs each loop body once at scale 1 and checks its result.
+
+Scale means **repetitions of one operation**, each using the same 1,024-element
+input. Empty-input cases repeat the corresponding operation on an empty input.
+For example, `sum` at scale 8 calls `sum(xs)` eight times per measured body;
+`filter_all` at scale 8 creates and fully consumes eight filter iterators.
+The report gives time and allocation per body at that scale. Scale changes the
+amount of repeated work, not the collection size. These tests measure operation
+costs at a fixed size, rather than how an algorithm grows with input size.
+
+Collection inputs and accumulators are prepared before `t.loop()`. Range inputs
+are consuming iterators, so `sum_range` and `zip_mixed` create a fresh range for
+each operation inside the body. Result checks run after the loop and tolerate
+no bodies when setup exhausts the time budget.
+Checksums and consumed counts cover all completed bodies. Collection tests check
+the accumulated lengths and the final contents. Constructors include output
+allocation; dict and set updates reuse a target after its first population, so
+subsequent updates measure replacement or duplicate insertion without growth.
+Each measured invocation starts with fresh setup.
+
+The builtin tests cover numeric sum variants, extrema with and without defaults,
+filter selectivity and mixed zip iterators. The input permutation avoids
+monotonic extrema. Lazy iterators are consumed with ordinary loops so another
+builtin under comparison cannot hide their cost. The `control` case traverses
+the input directly to help assess measurement noise. Enumeration retains its C
+implementation; its cases cover the declaration change and provide another
+iterator control.
+
+The collection tests cover list, dict and set construction, list and bytearray
+slice assignment, dict and set updates, and set disjointness. The disjointness
+cases cover a full scan, an immediate overlap, an empty set, and a one-element
+set against 1,024 elements to exercise the smaller-set path. Bytearray slice
+inputs include every byte value.
+
+The disjoint and empty-set cases and both bytearray slice cases expose iterator
+exhaustion bugs fixed in #3104. Before that fix, `StopIteration` escapes the
+operation and the completion checks fail. Report a failed baseline rather than
+treating the failure time as an operation latency or speedup. The header and
+iterator-registration edits accompany the same builtin migration and do not add
+separate collection operations.
+
+## Comparing implementations
+
+Record the first implementation, then run the second against the same reference:
+
+```sh
+acton test perf --module builtin_functions --module collection_iterators --record
+# Build the other implementation, keeping these benchmark sources and perf_data.
+acton test perf --module builtin_functions --module collection_iterators --json > comparison.json
+```
+
+A compatible baseline supplies its chosen scale. Keep that scale fixed between
+implementations; independently calibrated scales measure different workloads.
+Use `--scale N` to choose an exact scale and `--time 10s` to extend the budget:
+
+```sh
+acton test perf --module builtin_functions --name '(control|filter_all)' --scale 256 --time 10s
+```
+
+Keep the compiler, measurement code, machine, build options and worker count
+the same when isolating a builtin change. Rebuild with `make` and regenerate
+`test/perf/out` when switching implementations. Performance mode bypasses saved
+test results, but that does not replace rebuilding generated code. On macOS,
+both installations need the elapsed GC clock fix from #3107.
+
+Use new recordings for these loop tests; the earlier fixed-repetition benchmarks
+have different names, inputs and measurement boundaries. Repeat comparisons in
+alternating process order, retain JSON reports and inspect controls, CPU work
+and allocation alongside wall time. Confidence markers describe variation within
+one process, and do not capture variation between processes. Peak RSS includes
+setup, calibration and warmup and is not an allocation or leak verdict.
+
+See the [performance guide](../../docs/acton-guide/src/testing/performance.md)
+and [baseline workflow](../../docs/acton-guide/src/testing/perf_record.md) for
+measurement definitions and compatibility rules.

--- a/test/perf/src/builtin_functions.act
+++ b/test/perf/src/builtin_functions.act
@@ -1,0 +1,276 @@
+import testing
+
+
+# Scale repeats an operation on the same 1024-element input. Construct inputs
+# before t.loop(), and check accumulated results after it. Consume lazy
+# iterators directly so list() or sum() cannot mask their cost.
+size = 1024
+
+def inputs() -> list[int]:
+    # A permutation avoids measuring only monotonically increasing extrema.
+    # Keep the minimum last so returning the first element cannot pass.
+    return [((i + 1) * 73) % size for i in range(size)]
+
+
+def traverse(t: testing.SyncT, xs: list[int]):
+    total = 0
+    repeats = 0
+    for scale in t.loop():
+        repeats += scale
+        for _ in range(scale):
+            for x in xs:
+                total += x
+    testing.assertEqual(total, repeats * len(xs) * (len(xs) - 1) // 2)
+
+def add_ints(t: testing.SyncT, xs: list[int]):
+    total = 0
+    repeats = 0
+    for scale in t.loop():
+        repeats += scale
+        for _ in range(scale):
+            total += sum(xs)
+    testing.assertEqual(total, repeats * len(xs) * (len(xs) - 1) // 2)
+
+def maximum(t: testing.SyncT, xs: list[int]):
+    total = 0
+    repeats = 0
+    for scale in t.loop():
+        repeats += scale
+        for _ in range(scale):
+            total += max(xs, -1)
+    testing.assertEqual(total, repeats * (len(xs) - 1))
+
+def minimum(t: testing.SyncT, xs: list[int]):
+    total = 0
+    repeats = 0
+    for scale in t.loop():
+        repeats += scale
+        for _ in range(scale):
+            total += min(xs, size)
+    testing.assertEqual(total, repeats * (size if len(xs) == 0 else 0))
+
+def maximum_def(t: testing.SyncT, xs: list[int]):
+    total = 0
+    repeats = 0
+    for scale in t.loop():
+        repeats += scale
+        for _ in range(scale):
+            total += max_def(xs, -1)
+    testing.assertEqual(total, repeats * (len(xs) - 1))
+
+def minimum_def(t: testing.SyncT, xs: list[int]):
+    total = 0
+    repeats = 0
+    for scale in t.loop():
+        repeats += scale
+        for _ in range(scale):
+            total += min_def(xs, size)
+    testing.assertEqual(total, repeats * (size if len(xs) == 0 else 0))
+
+def increment(x: int) -> int:
+    return x + 1
+
+def mapped(t: testing.SyncT, xs: list[int]):
+    total = 0
+    count = 0
+    repeats = 0
+    for scale in t.loop():
+        repeats += scale
+        for _ in range(scale):
+            for x in map(increment, xs):
+                total += x
+                count += 1
+    testing.assertEqual(count, repeats * len(xs))
+    testing.assertEqual(total, repeats * len(xs) * (len(xs) + 1) // 2)
+
+def keep_all(x: int) -> bool:
+    return True
+
+def keep_even(x: int) -> bool:
+    return x % 2 == 0
+
+def keep_rare(x: int) -> bool:
+    return x % 128 == 0
+
+def keep_none(x: int) -> bool:
+    return False
+
+def filtered(t: testing.SyncT, xs: list[int], predicate: (int)->bool,
+             expected_count: int, expected_sum: int):
+    total = 0
+    count = 0
+    repeats = 0
+    for scale in t.loop():
+        repeats += scale
+        for _ in range(scale):
+            for x in filter(predicate, xs):
+                total += x
+                count += 1
+    testing.assertEqual(count, repeats * expected_count)
+    testing.assertEqual(total, repeats * expected_sum)
+
+def zipped(t: testing.SyncT, xs: list[int]):
+    total = 0
+    count = 0
+    repeats = 0
+    for scale in t.loop():
+        repeats += scale
+        for _ in range(scale):
+            for a, b in zip(xs, xs):
+                total += a + b
+                count += 1
+    testing.assertEqual(count, repeats * len(xs))
+    testing.assertEqual(total, repeats * len(xs) * (len(xs) - 1))
+
+def enumerated(t: testing.SyncT, xs: list[int]):
+    total = 0
+    count = 0
+    repeats = 0
+    for scale in t.loop():
+        repeats += scale
+        for _ in range(scale):
+            for i, x in enumerate(xs, 7):
+                total += i + x
+                count += 1
+    testing.assertEqual(count, repeats * len(xs))
+    testing.assertEqual(total, repeats * len(xs) * (len(xs) - 1 + 7))
+
+
+def _test_control(t: testing.SyncT):
+    traverse(t, inputs())
+
+def _test_enumerate(t: testing.SyncT):
+    enumerated(t, inputs())
+
+def _test_enumerate_empty(t: testing.SyncT):
+    enumerated(t, [])
+
+def _test_sum(t: testing.SyncT):
+    add_ints(t, inputs())
+
+def _test_sum_empty(t: testing.SyncT):
+    add_ints(t, [])
+
+def _test_sum_float(t: testing.SyncT):
+    xs = [float(i) for i in range(size)]
+    total = 0.0
+    repeats = 0
+    for scale in t.loop():
+        repeats += scale
+        for _ in range(scale):
+            total += sum(xs)
+    testing.assertEqual(total, float(repeats * size * (size - 1) // 2))
+
+def _test_sum_bigint(t: testing.SyncT):
+    xs = [bigint(i) for i in range(size)]
+    total = bigint(0)
+    repeats = 0
+    for scale in t.loop():
+        repeats += scale
+        for _ in range(scale):
+            total += sum(xs)
+    testing.assertEqual(total, bigint(repeats * size * (size - 1) // 2))
+
+def _test_sum_start(t: testing.SyncT):
+    xs = inputs()
+    total = 0
+    repeats = 0
+    for scale in t.loop():
+        repeats += scale
+        for _ in range(scale):
+            total += sum(xs, 7)
+    testing.assertEqual(total, repeats * (size * (size - 1) // 2 + 7))
+
+def _test_sum_range(t: testing.SyncT):
+    total = 0
+    repeats = 0
+    for scale in t.loop():
+        repeats += scale
+        for _ in range(scale):
+            total += sum(range(size))
+    testing.assertEqual(total, repeats * size * (size - 1) // 2)
+
+def _test_max(t: testing.SyncT):
+    xs = inputs()
+    total = 0
+    repeats = 0
+    for scale in t.loop():
+        repeats += scale
+        for _ in range(scale):
+            total += max(xs)
+    testing.assertEqual(total, repeats * (size - 1))
+
+def _test_min(t: testing.SyncT):
+    xs = inputs()
+    total = 0
+    for scale in t.loop():
+        for _ in range(scale):
+            total += min(xs)
+    testing.assertEqual(total, 0)
+
+def _test_max_default(t: testing.SyncT):
+    maximum(t, inputs())
+
+def _test_min_default(t: testing.SyncT):
+    minimum(t, inputs())
+
+def _test_max_empty(t: testing.SyncT):
+    maximum(t, [])
+
+def _test_min_empty(t: testing.SyncT):
+    minimum(t, [])
+
+def _test_max_def(t: testing.SyncT):
+    maximum_def(t, inputs())
+
+def _test_min_def(t: testing.SyncT):
+    minimum_def(t, inputs())
+
+def _test_max_def_empty(t: testing.SyncT):
+    maximum_def(t, [])
+
+def _test_min_def_empty(t: testing.SyncT):
+    minimum_def(t, [])
+
+def _test_map(t: testing.SyncT):
+    mapped(t, inputs())
+
+def _test_map_empty(t: testing.SyncT):
+    mapped(t, [])
+
+def _test_filter_all(t: testing.SyncT):
+    filtered(t, inputs(), keep_all, size, size * (size - 1) // 2)
+
+def _test_filter_half(t: testing.SyncT):
+    n = size // 2
+    filtered(t, inputs(), keep_even, n, n * (n - 1))
+
+def _test_filter_rare(t: testing.SyncT):
+    n = size // 128
+    filtered(t, inputs(), keep_rare, n, 128 * n * (n - 1) // 2)
+
+def _test_filter_none(t: testing.SyncT):
+    filtered(t, inputs(), keep_none, 0, 0)
+
+def _test_filter_empty(t: testing.SyncT):
+    filtered(t, [], keep_all, 0, 0)
+
+def _test_zip(t: testing.SyncT):
+    zipped(t, inputs())
+
+def _test_zip_empty(t: testing.SyncT):
+    zipped(t, [])
+
+def _test_zip_mixed(t: testing.SyncT):
+    xs = inputs()
+    total = 0
+    count = 0
+    repeats = 0
+    for scale in t.loop():
+        repeats += scale
+        for _ in range(scale):
+            for a, b in zip(xs, range(size)):
+                total += a + b
+                count += 1
+    testing.assertEqual(count, repeats * size)
+    testing.assertEqual(total, repeats * size * (size - 1))

--- a/test/perf/src/collection_iterators.act
+++ b/test/perf/src/collection_iterators.act
@@ -1,0 +1,184 @@
+import testing
+
+
+# Scale repeats one operation on the same input. Input construction and result
+# checks are outside t.loop(); output allocation remains part of the operation.
+size = 1024
+
+def inputs() -> list[int]:
+    return [i for i in range(size)]
+
+def items() -> list[(int, int)]:
+    return [(i, i + 1) for i in range(size)]
+
+
+def construct_list(t: testing.SyncT, xs: list[int]):
+    count = 0
+    repeats = 0
+    last: list[int] = []
+    for scale in t.loop():
+        repeats += scale
+        for _ in range(scale):
+            last = list(xs)
+            count += len(last)
+    testing.assertEqual(count, repeats * len(xs))
+    if repeats > 0:
+        testing.assertEqual(last, xs)
+
+def assign_list_slice(t: testing.SyncT, xs: list[int]):
+    count = 0
+    repeats = 0
+    target = [-1]
+    for scale in t.loop():
+        repeats += scale
+        for _ in range(scale):
+            target[:] = xs
+            count += len(target)
+    testing.assertEqual(count, repeats * len(xs))
+    if repeats > 0:
+        testing.assertEqual(target, xs)
+
+def construct_dict(t: testing.SyncT, xs: list[(int, int)]):
+    count = 0
+    repeats = 0
+    last: dict[int, int] = {}
+    for scale in t.loop():
+        repeats += scale
+        for _ in range(scale):
+            last = dict(xs)
+            count += len(last)
+    testing.assertEqual(count, repeats * len(xs))
+    if repeats > 0:
+        for k, v in xs:
+            testing.assertEqual(last[k], v)
+
+def update_dict(t: testing.SyncT, xs: list[(int, int)]):
+    # After the first update, measure replacement without table growth.
+    target: dict[int, int] = {}
+    count = 0
+    repeats = 0
+    for scale in t.loop():
+        repeats += scale
+        for _ in range(scale):
+            target.update(xs)
+            count += len(target)
+    testing.assertEqual(count, repeats * len(xs))
+    if repeats > 0:
+        for k, v in xs:
+            testing.assertEqual(target[k], v)
+
+def construct_set(t: testing.SyncT, xs: list[int]):
+    count = 0
+    repeats = 0
+    last: set[int] = set()
+    for scale in t.loop():
+        repeats += scale
+        for _ in range(scale):
+            last = set(xs)
+            count += len(last)
+    testing.assertEqual(count, repeats * len(xs))
+    if repeats > 0:
+        for x in xs:
+            testing.assertIn(x, last)
+
+def update_set(t: testing.SyncT, xs: list[int]):
+    # After the first update, measure duplicate insertion without table growth.
+    target: set[int] = set()
+    count = 0
+    repeats = 0
+    for scale in t.loop():
+        repeats += scale
+        for _ in range(scale):
+            target.update(xs)
+            count += len(target)
+    testing.assertEqual(count, repeats * len(xs))
+    if repeats > 0:
+        for x in xs:
+            testing.assertIn(x, target)
+
+def disjoint(t: testing.SyncT, xs: set[int], ys: set[int], expected: bool):
+    matches = 0
+    completed = 0
+    repeats = 0
+    for scale in t.loop():
+        repeats += scale
+        for _ in range(scale):
+            if Set.isdisjoint(xs, ys):
+                matches += 1
+            completed += 1
+    testing.assertEqual(completed, repeats)
+    testing.assertEqual(matches, repeats if expected else 0)
+
+def assign_bytearray_slice(t: testing.SyncT, xs: list[int]):
+    target = bytearray(b"_")
+    count = 0
+    completed = 0
+    repeats = 0
+    for scale in t.loop():
+        repeats += scale
+        for _ in range(scale):
+            target[:] = xs
+            count += len(target)
+            completed += 1
+    testing.assertEqual(completed, repeats)
+    testing.assertEqual(count, repeats * len(xs))
+    if repeats > 0:
+        testing.assertEqual(len(target), len(xs))
+        for i in range(len(xs)):
+            testing.assertEqual(target[i], xs[i])
+
+
+def _test_list(t: testing.SyncT):
+    construct_list(t, inputs())
+
+def _test_list_empty(t: testing.SyncT):
+    construct_list(t, [])
+
+def _test_list_slice(t: testing.SyncT):
+    assign_list_slice(t, inputs())
+
+def _test_list_slice_empty(t: testing.SyncT):
+    assign_list_slice(t, [])
+
+def _test_dict(t: testing.SyncT):
+    construct_dict(t, items())
+
+def _test_dict_empty(t: testing.SyncT):
+    construct_dict(t, [])
+
+def _test_dict_update(t: testing.SyncT):
+    update_dict(t, items())
+
+def _test_dict_update_empty(t: testing.SyncT):
+    update_dict(t, [])
+
+def _test_set(t: testing.SyncT):
+    construct_set(t, inputs())
+
+def _test_set_empty(t: testing.SyncT):
+    construct_set(t, [])
+
+def _test_set_update(t: testing.SyncT):
+    update_set(t, inputs())
+
+def _test_set_update_empty(t: testing.SyncT):
+    update_set(t, [])
+
+def _test_set_isdisjoint(t: testing.SyncT):
+    disjoint(t, set(inputs()), set([size + i for i in range(size)]), True)
+
+def _test_set_isdisjoint_overlap(t: testing.SyncT):
+    disjoint(t, set(inputs()), set(inputs()), False)
+
+def _test_set_isdisjoint_empty(t: testing.SyncT):
+    disjoint(t, set(inputs()), set(), True)
+
+def _test_set_isdisjoint_unbalanced(t: testing.SyncT):
+    # Exercise the branch that swaps arguments to scan the smaller set.
+    disjoint(t, {size}, set(inputs()), True)
+
+def _test_bytearray_slice(t: testing.SyncT):
+    assign_bytearray_slice(t, [i % 256 for i in range(size)])
+
+def _test_bytearray_slice_empty(t: testing.SyncT):
+    assign_bytearray_slice(t, [])


### PR DESCRIPTION
Use the new calibrated benchmark loop testing introduced in #3112 to test builtin functions and collection types.