### PR TITLE
Add performance scaling studies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,7 @@ help:
 	@echo "Available make targets:"
 	@echo "  all     - build everything"
 	@echo "  test    - run the test suite"
+	@echo "  test-performance - run live perf and scale integration tests on a quiet machine"
 	@echo "  make PROFILE=1 dist/bin/acton - build profiled acton binary"
 	@echo "  rpms    - build RPM package from existing dist/"
 	@echo ""
@@ -522,6 +523,7 @@ dist/deps/libyyjson: deps/libyyjson $(DIST_ZIG)
 # top level targets
 .PHONY: test test-builtins test-compiler test-db test-examples test-lang test-regressions test-rts test-stdlib online-tests
 .PHONY: test-compiler-accept test-lib-accept test-acton-goldens-accept test-goldens-accept
+.PHONY: test-performance
 # These run stack against libacton/acton, which link liblmdb, so the bdeps
 # archives must exist first. (test, test-stdlib, test-incremental, online-tests
 # already pull it in transitively via dist/bin/acton[c].)
@@ -536,6 +538,9 @@ test: dist/bin/acton
 	$(MAKE) test-stdlib
 	$(MAKE) -C backend test
 	$(MAKE) test-rts-db
+
+test-performance: dist/bin/acton
+	cd compiler && ACTON_TEST_PERFORMANCE=1 stack test acton:test_acton --ta '-p "/live performance/" --num-threads=1'
 
 test-builtins:
 	cd compiler && stack test acton --ta '-p "Builtins"'

--- a/base/src/testing.act
+++ b/base/src/testing.act
@@ -358,13 +358,14 @@ class PerfLoop(Iterator[int]):
     _yield_scale: ?int
     _report_result: ?action(?bool, ?Exception, ?str) -> None
 
-    def __init__(self, phase: int=0, scale: int=1, budget_ms: float=0.0, remaining_ms: float=0.0, target_ms: float=0.0):
+    def __init__(self, phase: int=0, scale: int=1, budget_ms: float=0.0, remaining_ms: float=0.0, target_ms: float=0.0, once: bool=False):
         self._phase = phase
         self.scale = scale
         self.iterations = 0
         self._budget_ms = budget_ms
         self._remaining_ms = remaining_ms
         self._target_ms = target_ms
+        self._once = once
         self._previous_wall_ms = 0.0
         self._sw = time.Stopwatch()
         self.calibration = []
@@ -417,6 +418,8 @@ class PerfLoop(Iterator[int]):
         self.iterations += completed
         if self._phase == 0:
             return 1 if self.iterations == 0 else None
+        if self._once:
+            return self.scale if self.iterations == 0 else None
         elapsed = self._sw.elapsed().to_float() * 1000.0
         if completed == 0:
             # Setup uses the total budget, but a run may finish its first body
@@ -1215,6 +1218,7 @@ class TestInfo(object):
 
 class TestRunnerConfig(object):
     perf_mode: bool
+    scaling: bool
     stress_mode: bool
     max_iter: int
     min_iter: int
@@ -1256,18 +1260,22 @@ class TestRunnerConfig(object):
         self.tags = split_tags(args.get_strlist("tag"))
         self.time_ms = args.get_int("time")
         self.scale = args.get_int("scale")
+        self.scaling = args.get_bool("scaling")
         if perf_mode and (self.time_ms <= 0 or self.scale < 0):
             raise ValueError("Performance time must be positive and scale must be non-negative")
+        if self.scaling and (not perf_mode or self.scale <= 0):
+            raise ValueError("--scaling requires performance mode and a positive --scale")
 
 class PerfRun(object):
-    """Calibrate once, then collect fresh invocations within one elapsed budget."""
+    """Collect timed invocations, or one fixed-work sample after one warmup."""
     calibration: list[dict[str, value]]
 
-    def __init__(self, time_ms: int, scale: int=0):
+    def __init__(self, time_ms: int, scale: int=0, scaling: bool=False):
         self.time_ms = time_ms
+        self.scaling = scaling
         self.scale = max([1, scale])
         self.loop = False
-        self.phase = "calibrate" if scale == 0 else "warmup"
+        self.phase = "calibrate" if scale == 0 and not scaling else "warmup"
         self.warmup_duration_ms = 0.0
         self.measurement_ms = 0.0
         self.loop_iterations = 0
@@ -1278,6 +1286,10 @@ class PerfRun(object):
         return max([0.0, float(self.time_ms) - self._sw.elapsed().to_float() * 1000.0])
 
     def next_loop(self, samples: int) -> PerfLoop:
+        if self.scaling:
+            # The parent bounds the study. Each child warms up once, then takes
+            # one sample without filling a time budget or batching loop bodies.
+            return PerfLoop(2 if self.phase == "warmup" else 3, self.scale, once=True)
         remaining = self.remaining_ms()
         if self.phase == "calibrate":
             return PerfLoop(1, self.scale, min([remaining, float(self.time_ms) / 3.0]), remaining, float(self.time_ms) / 10.0)
@@ -1297,7 +1309,7 @@ class PerfRun(object):
                     self.phase = "measure"
         elif self.phase == "warmup":
             self.warmup_duration_ms = elapsed_ms
-            if self.warmup_duration_ms >= float(self.time_ms) / 10.0:
+            if self.scaling or self.warmup_duration_ms >= float(self.time_ms) / 10.0:
                 self.phase = "measure"
         else:
             self.measurement_ms += wall_ms
@@ -1352,7 +1364,7 @@ actor TestExecutor(syscap, config, t: Test, report_complete, report_progress, en
     var iteration = 0
     var invocation = 0
     var accepting_result = False
-    perf_run = PerfRun(config.time_ms, config.scale) if config.perf_mode else None
+    perf_run = PerfRun(config.time_ms, config.scale, config.scaling) if config.perf_mode else None
     perf_phase_sw = time.Stopwatch()
     var stress_drift_rank = max([0, executor_id - stress_nodrift_workers])
     var stress_drift_workers = max([1, stress_workers - stress_nodrift_workers])
@@ -1521,6 +1533,7 @@ actor TestExecutor(syscap, config, t: Test, report_complete, report_progress, en
                     "version": "3",
                     "scale": perf_run.scale,
                     "loop": perf_run.loop,
+                    "scaling": perf_run.scaling,
                     "time_budget_ms": config.time_ms,
                     "warmup_duration_ms": perf_run.warmup_duration_ms,
                     "measurement_ms": perf_run.measurement_ms,
@@ -1586,6 +1599,9 @@ actor TestExecutor(syscap, config, t: Test, report_complete, report_progress, en
         if success == True and exception is None and not skipped and loop_status in [1, 3]:
             success = False
             exception = ValueError("Benchmark loop must run to exhaustion")
+        if config.scaling and success == True and exception is None and not skipped and loop_status == 0:
+            success = False
+            exception = ValueError("Scaling measurements require t.loop()")
         if perf_run is not None:
             if invocation == 1:
                 perf_run.loop = loop_status != 0
@@ -1606,7 +1622,7 @@ actor TestExecutor(syscap, config, t: Test, report_complete, report_progress, en
             if phase != perf_run.phase and (perf_run.loop or perf_run.phase == "measure"):
                 perf_phase_sw.reset()
             if not measured:
-                if perf_run.remaining_ms() > 0.0:
+                if perf_run.scaling or perf_run.remaining_ms() > 0.0:
                     if last_report.elapsed().to_float() > 0.05:
                         _emit_result(False)
                     after 0: _run_fn(test)
@@ -1644,7 +1660,7 @@ actor TestExecutor(syscap, config, t: Test, report_complete, report_progress, en
         if skipped:
             complete = True
         if perf_run is not None:
-            complete = perf_run.remaining_ms() <= 0.0 or (perf_run.loop and completed_iterations >= 4)
+            complete = perf_run.scaling or perf_run.remaining_ms() <= 0.0 or (perf_run.loop and completed_iterations >= 4)
         elif config.stress_mode:
             if config.max_time > 0.0 and test_dur > config.max_time:
                 complete = True
@@ -1684,7 +1700,7 @@ actor TestExecutor(syscap, config, t: Test, report_complete, report_progress, en
             report_complete(executor_id, t, test_info)
 
     def _run_fn(t: Test):
-        if perf_run is not None and perf_run.remaining_ms() <= 0.0:
+        if perf_run is not None and not perf_run.scaling and perf_run.remaining_ms() <= 0.0:
             _finish_budget()
             return
         _stress_drift_delay()
@@ -2406,6 +2422,7 @@ actor test_runner(env: Env,
         tp.add_option("min-time", "int", default=50, help="Minimum time to run a test in milliseconds")
         tp.add_option("time", "int", default=5000, help="Total performance budget in milliseconds")
         tp.add_option("scale", "int", default=0, help="Performance workload scale (0 = calibrate)")
+        tp.add_bool("scaling", "Measure one fixed workload after one warmup invocation")
         tp.add_option("stress-workers", "int", default=0, help="Concurrent stress workers to run (0 = auto)")
         tp.add_option("tag", "strlist", default=[], help="Enable test capability tag")
         pp = tp.add_cmd("perf", "Performance benchmark tests", _run_perf_tests)

--- a/base/src/testing.ext.c
+++ b/base/src/testing.ext.c
@@ -102,7 +102,7 @@ static bool testing_loop_end(testingQ_PerfLoop self) {
 }
 
 static void testing_loop_batch(testingQ_PerfLoop self, uint64_t completed) {
-    if (self->_phase < 2) {
+    if (self->_phase < 2 || self->_once) {
         self->_batch_size = 1;
         return;
     }

--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -648,9 +648,9 @@ buildProjectOnce gopts opts = do
 
 -- | Entry point for acton test; configures options and selects mode/watch.
 runTests :: C.GlobalOptions -> C.TestCommand -> IO ()
-runTests gopts (C.TestScaleReport path) = do
+runTests gopts (C.TestScaleReport path baseline) = do
     color <- useColor gopts
-    printScaleRecording color path
+    printScaleRecording color path baseline
 runTests gopts cmd = do
     let (mode, topts) =
           case cmd of
@@ -679,7 +679,8 @@ runTests gopts cmd = do
 
 -- | Build once and then list/run tests based on the selected mode.
 runTestsOnce :: C.GlobalOptions -> C.CompileOptions -> C.TestOptions -> TestMode -> Paths -> IO ()
-runTestsOnce gopts opts topts mode paths = do
+runTestsOnce gopts opts topts0 mode paths = do
+    (topts, baseline) <- if mode == TestModeScale then prepareScalingComparison paths topts0 else return (topts0, Nothing)
     modules <- withProjectLockNotice gopts (projPath paths) $ do
       srcFiles <- projectSourceFiles paths
       selected <- selectTestSources gopts opts paths topts srcFiles
@@ -693,7 +694,7 @@ runTestsOnce gopts opts topts mode paths = do
         let maxParallel = if mode `elem` [TestModePerf, TestModeScale, TestModeStress] then 1 else maxParallel0
         useColorOut <- useColor gopts
         testStart <- getTime Monotonic
-        exitCode <- runProjectTests useColorOut gopts opts paths topts mode modules maxParallel
+        exitCode <- runProjectTests useColorOut gopts opts paths topts mode modules maxParallel baseline
         logTiming gopts opts putStrLn "test execution and cache" testStart
         exitWithTestCode exitCode
 
@@ -729,7 +730,7 @@ runTestsWatch gopts opts topts mode paths = do
                     do
                       useColorOut <- useColor gopts
                       testStart <- getTime Monotonic
-                      void $ runProjectTests useColorOut gopts opts paths topts mode modulesToTest testParallel
+                      void $ runProjectTests useColorOut gopts opts paths topts mode modulesToTest testParallel Nothing
                       logTiming gopts opts (progressLogLine progressUI) "test execution and cache" testStart
                 return (not hadErrors)
         runWatchProject gopts projDir srcRoot sched runOnce

--- a/compiler/acton/Main.hs
+++ b/compiler/acton/Main.hs
@@ -53,6 +53,8 @@ import Control.Concurrent.MVar
 import Control.Exception (throw,catch,finally,IOException,try,SomeException,onException,evaluate,bracket,mask)
 import qualified Control.Concurrent.Async as Async
 import ProcessUtil (stopProcessGroup)
+import TestScale (validateScalingOptions)
+import ScaleReport (printScaleRecording)
 import Control.Concurrent (ThreadId, forkIO, killThread, threadDelay, throwTo)
 import Control.Concurrent.Chan (Chan, newChan, writeChan, readChan)
 import Control.Monad
@@ -646,15 +648,21 @@ buildProjectOnce gopts opts = do
 
 -- | Entry point for acton test; configures options and selects mode/watch.
 runTests :: C.GlobalOptions -> C.TestCommand -> IO ()
+runTests gopts (C.TestScaleReport path) = do
+    color <- useColor gopts
+    printScaleRecording color path
 runTests gopts cmd = do
     let (mode, topts) =
           case cmd of
             C.TestRun opts  -> (TestModeRun, opts)
             C.TestList opts -> (TestModeList, opts)
             C.TestPerf opts -> (TestModePerf, opts)
+            C.TestScale opts -> (TestModeScale, opts)
             C.TestStress opts -> (TestModeStress, opts)
         gopts' = if C.testJson topts then gopts { C.quiet = True } else gopts
         opts0 = C.testCompile topts
+    when (mode == TestModeScale) $
+      mapM_ printErrorAndExit (validateScalingOptions topts)
     when (C.testRecord topts && mode /= TestModePerf) $
       printErrorAndExit "--record requires acton test perf"
     let opts = opts0
@@ -682,7 +690,7 @@ runTestsOnce gopts opts topts mode paths = do
       TestModeList -> listProjectTests opts paths topts modules
       _ -> do
         maxParallel0 <- testMaxParallel gopts
-        let maxParallel = if mode `elem` [TestModePerf, TestModeStress] then 1 else maxParallel0
+        let maxParallel = if mode `elem` [TestModePerf, TestModeScale, TestModeStress] then 1 else maxParallel0
         useColorOut <- useColor gopts
         testStart <- getTime Monotonic
         exitCode <- runProjectTests useColorOut gopts opts paths topts mode modules maxParallel
@@ -702,7 +710,7 @@ runTestsWatch gopts opts topts mode paths = do
             progressUI = cwProgressUI watchCtx
             progressState = cwProgressState watchCtx
         testParallel0 <- testMaxParallel gopts
-        let testParallel = if mode `elem` [TestModePerf, TestModeStress] then 1 else testParallel0
+        let testParallel = if mode `elem` [TestModePerf, TestModeScale, TestModeStress] then 1 else testParallel0
         let runOnce gen mChanged = do
               withProjectLockForGen gopts sched gen projDir $ do
                 logProjectBuild gopts progressUI progressState projDir

--- a/compiler/acton/PerfMemory.hs
+++ b/compiler/acton/PerfMemory.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+module PerfMemory (MemoryStatus(..), readMemoryStatus) where
+
+import Data.Word (Word64)
+import Foreign (Ptr, alloca, allocaBytes, peek)
+import Foreign.C.String (CString, peekCString)
+import Foreign.C.Types (CInt(..), CSize(..))
+
+data MemoryStatus = MemoryStatus
+  { memoryTotal :: Integer
+  , memoryAvailable :: Integer
+  , memoryProcess :: Integer
+  } deriving (Eq, Show)
+
+foreign import ccall safe "acton_perf_memory"
+  c_perfMemory :: CInt -> Ptr Word64 -> Ptr Word64 -> Ptr Word64 -> CString -> CSize -> IO CInt
+
+-- | Current byte counts for the host and an optional process. Linux host values
+-- respect visible cgroup limits; macOS headroom is a conservative VM estimate.
+-- Nothing leaves memoryProcess at zero. A failed read, including an exited PID,
+-- is an error: the caller must not continue a resource-limited run unguarded.
+-- Sampling is best effort and cannot guarantee that an allocation avoids OOM.
+readMemoryStatus :: Maybe Int -> IO (Either String MemoryStatus)
+readMemoryStatus process
+  | Just pid <- process, pid <= 0 || toInteger pid > toInteger (maxBound :: CInt) =
+      return (Left "Invalid process ID for memory observation")
+  | otherwise = alloca $ \total -> alloca $ \available -> alloca $ \used ->
+      allocaBytes 512 $ \message -> do
+        status <- c_perfMemory (maybe 0 fromIntegral process) total available used message 512
+        if status /= 0
+          then Left <$> peekCString message
+          else do
+            result <- MemoryStatus <$> (toInteger <$> peek total)
+                                   <*> (toInteger <$> peek available)
+                                   <*> (toInteger <$> peek used)
+            return (Right result)

--- a/compiler/acton/PerfMemoryTests.hs
+++ b/compiler/acton/PerfMemoryTests.hs
@@ -1,0 +1,26 @@
+module PerfMemoryTests (perfMemoryTests) where
+
+import System.Directory (canonicalizePath)
+import System.Exit (ExitCode(..))
+import System.FilePath ((</>))
+import System.IO.Temp (withSystemTempDirectory)
+import System.Process (readProcessWithExitCode)
+import Test.Tasty
+import Test.Tasty.HUnit
+
+perfMemoryTests :: TestTree
+perfMemoryTests = testGroup "live memory observation"
+  [ nativeTest "host and process readings" "perf_memory_probe" ["perf_memory.c"]
+  , nativeTest "Linux cgroup boundaries" "perf_memory_test" []
+  ]
+  where
+    nativeTest label name extra = testCase label $
+      withSystemTempDirectory "acton-perf-memory" $ \tmp -> do
+        sources <- canonicalizePath "cbits"
+        let binary = tmp </> name
+            args = ["-Wall", "-Wextra", "-Werror", "-O2"]
+              ++ map (sources </>) ((name ++ ".c") : extra) ++ ["-o", binary]
+        (compiled, out, err) <- readProcessWithExitCode "cc" args ""
+        assertEqual (out ++ err) ExitSuccess compiled
+        (status, stdout, stderr) <- readProcessWithExitCode binary [tmp] ""
+        assertEqual (stdout ++ stderr) ExitSuccess status

--- a/compiler/acton/PerfTests.hs
+++ b/compiler/acton/PerfTests.hs
@@ -39,7 +39,7 @@ perfTests = testGroup "performance baselines"
       assertEqual "milliseconds are accepted" 250 (C.testTime explicit)
       forM_ [("5s", 5000), ("1.5s", 1500), ("0.001s", 1)] $ \(duration, expected) ->
         assertEqual duration expected . C.testTime =<< parsePerfOptions ["--time", duration]
-      forM_ ["0ms", "-1s", "0.1ms", "100", "1m", "1e100s", "NaNs"] $ \duration ->
+      forM_ ["0ms", "-1s", "0.1ms", "100", "1e100s", "NaNs"] $ \duration ->
         case parseOptions ["test", "perf", "--time", duration] of
           O.Failure _ -> return ()
           _ -> assertFailure ("--time must reject " ++ duration)
@@ -98,7 +98,7 @@ perfTests = testGroup "performance baselines"
           assertEqual text ExitSuccess code
           assertBool text ("--time DURATION" `isInfixOf` unwords (words text))
           assertBool text ("--scale N" `isInfixOf` unwords (words text))
-          assertBool text (not (any (`isInfixOf` text) ["--iter", "--min-time", "--max-time", "--warmup"]))
+          assertBool text (not (any (`isInfixOf` text) ["--iter", "--min-time", "--max-time", "--warmup", "--scaling", "--start-scale", "--max-memory"]))
         _ -> assertFailure "expected performance help"
   , testCase "all metrics require the same complete performance identity" $ do
       let old = sample 10 0 10
@@ -162,11 +162,14 @@ perfTests = testGroup "performance baselines"
       let old = sample 10 0 10
       assertEqual "reuse the recorded workload" (Just 7) (perfBaselineScale old identity)
       forM_ [changeIdentity "machine" Aeson.Null old, changeIdentity "scale" (Aeson.Number 0) old,
+             changeIdentity "scaling" (Aeson.Bool True) old,
              changeIdentity "loop" (Aeson.Bool False) old, changeIdentity "version" (Aeson.String "2") old,
              KM.delete "perf_info" old] $ \baseline ->
         assertEqual "cannot reuse a missing or incompatible scale" Nothing (perfBaselineScale baseline identity)
       assertEqual "worker count is checked after execution" (Just 7)
         (perfBaselineScale (changeIdentity "workers" (Aeson.Number 2) old) identity)
+      assertEqual "fixed-work samples cannot compare with time-budgeted samples" (Just "measurement sampling mode differs")
+        (perfComparisonReason "wall_duration" (changeIdentity "scaling" (Aeson.Bool True) old) old)
   , testCase "timing and allocation changes use the recorded measurement" $ do
       let old = identified $ KM.fromList [("avg_wall_duration", Aeson.Number 10), ("mem_usage_delta_avg", Aeson.Number 100)]
           new = identified $ KM.fromList [("avg_wall_duration", Aeson.Number 12), ("mem_usage_delta_avg", Aeson.Number 50)]

--- a/compiler/acton/PerfTests.hs
+++ b/compiler/acton/PerfTests.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-module PerfTests (perfTests) where
+module PerfTests (perfTests, perfIntegrationTests) where
 
 import Control.Monad
 import qualified Acton.CommandLineParser as C
@@ -361,7 +361,17 @@ perfTests = testGroup "performance baselines"
       forM_ [res { trComplete = False }, res { trSuccess = Just False }, res { trSkipped = True },
              res { trException = Just "error" }, res { trNumIterations = 0 }, res { trSnapshotUpdated = True }] $ \invalid ->
         assertEqual "no performance lines" [] (renderPerf 79 False Nothing invalid)
-  , testCase "recording runs fresh tests and preserves unselected measurements" $
+  , testCase "record requires performance mode" $ do
+      acton <- canonicalizePath "../../dist/bin/acton"
+      forM_ [[], ["stress"], ["list"]] $ \mode -> do
+        (code, _, err) <- readCreateProcessWithExitCode (proc acton (["test"] ++ mode ++ ["--record"])) ""
+        assertBool err (code /= ExitSuccess && "--record requires acton test perf" `isInfixOf` err)
+  ]
+
+-- Real measurements need a quiet machine; enable them with make test-performance.
+perfIntegrationTests :: TestTree
+perfIntegrationTests =
+    testCase "recording runs fresh tests and preserves unselected measurements" $
       withSystemTempDirectory "acton-perf-record" $ \proj -> do
         acton <- canonicalizePath "../../dist/bin/acton"
         let name = "perf_record"
@@ -704,12 +714,6 @@ perfTests = testGroup "performance baselines"
           assertEqual "recorded scale reaches every loop body" (Just (Aeson.Number 25000)) (KM.lookup "scale" reusedInfo)
           assertEqual "reused scale skips calibration" (Just (Aeson.toJSON ([] :: [Aeson.Value]))) (KM.lookup "calibration" reusedInfo)
           assertEqual "default reuse leaves the new baseline intact" replaced =<< BL.readFile baseline
-  , testCase "record requires performance mode" $ do
-      acton <- canonicalizePath "../../dist/bin/acton"
-      forM_ [[], ["stress"], ["list"]] $ \mode -> do
-        (code, _, err) <- readCreateProcessWithExitCode (proc acton (["test"] ++ mode ++ ["--record"])) ""
-        assertBool err (code /= ExitSuccess && "--record requires acton test perf" `isInfixOf` err)
-  ]
 
 parseOptions :: [String] -> O.ParserResult C.CmdLineOptions
 parseOptions = O.execParserPure C.cmdLinePrefs (O.info (C.cmdLineParser O.<**> O.helper) mempty)

--- a/compiler/acton/ScaleOptionTests.hs
+++ b/compiler/acton/ScaleOptionTests.hs
@@ -76,18 +76,35 @@ scaleOptionTests = testGroup "performance scaling options"
       forM_ [["test", "scale", "--report", "run.jsonl", "--color", "never"],
              ["test", "--color", "never", "scale", "--report", "run.jsonl"]] $ \args ->
         case parseOptions args of
-          O.Success (C.CmdOpt globals (C.Test (C.TestScaleReport path))) -> do
+          O.Success (C.CmdOpt globals (C.Test (C.TestScaleReport path Nothing))) -> do
             assertEqual "recording path" "run.jsonl" path
             assertEqual "display options apply" C.Never (C.color globals)
           _ -> assertFailure ("expected saved report: " ++ unwords args)
       forM_ [["--max-time", "1s"], ["--name", "dct"], ["--start-scale", "2"], ["--json"], ["--record"]] $ \args ->
         rejects (["test", "scale", "--report", "run.jsonl"] ++ args)
+  , testCase "comparison always takes one baseline file in live and report modes" $ do
+      forM_ [["--compare", "before.jsonl"], ["--name", "dct", "--compare", "before.jsonl"],
+             ["--compare", "before.jsonl", "--max-time", "2m"]] $ \args -> do
+        opts <- parseScale args
+        assertEqual "live baseline" (Just "before.jsonl") (C.testCompare opts)
+      forM_ [["--report", "after.jsonl", "--compare", "before.jsonl"],
+             ["--compare", "before.jsonl", "--report", "after.jsonl"]] $ \args ->
+        case parseOptions (["test", "scale"] ++ args) of
+          O.Success (C.CmdOpt _ (C.Test (C.TestScaleReport path baseline))) ->
+            assertEqual "current and baseline have fixed roles" ("after.jsonl", Just "before.jsonl") (path, baseline)
+          O.Failure failure -> assertFailure (fst (O.renderFailure failure "acton"))
+          _ -> assertFailure "expected comparison report"
+      forM_ [["--report", "one", "two"], ["--compare", "one", "two"],
+             ["--compare", "one", "--compare", "two"], ["--report", "one", "--report", "two"]] $ \args ->
+        rejects (["test", "scale"] ++ args)
+      forM_ [[], ["perf"], ["list"], ["stress"]] $ \mode ->
+        rejects (["test"] ++ mode ++ ["--compare", "before.jsonl"])
   , testCase "scale help exposes study and report controls" $
       case parseOptions ["test", "scale", "--help"] of
         O.Failure failure -> do
           let (text, code) = O.renderFailure failure "acton"
           assertEqual text ExitSuccess code
-          forM_ ["--start-scale N", "--max-memory LIMIT", "--max-time DURATION", "--report FILE"] $ \option ->
+          forM_ ["--start-scale N", "--max-memory LIMIT", "--max-time DURATION", "--report FILE", "--compare FILE"] $ \option ->
             assertBool text (option `isInfixOf` unwords (words text))
           assertBool text (not (any (`isInfixOf` text) ["--scaling", "--scale N", "--time DURATION", "--iter", "--min-time"]))
         _ -> assertFailure "expected scale help"

--- a/compiler/acton/ScaleOptionTests.hs
+++ b/compiler/acton/ScaleOptionTests.hs
@@ -1,0 +1,108 @@
+module ScaleOptionTests (scaleOptionTests) where
+
+import Control.Monad (forM_)
+import Data.List (isInfixOf)
+import qualified Acton.CommandLineParser as C
+import qualified Options.Applicative as O
+import System.Exit (ExitCode(..))
+import Test.Tasty
+import Test.Tasty.HUnit
+
+scaleOptionTests :: TestTree
+scaleOptionTests = testGroup "performance scaling options"
+  [ testCase "scale captures explicit resource limits" $ do
+      opts <- parseScale ["--start-scale", "1000", "--max-memory", "50%", "--max-time", "2h"]
+      assertEqual "starting scale" (Just 1000) (C.testStartScale opts)
+      assertEqual "memory percentage" (Just (C.MemoryPercent 50)) (C.testMaxMemory opts)
+      assertEqual "duration is stored in milliseconds" 7200000 (C.testMaxTime opts)
+      assertBool "the total limit is explicit" (C.testMaxTimeSet opts)
+  , testCase "scale needs no flags and defaults to release builds" $ do
+      opts <- parseScale []
+      assertEqual "release by default" C.ReleaseFast (C.optimize (C.testCompile opts))
+      assertEqual "default starting scale is chosen by the runner" Nothing (C.testStartScale opts)
+      assertEqual "default memory limit is chosen by the runner" Nothing (C.testMaxMemory opts)
+      assertBool "default total limit is chosen by the runner" (not (C.testMaxTimeSet opts))
+      explicit <- parseScale ["--optimize", "Debug"]
+      assertEqual "explicit debug remains available" C.Debug (C.optimize (C.testCompile explicit))
+  , testCase "memory limits preserve exact byte units and finite percentages" $ do
+      forM_ [("1", C.MemoryBytes 1), ("256B", C.MemoryBytes 256),
+             ("2MiB", C.MemoryBytes (2 * 1024^2)), ("3gib", C.MemoryBytes (3 * 1024^3)),
+             ("1TB", C.MemoryBytes (1000^4)), ("1TiB", C.MemoryBytes (1024^4)),
+             ("0.5%", C.MemoryPercent 0.5), ("100%", C.MemoryPercent 100)] $ \(value, expected) ->
+        assertEqual value (Just expected) . C.testMaxMemory =<< parseScale ["--max-memory", value]
+      forM_ ["0", "-1MiB", "1.5GiB", "1XB", "0%", "-1%", "100.1%", "NaN%", "1e1000%"] $ \value ->
+        rejects ["test", "scale", "--max-memory", value]
+  , testCase "study durations are finite and starting scales are positive" $ do
+      forM_ [("250ms", 250), ("1.5s", 1500), ("2m", 120000), ("0.5H", 1800000)] $ \(value, expected) ->
+        assertEqual value expected . C.testMaxTime =<< parseScale ["--max-time", value]
+      forM_ ["0ms", "-1s", "0.1ms", "10", "1d", "NaNs", "1e100h"] $ \value ->
+        rejects ["test", "scale", "--max-time", value]
+      forM_ [1, maxBound :: Int] $ \value ->
+        assertEqual "positive starting scale" (Just value) . C.testStartScale =<< parseScale ["--start-scale", show value]
+      forM_ ["0", "-1", "1.5", show (toInteger (maxBound :: Int) + 1)] $ \value ->
+        rejects ["test", "scale", "--start-scale", value]
+  , testCase "scale and perf reject each other's workload controls" $ do
+      forM_ [["--scale", "7"], ["--time", "1s"], ["--iter", "1"],
+             ["--min-iter", "1"], ["--max-iter", "1"], ["--min-time", "1"],
+             ["--stress-workers", "1"], ["--scaling"]] $ \args ->
+        rejects (["test", "scale"] ++ args)
+      forM_ [["--start-scale", "1"], ["--max-memory", "50%"],
+             ["--max-time", "1h"], ["--scaling"]] $ \args ->
+        rejects (["test", "perf"] ++ args)
+  , testCase "ordinary limits keep milliseconds and reject scaling controls" $ do
+      forM_ [[], ["list"], ["stress"]] $ \mode ->
+        forM_ [["--scaling"], ["--start-scale", "1"], ["--max-memory", "50%"]] $ \args ->
+          rejects (["test"] ++ mode ++ args)
+      case parseOptions ["test", "stress", "--max-time", "0"] of
+        O.Success (C.CmdOpt _ (C.Test (C.TestStress opts))) ->
+          assertEqual "ordinary zero retains the unlimited convention" (0, True) (C.testMaxTime opts, C.testMaxTimeSet opts)
+        _ -> assertFailure "expected ordinary millisecond limit"
+  , testCase "global options and test selection work throughout scale commands" $ do
+      let selection = ["--module", "timers", "--name", "increasing", "--tag", "input"]
+      forM_
+        [ ["test", "--color", "never", "scale", "--start-scale", "7"] ++ selection
+        , ["test", "scale", "--color", "never", "--start-scale", "7"] ++ selection
+        , ["test", "scale", "--start-scale", "7", "--color", "never"] ++ selection
+        , ["test", "scale", "--start-scale", "7"] ++ selection ++ ["--color", "never"]
+        ] $ \args -> case parseOptions args of
+          O.Success (C.CmdOpt globals (C.Test (C.TestScale opts))) -> do
+            assertEqual (unwords args) C.Never (C.color globals)
+            assertEqual "scale and selection survive global options"
+              (Just 7, ["timers"], ["increasing"], ["input"])
+              (C.testStartScale opts, C.testModules opts, C.testNames opts, C.testTags opts)
+          O.Failure failure -> assertFailure (fst (O.renderFailure failure "acton"))
+          _ -> assertFailure ("unexpected command: " ++ unwords args)
+  , testCase "saved reports are independent of study options" $ do
+      forM_ [["test", "scale", "--report", "run.jsonl", "--color", "never"],
+             ["test", "--color", "never", "scale", "--report", "run.jsonl"]] $ \args ->
+        case parseOptions args of
+          O.Success (C.CmdOpt globals (C.Test (C.TestScaleReport path))) -> do
+            assertEqual "recording path" "run.jsonl" path
+            assertEqual "display options apply" C.Never (C.color globals)
+          _ -> assertFailure ("expected saved report: " ++ unwords args)
+      forM_ [["--max-time", "1s"], ["--name", "dct"], ["--start-scale", "2"], ["--json"], ["--record"]] $ \args ->
+        rejects (["test", "scale", "--report", "run.jsonl"] ++ args)
+  , testCase "scale help exposes study and report controls" $
+      case parseOptions ["test", "scale", "--help"] of
+        O.Failure failure -> do
+          let (text, code) = O.renderFailure failure "acton"
+          assertEqual text ExitSuccess code
+          forM_ ["--start-scale N", "--max-memory LIMIT", "--max-time DURATION", "--report FILE"] $ \option ->
+            assertBool text (option `isInfixOf` unwords (words text))
+          assertBool text (not (any (`isInfixOf` text) ["--scaling", "--scale N", "--time DURATION", "--iter", "--min-time"]))
+        _ -> assertFailure "expected scale help"
+  ]
+
+parseOptions :: [String] -> O.ParserResult C.CmdLineOptions
+parseOptions = O.execParserPure C.cmdLinePrefs (O.info (C.cmdLineParser O.<**> O.helper) mempty)
+
+parseScale :: [String] -> IO C.TestOptions
+parseScale args = case parseOptions (["test", "scale"] ++ args) of
+    O.Success (C.CmdOpt _ (C.Test (C.TestScale opts))) -> return opts
+    O.Failure failure -> assertFailure (fst (O.renderFailure failure "acton")) >> fail "invalid options"
+    _ -> assertFailure "expected scale options" >> fail "invalid command"
+
+rejects :: [String] -> Assertion
+rejects args = case parseOptions args of
+    O.Failure _ -> return ()
+    _ -> assertFailure ("must reject " ++ unwords args)

--- a/compiler/acton/ScaleReport.hs
+++ b/compiler/acton/ScaleReport.hs
@@ -1,0 +1,336 @@
+{-# LANGUAGE OverloadedStrings #-}
+module ScaleReport
+  ( ScaleData, addScaleEvent, scaleCharts, scaleSummary, printScaleReport, printScaleRecording
+  , Chart(..), ChartKind(..), ChartPoint(..), chartGuide, chartText, chartPixels, kittyImage, kittyTerminal
+  ) where
+
+import Codec.Compression.Zlib (compress)
+import Control.Exception (bracket_)
+import Control.Monad (forM_, when)
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KM
+import qualified Data.Aeson.Types as Aeson
+import Data.Bits (bit, (.|.))
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BC
+import qualified Data.ByteString.Base64 as Base64
+import qualified Data.ByteString.Lazy as BL
+import qualified Data.ByteString.Lazy.Char8 as BLC
+import Data.Char (chr, isPrint)
+import qualified Data.IntMap.Strict as IM
+import qualified Data.Map.Strict as M
+import Data.List (foldl', isPrefixOf, intercalate)
+import Data.Maybe (fromMaybe)
+import System.Environment (getEnvironment)
+import System.IO
+import TerminalSize (queryTermSize)
+import TestPerf (perfNumber)
+import TestFormat (testColorApply, testColorBold)
+import Text.Printf (printf)
+
+-- Only accepted curve samples are retained: (point complete, [(wall ms, RSS)]).
+-- Diagnostics remain in the journal, not in the chart's in-memory history.
+type ScaleData = IM.IntMap (Bool, [(Double, Double)])
+
+data ChartPoint = ChartPoint
+    { chartScale :: Double
+    , chartMinimum :: Double
+    , chartMean :: Double
+    , chartMaximum :: Double
+    , chartComplete :: Bool
+    } deriving (Eq, Show)
+
+data ChartKind = WallTime | TimePerScale | PeakMemory deriving (Eq, Show)
+data Chart = Chart ChartKind [ChartPoint] deriving (Eq, Show)
+
+chartStyle :: ChartKind -> (String, [Int])
+chartStyle WallTime = ("Wall time (ms)", [56, 189, 248])
+chartStyle TimePerScale = ("Time / scale (µs)", [192, 132, 252])
+chartStyle PeakMemory = ("Process peak memory (MiB)", [45, 212, 191])
+
+scaleSummary :: ScaleData -> String
+scaleSummary points = case (IM.lookupMin points, IM.lookupMax points) of
+    (Just (lo, _), Just (hi, _)) ->
+      count complete "size" ++ (if partial == 0 then "" else " + " ++ show partial ++ " partial")
+      ++ " · " ++ count samples "curve sample" ++ " · scale " ++ show lo ++ " … " ++ show hi
+    _ -> "No measurements"
+  where
+    complete = length (filter fst (IM.elems points))
+    partial = IM.size points - complete
+    samples = sum (map (length . snd) (IM.elems points))
+    count n noun = show n ++ " " ++ noun ++ if n == 1 then "" else "s"
+
+-- An illustrative proportionality line, not a fit or a complexity verdict.
+-- Anchor at the largest completed size; partial samples cannot set the guide.
+chartGuide :: Chart -> [(Double, Double)]
+chartGuide (Chart WallTime points) = case (points, reverse (filter chartComplete points)) of
+    (first:_, anchor:_) | chartScale first < chartScale anchor ->
+      [(chartScale first, chartMean anchor * (chartScale first / chartScale anchor)),
+       (chartScale anchor, chartMean anchor)]
+    _ -> []
+chartGuide _ = []
+
+addScaleEvent :: Aeson.Object -> ScaleData -> ScaleData
+addScaleEvent event points = fromMaybe points $ do
+    n <- KM.lookup "scale" event >>= Aeson.parseMaybe Aeson.parseJSON
+    if n <= 0 then Nothing else case KM.lookup "event" event of
+      Just (Aeson.String "point") -> Just (IM.adjust (\(_, xs) -> (True, xs)) n points)
+      Just (Aeson.String "sample")
+        | KM.lookup "accepted" event == Just (Aeson.Bool True)
+        , KM.lookup "reference" event /= Just (Aeson.Bool True)
+        , Just (Aeson.Object result) <- KM.lookup "result" event -> do
+            wall <- perfNumber result "avg_wall_duration"
+            rss <- perfNumber result "peak_rss"
+            if wall <= 0 || rss <= 0 then Nothing else
+              wall `seq` rss `seq` Just (IM.insertWith
+                (\(_, new) (done, old) -> (done, new ++ old)) n (False, [(wall, rss)]) points)
+      _ -> Nothing
+
+scaleCharts :: ScaleData -> [Chart]
+scaleCharts points =
+    [ chart WallTime (\_ (wall, _) -> wall)
+    , chart TimePerScale (\n (wall, _) -> wall * 1000 / n)
+    , chart PeakMemory (\_ (_, rss) -> rss / 1048576)
+    ]
+  where
+    chart title value = Chart title
+      [ ChartPoint scale (minimum ys) (sum ys / fromIntegral (length ys)) (maximum ys) done
+      | (n, (done, xs)) <- IM.toAscList points, not (null xs)
+      , let scale = fromIntegral n; ys = map (value scale) xs ]
+
+-- Keep only chart data while consuming the journal; raw sample diagnostics can
+-- be large. A killed writer may leave one unfinished final JSON record.
+printScaleRecording :: Bool -> FilePath -> IO ()
+printScaleRecording useColor path = do
+    (reports, stopped) <- withBinaryFile path ReadMode $ \input -> do
+      records <- BLC.split '\n' <$> BL.hGetContents input
+      case records of
+        first:rest -> do
+          header <- decode 1 first
+          case (KM.lookup "event" header, KM.lookup "version" header) of
+            (Just (Aeson.String "study"), Just (Aeson.Number version)) | version `elem` [1, 2] ->
+              readRecords 2 M.empty Nothing rest
+            _ -> invalid 1 "expected a scaling study journal (version 1 or 2)"
+        [] -> invalid 1 "empty scaling journal"
+    putStrLn ("Recording: " ++ show path)
+    when (all (IM.null . fst) (M.elems reports)) $
+      putStrLn "No accepted measurements in this recording."
+    forM_ (M.toAscList reports) $ \((modName, testName), (points, reason)) -> do
+      printScaleReport useColor (modName ++ "." ++ testName) points
+      forM_ reason (putStrLn . ("  " ++) . clean)
+    putStrLn (maybe "Recording is incomplete: no completion event was recorded." (("Stopped: " ++) . clean) stopped)
+  where
+    clean = map (\c -> if isPrint c then c else ' ')
+    invalid line message = ioError (userError (path ++ ":" ++ show (line :: Int) ++ ": " ++ message))
+    decode line = either (invalid line) return . Aeson.eitherDecode
+    readRecords _ reports stopped [] = return (reports, stopped)
+    readRecords line reports stopped (record:rest)
+      | BL.null record && null rest = return (reports, stopped)
+      | otherwise = line `seq` case Aeson.eitherDecode record of
+          Left _ | null rest -> do
+            hPutStrLn stderr (show path ++ ":" ++ show line ++ ": ignoring an unfinished final record")
+            return (reports, stopped)
+          Left message -> invalid line message
+          Right event -> case KM.lookup "event" event of
+            Just (Aeson.String kind) | kind `elem` ["sample", "point", "test_end"] -> do
+              key <- either (invalid line) return
+                (Aeson.parseEither (\obj -> (,) <$> obj Aeson..: "module" <*> obj Aeson..: "test") event)
+              let (previous, reason) = M.findWithDefault (IM.empty, Nothing) key reports
+                  points = addScaleEvent event previous
+              reason' <- if kind == "test_end"
+                then Just <$> either (invalid line) return (Aeson.parseEither (Aeson..: "reason") event)
+                else return reason
+              let reports' = M.insert key (points, reason') reports
+              points `seq` reports' `seq` readRecords (line + 1) reports' stopped rest
+            Just (Aeson.String "end") -> do
+              reason <- either (invalid line) return (Aeson.parseEither (Aeson..: "reason") event)
+              readRecords (line + 1) reports (Just reason) rest
+            Just (Aeson.String "study") -> invalid line "unexpected second study header"
+            _ -> readRecords (line + 1) reports stopped rest
+
+-- Be conservative without querying stdin or consuming the user's keystrokes.
+-- Multiplexers get text until their graphics passthrough is supported here.
+kittyTerminal :: Bool -> [(String, String)] -> Bool
+kittyTerminal tty env = tty && not multiplexer && term /= "dumb"
+    && (term `elem` ["xterm-kitty", "xterm-ghostty"] || program `elem` ["kitty", "ghostty"])
+  where
+    term = fromMaybe "" (lookup "TERM" env)
+    program = fromMaybe "" (lookup "TERM_PROGRAM" env)
+    multiplexer = any (\key -> maybe False (not . null) (lookup key env)) ["TMUX", "STY"]
+               || any (`isPrefixOf` term) ["screen", "tmux"]
+
+printScaleReport :: Bool -> String -> ScaleData -> IO ()
+printScaleReport useColor name points = when (not (IM.null points)) $ do
+    tty <- hIsTerminalDevice stdout
+    (rows, cols) <- if tty then fromMaybe (24, 80) <$> queryTermSize else return (24, 80)
+    graphics <- kittyTerminal tty <$> getEnvironment
+    -- Leave room for the labels and never move above the visible screen.
+    when (rows >= 10 && cols >= 40) $ do
+      let width = min 96 (cols - 13)
+          height = min 12 (rows - 6)
+      let paint = testColorApply useColor
+      putStrLn ("\n" ++ paint [testColorBold] ("Scaling charts: " ++ map (\c -> if isPrint c then c else ' ') name))
+      putStrLn (scaleSummary points)
+      putStrLn "Logarithmic axes; means and min–max ranges; ○ = partial point."
+      forM_ (scaleCharts points) $ \chart@(Chart kind _) -> do
+        let rgb = snd (chartStyle kind)
+            accent = "\ESC[38;2;" ++ intercalate ";" (map show rgb) ++ "m"
+            style row line
+              | row == 0 = paint [testColorBold, accent] line
+              | row <= height = take 11 line ++ paint [accent] (drop 11 line)
+              | otherwise = line
+        putStr (unlines (zipWith style [0..] (chartText graphics width height chart)))
+        when graphics $ do
+          -- The text reserves space first, including when output scrolls.
+          -- C=1 keeps the image from moving the cursor; return below the axes.
+          -- End any interrupted graphics command before restoring the cursor.
+          bracket_ (putStr ("\ESC[" ++ show (height + 2) ++ "A\ESC[12G"))
+            (putStr ("\ESC\\\ESC[" ++ show (height + 2) ++ "B\r") >> hFlush stdout)
+            (BS.hPut stdout (kittyImage width height (chartPixels useColor width height chart)))
+        case chartGuide chart of
+          [_, (n, _)] -> putStrLn (paint ["\ESC[38;2;251;191;36m"] ("  ┄ time ∝ scale · anchored at scale " ++ printf "%.0f" n))
+          _ -> return ()
+        putStrLn ""
+      putStrLn "Flat time/scale means roughly linear time over these sizes."
+      putStrLn "Peak memory includes process startup, setup, warmup and teardown."
+      hFlush stdout
+
+-- Positions are fractions of the plot area. A decade grid keeps small timing
+-- differences from looking like large changes. Constant series still have range.
+layout :: Chart -> ([(Double, String)], [(Double, String)], [ChartPoint], [(Double, Double)])
+layout (Chart _ []) = ([], [], [], [])
+layout chart@(Chart _ points) = (ticks xbounds, ticks ybounds, map project points, guide)
+  where
+    xbounds = bounds (map chartScale points)
+    ybounds = bounds (concatMap (\p -> [chartMinimum p, chartMaximum p]) points)
+    bounds values =
+      let lo = logBase 10 (minimum values); hi = logBase 10 (maximum values)
+          lower = fromIntegral (floor (lo + 1e-10) :: Int)
+          upper = fromIntegral (ceiling (hi - 1e-10) :: Int)
+      in if lower >= upper then (lo - 0.5, hi + 0.5) else (lower, upper)
+    position (lo, hi) value = (logBase 10 value - lo) / (hi - lo)
+    ticks limits@(lo, hi) =
+      [ (position limits (10 ** fromIntegral n), if n >= 0 && n <= 3 then show (10^n :: Int) else "1e" ++ show n)
+      | n <- [ceiling lo, ceiling lo + max 1 (ceiling ((hi - lo) / 4)) .. floor hi :: Int] ]
+    -- Clip before rasterization: clamping every pixel would draw a false line
+    -- along the bottom edge wherever the guide lies below the measured range.
+    guide = case [(position xbounds n, position ybounds t) | (n, t) <- chartGuide chart] of
+      [(ax, ay), (bx, by)] | bx > ax && by > ay ->
+        let slope = (by - ay) / (bx - ax)
+            left = max ax (ax - ay / slope)
+            right = min bx (ax + (1 - ay) / slope)
+        in [(u, ay + (u - ax) * slope) | left < right, u <- [left, right]]
+      _ -> []
+    project p = p { chartScale = position xbounds (chartScale p)
+                  , chartMinimum = position ybounds (chartMinimum p)
+                  , chartMean = position ybounds (chartMean p)
+                  , chartMaximum = position ybounds (chartMaximum p) }
+
+chartText :: Bool -> Int -> Int -> Chart -> [String]
+chartText graphics width height chart@(Chart kind raw) =
+    [heading] ++
+    [ pad 10 (fromMaybe "" (lookup row labels)) ++ "│" ++ plotRow row | row <- [0..height-1] ] ++
+    [replicate 10 ' ' ++ "└" ++ replicate width '─', "     scale " ++ xlabels]
+  where
+    (xticks, yticks, points, guide) = layout chart
+    title = "  ◆ " ++ fst (chartStyle kind)
+    lastValue = case reverse raw of
+      p:_ -> "last " ++ number (chartMean p) ++ if chartComplete p then "" else " (partial)"
+      _ -> ""
+    heading = title ++ if length title + length lastValue + 3 <= width + 11
+                        then replicate (width + 11 - length title - length lastValue) ' ' ++ lastValue else ""
+    number n | n >= 1e5 || n < 0.001 = printf "%.2e" n
+             | otherwise = printf "%.*f" (max 0 (2 - floor (logBase 10 n)) :: Int) n
+    labels = [(y height value, label) | (value, label) <- yticks]
+    -- Give the end ticks priority and leave a gap between labels on narrow
+    -- terminals. Overwriting a neighbouring label could change its number.
+    xlabels = foldl' place (replicate width ' ') (case xticks of [] -> []; first:rest -> first : reverse rest)
+    place line (value, label) =
+      let start = max 0 (min (width - length label) (x width value - length label `div` 2))
+          occupied = take (length label + 2) (drop (max 0 (start - 1)) line)
+      in if any (/= ' ') occupied then line
+         else take start line ++ label ++ drop (start + length label) line
+    dots = drawing (2 * width) (4 * height) 2 4 (segments points)
+    guideDots = drawing width height 1 1 (zip guide (drop 1 guide))
+    marks = IM.fromList [(y height (chartMean p) * width + x width (chartScale p),
+                         if chartComplete p then '●' else '○') | p <- points]
+    plotRow row
+      | graphics = replicate width ' '
+      | otherwise = [fromMaybe (braille col row) (IM.lookup (row * width + col) marks) | col <- [0..width-1]]
+    braille col row =
+      let bits = foldl' (.|.) 0
+            [ bit b | (dx, dy, b) <- [(0,0,0),(0,1,1),(0,2,2),(1,0,3),(1,1,4),(1,2,5),(0,3,6),(1,3,7)]
+                    , IM.member ((row * 4 + dy) * width * 2 + col * 2 + dx) dots ]
+      in if bits == 0 && col `mod` 3 == 0 && IM.member (row * width + col) guideDots then '·'
+         else chr (0x2800 + bits)
+    pad n s = replicate (max 0 (n - length s)) ' ' ++ s
+
+x :: Int -> Double -> Int
+x size value = max 0 (min (size - 1) (round (value * fromIntegral (size - 1))))
+
+y :: Int -> Double -> Int
+y size value = x size (1 - value)
+
+-- One set of line and range geometry feeds both terminal representations.
+segments :: [ChartPoint] -> [((Double, Double), (Double, Double))]
+segments points = zip centres (drop 1 centres) ++
+    [((chartScale p, chartMinimum p), (chartScale p, chartMaximum p)) | p <- points]
+  where centres = [(chartScale p, chartMean p) | p <- points]
+
+-- Cell centres align raster marks with the surrounding terminal text.
+drawing :: Int -> Int -> Int -> Int -> [((Double, Double), (Double, Double))] -> IM.IntMap ()
+drawing width height cellWidth cellHeight edges = IM.fromList
+    [(py * width + px, ()) | (a, b) <- edges, (px, py) <- line (pixel a) (pixel b)]
+  where
+    pixel (u, v) = (round (u * fromIntegral (width - cellWidth) + fromIntegral (cellWidth - 1) / 2),
+                    round ((1 - v) * fromIntegral (height - cellHeight) + fromIntegral (cellHeight - 1) / 2))
+    line (ax, ay) (bx, by) =
+      let steps = max 1 (max (abs (bx - ax)) (abs (by - ay)))
+      in [(ax + round (fromIntegral (bx - ax) * fromIntegral i / fromIntegral steps :: Double),
+           ay + round (fromIntegral (by - ay) * fromIntegral i / fromIntegral steps :: Double)) | i <- [0..steps]]
+
+chartPixels :: Bool -> Int -> Int -> Chart -> BS.ByteString
+chartPixels useColor cols rows chart@(Chart kind _) = BS.pack (concatMap pixel [0..width*height-1])
+  where
+    width = cols * 8
+    height = rows * 16
+    (xticks, yticks, points, guide) = layout chart
+    -- A seven-pixel horizontal inset keeps the six-pixel highlight inside
+    -- the image even when the latest size falls exactly on an axis limit.
+    lines = drawing width height 14 16 (segments points)
+    guideLine = drawing width height 14 16 (zip guide (drop 1 guide))
+    marks = IM.fromList
+      [ ((cy + dy) * width + cx + dx, alpha)
+      | (index, p) <- zip [0..] points
+      , let cx = round (chartScale p * fromIntegral (width - 14) + 6.5)
+            cy = round ((1 - chartMean p) * fromIntegral (height - 16) + 7.5)
+            radius = if index == length points - 1 then 6 else 3
+      , dx <- [-radius..radius], dy <- [-radius..radius]
+      , cx + dx >= 0, cx + dx < width, cy + dy >= 0, cy + dy < height
+      , let distance = dx*dx + dy*dy
+      , distance <= 9 || (radius == 6 && distance >= 25 && distance <= 36)
+      , let alpha = if distance > 9 then 150 else if distance <= 4 && not (chartComplete p) then 0 else 255 ]
+    gridX = [round (v * fromIntegral (width - 14) + 6.5) | (v, _) <- xticks]
+    gridY = [round ((1 - v) * fromIntegral (height - 16) + 7.5) | (v, _) <- yticks]
+    pixel i = case IM.lookup i marks of
+      Just alpha -> accent alpha
+      Nothing | IM.member i lines -> accent 255
+              | IM.member i guideLine && (i `mod` width - i `div` width) `mod` 12 < 6 -> gold
+              | i `mod` width `elem` gridX || i `div` width `elem` gridY -> [128, 128, 128, 50]
+              | otherwise -> [0, 0, 0, 0]
+    accent alpha = map fromIntegral (if useColor then snd (chartStyle kind) else [190, 190, 190]) ++ [alpha]
+    gold = (if useColor then [251, 191, 36] else [150, 150, 150]) ++ [210]
+
+-- Direct transmission works without a shared filesystem (including over SSH).
+-- Kitty accepts zlib-compressed RGBA; SVG or a PNG encoder is unnecessary.
+kittyImage :: Int -> Int -> BS.ByteString -> BS.ByteString
+kittyImage cols rows pixels = chunks metadata encoded
+  where
+    encoded = Base64.encode (BL.toStrict (compress (BL.fromStrict pixels)))
+    metadata = BC.pack ("a=T,f=32,o=z,s=" ++ show (cols * 8) ++ ",v=" ++ show (rows * 16)
+                        ++ ",c=" ++ show cols ++ ",r=" ++ show rows ++ ",C=1,")
+    chunks prefix bytes =
+      let (chunk, rest) = BS.splitAt 4096 bytes
+          more = if BS.null rest then "0" else "1"
+          command = "\ESC_G" <> prefix <> "q=2,m=" <> more <> ";" <> chunk <> "\ESC\\"
+      in if BS.null rest then command else command <> chunks "" rest

--- a/compiler/acton/ScaleReport.hs
+++ b/compiler/acton/ScaleReport.hs
@@ -1,11 +1,13 @@
 {-# LANGUAGE OverloadedStrings #-}
 module ScaleReport
-  ( ScaleData, addScaleEvent, scaleCharts, scaleSummary, printScaleReport, printScaleRecording
+  ( ScaleData, ScaleSeries(..), ScaleRecording(..), readScaleRecording, printScaleRecording
+  , scaleSeriesReason, addScaleEvent, scaleCharts, scaleSummary, printScaleReport
   , Chart(..), ChartKind(..), ChartPoint(..), chartGuide, chartText, chartPixels, kittyImage, kittyTerminal
   ) where
 
 import Codec.Compression.Zlib (compress)
 import Control.Exception (bracket_)
+import Control.Applicative ((<|>))
 import Control.Monad (forM_, when)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KM
@@ -22,15 +24,132 @@ import qualified Data.Map.Strict as M
 import Data.List (foldl', isPrefixOf, intercalate)
 import Data.Maybe (fromMaybe)
 import System.Environment (getEnvironment)
+import System.FilePath (takeFileName)
 import System.IO
 import TerminalSize (queryTermSize)
-import TestPerf (perfNumber)
+import TestPerf (perfNumber, perfInfo, perfSamplingReason)
 import TestFormat (testColorApply, testColorBold)
 import Text.Printf (printf)
 
 -- Only accepted curve samples are retained: (point complete, [(wall ms, RSS)]).
 -- Diagnostics remain in the journal, not in the chart's in-memory history.
 type ScaleData = IM.IntMap (Bool, [(Double, Double)])
+
+data ScaleSeries = ScaleSeries
+    { seriesData :: ScaleData
+    , seriesInfo :: Maybe Aeson.Object
+    , seriesIssue :: Maybe String
+    , seriesReason :: Maybe String
+    } deriving Show
+
+data ScaleRecording = ScaleRecording
+    { recordingPath :: FilePath
+    , recordingHeader :: Aeson.Object
+    , recordingTests :: M.Map (String, String) ScaleSeries
+    , recordingStopped :: Maybe String
+    } deriving Show
+
+-- Retain chart values and measurement identity, never the raw diagnostics. Old
+-- journals remain viewable even when their identity cannot support comparison.
+readScaleRecording :: FilePath -> IO ScaleRecording
+readScaleRecording path = withBinaryFile path ReadMode $ \input -> do
+    records <- BLC.split '\n' <$> BL.hGetContents input
+    case records of
+      first:rest -> do
+        header <- decode 1 first
+        case (KM.lookup "event" header, KM.lookup "version" header) of
+          (Just (Aeson.String "study"), Just (Aeson.Number version)) | version `elem` [1, 2, 3] -> do
+            let tests = case Aeson.parseMaybe key header of
+                  Just name -> M.singleton name emptySeries
+                  Nothing -> M.empty
+            (reports, stopped) <- readRecords 2 tests Nothing rest
+            return (ScaleRecording path header reports stopped)
+          _ -> invalid 1 "expected a scaling study journal (version 1, 2 or 3)"
+      [] -> invalid 1 "empty scaling journal"
+  where
+    emptySeries = ScaleSeries IM.empty Nothing Nothing Nothing
+    key obj = (,) <$> obj Aeson..: "module" <*> obj Aeson..: "test"
+    invalid line message = ioError (userError (path ++ ":" ++ show (line :: Int) ++ ": " ++ message))
+    decode line = either (invalid line) return . Aeson.eitherDecode
+    readRecords _ reports stopped [] = return (reports, stopped)
+    readRecords line reports stopped (record:rest)
+      | BL.null record && null rest = return (reports, stopped)
+      | otherwise = line `seq` case Aeson.eitherDecode record of
+          Left _ | null rest -> do
+            hPutStrLn stderr (show path ++ ":" ++ show line ++ ": ignoring an unfinished final record")
+            return (reports, stopped)
+          Left message -> invalid line message
+          Right event -> case KM.lookup "event" event of
+            Just (Aeson.String kind) | kind `elem` ["sample_start", "sample", "point", "test_end"] -> do
+              name <- either (invalid line) return (Aeson.parseEither key event)
+              let previous = M.findWithDefault emptySeries name reports
+                  points = addScaleEvent event (seriesData previous)
+                  accepted = kind == "sample" && KM.lookup "accepted" event == Just (Aeson.Bool True)
+                           && KM.lookup "reference" event /= Just (Aeson.Bool True)
+                  info = case KM.lookup "result" event of
+                    Just (Aeson.Object result) -> perfInfo result
+                    _ -> Nothing
+                  identityIssue = case info of
+                    Nothing -> Just "performance identity is unavailable"
+                    Just current
+                      | KM.lookup "scale" current /= KM.lookup "scale" event -> Just "sample workload scale differs from its recorded size"
+                      | KM.lookup "scaling" current /= Just (Aeson.Bool True)
+                        || KM.lookup "loop" current /= Just (Aeson.Bool True) -> Just "sample is not a scaling measurement"
+                      | otherwise -> perfSamplingReason current current
+                          <|> (seriesInfo previous >>= (`perfSamplingReason` current))
+              reason <- if kind == "test_end"
+                then Just <$> either (invalid line) return (Aeson.parseEither (Aeson..: "reason") event)
+                else return (seriesReason previous)
+              let updated = previous
+                    { seriesData = points, seriesReason = reason
+                    , seriesInfo = seriesInfo previous <|> if accepted then info else Nothing
+                    , seriesIssue = seriesIssue previous <|> if accepted then identityIssue else Nothing
+                    }
+                  reports' = M.insert name updated reports
+              points `seq` seriesInfo updated `seq` seriesIssue updated `seq` reports' `seq` readRecords (line + 1) reports' stopped rest
+            Just (Aeson.String "end") -> do
+              reason <- either (invalid line) return (Aeson.parseEither (Aeson..: "reason") event)
+              readRecords (line + 1) reports (Just reason) rest
+            Just (Aeson.String "study") -> invalid line "unexpected second study header"
+            _ -> readRecords (line + 1) reports stopped rest
+
+scaleSeriesReason :: ScaleSeries -> ScaleSeries -> Maybe String
+scaleSeriesReason old new = seriesIssue old <|> seriesIssue new <|>
+    case (seriesInfo old, seriesInfo new) of
+      (Just a, Just b) -> perfSamplingReason a b
+      _ -> Just "performance identity is unavailable"
+
+printScaleRecording :: Bool -> FilePath -> Maybe FilePath -> IO ()
+printScaleRecording useColor path baselinePath = do
+    current <- readScaleRecording path
+    baseline <- mapM readScaleRecording baselinePath
+    let reports = recordingTests current
+        pairs = case baseline of
+          Nothing -> M.map (\new -> (new, Nothing)) reports
+          Just old -> M.intersectionWith (\new previous -> (new, Just previous)) reports (recordingTests old)
+    forM_ baseline $ \old -> do
+      when (M.null pairs) (ioError (userError "The recordings contain no matching benchmarks"))
+      forM_ (M.toAscList pairs) $ \((modName, testName), (new, previous)) ->
+        forM_ (previous >>= (`scaleSeriesReason` new)) $ \reason ->
+          ioError (userError ("Cannot compare " ++ modName ++ "." ++ testName ++ ": " ++ reason))
+      when (M.keys reports /= M.keys (recordingTests old)) $
+        putStrLn "Only benchmarks present in both recordings are compared."
+    putStrLn ("Recording: " ++ show path)
+    forM_ baseline $ \old -> putStrLn ("Baseline: " ++ show (recordingPath old))
+    when (all (IM.null . seriesData) (M.elems reports)) $
+      putStrLn "No accepted measurements in this recording."
+    forM_ (M.toAscList pairs) $ \((modName, testName), (current, old)) -> do
+      forM_ baseline $ \previous -> do
+        putStrLn ("Current: " ++ clean (takeFileName path))
+        putStrLn ("Baseline: " ++ clean (takeFileName (recordingPath previous)))
+      printScaleReport useColor (modName ++ "." ++ testName) (seriesData current) (maybe IM.empty seriesData old)
+      forM_ (seriesReason current) (putStrLn . ("  " ++) . clean)
+      forM_ (old >>= seriesReason) (putStrLn . ("  Baseline: " ++) . clean)
+    putStrLn (maybe "Recording is incomplete: no completion event was recorded." (("Stopped: " ++) . clean) (recordingStopped current))
+    forM_ baseline $ \old -> putStrLn
+      (maybe "Baseline is incomplete: no completion event was recorded." (("Baseline stopped: " ++) . clean) (recordingStopped old))
+  where
+    clean = map (\c -> if isPrint c then c else ' ')
 
 data ChartPoint = ChartPoint
     { chartScale :: Double
@@ -41,7 +160,7 @@ data ChartPoint = ChartPoint
     } deriving (Eq, Show)
 
 data ChartKind = WallTime | TimePerScale | PeakMemory deriving (Eq, Show)
-data Chart = Chart ChartKind [ChartPoint] deriving (Eq, Show)
+data Chart = Chart ChartKind [ChartPoint] [ChartPoint] deriving (Eq, Show)
 
 chartStyle :: ChartKind -> (String, [Int])
 chartStyle WallTime = ("Wall time (ms)", [56, 189, 248])
@@ -63,7 +182,7 @@ scaleSummary points = case (IM.lookupMin points, IM.lookupMax points) of
 -- An illustrative proportionality line, not a fit or a complexity verdict.
 -- Anchor at the largest completed size; partial samples cannot set the guide.
 chartGuide :: Chart -> [(Double, Double)]
-chartGuide (Chart WallTime points) = case (points, reverse (filter chartComplete points)) of
+chartGuide (Chart WallTime points _) = case (points, reverse (filter chartComplete points)) of
     (first:_, anchor:_) | chartScale first < chartScale anchor ->
       [(chartScale first, chartMean anchor * (chartScale first / chartScale anchor)),
        (chartScale anchor, chartMean anchor)]
@@ -86,67 +205,18 @@ addScaleEvent event points = fromMaybe points $ do
                 (\(_, new) (done, old) -> (done, new ++ old)) n (False, [(wall, rss)]) points)
       _ -> Nothing
 
-scaleCharts :: ScaleData -> [Chart]
-scaleCharts points =
+scaleCharts :: ScaleData -> ScaleData -> [Chart]
+scaleCharts points baseline =
     [ chart WallTime (\_ (wall, _) -> wall)
     , chart TimePerScale (\n (wall, _) -> wall * 1000 / n)
     , chart PeakMemory (\_ (_, rss) -> rss / 1048576)
     ]
   where
-    chart title value = Chart title
+    chart title value = Chart title (series value points) (series value baseline)
+    series value dataPoints =
       [ ChartPoint scale (minimum ys) (sum ys / fromIntegral (length ys)) (maximum ys) done
-      | (n, (done, xs)) <- IM.toAscList points, not (null xs)
+      | (n, (done, xs)) <- IM.toAscList dataPoints, not (null xs)
       , let scale = fromIntegral n; ys = map (value scale) xs ]
-
--- Keep only chart data while consuming the journal; raw sample diagnostics can
--- be large. A killed writer may leave one unfinished final JSON record.
-printScaleRecording :: Bool -> FilePath -> IO ()
-printScaleRecording useColor path = do
-    (reports, stopped) <- withBinaryFile path ReadMode $ \input -> do
-      records <- BLC.split '\n' <$> BL.hGetContents input
-      case records of
-        first:rest -> do
-          header <- decode 1 first
-          case (KM.lookup "event" header, KM.lookup "version" header) of
-            (Just (Aeson.String "study"), Just (Aeson.Number version)) | version `elem` [1, 2] ->
-              readRecords 2 M.empty Nothing rest
-            _ -> invalid 1 "expected a scaling study journal (version 1 or 2)"
-        [] -> invalid 1 "empty scaling journal"
-    putStrLn ("Recording: " ++ show path)
-    when (all (IM.null . fst) (M.elems reports)) $
-      putStrLn "No accepted measurements in this recording."
-    forM_ (M.toAscList reports) $ \((modName, testName), (points, reason)) -> do
-      printScaleReport useColor (modName ++ "." ++ testName) points
-      forM_ reason (putStrLn . ("  " ++) . clean)
-    putStrLn (maybe "Recording is incomplete: no completion event was recorded." (("Stopped: " ++) . clean) stopped)
-  where
-    clean = map (\c -> if isPrint c then c else ' ')
-    invalid line message = ioError (userError (path ++ ":" ++ show (line :: Int) ++ ": " ++ message))
-    decode line = either (invalid line) return . Aeson.eitherDecode
-    readRecords _ reports stopped [] = return (reports, stopped)
-    readRecords line reports stopped (record:rest)
-      | BL.null record && null rest = return (reports, stopped)
-      | otherwise = line `seq` case Aeson.eitherDecode record of
-          Left _ | null rest -> do
-            hPutStrLn stderr (show path ++ ":" ++ show line ++ ": ignoring an unfinished final record")
-            return (reports, stopped)
-          Left message -> invalid line message
-          Right event -> case KM.lookup "event" event of
-            Just (Aeson.String kind) | kind `elem` ["sample", "point", "test_end"] -> do
-              key <- either (invalid line) return
-                (Aeson.parseEither (\obj -> (,) <$> obj Aeson..: "module" <*> obj Aeson..: "test") event)
-              let (previous, reason) = M.findWithDefault (IM.empty, Nothing) key reports
-                  points = addScaleEvent event previous
-              reason' <- if kind == "test_end"
-                then Just <$> either (invalid line) return (Aeson.parseEither (Aeson..: "reason") event)
-                else return reason
-              let reports' = M.insert key (points, reason') reports
-              points `seq` reports' `seq` readRecords (line + 1) reports' stopped rest
-            Just (Aeson.String "end") -> do
-              reason <- either (invalid line) return (Aeson.parseEither (Aeson..: "reason") event)
-              readRecords (line + 1) reports (Just reason) rest
-            Just (Aeson.String "study") -> invalid line "unexpected second study header"
-            _ -> readRecords (line + 1) reports stopped rest
 
 -- Be conservative without querying stdin or consuming the user's keystrokes.
 -- Multiplexers get text until their graphics passthrough is supported here.
@@ -159,8 +229,8 @@ kittyTerminal tty env = tty && not multiplexer && term /= "dumb"
     multiplexer = any (\key -> maybe False (not . null) (lookup key env)) ["TMUX", "STY"]
                || any (`isPrefixOf` term) ["screen", "tmux"]
 
-printScaleReport :: Bool -> String -> ScaleData -> IO ()
-printScaleReport useColor name points = when (not (IM.null points)) $ do
+printScaleReport :: Bool -> String -> ScaleData -> ScaleData -> IO ()
+printScaleReport useColor name points baseline = when (not (IM.null points && IM.null baseline)) $ do
     tty <- hIsTerminalDevice stdout
     (rows, cols) <- if tty then fromMaybe (24, 80) <$> queryTermSize else return (24, 80)
     graphics <- kittyTerminal tty <$> getEnvironment
@@ -171,14 +241,17 @@ printScaleReport useColor name points = when (not (IM.null points)) $ do
       let paint = testColorApply useColor
       putStrLn ("\n" ++ paint [testColorBold] ("Scaling charts: " ++ map (\c -> if isPrint c then c else ' ') name))
       putStrLn (scaleSummary points)
-      putStrLn "Logarithmic axes; means and min–max ranges; ○ = partial point."
-      forM_ (scaleCharts points) $ \chart@(Chart kind _) -> do
+      when (not (IM.null baseline)) (putStrLn ("Baseline: " ++ scaleSummary baseline))
+      putStrLn "Logarithmic axes; means and min–max ranges; hollow markers = partial points."
+      forM_ (scaleCharts points baseline) $ \chart@(Chart kind _ old) -> do
         let rgb = snd (chartStyle kind)
             accent = "\ESC[38;2;" ++ intercalate ";" (map show rgb) ++ "m"
             style row line
               | row == 0 = paint [testColorBold, accent] line
               | row <= height = take 11 line ++ paint [accent] (drop 11 line)
               | otherwise = line
+        when (not (null old)) $
+          putStrLn (paint [accent] "  ● ━ current" ++ "    " ++ paint [if graphics then "\ESC[38;2;251;146;60m" else accent] "◆ ┄ baseline" ++ "    ◈ overlapping points")
         putStr (unlines (zipWith style [0..] (chartText graphics width height chart)))
         when graphics $ do
           -- The text reserves space first, including when output scrolls.
@@ -197,12 +270,12 @@ printScaleReport useColor name points = when (not (IM.null points)) $ do
 
 -- Positions are fractions of the plot area. A decade grid keeps small timing
 -- differences from looking like large changes. Constant series still have range.
-layout :: Chart -> ([(Double, String)], [(Double, String)], [ChartPoint], [(Double, Double)])
-layout (Chart _ []) = ([], [], [], [])
-layout chart@(Chart _ points) = (ticks xbounds, ticks ybounds, map project points, guide)
+layout :: Chart -> ([(Double, String)], [(Double, String)], [ChartPoint], [ChartPoint], [(Double, Double)])
+layout (Chart _ [] []) = ([], [], [], [], [])
+layout chart@(Chart _ points baseline) = (ticks xbounds, ticks ybounds, map project points, map project baseline, guide)
   where
-    xbounds = bounds (map chartScale points)
-    ybounds = bounds (concatMap (\p -> [chartMinimum p, chartMaximum p]) points)
+    xbounds = bounds (map chartScale (points ++ baseline))
+    ybounds = bounds (concatMap (\p -> [chartMinimum p, chartMaximum p]) (points ++ baseline))
     bounds values =
       let lo = logBase 10 (minimum values); hi = logBase 10 (maximum values)
           lower = fromIntegral (floor (lo + 1e-10) :: Int)
@@ -227,12 +300,12 @@ layout chart@(Chart _ points) = (ticks xbounds, ticks ybounds, map project point
                   , chartMaximum = position ybounds (chartMaximum p) }
 
 chartText :: Bool -> Int -> Int -> Chart -> [String]
-chartText graphics width height chart@(Chart kind raw) =
+chartText graphics width height chart@(Chart kind raw _) =
     [heading] ++
     [ pad 10 (fromMaybe "" (lookup row labels)) ++ "│" ++ plotRow row | row <- [0..height-1] ] ++
     [replicate 10 ' ' ++ "└" ++ replicate width '─', "     scale " ++ xlabels]
   where
-    (xticks, yticks, points, guide) = layout chart
+    (xticks, yticks, points, baseline, guide) = layout chart
     title = "  ◆ " ++ fst (chartStyle kind)
     lastValue = case reverse raw of
       p:_ -> "last " ++ number (chartMean p) ++ if chartComplete p then "" else " (partial)"
@@ -251,16 +324,23 @@ chartText graphics width height chart@(Chart kind raw) =
       in if any (/= ' ') occupied then line
          else take start line ++ label ++ drop (start + length label) line
     dots = drawing (2 * width) (4 * height) 2 4 (segments points)
+    oldDots = drawing (2 * width) (4 * height) 2 4 (segments baseline)
     guideDots = drawing width height 1 1 (zip guide (drop 1 guide))
     marks = IM.fromList [(y height (chartMean p) * width + x width (chartScale p),
                          if chartComplete p then '●' else '○') | p <- points]
+    oldMarks = IM.fromList [(y height (chartMean p) * width + x width (chartScale p), if chartComplete p then '◆' else '◇') | p <- baseline]
+    mark i = case (IM.lookup i marks, IM.lookup i oldMarks) of
+      (Just '●', Just _) -> Just '◈'
+      (Just c, _) -> Just c
+      (_, old) -> old
     plotRow row
       | graphics = replicate width ' '
-      | otherwise = [fromMaybe (braille col row) (IM.lookup (row * width + col) marks) | col <- [0..width-1]]
+      | otherwise = [fromMaybe (braille col row) (mark (row * width + col)) | col <- [0..width-1]]
     braille col row =
       let bits = foldl' (.|.) 0
             [ bit b | (dx, dy, b) <- [(0,0,0),(0,1,1),(0,2,2),(1,0,3),(1,1,4),(1,2,5),(0,3,6),(1,3,7)]
-                    , IM.member ((row * 4 + dy) * width * 2 + col * 2 + dx) dots ]
+                    , let i = (row * 4 + dy) * width * 2 + col * 2 + dx
+                    , IM.member i dots || ((col + row) `mod` 3 /= 2 && IM.member i oldDots) ]
       in if bits == 0 && col `mod` 3 == 0 && IM.member (row * width + col) guideDots then '·'
          else chr (0x2800 + bits)
     pad n s = replicate (max 0 (n - length s)) ' ' ++ s
@@ -290,15 +370,23 @@ drawing width height cellWidth cellHeight edges = IM.fromList
            ay + round (fromIntegral (by - ay) * fromIntegral i / fromIntegral steps :: Double)) | i <- [0..steps]]
 
 chartPixels :: Bool -> Int -> Int -> Chart -> BS.ByteString
-chartPixels useColor cols rows chart@(Chart kind _) = BS.pack (concatMap pixel [0..width*height-1])
+chartPixels useColor cols rows chart@(Chart kind _ _) = BS.pack (concatMap pixel [0..width*height-1])
   where
     width = cols * 8
     height = rows * 16
-    (xticks, yticks, points, guide) = layout chart
+    (xticks, yticks, points, baseline, guide) = layout chart
     -- A seven-pixel horizontal inset keeps the six-pixel highlight inside
     -- the image even when the latest size falls exactly on an axis limit.
     lines = drawing width height 14 16 (segments points)
+    oldLines = drawing width height 14 16 (segments baseline)
     guideLine = drawing width height 14 16 (zip guide (drop 1 guide))
+    oldMarks = IM.fromList
+      [ ((cy + dy) * width + cx + dx, ())
+      | p <- baseline
+      , let cx = round (chartScale p * fromIntegral (width - 14) + 6.5)
+            cy = round ((1 - chartMean p) * fromIntegral (height - 16) + 7.5)
+      , dx <- [-5..5], dy <- [-5..5], (if chartComplete p then abs dx + abs dy <= 5 else abs dx + abs dy `elem` [4, 5])
+      , cx + dx >= 0, cx + dx < width, cy + dy >= 0, cy + dy < height ]
     marks = IM.fromList
       [ ((cy + dy) * width + cx + dx, alpha)
       | (index, p) <- zip [0..] points
@@ -315,10 +403,12 @@ chartPixels useColor cols rows chart@(Chart kind _) = BS.pack (concatMap pixel [
     pixel i = case IM.lookup i marks of
       Just alpha -> accent alpha
       Nothing | IM.member i lines -> accent 255
+              | IM.member i oldMarks || (IM.member i oldLines && (i `mod` width - i `div` width) `mod` 12 < 6) -> recorded
               | IM.member i guideLine && (i `mod` width - i `div` width) `mod` 12 < 6 -> gold
               | i `mod` width `elem` gridX || i `div` width `elem` gridY -> [128, 128, 128, 50]
               | otherwise -> [0, 0, 0, 0]
     accent alpha = map fromIntegral (if useColor then snd (chartStyle kind) else [190, 190, 190]) ++ [alpha]
+    recorded = (if useColor then [251, 146, 60] else [235, 235, 235]) ++ [255]
     gold = (if useColor then [251, 191, 36] else [150, 150, 150]) ++ [210]
 
 -- Direct transmission works without a shared filesystem (including over SSH).

--- a/compiler/acton/ScaleReportTests.hs
+++ b/compiler/acton/ScaleReportTests.hs
@@ -10,6 +10,7 @@ import qualified Data.ByteString.Char8 as BC
 import qualified Data.ByteString.Base64 as Base64
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.IntMap.Strict as IM
+import qualified Data.Map.Strict as M
 import Data.List (foldl', isInfixOf)
 import Data.Word (Word8)
 import ScaleReport
@@ -32,10 +33,10 @@ scaleReportTests = testGroup "terminal charts"
                      sample 8 0 1 True False]
           points = foldl' (flip addScaleEvent) IM.empty samples
       assertEqual "linear work has constant time per scale and preserves sample ranges"
-        [ Chart WallTime [ChartPoint 2 8 10 12 True, ChartPoint 4 16 20 24 False]
-        , Chart TimePerScale [ChartPoint 2 4000 5000 6000 True, ChartPoint 4 4000 5000 6000 False]
-        , Chart PeakMemory [ChartPoint 2 1 1 1 True, ChartPoint 4 2 2 2 False]
-        ] (scaleCharts points)
+        [ Chart WallTime [ChartPoint 2 8 10 12 True, ChartPoint 4 16 20 24 False] []
+        , Chart TimePerScale [ChartPoint 2 4000 5000 6000 True, ChartPoint 4 4000 5000 6000 False] []
+        , Chart PeakMemory [ChartPoint 2 1 1 1 True, ChartPoint 4 2 2 2 False] []
+        ] (scaleCharts points IM.empty)
       assertEqual "summary distinguishes finished sizes and accepted partial samples"
         "1 size + 1 partial · 6 curve samples · scale 2 … 4" (scaleSummary points)
   , testCase "saved journals replay outside a project, preserving separate tests and partial sizes" $
@@ -88,17 +89,50 @@ scaleReportTests = testGroup "terminal charts"
           assertBool (out ++ err) (code /= ExitSuccess)
           assertBool "bad input has a diagnostic" (not (null err))
           assertBool "bad input is not presented as a valid report" (not ("Scaling charts:" `isInfixOf` out))
+  , testCase "comparisons retain sample identity and reject a later incompatible sample" $ do
+      let named = KM.insert "module" (Aeson.String "alpha") . KM.insert "test" (Aeson.String "same")
+          measured machine workers n = named $ KM.mapWithKey
+            (\key value -> case (key, value) of
+              ("result", Aeson.Object result) -> Aeson.Object (KM.insert "perf_info" (identity machine workers n) result)
+              _ -> value) (sample n 10 1048576 True False)
+          identity machine workers n = Aeson.object
+            ["machine" Aeson..= (machine :: String), "workers" Aeson..= (workers :: Int),
+             "scale" Aeson..= n, "scaling" Aeson..= True, "loop" Aeson..= True,
+             "version" Aeson..= ("3" :: String), "gc" Aeson..= ("natural" :: String),
+             "tags" Aeson..= ([] :: [String]), "build" Aeson..= Aeson.object
+               ["target" Aeson..= ("native" :: String), "optimize" Aeson..= ("ReleaseFast" :: String),
+                "cpu" Aeson..= ("" :: String), "no_threads" Aeson..= False, "db" Aeson..= False, "no_dbp" Aeson..= False]]
+          events = [header 3, measured "machine-a" 2 1, measured "machine-a" 2 3, ending]
+      withRecording events $ \path _ -> do
+        recording <- readScaleRecording path
+        let series = recordingTests recording M.! ("alpha", "same")
+        assertEqual "different workload sizes share one sampling identity" Nothing (scaleSeriesReason series series)
+        acton <- canonicalizePath "../../dist/bin/acton"
+        let baseline = takeDirectory path </> "baseline.jsonl"
+            compare = readCreateProcessWithExitCode
+              (proc acton ["test", "scale", "--compare", baseline, "--report", path, "--color", "never"])
+                { cwd = Just (takeDirectory path) } ""
+        copyFile path baseline
+        (code, out, err) <- compare
+        assertEqual (out ++ err) ExitSuccess code
+        assertBool out ("baseline" `isInfixOf` out && "current" `isInfixOf` out)
+        forM_ [("machine-b", 2, "machine identity"), ("machine-a", 3, "worker count")] $ \(machine, workers, reason) -> do
+          BL.writeFile path (BL.concat [Aeson.encode event <> "\n" | event <-
+            [header 3, measured "machine-a" 2 1, measured machine workers 3, ending]])
+          (code, out, err) <- compare
+          assertBool (out ++ err) (code /= ExitSuccess && reason `isInfixOf` err)
+          assertBool "no invalid overlay is displayed" (not ("Scaling charts:" `isInfixOf` out))
   , testCase "the proportional guide uses the largest completed size, without fitting or extrapolating" $ do
       let points = [ChartPoint 1 10 10 10 True, ChartPoint 100 20 20 20 True,
                     ChartPoint 200 100 100 100 False]
       assertEqual "proportional time, anchored at size 100" [(1, 0.2), (100, 20)]
-        (chartGuide (Chart WallTime points))
-      forM_ [Chart WallTime [], Chart WallTime [head points],
-             Chart WallTime [p {chartComplete = False} | p <- points],
-             Chart TimePerScale points, Chart PeakMemory points] $ \chart ->
+        (chartGuide (Chart WallTime points []))
+      forM_ [Chart WallTime [] [], Chart WallTime [head points] [],
+             Chart WallTime [p {chartComplete = False} | p <- points] [],
+             Chart TimePerScale points [], Chart PeakMemory points []] $ \chart ->
         assertEqual "only wall time with a completed span has a guide" [] (chartGuide chart)
   , testCase "a guide below the visible range is clipped rather than clamped to the axis" $ do
-      let chart = Chart WallTime [ChartPoint 1 1 1 1 True, ChartPoint 1e6 1 1 1 True]
+      let chart = Chart WallTime [ChartPoint 1 1 1 1 True, ChartPoint 1e6 1 1 1 True] []
           pixels = BS.unpack (chartPixels True 67 12 chart)
           rgbas [] = []
           rgbas (r:g:b:a:rest) = (r,g,b,a) : rgbas rest
@@ -107,7 +141,7 @@ scaleReportTests = testGroup "terminal charts"
       assertBool "part of the guide is visible" (not (null gold))
       assertBool "it enters the plot only in the final decade"
         (all (\i -> i `mod` 536 > 450) gold)
-      let diagonal = Chart WallTime [ChartPoint 1 1 1 1 True, ChartPoint 1000 4 4 4 True]
+      let diagonal = Chart WallTime [ChartPoint 1 1 1 1 True, ChartPoint 1000 4 4 4 True] []
       assertBool "a near-diagonal guide still contains visible dashes"
         (any (\(r,g,b,a) -> r > g && g > b && a > 0)
           (rgbas (BS.unpack (chartPixels True 67 12 diagonal))))
@@ -118,19 +152,37 @@ scaleReportTests = testGroup "terminal charts"
                     [ChartPoint n 1 1 1 True | n <- [1,10,100]],
                     [ChartPoint 1 0.00001 0.00001 0.00001 True, ChartPoint 1e12 1e6 1e6 1e6 True]]
       forM_ curves $ \points -> forM_ [(27,4), (67,12), (96,12)] $ \(width, height) -> do
-        let chart = Chart WallTime points
+        let chart = Chart WallTime points []
             output = chartText False width height chart
         assertEqual "title, plot, baseline and scale labels" (height + 3) (length output)
         assertBool (show output) (all ((<= width + 11) . length) output)
         assertBool "text fallback has no escape codes" (all (notElem '\ESC') output)
         assertEqual "RGBA has four bytes per pixel" (width * 8 * height * 16 * 4)
           (BS.length (chartPixels True width height chart))
-      let partial = unlines (chartText False 67 12 (Chart WallTime [ChartPoint 1 1 1 1 False]))
+      let partial = unlines (chartText False 67 12 (Chart WallTime [ChartPoint 1 1 1 1 False] []))
       assertBool "a completed sample in an unfinished point stays hollow" ('○' `elem` partial)
       let narrow = chartText False 27 8 (Chart WallTime
-            [ChartPoint 1 1 1 1 True, ChartPoint 1e6 1e6 1e6 1e6 True])
+            [ChartPoint 1 1 1 1 True, ChartPoint 1e6 1e6 1e6 1e6 True] [])
       assertEqual "narrow axes show whole, separated decade labels"
         ["scale", "1", "100", "1e4", "1e6"] (words (last narrow))
+  , testCase "recorded and new curves share axes without losing the unmatched range" $ do
+      let current = [ChartPoint 1 1 2 3 True, ChartPoint 10 4 5 6 False]
+          old = [ChartPoint 1 10 12 14 True, ChartPoint 1e6 800 900 1000 False]
+          chart = Chart WallTime current old
+          text = unlines (chartText False 67 12 chart)
+          rgbas [] = []
+          rgbas (r:g:b:a:rest) = (r,g,b,a) : rgbas rest
+          rgbas _ = error "incomplete RGBA"
+          colors = rgbas (BS.unpack (chartPixels True 27 4 chart))
+      forM_ ['●', '○', '◆', '◇'] $ \mark -> assertBool "both series and partial samples remain distinguishable" (mark `elem` text)
+      assertBool "old sizes beyond an interrupted new curve remain visible" ("1e6" `isInfixOf` text)
+      assertBool "new curve has its own color" ((56,189,248,255) `elem` colors)
+      assertBool "recorded curve has its own color" ((251,146,60,255) `elem` colors)
+      assertBool "monochrome preserves both styles without colored pixels"
+        (all (\(r,g,b,_) -> r == g && g == b) (rgbas (BS.unpack (chartPixels False 27 4 chart))))
+      assertEqual "recorded points do not change the proportional guide" [] (chartGuide chart)
+      let coincident = unlines (chartText False 67 12 (Chart WallTime (take 1 current) (take 1 current)))
+      assertBool "coincident means retain both series' presence" ('◈' `elem` coincident)
   , testCase "graphics selection is conservative and never applies to redirected output" $ do
       forM_ [[("TERM", "xterm-kitty")], [("TERM", "xterm-ghostty")],
              [("TERM", "xterm-256color"), ("TERM_PROGRAM", "ghostty")]] $ \env -> do

--- a/compiler/acton/ScaleReportTests.hs
+++ b/compiler/acton/ScaleReportTests.hs
@@ -1,0 +1,179 @@
+{-# LANGUAGE OverloadedStrings #-}
+module ScaleReportTests (scaleReportTests) where
+
+import Codec.Compression.Zlib (decompress)
+import Control.Monad (forM_)
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KM
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BC
+import qualified Data.ByteString.Base64 as Base64
+import qualified Data.ByteString.Lazy as BL
+import qualified Data.IntMap.Strict as IM
+import Data.List (foldl', isInfixOf)
+import Data.Word (Word8)
+import ScaleReport
+import System.Directory
+import System.Exit (ExitCode(..))
+import System.FilePath
+import System.IO.Temp (withSystemTempDirectory)
+import System.Process
+import System.Random (mkStdGen, randoms)
+import Test.Tasty
+import Test.Tasty.HUnit
+
+scaleReportTests :: TestTree
+scaleReportTests = testGroup "terminal charts"
+  [ testCase "charts preserve ranges and partial points, excluding reference and rejected samples" $ do
+      let samples = [sample 2 t 1048576 True False | t <- [8, 10, 12]]
+                 ++ [KM.fromList [("event", Aeson.String "point"), ("scale", Aeson.Number 2)]]
+                 ++ [sample 4 t 2097152 True False | t <- [16, 20, 24]]
+                 ++ [sample 8 32 1 False False, sample 2 9999 1 True True,
+                     sample 8 0 1 True False]
+          points = foldl' (flip addScaleEvent) IM.empty samples
+      assertEqual "linear work has constant time per scale and preserves sample ranges"
+        [ Chart WallTime [ChartPoint 2 8 10 12 True, ChartPoint 4 16 20 24 False]
+        , Chart TimePerScale [ChartPoint 2 4000 5000 6000 True, ChartPoint 4 4000 5000 6000 False]
+        , Chart PeakMemory [ChartPoint 2 1 1 1 True, ChartPoint 4 2 2 2 False]
+        ] (scaleCharts points)
+      assertEqual "summary distinguishes finished sizes and accepted partial samples"
+        "1 size + 1 partial · 6 curve samples · scale 2 … 4" (scaleSummary points)
+  , testCase "saved journals replay outside a project, preserving separate tests and partial sizes" $
+      forM_ [1, 2] $ \version -> do
+        let named modName = KM.insert "module" (Aeson.String modName) . KM.insert "test" (Aeson.String "same")
+            events = header version
+              : map (named "alpha") ([sample 1 t 1048576 True False | t <- [1,2,3]]
+                  ++ [KM.fromList [("event", Aeson.String "point"), ("scale", Aeson.Number 1)],
+                      sample 2 4 1048576 True False, sample 1 9999 1048576 True True,
+                      sample 3 8888 1048576 False False,
+                      KM.fromList [("event", Aeson.String "test_end"),
+                                   ("reason", Aeson.String "Reference measurements did not settle")]])
+              ++ map (named "beta") ([sample 1 20 1048576 True False | _ <- [1..3]]
+                  ++ [KM.fromList [("event", Aeson.String "point"), ("scale", Aeson.Number 1)]])
+              ++ [ending]
+        withRecording events $ \path run -> do
+          before <- BS.readFile path
+          (code, out, err) <- run
+          assertEqual (out ++ err) ExitSuccess code
+          forM_ ["Scaling charts: alpha.same", "Scaling charts: beta.same",
+                 "1 size + 1 partial · 4 curve samples", "1 size · 3 curve samples",
+                 "Reference measurements did not settle", "Stopped: all selected studies finished"] $ \text ->
+            assertBool out (text `isInfixOf` out)
+          assertBool "plain reports have no terminal escapes" (notElem '\ESC' (out ++ err))
+          assertEqual "replay never changes the recording" before =<< BS.readFile path
+          assertEqual "replay creates no build or measurement files" [takeFileName path] =<< listDirectory (takeDirectory path)
+  , testCase "incomplete journals retain samples and diagnose an unfinished final record" $
+      withRecording [header 2, KM.insert "module" (Aeson.String "alpha")
+        (KM.insert "test" (Aeson.String "same") (sample 1 10 1048576 True False))] $ \path run -> do
+          forM_ [False, True] $ \truncated -> do
+            if truncated then BS.appendFile path "{\"event\":\"sample\"" else return ()
+            (code, out, err) <- run
+            assertEqual (out ++ err) ExitSuccess code
+            assertBool out ("0 sizes + 1 partial · 1 curve sample" `isInfixOf` out)
+            assertBool out ("Recording is incomplete" `isInfixOf` out)
+            assertEqual "only an unfinished JSON record needs a warning" truncated ("unfinished final record" `isInfixOf` err)
+          BS.appendFile path "\n"
+          (code, out, err) <- run
+          assertBool "a malformed complete record is an error" (code /= ExitSuccess)
+          assertBool err (":3:" `isInfixOf` err)
+          assertBool "invalid journals are not presented as valid charts" (not ("Scaling charts:" `isInfixOf` out))
+  , testCase "empty measurements are explicit and unrelated or unsupported files are rejected" $ do
+      withRecording [header 2, ending] $ \_ run -> do
+        (code, out, err) <- run
+        assertEqual (out ++ err) ExitSuccess code
+        assertBool out ("No accepted measurements" `isInfixOf` out)
+      forM_ [[], [KM.empty], [header 99], [header 2, header 2]] $ \events ->
+        withRecording events $ \_ run -> do
+          (code, out, err) <- run
+          assertBool (out ++ err) (code /= ExitSuccess)
+          assertBool "bad input has a diagnostic" (not (null err))
+          assertBool "bad input is not presented as a valid report" (not ("Scaling charts:" `isInfixOf` out))
+  , testCase "the proportional guide uses the largest completed size, without fitting or extrapolating" $ do
+      let points = [ChartPoint 1 10 10 10 True, ChartPoint 100 20 20 20 True,
+                    ChartPoint 200 100 100 100 False]
+      assertEqual "proportional time, anchored at size 100" [(1, 0.2), (100, 20)]
+        (chartGuide (Chart WallTime points))
+      forM_ [Chart WallTime [], Chart WallTime [head points],
+             Chart WallTime [p {chartComplete = False} | p <- points],
+             Chart TimePerScale points, Chart PeakMemory points] $ \chart ->
+        assertEqual "only wall time with a completed span has a guide" [] (chartGuide chart)
+  , testCase "a guide below the visible range is clipped rather than clamped to the axis" $ do
+      let chart = Chart WallTime [ChartPoint 1 1 1 1 True, ChartPoint 1e6 1 1 1 True]
+          pixels = BS.unpack (chartPixels True 67 12 chart)
+          rgbas [] = []
+          rgbas (r:g:b:a:rest) = (r,g,b,a) : rgbas rest
+          rgbas _ = error "incomplete RGBA pixel"
+          gold = [i | (i,(r,g,b,a)) <- zip [0..] (rgbas pixels), r > g, g > b, a > 0]
+      assertBool "part of the guide is visible" (not (null gold))
+      assertBool "it enters the plot only in the final decade"
+        (all (\i -> i `mod` 536 > 450) gold)
+      let diagonal = Chart WallTime [ChartPoint 1 1 1 1 True, ChartPoint 1000 4 4 4 True]
+      assertBool "a near-diagonal guide still contains visible dashes"
+        (any (\(r,g,b,a) -> r > g && g > b && a > 0)
+          (rgbas (BS.unpack (chartPixels True 67 12 diagonal))))
+      assertBool "monochrome keeps every visible pixel neutral"
+        (all (\(r,g,b,_) -> r == g && g == b) (rgbas (BS.unpack (chartPixels False 67 12 chart))))
+  , testCase "empty, singleton, constant and wide-ranging plots fit the terminal" $ do
+      let curves = [[], [ChartPoint 1 1 1 1 False],
+                    [ChartPoint n 1 1 1 True | n <- [1,10,100]],
+                    [ChartPoint 1 0.00001 0.00001 0.00001 True, ChartPoint 1e12 1e6 1e6 1e6 True]]
+      forM_ curves $ \points -> forM_ [(27,4), (67,12), (96,12)] $ \(width, height) -> do
+        let chart = Chart WallTime points
+            output = chartText False width height chart
+        assertEqual "title, plot, baseline and scale labels" (height + 3) (length output)
+        assertBool (show output) (all ((<= width + 11) . length) output)
+        assertBool "text fallback has no escape codes" (all (notElem '\ESC') output)
+        assertEqual "RGBA has four bytes per pixel" (width * 8 * height * 16 * 4)
+          (BS.length (chartPixels True width height chart))
+      let partial = unlines (chartText False 67 12 (Chart WallTime [ChartPoint 1 1 1 1 False]))
+      assertBool "a completed sample in an unfinished point stays hollow" ('○' `elem` partial)
+      let narrow = chartText False 27 8 (Chart WallTime
+            [ChartPoint 1 1 1 1 True, ChartPoint 1e6 1e6 1e6 1e6 True])
+      assertEqual "narrow axes show whole, separated decade labels"
+        ["scale", "1", "100", "1e4", "1e6"] (words (last narrow))
+  , testCase "graphics selection is conservative and never applies to redirected output" $ do
+      forM_ [[("TERM", "xterm-kitty")], [("TERM", "xterm-ghostty")],
+             [("TERM", "xterm-256color"), ("TERM_PROGRAM", "ghostty")]] $ \env -> do
+        assertBool (show env) (kittyTerminal True env)
+        assertBool "redirection wins over terminal environment" (not (kittyTerminal False env))
+        forM_ [[("TMUX", "/tmp/tmux")], [("STY", "123.tty")],
+               [("TERM", "screen-256color")], [("TERM", "tmux-256color")], [("TERM", "dumb")]] $ \override ->
+          assertBool (show (override ++ env)) (not (kittyTerminal True (override ++ env)))
+      forM_ [[], [("TERM", "xterm-256color")], [("TERM_PROGRAM", "WezTerm")]] $ \env ->
+        assertBool "unknown or optional graphics support uses text" (not (kittyTerminal True env))
+  , testCase "Kitty transfers round-trip through multiple quiet bounded chunks" $ do
+      let pixels = BS.pack (take (80 * 8 * 12 * 16 * 4) (randoms (mkStdGen 42) :: [Word8]))
+          stream = kittyImage 80 12 pixels
+          frames = [BS.drop 2 part | part <- BC.split '\ESC' stream, "_G" `BS.isPrefixOf` part]
+          fields = map (BC.split ',' . BS.takeWhile (/= 59)) frames
+          payloads = map (BS.drop 1 . BS.dropWhile (/= 59)) frames
+      assertBool "fixture exercises continuation frames" (length frames > 2)
+      forM_ fields $ \keys -> assertBool "no terminal replies" ("q=2" `elem` keys)
+      forM_ ["a=T", "f=32", "o=z", "s=640", "v=192", "c=80", "r=12", "C=1"] $ \key ->
+        assertBool (show key) (key `elem` head fields)
+      forM_ payloads $ \payload -> do
+        assertBool "payload <= 4096 bytes" (BS.length payload <= 4096)
+        assertEqual "base64 chunk boundary" 0 (BS.length payload `mod` 4)
+      forM_ (init fields) $ \keys -> assertBool "all non-final frames continue" ("m=1" `elem` keys)
+      forM_ (tail fields) $ \keys -> assertEqual "continuations only carry m and q" 2 (length keys)
+      assertBool "final frame terminates the transfer" ("m=0" `elem` last fields)
+      compressed <- either (\err -> assertFailure err >> fail err) return (Base64.decode (BS.concat payloads))
+      assertEqual "the terminal receives every RGBA pixel unchanged" pixels
+        (BL.toStrict (decompress (BL.fromStrict compressed)))
+  ]
+  where
+    header :: Int -> Aeson.Object
+    header version = KM.fromList [("event", Aeson.String "study"), ("version", Aeson.toJSON version)]
+    ending = KM.fromList [("event", Aeson.String "end"), ("reason", Aeson.String "all selected studies finished")]
+    withRecording events action = withSystemTempDirectory "acton-scale-report" $ \directory -> do
+      acton <- canonicalizePath "../../dist/bin/acton"
+      let path = directory </> "recording.jsonl"
+          run = readCreateProcessWithExitCode
+            (proc acton ["test", "scale", "--report", path, "--color", "never"]) { cwd = Just directory } ""
+      BL.writeFile path (BL.concat [Aeson.encode event <> "\n" | event <- events])
+      action path run
+    sample :: Int -> Double -> Double -> Bool -> Bool -> Aeson.Object
+    sample n wall rss accepted reference = KM.fromList
+      [ ("event", Aeson.String "sample"), ("scale", Aeson.toJSON n)
+      , ("accepted", Aeson.Bool accepted), ("reference", Aeson.Bool reference)
+      , ("result", Aeson.object ["avg_wall_duration" Aeson..= wall, "peak_rss" Aeson..= rss]) ]

--- a/compiler/acton/ScaleTests.hs
+++ b/compiler/acton/ScaleTests.hs
@@ -1,0 +1,425 @@
+{-# LANGUAGE OverloadedStrings #-}
+module ScaleTests (scaleTests) where
+
+import qualified Acton.CommandLineParser as C
+import qualified Acton.Fingerprint as Fingerprint
+import Acton.Testing (TestResult(..))
+import Control.Exception (throwIO)
+import Control.Monad (forM_, when)
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KM
+import qualified Data.Aeson.Types as AesonTypes
+import qualified Data.ByteString.Lazy.Char8 as BL
+import qualified Data.IntMap.Strict as IM
+import Data.IORef
+import Data.List (find, isInfixOf)
+import Data.Maybe (isJust)
+import qualified Options.Applicative as O
+import PerfMemory (MemoryStatus(..))
+import ScaleReportTests (scaleReportTests)
+import System.Clock (Clock(Monotonic), fromNanoSecs, getTime)
+import System.Directory
+import System.Exit
+import System.FilePath
+import System.IO.Temp (withSystemTempDirectory)
+import System.Process
+import Test.Tasty
+import Test.Tasty.HUnit
+import TestScale
+
+scaleTests :: TestTree
+scaleTests = testGroup "performance scaling studies"
+  [ testCase "means and estimated errors use all measured samples" $ do
+      assertEqual "empty samples have no mean" Nothing (scaleMean [])
+      closeTo (13 / 3) (scaleMean [9, 1, 3])
+      closeTo 4.5 (scaleMean [9, 2, 6, 1])
+      closeTo (1 / (sqrt 3 * 11)) (scaleError (point 1 [10, 11, 12] 100))
+      assertEqual "fewer than three samples cannot establish precision" Nothing
+        (scaleError (point 1 [10, 10] 100))
+      closeTo 0 (scaleError (point 1 [10, 10, 10] 100))
+  , testCase "extra samples improve estimated mean precision up to seven" $ do
+      let retries = [8, 12, 10, 10, 10, 10, 10]
+          at n = point 1 (take n retries) 100
+      forM_ [0, 3, 5] $ \n -> assertBool ("needs more at " ++ show n) (scaleNeedsSamples (at n))
+      assertBool "seven samples resolve this variation" (scaleReliable (at 7))
+      assertBool "the resolved point does not retry" (not (scaleNeedsSamples (at 7)))
+      assertBool "five can suffice" (scaleReliable (point 1 [10, 12, 11, 11, 11] 100))
+      let noisy = point 1 [1, 10, 19, 10, 10, 10, 10] 100
+          tiny = point 1 [0.001, 0.001, 0.001] 100
+      assertBool "seven does not imply reliability" (not (scaleReliable noisy))
+      assertBool "noise cannot cause unbounded retries" (not (scaleNeedsSamples noisy))
+      assertBool "tiny results advance instead of retrying" (not (scaleNeedsSamples tiny))
+      assertBool "zero spread cannot rescue a tiny result" (not (scaleReliable tiny))
+  , testCase "growth consistently uses means for observed work" $ do
+      let first = point 10 [9.9, 10, 10.1] 100
+      closeTo 1 (scaleGrowth first (point 20 [19.9, 20, 20.1] 100))
+      closeTo 2 (scaleGrowth first (point 20 [39.9, 40, 40.1] 100))
+      closeTo (log (61 / 30) / log 2)
+        (scaleGrowth (point 10 [10, 10, 10] 100) (point 20 [20, 20, 21] 100))
+      assertEqual "scale must increase" Nothing (scaleGrowth first first)
+      assertEqual "scales indistinguishable as doubles have no growth estimate" Nothing
+        (scaleGrowth (point (maxBound - 1) [10, 10, 10] 100) (point maxBound [20, 20, 20] 100))
+  , testCase "growth suppresses noisy tiny and undersampled points" $ do
+      let reliable = point 10 [10, 10, 10] 100
+      forM_ [point 20 [10, 20, 30] 100, point 20 [0.01, 0.02, 0.03] 100,
+             point 20 [20, 20] 100, point 20 [] 100] $ \unreliable -> do
+        assertEqual "new point must be reliable" Nothing (scaleGrowth reliable unreliable)
+        assertEqual "old point must be reliable" Nothing (scaleGrowth (unreliable { pointScale = 5 }) reliable)
+  , testCase "stable growth needs broad coverage and five consecutive slopes" $ do
+      let linear = curve fromIntegral [0..10]
+      assertEqual "512-fold coverage is still too narrow" Nothing (stableGrowth (tail linear))
+      assertTrend 32 1 (stableGrowth linear)
+      assertEqual "old coverage cannot replace the five-slope confirmation window" Nothing
+        (stableGrowth (take 4 linear ++ [point 1 [1, 1, 1] 100]))
+      assertEqual "small steps near the memory limit do not confirm growth" Nothing
+        (stableGrowth [point n (replicate 3 (fromIntegral n)) 100 | n <- [1600, 1500, 1400, 1300, 1200, 1100, 1]])
+      let tinyStart = curve (\n -> if n < 8 then 0.001 else fromIntegral n / 8) [0..13]
+      assertEqual "tiny early probes do not count toward reliable coverage" Nothing
+        (stableGrowth (tail tinyStart))
+      assertTrend 256 1 (stableGrowth tinyStart)
+  , testCase "bends and noisy points reset the stable window" $ do
+      let bent n = if n <= 256 then fromIntegral n else fromIntegral n ^ (2 :: Int) / 256
+      assertEqual "a recent bend must remain visible" Nothing (stableGrowth (curve bent [0..12]))
+      assertTrend 256 2 (stableGrowth (curve bent [0..13]))
+      let recent = curve fromIntegral [0..10]
+          noisy = point 256 [128, 256, 384] 100
+      assertEqual "one noisy point breaks otherwise consistent recent growth" Nothing
+        (stableGrowth (take 2 recent ++ [noisy] ++ drop 3 recent))
+      let times = scanl (\t exponent -> t * 2 ** exponent) 32 [0.8, 0.9, 1, 1.1, 1.2]
+          gradual = reverse (zipWith (\n t -> point n (replicate 3 t) 100) [32, 64, 128, 256, 512, 1024] times)
+      assertEqual "small adjacent changes cannot hide a wider total bend" Nothing
+        (stableGrowth (gradual ++ [point 1 [1, 1, 1] 100]))
+  , testCase "next scale slows near memory limits and cannot overflow" $ do
+      assertEqual "no data gives no next scale" Nothing (nextScale 1000 [])
+      assertEqual "comfortable headroom doubles scale" (Just 200) (nextScale 1000 [point 100 [1] 100])
+      assertEqual "quadratic memory growth reduces the next step" (Just 141)
+        (nextScale 1000 [point 100 [1] 400, point 50 [1] 100])
+      assertEqual "no useful headroom ends the sweep" Nothing (nextScale 125 [point 100 [1] 100])
+      assertEqual "integer boundary ends the sweep" Nothing (nextScale 1000 [point maxBound [1] 100])
+      assertEqual "the last step is clamped without wrapping" (Just maxBound)
+        (nextScale 1000 [point (maxBound `div` 2 + 1) [1] 100])
+  , testCase "memory ceilings retain an available-memory reserve" $ do
+      let mib = 1024^2
+      assertEqual "percentage uses total memory" (Right (500, 100))
+        (scaleMemoryLimit (C.MemoryPercent 50) (MemoryStatus 1000 900 0))
+      assertEqual "an explicit byte ceiling is retained" (Right (200, 100))
+        (scaleMemoryLimit (C.MemoryBytes 200) (MemoryStatus 1000 900 0))
+      assertEqual "available memory caps the child below the requested ceiling" (Right (44 * mib, 256 * mib))
+        (scaleMemoryLimit (C.MemoryBytes (200 * mib)) (MemoryStatus (4000 * mib) (300 * mib) 0))
+      case scaleMemoryLimit (C.MemoryPercent 50) (MemoryStatus 1000 100 0) of
+        Left _ -> return ()
+        Right limit -> assertFailure ("a depleted reserve must prevent launch: " ++ show limit)
+  , testCase "scaling rejects recording snapshot updates and watch" $ do
+      forM_ [["--record"], ["--accept"], ["--watch"]] $ \args -> do
+        (_, opts) <- parseScale args
+        assertBool (unwords args) (isJust (validateScalingOptions opts))
+      forM_ [[], ["--start-scale", "1000", "--max-memory", "128MiB", "--max-time", "2s"]] $ \args ->
+        assertEqual (unwords args) Nothing . validateScalingOptions . snd =<< parseScale args
+  , testGroup "adaptive controller"
+      [ testCase "linear quadratic logarithmic and constant curves settle over a broad range" $
+          forM_ [("linear", fromIntegral, Just 1),
+                 ("quadratic", \n -> fromIntegral n ^ (2 :: Int), Just 2),
+                 ("nlogn", \n -> fromIntegral n * logBase 2 (fromIntegral n + 1), Nothing),
+                 ("constant", const 1, Just 0)] $ \(name, model, exponent) -> do
+            (code, events) <- simulate name (\n _ -> modelResult n (model n))
+            assertEqual name 0 code
+            summary <- assertSummary "stable" (1, 1024) (11, 33) events
+            assertEqual "growth summarizes the recent six sizes" (Just (Aeson.Number 32)) (KM.lookup "stable_from_scale" summary)
+            lo <- field "growth_min" summary
+            hi <- field "growth_max" summary
+            case exponent of
+              Just expected -> closeTo expected (Just lo) >> closeTo expected (Just hi)
+              Nothing -> assertBool "n log n is locally between linear and quadratic" (lo > 1 && hi < 1.3)
+            forM_ (eventsOf "point" events) $ \p -> do
+              n <- field "scale" p
+              closeTo (model n) . Just =<< field "wall_mean_ms" p
+              assertEqual "constant repeats use three samples" (Just (Aeson.Number 3)) (KM.lookup "samples" p)
+              closeTo 0 . Just =<< field "relative_standard_error" p
+              assertEqual "point precision is recorded" (Just (Aeson.Bool True)) (KM.lookup "reliable" p)
+              assertBool "mean statistics replace the old median field" (not (KM.member "wall_median_ms" p))
+            let references = eventsOf "reference" events
+                decisions = filter (\e -> KM.lookup "event" e `elem` [Just (Aeson.String "point"), Just (Aeson.String "reference")]) events
+            assertEqual "periodic checks plus a final check" 3 (length references)
+            assertEqual "the final decision follows a fresh reference" (Just (Aeson.String "reference")) (KM.lookup "event" (last decisions))
+            forM_ references $ \r -> assertEqual "the reference settled" (Just (Aeson.Bool True)) (KM.lookup "stable" r)
+            assertSampleProvenance events
+      , testCase "precision controls the actual three five and seven sample batches" $ do
+          let model n i = fromIntegral n * case n of
+                1 -> cycle [0.9, 1.1, 1, 1, 1] !! (i - 1)
+                2 -> cycle [0.8, 1.2, 1, 1, 1, 1, 1] !! (i - 1)
+                _ -> 1
+          (code, events) <- simulate "repeats" (\n i -> modelResult n (model n i))
+          assertEqual "the additional samples resolve precision" 0 code
+          _ <- assertSummary "stable" (1, 1024) (11, 39) events
+          forM_ (eventsOf "point" events) $ \p -> do
+            n <- field "scale" p :: IO Int
+            let expected = if n == 1 then 5 else if n == 2 then 7 else 3
+                samples = filter (\e -> KM.lookup "scale" e == Just (Aeson.toJSON n)
+                                    && KM.lookup "reference" e == Just (Aeson.Bool False)) (eventsOf "sample" events)
+            assertEqual "journaled point count matches the collected batch" (Just (Aeson.toJSON expected)) (KM.lookup "samples" p)
+            assertEqual "the controller actually took that many samples" expected (length samples)
+            closeTo (fromIntegral n) . Just =<< field "wall_mean_ms" p
+          forM_ (eventsOf "reference" events) $ \r ->
+            assertEqual "references use the same precision policy" (Just (Aeson.Number 5)) (KM.lookup "samples" r)
+      , testCase "a bend extends exploration until the new trend is confirmed" $ do
+          let model n = if n <= 256 then fromIntegral n else fromIntegral n ^ (2 :: Int) / 256
+          (code, events) <- simulate "bend" (\n _ -> modelResult n (model n))
+          assertEqual "the later segment settles" 0 code
+          summary <- assertSummary "stable" (1, 8192) (14, 42) events
+          assertEqual "the reported window starts at the bend" (Just (Aeson.Number 256)) (KM.lookup "stable_from_scale" summary)
+          closeTo 2 . Just =<< field "growth_min" summary
+          closeTo 2 . Just =<< field "growth_max" summary
+      , testCase "tiny probes do not choose the reference or establish coverage" $ do
+          let model n = if n < 8 then 0.001 else fromIntegral n / 8
+          (code, events) <- simulate "tiny_start" (\n _ -> modelResult n (model n))
+          assertEqual "measurable work eventually settles" 0 code
+          _ <- assertSummary "stable" (1, 8192) (14, 42) events
+          forM_ (eventsOf "reference" events) $ \r ->
+            assertEqual "the first measurable scale is the reference" (Just (Aeson.Number 8)) (KM.lookup "scale" r)
+      , testCase "a fresh reference can reject an otherwise stable curve" $ do
+          (code, events) <- simulate "drift" (\n i -> modelResult n (if n == 1 && i > 9 then 2 else fromIntegral n))
+          assertEqual "unsettled drift is an inconclusive study" 0 code
+          summary <- assertSummary "inconclusive" (1, 4096) (13, 39) events
+          assertEqual "reference failure explains the outcome" (Just (Aeson.String "Reference measurements did not settle")) (KM.lookup "reason" summary)
+          assertEqual "an inconclusive result cannot claim a growth range" (Just Aeson.Null) (KM.lookup "growth_min" summary)
+          assertEqual "two periodic successes do not bypass three later failures"
+            (map (Just . Aeson.Bool) [True, True, False, False, False])
+            (map (KM.lookup "stable") (eventsOf "reference" events))
+      , testCase "persistently tiny or noisy timing stops without an endless search" $
+          forM_ [("tiny", \_ -> 0.001, 3),
+                 ("noisy", \i -> cycle [0.1, 1, 1.9, 1, 1, 1, 1] !! (i - 1), 7)] $ \(name, model, repeats) -> do
+            (code, events) <- simulate name (\n i -> modelResult n (model i))
+            assertEqual name 0 code
+            summary <- assertSummary "inconclusive" (1, 2^19) (20, 20 * repeats) events
+            assertEqual "unreliable timing explains the outcome"
+              (Just (Aeson.String "Timing stayed too short or noisy across 20 successive sizes")) (KM.lookup "reason" summary)
+            assertBool "there is no reliable reference to recheck" (null (eventsOf "reference" events))
+            forM_ (eventsOf "point" events) $ \p -> do
+              assertEqual "unreliable samples remain visible" (Just (Aeson.Bool False)) (KM.lookup "reliable" p)
+              assertEqual "no unsupported local growth is reported" (Just Aeson.Null) (KM.lookup "observed_exponent" p)
+      , testCase "a result for the wrong scale cannot enter the curve" $ do
+          (code, events) <- simulate "wrong_scale" (\n _ -> modelResult (n + 1) 1)
+          assertEqual "mismatched provenance fails the study" 1 code
+          sample <- requireEvent "sample" events
+          assertEqual "the rejected result is still journaled" (Just (Aeson.Bool False)) (KM.lookup "accepted" sample)
+          assertBool "no point uses a different workload" (null (eventsOf "point" events))
+      ]
+  , testCase "exited samples leave time for output capture" $
+      withCreateProcess (proc "sh" ["-c", "exit 0"]) $ \_ _ _ process -> do
+        pid <- fmap (fmap fromIntegral) (getPid process)
+        assertBool "the process ID is captured before waiting" (isJust pid)
+        _ <- waitForProcess process
+        assertEqual "the process handle has been reaped" Nothing =<< getPid process
+        now <- getTime Monotonic
+        reason <- watchScaleProcess (ScaleLimits (now + fromNanoSecs 40000000) 1 0) pid process
+        assertEqual "an exited child must not report a monitoring failure" "time limit reached" reason
+  , testCase "unavailable monitoring stops the study unsuccessfully" $
+      withSystemTempDirectory "acton-scaling-monitor" $ \directory -> do
+        (gopts, opts) <- parseScale ["--max-memory", "1B", "--max-time", "2s"]
+        let reason = "memory monitoring unavailable: injected failure"
+        code <- runScalingStudy False gopts opts directory KM.empty [("sample", "test")]
+          (\_ _ _ _ -> throwIO (ScalingStopped reason))
+        assertEqual "an unavailable guard cannot report success" 2 code
+        files <- filter ((== ".jsonl") . takeExtension) <$> listDirectory directory
+        assertEqual "one journal is retained" 1 (length files)
+        events <- BL.readFile (directory </> head files) >>= decodeEvents . BL.unpack
+        assertEnd reason events
+        assertBool "an unguarded sample cannot contribute a point" (null (eventsOf "point" events))
+  , scaleReportTests
+  , testCase "scaling journals completed work when later work stops" $
+      withSystemTempDirectory "acton-perf-scaling" $ \project -> do
+        acton <- canonicalizePath "../../dist/bin/acton"
+        let name = "scale_tests"
+            fingerprint = Fingerprint.formatFingerprint
+              (Fingerprint.updateFingerprintPrefix (Fingerprint.fingerprintPrefixForName name) 1)
+            baseline = project </> "perf_data"
+            run test memory duration = do
+              (code, out, err) <- readCreateProcessWithExitCode
+                (proc acton ["test", "scale", "--start-scale", "1000", "--max-time", duration,
+                             "--max-memory", memory, "--json", "--name", test]) { cwd = Just project } ""
+              assertBool (out ++ err) (not (null out))
+              assertBool "JSON output has no terminal escapes" (not ('\ESC' `elem` out))
+              events <- decodeEvents out
+              study <- requireEvent "study" events
+              path <- field "path" study
+              assertBool "HTML is no longer generated" . not =<< doesFileExist (replaceExtension path "html")
+              saved <- BL.readFile path >>= decodeEvents . BL.unpack
+              assertEqual "flushed journal matches the streamed events" events saved
+              assertEqual "the fixed baseline remains untouched" "{}\n" =<< readFile baseline
+              return (code, events, out ++ err)
+        createDirectoryIfMissing True (project </> "src")
+        writeFile (project </> "Build.act") $ unlines ["name = " ++ show name, "fingerprint = " ++ fingerprint]
+        writeFile baseline "{}\n"
+        writeFile (project </> "src/sample.act") $ unlines
+          [ "import testing"
+          , "import time"
+          , ""
+          , "def _test_partial(t: testing.SyncT):"
+          , "    for scale in t.loop():"
+          , "        assert scale >= 1000"
+          , "        target = 0.001 if scale == 1000 else 10.0"
+          , "        sw = time.Stopwatch()"
+          , "        while sw.elapsed().to_float() < target:"
+          , "            pass"
+          , ""
+          , "def _test_failure(t: testing.SyncT):"
+          , "    for scale in t.loop():"
+          , "        raise ValueError(\"scaling failure\")"
+          , ""
+          , "def _test_without_loop(t: testing.SyncT):"
+          , "    pass"
+          , ""
+          , "def _test_slow(t: testing.SyncT):"
+          , "    for scale in t.loop():"
+          , "        sw = time.Stopwatch()"
+          , "        while sw.elapsed().to_float() < 10.0:"
+          , "            pass"
+          , ""
+          , "def _test_stdout(t: testing.SyncT):"
+          , "    for scale in t.loop():"
+          , "        print(\"x\" * 2097152, end=\"\", flush=True)"
+          , ""
+          , "def _test_stderr(t: testing.SyncT):"
+          , "    for scale in t.loop():"
+          , "        print(\"x\" * 2097152, end=\"\", err=True, flush=True)"
+          ]
+        (partialCode, partial, partialOutput) <- run "partial" "128MiB" "2s"
+        assertEqual partialOutput ExitSuccess partialCode
+        assertEnd "time limit reached" partial
+        started <- requireEvent "sample_start" partial
+        assertEqual "the first requested scale is journaled before execution" (Just (Aeson.Number 1000)) (KM.lookup "scale" started)
+        let samples = eventsOf "sample" partial
+        assertBool "completed samples survive the later timeout" (not (null samples))
+        forM_ samples $ \sample -> do
+          assertEqual "only validated samples are accepted" (Just (Aeson.Bool True)) (KM.lookup "accepted" sample)
+          raw <- field "result" sample
+          info <- field "perf_info" raw
+          assertEqual "only the completed starting scale contributes samples" (Just (Aeson.Number 1000)) (KM.lookup "scale" sample)
+          assertEqual "fixed scale reaches the measured invocation" (KM.lookup "scale" sample) (KM.lookup "scale" info)
+          assertEqual "one measured invocation per child" (Just (Aeson.Number 1)) (KM.lookup "num_iterations" raw)
+          assertEqual "one measured loop body per child" (Just (Aeson.Number 1)) (KM.lookup "loop_iterations" raw)
+          assertEqual "scaling sample provenance" (Just (Aeson.Bool True)) (KM.lookup "scaling" info)
+          assertEqual "fixed-scale study samples do not calibrate" (Just (Aeson.toJSON ([] :: [Int]))) (KM.lookup "calibration" info)
+          warmup <- field "warmup_duration_ms" info :: IO Double
+          assertBool "the child completed warmup" (warmup > 0)
+        forM_ [("failure", "scaling failure"), ("without_loop", "require")] $ \(test, message) -> do
+          (code, events, output) <- run test "128MiB" "2s"
+          assertBool output (code /= ExitSuccess)
+          assertBool output (message `isInfixOf` output)
+          assertBool "failed workloads produce no accepted point" (null (eventsOf "point" events))
+          forM_ (eventsOf "sample" events) $ \sample ->
+            assertEqual "a failed result is not accepted" (Just (Aeson.Bool False)) (KM.lookup "accepted" sample)
+          _ <- requireEvent "end" events
+          return ()
+        (memoryCode, memory, memoryOutput) <- run "slow" "1B" "2s"
+        assertEqual memoryOutput ExitSuccess memoryCode
+        assertEnd "memory limit reached" memory
+        assertBool "the memory guard stops before accepting a point" (null (eventsOf "point" memory))
+        forM_ ["stdout", "stderr"] $ \test -> do
+          (code, events, output) <- run test "128MiB" "10s"
+          assertBool output (code /= ExitSuccess)
+          assertEnd "sample output exceeded 1MiB per stream" events
+          assertBool "oversized unterminated output cannot contribute a point" (null (eventsOf "point" events))
+  ]
+
+point :: Int -> [Double] -> Double -> ScalePoint
+point scale times rss = ScalePoint scale
+    [KM.fromList [("avg_wall_duration", Aeson.toJSON t), ("peak_rss", Aeson.toJSON rss)] | t <- times]
+
+curve :: (Int -> Double) -> [Int] -> [ScalePoint]
+curve model powers = reverse [point n (replicate 3 (model n)) 100 | power <- powers, let n = 2^power]
+
+assertTrend :: Int -> Double -> Maybe (Int, Double, Double) -> Assertion
+assertTrend start exponent result = case result of
+    Just (first, lo, hi) -> do
+      assertEqual "the recent range starts at the oldest confirming point" start first
+      closeTo exponent (Just lo)
+      closeTo exponent (Just hi)
+    Nothing -> assertFailure "expected a stable recent trend"
+
+closeTo :: Double -> Maybe Double -> Assertion
+closeTo expected actual = assertBool (show actual) (maybe False (\x -> abs (x - expected) < 1e-9) actual)
+
+-- Simulated timings exercise the real controller and journal without waiting
+-- for large workloads. The invocation count also identifies later references.
+simulate :: String -> (Int -> Int -> TestResult) -> IO (Int, [Aeson.Object])
+simulate name result = withSystemTempDirectory ("acton-scale-" ++ name) $ \directory -> do
+    (gopts, opts) <- parseScale ["--max-memory", "128MiB", "--max-time", "30s"]
+    calls <- newIORef IM.empty
+    code <- runScalingStudy False gopts opts directory KM.empty [("sample", name)] $ \_ scale modName testName -> do
+      counts <- readIORef calls
+      when (sum (IM.elems counts) >= 500) (assertFailure "the simulated study did not stop")
+      let invocation = IM.findWithDefault 0 scale counts + 1
+      writeIORef calls (IM.insert scale invocation counts)
+      return ((result scale invocation) { trModule = modName, trName = testName })
+    files <- filter ((== ".jsonl") . takeExtension) <$> listDirectory directory
+    assertEqual "each run writes one journal" 1 (length files)
+    events <- BL.readFile (directory </> head files) >>= decodeEvents . BL.unpack
+    return (code, events)
+
+modelResult :: Int -> Double -> TestResult
+modelResult scale wall = TestResult
+    { trModule = "sample", trName = "model", trComplete = True, trSuccess = Just True
+    , trSkipped = False, trSkipReason = Nothing, trException = Nothing
+    , trOutput = Nothing, trStdOut = Nothing, trStdErr = Nothing, trFlaky = False
+    , trNumSkipped = 0, trNumFailures = 0, trNumErrors = 0, trNumIterations = 1
+    , trTestDuration = wall, trSnapshotUpdated = False, trCached = False
+    , trRaw = Aeson.object ["complete" Aeson..= True, "success" Aeson..= True,
+        "skipped" Aeson..= False, "num_iterations" Aeson..= (1 :: Int), "loop_iterations" Aeson..= (1 :: Int),
+        "avg_wall_duration" Aeson..= wall, "peak_rss" Aeson..= (1048576 :: Int),
+        "perf_info" Aeson..= Aeson.object ["scale" Aeson..= scale, "loop" Aeson..= True, "scaling" Aeson..= True]]
+    }
+
+assertSummary :: String -> (Int, Int) -> (Int, Int) -> [Aeson.Object] -> IO Aeson.Object
+assertSummary outcome (first, final) (points, samples) events = do
+    summary <- requireEvent "test_end" events
+    assertEqual "study outcome" (Just (Aeson.toJSON outcome)) (KM.lookup "outcome" summary)
+    assertEqual "covered range begins at the first sampled scale" (Just (Aeson.toJSON first)) (KM.lookup "min_scale" summary)
+    assertEqual "the controller reached the expected final scale" (Just (Aeson.toJSON final)) (KM.lookup "max_scale" summary)
+    assertEqual "all curve points are counted" (Just (Aeson.toJSON points)) (KM.lookup "points" summary)
+    assertEqual "curve samples exclude reference checks" (Just (Aeson.toJSON samples)) (KM.lookup "samples" summary)
+    assertEqual "each reported point is journaled" points (length (eventsOf "point" events))
+    assertEnd "all selected studies finished" events
+    return summary
+
+assertSampleProvenance :: [Aeson.Object] -> Assertion
+assertSampleProvenance events = forM_ (eventsOf "sample" events) $ \sample -> do
+    assertEqual "completed valid samples are accepted" (Just (Aeson.Bool True)) (KM.lookup "accepted" sample)
+    raw <- field "result" sample
+    info <- field "perf_info" raw
+    assertEqual "the measured workload matches the requested scale" (KM.lookup "scale" sample) (KM.lookup "scale" info)
+    assertEqual "the measurement is complete" (Just (Aeson.Bool True)) (KM.lookup "complete" raw)
+    assertEqual "one measured invocation" (Just (Aeson.Number 1)) (KM.lookup "num_iterations" raw)
+    assertEqual "one measured loop body" (Just (Aeson.Number 1)) (KM.lookup "loop_iterations" raw)
+
+parseScale :: [String] -> IO (C.GlobalOptions, C.TestOptions)
+parseScale args = case O.execParserPure C.cmdLinePrefs (O.info (C.cmdLineParser O.<**> O.helper) mempty) (["test", "scale"] ++ args) of
+    O.Success (C.CmdOpt gopts (C.Test (C.TestScale opts))) -> return (gopts, opts)
+    O.Failure failure -> assertFailure (fst (O.renderFailure failure "acton")) >> fail "invalid options"
+    _ -> assertFailure "expected scale options" >> fail "invalid command"
+
+decodeEvents :: String -> IO [Aeson.Object]
+decodeEvents text = do
+    let lines = filter (not . BL.null) (BL.lines (BL.pack text))
+    when (null lines) (assertFailure "expected scaling journal events")
+    mapM (\line -> case Aeson.eitherDecode line of
+      Right (Aeson.Object obj) -> return obj
+      _ -> assertFailure ("invalid journal event: " ++ BL.unpack line) >> fail "invalid journal") lines
+
+eventsOf :: String -> [Aeson.Object] -> [Aeson.Object]
+eventsOf kind = filter ((== Just (Aeson.toJSON kind)) . KM.lookup "event")
+
+requireEvent :: String -> [Aeson.Object] -> IO Aeson.Object
+requireEvent kind events = case find ((== Just (Aeson.toJSON kind)) . KM.lookup "event") events of
+    Just event -> return event
+    Nothing -> assertFailure ("missing " ++ kind ++ " event: " ++ show events) >> fail "missing event"
+
+field :: Aeson.FromJSON a => Aeson.Key -> Aeson.Object -> IO a
+field key obj = case KM.lookup key obj >>= AesonTypes.parseMaybe Aeson.parseJSON of
+    Just value -> return value
+    Nothing -> assertFailure ("missing " ++ show key ++ ": " ++ show obj) >> fail "missing field"
+
+assertEnd :: String -> [Aeson.Object] -> Assertion
+assertEnd reason events = do
+    end <- requireEvent "end" events
+    assertEqual "study stop reason" (Just (Aeson.toJSON reason)) (KM.lookup "reason" end)

--- a/compiler/acton/ScaleTests.hs
+++ b/compiler/acton/ScaleTests.hs
@@ -10,13 +10,18 @@ import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KM
 import qualified Data.Aeson.Types as AesonTypes
 import qualified Data.ByteString.Lazy.Char8 as BL
+import qualified Data.ByteString as BS
 import qualified Data.IntMap.Strict as IM
+import qualified Data.Map.Strict as M
 import Data.IORef
+import Data.Char (isHexDigit)
 import Data.List (find, isInfixOf)
 import Data.Maybe (isJust)
 import qualified Options.Applicative as O
 import PerfMemory (MemoryStatus(..))
 import ScaleReportTests (scaleReportTests)
+import ScaleReport (ScaleRecording(..), ScaleSeries(..), readScaleRecording)
+import TestPerf (perfInfo)
 import System.Clock (Clock(Monotonic), fromNanoSecs, getTime)
 import System.Directory
 import System.Exit
@@ -217,7 +222,7 @@ scaleTests = testGroup "performance scaling studies"
       withSystemTempDirectory "acton-scaling-monitor" $ \directory -> do
         (gopts, opts) <- parseScale ["--max-memory", "1B", "--max-time", "2s"]
         let reason = "memory monitoring unavailable: injected failure"
-        code <- runScalingStudy False gopts opts directory KM.empty [("sample", "test")]
+        code <- runScalingStudy False gopts opts directory KM.empty [("sample", "test", Nothing)] Nothing
           (\_ _ _ _ -> throwIO (ScalingStopped reason))
         assertEqual "an unavailable guard cannot report success" 2 code
         files <- filter ((== ".jsonl") . takeExtension) <$> listDirectory directory
@@ -225,6 +230,45 @@ scaleTests = testGroup "performance scaling studies"
         events <- BL.readFile (directory </> head files) >>= decodeEvents . BL.unpack
         assertEnd reason events
         assertBool "an unguarded sample cannot contribute a point" (null (eventsOf "point" events))
+  , testCase "comparison replays completed recorded sizes without adaptive early stopping" $
+      withSystemTempDirectory "acton-scale-replay" $ \directory -> do
+        (gopts, opts) <- parseScale ["--max-memory", "128MiB", "--max-time", "30s", "--json"]
+        let sizes = [1,3..49]
+            points = IM.fromList [(n, (True, [(0.001, 1048576)])) | n <- sizes]
+            Aeson.Object raw = trRaw (modelResult 1 0.001)
+            series = ScaleSeries (IM.insert 50 (False, [(0.001, 1048576)]) points) (perfInfo raw) Nothing Nothing
+            baseline = ScaleRecording "old.jsonl" KM.empty (M.singleton ("sample", "test") series) Nothing
+            implementation = replicate 64 'a'
+        calls <- newIORef []
+        code <- runScalingStudy False gopts opts directory KM.empty [("sample", "test", Just implementation)] (Just baseline) $ \_ n _ _ -> do
+          modifyIORef' calls (++ [n])
+          return (modelResult n 0.001)
+        assertEqual "all scheduled sizes completed" 0 code
+        assertEqual "partial baseline point is excluded and 20 tiny sizes do not stop replay"
+          (concatMap (replicate 3) sizes) =<< readIORef calls
+        [name] <- listDirectory directory
+        assertBool name ("sample.test__" `isInfixOf` name && "__aaaaaaaaaaaa.jsonl" `isInfixOf` name)
+        recording <- readScaleRecording (directory </> name)
+        assertEqual "full implementation identity is retained" (Just (Aeson.toJSON implementation))
+          (KM.lookup "implementation_hash" (recordingHeader recording))
+        assertEqual "completion describes replay" (Just "Completed baseline sizes remeasured")
+          (seriesReason (recordingTests recording M.! ("sample", "test")))
+  , testCase "each benchmark owns its journal while sharing the command budget" $
+      withSystemTempDirectory "acton-scale-files" $ \directory -> do
+        (gopts, opts) <- parseScale ["--max-memory", "128MiB", "--max-time", "30s", "--json"]
+        code <- runScalingStudy False gopts opts directory KM.empty
+          [("sample", "one", Nothing), ("sample", "two", Nothing)] Nothing $ \_ n _ name ->
+            if name == "two" then throwIO (ScalingStopped "time limit reached") else return (modelResult n 1)
+        assertEqual "the time ceiling is a normal stop" 0 code
+        files <- listDirectory directory
+        assertEqual "one journal per benchmark" 2 (length files)
+        recordings <- mapM (readScaleRecording . (directory </>)) files
+        let one = head [r | r <- recordings, M.member ("sample", "one") (recordingTests r)]
+            two = head [r | r <- recordings, M.member ("sample", "two") (recordingTests r)]
+        assertEqual "the first file only claims its own completion" (Just "benchmark finished") (recordingStopped one)
+        assertEqual "the unfinished benchmark has its own reason" (Just "time limit reached") (recordingStopped two)
+        assertEqual "both files identify the common command"
+          (KM.lookup "run_id" (recordingHeader one)) (KM.lookup "run_id" (recordingHeader two))
   , scaleReportTests
   , testCase "scaling journals completed work when later work stops" $
       withSystemTempDirectory "acton-perf-scaling" $ \project -> do
@@ -261,6 +305,9 @@ scaleTests = testGroup "performance scaling studies"
           , "        sw = time.Stopwatch()"
           , "        while sw.elapsed().to_float() < target:"
           , "            pass"
+          , ""
+          , "def _test__test_partial(t: testing.SyncT):"
+          , "    raise ValueError(\"wrong benchmark selected\")"
           , ""
           , "def _test_failure(t: testing.SyncT):"
           , "    for scale in t.loop():"
@@ -302,6 +349,32 @@ scaleTests = testGroup "performance scaling studies"
           assertEqual "fixed-scale study samples do not calibrate" (Just (Aeson.toJSON ([] :: [Int]))) (KM.lookup "calibration" info)
           warmup <- field "warmup_duration_ms" info :: IO Double
           assertBool "the child completed warmup" (warmup > 0)
+        originalHeader <- requireEvent "study" partial
+        originalPath <- field "path" originalHeader
+        implementation <- field "implementation_hash" originalHeader :: IO String
+        assertBool "a real benchmark has a full implementation digest"
+          (length implementation == 64 && all isHexDigit implementation)
+        assertBool "the filename includes the benchmark and short implementation digest"
+          (("scale_tests.sample._test_partial__" `isInfixOf` takeFileName originalPath)
+            && ("__" ++ take 12 implementation ++ ".jsonl") `isInfixOf` takeFileName originalPath)
+        original <- BS.readFile originalPath
+        (compareCode, compareOut, compareErr) <- readCreateProcessWithExitCode
+          (proc acton ["test", "scale", "--compare", originalPath, "--max-time", "2s", "--json"])
+            { cwd = Just project } ""
+        assertEqual (compareOut ++ compareErr) ExitSuccess compareCode
+        compared <- decodeEvents compareOut
+        compareHeader <- requireEvent "study" compared
+        comparePath <- field "path" compareHeader
+        assertBool "comparison writes a distinct journal" (originalPath /= comparePath)
+        assertEqual "sampling options do not change implementation identity"
+          (KM.lookup "implementation_hash" originalHeader) (KM.lookup "implementation_hash" compareHeader)
+        forM_ (eventsOf "sample_start" compared) $ \event -> do
+          assertEqual "recorded scale is replayed without calibration" (Just (Aeson.Number 1000)) (KM.lookup "scale" event)
+          assertEqual "the recorded raw identity excludes a colliding display name"
+            (Just (Aeson.String "_test_partial")) (KM.lookup "test" event)
+        summary <- requireEvent "test_end" compared
+        assertEqual "the recorded schedule completed" (Just (Aeson.String "compared")) (KM.lookup "outcome" summary)
+        assertEqual "the old recording is unchanged" original =<< BS.readFile originalPath
         forM_ [("failure", "scaling failure"), ("without_loop", "require")] $ \(test, message) -> do
           (code, events, output) <- run test "128MiB" "2s"
           assertBool output (code /= ExitSuccess)
@@ -346,7 +419,7 @@ simulate :: String -> (Int -> Int -> TestResult) -> IO (Int, [Aeson.Object])
 simulate name result = withSystemTempDirectory ("acton-scale-" ++ name) $ \directory -> do
     (gopts, opts) <- parseScale ["--max-memory", "128MiB", "--max-time", "30s"]
     calls <- newIORef IM.empty
-    code <- runScalingStudy False gopts opts directory KM.empty [("sample", name)] $ \_ scale modName testName -> do
+    code <- runScalingStudy False gopts opts directory KM.empty [("sample", name, Nothing)] Nothing $ \_ scale modName testName -> do
       counts <- readIORef calls
       when (sum (IM.elems counts) >= 500) (assertFailure "the simulated study did not stop")
       let invocation = IM.findWithDefault 0 scale counts + 1
@@ -367,7 +440,11 @@ modelResult scale wall = TestResult
     , trRaw = Aeson.object ["complete" Aeson..= True, "success" Aeson..= True,
         "skipped" Aeson..= False, "num_iterations" Aeson..= (1 :: Int), "loop_iterations" Aeson..= (1 :: Int),
         "avg_wall_duration" Aeson..= wall, "peak_rss" Aeson..= (1048576 :: Int),
-        "perf_info" Aeson..= Aeson.object ["scale" Aeson..= scale, "loop" Aeson..= True, "scaling" Aeson..= True]]
+        "perf_info" Aeson..= Aeson.object ["scale" Aeson..= scale, "loop" Aeson..= True, "scaling" Aeson..= True,
+          "machine" Aeson..= ("test-machine" :: String), "version" Aeson..= ("3" :: String),
+          "workers" Aeson..= (2 :: Int), "gc" Aeson..= ("natural" :: String), "tags" Aeson..= ([] :: [String]),
+          "build" Aeson..= Aeson.object ["target" Aeson..= ("native" :: String), "optimize" Aeson..= ("ReleaseFast" :: String),
+            "cpu" Aeson..= ("" :: String), "no_threads" Aeson..= False, "db" Aeson..= False, "no_dbp" Aeson..= False]]]
     }
 
 assertSummary :: String -> (Int, Int) -> (Int, Int) -> [Aeson.Object] -> IO Aeson.Object
@@ -379,7 +456,7 @@ assertSummary outcome (first, final) (points, samples) events = do
     assertEqual "all curve points are counted" (Just (Aeson.toJSON points)) (KM.lookup "points" summary)
     assertEqual "curve samples exclude reference checks" (Just (Aeson.toJSON samples)) (KM.lookup "samples" summary)
     assertEqual "each reported point is journaled" points (length (eventsOf "point" events))
-    assertEnd "all selected studies finished" events
+    assertEnd "benchmark finished" events
     return summary
 
 assertSampleProvenance :: [Aeson.Object] -> Assertion

--- a/compiler/acton/ScaleTests.hs
+++ b/compiler/acton/ScaleTests.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-module ScaleTests (scaleTests) where
+module ScaleTests (scaleTests, scaleIntegrationTests) where
 
 import qualified Acton.CommandLineParser as C
 import qualified Acton.Fingerprint as Fingerprint
@@ -270,7 +270,12 @@ scaleTests = testGroup "performance scaling studies"
         assertEqual "both files identify the common command"
           (KM.lookup "run_id" (recordingHeader one)) (KM.lookup "run_id" (recordingHeader two))
   , scaleReportTests
-  , testCase "scaling journals completed work when later work stops" $
+  ]
+
+-- Real measurements need a quiet machine; enable them with make test-performance.
+scaleIntegrationTests :: TestTree
+scaleIntegrationTests =
+    testCase "scaling journals completed work when later work stops" $
       withSystemTempDirectory "acton-perf-scaling" $ \project -> do
         acton <- canonicalizePath "../../dist/bin/acton"
         let name = "scale_tests"
@@ -393,7 +398,6 @@ scaleTests = testGroup "performance scaling studies"
           assertBool output (code /= ExitSuccess)
           assertEnd "sample output exceeded 1MiB per stream" events
           assertBool "oversized unterminated output cannot contribute a point" (null (eventsOf "point" events))
-  ]
 
 point :: Int -> [Double] -> Double -> ScalePoint
 point scale times rss = ScalePoint scale

--- a/compiler/acton/TerminalSize.hs
+++ b/compiler/acton/TerminalSize.hs
@@ -2,6 +2,7 @@
 
 module TerminalSize
   ( TermSize
+  , queryTermSize
   , initTermSize
   , termSizeCurrent
   , termSizeSync

--- a/compiler/acton/TestPerf.hs
+++ b/compiler/acton/TestPerf.hs
@@ -5,6 +5,7 @@ module TestPerf
   , perfStatKey
   , perfInfo
   , perfCounterInfo
+  , perfHostReason, perfSamplingReason
   , perfComparisonReason
   , perfBaselineScale
   , perfComparable
@@ -79,16 +80,27 @@ perfComparisonReason :: String -> Aeson.Object -> Aeson.Object -> Maybe String
 perfComparisonReason metric old new = case (perfInfo old, perfInfo new) of
     (Nothing, _) -> Just "baseline has no performance identity; record a new baseline"
     (_, Nothing) -> Just "current performance identity is unavailable"
-    (Just a, Just b) | scaling a /= scaling b -> Just "measurement sampling mode differs"
-    (Just a, Just b) -> case metadataReason (hostKeys ++ ["scale", "loop", "workers"]) a b of
+    (Just a, Just b) -> case perfSamplingReason a b of
       Just reason -> Just reason
-      Nothing
-        | metric `elem` ["instructions", "cycles", "ipc"] -> case (perfCounterInfo old, perfCounterInfo new) of
-            (Just ca, Just cb) -> metadataReason ["version", "backend", "scope"] ca cb
-            _ -> Just "hardware counter scope is unavailable"
-        | otherwise -> Nothing
+      Nothing -> case metadataReason ["scale"] a b of
+        Just reason -> Just reason
+        Nothing
+          | metric `elem` ["instructions", "cycles", "ipc"] -> case (perfCounterInfo old, perfCounterInfo new) of
+              (Just ca, Just cb) -> metadataReason ["version", "backend", "scope"] ca cb
+              _ -> Just "hardware counter scope is unavailable"
+          | otherwise -> Nothing
+
+-- Scaling curves compare many sizes, while retaining the same environment and
+-- sampling contract. Workload scale is checked separately for fixed-size deltas.
+perfSamplingReason :: Aeson.Object -> Aeson.Object -> Maybe String
+perfSamplingReason old new
+  | scaling old /= scaling new = Just "measurement sampling mode differs"
+  | otherwise = metadataReason (hostKeys ++ ["loop", "workers"]) old new
   where
     scaling info = AesonKM.lookup (AesonKey.fromString "scaling") info == Just (Aeson.Bool True)
+
+perfHostReason :: Aeson.Object -> Aeson.Object -> Maybe String
+perfHostReason = metadataReason hostKeys
 
 -- Select the recorded workload scale before launching the process. The completed
 -- run must still pass the actual worker-count and loop checks above.

--- a/compiler/acton/TestPerf.hs
+++ b/compiler/acton/TestPerf.hs
@@ -79,6 +79,7 @@ perfComparisonReason :: String -> Aeson.Object -> Aeson.Object -> Maybe String
 perfComparisonReason metric old new = case (perfInfo old, perfInfo new) of
     (Nothing, _) -> Just "baseline has no performance identity; record a new baseline"
     (_, Nothing) -> Just "current performance identity is unavailable"
+    (Just a, Just b) | scaling a /= scaling b -> Just "measurement sampling mode differs"
     (Just a, Just b) -> case metadataReason (hostKeys ++ ["scale", "loop", "workers"]) a b of
       Just reason -> Just reason
       Nothing
@@ -86,12 +87,15 @@ perfComparisonReason metric old new = case (perfInfo old, perfInfo new) of
             (Just ca, Just cb) -> metadataReason ["version", "backend", "scope"] ca cb
             _ -> Just "hardware counter scope is unavailable"
         | otherwise -> Nothing
+  where
+    scaling info = AesonKM.lookup (AesonKey.fromString "scaling") info == Just (Aeson.Bool True)
 
 -- Select the recorded workload scale before launching the process. The completed
 -- run must still pass the actual worker-count and loop checks above.
 perfBaselineScale :: Aeson.Object -> Aeson.Object -> Maybe Int
 perfBaselineScale baseline currentInfo = do
     old <- perfInfo baseline
+    guard (AesonKM.lookup (AesonKey.fromString "scaling") old /= Just (Aeson.Bool True))
     guard (not (isJust (metadataReason hostKeys old currentInfo)))
     guard (AesonKM.lookup (AesonKey.fromString "loop") old == Just (Aeson.Bool True))
     value <- AesonKM.lookup (AesonKey.fromString "scale") old >>= AesonTypes.parseMaybe Aeson.parseJSON

--- a/compiler/acton/TestRunner.hs
+++ b/compiler/acton/TestRunner.hs
@@ -15,6 +15,7 @@ import qualified FileUtil
 import TestFormat
 import TestOutput
 import TestPerf
+import TestScale
 import TestUI
 import Control.Applicative ((<|>))
 import Control.Concurrent.Async
@@ -48,6 +49,7 @@ import qualified Crypto.Hash.SHA256 as SHA256
 import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
 import qualified Data.Text.Encoding as TE
+import Data.Text.Encoding.Error (lenientDecode)
 import Data.Time.Clock (UTCTime)
 import Control.Exception (IOException, SomeException, SomeAsyncException, AsyncException(..), displayException, evaluate, mask, onException, try, fromException, throwIO, finally)
 import TerminalSize (termFitAnsiRight)
@@ -55,7 +57,7 @@ import qualified Text.Regex.TDFA as TDFA
 import Data.Version (showVersion)
 import qualified Paths_acton
 
-data TestMode = TestModeRun | TestModeList | TestModePerf | TestModeStress deriving (Eq, Show)
+data TestMode = TestModeRun | TestModeList | TestModePerf | TestModeScale | TestModeStress deriving (Eq, Show)
 
 data TestSpec = TestSpec
   { tsModule :: String
@@ -232,6 +234,17 @@ runProjectTests useColorOut gopts opts paths topts mode modules maxParallel = do
           else do
             putStrLn "Nothing to test"
             return 0
+      else if mode == TestModeScale
+      then do
+        host <- readPerfHostInfo opts topts
+        let callbacks = TestProgressCallbacks (const (return ())) (const (return ())) (const (return ()))
+            runSample limits scale modName testName = do
+              now <- getTime Monotonic
+              let remaining = max 1 (fromInteger (toNanoSecs (scaleDeadline limits - now) `div` 1000000))
+                  sampleOptions = topts { C.testScale = Just scale, C.testTime = remaining }
+              runModuleTestStreaming opts paths sampleOptions mode host Nothing (Just limits)
+                modName testName False callbacks
+        runScalingStudy useColorOut gopts topts (projOut paths </> "perf_scaling") host allTests runSample
       else do
         let maxNameLen = maximum (0 : map (length . tsDisplay) specs)
             nameWidth = max 20 (maxNameLen + 5)
@@ -363,7 +376,7 @@ runProjectTests useColorOut gopts opts paths topts mode modules maxParallel = do
                             let baselineScale = lookupPerfData perfData initRes >>= (\old -> perfBaselineScale old perfHostInfo)
                             mask $ \unmask -> do
                               worker <- async $ unmask $ mask $ \restore -> do
-                                resE <- try (restore (runModuleTestStreaming opts paths topts mode perfHostInfo baselineScale (tsModule spec) (tsName spec)
+                                resE <- try (restore (runModuleTestStreaming opts paths topts mode perfHostInfo baselineScale Nothing (tsModule spec) (tsName spec)
                                                        (tpuEnabled ui) callbacks))
                                           :: IO (Either SomeException TestResult)
                                 case resE of
@@ -625,17 +638,19 @@ runModuleTestStreaming :: C.CompileOptions
                        -> TestMode
                        -> Aeson.Object
                        -> Maybe Int
+                       -> Maybe ScaleLimits
                        -> String
                        -> String
                        -> Bool
                        -> TestProgressCallbacks
                        -> IO TestResult
-runModuleTestStreaming opts paths topts mode perfHostInfo baselineScale modName testName allowLive callbacks = do
+runModuleTestStreaming opts paths topts mode perfHostInfo baselineScale limits modName testName allowLive callbacks = do
     environment <- getEnvironment
     let binPath = testBinaryPath opts paths modName
         modeArgs =
           case mode of
             TestModePerf -> ["perf"]
+            TestModeScale -> ["perf"]
             TestModeStress -> ["stress"]
             _ -> []
         cmd = ["test", testName] ++ modeArgs ++ testCmdArgs mode topts
@@ -667,19 +682,19 @@ runModuleTestStreaming opts paths topts mode perfHostInfo baselineScale modName 
                           Nothing -> addStdErr line
     let procSpec = (proc binPath cmd)
           { cwd = Just (projPath paths)
-          , env = Just ((if mode == TestModePerf then [("ACTON_TEST_PERF", "1")] else [])
+          , env = Just ((if mode `elem` [TestModePerf, TestModeScale] then [("ACTON_TEST_PERF", "1")] else [])
               ++ filter ((/= "ACTON_TEST_PERF") . fst) environment)
-          , create_group = C.watch opts
-          , delegate_ctlc = not (C.watch opts)
+          , create_group = C.watch opts || isJust limits
+          , delegate_ctlc = not (C.watch opts || isJust limits)
           }
-    procRes <- try (readProcessWithExitCodeStreaming procSpec onOutLine onErrLine) :: IO (Either SomeException ExitCode)
+    procRes <- try (readProcessWithExitCodeStreaming procSpec limits onOutLine onErrLine) :: IO (Either SomeException ExitCode)
     (exitCode, interruptedByUser) <-
       case procRes of
         Right code ->
           return (code, False)
         Left ex ->
           case fromException ex of
-            Just UserInterrupt ->
+            Just UserInterrupt | not (isJust limits) ->
               return (ExitFailure (-2), True)
             _ -> throwIO ex
     final <- readIORef resultRef
@@ -1052,7 +1067,8 @@ effectiveTestTiming mode topts =
 -- | Build test runner arguments from TestOptions limits.
 testCmdArgs :: TestMode -> C.TestOptions -> [String]
 testCmdArgs mode topts
-  | mode == TestModePerf = ["--time", show (C.testTime topts)] ++ tagArgs
+  | mode `elem` [TestModePerf, TestModeScale] = ["--time", show (C.testTime topts)]
+      ++ ["--scaling" | mode == TestModeScale] ++ tagArgs
   | otherwise =
     let iter = C.testIter topts
         rawMaxIter = C.testMaxIter topts
@@ -1440,8 +1456,8 @@ writePerfData paths baseline results = do
         (T.unpack (TE.decodeUtf8 (BL.toStrict (Aeson.encode updated))))
 
 -- | Drain both process streams through callbacks without retaining another copy.
-readProcessWithExitCodeStreaming :: CreateProcess -> (T.Text -> IO ()) -> (T.Text -> IO ()) -> IO ExitCode
-readProcessWithExitCodeStreaming cp onOutLine onErrLine = mask $ \restore -> do
+readProcessWithExitCodeStreaming :: CreateProcess -> Maybe ScaleLimits -> (T.Text -> IO ()) -> (T.Text -> IO ()) -> IO ExitCode
+readProcessWithExitCodeStreaming cp limits onOutLine onErrLine = mask $ \restore -> do
     let cp' = cp { std_in = NoStream, std_out = CreatePipe, std_err = CreatePipe }
     withCreateProcess cp' $ \_ mOut mErr ph -> do
       pid <- getPid ph
@@ -1454,23 +1470,47 @@ readProcessWithExitCodeStreaming cp onOutLine onErrLine = mask $ \restore -> do
           readLines onLine mH =
             case mH of
               Nothing -> return ()
+              Just h | isJust limits -> readLimited h onLine
               Just h -> do
                 let go = do
                       eof <- hIsEOF h
                       unless eof $ TIO.hGetLine h >>= onLine >> go
                 go
                 hClose h
-      let capture = restore $
-            withAsync (readLines onOutLine mOut) $ \outReader ->
-              withAsync (readLines onErrLine mErr) $ \errReader -> do
+          -- Studies can run for hours. Bound the raw stream and a single
+          -- unterminated line before decoding or passing it to the parser.
+          readLimited h emitLine = go 0 BS.empty
+            where
+              decode = TE.decodeUtf8With lenientDecode
+              go count pending = do
+                chunk <- BS.hGetSome h 32768
+                if BS.null chunk then do
+                  unless (BS.null pending) (emitLine (decode pending))
+                  hClose h
+                else do
+                  let size = count + BS.length chunk
+                  when (size > 1048576) $
+                    throwIO (ScalingStopped "sample output exceeded 1MiB per stream")
+                  rest <- linesOf (pending <> chunk)
+                  go size rest
+              linesOf buffer = case BS.break (== '\n') buffer of
+                (_, suffix) | BS.null suffix -> return buffer
+                (line, suffix) -> emitLine (decode line) >> linesOf (BS.drop 1 suffix)
+      let capture = restore $ do
+            (code, _) <- concurrently
+              (do
                 code <- waitForProcess ph
                 when (create_group cp') stop
-                wait outReader
-                wait errReader
-                return code
+                return code)
+              (concurrently (readLines onOutLine mOut) (readLines onErrLine mErr))
+            return code
+      let guarded = case limits of
+            Nothing -> capture
+            Just bounds -> race capture (restore (watchScaleProcess bounds (fromIntegral <$> pid) ph))
+              >>= either return (throwIO . ScalingStopped)
       if create_group cp'
-        then capture `finally` stop
-        else capture `onException` (terminateProcess ph >> void (waitForProcess ph))
+        then guarded `finally` stop
+        else guarded `onException` (terminateProcess ph >> void (waitForProcess ph))
 
 fmtTime :: TimeSpec -> String
 fmtTime t =

--- a/compiler/acton/TestRunner.hs
+++ b/compiler/acton/TestRunner.hs
@@ -3,6 +3,7 @@ module TestRunner
   , listProjectTests
   , runProjectTests
   , selectTestSources
+  , prepareScalingComparison
   ) where
 
 import qualified Acton.CommandLineParser as C
@@ -16,6 +17,7 @@ import TestFormat
 import TestOutput
 import TestPerf
 import TestScale
+import ScaleReport (ScaleRecording(..), ScaleSeries(..), readScaleRecording, scaleSeriesReason)
 import TestUI
 import Control.Applicative ((<|>))
 import Control.Concurrent.Async
@@ -27,6 +29,7 @@ import Data.List (isPrefixOf, isSuffixOf, foldl', isInfixOf, intercalate)
 import qualified Data.List
 import Data.Maybe (catMaybes, listToMaybe, isJust)
 import qualified Data.Map as M
+import qualified Data.IntMap.Strict as IM
 import qualified Data.Set as Set
 import System.Clock
 import System.Directory
@@ -119,6 +122,34 @@ isWindowsTarget targetTriple =
 modulesOpt paths topts = [ proj ++ "." ++ m | m <- C.testModules topts ]
   where proj = projName paths
 
+-- Resolve a recorded benchmark before selecting compilation roots. File names
+-- are labels; the literal module and test identities come from the journal.
+prepareScalingComparison :: Paths -> C.TestOptions -> IO (C.TestOptions, Maybe ScaleRecording)
+prepareScalingComparison paths opts = case C.testCompare opts of
+    Nothing -> return (opts, Nothing)
+    Just path -> do
+      recording <- readScaleRecording path
+      regexes <- compileTestNameRegexes (C.testNames opts)
+      let selected = M.filterWithKey (\(modName, name) _ ->
+            not (null (filterModules (modulesOpt paths opts) [modName]))
+            && not (null (filterTests regexes [name]))) (recordingTests recording)
+      case M.toList selected of
+        [((modName, name), series)] -> do
+          forM_ (scaleSeriesReason series series) $ \reason ->
+            ioError (userError ("Cannot compare: " ++ reason))
+          when (null [n | (n, (True, _)) <- IM.toAscList (seriesData series),
+                         maybe True (n >=) (C.testStartScale opts)]) $
+            ioError (userError "The baseline has no completed sizes in the selected range")
+          case Data.List.stripPrefix (projName paths ++ ".") modName of
+            Nothing -> ioError (userError "The recorded benchmark belongs to a different project")
+            Just localModule -> return
+              (opts { C.testModules = [localModule], C.testNames = [concatMap escape name] },
+               Just recording { recordingTests = selected })
+        [] -> ioError (userError "No benchmark in the baseline matches the selection")
+        _ -> ioError (userError "The baseline contains multiple benchmarks; select one with --module and/or --name")
+  where
+    escape c = if c `elem` ("\\.^$|?*+()[]{}" :: String) then ['\\', c] else [c]
+
 -- | Select compilation roots without changing the contents of module caches.
 -- A cached test list can confirm a match, but cannot rule one out: a changed
 -- import may change an inferred function type and make it eligible as a test.
@@ -208,15 +239,16 @@ listProjectTests opts paths topts modules = do
           exitSuccess
 
 -- | Run selected tests concurrently, stream results, and return an exit code.
-runProjectTests :: Bool -> C.GlobalOptions -> C.CompileOptions -> Paths -> C.TestOptions -> TestMode -> [String] -> Int -> IO Int
-runProjectTests useColorOut gopts opts paths topts mode modules maxParallel = do
+runProjectTests :: Bool -> C.GlobalOptions -> C.CompileOptions -> Paths -> C.TestOptions -> TestMode -> [String] -> Int -> Maybe ScaleRecording -> IO Int
+runProjectTests useColorOut gopts opts paths topts mode modules maxParallel baseline = do
     timeStart <- getTime Monotonic
     let emitJson = C.testJson topts
     nameRegexes <- compileTestNameRegexes (C.testNames topts)
     let wantedModules = Data.List.sort (filterModules (modulesOpt paths topts) modules)
     testsByModule <- forM wantedModules $ \modName -> do
       names <- listModuleTests opts paths modName
-      let wantedNames = Data.List.sort (filterTests nameRegexes names)
+      let wantedNames = Data.List.sort [name | name <- filterTests nameRegexes names,
+            maybe True (M.member (modName, name) . recordingTests) baseline]
       return (modName, wantedNames)
     let specs =
           [ TestSpec modName testName (displayTestName testName)
@@ -224,6 +256,8 @@ runProjectTests useColorOut gopts opts paths topts mode modules maxParallel = do
           , testName <- names
           ]
         allTests = [ (tsModule spec, tsName spec) | spec <- specs ]
+    forM_ baseline $ \old -> when (allTests /= M.keys (recordingTests old)) $
+      ioError (userError "The recorded benchmark was not found in this project")
     if null specs
       then do
         if emitJson
@@ -237,6 +271,16 @@ runProjectTests useColorOut gopts opts paths topts mode modules maxParallel = do
       else if mode == TestModeScale
       then do
         host <- readPerfHostInfo opts topts
+        forM_ baseline $ \old -> forM_ (M.elems (recordingTests old)) $ \series ->
+          forM_ (seriesInfo series >>= (`perfHostReason` host)) $ \reason ->
+            ioError (userError ("Cannot compare: " ++ reason))
+        revision <- gitOutput ["rev-parse", "HEAD"]
+        dirty <- fmap (fmap (not . null)) (gitOutput ["status", "--porcelain", "--untracked-files=normal"])
+        let provenance = AesonKM.union host (AesonKM.fromList
+              [(AesonKey.fromString "compiler_version", Aeson.toJSON getVer), (AesonKey.fromString "git_revision", Aeson.toJSON revision), (AesonKey.fromString "git_dirty", Aeson.toJSON dirty)])
+        tests <- forM testsByModule $ \(modName, names) -> do
+          hashes <- readModuleNameHashes paths modName
+          return [(modName, name, fmap (BS.unpack . Base16.encode . InterfaceFiles.nhImplHash . snd) (lookupTestInfo hashes name)) | name <- names]
         let callbacks = TestProgressCallbacks (const (return ())) (const (return ())) (const (return ()))
             runSample limits scale modName testName = do
               now <- getTime Monotonic
@@ -244,7 +288,7 @@ runProjectTests useColorOut gopts opts paths topts mode modules maxParallel = do
                   sampleOptions = topts { C.testScale = Just scale, C.testTime = remaining }
               runModuleTestStreaming opts paths sampleOptions mode host Nothing (Just limits)
                 modName testName False callbacks
-        runScalingStudy useColorOut gopts topts (projOut paths </> "perf_scaling") host allTests runSample
+        runScalingStudy useColorOut gopts topts (projOut paths </> "perf_scaling") provenance (concat tests) baseline runSample
       else do
         let maxNameLen = maximum (0 : map (length . tsDisplay) specs)
             nameWidth = max 20 (maxNameLen + 5)
@@ -451,6 +495,12 @@ runProjectTests useColorOut gopts opts paths topts mode modules maxParallel = do
               _ <- printTestSummary (tpuUseColor ui) (timeEnd - timeStart) showCached results
               return (testExitCode results)
   where
+    gitOutput args = do
+      result <- try (readCreateProcessWithExitCode (proc "git" args) { cwd = Just (projPath paths) } "")
+        :: IO (Either IOException (ExitCode, String, String))
+      return $ case result of
+        Right (ExitSuccess, output, _) -> Just (trim output)
+        _ -> Nothing
     mkRunContext opts' topts' mode' = TestRunContext
       { trcCompilerVersion = getVer
       , trcTarget = C.target opts'

--- a/compiler/acton/TestScale.hs
+++ b/compiler/acton/TestScale.hs
@@ -1,0 +1,360 @@
+{-# LANGUAGE OverloadedStrings #-}
+module TestScale
+  ( ScaleLimits(..), ScalingStopped(..), ScalePoint(..)
+  , validateScalingOptions, runScalingStudy, watchScaleProcess
+  , scaleMean, scaleError, scaleReliable, scaleNeedsSamples, scaleGrowth, stableGrowth
+  , nextScale, scaleMemoryLimit
+  ) where
+
+import qualified Acton.CommandLineParser as C
+import Acton.Testing (TestResult(..))
+import TestPerf
+import PerfMemory
+import ScaleReport (addScaleEvent, printScaleReport)
+import TerminalSize (queryTermSize, termFitAnsiRight)
+import Control.Concurrent (threadDelay)
+import Control.Exception
+import Control.Monad
+import Data.Char (isAscii, isAlphaNum)
+import Data.Maybe (fromMaybe, isJust, mapMaybe)
+import Data.IORef
+import qualified Data.IntMap.Strict as IM
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.KeyMap as KM
+import qualified Data.ByteString.Lazy.Char8 as BL
+import Data.Time (getCurrentTime, formatTime, defaultTimeLocale)
+import System.Clock
+import System.Directory
+import System.FilePath
+import System.IO
+import System.Process
+import Text.Printf
+
+data ScaleLimits = ScaleLimits
+    { scaleDeadline :: TimeSpec
+    , scaleMemory :: Integer
+    , scaleReserve :: Integer
+    }
+
+data ScalingStopped = ScalingStopped String deriving Show
+instance Exception ScalingStopped
+
+data ScalePoint = ScalePoint
+    { pointScale :: Int
+    , pointSamples :: [Aeson.Object]
+    } deriving Show
+
+validateScalingOptions :: C.TestOptions -> Maybe String
+validateScalingOptions opts
+  | C.testRecord opts = Just "Scaling studies save every sample automatically; --record updates fixed-scale perf_data"
+  | C.testSnapshotUpdate opts = Just "Scaling studies cannot update test snapshots"
+  | C.watch (C.testCompile opts) = Just "Scaling studies cannot run with --watch"
+  | otherwise = Nothing
+
+-- Reserve memory for the machine as well as bounding the child itself.
+scaleMemoryLimit :: C.MemoryLimit -> MemoryStatus -> Either String (Integer, Integer)
+scaleMemoryLimit requested status =
+    let total = memoryTotal status
+        reserve = min (256 * 1024 * 1024) (total `div` 10)
+        wanted = case requested of
+          C.MemoryBytes n -> n
+          C.MemoryPercent n -> floor (fromIntegral total * n / 100)
+        cap = min wanted (memoryAvailable status - reserve)
+    in if cap <= 0 then Left "Not enough available memory to start a scaling study"
+       else Right (cap, reserve)
+
+watchScaleProcess :: ScaleLimits -> Maybe Int -> ProcessHandle -> IO String
+watchScaleProcess limits pid process =
+    case pid of
+      Nothing -> return "Memory monitoring could not obtain the child process ID"
+      Just child -> loop child
+  where
+    loop child = do
+      now <- getTime Monotonic
+      if now >= scaleDeadline limits then return "time limit reached"
+      else do
+        exited <- getProcessExitCode process
+        case exited of
+          Just _ -> threadDelay 20000 >> loop child
+          Nothing -> do
+            status <- readMemoryStatus (Just child)
+            case status of
+              Left err -> do
+                -- The child can exit between checking its status and sampling it.
+                done <- getProcessExitCode process
+                if isJust done then threadDelay 20000 >> loop child
+                else return ("memory monitoring unavailable: " ++ err)
+              Right memory
+                | memoryProcess memory >= scaleMemory limits -> return "memory limit reached"
+                | memoryAvailable memory <= scaleReserve limits -> return "available memory reserve reached"
+                | otherwise -> threadDelay 50000 >> loop child
+
+scaleMean :: [Double] -> Maybe Double
+scaleMean [] = Nothing
+scaleMean xs = Just (sum xs / fromIntegral (length xs))
+
+pointValues :: String -> ScalePoint -> [Double]
+pointValues metric = mapMaybe (`perfNumber` metric) . pointSamples
+
+-- Estimated precision of the mean guides sampling. This is a stopping heuristic,
+-- not a confidence interval: repeats can share noise and sampling is adaptive.
+scaleError :: ScalePoint -> Maybe Double
+scaleError point = do
+    let values = pointValues "avg_wall_duration" point
+        n = fromIntegral (length values)
+    mean <- scaleMean values
+    guard (n >= 3 && mean > 0)
+    return (sqrt (sum [((x - mean) / mean)^2 | x <- values] / (n * (n - 1))))
+
+scaleReliable :: ScalePoint -> Bool
+scaleReliable point = maybe False (>= 0.1) (scaleMean (pointValues "avg_wall_duration" point))
+                   && maybe False (<= 0.05) (scaleError point)
+
+scaleNeedsSamples :: ScalePoint -> Bool
+scaleNeedsSamples point =
+    let n = length (pointSamples point)
+    in n < 3 || (n < 7 && maybe False (>= 0.1) (scaleMean (pointValues "avg_wall_duration" point))
+                       && not (scaleReliable point))
+
+-- Growth is an observation over an explicit range, not an asymptotic bound.
+scaleGrowth :: ScalePoint -> ScalePoint -> Maybe Double
+scaleGrowth old new = do
+    guard (scaleReliable old && scaleReliable new)
+    a <- scaleMean (pointValues "avg_wall_duration" old)
+    b <- scaleMean (pointValues "avg_wall_duration" new)
+    guard (pointScale new > pointScale old)
+    let scaleLog = log (fromIntegral (pointScale new) / fromIntegral (pointScale old))
+        growth = log (b / a) / scaleLog
+    guard (scaleLog > 0 && not (isNaN growth || isInfinite growth))
+    return growth
+
+-- Newest point first. Broad coverage prevents an early, short flat segment from
+-- ending exploration. The last two growth rates confirm the preceding three;
+-- bends or noisy points reset this window without discarding earlier data.
+stableGrowth :: [ScalePoint] -> Maybe (Int, Double, Double)
+stableGrowth points = do
+    let recent = take 6 points
+        reliable = filter scaleReliable points
+    guard (length recent == 6 && not (null reliable))
+    guard (toInteger (pointScale (head recent)) >= 1000 * toInteger (pointScale (last reliable)))
+    let pairs = zip (tail recent) recent
+    guard (all (\(old, new) -> 2 * toInteger (pointScale new) >= 3 * toInteger (pointScale old)) pairs)
+    slopes <- mapM (uncurry scaleGrowth) pairs
+    let lo = minimum slopes
+        hi = maximum slopes
+    guard (hi - lo <= 0.25)
+    return (pointScale (last recent), lo, hi)
+
+-- Slow down the geometric sweep near the memory boundary. Prediction is only
+-- a sizing hint; the live monitor remains responsible for stopping the child.
+nextScale :: Integer -> [ScalePoint] -> Maybe Int
+nextScale cap _ | cap <= 0 = Nothing
+nextScale _ [] = Nothing
+nextScale cap (point:older) =
+    let current = pointScale point
+        peak p = maximum (1 : pointValues "peak_rss" p)
+        exponent = case older of
+          previous:_ | pointScale previous < current ->
+            let scaleLog = log (fromIntegral current / fromIntegral (pointScale previous))
+                growth = log (peak point / peak previous) / scaleLog
+            in if scaleLog <= 0 || isNaN growth || isInfinite growth then 1 else max 1 growth
+          _ -> 1
+        factor = min 2 ((0.8 * fromIntegral cap / peak point) ** (1 / exponent))
+        candidate = min (toInteger (maxBound :: Int)) (floor (fromIntegral current * factor))
+    in if factor < 1.1 || candidate <= toInteger current then Nothing else Just (fromInteger candidate)
+
+-- Each sample has its own process and the same amount of warmup and measured
+-- work. The callback reuses the ordinary test runner's result handling.
+runScalingStudy :: Bool -> C.GlobalOptions -> C.TestOptions -> FilePath -> Aeson.Object -> [(String, String)]
+                -> (ScaleLimits -> Int -> String -> String -> IO TestResult) -> IO Int
+runScalingStudy useColor gopts opts directory host tests runSample = do
+    memory <- readMemoryStatus Nothing >>= either (ioError . userError) return
+    (cap, reserve) <- either (ioError . userError) return
+      (scaleMemoryLimit (fromMaybe (C.MemoryPercent 50) (C.testMaxMemory opts)) memory)
+    start <- getTime Monotonic
+    let duration = if C.testMaxTimeSet opts then C.testMaxTime opts else 3600000
+        limits = ScaleLimits (start + fromNanoSecs (toInteger duration * 1000000)) cap reserve
+    timestamp <- formatTime defaultTimeLocale "%Y%m%dT%H%M%S.%qZ" <$> getCurrentTime
+    createDirectoryIfMissing True directory
+    tty <- hIsTerminalDevice stdout
+    let component = take 80 . map (\c -> if isAscii c && (isAlphaNum c || c `elem` ("._-" :: String)) then c else '_')
+        name = case tests of
+          [] -> "study"
+          (modName, testName):rest -> component modName ++ "." ++ component testName
+            ++ if null rest then "" else "+" ++ show (length rest) ++ "-more"
+        path = directory </> (name ++ "-" ++ timestamp) <.> "jsonl"
+        say = unless (C.testJson opts) . putStrLn
+        progress = not (C.testJson opts || C.quiet gopts || C.noProgress gopts)
+        live = progress && (tty || C.tty gopts)
+        terminal text = when live (putStr text >> hFlush stdout)
+        clearProgress = terminal "\r\ESC[K"
+        updateProgress text = when live $ do
+          (_, cols) <- fromMaybe (24, 80) <$> queryTermSize
+          terminal ("\r" ++ termFitAnsiRight (max 0 (cols - 1)) text ++ "\ESC[K")
+    chartData <- newIORef IM.empty
+    code <- withFile path WriteMode $ \journal -> do
+      let emit fields = do
+            let obj = KM.fromList fields
+                line = Aeson.encode (Aeson.Object obj)
+            BL.hPutStrLn journal line
+            hFlush journal
+            when (C.testJson opts) (BL.putStrLn line >> hFlush stdout)
+            unless (C.testJson opts) (modifyIORef' chartData (addScaleEvent obj))
+          event kind fields = emit (("event" Aeson..= (kind :: String)) : fields)
+          finish reason code = do
+            now <- getTime Monotonic
+            event "end" ["reason" Aeson..= reason, "elapsed_ms" Aeson..= milliseconds (now - start)]
+            say ("Stopped: " ++ reason)
+            say ("Results: " ++ path)
+            return code
+          sample modName testName scale reference = do
+            now <- getTime Monotonic
+            when (now >= scaleDeadline limits) (throwIO (ScalingStopped "time limit reached"))
+            event "sample_start" ["module" Aeson..= modName, "test" Aeson..= testName,
+                                  "scale" Aeson..= scale, "reference" Aeson..= reference]
+            res <- runSample limits scale modName testName
+            let raw = trRaw res
+            checked <- try (case testPerfData res of
+              Just obj | trNumIterations res == 1, Just info <- perfInfo obj,
+                         KM.lookup "loop_iterations" obj == Just (Aeson.Number 1),
+                         KM.lookup "scaling" info == Just (Aeson.Bool True),
+                         KM.lookup "scale" info == Just (Aeson.toJSON scale) -> do
+                when (maybe True (<= 0) (perfNumber obj "avg_wall_duration")) $
+                  throwIO (ScalingStopped "wall time measurement unavailable")
+                case perfNumber obj "peak_rss" of
+                  Nothing -> throwIO (ScalingStopped "peak memory measurement unavailable")
+                  Just peak | peak >= fromIntegral cap -> throwIO (ScalingStopped "memory limit reached")
+                  _ -> return obj
+              _ -> throwIO (userError (fromMaybe "Scaling requires a successful test with one measured t.loop() body" (trException res))))
+                :: IO (Either SomeException Aeson.Object)
+            event "sample" ["module" Aeson..= modName, "test" Aeson..= testName,
+                            "scale" Aeson..= scale, "reference" Aeson..= reference, "result" Aeson..= raw,
+                            "stdout" Aeson..= trStdOut res, "stderr" Aeson..= trStdErr res,
+                            "exception" Aeson..= trException res,
+                            "accepted" Aeson..= either (const False) (const True) checked]
+            obj <- either throwIO return checked
+            -- Raw results, including diagnostics, are already on disk.
+            return (KM.filterWithKey (\key _ -> key `elem` ["avg_wall_duration", "peak_rss"]) obj)
+          collect modName testName scale reference = do
+            when (progress && not live) (say ("  sampling " ++ label))
+            gather [] `finally` clearProgress
+            where
+              label = (if reference then "reference scale " else "scale ") ++ show scale
+              gather samples = do
+                let point = ScalePoint scale samples
+                if scaleNeedsSamples point then do
+                  let count = length samples
+                      target = count + if null samples then 3 else 2
+                  more <- forM [count + 1 .. target] $ \index -> do
+                    updateProgress ("  " ++ label ++ " · sample " ++ show index ++ "/" ++ show target)
+                    sample modName testName scale reference
+                  gather (samples ++ more)
+                else return point
+          checkReference modName testName reference = do
+            measured <- collect modName testName (pointScale reference) True
+            let drift = do
+                  guard (scaleReliable reference && scaleReliable measured)
+                  before <- scaleMean (pointValues "avg_wall_duration" reference)
+                  after <- scaleMean (pointValues "avg_wall_duration" measured)
+                  return (after / before - 1)
+                stable = maybe False ((<= 0.2) . abs) drift
+            event "reference" ["module" Aeson..= modName, "test" Aeson..= testName,
+                               "scale" Aeson..= pointScale reference, "change" Aeson..= drift,
+                               "samples" Aeson..= length (pointSamples measured),
+                               "relative_standard_error" Aeson..= scaleError measured,
+                               "stable" Aeson..= stable]
+            unless stable $ say "  Reference measurements changed or remain noisy; continuing to check the trend."
+            return stable
+          endTest modName testName outcome reason points trend = do
+            let first = pointScale (last points)
+                final = pointScale (head points)
+                samples = sum (map (length . pointSamples) points)
+            event "test_end" ["module" Aeson..= modName, "test" Aeson..= testName,
+                              "outcome" Aeson..= (outcome :: String), "reason" Aeson..= reason,
+                              "min_scale" Aeson..= first, "max_scale" Aeson..= final,
+                              "points" Aeson..= length points, "samples" Aeson..= samples,
+                              "stable_from_scale" Aeson..= fmap (\(start, _, _) -> start) trend,
+                              "growth_min" Aeson..= fmap (\(_, lo, _) -> lo) trend,
+                              "growth_max" Aeson..= fmap (\(_, _, hi) -> hi) trend]
+            say ("  " ++ reason ++ "; " ++ show (length points) ++ " sizes, " ++ show samples
+                 ++ " curve samples, scales " ++ show first ++ " … " ++ show final)
+            forM_ trend $ \(start, lo, hi) ->
+              say (printf "  Recent growth: n^%.2f … n^%.2f over scales %d … %d" lo hi start final)
+          study modName testName scale points reference driftFailures = do
+            point <- collect modName testName scale False
+            let points' = point : points
+                growth = case points of old:_ -> scaleGrowth old point; [] -> Nothing
+                trend = stableGrowth points'
+                reference' = case reference of
+                  Nothing | scaleReliable point -> Just point
+                  _ -> reference
+            event "point" ["module" Aeson..= modName, "test" Aeson..= testName,
+                           "scale" Aeson..= scale, "samples" Aeson..= length (pointSamples point),
+                           "wall_mean_ms" Aeson..= scaleMean (pointValues "avg_wall_duration" point),
+                           "relative_standard_error" Aeson..= scaleError point,
+                           "reliable" Aeson..= scaleReliable point,
+                           "observed_exponent" Aeson..= growth]
+            say (formatPoint point growth)
+            -- Start with the first measurable size, rather than a noisy tiny
+            -- probe. Always recheck it before declaring the recent trend stable.
+            checked <- case reference of
+              Just ref | isJust trend || length points' `mod` 4 == 0 ->
+                Just <$> checkReference modName testName ref
+              _ -> return Nothing
+            let failures = case checked of
+                  Just True -> 0
+                  Just False -> driftFailures + 1
+                  Nothing -> driftFailures
+                finish = endTest modName testName
+            if isJust trend && checked == Just True then
+              finish "stable" "Growth stable over the measured range" points' trend
+            else if failures >= 3 then
+              finish "inconclusive" "Reference measurements did not settle" points' Nothing
+            else if length (takeWhile (not . scaleReliable) points') >= 20 then
+              finish "inconclusive" "Timing stayed too short or noisy across 20 successive sizes" points' Nothing
+            else case nextScale cap points' of
+              Nothing -> finish "limited" "Next scale approaches the memory or integer limit" points' Nothing
+              Just next -> study modName testName next points' reference' failures
+      event "study" ["version" Aeson..= (2 :: Int), "host" Aeson..= host,
+                     "max_memory_bytes" Aeson..= cap, "reserve_bytes" Aeson..= reserve,
+                     "max_time_ms" Aeson..= duration, "start_scale" Aeson..= fromMaybe 1 (C.testStartScale opts),
+                     "memory_protection" Aeson..= ("monitored; abrupt allocations can exceed the limit" :: String),
+                     "path" Aeson..= path]
+      say "Scaling study: adaptive range, 3–7 samples per size, one warmup per sample"
+      say ("Safety limits: " ++ show duration ++ "ms, memory ceiling " ++ bytes cap)
+      say "Memory protection is monitored; abrupt allocations can exceed the limit."
+      say ("Results: " ++ path)
+      outcome <- try $ flip finally (terminal "\ESC[?25h") $ do
+        terminal "\ESC[?25l"
+        forM_ tests $ \(modName, testName) -> do
+          writeIORef chartData IM.empty
+          say ("\nScaling " ++ modName ++ "." ++ testName)
+          say "       scale          mean          min … max             time/scale       peak RSS       growth"
+          study modName testName (fromMaybe 1 (C.testStartScale opts)) [] Nothing (0 :: Int)
+            `finally` unless (C.testJson opts)
+              (readIORef chartData >>= printScaleReport useColor (modName ++ "." ++ testName))
+      case outcome of
+        Right () -> finish "all selected studies finished" 0
+        Left ex | Just (ScalingStopped reason) <- fromException ex ->
+                    finish reason (if reason `elem` ["time limit reached", "memory limit reached", "available memory reserve reached"] then 0 else 2)
+                | Just UserInterrupt <- fromException ex -> finish "interrupted" 130
+                | Just async <- (fromException ex :: Maybe SomeAsyncException) -> throwIO async
+                | otherwise -> finish (displayException (ex :: SomeException)) 1
+    return code
+
+milliseconds :: TimeSpec -> Double
+milliseconds t = fromIntegral (toNanoSecs t) / 1000000
+
+bytes :: Integer -> String
+bytes n = printf "%.1f MiB" (fromIntegral n / 1048576 :: Double)
+
+formatPoint :: ScalePoint -> Maybe Double -> String
+formatPoint point growth =
+    let values = pointValues "avg_wall_duration" point
+        mean = fromMaybe 0 (scaleMean values)
+        peak = maximum (0 : pointValues "peak_rss" point)
+        trend :: String
+        trend = maybe "inconclusive" (printf "n^%.2f") growth
+    in printf "%12d  %10.3f ms  %9.3f … %9.3f ms  %10.3f µs  %10.1f MiB  %s"
+         (pointScale point) mean (if null values then 0 else minimum values) (maximum (0:values))
+         (mean * 1000 / fromIntegral (pointScale point)) (peak / 1048576) trend

--- a/compiler/acton/TestScale.hs
+++ b/compiler/acton/TestScale.hs
@@ -10,15 +10,16 @@ import qualified Acton.CommandLineParser as C
 import Acton.Testing (TestResult(..))
 import TestPerf
 import PerfMemory
-import ScaleReport (addScaleEvent, printScaleReport)
+import ScaleReport (ScaleRecording(..), ScaleSeries(..), addScaleEvent, printScaleReport)
 import TerminalSize (queryTermSize, termFitAnsiRight)
 import Control.Concurrent (threadDelay)
 import Control.Exception
 import Control.Monad
-import Data.Char (isAscii, isAlphaNum)
+import Data.Char (isAscii, isAlphaNum, isPrint)
 import Data.Maybe (fromMaybe, isJust, mapMaybe)
 import Data.IORef
 import qualified Data.IntMap.Strict as IM
+import qualified Data.Map.Strict as M
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KM
 import qualified Data.ByteString.Lazy.Char8 as BL
@@ -28,6 +29,7 @@ import System.Directory
 import System.FilePath
 import System.IO
 import System.Process
+import qualified System.Posix.IO as PIO
 import Text.Printf
 
 data ScaleLimits = ScaleLimits
@@ -165,25 +167,20 @@ nextScale cap (point:older) =
 
 -- Each sample has its own process and the same amount of warmup and measured
 -- work. The callback reuses the ordinary test runner's result handling.
-runScalingStudy :: Bool -> C.GlobalOptions -> C.TestOptions -> FilePath -> Aeson.Object -> [(String, String)]
+runScalingStudy :: Bool -> C.GlobalOptions -> C.TestOptions -> FilePath -> Aeson.Object -> [(String, String, Maybe String)] -> Maybe ScaleRecording
                 -> (ScaleLimits -> Int -> String -> String -> IO TestResult) -> IO Int
-runScalingStudy useColor gopts opts directory host tests runSample = do
+runScalingStudy useColor gopts opts directory host tests baseline runSample = do
     memory <- readMemoryStatus Nothing >>= either (ioError . userError) return
     (cap, reserve) <- either (ioError . userError) return
       (scaleMemoryLimit (fromMaybe (C.MemoryPercent 50) (C.testMaxMemory opts)) memory)
     start <- getTime Monotonic
     let duration = if C.testMaxTimeSet opts then C.testMaxTime opts else 3600000
         limits = ScaleLimits (start + fromNanoSecs (toInteger duration * 1000000)) cap reserve
-    timestamp <- formatTime defaultTimeLocale "%Y%m%dT%H%M%S.%qZ" <$> getCurrentTime
+    runId <- formatTime defaultTimeLocale "%Y-%m-%dT%H-%M-%S.%qZ" <$> getCurrentTime
     createDirectoryIfMissing True directory
     tty <- hIsTerminalDevice stdout
-    let component = take 80 . map (\c -> if isAscii c && (isAlphaNum c || c `elem` ("._-" :: String)) then c else '_')
-        name = case tests of
-          [] -> "study"
-          (modName, testName):rest -> component modName ++ "." ++ component testName
-            ++ if null rest then "" else "+" ++ show (length rest) ++ "-more"
-        path = directory </> (name ++ "-" ++ timestamp) <.> "jsonl"
-        say = unless (C.testJson opts) . putStrLn
+    let say = unless (C.testJson opts) . putStrLn
+        clean = map (\c -> if isPrint c then c else ' ')
         progress = not (C.testJson opts || C.quiet gopts || C.noProgress gopts)
         live = progress && (tty || C.tty gopts)
         terminal text = when live (putStr text >> hFlush stdout)
@@ -191,156 +188,192 @@ runScalingStudy useColor gopts opts directory host tests runSample = do
         updateProgress text = when live $ do
           (_, cols) <- fromMaybe (24, 80) <$> queryTermSize
           terminal ("\r" ++ termFitAnsiRight (max 0 (cols - 1)) text ++ "\ESC[K")
-    chartData <- newIORef IM.empty
-    code <- withFile path WriteMode $ \journal -> do
-      let emit fields = do
-            let obj = KM.fromList fields
-                line = Aeson.encode (Aeson.Object obj)
-            BL.hPutStrLn journal line
-            hFlush journal
-            when (C.testJson opts) (BL.putStrLn line >> hFlush stdout)
-            unless (C.testJson opts) (modifyIORef' chartData (addScaleEvent obj))
-          event kind fields = emit (("event" Aeson..= (kind :: String)) : fields)
-          finish reason code = do
-            now <- getTime Monotonic
-            event "end" ["reason" Aeson..= reason, "elapsed_ms" Aeson..= milliseconds (now - start)]
-            say ("Stopped: " ++ reason)
-            say ("Results: " ++ path)
-            return code
-          sample modName testName scale reference = do
-            now <- getTime Monotonic
-            when (now >= scaleDeadline limits) (throwIO (ScalingStopped "time limit reached"))
-            event "sample_start" ["module" Aeson..= modName, "test" Aeson..= testName,
-                                  "scale" Aeson..= scale, "reference" Aeson..= reference]
-            res <- runSample limits scale modName testName
-            let raw = trRaw res
-            checked <- try (case testPerfData res of
-              Just obj | trNumIterations res == 1, Just info <- perfInfo obj,
-                         KM.lookup "loop_iterations" obj == Just (Aeson.Number 1),
-                         KM.lookup "scaling" info == Just (Aeson.Bool True),
-                         KM.lookup "scale" info == Just (Aeson.toJSON scale) -> do
-                when (maybe True (<= 0) (perfNumber obj "avg_wall_duration")) $
-                  throwIO (ScalingStopped "wall time measurement unavailable")
-                case perfNumber obj "peak_rss" of
-                  Nothing -> throwIO (ScalingStopped "peak memory measurement unavailable")
-                  Just peak | peak >= fromIntegral cap -> throwIO (ScalingStopped "memory limit reached")
-                  _ -> return obj
-              _ -> throwIO (userError (fromMaybe "Scaling requires a successful test with one measured t.loop() body" (trException res))))
-                :: IO (Either SomeException Aeson.Object)
-            event "sample" ["module" Aeson..= modName, "test" Aeson..= testName,
-                            "scale" Aeson..= scale, "reference" Aeson..= reference, "result" Aeson..= raw,
-                            "stdout" Aeson..= trStdOut res, "stderr" Aeson..= trStdErr res,
-                            "exception" Aeson..= trException res,
-                            "accepted" Aeson..= either (const False) (const True) checked]
-            obj <- either throwIO return checked
-            -- Raw results, including diagnostics, are already on disk.
-            return (KM.filterWithKey (\key _ -> key `elem` ["avg_wall_duration", "peak_rss"]) obj)
-          collect modName testName scale reference = do
-            when (progress && not live) (say ("  sampling " ++ label))
-            gather [] `finally` clearProgress
-            where
-              label = (if reference then "reference scale " else "scale ") ++ show scale
-              gather samples = do
-                let point = ScalePoint scale samples
-                if scaleNeedsSamples point then do
-                  let count = length samples
-                      target = count + if null samples then 3 else 2
-                  more <- forM [count + 1 .. target] $ \index -> do
-                    updateProgress ("  " ++ label ++ " · sample " ++ show index ++ "/" ++ show target)
-                    sample modName testName scale reference
-                  gather (samples ++ more)
-                else return point
-          checkReference modName testName reference = do
-            measured <- collect modName testName (pointScale reference) True
-            let drift = do
-                  guard (scaleReliable reference && scaleReliable measured)
-                  before <- scaleMean (pointValues "avg_wall_duration" reference)
-                  after <- scaleMean (pointValues "avg_wall_duration" measured)
-                  return (after / before - 1)
-                stable = maybe False ((<= 0.2) . abs) drift
-            event "reference" ["module" Aeson..= modName, "test" Aeson..= testName,
-                               "scale" Aeson..= pointScale reference, "change" Aeson..= drift,
-                               "samples" Aeson..= length (pointSamples measured),
-                               "relative_standard_error" Aeson..= scaleError measured,
-                               "stable" Aeson..= stable]
-            unless stable $ say "  Reference measurements changed or remain noisy; continuing to check the trend."
-            return stable
-          endTest modName testName outcome reason points trend = do
-            let first = pointScale (last points)
-                final = pointScale (head points)
-                samples = sum (map (length . pointSamples) points)
-            event "test_end" ["module" Aeson..= modName, "test" Aeson..= testName,
-                              "outcome" Aeson..= (outcome :: String), "reason" Aeson..= reason,
-                              "min_scale" Aeson..= first, "max_scale" Aeson..= final,
-                              "points" Aeson..= length points, "samples" Aeson..= samples,
-                              "stable_from_scale" Aeson..= fmap (\(start, _, _) -> start) trend,
-                              "growth_min" Aeson..= fmap (\(_, lo, _) -> lo) trend,
-                              "growth_max" Aeson..= fmap (\(_, _, hi) -> hi) trend]
-            say ("  " ++ reason ++ "; " ++ show (length points) ++ " sizes, " ++ show samples
-                 ++ " curve samples, scales " ++ show first ++ " … " ++ show final)
-            forM_ trend $ \(start, lo, hi) ->
-              say (printf "  Recent growth: n^%.2f … n^%.2f over scales %d … %d" lo hi start final)
-          study modName testName scale points reference driftFailures = do
-            point <- collect modName testName scale False
-            let points' = point : points
-                growth = case points of old:_ -> scaleGrowth old point; [] -> Nothing
-                trend = stableGrowth points'
-                reference' = case reference of
-                  Nothing | scaleReliable point -> Just point
-                  _ -> reference
-            event "point" ["module" Aeson..= modName, "test" Aeson..= testName,
-                           "scale" Aeson..= scale, "samples" Aeson..= length (pointSamples point),
-                           "wall_mean_ms" Aeson..= scaleMean (pointValues "avg_wall_duration" point),
-                           "relative_standard_error" Aeson..= scaleError point,
-                           "reliable" Aeson..= scaleReliable point,
-                           "observed_exponent" Aeson..= growth]
-            say (formatPoint point growth)
-            -- Start with the first measurable size, rather than a noisy tiny
-            -- probe. Always recheck it before declaring the recent trend stable.
-            checked <- case reference of
-              Just ref | isJust trend || length points' `mod` 4 == 0 ->
-                Just <$> checkReference modName testName ref
-              _ -> return Nothing
-            let failures = case checked of
-                  Just True -> 0
-                  Just False -> driftFailures + 1
-                  Nothing -> driftFailures
-                finish = endTest modName testName
-            if isJust trend && checked == Just True then
-              finish "stable" "Growth stable over the measured range" points' trend
-            else if failures >= 3 then
-              finish "inconclusive" "Reference measurements did not settle" points' Nothing
-            else if length (takeWhile (not . scaleReliable) points') >= 20 then
-              finish "inconclusive" "Timing stayed too short or noisy across 20 successive sizes" points' Nothing
-            else case nextScale cap points' of
-              Nothing -> finish "limited" "Next scale approaches the memory or integer limit" points' Nothing
-              Just next -> study modName testName next points' reference' failures
-      event "study" ["version" Aeson..= (2 :: Int), "host" Aeson..= host,
-                     "max_memory_bytes" Aeson..= cap, "reserve_bytes" Aeson..= reserve,
-                     "max_time_ms" Aeson..= duration, "start_scale" Aeson..= fromMaybe 1 (C.testStartScale opts),
-                     "memory_protection" Aeson..= ("monitored; abrupt allocations can exceed the limit" :: String),
-                     "path" Aeson..= path]
-      say "Scaling study: adaptive range, 3–7 samples per size, one warmup per sample"
-      say ("Safety limits: " ++ show duration ++ "ms, memory ceiling " ++ bytes cap)
-      say "Memory protection is monitored; abrupt allocations can exceed the limit."
-      say ("Results: " ++ path)
-      outcome <- try $ flip finally (terminal "\ESC[?25h") $ do
-        terminal "\ESC[?25l"
-        forM_ tests $ \(modName, testName) -> do
-          writeIORef chartData IM.empty
-          say ("\nScaling " ++ modName ++ "." ++ testName)
-          say "       scale          mean          min … max             time/scale       peak RSS       growth"
-          study modName testName (fromMaybe 1 (C.testStartScale opts)) [] Nothing (0 :: Int)
-            `finally` unless (C.testJson opts)
-              (readIORef chartData >>= printScaleReport useColor (modName ++ "." ++ testName))
-      case outcome of
-        Right () -> finish "all selected studies finished" 0
-        Left ex | Just (ScalingStopped reason) <- fromException ex ->
-                    finish reason (if reason `elem` ["time limit reached", "memory limit reached", "available memory reserve reached"] then 0 else 2)
-                | Just UserInterrupt <- fromException ex -> finish "interrupted" 130
-                | Just async <- (fromException ex :: Maybe SomeAsyncException) -> throwIO async
-                | otherwise -> finish (displayException (ex :: SomeException)) 1
-    return code
+    let runTests [] = return 0
+        runTests ((modName, testName, implementation):rest) = do
+          benchmarkStart <- getTime Monotonic
+          recordedAt <- getCurrentTime
+          let timestamp = formatTime defaultTimeLocale "%Y-%m-%dT%H-%M-%S." recordedAt
+                       ++ take 6 (formatTime defaultTimeLocale "%q" recordedAt) ++ "Z"
+          let component = take 64 . map (\c -> if isAscii c && (isAlphaNum c || c `elem` ("._-" :: String)) then c else '_')
+              name = component modName ++ "." ++ component testName
+              path = directory </> (name ++ "__" ++ timestamp ++ "__" ++ maybe "unknown" (take 12) implementation) <.> "jsonl"
+              old = baseline >>= M.lookup (modName, testName) . recordingTests
+              oldData = maybe IM.empty seriesData old
+              schedule = [n | (n, (True, _)) <- IM.toAscList oldData, maybe True (n >=) (C.testStartScale opts)]
+              firstScale = case schedule of n:_ -> n; [] -> fromMaybe 1 (C.testStartScale opts)
+          chartData <- newIORef IM.empty
+          (code, finished) <- bracket
+            (PIO.openFd path PIO.WriteOnly PIO.defaultFileFlags { PIO.creat = Just 0o600, PIO.exclusive = True } >>= PIO.fdToHandle)
+            hClose $ \journal -> do
+              let emit fields = do
+                    let obj = KM.fromList fields
+                        line = Aeson.encode (Aeson.Object obj)
+                    BL.hPutStrLn journal line
+                    hFlush journal
+                    when (C.testJson opts) (BL.putStrLn line >> hFlush stdout)
+                    unless (C.testJson opts) (modifyIORef' chartData (addScaleEvent obj))
+                  event kind fields = emit (("event" Aeson..= (kind :: String)) : fields)
+                  finish reason code = do
+                    now <- getTime Monotonic
+                    event "end" ["reason" Aeson..= reason, "elapsed_ms" Aeson..= milliseconds (now - benchmarkStart)]
+                    say ("Stopped: " ++ reason)
+                    say ("Results: " ++ path)
+                    return code
+                  sample modName testName scale reference = do
+                    now <- getTime Monotonic
+                    when (now >= scaleDeadline limits) (throwIO (ScalingStopped "time limit reached"))
+                    event "sample_start" ["module" Aeson..= modName, "test" Aeson..= testName,
+                                          "scale" Aeson..= scale, "reference" Aeson..= reference]
+                    res <- runSample limits scale modName testName
+                    let raw = trRaw res
+                    checked <- try (case testPerfData res of
+                      Just obj | trNumIterations res == 1, Just info <- perfInfo obj,
+                                 KM.lookup "loop_iterations" obj == Just (Aeson.Number 1),
+                                 KM.lookup "scaling" info == Just (Aeson.Bool True),
+                                 KM.lookup "scale" info == Just (Aeson.toJSON scale) -> do
+                        when (maybe True (<= 0) (perfNumber obj "avg_wall_duration")) $
+                          throwIO (ScalingStopped "wall time measurement unavailable")
+                        forM_ old $ \previous -> do
+                          let issue = seriesInfo previous >>= (`perfSamplingReason` info)
+                          forM_ issue (throwIO . userError . ("Cannot compare: " ++))
+                        case perfNumber obj "peak_rss" of
+                          Nothing -> throwIO (ScalingStopped "peak memory measurement unavailable")
+                          Just peak | peak >= fromIntegral cap -> throwIO (ScalingStopped "memory limit reached")
+                          _ -> return obj
+                      _ -> throwIO (userError (fromMaybe "Scaling requires a successful test with one measured t.loop() body" (trException res))))
+                        :: IO (Either SomeException Aeson.Object)
+                    event "sample" ["module" Aeson..= modName, "test" Aeson..= testName,
+                                    "scale" Aeson..= scale, "reference" Aeson..= reference, "result" Aeson..= raw,
+                                    "stdout" Aeson..= trStdOut res, "stderr" Aeson..= trStdErr res,
+                                    "exception" Aeson..= trException res,
+                                    "accepted" Aeson..= either (const False) (const True) checked]
+                    obj <- either throwIO return checked
+                    -- Raw results, including diagnostics, are already on disk.
+                    return (KM.filterWithKey (\key _ -> key `elem` ["avg_wall_duration", "peak_rss"]) obj)
+                  collect modName testName scale reference = do
+                    when (progress && not live) (say ("  sampling " ++ label))
+                    gather [] `finally` clearProgress
+                    where
+                      label = (if reference then "reference scale " else "scale ") ++ show scale
+                      gather samples = do
+                        let point = ScalePoint scale samples
+                        if scaleNeedsSamples point then do
+                          let count = length samples
+                              target = count + if null samples then 3 else 2
+                          more <- forM [count + 1 .. target] $ \index -> do
+                            updateProgress ("  " ++ label ++ " · sample " ++ show index ++ "/" ++ show target)
+                            sample modName testName scale reference
+                          gather (samples ++ more)
+                        else return point
+                  checkReference modName testName reference = do
+                    measured <- collect modName testName (pointScale reference) True
+                    let drift = do
+                          guard (scaleReliable reference && scaleReliable measured)
+                          before <- scaleMean (pointValues "avg_wall_duration" reference)
+                          after <- scaleMean (pointValues "avg_wall_duration" measured)
+                          return (after / before - 1)
+                        stable = maybe False ((<= 0.2) . abs) drift
+                    event "reference" ["module" Aeson..= modName, "test" Aeson..= testName,
+                                       "scale" Aeson..= pointScale reference, "change" Aeson..= drift,
+                                       "samples" Aeson..= length (pointSamples measured),
+                                       "relative_standard_error" Aeson..= scaleError measured,
+                                       "stable" Aeson..= stable]
+                    unless stable $ say "  Reference measurements changed or remain noisy; continuing to check the trend."
+                    return stable
+                  endTest modName testName outcome reason points trend = do
+                    let first = pointScale (last points)
+                        final = pointScale (head points)
+                        samples = sum (map (length . pointSamples) points)
+                    event "test_end" ["module" Aeson..= modName, "test" Aeson..= testName,
+                                      "outcome" Aeson..= (outcome :: String), "reason" Aeson..= reason,
+                                      "min_scale" Aeson..= first, "max_scale" Aeson..= final,
+                                      "points" Aeson..= length points, "samples" Aeson..= samples,
+                                      "stable_from_scale" Aeson..= fmap (\(start, _, _) -> start) trend,
+                                      "growth_min" Aeson..= fmap (\(_, lo, _) -> lo) trend,
+                                      "growth_max" Aeson..= fmap (\(_, _, hi) -> hi) trend]
+                    say ("  " ++ reason ++ "; " ++ show (length points) ++ " sizes, " ++ show samples
+                         ++ " curve samples, scales " ++ show first ++ " … " ++ show final)
+                    forM_ trend $ \(start, lo, hi) ->
+                      say (printf "  Recent growth: n^%.2f … n^%.2f over scales %d … %d" lo hi start final)
+                  study modName testName scale points reference driftFailures pending = do
+                    point <- collect modName testName scale False
+                    let points' = point : points
+                        growth = case points of old:_ -> scaleGrowth old point; [] -> Nothing
+                        trend = stableGrowth points'
+                        reference' = case reference of
+                          Nothing | scaleReliable point -> Just point
+                          _ -> reference
+                    event "point" ["module" Aeson..= modName, "test" Aeson..= testName,
+                                   "scale" Aeson..= scale, "samples" Aeson..= length (pointSamples point),
+                                   "wall_mean_ms" Aeson..= scaleMean (pointValues "avg_wall_duration" point),
+                                   "relative_standard_error" Aeson..= scaleError point,
+                                   "reliable" Aeson..= scaleReliable point,
+                                   "observed_exponent" Aeson..= growth]
+                    say (formatPoint point growth)
+                    -- Start with the first measurable size, rather than a noisy tiny
+                    -- probe. Always recheck it before declaring the recent trend stable.
+                    checked <- case reference of
+                      Just ref | not (isJust old) && (isJust trend || length points' `mod` 4 == 0) ->
+                        Just <$> checkReference modName testName ref
+                      _ -> return Nothing
+                    let failures = case checked of
+                          Just True -> 0
+                          Just False -> driftFailures + 1
+                          Nothing -> driftFailures
+                        finish = endTest modName testName
+                    if isJust old then case pending of
+                      [] -> finish "compared" "Completed baseline sizes remeasured" points' Nothing
+                      next:rest -> study modName testName next points' reference' failures rest
+                    else if isJust trend && checked == Just True then
+                      finish "stable" "Growth stable over the measured range" points' trend
+                    else if failures >= 3 then
+                      finish "inconclusive" "Reference measurements did not settle" points' Nothing
+                    else if length (takeWhile (not . scaleReliable) points') >= 20 then
+                      finish "inconclusive" "Timing stayed too short or noisy across 20 successive sizes" points' Nothing
+                    else case nextScale cap points' of
+                      Nothing -> finish "limited" "Next scale approaches the memory or integer limit" points' Nothing
+                      Just next -> study modName testName next points' reference' failures []
+              event "study" ["version" Aeson..= (3 :: Int), "host" Aeson..= host,
+                             "module" Aeson..= modName, "test" Aeson..= testName,
+                             "recorded_at" Aeson..= recordedAt, "run_id" Aeson..= runId,
+                             "implementation_hash" Aeson..= implementation,
+                             "baseline" Aeson..= fmap recordingPath baseline,
+                             "max_memory_bytes" Aeson..= cap, "reserve_bytes" Aeson..= reserve,
+                             "max_time_ms" Aeson..= duration, "start_scale" Aeson..= firstScale,
+                             "memory_protection" Aeson..= ("monitored; abrupt allocations can exceed the limit" :: String),
+                             "path" Aeson..= path]
+              say ((if isJust old then "Scaling comparison: recorded sizes" else "Scaling study: adaptive range")
+                   ++ ", 3–7 samples per size, one warmup per sample")
+              say ("Safety limits: " ++ show duration ++ "ms, memory ceiling " ++ bytes cap)
+              say "Memory protection is monitored; abrupt allocations can exceed the limit."
+              say ("Results: " ++ path)
+              outcome <- try $ flip finally (terminal "\ESC[?25h") $ do
+                terminal "\ESC[?25l"
+                say ("\nScaling " ++ modName ++ "." ++ testName)
+                forM_ baseline $ \previous -> say ("Baseline: " ++ clean (recordingPath previous))
+                say "       scale          mean          min … max             time/scale       peak RSS       growth"
+                study modName testName firstScale [] Nothing (0 :: Int) (drop 1 schedule)
+                  `finally` unless (C.testJson opts) (do
+                    points <- readIORef chartData
+                    when (isJust old) $ do
+                      say ("Current: " ++ takeFileName path)
+                      forM_ baseline (say . ("Baseline: " ++) . clean . takeFileName . recordingPath)
+                      let completed = length [n | n <- schedule, Just (True, _) <- [IM.lookup n points]]
+                      say ("Replayed " ++ show completed ++ " of " ++ show (length schedule) ++ " recorded sizes")
+                      forM_ (old >>= seriesReason) (say . ("Baseline: " ++) . clean)
+                      forM_ baseline $ \previous -> say (maybe "Baseline recording is incomplete"
+                        (("Baseline stopped: " ++) . clean) (recordingStopped previous))
+                    printScaleReport useColor (modName ++ "." ++ testName) points oldData)
+              code <- case outcome of
+                Right () -> finish "benchmark finished" 0
+                Left ex | Just (ScalingStopped reason) <- fromException ex ->
+                            finish reason (if reason `elem` ["time limit reached", "memory limit reached", "available memory reserve reached"] then 0 else 2)
+                        | Just UserInterrupt <- fromException ex -> finish "interrupted" 130
+                        | Just async <- (fromException ex :: Maybe SomeAsyncException) -> throwIO async
+                        | otherwise -> finish (displayException (ex :: SomeException)) 1
+              return (code, case outcome of Right () -> True; _ -> False)
+          if finished then runTests rest else return code
+    runTests tests
 
 milliseconds :: TimeSpec -> Double
 milliseconds t = fromIntegral (toNanoSecs t) / 1000000

--- a/compiler/acton/cbits/perf_memory.c
+++ b/compiler/acton/cbits/perf_memory.c
@@ -1,0 +1,274 @@
+/* Live observations for the performance scaling controller, in bytes.
+ * These are sampled estimates, not a reservation or an OOM guarantee. */
+#include <stdint.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <errno.h>
+#include <string.h>
+
+static int memory_error(char *error, size_t size, const char *format, ...) {
+    va_list args;
+    va_start(args, format);
+    vsnprintf(error, size, format, args);
+    va_end(args);
+    return -1;
+}
+
+static uint64_t smaller(uint64_t a, uint64_t b) {
+    return a < b ? a : b;
+}
+
+#if defined(__linux__)
+#include <stdlib.h>
+#include <inttypes.h>
+#include <limits.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+static int has_word(const char *list, const char *word) {
+    size_t n = strlen(word);
+    for (const char *p = list; p && *p; p = strchr(p, ',')) {
+        if (*p == ',') p++;
+        if (strncmp(p, word, n) == 0 && (p[n] == ',' || p[n] == '\0')) return 1;
+    }
+    return 0;
+}
+
+/* mountinfo escapes whitespace and backslashes as octal sequences. */
+static void unescape_path(char *path) {
+    char *out = path;
+    for (char *p = path; *p; p++) {
+        if (*p == '\\' && p[1] >= '0' && p[1] <= '7'
+            && p[2] >= '0' && p[2] <= '7' && p[3] >= '0' && p[3] <= '7') {
+            *out++ = (char)((p[1] - '0') * 64 + (p[2] - '0') * 8 + p[3] - '0');
+            p += 3;
+        } else {
+            *out++ = *p;
+        }
+    }
+    *out = '\0';
+}
+
+static int cgroup_path(int pid, int *version, char *group, char *error, size_t size) {
+    char path[64];
+    snprintf(path, sizeof(path), "/proc/%d/cgroup", pid);
+    FILE *file = fopen(path, "r");
+    if (!file) return memory_error(error, size, "Cannot read %s: %s", path, strerror(errno));
+    char *line = NULL;
+    size_t capacity = 0;
+    *version = 0;
+    while (getline(&line, &capacity, file) >= 0) {
+        char *controllers = strchr(line, ':');
+        char *member = controllers ? strchr(controllers + 1, ':') : NULL;
+        if (!member) continue;
+        *controllers++ = '\0';
+        *member++ = '\0';
+        member[strcspn(member, "\n")] = '\0';
+        int candidate = has_word(controllers, "memory") ? 1 : strcmp(line, "0") == 0 ? 2 : 0;
+        if (!candidate || (*version == 1 && candidate == 2)) continue;
+        if (member[0] != '/' || strlen(member) >= PATH_MAX
+            || strstr(member, "/../") || strcmp(member, "/..") == 0
+            || (strlen(member) >= 3 && strcmp(member + strlen(member) - 3, "/..") == 0)) {
+            free(line);
+            fclose(file);
+            return memory_error(error, size, "Cannot resolve process memory cgroup");
+        }
+        strcpy(group, member);
+        *version = candidate;
+    }
+    int failed = ferror(file);
+    free(line);
+    fclose(file);
+    return failed ? memory_error(error, size, "Cannot read %s", path) : 0;
+}
+
+static int cgroup_mount(int version, const char *group, char *mount, char *directory,
+                        char *error, size_t size) {
+    FILE *file = fopen("/proc/self/mountinfo", "r");
+    if (!file) return memory_error(error, size, "Cannot read cgroup mounts: %s", strerror(errno));
+    char *line = NULL;
+    size_t capacity = 0, best = SIZE_MAX;
+    while (getline(&line, &capacity, file) >= 0) {
+        char *separator = strstr(line, " - ");
+        if (!separator) continue;
+        char *tail = separator + 3, *save = NULL;
+        char *type = strtok_r(tail, " ", &save);
+        char *source = strtok_r(NULL, " ", &save);
+        char *options = strtok_r(NULL, " \n", &save);
+        if (!type || !source || !options) continue;
+        if (version == 2 ? strcmp(type, "cgroup2") != 0
+                         : strcmp(type, "cgroup") != 0 || !has_word(options, "memory")) continue;
+        *separator = '\0';
+        save = NULL;
+        char *root = NULL, *point = NULL;
+        for (int field = 1; field <= 5; field++) {
+            char *value = strtok_r(field == 1 ? line : NULL, " ", &save);
+            if (!value) break;
+            if (field == 4) root = value;
+            if (field == 5) point = value;
+        }
+        if (!root || !point) continue;
+        unescape_path(root);
+        unescape_path(point);
+        size_t n = strlen(root);
+        const char *relative = NULL;
+        if (strcmp(root, "/") == 0) relative = group;
+        else if (strncmp(group, root, n) == 0 && (group[n] == '/' || group[n] == '\0')) relative = group + n;
+        /* Prefer the mount exposing the most ancestors. A namespace can still
+         * hide limits above its root; they cannot be observed from here. */
+        if (!relative || n >= best || strlen(point) + strlen(relative) >= PATH_MAX) continue;
+        strcpy(mount, point);
+        snprintf(directory, PATH_MAX, "%s%s", point, relative);
+        size_t length = strlen(directory);
+        if (length > 1 && directory[length - 1] == '/') directory[length - 1] = '\0';
+        best = n;
+    }
+    int failed = ferror(file);
+    free(line);
+    fclose(file);
+    if (failed || best == SIZE_MAX) return memory_error(error, size, "Cannot resolve process memory cgroup mount");
+    return 0;
+}
+
+/* 0 means absent (a root or disabled controller), 1 a value, -1 an error. */
+static int cgroup_number(const char *directory, const char *name, uint64_t *value,
+                         char *error, size_t size) {
+    char path[PATH_MAX + 64];
+    snprintf(path, sizeof(path), "%s/%s", directory, name);
+    FILE *file = fopen(path, "r");
+    if (!file) {
+        if (errno == ENOENT) return 0;
+        return memory_error(error, size, "Cannot read %s: %s", path, strerror(errno));
+    }
+    char text[80], extra;
+    int count = fscanf(file, "%79s %c", text, &extra);
+    fclose(file);
+    if (count != 1) return memory_error(error, size, "Invalid memory counter in %s", path);
+    if (strcmp(text, "max") == 0 && strcmp(name, "memory.max") == 0) {
+        *value = UINT64_MAX;
+        return 1;
+    }
+    char *end;
+    errno = 0;
+    unsigned long long parsed = strtoull(text, &end, 10);
+    if (text[0] < '0' || text[0] > '9' || *end || errno == ERANGE)
+        return memory_error(error, size, "Invalid memory counter in %s", path);
+    *value = (uint64_t)parsed;
+    return 1;
+}
+
+static int cgroup_memory(int pid, uint64_t *total, uint64_t *available, char *error, size_t size) {
+    int version;
+    char group[PATH_MAX], mount[PATH_MAX], directory[PATH_MAX];
+    if (cgroup_path(pid, &version, group, error, size)) return -1;
+    if (!version) return 0;
+    if (cgroup_mount(version, group, mount, directory, error, size)) return -1;
+    for (;;) {
+        struct stat info;
+        if (stat(directory, &info) != 0 || !S_ISDIR(info.st_mode))
+            return memory_error(error, size, "Memory cgroup directory is unavailable");
+        uint64_t limit, used;
+        int found = cgroup_number(directory, version == 2 ? "memory.max" : "memory.limit_in_bytes", &limit, error, size);
+        if (found < 0) return -1;
+        if (version == 1 && !found) return memory_error(error, size, "Memory cgroup limit is unavailable");
+        if (found && limit != UINT64_MAX) {
+            if (cgroup_number(directory, version == 2 ? "memory.current" : "memory.usage_in_bytes", &used, error, size) != 1)
+                return memory_error(error, size, "Memory cgroup usage is unavailable");
+            *total = smaller(*total, limit);
+            *available = smaller(*available, used < limit ? limit - used : 0);
+        }
+        if (strcmp(directory, mount) == 0) break;
+        char *slash = strrchr(directory, '/');
+        if (!slash || slash < directory + strlen(mount))
+            return memory_error(error, size, "Cannot walk process memory cgroup ancestors");
+        *slash = '\0';
+    }
+    return 0;
+}
+
+int acton_perf_memory(int pid, uint64_t *total, uint64_t *available, uint64_t *process,
+                      char *error, size_t size) {
+    *total = *available = *process = 0;
+    FILE *file = fopen("/proc/meminfo", "r");
+    if (!file) return memory_error(error, size, "Cannot read /proc/meminfo: %s", strerror(errno));
+    char line[256], key[64], unit[8];
+    uint64_t kb;
+    int found = 0;
+    while (fgets(line, sizeof(line), file)) {
+        if (sscanf(line, "%63[^:]: %" SCNu64 " %7s", key, &kb, unit) != 3) continue;
+        if (strcmp(key, "MemTotal") != 0 && strcmp(key, "MemAvailable") != 0) continue;
+        if (strcmp(unit, "kB") != 0 || kb > UINT64_MAX / 1024) {
+            fclose(file);
+            return memory_error(error, size, "Invalid memory size in /proc/meminfo");
+        }
+        if (strcmp(key, "MemTotal") == 0) { *total = kb * 1024; found |= 1; }
+        else { *available = kb * 1024; found |= 2; }
+    }
+    int failed = ferror(file);
+    fclose(file);
+    if (failed || found != 3 || !*total) return memory_error(error, size, "Host memory availability is unavailable");
+    *available = smaller(*available, *total);
+    if (pid) {
+        char path[64];
+        snprintf(path, sizeof(path), "/proc/%d/statm", pid);
+        file = fopen(path, "r");
+        if (!file) return memory_error(error, size, "Cannot read process memory: %s", strerror(errno));
+        uint64_t virtual_pages, resident_pages;
+        int count = fscanf(file, "%" SCNu64 " %" SCNu64, &virtual_pages, &resident_pages);
+        fclose(file);
+        long page_size = sysconf(_SC_PAGESIZE);
+        if (count != 2 || page_size <= 0 || resident_pages > UINT64_MAX / (uint64_t)page_size)
+            return memory_error(error, size, "Invalid process resident memory");
+        /* statm RSS is cheap and approximate. It does not include descendants. */
+        *process = resident_pages * (uint64_t)page_size;
+    }
+    return cgroup_memory(pid ? pid : (int)getpid(), total, available, error, size);
+}
+
+#elif defined(__APPLE__) && defined(__MACH__)
+#include <mach/mach.h>
+#include <libproc.h>
+#include <sys/resource.h>
+
+int acton_perf_memory(int pid, uint64_t *total, uint64_t *available, uint64_t *process,
+                      char *error, size_t size) {
+    *total = *available = *process = 0;
+    mach_port_t host = mach_host_self();
+    host_basic_info_data_t basic;
+    mach_msg_type_number_t basic_count = HOST_BASIC_INFO_COUNT;
+    vm_statistics64_data_t vm;
+    mach_msg_type_number_t vm_count = HOST_VM_INFO64_COUNT;
+    vm_size_t page_size;
+    kern_return_t result = host_info(host, HOST_BASIC_INFO, (host_info_t)&basic, &basic_count);
+    if (result == KERN_SUCCESS) result = host_page_size(host, &page_size);
+    if (result == KERN_SUCCESS) result = host_statistics64(host, HOST_VM_INFO64, (host_info64_t)&vm, &vm_count);
+    mach_port_deallocate(mach_task_self(), host);
+    if (result != KERN_SUCCESS || basic_count < HOST_BASIC_INFO_COUNT || vm_count < HOST_VM_INFO64_REV1_COUNT)
+        return memory_error(error, size, "Cannot read host memory: Mach error %d", result);
+    if (!basic.max_mem || !page_size) return memory_error(error, size, "Invalid host memory size");
+    *total = basic.max_mem;
+    /* free_count already includes speculative pages. Subtracting all anonymous
+     * pages gives a lower bound on inactive file-backed pages. Do not count
+     * anonymous, wired or compressed memory as available, or add purgeable pages
+     * which can overlap these queues. This estimate can stop a run early. */
+    uint64_t inactive_file = vm.inactive_count > vm.internal_page_count ? vm.inactive_count - vm.internal_page_count : 0;
+    *available = smaller(*total, ((uint64_t)vm.free_count + inactive_file) * (uint64_t)page_size);
+    if (pid) {
+        struct rusage_info_v0 usage;
+        if (proc_pid_rusage(pid, RUSAGE_INFO_V0, (rusage_info_t *)&usage) != 0)
+            return memory_error(error, size, "Cannot read process footprint: %s", strerror(errno));
+        /* Physical footprint includes compressed charges; RSS can fall under
+         * pressure even while the process retains its allocations. */
+        *process = usage.ri_phys_footprint;
+    }
+    return 0;
+}
+
+#else
+int acton_perf_memory(int pid, uint64_t *total, uint64_t *available, uint64_t *process,
+                      char *error, size_t size) {
+    (void)pid; (void)total; (void)available; (void)process;
+    return memory_error(error, size, "Live memory observation requires Linux or macOS");
+}
+#endif

--- a/compiler/acton/cbits/perf_memory.c
+++ b/compiler/acton/cbits/perf_memory.c
@@ -117,10 +117,13 @@ static int cgroup_mount(int version, const char *group, char *mount, char *direc
         else if (strncmp(group, root, n) == 0 && (group[n] == '/' || group[n] == '\0')) relative = group + n;
         /* Prefer the mount exposing the most ancestors. A namespace can still
          * hide limits above its root; they cannot be observed from here. */
-        if (!relative || n >= best || strlen(point) + strlen(relative) >= PATH_MAX) continue;
+        if (!relative || n >= best) continue;
+        size_t point_length = strlen(point), relative_length = strlen(relative);
+        if (point_length >= PATH_MAX || relative_length >= PATH_MAX - point_length) continue;
         strcpy(mount, point);
-        snprintf(directory, PATH_MAX, "%s%s", point, relative);
-        size_t length = strlen(directory);
+        memcpy(directory, point, point_length);
+        memcpy(directory + point_length, relative, relative_length + 1);
+        size_t length = point_length + relative_length;
         if (length > 1 && directory[length - 1] == '/') directory[length - 1] = '\0';
         best = n;
     }
@@ -159,7 +162,7 @@ static int cgroup_number(const char *directory, const char *name, uint64_t *valu
 }
 
 static int cgroup_memory(int pid, uint64_t *total, uint64_t *available, char *error, size_t size) {
-    int version;
+    int version = 0;
     char group[PATH_MAX], mount[PATH_MAX], directory[PATH_MAX];
     if (cgroup_path(pid, &version, group, error, size)) return -1;
     if (!version) return 0;

--- a/compiler/acton/cbits/perf_memory_probe.c
+++ b/compiler/acton/cbits/perf_memory_probe.c
@@ -1,0 +1,50 @@
+#include <stdint.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+
+extern int acton_perf_memory(int, uint64_t *, uint64_t *, uint64_t *, char *, size_t);
+
+static uint64_t observe(int pid) {
+    uint64_t total, available, process;
+    char error[512];
+    if (acton_perf_memory(pid, &total, &available, &process, error, sizeof(error))) {
+        fprintf(stderr, "%s\n", error);
+        exit(1);
+    }
+    printf("pid=%d total=%" PRIu64 " available=%" PRIu64 " process=%" PRIu64 "\n",
+           pid, total, available, process);
+    if (!total || available > total || (pid == 0 && process != 0) || (pid != 0 && process == 0)) exit(2);
+    return process;
+}
+
+int main(void) {
+    observe(0);
+    uint64_t before = observe((int)getpid());
+    const size_t size = 32 * 1024 * 1024;
+    volatile char *memory = malloc(size);
+    if (!memory) return 3;
+    for (size_t i = 0; i < size; i += 4096) memory[i] = 1;
+    uint64_t after = observe((int)getpid());
+    if (after < before + size / 2) return 4;
+    free((void *)memory);
+    uint64_t total, available, process;
+    char error[512];
+    if (!acton_perf_memory(2147483647, &total, &available, &process, error, sizeof(error))) return 5;
+    printf("missing PID rejected: %s\n", error);
+    struct timespec start, end;
+    clock_gettime(CLOCK_MONOTONIC, &start);
+    for (int i = 0; i < 1000; i++) {
+        if (acton_perf_memory((int)getpid(), &total, &available, &process, error, sizeof(error))) {
+            fprintf(stderr, "%s\n", error);
+            return 6;
+        }
+    }
+    clock_gettime(CLOCK_MONOTONIC, &end);
+    double seconds = end.tv_sec - start.tv_sec + (end.tv_nsec - start.tv_nsec) / 1e9;
+    printf("sampling cost: %.1f microseconds/call across 1000 calls\n", seconds * 1000.0);
+    puts("native memory probe passed");
+    return 0;
+}

--- a/compiler/acton/cbits/perf_memory_test.c
+++ b/compiler/acton/cbits/perf_memory_test.c
@@ -1,0 +1,142 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+static char fixture[1024];
+static FILE *fixture_fopen(const char *path, const char *mode);
+
+/* The Linux sampler uses only POSIX filesystem APIs, so these fixtures can also
+ * exercise its cgroup policy on a macOS development host. */
+#ifndef __linux__
+#define __linux__ 1
+#endif
+#define fopen fixture_fopen
+#include "perf_memory.c"
+#undef fopen
+
+static FILE *fixture_fopen(const char *path, const char *mode) {
+    char mapped[2048];
+    const char *name = NULL;
+    if (strcmp(path, "/proc/meminfo") == 0) name = "meminfo";
+    else if (strcmp(path, "/proc/self/mountinfo") == 0) name = "mountinfo";
+    else if (strncmp(path, "/proc/", 6) == 0 && strstr(path, "/cgroup")) name = "cgroup";
+    else if (strncmp(path, "/proc/", 6) == 0 && strstr(path, "/statm")) name = "statm";
+    if (!name) return fopen(path, mode);
+    snprintf(mapped, sizeof(mapped), "%s/%s", fixture, name);
+    return fopen(mapped, mode);
+}
+
+static void write_text(const char *name, const char *text) {
+    char path[2048];
+    snprintf(path, sizeof(path), "%s/%s", fixture, name);
+    FILE *file = fopen(path, "w");
+    if (!file || fputs(text, file) < 0 || fclose(file)) abort();
+}
+
+static void remove_file(const char *name) {
+    char path[2048];
+    snprintf(path, sizeof(path), "%s/%s", fixture, name);
+    if (unlink(path)) abort();
+}
+
+static void make_directory(const char *name) {
+    char path[2048];
+    snprintf(path, sizeof(path), "%s/%s", fixture, name);
+    if (mkdir(path, 0700)) abort();
+}
+
+static void mount_table(const char *root, int version) {
+    char text[4096], escaped[2048];
+    size_t i = 0;
+    for (const char *p = fixture; *p; p++) {
+        if (*p == ' ') { memcpy(escaped + i, "\\040", 4); i += 4; }
+        else escaped[i++] = *p;
+    }
+    escaped[i] = '\0';
+    snprintf(text, sizeof(text), "29 23 0:26 %s %s/cg rw - %s cgroup %s\n",
+             root, escaped, version == 2 ? "cgroup2" : "cgroup", version == 2 ? "rw" : "rw,cpu,memory");
+    write_text("mountinfo", text);
+}
+
+static void expect(const char *name, uint64_t expected_total, uint64_t expected_available) {
+    uint64_t total, available, process;
+    char error[512];
+    int result = acton_perf_memory(0, &total, &available, &process, error, sizeof(error));
+    if (result || total != expected_total || available != expected_available || process != 0) {
+        fprintf(stderr, "%s: result=%d total=%" PRIu64 " available=%" PRIu64 " error=%s\n",
+                name, result, total, available, result ? error : "none");
+        exit(1);
+    }
+}
+
+static void expect_error(const char *name) {
+    uint64_t total, available, process;
+    char error[512];
+    if (!acton_perf_memory(0, &total, &available, &process, error, sizeof(error))) {
+        fprintf(stderr, "%s unexpectedly succeeded\n", name);
+        exit(1);
+    }
+}
+
+int main(int argc, char **argv) {
+    /* The caller owns this temporary directory and removes it after the test. */
+    if (argc != 2 || snprintf(fixture, sizeof(fixture), "%s/cgroup fixtures.XXXXXX", argv[1]) >= (int)sizeof(fixture)) return 2;
+    if (!mkdtemp(fixture)) return 2;
+    make_directory("cg");
+    make_directory("cg/parent");
+    make_directory("cg/parent/leaf");
+    write_text("meminfo", "MemTotal: 1048576 kB\nMemAvailable: 786432 kB\n");
+    write_text("statm", "16 8 4 0 0 0 0\n");
+    write_text("cgroup", "0::/parent/leaf\n");
+    mount_table("/", 2);
+    write_text("cg/parent/memory.max", "536870912\n");
+    write_text("cg/parent/memory.current", "503316480\n");
+    write_text("cg/parent/leaf/memory.max", "268435456\n");
+    write_text("cg/parent/leaf/memory.current", "67108864\n");
+    expect("ancestor headroom and child capacity", 268435456, 33554432);
+    write_text("cg/parent/leaf/memory.current", "300000000\n");
+    expect("usage above limit", 268435456, 0);
+    write_text("cg/parent/memory.max", "max\n");
+    write_text("cg/parent/leaf/memory.max", "max\n");
+    expect("unlimited groups retain host availability", 1073741824, 805306368);
+    write_text("cg/parent/leaf/memory.max", "-1\n");
+    expect_error("negative limit");
+    write_text("cg/parent/leaf/memory.max", "1.5\n");
+    expect_error("fractional limit");
+    write_text("cg/parent/leaf/memory.max", "268435456\n");
+    remove_file("cg/parent/leaf/memory.current");
+    expect_error("missing usage");
+    write_text("cg/parent/leaf/memory.current", "max\n");
+    expect_error("invalid usage");
+    write_text("cg/parent/leaf/memory.current", "67108864\n");
+    write_text("cg/parent/memory.max", "536870912\n");
+    write_text("cgroup", "0::/container/parent/leaf\n");
+    mount_table("/container", 2);
+    expect("mount root and escaped mountpoint", 268435456, 33554432);
+    write_text("cgroup", "0::/\n");
+    mount_table("/", 2);
+    write_text("cg/memory.max", "67108864\n");
+    write_text("cg/memory.current", "16777216\n");
+    expect("namespace root still has a limit", 67108864, 50331648);
+    write_text("cgroup", "0::/parent/missing\n");
+    expect_error("vanished cgroup");
+    write_text("cgroup", "0::/../outside\n");
+    expect_error("membership outside the namespace");
+    write_text("cgroup", "2:cpu,memory:/parent/leaf\n");
+    mount_table("/", 1);
+    write_text("cg/memory.limit_in_bytes", "9223372036854771712\n");
+    write_text("cg/memory.usage_in_bytes", "0\n");
+    write_text("cg/parent/memory.limit_in_bytes", "536870912\n");
+    write_text("cg/parent/memory.usage_in_bytes", "503316480\n");
+    write_text("cg/parent/leaf/memory.limit_in_bytes", "268435456\n");
+    write_text("cg/parent/leaf/memory.usage_in_bytes", "67108864\n");
+    expect("v1 ancestor limits", 268435456, 33554432);
+    write_text("cgroup", "1:name=systemd:/\n");
+    expect("no memory controller", 1073741824, 805306368);
+    write_text("meminfo", "MemTotal: 1048576 kB\n");
+    expect_error("missing MemAvailable");
+    printf("native Linux memory fixtures passed (%s)\n", fixture);
+    return 0;
+}

--- a/compiler/acton/cbits/perf_memory_test.c
+++ b/compiler/acton/cbits/perf_memory_test.c
@@ -135,6 +135,27 @@ int main(int argc, char **argv) {
     expect("v1 ancestor limits", 268435456, 33554432);
     write_text("cgroup", "1:name=systemd:/\n");
     expect("no memory controller", 1073741824, 805306368);
+    remove_file("cgroup");
+    expect_error("unreadable cgroup membership");
+    write_text("cgroup", "1:name=systemd:/\n");
+
+    /* Check the join directly: stat() would hide a truncated path later. */
+    mount_table("/", 2);
+    char group[PATH_MAX], mount[PATH_MAX], directory[PATH_MAX], error[512];
+    size_t group_length = PATH_MAX - 1 - (strlen(fixture) + 3);
+    memset(group, 'x', sizeof(group));
+    group[0] = '/';
+    group[group_length] = '\0';
+    if (cgroup_mount(2, group, mount, directory, error, sizeof(error))
+        || strlen(directory) != PATH_MAX - 1
+        || strcmp(directory + strlen(mount), group) != 0) abort();
+    group[group_length] = 'x';
+    group[group_length + 1] = '\0';
+    strcpy(mount, "unchanged");
+    strcpy(directory, "unchanged");
+    if (!cgroup_mount(2, group, mount, directory, error, sizeof(error))
+        || strcmp(mount, "unchanged") || strcmp(directory, "unchanged")) abort();
+
     write_text("meminfo", "MemTotal: 1048576 kB\n");
     expect_error("missing MemAvailable");
     printf("native Linux memory fixtures passed (%s)\n", fixture);

--- a/compiler/acton/package.yaml.in
+++ b/compiler/acton/package.yaml.in
@@ -15,6 +15,9 @@ copyright:           "Data Ductus, Deutsche Telekom"
 # common to point users to the README.md file.
 description:         Please see the README on Github at <https://github.com/githubuser/simple#readme>
 
+c-sources:
+  - cbits/perf_memory.c
+
 dependencies:
   - MissingH
   - libacton
@@ -22,6 +25,7 @@ dependencies:
   - async
   - base >= 4.7 && < 5
   - base16-bytestring
+  - base64-bytestring
   - binary
   - bytestring
   - clock
@@ -60,6 +64,7 @@ dependencies:
   - unordered-containers
   - wcwidth
   - regex-tdfa
+  - zlib
   
 executables:
   acton:
@@ -77,7 +82,10 @@ executables:
       - TestFormat
       - TestOutput
       - TestPerf
+      - PerfMemory
       - TestRunner
+      - TestScale
+      - ScaleReport
       - TestUI
     ghc-options:
       - -threaded

--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -35,6 +35,9 @@ import qualified Repl
 import qualified WatchTests
 import qualified PerfTests
 import qualified TestOutputTests
+import qualified ScaleOptionTests
+import qualified ScaleTests
+import qualified PerfMemoryTests
 import qualified TestGolden
 
 -- The default is to build and run each test program with the expectation that
@@ -80,6 +83,9 @@ main = do
       , WatchTests.watchProcessTests
       , PerfTests.perfTests
       , TestOutputTests.testOutputTests
+      , ScaleOptionTests.scaleOptionTests
+      , ScaleTests.scaleTests
+      , PerfMemoryTests.perfMemoryTests
       , crossCompileTests
       , pkgCliTests
       ]

--- a/compiler/acton/test.hs
+++ b/compiler/acton/test.hs
@@ -47,6 +47,7 @@ import qualified TestGolden
 -- the file with __rf.act (for Run Failure).
 
 main = do
+    environment <- getEnvironment
 #if defined(darwin_HOST_OS)
     let segfault_exitcode = (ExitFailure (-11))
 #else
@@ -88,7 +89,8 @@ main = do
       , PerfMemoryTests.perfMemoryTests
       , crossCompileTests
       , pkgCliTests
-      ]
+      ] ++ [ testGroup "live performance" [PerfTests.perfIntegrationTests, ScaleTests.scaleIntegrationTests]
+           | lookup "ACTON_TEST_PERFORMANCE" environment == Just "1" ]
   where timeout :: Timeout
         timeout = mkTimeout (30*60*1000000)
         -- this normally doesn't take long on a local machine but in GitHub

--- a/compiler/lib/src/Acton/CommandLineParser.hs
+++ b/compiler/lib/src/Acton/CommandLineParser.hs
@@ -152,7 +152,7 @@ data TestCommand
     | TestList TestOptions
     | TestPerf TestOptions
     | TestScale TestOptions
-    | TestScaleReport FilePath
+    | TestScaleReport FilePath (Maybe FilePath)
     | TestStress TestOptions
     deriving Show
 
@@ -175,6 +175,7 @@ data TestOptions = TestOptions
     , testScale        :: Maybe Int
     , testStartScale   :: Maybe Int
     , testMaxMemory    :: Maybe MemoryLimit
+    , testCompare      :: Maybe FilePath
     , testStressWorkers :: Int
     , testTags         :: [String]
     , testMaxIterSet   :: Bool
@@ -514,8 +515,12 @@ testCommand =
       )
     <|> (TestRun <$> testOptions OrdinaryOptions)
   where
-    scaleCommand = TestScaleReport <$> strOption (long "report" <> metavar "FILE" <> help "Render charts from a saved scaling journal without running tests")
-               <|> TestScale <$> testOptions ScaleOptions
+    scaleCommand = scaling
+      <$> optional (strOption (long "compare" <> metavar "FILE" <> help "Compare against a saved scaling journal; live runs remeasure its completed sizes"))
+      <*> (Left <$> strOption (long "report" <> metavar "FILE" <> help "Render charts from a saved scaling journal without running tests")
+           <|> Right <$> testOptions ScaleOptions)
+    scaling baseline (Left path) = TestScaleReport path baseline
+    scaling baseline (Right opts) = TestScale opts { testCompare = baseline }
 
 data TestOptionsMode = OrdinaryOptions | PerfOptions | ScaleOptions deriving Eq
 
@@ -565,6 +570,7 @@ testOptions mode = mkTestOptions
         , testScale = testScale
         , testStartScale = testStartScale
         , testMaxMemory = testMaxMemory
+        , testCompare = Nothing
         , testStressWorkers = testStressWorkers
         , testTags = testTags
         , testMaxIterSet = isJust testMaxIterOpt

--- a/compiler/lib/src/Acton/CommandLineParser.hs
+++ b/compiler/lib/src/Acton/CommandLineParser.hs
@@ -151,8 +151,12 @@ data TestCommand
     = TestRun TestOptions
     | TestList TestOptions
     | TestPerf TestOptions
+    | TestScale TestOptions
+    | TestScaleReport FilePath
     | TestStress TestOptions
     deriving Show
+
+data MemoryLimit = MemoryPercent Double | MemoryBytes Integer deriving (Show, Eq)
 
 data TestOptions = TestOptions
     { testCompile      :: CompileOptions
@@ -169,6 +173,8 @@ data TestOptions = TestOptions
     , testMinTime      :: Int
     , testTime         :: Int
     , testScale        :: Maybe Int
+    , testStartScale   :: Maybe Int
+    , testMaxMemory    :: Maybe MemoryLimit
     , testStressWorkers :: Int
     , testTags         :: [String]
     , testMaxIterSet   :: Bool
@@ -501,14 +507,20 @@ requestedOptimizeOption = resolveOptimizeOption
 testCommand :: Parser TestCommand
 testCommand =
     hsubparser
-      (  command "list" (info (TestList <$> testOptions False) (progDesc "List project tests"))
-      <> command "perf" (info (TestPerf <$> testOptions True) (progDesc "Measure test performance"))
-      <> command "stress" (info (TestStress <$> testOptions False) (progDesc "Run stress tests"))
+      (  command "list" (info (TestList <$> testOptions OrdinaryOptions) (progDesc "List project tests"))
+      <> command "perf" (info (TestPerf <$> testOptions PerfOptions) (progDesc "Measure test performance"))
+      <> command "scale" (info scaleCommand (progDesc "Measure how performance changes with workload scale"))
+      <> command "stress" (info (TestStress <$> testOptions OrdinaryOptions) (progDesc "Run stress tests"))
       )
-    <|> (TestRun <$> testOptions False)
+    <|> (TestRun <$> testOptions OrdinaryOptions)
+  where
+    scaleCommand = TestScaleReport <$> strOption (long "report" <> metavar "FILE" <> help "Render charts from a saved scaling journal without running tests")
+               <|> TestScale <$> testOptions ScaleOptions
 
-testOptions :: Bool -> Parser TestOptions
-testOptions perfMode = mkTestOptions
+data TestOptionsMode = OrdinaryOptions | PerfOptions | ScaleOptions deriving Eq
+
+testOptions :: TestOptionsMode -> Parser TestOptions
+testOptions mode = mkTestOptions
     <$> compileOptionsWith (fromMaybe defaultOptimize <$> requestedOptimizeOption)
     <*> switch (long "show-log"      <> help "Show test log output")
     <*> switch (long "show-cached"   <> help "Show cached test results")
@@ -519,18 +531,23 @@ testOptions perfMode = mkTestOptions
     <*> ordinary (-1) (option auto (long "iter" <> metavar "N" <> value (-1) <> help "Number of iterations to run a test"))
     <*> ordinary Nothing (optional (option auto (long "max-iter" <> metavar "N" <> help "Maximum number of iterations to run a test (mode defaults when omitted)")))
     <*> ordinary 3 (option auto (long "min-iter" <> metavar "N" <> value 3 <> help "Minimum number of iterations to run a test"))
-    <*> ordinary Nothing (optional (option auto (long "max-time" <> metavar "MS" <> help "Maximum time to run a test in milliseconds (0 = no time limit, mode defaults when omitted)")))
+    <*> (case mode of
+           ScaleOptions -> optional (option durationReader (long "max-time" <> metavar "DURATION" <> help "Maximum scaling study duration (e.g. 2h; default: 1h)"))
+           PerfOptions -> pure Nothing
+           OrdinaryOptions -> optional (option auto (long "max-time" <> metavar "MS" <> help "Maximum time to run a test in milliseconds (0 = no time limit, mode defaults when omitted)")))
     <*> ordinary Nothing (optional (option auto (long "min-time" <> metavar "MS" <> help "Minimum time to run a test in milliseconds")))
-    <*> (if perfMode then option durationReader (long "time" <> metavar "DURATION" <> value 5000 <> help "Total budget per benchmark, including calibration (e.g. 5s or 250ms; default: 5s)") else pure 5000)
-    <*> (if perfMode then optional (option scaleReader (long "scale" <> metavar "N" <> help "Use this positive workload scale for t.loop(), skipping calibration")) else pure Nothing)
+    <*> (if mode == PerfOptions then option durationReader (long "time" <> metavar "DURATION" <> value 5000 <> help "Total budget per benchmark, including calibration (e.g. 5s or 250ms; default: 5s)") else pure 5000)
+    <*> (if mode == PerfOptions then optional (option scaleReader (long "scale" <> metavar "N" <> help "Use this positive workload scale for t.loop(), skipping calibration")) else pure Nothing)
+    <*> (if mode == ScaleOptions then optional (option scaleReader (long "start-scale" <> metavar "N" <> help "First positive workload scale in a scaling study (default: 1)")) else pure Nothing)
+    <*> (if mode == ScaleOptions then optional (option memoryLimitReader (long "max-memory" <> metavar "LIMIT" <> help "Scaling study memory limit, as bytes or a percentage (e.g. 2GiB or 50%; default: 50%)")) else pure Nothing)
     <*> ordinary 0 (option auto (long "stress-workers" <> metavar "N" <> value 0 <> help "Concurrent stress workers to run in stress mode (0 = auto)"))
     <*> many (strOption (long "tag" <> metavar "TAG" <> help "Enable test capability TAG for testing.require()"))
     <*> many (strOption (long "module" <> metavar "MODULE" <> help "Filter on test module name"))
     <*> many (strOption (long "name" <> metavar "NAME" <> help "Filter on test name (regex, anchored; use .* for substrings)"))
   where
-    defaultOptimize = if perfMode then ReleaseFast else Debug
-    ordinary fallback parser = if perfMode then pure fallback else parser
-    mkTestOptions testCompile testShowLog testShowCached testNoCache testJson testRecord testSnapshotUpdate testIter testMaxIterOpt testMinIter testMaxTimeOpt testMinTimeOpt testTime testScale testStressWorkers testTags testModules testNames =
+    defaultOptimize = if mode == OrdinaryOptions then Debug else ReleaseFast
+    ordinary fallback parser = if mode == OrdinaryOptions then parser else pure fallback
+    mkTestOptions testCompile testShowLog testShowCached testNoCache testJson testRecord testSnapshotUpdate testIter testMaxIterOpt testMinIter testMaxTimeOpt testMinTimeOpt testTime testScale testStartScale testMaxMemory testStressWorkers testTags testModules testNames =
       TestOptions
         { testCompile = testCompile
         , testShowLog = testShowLog
@@ -546,6 +563,8 @@ testOptions perfMode = mkTestOptions
         , testMinTime = fromMaybe 50 testMinTimeOpt
         , testTime = testTime
         , testScale = testScale
+        , testStartScale = testStartScale
+        , testMaxMemory = testMaxMemory
         , testStressWorkers = testStressWorkers
         , testTags = testTags
         , testMaxIterSet = isJust testMaxIterOpt
@@ -560,12 +579,24 @@ scaleReader = eitherReader $ \s -> case reads s :: [(Integer, String)] of
     [(n, "")] | n > 0 && n <= toInteger (maxBound :: Int) -> Right (fromInteger n)
     _ -> Left "Expected a positive workload scale that fits in an integer"
 
+memoryLimitReader :: ReadM MemoryLimit
+memoryLimitReader = eitherReader $ \s -> case reads s :: [(Double, String)] of
+    [(p, "%")] | not (isNaN p || isInfinite p) && p > 0 && p <= 100 -> Right (MemoryPercent p)
+    _ -> case reads s :: [(Integer, String)] of
+      [(n, unit)] | n > 0, Just factor <- lookup (map toLower unit) units -> Right (MemoryBytes (n * factor))
+      _ -> Left "Expected positive integer bytes (e.g. 2GiB) or a percentage greater than 0 and at most 100%"
+  where
+    units = [("", 1), ("b", 1), ("kb", 1000), ("mb", 1000^2), ("gb", 1000^3), ("tb", 1000^4),
+             ("kib", 1024), ("mib", 1024^2), ("gib", 1024^3), ("tib", 1024^4)]
+
 durationReader :: ReadM Int
 durationReader = eitherReader $ \s -> case reads s :: [(Double, String)] of
     [(number, unit)] ->
       let milliseconds = case map toLower unit of
             "ms" -> number
             "s" -> number * 1000
+            "m" -> number * 60000
+            "h" -> number * 3600000
             _ -> 0
       in if isNaN milliseconds || isInfinite milliseconds || milliseconds < 1
            then Left expected
@@ -575,7 +606,7 @@ durationReader = eitherReader $ \s -> case reads s :: [(Double, String)] of
                      else Right (fromInteger rounded)
     _ -> Left expected
   where
-    expected = "Expected a positive duration such as 5s or 250ms (minimum 1ms)"
+    expected = "Expected a positive duration such as 250ms, 5s, 2m or 1h (minimum 1ms)"
 
 depOverrideReader :: ReadM (String,String)
 depOverrideReader = eitherReader $ \s ->

--- a/docs/acton-dev-guide/src/getting_started/tests.md
+++ b/docs/acton-dev-guide/src/getting_started/tests.md
@@ -25,6 +25,20 @@ make test-rts
 make test-backend
 ```
 
+## Performance integration tests
+
+Live `acton test perf` and `acton test scale` integration tests are opt-in:
+
+```sh
+make test-performance
+```
+
+Run these on a quiet machine with suitable hardware. The target enables
+`ACTON_TEST_PERFORMANCE=1` and runs the `live performance` group sequentially.
+Normal `make test` and `stack test` runs keep the option, statistics, recording
+report, memory-monitor and simulated-controller checks, without collecting live
+benchmark measurements.
+
 ## Snapshot / acceptance tests
 
 Some compiler suites have explicit accept targets that update expected output:

--- a/docs/acton-guide/src/testing.md
+++ b/docs/acton-guide/src/testing.md
@@ -50,8 +50,9 @@ For snapshot-based assertions, see [Snapshot testing](testing/snapshot.md).
 
 Use `acton test perf` to measure tests with warmup and fresh performance
 measurements. Use `for scale in t.loop():` to measure a region while excluding
-setup and teardown; ordinary testing runs its body once at scale 1. See
-[Performance testing](testing/performance.md) for the lifecycle and examples.
+setup and teardown; ordinary testing runs its body once at scale 1. Use
+`acton test scale` to explore growth automatically across increasing workloads.
+See [Performance testing](testing/performance.md) for the lifecycle and examples.
 
 ## Cached test results
 

--- a/docs/acton-guide/src/testing/performance.md
+++ b/docs/acton-guide/src/testing/performance.md
@@ -134,19 +134,58 @@ needed. Completed measurements remain in the table. Redirected output prints
 one status line per size or reference check; `--no-progress` suppresses sampling
 status.
 
-Each study writes its own JSON Lines journal under `out/perf_scaling/`.
-Filenames include the module, test name and UTC timestamp. When several tests
-are selected, the first test's name is followed by `+N-more`; the journal contains
-the whole study.
+Each benchmark writes its own JSON Lines journal under `out/perf_scaling/`.
+Filenames include the module, test name, UTC timestamp and a short implementation
+hash, for example
+`perf.dct._test_dct__2026-09-11T19-05-20.643370Z__a1b2c3d4e5f6.jsonl`.
+The header retains the full hash, timestamp, machine and build settings,
+compiler version and available Git revision and dirty status. A common run ID
+connects benchmarks selected by the same command. Renaming a file is harmless;
+the journal contents identify its benchmark.
+
+The implementation hash covers the test's typed Acton code and its tracked
+implementation dependencies. Changing the sampling settings does not change
+this hash. It does not cover external input files, handwritten C or the
+compiler/runtime binaries. Those can affect performance even when the benchmark
+hash stays the same. An unavailable hash is shown as `unknown` in the filename.
+
 To display an earlier recording with the same terminal charts:
 
 ```sh
-acton test scale --report out/perf_scaling/perf.dct._test_dct-20260911T185315.562647000000Z.jsonl
+acton test scale --report after.jsonl
 ```
 
 Use the path printed by that run. Rendering only reads the journal, so it works
 outside the project without compiling or running tests. Completed samples from
 interrupted studies remain visible, with unfinished sizes marked as partial.
+
+Compare two recordings, or run the benchmark again against a recording:
+
+```sh
+acton test scale --report after.jsonl --compare before.jsonl
+acton test scale --compare before.jsonl
+```
+
+Each option takes one filename. `--compare` always supplies the baseline.
+The charts overlay at most two studies, with solid current curves and dashed
+baseline curves. Both retain their full recorded ranges and distinguish partial
+points. Comparison requires the same machine, build settings, input tags,
+measurement version, loop usage, GC policy and runtime worker count. Different
+implementation hashes are expected. Files without enough measurement identity
+can still be displayed individually.
+
+A live comparison selects the recorded benchmark before compilation, then
+remeasures its completed sizes in ascending order using fresh processes and the
+usual warmup and repeat policy. It finishes after those sizes rather than
+stopping early when a growth trend appears stable. `--start-scale` restricts the
+schedule to recorded sizes at or above that value. Current time and memory
+ceilings still apply; an early stop retains the partial curve and reports which
+baseline sizes were not reached. Every run writes a new recording and leaves
+the baseline untouched.
+
+Older journals containing multiple benchmarks require `--module` and/or `--name`
+to select one for a live comparison. Two-file reports compare matching benchmark
+identities. Old timestamp-only filenames and journal formats remain readable.
 
 Every sample start and completed result is flushed immediately, so
 interruption leaves the completed work available and identifies the unfinished

--- a/docs/acton-guide/src/testing/performance.md
+++ b/docs/acton-guide/src/testing/performance.md
@@ -35,6 +35,148 @@ finishes a whole invocation, so slow work can overrun it. A separate watchdog
 allows at least five minutes for a slow test; longer budgets extend it.
 Compilation is outside the benchmark budget.
 
+## Studying growth with input size
+
+Use `acton test scale` to explore how performance changes with input size:
+
+```sh
+acton test scale
+```
+
+No flags are required. The runner increases the workload and collects repeated
+measurements until the observed growth settles over a broad range, or a resource
+limit stops the study. There is no fixed number of points or target duration.
+To select a starting scale or change the resource ceilings:
+
+```sh
+acton test scale --name my_test \
+    --start-scale 1000 --max-memory 50% --max-time 2h
+```
+
+The study starts at scale 1 unless `--start-scale` is given. It normally doubles
+the scale between points, taking smaller steps when previous measurements predict
+that the next workload will approach the memory ceiling. Short and noisy points
+remain in the results. The default ceiling is 50% of physical memory, reduced by
+visible container limits and available memory headroom. `--max-memory` also
+accepts byte quantities such as `512MiB` or `4GiB`. The runner prints the actual
+ceiling before starting.
+
+`--max-time` caps the entire study across all selected tests, including process
+startup, warmup, setup and teardown. It defaults to one hour; durations support
+`ms`, `s`, `m` and `h`. Compilation is outside this budget. The parent stops a
+running sample when the deadline expires. This is a safety ceiling, not the usual
+completion condition. `--time` and `--scale` belong to `acton test perf`; use
+`--max-time` and `--start-scale` with `acton test scale`.
+
+Scale must represent the workload dimension you want to investigate. For example,
+sorting `scale` elements tests growth with input size. Sorting the same small
+list `scale` times measures repetition. If scale represents the side length of
+a matrix, quadratic growth in its element count is expected. The runner can
+require `t.loop()`, but cannot verify what the test does with the yielded value.
+
+Each point starts with three samples. If mean wall time is at least 0.1ms and
+the estimated relative standard error exceeds 5%, the runner takes two more
+samples, then another two if needed, for at most seven. Relative standard error
+is the sample standard deviation divided by the square root of the sample count
+and by the mean. It guides sampling; it is not a confidence guarantee. A point
+below the timing floor advances to a larger scale instead of collecting more
+samples at the same size.
+
+Every sample uses a fresh process that runs one complete warmup invocation
+followed by one complete measured invocation. In both invocations, `t.loop()`
+yields the requested scale exactly once. The measured invocation has fresh setup
+and teardown, while retaining the process's warmed runtime and GC state. Three
+samples therefore cost six complete invocations. No extra loop repetitions fill
+a time budget. Natural GC remains enabled. Peak RSS includes startup, setup,
+warmup and teardown; it is process capacity, not a count of live application
+data. Allocation volume is recorded separately.
+
+The table and plots show mean wall time, sample ranges, time per unit of scale,
+peak RSS and observed growth between successive sizes. An exponent near 1 means
+time grew roughly linearly over those sizes; near 2 means roughly quadratically.
+A growth estimate needs at least three samples at both sizes, mean times of at
+least 0.1ms and relative standard errors no greater than 5%.
+
+The runner reports stable growth after covering at least 1000 times the first
+reliable scale and finding five consecutive reliable growth estimates whose
+total spread is at most 0.25. Each step in that window must increase scale by at
+least 1.5 times. A bend or unreliable point breaks the window. The first reliable
+scale is rechecked every four sizes and before declaring stability. Each check
+uses three to seven samples under the same precision rule. It must remain
+reliable and its mean must stay within 20% of the original mean. Reference checks
+are separate observations, not additional curve samples. The study ends as
+inconclusive after three consecutive failed reference checks, or 20 consecutive
+sizes that remain too short or too variable.
+
+These are practical stopping heuristics. Stable growth describes the measured
+range; it does not prove an algorithm's asymptotic complexity or rule out a bend
+at a larger size. The result includes the covered scales, point and sample counts,
+and the recent scale range that supports its growth summary. A resource limit
+leaves a partial curve with the stopping reason.
+
+Each benchmark ends with terminal charts for time, time divided by scale and
+process peak memory. Both axes are logarithmic. Points show means, bars show
+sample ranges, and hollow points mark incomplete sampling at a size. Flat
+time/scale suggests roughly linear time over the measured range. The wall-time
+chart includes a dashed guide for time proportional to scale, anchored at the
+largest completed size. It is an illustration, not a fitted model or a complexity
+claim. Each chart highlights its latest point and shows its latest mean.
+Cyan, violet and teal distinguish time, time/scale and memory; `--color never`
+and `NO_COLOR` select monochrome output. The summary counts curve samples
+separately from reference checks and identifies partial sizes. Kitty and
+Ghostty use inline graphics; other terminals, multiplexers and redirected output
+use Unicode plots. Very small terminals keep the table without charts. No
+external image viewer is needed, and drawing happens after measurement.
+
+While sampling, one terminal line shows the current scale and sample number.
+The target increases from three to five or seven when more measurements are
+needed. Completed measurements remain in the table. Redirected output prints
+one status line per size or reference check; `--no-progress` suppresses sampling
+status.
+
+Each study writes its own JSON Lines journal under `out/perf_scaling/`.
+Filenames include the module, test name and UTC timestamp. When several tests
+are selected, the first test's name is followed by `+N-more`; the journal contains
+the whole study.
+To display an earlier recording with the same terminal charts:
+
+```sh
+acton test scale --report out/perf_scaling/perf.dct._test_dct-20260911T185315.562647000000Z.jsonl
+```
+
+Use the path printed by that run. Rendering only reads the journal, so it works
+outside the project without compiling or running tests. Completed samples from
+interrupted studies remain visible, with unfinished sizes marked as partial.
+
+Every sample start and completed result is flushed immediately, so
+interruption leaves the completed work available and identifies the unfinished
+sample. `--json`
+streams these same events to standard output. The final event explains whether
+the study reached a time or memory limit, completed its selected tests, was
+interrupted, or encountered an error. No interrupted measurement is fitted as a
+completed point. The ordinary `perf_data` baseline is untouched; `--record` and
+snapshot updates are not supported during a scaling study.
+Each sample may emit at most 1MiB on each output stream. Exceeding this limit
+stops the study with an error so diagnostic output cannot exhaust the runner's
+memory during a long study. Raw diagnostics stay in the journal; terminal charts
+retain only timing and peak memory samples for the current benchmark.
+
+The memory guard monitors the benchmark process during execution and leaves a
+reserve for other work. Linux observes RSS and visible cgroup memory limits;
+macOS observes physical footprint and uses a conservative estimate of available
+pages. This is a best-effort guard, not a memory reservation or an OS-enforced
+allocation limit. A sudden allocation can exceed it before the next observation,
+and macOS can stop earlier than its apparent reclaimable memory would suggest.
+Memory in separate child processes is not included in the benchmark process's
+ceiling, although the machine's available headroom is still checked. Unavailable
+memory observations stop the study with an error. Supported platforms are Linux
+and macOS.
+
+Compare curves only on the same machine, at matching scales and with matching
+build, input and runtime settings. Cache effects, GC, input distribution and
+machine load all affect observed growth; the raw results retain timing and CPU
+counters for investigating these effects.
+
 ## Choosing the measured work
 
 Use `for scale in t.loop():` on a `testing.SyncT`, `testing.AsyncT` or

--- a/test/stdlib_tests/src/test_testing_perf.act
+++ b/test/stdlib_tests/src/test_testing_perf.act
@@ -60,6 +60,24 @@ def _test_loop_preserves_recorded_scale(t: testing.SyncT):
     assert len(run.calibration) == 0
 
 
+def _test_scaling_measures_one_body_after_one_warmup(t: testing.SyncT):
+    run = testing.PerfRun(1, scale=37, scaling=True)
+    run.loop = True
+    assert run.phase == "warmup"
+    warmup = run.next_loop(0)
+    assert list(warmup.claim()) == [37]
+    assert warmup.iterations == 1
+    assert warmup._wall_ns == 0
+    assert not run.observe(warmup, 0.0, 0.0)
+    assert run.phase == "measure"
+    sample = run.next_loop(0)
+    assert list(sample.claim()) == [37]
+    assert sample.iterations == 1
+    assert run.observe(sample, 0.0, float(sample._wall_ns) / 1000000.0)
+    assert run.loop_iterations == 1
+    assert len(run.calibration) == 0
+
+
 def _test_ordinary_loop_and_closed_context(t: testing.SyncT):
     loop = testing.PerfLoop()
     assert list(loop.claim()) == [1]


### PR DESCRIPTION
Add acton test scale to explore how time and memory usage grow with workload size. It increases the scale passed through t.loop(), repeats measurements, and checks a reference workload before reporting stable growth. Studies have configurable time limits and monitored memory limits.

Show progress and terminal charts, and save each benchmark in a recording named with its module, test, timestamp and implementation hash. --report FILE displays a recording; --compare FILE compares it with another recording or remeasures its completed sizes in a new run.

Keep live perf and scale integration tests behind make test-performance so normal CI runs the deterministic checks.
