### PR TITLE
Improve workload scaling measurements

### DIFF
--- a/base/rts/perf.c
+++ b/base/rts/perf.c
@@ -1,6 +1,8 @@
 #include "perf.h"
 
 #include <errno.h>
+#include <inttypes.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <uv.h>
@@ -18,6 +20,36 @@
 static const char *perf_status = "not enabled at process start";
 static const char *perf_scope = "process:user+kernel";
 static bool perf_enabled;
+
+bool rts_perf_peak_rss(uint64_t *bytes) {
+#if defined(__linux__)
+    // getrusage retains the launcher's high-water mark across exec on Linux.
+    // VmHWM belongs to this executable's address space instead.
+    FILE *status = fopen("/proc/self/status", "r");
+    if (!status)
+        return false;
+    char line[256], unit[3];
+    uint64_t kib;
+    bool found = false;
+    while (fgets(line, sizeof(line), status)) {
+        if (sscanf(line, "VmHWM: %" SCNu64 " %2s", &kib, unit) == 2
+                && strcmp(unit, "kB") == 0 && kib <= UINT64_MAX / 1024) {
+            *bytes = kib * 1024;
+            found = true;
+            break;
+        }
+    }
+    fclose(status);
+    return found;
+#else
+    uv_rusage_t usage;
+    if (uv_getrusage(&usage) != 0)
+        return false;
+    // libuv normalizes ru_maxrss to KiB on supported platforms.
+    *bytes = usage.ru_maxrss * 1024;
+    return true;
+#endif
+}
 
 #if defined(__linux__) && defined(PERF_ATTR_SIZE_VER7)
 static int perf_cycles_fd = -1;

--- a/base/rts/perf.h
+++ b/base/rts/perf.h
@@ -14,6 +14,7 @@ struct rts_perf_sample {
 
 void rts_perf_init(void);
 void rts_perf_read(struct rts_perf_sample *sample);
+bool rts_perf_peak_rss(uint64_t *bytes);
 const char *rts_perf_backend(void);
 const char *rts_perf_scope(void);
 const char *rts_perf_status(void);

--- a/base/src/acton/rts.act
+++ b/base/src/acton/rts.act
@@ -66,7 +66,7 @@ def get_rss(cap: SysCap) -> u64:
     NotImplemented
 
 def get_peak_rss(cap: SysCap) -> ?u64:
-    """Get the process lifetime peak resident set size in bytes.
+    """Get this executable's peak resident set size in bytes.
 
     Includes startup and all threads. Returns None if unavailable.
     """

--- a/base/src/acton/rts.ext.c
+++ b/base/src/acton/rts.ext.c
@@ -79,11 +79,10 @@ int64_t actonQ_rtsQ_rss (B_SysCap cap) {
 }
 
 B_u64 actonQ_rtsQ_get_peak_rss (B_SysCap cap) {
-    uv_rusage_t usage;
-    if (uv_getrusage(&usage) != 0)
+    uint64_t bytes;
+    if (!rts_perf_peak_rss(&bytes))
         return (B_u64)B_None;
-    // libuv normalizes ru_maxrss to KiB on all supported platforms.
-    return toB_u64(usage.ru_maxrss * 1024);
+    return toB_u64(bytes);
 }
 
 B_tuple actonQ_rtsQ_perf_snapshot (B_SysCap cap) {

--- a/base/src/testing.act
+++ b/base/src/testing.act
@@ -332,7 +332,6 @@ class PerfLoop(Iterator[int]):
 
     Phases: 0 ordinary, 1 calibration, 2 warmup, 3 measurement.
     """
-    calibration: list[dict[str, value]]
     _state: u64
     _last_wall_ns: u64
     _start_wall_ns: u64
@@ -358,17 +357,14 @@ class PerfLoop(Iterator[int]):
     _yield_scale: ?int
     _report_result: ?action(?bool, ?Exception, ?str) -> None
 
-    def __init__(self, phase: int=0, scale: int=1, budget_ms: float=0.0, remaining_ms: float=0.0, target_ms: float=0.0, once: bool=False):
+    def __init__(self, phase: int=0, scale: int=1, budget_ms: float=0.0, remaining_ms: float=0.0, once: bool=False):
         self._phase = phase
-        self.scale = scale
+        self._scale = scale
         self.iterations = 0
         self._budget_ms = budget_ms
         self._remaining_ms = remaining_ms
-        self._target_ms = target_ms
         self._once = once
-        self._previous_wall_ms = 0.0
         self._sw = time.Stopwatch()
-        self.calibration = []
         self._state = 0
         self._last_wall_ns = 0
         self._start_wall_ns = 0
@@ -419,25 +415,17 @@ class PerfLoop(Iterator[int]):
         if self._phase == 0:
             return 1 if self.iterations == 0 else None
         if self._once:
-            return self.scale if self.iterations == 0 else None
+            return self._scale if self.iterations == 0 else None
         elapsed = self._sw.elapsed().to_float() * 1000.0
         if completed == 0:
             # Setup uses the total budget, but a run may finish its first body
             # after its individual slice expires.
-            return self.scale if elapsed < self._remaining_ms else None
-        if self._phase == 1:
-            wall_ms = float(self._last_wall_ns) / 1000000.0
-            self.calibration.append({"scale": self.scale, "wall_ms": wall_ms})
-            if wall_ms >= self._target_ms or elapsed >= self._budget_ms or self.scale >= 2**30:
-                # Doubling the input can overshoot badly for nonlinear workloads.
-                if self.iterations > 1 and abs(self._previous_wall_ms - self._target_ms) <= abs(wall_ms - self._target_ms):
-                    self.scale //= 2
-                return None
-            self._previous_wall_ms = wall_ms
-            self.scale *= 2
-        elif elapsed >= self._budget_ms:
+            return self._scale if elapsed < self._remaining_ms else None
+        # Calibration changes scale between invocations, so setup sees the
+        # same scale as the single calibration body.
+        if self._phase == 1 or elapsed >= self._budget_ms:
             return None
-        return self.scale
+        return self._scale
 
     def counters(self) -> dict[str, float]:
         counts: dict[str, float] = {}
@@ -458,6 +446,10 @@ class SyncT(value):
         self.tags = tags
         self._loop = loop if loop is not None else PerfLoop()
 
+    def scale(self) -> int:
+        """Workload scale, fixed for this invocation; available before t.loop()."""
+        return self._loop._scale
+
     def loop(self) -> Iterator[int]:
         """Measure this loop's bodies, yielding the workload scale each time."""
         return self._loop.claim()
@@ -475,6 +467,10 @@ class AsyncT(value):
         self.log_handler = log_handler
         self.tags = tags
         self._loop = loop if loop is not None else PerfLoop()
+
+    def scale(self) -> int:
+        """Workload scale, fixed for this invocation; available before t.loop()."""
+        return self._loop._scale
 
     def loop(self) -> Iterator[int]:
         """Measure this loop's bodies, yielding the workload scale each time."""
@@ -504,6 +500,10 @@ class EnvT(value):
         self.log_handler = log_handler
         self.tags = tags
         self._loop = loop if loop is not None else PerfLoop()
+
+    def scale(self) -> int:
+        """Workload scale, fixed for this invocation; available before t.loop()."""
+        return self._loop._scale
 
     def loop(self) -> Iterator[int]:
         """Measure this loop's bodies, yielding the workload scale each time."""
@@ -1280,6 +1280,7 @@ class PerfRun(object):
         self.measurement_ms = 0.0
         self.loop_iterations = 0
         self.calibration = []
+        self._previous_invocation_ms = 0.0
         self._sw = time.Stopwatch()
 
     def remaining_ms(self) -> float:
@@ -1292,16 +1293,30 @@ class PerfRun(object):
             return PerfLoop(2 if self.phase == "warmup" else 3, self.scale, once=True)
         remaining = self.remaining_ms()
         if self.phase == "calibrate":
-            return PerfLoop(1, self.scale, min([remaining, float(self.time_ms) / 3.0]), remaining, float(self.time_ms) / 10.0)
+            return PerfLoop(1, self.scale, remaining_ms=remaining)
         if self.phase == "warmup":
             return PerfLoop(2, self.scale, min([remaining, float(self.time_ms) / 10.0]), remaining)
         return PerfLoop(3, self.scale, remaining / float(max([1, 4 - samples])), remaining)
 
-    def observe(self, loop: PerfLoop, elapsed_ms: float, wall_ms: float) -> bool:
+    def observe(self, loop: PerfLoop, elapsed_ms: float, invocation_ms: float) -> bool:
         """Preparation never contributes a statistical sample."""
         if self.phase == "calibrate":
-            self.scale = loop.scale if self.loop else 1
-            self.calibration = loop.calibration
+            if self.loop:
+                wall_ms = float(loop._last_wall_ns) / 1000000.0
+                target_ms = float(self.time_ms) / 10.0
+                self.calibration.append({"scale": self.scale, "wall_ms": wall_ms, "invocation_ms": invocation_ms})
+                # Setup and teardown must also fit repeated invocations into
+                # the budget, even when the operation itself is very cheap.
+                if invocation_ms < target_ms and elapsed_ms < float(self.time_ms) / 3.0 and self.scale < 2**30:
+                    self._previous_invocation_ms = invocation_ms
+                    self.scale *= 2
+                    return False
+                # Doubling can overshoot badly for nonlinear workloads. Choose
+                # the closer of the last two scales, then warm it up afresh.
+                if len(self.calibration) > 1 and abs(self._previous_invocation_ms - target_ms) <= abs(invocation_ms - target_ms):
+                    self.scale //= 2
+            else:
+                self.scale = 1
             self.phase = "warmup"
             if not self.loop:
                 self.warmup_duration_ms = elapsed_ms
@@ -1312,7 +1327,7 @@ class PerfRun(object):
             if self.scaling or self.warmup_duration_ms >= float(self.time_ms) / 10.0:
                 self.phase = "measure"
         else:
-            self.measurement_ms += wall_ms
+            self.measurement_ms += float(loop._wall_ns) / 1000000.0 if self.loop else invocation_ms
             self.loop_iterations += loop.iterations if self.loop else 0
             return True
         return False
@@ -1617,8 +1632,7 @@ actor TestExecutor(syscap, config, t: Test, report_complete, report_progress, en
         complete = config.perf_mode and (success != True or exception is not None)
         if perf_run is not None and not complete and not skipped:
             phase = perf_run.phase
-            wall_ms = float(loop._wall_ns) / 1000000.0 if perf_run.loop else full_dur
-            measured = perf_run.observe(loop, perf_phase_sw.elapsed().to_float() * 1000.0, wall_ms)
+            measured = perf_run.observe(loop, perf_phase_sw.elapsed().to_float() * 1000.0, full_dur)
             if phase != perf_run.phase and (perf_run.loop or perf_run.phase == "measure"):
                 perf_phase_sw.reset()
             if not measured:

--- a/compiler/acton/PerfTests.hs
+++ b/compiler/acton/PerfTests.hs
@@ -381,7 +381,8 @@ perfIntegrationTests =
               (Fingerprint.updateFingerprintPrefix (Fingerprint.fingerprintPrefixForName name) 1)
             baseline = proj </> "perf_data"
             run args = readCreateProcessWithExitCode
-              (proc acton (["test", "perf", "--time", "100ms", "--color", "never"] ++ args)) { cwd = Just proj } ""
+              (proc acton (["test", "perf", "--color", "never"] ++
+                [arg | "--time" `notElem` args, arg <- ["--time", "100ms"]] ++ args)) { cwd = Just proj } ""
             runOK args = do
               (code, out, err) <- run args
               assertEqual (unwords args ++ "\n" ++ out ++ err) ExitSuccess code
@@ -426,18 +427,39 @@ perfIntegrationTests =
           , "    assert peak is not None and peak < 64 * 1048576"
           , "    t.success()"
           , ""
+          , "actor _test_slow_setup(t: testing.EnvT):"
+          , "    acton.rts.sleep(t.env.syscap, 0.2)"
+          , "    for scale in t.loop():"
+          , "        assert False, \"No body should run after setup exhausts the budget\""
+          , "    t.success()"
+          , ""
           , "actor _test_looped(t: testing.EnvT):"
+          , "    setup_scale = t.scale()"
           , "    expected_scale = t.env.getenv(\"ACTON_PERF_EXPECT_SCALE\")"
           , "    for scale in t.loop():"
-          , "        assert scale > 0"
+          , "        assert scale == setup_scale"
           , "        if expected_scale is not None:"
           , "            assert scale == int(expected_scale)"
           , "    t.success()"
           , ""
           , "actor LoopWorker(t: testing.AsyncT):"
+          , "    setup_scale = t.scale()"
           , "    for scale in t.loop():"
-          , "        assert scale > 0"
+          , "        assert scale == setup_scale"
           , "    t.success()"
+          , ""
+          , "def _test_calibration_setup(t: testing.SyncT):"
+          , "    data = list(range(t.scale()))"
+          , "    start = time.monotonic().unix_ns()"
+          , "    while time.monotonic().unix_ns() - start < t.scale() * 1000000:"
+          , "        pass"
+          , "    for scale in t.loop():"
+          , "        assert scale == len(data)"
+          , ""
+          , "def _test_allocation_setup(t: testing.SyncT):"
+          , "    data = \"x\" * (t.scale() * 1048576)"
+          , "    for scale in t.loop():"
+          , "        assert len(data) == scale * 1048576"
           , ""
           , "actor _test_helper_workload(t: testing.AsyncT):"
           , "    LoopWorker(t)"
@@ -496,6 +518,7 @@ perfIntegrationTests =
           , "    t.success()"
           , ""
           , "actor _test_counter_activation(t: testing.EnvT):"
+          , "    assert t.scale() == 1"
           , "    assert t.env.getenv(\"ACTON_TEST_PERF\") is None"
           , "    info = acton.rts.perf_info(t.env.syscap)"
           , "    if \"perf\" in t.env.argv:"
@@ -661,6 +684,11 @@ perfIntegrationTests =
         duration <- requireNumber "duration_ms" slow
         assertBool "the slow invocation completed past the former watchdog" (duration >= 3000)
         assertBool slowOut (not ("TimeoutError" `isInfixOf` slowOut))
+        (setupCode, setupOut, setupErr) <- run ["--name", "slow_setup", "--json"]
+        assertBool (setupOut ++ setupErr) (setupCode /= ExitSuccess)
+        exhausted <- singleJsonTest setupOut
+        assertEqual "setup can exhaust calibration before its first body" (Just Aeson.Null) (KM.lookup "performance" exhausted)
+        assertBool setupOut (not ("No body should run" `isInfixOf` setupOut))
         looped <- runLoop "100ms" "50000" ["--record", "--scale", "50000", "--tag", "beta, alpha", "--tag", "alpha"] >>= requireObject "measurements"
         loopedInfo <- requireObject "perf_info" looped
         assertEqual "author opted into loop measurement" (Just (Aeson.Bool True)) (KM.lookup "loop" loopedInfo)
@@ -680,6 +708,13 @@ perfIntegrationTests =
         case KM.lookup "calibration" helperInfo of
           Just (Aeson.Array observations) -> assertBool "automatic scale records calibration observations" (not (null observations))
           _ -> assertFailure "missing calibration observations"
+        setupOut <- runOK ["--name", "calibration_setup", "--time", "500ms", "--json"]
+        setupInfo <- singleJsonTest setupOut >>= requireObject "performance" >>= requireObject "measurements" >>= requireObject "perf_info"
+        assertBool "calibration rebuilds scale-sized setup at increasing sizes" . (> 1) =<< requireNumber "scale" setupInfo
+        assertBool "calibrated setup retains warmup" . (> 0) =<< requireNumber "warmup_duration_ms" setupInfo
+        allocationOut <- runOK ["--name", "allocation_setup", "--scale", "8", "--time", "500ms", "--json"]
+        allocation <- singleJsonTest allocationOut >>= requireObject "performance" >>= requireObject "measurements"
+        assertBool "8MiB of setup allocation is excluded from the measured body" . (< 4096) =<< requireNumber "mem_usage_delta_avg" allocation
         lateOut <- runOK ["--name", "late_loop", "--json"]
         lateInfo <- singleJsonTest lateOut >>= requireObject "performance" >>= requireObject "measurements" >>= requireObject "perf_info"
         assertEqual "late loop requests and duplicate completions cannot change measurement identity"

--- a/compiler/acton/PerfTests.hs
+++ b/compiler/acton/PerfTests.hs
@@ -13,6 +13,8 @@ import qualified Data.ByteString.Lazy.Char8 as BL8
 import Data.List (isInfixOf, isSuffixOf, find, elemIndices)
 import TerminalSize (termVisibleLength, termFitAnsiRight, termRenderedRows)
 import qualified Data.Map as M
+import Foreign.Marshal.Alloc (allocaBytes)
+import Foreign.Marshal.Utils (fillBytes)
 import System.Directory
 import System.Environment (getEnvironment)
 import System.Exit
@@ -419,6 +421,11 @@ perfIntegrationTests =
           , "actor _test_slow(t: testing.AsyncT):"
           , "    after 3.5: t.success()"
           , ""
+          , "actor _test_peak_rss(t: testing.EnvT):"
+          , "    peak = acton.rts.get_peak_rss(t.env.syscap)"
+          , "    assert peak is not None and peak < 64 * 1048576"
+          , "    t.success()"
+          , ""
           , "actor _test_looped(t: testing.EnvT):"
           , "    expected_scale = t.env.getenv(\"ACTON_PERF_EXPECT_SCALE\")"
           , "    for scale in t.loop():"
@@ -499,6 +506,22 @@ perfIntegrationTests =
           , "    t.success()"
           ]
         _ <- runOK ["--name", "counter_activation"]
+        -- The child must report its own peak, even after exec from a large parent.
+        allocaBytes (128 * 1048576) $ \memory -> do
+          fillBytes memory 1 (128 * 1048576)
+          (code, out, err) <- readCreateProcessWithExitCode
+            (proc (proj </> "out/bin/.test_sample")
+              ["--rts-wthreads", "1", "test", "_test_peak_rss_wrapper",
+               "--max-iter", "1", "--min-iter", "1", "--max-time", "1000000", "--min-time", "1"])
+              { cwd = Just proj } ""
+          assertEqual (out ++ err) ExitSuccess code
+          let results = [info | line <- lines err,
+                               Right event <- [Aeson.eitherDecode (BL8.pack line)],
+                               Just (Aeson.Object info) <- [KM.lookup "test_info" event],
+                               KM.lookup "complete" info == Just (Aeson.Bool True)]
+          case results of
+            [info] -> assertEqual (out ++ err) (Just (Aeson.Bool True)) (KM.lookup "success" info)
+            _ -> assertFailure ("Expected a completed peak RSS probe\n" ++ out ++ err)
         environment <- getEnvironment
         let runLoop budget expected args = do
               (code, out, err) <- readCreateProcessWithExitCode

--- a/compiler/acton/ScaleOptionTests.hs
+++ b/compiler/acton/ScaleOptionTests.hs
@@ -11,8 +11,9 @@ import Test.Tasty.HUnit
 scaleOptionTests :: TestTree
 scaleOptionTests = testGroup "performance scaling options"
   [ testCase "scale captures explicit resource limits" $ do
-      opts <- parseScale ["--start-scale", "1000", "--max-memory", "50%", "--max-time", "2h"]
+      opts <- parseScale ["--start-scale", "1000", "--end-scale", "100000", "--max-memory", "50%", "--max-time", "2h"]
       assertEqual "starting scale" (Just 1000) (C.testStartScale opts)
+      assertEqual "inclusive endpoint" (Just 100000) (C.testEndScale opts)
       assertEqual "memory percentage" (Just (C.MemoryPercent 50)) (C.testMaxMemory opts)
       assertEqual "duration is stored in milliseconds" 7200000 (C.testMaxTime opts)
       assertBool "the total limit is explicit" (C.testMaxTimeSet opts)
@@ -20,6 +21,7 @@ scaleOptionTests = testGroup "performance scaling options"
       opts <- parseScale []
       assertEqual "release by default" C.ReleaseFast (C.optimize (C.testCompile opts))
       assertEqual "default starting scale is chosen by the runner" Nothing (C.testStartScale opts)
+      assertEqual "no endpoint means automatic exploration" Nothing (C.testEndScale opts)
       assertEqual "default memory limit is chosen by the runner" Nothing (C.testMaxMemory opts)
       assertBool "default total limit is chosen by the runner" (not (C.testMaxTimeSet opts))
       explicit <- parseScale ["--optimize", "Debug"]
@@ -39,19 +41,20 @@ scaleOptionTests = testGroup "performance scaling options"
         rejects ["test", "scale", "--max-time", value]
       forM_ [1, maxBound :: Int] $ \value ->
         assertEqual "positive starting scale" (Just value) . C.testStartScale =<< parseScale ["--start-scale", show value]
-      forM_ ["0", "-1", "1.5", show (toInteger (maxBound :: Int) + 1)] $ \value ->
-        rejects ["test", "scale", "--start-scale", value]
+      forM_ ["--start-scale", "--end-scale"] $ \option ->
+        forM_ ["0", "-1", "1.5", show (toInteger (maxBound :: Int) + 1)] $ \value ->
+          rejects ["test", "scale", option, value]
   , testCase "scale and perf reject each other's workload controls" $ do
       forM_ [["--scale", "7"], ["--time", "1s"], ["--iter", "1"],
              ["--min-iter", "1"], ["--max-iter", "1"], ["--min-time", "1"],
-             ["--stress-workers", "1"], ["--scaling"]] $ \args ->
+             ["--stress-workers", "1"], ["--scaling"], ["--min-scale", "1000"]] $ \args ->
         rejects (["test", "scale"] ++ args)
-      forM_ [["--start-scale", "1"], ["--max-memory", "50%"],
+      forM_ [["--start-scale", "1"], ["--end-scale", "1000"], ["--max-memory", "50%"],
              ["--max-time", "1h"], ["--scaling"]] $ \args ->
         rejects (["test", "perf"] ++ args)
   , testCase "ordinary limits keep milliseconds and reject scaling controls" $ do
       forM_ [[], ["list"], ["stress"]] $ \mode ->
-        forM_ [["--scaling"], ["--start-scale", "1"], ["--max-memory", "50%"]] $ \args ->
+        forM_ [["--scaling"], ["--start-scale", "1"], ["--end-scale", "1000"], ["--max-memory", "50%"]] $ \args ->
           rejects (["test"] ++ mode ++ args)
       case parseOptions ["test", "stress", "--max-time", "0"] of
         O.Success (C.CmdOpt _ (C.Test (C.TestStress opts))) ->
@@ -80,7 +83,7 @@ scaleOptionTests = testGroup "performance scaling options"
             assertEqual "recording path" "run.jsonl" path
             assertEqual "display options apply" C.Never (C.color globals)
           _ -> assertFailure ("expected saved report: " ++ unwords args)
-      forM_ [["--max-time", "1s"], ["--name", "dct"], ["--start-scale", "2"], ["--json"], ["--record"]] $ \args ->
+      forM_ [["--max-time", "1s"], ["--name", "dct"], ["--start-scale", "2"], ["--end-scale", "2"], ["--json"], ["--record"]] $ \args ->
         rejects (["test", "scale", "--report", "run.jsonl"] ++ args)
   , testCase "comparison always takes one baseline file in live and report modes" $ do
       forM_ [["--compare", "before.jsonl"], ["--name", "dct", "--compare", "before.jsonl"],
@@ -104,7 +107,7 @@ scaleOptionTests = testGroup "performance scaling options"
         O.Failure failure -> do
           let (text, code) = O.renderFailure failure "acton"
           assertEqual text ExitSuccess code
-          forM_ ["--start-scale N", "--max-memory LIMIT", "--max-time DURATION", "--report FILE", "--compare FILE"] $ \option ->
+          forM_ ["--start-scale N", "--end-scale N", "--max-memory LIMIT", "--max-time DURATION", "--report FILE", "--compare FILE"] $ \option ->
             assertBool text (option `isInfixOf` unwords (words text))
           assertBool text (not (any (`isInfixOf` text) ["--scaling", "--scale N", "--time DURATION", "--iter", "--min-time"]))
         _ -> assertFailure "expected scale help"

--- a/compiler/acton/ScaleReport.hs
+++ b/compiler/acton/ScaleReport.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 module ScaleReport
-  ( ScaleData, ScaleSeries(..), ScaleRecording(..), readScaleRecording, printScaleRecording
+  ( ScaleData, ScaleSample(..), ScaleSeries(..), ScaleRecording(..), readScaleRecording, printScaleRecording
   , scaleSeriesReason, addScaleEvent, scaleCharts, scaleSummary, printScaleReport
   , Chart(..), ChartKind(..), ChartPoint(..), chartGuide, chartText, chartPixels, kittyImage, kittyTerminal
   ) where
@@ -8,7 +8,7 @@ module ScaleReport
 import Codec.Compression.Zlib (compress)
 import Control.Exception (bracket_)
 import Control.Applicative ((<|>))
-import Control.Monad (forM_, when)
+import Control.Monad (forM_, unless, when)
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KM
 import qualified Data.Aeson.Types as Aeson
@@ -31,9 +31,16 @@ import TestPerf (perfNumber, perfInfo, perfSamplingReason)
 import TestFormat (testColorApply, testColorBold)
 import Text.Printf (printf)
 
--- Only accepted curve samples are retained: (point complete, [(wall ms, RSS)]).
+-- Only accepted curve samples are retained, with optional allocation data for
+-- older recordings. Missing allocation measurements must not become zeros.
 -- Diagnostics remain in the journal, not in the chart's in-memory history.
-type ScaleData = IM.IntMap (Bool, [(Double, Double)])
+type ScaleData = IM.IntMap (Bool, [ScaleSample])
+
+data ScaleSample = ScaleSample
+    { sampleWall :: !Double
+    , sampleRSS :: !Double
+    , sampleAllocated :: !(Maybe Double)
+    } deriving (Eq, Show)
 
 data ScaleSeries = ScaleSeries
     { seriesData :: ScaleData
@@ -138,18 +145,24 @@ printScaleRecording useColor path baselinePath = do
     forM_ baseline $ \old -> putStrLn ("Baseline: " ++ show (recordingPath old))
     when (all (IM.null . seriesData) (M.elems reports)) $
       putStrLn "No accepted measurements in this recording."
-    forM_ (M.toAscList pairs) $ \((modName, testName), (current, old)) -> do
+    forM_ (M.toAscList pairs) $ \((modName, testName), (new, old)) -> do
       forM_ baseline $ \previous -> do
         putStrLn ("Current: " ++ clean (takeFileName path))
         putStrLn ("Baseline: " ++ clean (takeFileName (recordingPath previous)))
-      printScaleReport useColor (modName ++ "." ++ testName) (seriesData current) (maybe IM.empty seriesData old)
-      forM_ (seriesReason current) (putStrLn . ("  " ++) . clean)
+      printScaleReport useColor (modName ++ "." ++ testName) (seriesData new) (maybe IM.empty seriesData old)
+      endpointStatus "  " current new
+      forM_ baseline $ \recording -> forM_ old (endpointStatus "  Baseline: " recording)
+      forM_ (seriesReason new) (putStrLn . ("  " ++) . clean)
       forM_ (old >>= seriesReason) (putStrLn . ("  Baseline: " ++) . clean)
     putStrLn (maybe "Recording is incomplete: no completion event was recorded." (("Stopped: " ++) . clean) (recordingStopped current))
     forM_ baseline $ \old -> putStrLn
       (maybe "Baseline is incomplete: no completion event was recorded." (("Baseline stopped: " ++) . clean) (recordingStopped old))
   where
     clean = map (\c -> if isPrint c then c else ' ')
+    endpointStatus prefix recording series =
+      forM_ (Aeson.parseMaybe (Aeson..: "end_scale") (recordingHeader recording)) $ \target ->
+        unless (maybe False fst (IM.lookup target (seriesData series))) $
+          putStrLn (prefix ++ "Requested end scale " ++ show target ++ " was not reached")
 
 data ChartPoint = ChartPoint
     { chartScale :: Double
@@ -159,12 +172,13 @@ data ChartPoint = ChartPoint
     , chartComplete :: Bool
     } deriving (Eq, Show)
 
-data ChartKind = WallTime | TimePerScale | PeakMemory deriving (Eq, Show)
+data ChartKind = WallTime | TimePerScale | Allocated | PeakMemory deriving (Eq, Show)
 data Chart = Chart ChartKind [ChartPoint] [ChartPoint] deriving (Eq, Show)
 
 chartStyle :: ChartKind -> (String, [Int])
 chartStyle WallTime = ("Wall time (ms)", [56, 189, 248])
 chartStyle TimePerScale = ("Time / scale (µs)", [192, 132, 252])
+chartStyle Allocated = ("Allocated (KiB)", [244, 114, 182])
 chartStyle PeakMemory = ("Process peak memory (MiB)", [45, 212, 191])
 
 scaleSummary :: ScaleData -> String
@@ -200,23 +214,32 @@ addScaleEvent event points = fromMaybe points $ do
         , Just (Aeson.Object result) <- KM.lookup "result" event -> do
             wall <- perfNumber result "avg_wall_duration"
             rss <- perfNumber result "peak_rss"
-            if wall <= 0 || rss <= 0 then Nothing else
-              wall `seq` rss `seq` Just (IM.insertWith
-                (\(_, new) (done, old) -> (done, new ++ old)) n (False, [(wall, rss)]) points)
+            let allocated = case perfNumber result "mem_usage_delta_avg" of
+                  Just bytes | bytes >= 0 -> Just bytes
+                  _ -> Nothing
+            if wall < 0 || rss <= 0 then Nothing else
+              let sample = ScaleSample wall rss allocated
+              in sample `seq` Just (IM.insertWith
+                (\(_, new) (done, old) -> (done, new ++ old)) n (False, [sample]) points)
       _ -> Nothing
 
 scaleCharts :: ScaleData -> ScaleData -> [Chart]
 scaleCharts points baseline =
-    [ chart WallTime (\_ (wall, _) -> wall)
-    , chart TimePerScale (\n (wall, _) -> wall * 1000 / n)
-    , chart PeakMemory (\_ (_, rss) -> rss / 1048576)
+    [ chart WallTime (\_ sample -> wall sample)
+    , chart TimePerScale (\n sample -> (* (1000 / n)) <$> wall sample)
+    , chart Allocated (\_ sample -> (/ 1024) <$> sampleAllocated sample)
+    , chart PeakMemory (\_ sample -> Just (sampleRSS sample / 1048576))
     ]
   where
+    -- A logarithmic time chart cannot represent a zero clock reading. Omit
+    -- the whole point, not individual samples that would bias its statistics.
+    wall sample = if sampleWall sample > 0 then Just (sampleWall sample) else Nothing
     chart title value = Chart title (series value points) (series value baseline)
     series value dataPoints =
       [ ChartPoint scale (minimum ys) (sum ys / fromIntegral (length ys)) (maximum ys) done
       | (n, (done, xs)) <- IM.toAscList dataPoints, not (null xs)
-      , let scale = fromIntegral n; ys = map (value scale) xs ]
+      , let scale = fromIntegral n
+      , Just ys <- [mapM (value scale) xs] ]
 
 -- Be conservative without querying stdin or consuming the user's keystrokes.
 -- Multiplexers get text until their graphics passthrough is supported here.
@@ -242,8 +265,11 @@ printScaleReport useColor name points baseline = when (not (IM.null points && IM
       putStrLn ("\n" ++ paint [testColorBold] ("Scaling charts: " ++ map (\c -> if isPrint c then c else ' ') name))
       putStrLn (scaleSummary points)
       when (not (IM.null baseline)) (putStrLn ("Baseline: " ++ scaleSummary baseline))
-      putStrLn "Logarithmic axes; means and min–max ranges; hollow markers = partial points."
-      forM_ (scaleCharts points baseline) $ \chart@(Chart kind _ old) -> do
+      putStrLn "Logarithmic axes unless labelled; means and min–max ranges; hollow markers = partial points."
+      when (any (any ((== 0) . sampleWall) . snd) (IM.elems points ++ IM.elems baseline)) $
+        putStrLn "Time charts omit sizes with zero clock readings (below resolution); memory charts retain them."
+      let charts = scaleCharts points baseline
+      forM_ [chart | chart@(Chart _ current old) <- charts, not (null current && null old)] $ \chart@(Chart kind _ old) -> do
         let rgb = snd (chartStyle kind)
             accent = "\ESC[38;2;" ++ intercalate ";" (map show rgb) ++ "m"
             style row line
@@ -252,6 +278,7 @@ printScaleReport useColor name points baseline = when (not (IM.null points && IM
               | otherwise = line
         when (not (null old)) $
           putStrLn (paint [accent] "  ● ━ current" ++ "    " ++ paint [if graphics then "\ESC[38;2;251;146;60m" else accent] "◆ ┄ baseline" ++ "    ◈ overlapping points")
+        when (linearAxis chart) (putStrLn "  Linear allocation axis, including zero.")
         putStr (unlines (zipWith style [0..] (chartText graphics width height chart)))
         when graphics $ do
           -- The text reserves space first, including when output scrolls.
@@ -265,6 +292,9 @@ printScaleReport useColor name points baseline = when (not (IM.null points && IM
           _ -> return ()
         putStrLn ""
       putStrLn "Flat time/scale means roughly linear time over these sizes."
+      putStrLn "Allocated bytes cover the measured region, not retained structure size."
+      when (any (\(Chart kind current old) -> kind == Allocated && null current && null old) charts) $
+        putStrLn "Allocation measurements are unavailable in this recording."
       putStrLn "Peak memory includes process startup, setup, warmup and teardown."
       hFlush stdout
 
@@ -272,10 +302,15 @@ printScaleReport useColor name points baseline = when (not (IM.null points && IM
 -- differences from looking like large changes. Constant series still have range.
 layout :: Chart -> ([(Double, String)], [(Double, String)], [ChartPoint], [ChartPoint], [(Double, Double)])
 layout (Chart _ [] []) = ([], [], [], [], [])
-layout chart@(Chart _ points baseline) = (ticks xbounds, ticks ybounds, map project points, map project baseline, guide)
+layout chart@(Chart _ points baseline) = (ticks xbounds, yticks, map project points, map project baseline, guide)
   where
     xbounds = bounds (map chartScale (points ++ baseline))
-    ybounds = bounds (concatMap (\p -> [chartMinimum p, chartMaximum p]) (points ++ baseline))
+    values = concatMap (\p -> [chartMinimum p, chartMaximum p]) (points ++ baseline)
+    ybounds = if linearAxis chart then (0, if maximum values > 0 then maximum values else 1) else bounds values
+    ypos value = if linearAxis chart then value / snd ybounds else position ybounds value
+    yticks = if linearAxis chart
+      then [(n, printf "%.3g" (n * snd ybounds)) | n <- [0, 0.25, 0.5, 0.75, 1]]
+      else ticks ybounds
     bounds values =
       let lo = logBase 10 (minimum values); hi = logBase 10 (maximum values)
           lower = fromIntegral (floor (lo + 1e-10) :: Int)
@@ -287,7 +322,7 @@ layout chart@(Chart _ points baseline) = (ticks xbounds, ticks ybounds, map proj
       | n <- [ceiling lo, ceiling lo + max 1 (ceiling ((hi - lo) / 4)) .. floor hi :: Int] ]
     -- Clip before rasterization: clamping every pixel would draw a false line
     -- along the bottom edge wherever the guide lies below the measured range.
-    guide = case [(position xbounds n, position ybounds t) | (n, t) <- chartGuide chart] of
+    guide = case [(position xbounds n, ypos t) | (n, t) <- chartGuide chart] of
       [(ax, ay), (bx, by)] | bx > ax && by > ay ->
         let slope = (by - ay) / (bx - ax)
             left = max ax (ax - ay / slope)
@@ -295,9 +330,13 @@ layout chart@(Chart _ points baseline) = (ticks xbounds, ticks ybounds, map proj
         in [(u, ay + (u - ax) * slope) | left < right, u <- [left, right]]
       _ -> []
     project p = p { chartScale = position xbounds (chartScale p)
-                  , chartMinimum = position ybounds (chartMinimum p)
-                  , chartMean = position ybounds (chartMean p)
-                  , chartMaximum = position ybounds (chartMaximum p) }
+                  , chartMinimum = ypos (chartMinimum p)
+                  , chartMean = ypos (chartMean p)
+                  , chartMaximum = ypos (chartMaximum p) }
+
+linearAxis :: Chart -> Bool
+linearAxis (Chart Allocated points baseline) = any ((== 0) . chartMinimum) (points ++ baseline)
+linearAxis _ = False
 
 chartText :: Bool -> Int -> Int -> Chart -> [String]
 chartText graphics width height chart@(Chart kind raw _) =

--- a/compiler/acton/ScaleReportTests.hs
+++ b/compiler/acton/ScaleReportTests.hs
@@ -30,15 +30,64 @@ scaleReportTests = testGroup "terminal charts"
                  ++ [KM.fromList [("event", Aeson.String "point"), ("scale", Aeson.Number 2)]]
                  ++ [sample 4 t 2097152 True False | t <- [16, 20, 24]]
                  ++ [sample 8 32 1 False False, sample 2 9999 1 True True,
-                     sample 8 0 1 True False]
+                     sample 8 (-1) 1 True False]
           points = foldl' (flip addScaleEvent) IM.empty samples
       assertEqual "linear work has constant time per scale and preserves sample ranges"
         [ Chart WallTime [ChartPoint 2 8 10 12 True, ChartPoint 4 16 20 24 False] []
         , Chart TimePerScale [ChartPoint 2 4000 5000 6000 True, ChartPoint 4 4000 5000 6000 False] []
+        , Chart Allocated [] []
         , Chart PeakMemory [ChartPoint 2 1 1 1 True, ChartPoint 4 2 2 2 False] []
         ] (scaleCharts points IM.empty)
       assertEqual "summary distinguishes finished sizes and accepted partial samples"
         "1 size + 1 partial · 6 curve samples · scale 2 … 4" (scaleSummary points)
+  , testCase "zero clock readings retain coverage and memory without biasing time charts" $ do
+      let events = [sample 1 t 1048576 True False | t <- [0, 0.001, 0.002]]
+                ++ [KM.fromList [("event", Aeson.String "point"), ("scale", Aeson.Number 1)],
+                    sample 2 0.002 2097152 True False]
+          points = foldl' (flip addScaleEvent) IM.empty events
+      assertEqual "all samples remain in the recorded coverage"
+        "1 size + 1 partial · 4 curve samples · scale 1 … 2" (scaleSummary points)
+      assertEqual "a time point is omitted in full, while its memory remains visible"
+        [ Chart WallTime [ChartPoint 2 0.002 0.002 0.002 False] []
+        , Chart TimePerScale [ChartPoint 2 1 1 1 False] []
+        , Chart Allocated [] []
+        , Chart PeakMemory [ChartPoint 1 1 1 1 True, ChartPoint 2 2 2 2 False] []
+        ] (scaleCharts points IM.empty)
+      withRecording (header 2 : map (KM.insert "module" (Aeson.String "alpha") .
+        KM.insert "test" (Aeson.String "same")) events ++ [ending]) $ \_ run -> do
+          (code, out, err) <- run
+          assertEqual (out ++ err) ExitSuccess code
+          assertBool out ("Time charts omit sizes with zero clock readings" `isInfixOf` out)
+  , testCase "allocation charts retain zero, ranges and missing measurements" $ do
+      let allocated bytes = KM.mapWithKey (\key value -> case (key, value) of
+            ("result", Aeson.Object result) -> Aeson.Object
+              (KM.insert "mem_usage_delta_avg" (Aeson.toJSON (bytes :: Double)) result)
+            _ -> value)
+          events = [allocated n (sample 1 1 1048576 True False) | n <- [0,1024,2048]]
+                ++ [KM.fromList [("event", Aeson.String "point"), ("scale", Aeson.Number 1)],
+                    allocated 0 (sample 2 2 1048576 True False),
+                    allocated 1024 (sample 4 4 1048576 True False),
+                    sample 4 4 1048576 True False]
+          points = foldl' (flip addScaleEvent) IM.empty events
+          chart = scaleCharts points IM.empty !! 2
+      assertEqual "missing samples do not become zeros or partial averages"
+        (Chart Allocated [ChartPoint 1 0 1 2 True, ChartPoint 2 0 0 0 False] []) chart
+      let output = unlines (chartText False 67 12 chart)
+      assertBool output ("0.000│" `isInfixOf` output && '○' `elem` output)
+      assertEqual "zero allocation still renders graphics" (67 * 8 * 12 * 16 * 4)
+        (BS.length (chartPixels True 67 12 chart))
+      let small = Chart Allocated [ChartPoint 1 0 0 0 True,
+                                   ChartPoint 2 (16/1024) (16/1024) (16/1024) True] []
+      assertBool "small allocation volumes use the full vertical range"
+        ('●' `elem` concat (take 3 (chartText False 67 12 small)))
+      withRecording (header 2 : map (KM.insert "module" (Aeson.String "alpha") .
+        KM.insert "test" (Aeson.String "same")) events ++ [ending]) $ \_ run -> do
+          (code, out, err) <- run
+          assertEqual (out ++ err) ExitSuccess code
+          assertBool out ("Linear allocation axis" `isInfixOf` out)
+          assertBool "older journals already contain allocation samples" ("Allocated (KiB)" `isInfixOf` out)
+          assertBool "known allocation data is not labelled unavailable"
+            (not ("Allocation measurements are unavailable" `isInfixOf` out))
   , testCase "saved journals replay outside a project, preserving separate tests and partial sizes" $
       forM_ [1, 2] $ \version -> do
         let named modName = KM.insert "module" (Aeson.String modName) . KM.insert "test" (Aeson.String "same")
@@ -63,6 +112,18 @@ scaleReportTests = testGroup "terminal charts"
           assertBool "plain reports have no terminal escapes" (notElem '\ESC' (out ++ err))
           assertEqual "replay never changes the recording" before =<< BS.readFile path
           assertEqual "replay creates no build or measurement files" [takeFileName path] =<< listDirectory (takeDirectory path)
+  , testCase "replay requires a completed point at the requested endpoint" $ do
+      let named = KM.insert "module" (Aeson.String "alpha") . KM.insert "test" (Aeson.String "same")
+          study = KM.insert "end_scale" (Aeson.Number 100000) (header 3)
+          partial = named (sample 100000 10 1048576 True False)
+          point = named (KM.fromList [("event", Aeson.String "point"), ("scale", Aeson.Number 100000)])
+      forM_ [Nothing, Just 100000, Just 200000] $ \completed ->
+        withRecording ([study, partial] ++ concat
+          [[named (sample n 10 1048576 True False), KM.insert "scale" (Aeson.toJSON n) point] | Just n <- [completed]] ++ [ending]) $ \_ run -> do
+          (code, out, err) <- run
+          assertEqual (out ++ err) ExitSuccess code
+          assertEqual "only the exact completed endpoint satisfies the target" (completed /= Just 100000)
+            ("Requested end scale 100000 was not reached" `isInfixOf` out)
   , testCase "incomplete journals retain samples and diagnose an unfinished final record" $
       withRecording [header 2, KM.insert "module" (Aeson.String "alpha")
         (KM.insert "test" (Aeson.String "same") (sample 1 10 1048576 True False))] $ \path run -> do

--- a/compiler/acton/ScaleTests.hs
+++ b/compiler/acton/ScaleTests.hs
@@ -20,7 +20,7 @@ import Data.Maybe (isJust)
 import qualified Options.Applicative as O
 import PerfMemory (MemoryStatus(..))
 import ScaleReportTests (scaleReportTests)
-import ScaleReport (ScaleRecording(..), ScaleSeries(..), readScaleRecording)
+import ScaleReport (ScaleSample(..), ScaleRecording(..), ScaleSeries(..), readScaleRecording)
 import TestPerf (perfInfo)
 import System.Clock (Clock(Monotonic), fromNanoSecs, getTime)
 import System.Directory
@@ -115,10 +115,11 @@ scaleTests = testGroup "performance scaling studies"
         Left _ -> return ()
         Right limit -> assertFailure ("a depleted reserve must prevent launch: " ++ show limit)
   , testCase "scaling rejects recording snapshot updates and watch" $ do
-      forM_ [["--record"], ["--accept"], ["--watch"]] $ \args -> do
+      forM_ [["--record"], ["--accept"], ["--watch"], ["--start-scale", "8", "--end-scale", "7"]] $ \args -> do
         (_, opts) <- parseScale args
         assertBool (unwords args) (isJust (validateScalingOptions opts))
-      forM_ [[], ["--start-scale", "1000", "--max-memory", "128MiB", "--max-time", "2s"]] $ \args ->
+      forM_ [[], ["--start-scale", "1000", "--max-memory", "128MiB", "--max-time", "2s"],
+             ["--end-scale", "1"], ["--start-scale", "8", "--end-scale", "8"]] $ \args ->
         assertEqual (unwords args) Nothing . validateScalingOptions . snd =<< parseScale args
   , testGroup "adaptive controller"
       [ testCase "linear quadratic logarithmic and constant curves settle over a broad range" $
@@ -126,7 +127,7 @@ scaleTests = testGroup "performance scaling studies"
                  ("quadratic", \n -> fromIntegral n ^ (2 :: Int), Just 2),
                  ("nlogn", \n -> fromIntegral n * logBase 2 (fromIntegral n + 1), Nothing),
                  ("constant", const 1, Just 0)] $ \(name, model, exponent) -> do
-            (code, events) <- simulate name (\n _ -> modelResult n (model n))
+            (code, events) <- simulate name [] (\n _ -> modelResult n (model n))
             assertEqual name 0 code
             summary <- assertSummary "stable" (1, 1024) (11, 33) events
             assertEqual "growth summarizes the recent six sizes" (Just (Aeson.Number 32)) (KM.lookup "stable_from_scale" summary)
@@ -148,12 +149,73 @@ scaleTests = testGroup "performance scaling studies"
             assertEqual "the final decision follows a fresh reference" (Just (Aeson.String "reference")) (KM.lookup "event" (last decisions))
             forM_ references $ \r -> assertEqual "the reference settled" (Just (Aeson.Bool True)) (KM.lookup "stable" r)
             assertSampleProvenance events
+      , testCase "explicit endpoint retains the curve past automatic stability" $ do
+          (code, events) <- simulate "endpoint" ["--end-scale", "100000"] (\n _ -> modelResult n (fromIntegral n))
+          assertEqual "the study succeeds" 0 code
+          sizes <- mapM (field "scale") (eventsOf "point" events) :: IO [Int]
+          assertEqual "smaller sizes remain and the exact target is measured" ([2^n | n <- [0..16]] ++ [100000]) sizes
+          summary <- requireEvent "test_end" events
+          assertEqual "the requested range is completed" (Just (Aeson.String "range")) (KM.lookup "outcome" summary)
+          assertEqual "the study finishes at its endpoint" (Just (Aeson.Number 100000)) (KM.lookup "max_scale" summary)
+          closeTo 1 . Just =<< field "growth_min" summary
+          ending <- requireEvent "end" events
+          assertEqual "target completion is explicit" (Just (Aeson.Bool True)) (KM.lookup "end_scale_reached" ending)
+          forM_ (eventsOf "point" events) $ \event -> do
+            n <- field "scale" event :: IO Int
+            forM_ ["allocated_mean_bytes", "allocated_min_bytes", "allocated_max_bytes"] $ \key ->
+              assertEqual "point events retain allocation summaries" (Just (Aeson.toJSON (n * 100))) (KM.lookup key event)
+      , testCase "explicit ranges finish exactly even without a stable growth estimate" $
+          forM_ [(3, 73, [3,6,12,24,48,73]), (1, 1, [1]), (maxBound, maxBound, [maxBound])] $ \(start, end, expected) -> do
+            (code, events) <- simulate "range" ["--start-scale", show start, "--end-scale", show end]
+              (\n _ -> modelResult n 1)
+            assertEqual "the requested range succeeds" 0 code
+            sizes <- mapM (field "scale") (eventsOf "point" events) :: IO [Int]
+            assertEqual "endpoints are inclusive without overshoot" expected sizes
+            summary <- assertSummary "range" (start, end) (length expected, 3 * length expected) events
+            assertEqual "range completion does not assert stable growth" (Just Aeson.Null) (KM.lookup "growth_min" summary)
+      , testCase "explicit endpoint postpones noisy timing stops but never resource limits" $ do
+          let target = 2^21 + 1 :: Int
+          (code, events) <- simulate "tiny_endpoint" ["--end-scale", show target] (\n _ -> modelResult n 0.001)
+          assertEqual "the tiny benchmark succeeds" 0 code
+          summary <- requireEvent "test_end" events
+          assertEqual "twenty short sizes cannot stop before the target" (Just (Aeson.toJSON target)) (KM.lookup "max_scale" summary)
+          (limited, stopped) <- simulate "limited_endpoint" ["--end-scale", "100000"] (\n _ ->
+            let result = modelResult n 1
+                Aeson.Object raw = trRaw result
+            in result { trRaw = Aeson.Object (KM.insert "peak_rss" (Aeson.Number 1073741824) raw) })
+          assertEqual "memory still limits the run" 0 limited
+          assertEnd "memory limit reached" stopped
+          ending <- requireEvent "end" stopped
+          assertEqual "unreached target is explicit" (Just (Aeson.Bool False)) (KM.lookup "end_scale_reached" ending)
+      , testCase "a partial endpoint does not complete the range" $ do
+          (code, events) <- simulate "partial_endpoint" ["--end-scale", "17"] $ \n i ->
+            let result = modelResult n 1
+                Aeson.Object raw = trRaw result
+            in if n == 17 && i == 3 then
+                 result { trRaw = Aeson.Object (KM.insert "peak_rss" (Aeson.Number 1073741824) raw) }
+               else result
+          assertEqual "the memory ceiling is a normal stop" 0 code
+          assertEnd "memory limit reached" events
+          assertEqual "two endpoint samples survive" 2 (length
+            [s | s <- eventsOf "sample" events, KM.lookup "scale" s == Just (Aeson.Number 17),
+                 KM.lookup "accepted" s == Just (Aeson.Bool True)])
+          ending <- requireEvent "end" events
+          assertEqual "the endpoint needs a complete sample batch" (Just (Aeson.Bool False)) (KM.lookup "end_scale_reached" ending)
+      , testCase "drifting references do not shorten an explicit range" $ do
+          (code, events) <- simulate "range_drift" ["--end-scale", "65537"]
+            (\n i -> modelResult n (if n == 1 && i > 3 then 2 else fromIntegral n))
+          assertEqual "the range succeeds despite drift" 0 code
+          assertBool "multiple reference checks detect drift"
+            (length [r | r <- eventsOf "reference" events, KM.lookup "stable" r == Just (Aeson.Bool False)] >= 3)
+          summary <- requireEvent "test_end" events
+          assertEqual "the requested endpoint is measured" (Just (Aeson.Number 65537)) (KM.lookup "max_scale" summary)
+          assertEqual "drift cannot produce a stable-growth claim" (Just Aeson.Null) (KM.lookup "growth_min" summary)
       , testCase "precision controls the actual three five and seven sample batches" $ do
           let model n i = fromIntegral n * case n of
                 1 -> cycle [0.9, 1.1, 1, 1, 1] !! (i - 1)
                 2 -> cycle [0.8, 1.2, 1, 1, 1, 1, 1] !! (i - 1)
                 _ -> 1
-          (code, events) <- simulate "repeats" (\n i -> modelResult n (model n i))
+          (code, events) <- simulate "repeats" [] (\n i -> modelResult n (model n i))
           assertEqual "the additional samples resolve precision" 0 code
           _ <- assertSummary "stable" (1, 1024) (11, 39) events
           forM_ (eventsOf "point" events) $ \p -> do
@@ -168,21 +230,21 @@ scaleTests = testGroup "performance scaling studies"
             assertEqual "references use the same precision policy" (Just (Aeson.Number 5)) (KM.lookup "samples" r)
       , testCase "a bend extends exploration until the new trend is confirmed" $ do
           let model n = if n <= 256 then fromIntegral n else fromIntegral n ^ (2 :: Int) / 256
-          (code, events) <- simulate "bend" (\n _ -> modelResult n (model n))
+          (code, events) <- simulate "bend" [] (\n _ -> modelResult n (model n))
           assertEqual "the later segment settles" 0 code
           summary <- assertSummary "stable" (1, 8192) (14, 42) events
           assertEqual "the reported window starts at the bend" (Just (Aeson.Number 256)) (KM.lookup "stable_from_scale" summary)
           closeTo 2 . Just =<< field "growth_min" summary
           closeTo 2 . Just =<< field "growth_max" summary
       , testCase "tiny probes do not choose the reference or establish coverage" $ do
-          let model n = if n < 8 then 0.001 else fromIntegral n / 8
-          (code, events) <- simulate "tiny_start" (\n _ -> modelResult n (model n))
+          let model n = if n < 4 then 0 else if n < 8 then 0.001 else fromIntegral n / 8
+          (code, events) <- simulate "tiny_start" [] (\n _ -> modelResult n (model n))
           assertEqual "measurable work eventually settles" 0 code
           _ <- assertSummary "stable" (1, 8192) (14, 42) events
           forM_ (eventsOf "reference" events) $ \r ->
             assertEqual "the first measurable scale is the reference" (Just (Aeson.Number 8)) (KM.lookup "scale" r)
       , testCase "a fresh reference can reject an otherwise stable curve" $ do
-          (code, events) <- simulate "drift" (\n i -> modelResult n (if n == 1 && i > 9 then 2 else fromIntegral n))
+          (code, events) <- simulate "drift" [] (\n i -> modelResult n (if n == 1 && i > 9 then 2 else fromIntegral n))
           assertEqual "unsettled drift is an inconclusive study" 0 code
           summary <- assertSummary "inconclusive" (1, 4096) (13, 39) events
           assertEqual "reference failure explains the outcome" (Just (Aeson.String "Reference measurements did not settle")) (KM.lookup "reason" summary)
@@ -191,9 +253,9 @@ scaleTests = testGroup "performance scaling studies"
             (map (Just . Aeson.Bool) [True, True, False, False, False])
             (map (KM.lookup "stable") (eventsOf "reference" events))
       , testCase "persistently tiny or noisy timing stops without an endless search" $
-          forM_ [("tiny", \_ -> 0.001, 3),
+          forM_ [("zero", \_ -> 0, 3), ("tiny", \_ -> 0.001, 3),
                  ("noisy", \i -> cycle [0.1, 1, 1.9, 1, 1, 1, 1] !! (i - 1), 7)] $ \(name, model, repeats) -> do
-            (code, events) <- simulate name (\n i -> modelResult n (model i))
+            (code, events) <- simulate name [] (\n i -> modelResult n (model i))
             assertEqual name 0 code
             summary <- assertSummary "inconclusive" (1, 2^19) (20, 20 * repeats) events
             assertEqual "unreliable timing explains the outcome"
@@ -203,7 +265,7 @@ scaleTests = testGroup "performance scaling studies"
               assertEqual "unreliable samples remain visible" (Just (Aeson.Bool False)) (KM.lookup "reliable" p)
               assertEqual "no unsupported local growth is reported" (Just Aeson.Null) (KM.lookup "observed_exponent" p)
       , testCase "a result for the wrong scale cannot enter the curve" $ do
-          (code, events) <- simulate "wrong_scale" (\n _ -> modelResult (n + 1) 1)
+          (code, events) <- simulate "wrong_scale" [] (\n _ -> modelResult (n + 1) 1)
           assertEqual "mismatched provenance fails the study" 1 code
           sample <- requireEvent "sample" events
           assertEqual "the rejected result is still journaled" (Just (Aeson.Bool False)) (KM.lookup "accepted" sample)
@@ -231,12 +293,13 @@ scaleTests = testGroup "performance scaling studies"
         assertEnd reason events
         assertBool "an unguarded sample cannot contribute a point" (null (eventsOf "point" events))
   , testCase "comparison replays completed recorded sizes without adaptive early stopping" $
+      forM_ [([], [1,3..49]), (["--start-scale", "8", "--end-scale", "17"], [9,11..17])] $ \(args, expected) ->
       withSystemTempDirectory "acton-scale-replay" $ \directory -> do
-        (gopts, opts) <- parseScale ["--max-memory", "128MiB", "--max-time", "30s", "--json"]
+        (gopts, opts) <- parseScale (["--max-memory", "128MiB", "--max-time", "30s", "--json"] ++ args)
         let sizes = [1,3..49]
-            points = IM.fromList [(n, (True, [(0.001, 1048576)])) | n <- sizes]
+            points = IM.fromList [(n, (True, [ScaleSample 0.001 1048576 Nothing])) | n <- sizes]
             Aeson.Object raw = trRaw (modelResult 1 0.001)
-            series = ScaleSeries (IM.insert 50 (False, [(0.001, 1048576)]) points) (perfInfo raw) Nothing Nothing
+            series = ScaleSeries (IM.insert 50 (False, [ScaleSample 0.001 1048576 Nothing]) points) (perfInfo raw) Nothing Nothing
             baseline = ScaleRecording "old.jsonl" KM.empty (M.singleton ("sample", "test") series) Nothing
             implementation = replicate 64 'a'
         calls <- newIORef []
@@ -244,8 +307,8 @@ scaleTests = testGroup "performance scaling studies"
           modifyIORef' calls (++ [n])
           return (modelResult n 0.001)
         assertEqual "all scheduled sizes completed" 0 code
-        assertEqual "partial baseline point is excluded and 20 tiny sizes do not stop replay"
-          (concatMap (replicate 3) sizes) =<< readIORef calls
+        assertEqual "only completed sizes inside the requested range are replayed, regardless of timing"
+          (concatMap (replicate 3) expected) =<< readIORef calls
         [name] <- listDirectory directory
         assertBool name ("sample.test__" `isInfixOf` name && "__aaaaaaaaaaaa.jsonl" `isInfixOf` name)
         recording <- readScaleRecording (directory </> name)
@@ -364,7 +427,7 @@ scaleIntegrationTests =
             && ("__" ++ take 12 implementation ++ ".jsonl") `isInfixOf` takeFileName originalPath)
         original <- BS.readFile originalPath
         (compareCode, compareOut, compareErr) <- readCreateProcessWithExitCode
-          (proc acton ["test", "scale", "--compare", originalPath, "--max-time", "2s", "--json"])
+          (proc acton ["test", "scale", "--compare", originalPath, "--end-scale", "1000", "--max-time", "2s", "--json"])
             { cwd = Just project } ""
         assertEqual (compareOut ++ compareErr) ExitSuccess compareCode
         compared <- decodeEvents compareOut
@@ -380,6 +443,10 @@ scaleIntegrationTests =
         summary <- requireEvent "test_end" compared
         assertEqual "the recorded schedule completed" (Just (Aeson.String "compared")) (KM.lookup "outcome" summary)
         assertEqual "the old recording is unchanged" original =<< BS.readFile originalPath
+        (unreachedCode, _, unreachedErr) <- readCreateProcessWithExitCode
+          (proc acton ["test", "scale", "--compare", originalPath, "--end-scale", "1001", "--json"])
+            { cwd = Just project } ""
+        assertBool unreachedErr (unreachedCode /= ExitSuccess && "baseline has no completed point at --end-scale" `isInfixOf` unreachedErr)
         forM_ [("failure", "scaling failure"), ("without_loop", "require")] $ \(test, message) -> do
           (code, events, output) <- run test "128MiB" "2s"
           assertBool output (code /= ExitSuccess)
@@ -419,9 +486,9 @@ closeTo expected actual = assertBool (show actual) (maybe False (\x -> abs (x - 
 
 -- Simulated timings exercise the real controller and journal without waiting
 -- for large workloads. The invocation count also identifies later references.
-simulate :: String -> (Int -> Int -> TestResult) -> IO (Int, [Aeson.Object])
-simulate name result = withSystemTempDirectory ("acton-scale-" ++ name) $ \directory -> do
-    (gopts, opts) <- parseScale ["--max-memory", "128MiB", "--max-time", "30s"]
+simulate :: String -> [String] -> (Int -> Int -> TestResult) -> IO (Int, [Aeson.Object])
+simulate name options result = withSystemTempDirectory ("acton-scale-" ++ name) $ \directory -> do
+    (gopts, opts) <- parseScale (["--max-memory", "128MiB", "--max-time", "30s"] ++ options)
     calls <- newIORef IM.empty
     code <- runScalingStudy False gopts opts directory KM.empty [("sample", name, Nothing)] Nothing $ \_ scale modName testName -> do
       counts <- readIORef calls
@@ -443,6 +510,7 @@ modelResult scale wall = TestResult
     , trTestDuration = wall, trSnapshotUpdated = False, trCached = False
     , trRaw = Aeson.object ["complete" Aeson..= True, "success" Aeson..= True,
         "skipped" Aeson..= False, "num_iterations" Aeson..= (1 :: Int), "loop_iterations" Aeson..= (1 :: Int),
+        "mem_usage_delta_avg" Aeson..= (toInteger scale * 100),
         "avg_wall_duration" Aeson..= wall, "peak_rss" Aeson..= (1048576 :: Int),
         "perf_info" Aeson..= Aeson.object ["scale" Aeson..= scale, "loop" Aeson..= True, "scaling" Aeson..= True,
           "machine" Aeson..= ("test-machine" :: String), "version" Aeson..= ("3" :: String),

--- a/compiler/acton/TestRunner.hs
+++ b/compiler/acton/TestRunner.hs
@@ -138,8 +138,12 @@ prepareScalingComparison paths opts = case C.testCompare opts of
           forM_ (scaleSeriesReason series series) $ \reason ->
             ioError (userError ("Cannot compare: " ++ reason))
           when (null [n | (n, (True, _)) <- IM.toAscList (seriesData series),
-                         maybe True (n >=) (C.testStartScale opts)]) $
+                         maybe True (n >=) (C.testStartScale opts),
+                         maybe True (n <=) (C.testEndScale opts)]) $
             ioError (userError "The baseline has no completed sizes in the selected range")
+          forM_ (C.testEndScale opts) $ \target ->
+            unless (maybe False fst (IM.lookup target (seriesData series))) $
+              ioError (userError "The baseline has no completed point at --end-scale; choose a recorded size or run a new study without --compare")
           case Data.List.stripPrefix (projName paths ++ ".") modName of
             Nothing -> ioError (userError "The recorded benchmark belongs to a different project")
             Just localModule -> return

--- a/compiler/acton/TestScale.hs
+++ b/compiler/acton/TestScale.hs
@@ -51,6 +51,8 @@ validateScalingOptions opts
   | C.testRecord opts = Just "Scaling studies save every sample automatically; --record updates fixed-scale perf_data"
   | C.testSnapshotUpdate opts = Just "Scaling studies cannot update test snapshots"
   | C.watch (C.testCompile opts) = Just "Scaling studies cannot run with --watch"
+  | maybe False (< fromMaybe 1 (C.testStartScale opts)) (C.testEndScale opts) =
+      Just "--end-scale must be at least --start-scale (default: 1)"
   | otherwise = Nothing
 
 -- Reserve memory for the machine as well as bounding the child itself.
@@ -199,9 +201,12 @@ runScalingStudy useColor gopts opts directory host tests baseline runSample = do
               path = directory </> (name ++ "__" ++ timestamp ++ "__" ++ maybe "unknown" (take 12) implementation) <.> "jsonl"
               old = baseline >>= M.lookup (modName, testName) . recordingTests
               oldData = maybe IM.empty seriesData old
-              schedule = [n | (n, (True, _)) <- IM.toAscList oldData, maybe True (n >=) (C.testStartScale opts)]
+              schedule = [n | (n, (True, _)) <- IM.toAscList oldData,
+                              maybe True (n >=) (C.testStartScale opts),
+                              maybe True (n <=) (C.testEndScale opts)]
               firstScale = case schedule of n:_ -> n; [] -> fromMaybe 1 (C.testStartScale opts)
           chartData <- newIORef IM.empty
+          reached <- newIORef False
           (code, finished) <- bracket
             (PIO.openFd path PIO.WriteOnly PIO.defaultFileFlags { PIO.creat = Just 0o600, PIO.exclusive = True } >>= PIO.fdToHandle)
             hClose $ \journal -> do
@@ -215,7 +220,11 @@ runScalingStudy useColor gopts opts directory host tests baseline runSample = do
                   event kind fields = emit (("event" Aeson..= (kind :: String)) : fields)
                   finish reason code = do
                     now <- getTime Monotonic
-                    event "end" ["reason" Aeson..= reason, "elapsed_ms" Aeson..= milliseconds (now - benchmarkStart)]
+                    targetReached <- readIORef reached
+                    event "end" ["reason" Aeson..= reason, "elapsed_ms" Aeson..= milliseconds (now - benchmarkStart),
+                                 "end_scale_reached" Aeson..= fmap (const targetReached) (C.testEndScale opts)]
+                    forM_ (C.testEndScale opts) $ \target -> unless targetReached $
+                      say ("Requested end scale " ++ show target ++ " was not reached")
                     say ("Stopped: " ++ reason)
                     say ("Results: " ++ path)
                     return code
@@ -231,7 +240,9 @@ runScalingStudy useColor gopts opts directory host tests baseline runSample = do
                                  KM.lookup "loop_iterations" obj == Just (Aeson.Number 1),
                                  KM.lookup "scaling" info == Just (Aeson.Bool True),
                                  KM.lookup "scale" info == Just (Aeson.toJSON scale) -> do
-                        when (maybe True (<= 0) (perfNumber obj "avg_wall_duration")) $
+                        -- A body shorter than one clock tick can measure zero.
+                        -- Keep it as an unreliable probe and try larger sizes.
+                        when (maybe True (< 0) (perfNumber obj "avg_wall_duration")) $
                           throwIO (ScalingStopped "wall time measurement unavailable")
                         forM_ old $ \previous -> do
                           let issue = seriesInfo previous >>= (`perfSamplingReason` info)
@@ -249,7 +260,7 @@ runScalingStudy useColor gopts opts directory host tests baseline runSample = do
                                     "accepted" Aeson..= either (const False) (const True) checked]
                     obj <- either throwIO return checked
                     -- Raw results, including diagnostics, are already on disk.
-                    return (KM.filterWithKey (\key _ -> key `elem` ["avg_wall_duration", "peak_rss"]) obj)
+                    return (KM.filterWithKey (\key _ -> key `elem` ["avg_wall_duration", "peak_rss", "mem_usage_delta_avg"]) obj)
                   collect modName testName scale reference = do
                     when (progress && not live) (say ("  sampling " ++ label))
                     gather [] `finally` clearProgress
@@ -299,13 +310,20 @@ runScalingStudy useColor gopts opts directory host tests baseline runSample = do
                     point <- collect modName testName scale False
                     let points' = point : points
                         growth = case points of old:_ -> scaleGrowth old point; [] -> Nothing
-                        trend = stableGrowth points'
+                        targetReached = C.testEndScale opts == Just scale
+                        automatic = not (isJust (C.testEndScale opts))
+                        trend = if automatic || targetReached then stableGrowth points' else Nothing
+                        allocated = mapM (`perfNumber` "mem_usage_delta_avg") (pointSamples point)
                         reference' = case reference of
                           Nothing | scaleReliable point -> Just point
                           _ -> reference
+                    writeIORef reached targetReached
                     event "point" ["module" Aeson..= modName, "test" Aeson..= testName,
                                    "scale" Aeson..= scale, "samples" Aeson..= length (pointSamples point),
                                    "wall_mean_ms" Aeson..= scaleMean (pointValues "avg_wall_duration" point),
+                                   "allocated_mean_bytes" Aeson..= (allocated >>= scaleMean),
+                                   "allocated_min_bytes" Aeson..= fmap minimum allocated,
+                                   "allocated_max_bytes" Aeson..= fmap maximum allocated,
                                    "relative_standard_error" Aeson..= scaleError point,
                                    "reliable" Aeson..= scaleReliable point,
                                    "observed_exponent" Aeson..= growth]
@@ -324,15 +342,23 @@ runScalingStudy useColor gopts opts directory host tests baseline runSample = do
                     if isJust old then case pending of
                       [] -> finish "compared" "Completed baseline sizes remeasured" points' Nothing
                       next:rest -> study modName testName next points' reference' failures rest
+                    else if targetReached then
+                      finish "range" ("Requested scale range measured" ++
+                        if isJust trend && checked == Just True then "" else "; growth remains inconclusive")
+                        points' (if checked == Just True then trend else Nothing)
                     else if isJust trend && checked == Just True then
                       finish "stable" "Growth stable over the measured range" points' trend
-                    else if failures >= 3 then
+                    else if automatic && failures >= 3 then
                       finish "inconclusive" "Reference measurements did not settle" points' Nothing
-                    else if length (takeWhile (not . scaleReliable) points') >= 20 then
+                    else if automatic && length (takeWhile (not . scaleReliable) points') >= 20 then
                       finish "inconclusive" "Timing stayed too short or noisy across 20 successive sizes" points' Nothing
                     else case nextScale cap points' of
                       Nothing -> finish "limited" "Next scale approaches the memory or integer limit" points' Nothing
-                      Just next -> study modName testName next points' reference' failures []
+                      Just next ->
+                        let chosen = case C.testEndScale opts of
+                              Just target | scale < target -> min next target
+                              _ -> next
+                        in study modName testName chosen points' reference' failures []
               event "study" ["version" Aeson..= (3 :: Int), "host" Aeson..= host,
                              "module" Aeson..= modName, "test" Aeson..= testName,
                              "recorded_at" Aeson..= recordedAt, "run_id" Aeson..= runId,
@@ -340,18 +366,22 @@ runScalingStudy useColor gopts opts directory host tests baseline runSample = do
                              "baseline" Aeson..= fmap recordingPath baseline,
                              "max_memory_bytes" Aeson..= cap, "reserve_bytes" Aeson..= reserve,
                              "max_time_ms" Aeson..= duration, "start_scale" Aeson..= firstScale,
+                             "end_scale" Aeson..= C.testEndScale opts,
                              "memory_protection" Aeson..= ("monitored; abrupt allocations can exceed the limit" :: String),
                              "path" Aeson..= path]
-              say ((if isJust old then "Scaling comparison: recorded sizes" else "Scaling study: adaptive range")
+              say ((if isJust old then "Scaling comparison: recorded sizes"
+                    else if isJust (C.testEndScale opts) then "Scaling study: requested range"
+                    else "Scaling study: adaptive range")
                    ++ ", 3–7 samples per size, one warmup per sample")
               say ("Safety limits: " ++ show duration ++ "ms, memory ceiling " ++ bytes cap)
+              forM_ (C.testEndScale opts) $ \target -> say ("Scale range: " ++ show firstScale ++ " … " ++ show target)
               say "Memory protection is monitored; abrupt allocations can exceed the limit."
               say ("Results: " ++ path)
               outcome <- try $ flip finally (terminal "\ESC[?25h") $ do
                 terminal "\ESC[?25l"
                 say ("\nScaling " ++ modName ++ "." ++ testName)
                 forM_ baseline $ \previous -> say ("Baseline: " ++ clean (recordingPath previous))
-                say "       scale          mean          min … max             time/scale       peak RSS       growth"
+                say "       scale          mean          min … max             time/scale      allocated       peak RSS       growth"
                 study modName testName firstScale [] Nothing (0 :: Int) (drop 1 schedule)
                   `finally` unless (C.testJson opts) (do
                     points <- readIORef chartData
@@ -386,8 +416,11 @@ formatPoint point growth =
     let values = pointValues "avg_wall_duration" point
         mean = fromMaybe 0 (scaleMean values)
         peak = maximum (0 : pointValues "peak_rss" point)
+        allocated :: String
+        allocated = maybe "unavailable" (\n -> printf "%.3g KiB" (n / 1024))
+          (scaleMean =<< mapM (`perfNumber` "mem_usage_delta_avg") (pointSamples point))
         trend :: String
         trend = maybe "inconclusive" (printf "n^%.2f") growth
-    in printf "%12d  %10.3f ms  %9.3f … %9.3f ms  %10.3f µs  %10.1f MiB  %s"
+    in printf "%12d  %10.3f ms  %9.3f … %9.3f ms  %10.3f µs  %13s  %10.1f MiB  %s"
          (pointScale point) mean (if null values then 0 else minimum values) (maximum (0:values))
-         (mean * 1000 / fromIntegral (pointScale point)) (peak / 1048576) trend
+         (mean * 1000 / fromIntegral (pointScale point)) allocated (peak / 1048576) trend

--- a/compiler/lib/src/Acton/CommandLineParser.hs
+++ b/compiler/lib/src/Acton/CommandLineParser.hs
@@ -174,6 +174,7 @@ data TestOptions = TestOptions
     , testTime         :: Int
     , testScale        :: Maybe Int
     , testStartScale   :: Maybe Int
+    , testEndScale     :: Maybe Int
     , testMaxMemory    :: Maybe MemoryLimit
     , testCompare      :: Maybe FilePath
     , testStressWorkers :: Int
@@ -544,6 +545,7 @@ testOptions mode = mkTestOptions
     <*> (if mode == PerfOptions then option durationReader (long "time" <> metavar "DURATION" <> value 5000 <> help "Total budget per benchmark, including calibration (e.g. 5s or 250ms; default: 5s)") else pure 5000)
     <*> (if mode == PerfOptions then optional (option scaleReader (long "scale" <> metavar "N" <> help "Use this positive workload scale for t.loop(), skipping calibration")) else pure Nothing)
     <*> (if mode == ScaleOptions then optional (option scaleReader (long "start-scale" <> metavar "N" <> help "First positive workload scale in a scaling study (default: 1)")) else pure Nothing)
+    <*> (if mode == ScaleOptions then optional (option scaleReader (long "end-scale" <> metavar "N" <> help "Measure through this workload scale and finish, subject to resource limits")) else pure Nothing)
     <*> (if mode == ScaleOptions then optional (option memoryLimitReader (long "max-memory" <> metavar "LIMIT" <> help "Scaling study memory limit, as bytes or a percentage (e.g. 2GiB or 50%; default: 50%)")) else pure Nothing)
     <*> ordinary 0 (option auto (long "stress-workers" <> metavar "N" <> value 0 <> help "Concurrent stress workers to run in stress mode (0 = auto)"))
     <*> many (strOption (long "tag" <> metavar "TAG" <> help "Enable test capability TAG for testing.require()"))
@@ -552,7 +554,7 @@ testOptions mode = mkTestOptions
   where
     defaultOptimize = if mode == OrdinaryOptions then Debug else ReleaseFast
     ordinary fallback parser = if mode == OrdinaryOptions then parser else pure fallback
-    mkTestOptions testCompile testShowLog testShowCached testNoCache testJson testRecord testSnapshotUpdate testIter testMaxIterOpt testMinIter testMaxTimeOpt testMinTimeOpt testTime testScale testStartScale testMaxMemory testStressWorkers testTags testModules testNames =
+    mkTestOptions testCompile testShowLog testShowCached testNoCache testJson testRecord testSnapshotUpdate testIter testMaxIterOpt testMinIter testMaxTimeOpt testMinTimeOpt testTime testScale testStartScale testEndScale testMaxMemory testStressWorkers testTags testModules testNames =
       TestOptions
         { testCompile = testCompile
         , testShowLog = testShowLog
@@ -569,6 +571,7 @@ testOptions mode = mkTestOptions
         , testTime = testTime
         , testScale = testScale
         , testStartScale = testStartScale
+        , testEndScale = testEndScale
         , testMaxMemory = testMaxMemory
         , testCompare = Nothing
         , testStressWorkers = testStressWorkers

--- a/docs/acton-guide/src/testing/performance.md
+++ b/docs/acton-guide/src/testing/performance.md
@@ -310,12 +310,15 @@ The result includes:
 - **Allocated:** average bytes reported by the GC allocation counter
   in the measured region, averaged per loop body or whole invocation. This
   measures allocation volume, not peak memory usage.
-- **Process peak RSS:** peak resident memory for the test process, below the table.
+- **Process peak RSS:** peak resident memory since the test executable started, below the table.
   This includes startup, the runtime, all threads, the test harness, calibration,
   warmup and measurement. It is recorded before computing the final statistics
   and is omitted on platforms where it is unavailable. RSS minus GC heap size
   is not used as a performance or leak verdict. No baseline delta is shown,
   because calibration and warmup can differ between runs.
+  Linux reads the executable's `VmHWM` rather than an inherited launcher peak.
+  Older Linux recordings may include the launcher's footprint; replay cannot
+  correct those recorded values.
 - **Outliers:** run averages outside the range from Q1 minus 1.5 times the
   interquartile range to Q3 plus 1.5 times that range. Quartiles use linear
   interpolation between sorted samples. Outliers remain in all statistics;

--- a/docs/acton-guide/src/testing/performance.md
+++ b/docs/acton-guide/src/testing/performance.md
@@ -61,12 +61,28 @@ visible container limits and available memory headroom. `--max-memory` also
 accepts byte quantities such as `512MiB` or `4GiB`. The runner prints the actual
 ceiling before starting.
 
+Use `--start-scale` and `--end-scale` to choose the range of workload sizes:
+
+```sh
+acton test scale --name list_touch --start-scale 1000 --end-scale 100000
+```
+
+The runner starts at 1 unless given a different start, chooses intermediate
+sizes adaptively, and measures the exact endpoint before finishing. An explicit
+endpoint prevents statistical stopping rules from ending the study early.
+The end must be at least the start; equal values measure a single size.
+Without an endpoint, automatic exploration continues until growth settles or
+a resource limit intervenes. Time and memory ceilings apply to explicit ranges
+too, and a study that stops short reports that the endpoint was not reached.
+Completing the requested range does not establish stable growth: the report
+separately describes the available growth evidence, which can be inconclusive.
+
 `--max-time` caps the entire study across all selected tests, including process
 startup, warmup, setup and teardown. It defaults to one hour; durations support
 `ms`, `s`, `m` and `h`. Compilation is outside this budget. The parent stops a
 running sample when the deadline expires. This is a safety ceiling, not the usual
 completion condition. `--time` and `--scale` belong to `acton test perf`; use
-`--max-time` and `--start-scale` with `acton test scale`.
+`--max-time`, `--start-scale` and `--end-scale` with `acton test scale`.
 
 Scale must represent the workload dimension you want to investigate. For example,
 sorting `scale` elements tests growth with input size. Sorting the same small
@@ -92,8 +108,9 @@ warmup and teardown; it is process capacity, not a count of live application
 data. Allocation volume is recorded separately.
 
 The table and plots show mean wall time, sample ranges, time per unit of scale,
-peak RSS and observed growth between successive sizes. An exponent near 1 means
-time grew roughly linearly over those sizes; near 2 means roughly quadratically.
+allocated bytes, peak RSS and observed growth between successive sizes. An
+exponent near 1 means time grew roughly linearly over those sizes; near 2 means
+roughly quadratically.
 A growth estimate needs at least three samples at both sizes, mean times of at
 least 0.1ms and relative standard errors no greater than 5%.
 
@@ -106,7 +123,9 @@ uses three to seven samples under the same precision rule. It must remain
 reliable and its mean must stay within 20% of the original mean. Reference checks
 are separate observations, not additional curve samples. The study ends as
 inconclusive after three consecutive failed reference checks, or 20 consecutive
-sizes that remain too short or too variable.
+sizes that remain too short or too variable. With `--end-scale`, the requested
+range determines completion. Periodic reference checks still run, and unstable
+measurements prevent a stable-growth claim without shortening the range.
 
 These are practical stopping heuristics. Stable growth describes the measured
 range; it does not prove an algorithm's asymptotic complexity or rule out a bend
@@ -114,19 +133,29 @@ at a larger size. The result includes the covered scales, point and sample count
 and the recent scale range that supports its growth summary. A resource limit
 leaves a partial curve with the stopping reason.
 
-Each benchmark ends with terminal charts for time, time divided by scale and
-process peak memory. Both axes are logarithmic. Points show means, bars show
-sample ranges, and hollow points mark incomplete sampling at a size. Flat
+Each benchmark ends with terminal charts for time, time divided by scale,
+allocated bytes and process peak memory. Axes are logarithmic, except that an
+allocation chart containing zero uses a labelled linear vertical axis. Missing
+allocation data is omitted rather than shown as zero. Points show means, bars show
+sample ranges, and hollow points mark incomplete sampling at a size.
+If any timing at a size is zero because the operation is shorter than the clock
+resolution, that size is omitted from time charts but retained in the recording
+and memory charts. Zero readings do not by themselves stop the study. Flat
 time/scale suggests roughly linear time over the measured range. The wall-time
 chart includes a dashed guide for time proportional to scale, anchored at the
 largest completed size. It is an illustration, not a fitted model or a complexity
 claim. Each chart highlights its latest point and shows its latest mean.
-Cyan, violet and teal distinguish time, time/scale and memory; `--color never`
-and `NO_COLOR` select monochrome output. The summary counts curve samples
+Cyan, violet, pink and teal distinguish time, time/scale, allocations and peak
+memory; `--color never` and `NO_COLOR` select monochrome output. The summary counts curve samples
 separately from reference checks and identifies partial sizes. Kitty and
 Ghostty use inline graphics; other terminals, multiplexers and redirected output
 use Unicode plots. Very small terminals keep the table without charts. No
 external image viewer is needed, and drawing happens after measurement.
+
+Allocations measure the volume allocated inside the measured body, not retained
+structure size. Building a fixture before `t.loop()` excludes its allocation
+volume; peak RSS still includes it. The allocation chart can be rendered from
+older journals that contain allocation samples, without rerunning the study.
 
 While sampling, one terminal line shows the current scale and sample number.
 The target increases from three to five or seven when more measurements are
@@ -178,10 +207,12 @@ A live comparison selects the recorded benchmark before compilation, then
 remeasures its completed sizes in ascending order using fresh processes and the
 usual warmup and repeat policy. It finishes after those sizes rather than
 stopping early when a growth trend appears stable. `--start-scale` restricts the
-schedule to recorded sizes at or above that value. Current time and memory
-ceilings still apply; an early stop retains the partial curve and reports which
-baseline sizes were not reached. Every run writes a new recording and leaves
-the baseline untouched.
+schedule to recorded sizes at or above that value. `--end-scale` includes recorded
+sizes up to the endpoint and requires a completed baseline point at that exact
+size. Choose a recorded size or run a new study to explore a different endpoint.
+Current time and memory ceilings still apply. An early
+stop retains the partial curve and reports which baseline sizes were not reached.
+Every run writes a new recording and leaves the baseline untouched.
 
 Older journals containing multiple benchmarks require `--module` and/or `--name`
 to select one for a live comparison. Two-file reports compare matching benchmark
@@ -198,7 +229,12 @@ snapshot updates are not supported during a scaling study.
 Each sample may emit at most 1MiB on each output stream. Exceeding this limit
 stops the study with an error so diagnostic output cannot exhaust the runner's
 memory during a long study. Raw diagnostics stay in the journal; terminal charts
-retain only timing and peak memory samples for the current benchmark.
+retain only timing, allocation and peak memory samples for the current benchmark.
+Point events include `allocated_mean_bytes`, `allocated_min_bytes` and
+`allocated_max_bytes`, or `null` when allocation measurements are unavailable.
+The header records `start_scale` and the optional `end_scale`. The final event's
+`end_scale_reached` is true only when that exact endpoint completed sampling,
+false if the study stopped short, and null when no endpoint was requested.
 
 The memory guard monitors the benchmark process during execution and leaves a
 reserve for other work. Linux observes RSS and visible cgroup memory limits;
@@ -226,12 +262,33 @@ sorted copy are measured. Ordinary testing runs the body once with scale 1.
 Tests without `t.loop()`, including tests without a context, measure their whole
 invocation.
 
-Scale is a positive integer whose meaning the author defines. The example sorts
-the same input `scale` times per body. It could instead control input size or the
+Read `t.scale()` before the loop to prepare an input of the requested size:
+
+```python
+def _test_lookup(t: testing.SyncT):
+    data = {i: i for i in range(t.scale())}
+    key = t.scale() - 1
+    for scale in t.loop():
+        assert data[key] == key
+```
+
+Scale stays fixed for the entire invocation and agrees with every value yielded
+by its loop. Calibration starts a fresh invocation for each candidate scale, so
+setup is rebuilt at the correct size. Warmup and measured invocations also run
+their own setup and teardown. Repeated bodies within one invocation share its
+setup; reset mutated state as needed. The getter is available on all three
+testing contexts and returns 1 in ordinary tests. Calling `t.scale()` alone does
+not opt into bracketed measurement; use `t.loop()` as well.
+
+Scale is a positive integer whose meaning the author defines. The sorting example
+runs on the same input `scale` times per body. It could instead control input size or the
 number of concurrent actors. Document that meaning. The runner tries increasing
 scales 1, 2, 4 and so on to find enough work for useful measurement. At the end of
 calibration, it chooses whichever of the last two scales ran closer to the target
-duration, then freezes that scale. A compatible baseline supplies its recorded
+duration, then freezes that scale. This target is one tenth of the budget for
+the complete invocation, including setup and teardown, so preparation leaves
+room for repeated measurements. Reported operation timings still exclude setup
+and teardown. A compatible baseline supplies its recorded
 scale instead.
 The calibration points show observed growth; they do not establish an algorithm's
 complexity. The terminal abbreviates long curves to the first and last two
@@ -380,8 +437,9 @@ scale, whether `loop` was used, worker count and `time_budget_ms`.
 setup and teardown across the measured invocations. Both are in milliseconds and
 exclude warmup. At the top level of `measurements`, `loop_iterations` counts
 completed measured bodies and `num_iterations` counts complete invocation samples.
-`calibration` retains each observed `{scale, wall_ms}` point; these are sizing
-observations, separate from the measured samples.
+`calibration` retains each observed `{scale, wall_ms, invocation_ms}` point;
+`wall_ms` times the body and `invocation_ms` includes setup and teardown. These
+are sizing observations, separate from the measured samples.
 
 See [Performance comparisons](perf_record.md) to record a baseline and compare
 later runs, or [Stress testing](stress.md) for concurrency-focused tests.

--- a/test/perf/README.md
+++ b/test/perf/README.md
@@ -1,71 +1,92 @@
 # Builtin and collection benchmarks
 
-Run these modules with a compiler that supports `t.loop()` and workload scale:
+Run these modules with a compiler that supports `t.scale()` and `t.loop()`:
 
 ```sh
 acton test list --module builtin_functions --module collection_iterators
 acton test perf --module builtin_functions --module collection_iterators
 ```
 
+Scale means **input element count**. Each loop body performs one operation on
+that input. For example, `sum` at scale 100000 sums a list of 100,000 elements;
+`filter_all` creates and fully consumes one filter iterator over that list.
+The report gives time and allocation per operation. Empty inputs stay empty at
+every scale, and their controls measure one empty operation per body.
+
+Read `t.scale()` to construct the input before `t.loop()`. Scale stays fixed
+throughout an invocation. Calibration, warmup and measured invocations each
+prepare their own inputs. Within an invocation, the runner repeats loop bodies
+as needed for the time budget. Ordinary `acton test` runs a body once at scale 1
+and checks its result.
+
 Performance mode builds optimized code and runs one benchmark process at a time.
-`t.loop()` handles calibration, warmup and measurement. Ordinary `acton test`
-runs each loop body once at scale 1 and checks its result.
+To use the representative input size from the earlier fixed-size benchmarks:
 
-Scale means **repetitions of one operation**, each using the same 1,024-element
-input. Empty-input cases repeat the corresponding operation on an empty input.
-For example, `sum` at scale 8 calls `sum(xs)` eight times per measured body;
-`filter_all` at scale 8 creates and fully consumes eight filter iterators.
-The report gives time and allocation per body at that scale. Scale changes the
-amount of repeated work, not the collection size. These tests measure operation
-costs at a fixed size, rather than how an algorithm grows with input size.
+```sh
+acton test perf --module builtin_functions --module collection_iterators --scale 1024
+```
 
-Collection inputs and accumulators are prepared before `t.loop()`. Range inputs
-are consuming iterators, so `sum_range` and `zip_mixed` create a fresh range for
-each operation inside the body. Result checks run after the loop and tolerate
-no bodies when setup exhausts the time budget.
-Checksums and consumed counts cover all completed bodies. Collection tests check
-the accumulated lengths and the final contents. Constructors include output
-allocation; dict and set updates reuse a target after its first population, so
-subsequent updates measure replacement or duplicate insertion without growth.
-Each measured invocation starts with fresh setup.
+To explore the growth curve over a chosen range:
+
+```sh
+acton test scale --module builtin_functions --name filter_all --start-scale 1 --end-scale 100000
+```
+
+Empty-input controls and operations that can return immediately need not get
+slower with scale. They are useful controls, but do not exercise a growing scan.
+Use `acton test perf --scale 1` for fixed empty-operation measurements.
+
+Collection inputs, mutable targets and accumulators are prepared before
+`t.loop()`. Range inputs are consuming iterators, so `sum_range` and `zip_mixed`
+create a fresh range inside each body. Result checks run after the loop and
+tolerate no bodies when setup exhausts the time budget. Checksums and consumed
+counts cover all completed bodies; collection tests check accumulated lengths
+and final contents.
+
+Constructors include output allocation. Dict updates start with all keys present
+and measure value replacement. Set updates start with all elements present and
+measure duplicate insertion. List and bytearray slice assignments start with a
+target of the matching size. These cases measure the same kind of operation
+from their first body, including when a scaling study measures just one body.
 
 The builtin tests cover numeric sum variants, extrema with and without defaults,
-filter selectivity and mixed zip iterators. The input permutation avoids
-monotonic extrema. Lazy iterators are consumed with ordinary loops so another
-builtin under comparison cannot hide their cost. The `control` case traverses
-the input directly to help assess measurement noise. Enumeration retains its C
-implementation; its cases cover the declaration change and provide another
-iterator control.
+filter selectivity and mixed zip iterators. The shared integer-list inputs contain
+every integer from 0 to scale minus one, with odd values first, then positive
+even values, and zero last. This permutation works at arbitrary positive scales
+and keeps the minimum away from the first element when the input has more than
+one element. Lazy iterators are consumed with ordinary loops so another builtin
+under comparison cannot hide their cost. The `control` case traverses the input directly to help
+assess measurement noise. Enumeration retains its C implementation and provides
+another iterator control.
 
-The collection tests cover list, dict and set construction, list and bytearray
-slice assignment, dict and set updates, and set disjointness. The disjointness
-cases cover a full scan, an immediate overlap, an empty set, and a one-element
-set against 1,024 elements to exercise the smaller-set path. Bytearray slice
-inputs include every byte value.
+The collection tests cover list, dict and set construction, slice assignment,
+dict and set updates, and set disjointness. Disjointness cases cover a full scan
+of two size-N sets, immediate overlap, a size-N set against an empty set, and a
+one-element set against N elements. The last case exercises the smaller-set path
+when N is greater than one. Bytearray slice inputs cycle through the byte values
+0 to 255, covering every byte value once scale reaches 256.
 
 The disjoint and empty-set cases and both bytearray slice cases expose iterator
 exhaustion bugs fixed in #3104. Before that fix, `StopIteration` escapes the
 operation and the completion checks fail. Report a failed baseline rather than
-treating the failure time as an operation latency or speedup. The header and
-iterator-registration edits accompany the same builtin migration and do not add
-separate collection operations.
+treating the failure time as an operation latency or speedup.
 
 ## Comparing implementations
 
 Record the first implementation, then run the second against the same reference:
 
 ```sh
-acton test perf --module builtin_functions --module collection_iterators --record
+acton test perf --module builtin_functions --module collection_iterators --scale 1024 --record
 # Build the other implementation, keeping these benchmark sources and perf_data.
 acton test perf --module builtin_functions --module collection_iterators --json > comparison.json
 ```
 
 A compatible baseline supplies its chosen scale. Keep that scale fixed between
-implementations; independently calibrated scales measure different workloads.
-Use `--scale N` to choose an exact scale and `--time 10s` to extend the budget:
+implementations; independently calibrated scales measure different input sizes.
+Use `--scale N` to choose an exact input size and `--time 10s` to extend the budget:
 
 ```sh
-acton test perf --module builtin_functions --name '(control|filter_all)' --scale 256 --time 10s
+acton test perf --module builtin_functions --name '(control|filter_all)' --scale 100000 --time 10s
 ```
 
 Keep the compiler, measurement code, machine, build options and worker count
@@ -74,12 +95,17 @@ the same when isolating a builtin change. Rebuild with `make` and regenerate
 test results, but that does not replace rebuilding generated code. On macOS,
 both installations need the elapsed GC clock fix from #3107.
 
-Use new recordings for these loop tests; the earlier fixed-repetition benchmarks
-have different names, inputs and measurement boundaries. Repeat comparisons in
-alternating process order, retain JSON reports and inspect controls, CPU work
-and allocation alongside wall time. Confidence markers describe variation within
-one process, and do not capture variation between processes. Peak RSS includes
-setup, calibration and warmup and is not an allocation or leak verdict.
+Create new recordings after this migration. Scale previously meant repetitions
+of an operation on a fixed 1,024-element input; it now means input element count,
+and each body performs one operation. The old measurements describe different
+workloads even when their numeric scales match. The permutation and initial
+mutable-target states have also changed.
+
+Repeat comparisons in alternating process order, retain JSON reports and inspect
+controls, CPU work and allocation alongside wall time. Confidence markers describe
+variation within one process, and do not capture variation between processes.
+Peak RSS includes setup, calibration and warmup and is not an allocation or leak
+verdict.
 
 See the [performance guide](../../docs/acton-guide/src/testing/performance.md)
 and [baseline workflow](../../docs/acton-guide/src/testing/perf_record.md) for

--- a/test/perf/src/builtin_functions.act
+++ b/test/perf/src/builtin_functions.act
@@ -1,71 +1,65 @@
 import testing
 
 
-# Scale repeats an operation on the same 1024-element input. Construct inputs
-# before t.loop(), and check accumulated results after it. Consume lazy
-# iterators directly so list() or sum() cannot mask their cost.
-size = 1024
-
-def inputs() -> list[int]:
-    # A permutation avoids measuring only monotonically increasing extrema.
-    # Keep the minimum last so returning the first element cannot pass.
-    return [((i + 1) * 73) % size for i in range(size)]
+# Scale is the number of input elements. Prepare inputs before t.loop(), then
+# measure one operation per body. Consume lazy iterators directly so list() or
+# sum() cannot mask their cost. Empty controls keep their input empty.
+def inputs(size: int) -> list[int]:
+    # Visit every value once for any positive size, with the minimum last.
+    return ([2 * i + 1 for i in range(size // 2)]
+            + [2 * i for i in range(1, (size + 1) // 2)] + [0])
 
 
 def traverse(t: testing.SyncT, xs: list[int]):
     total = 0
     repeats = 0
-    for scale in t.loop():
-        repeats += scale
-        for _ in range(scale):
-            for x in xs:
-                total += x
+    for _ in t.loop():
+        repeats += 1
+        for x in xs:
+            total += x
     testing.assertEqual(total, repeats * len(xs) * (len(xs) - 1) // 2)
 
 def add_ints(t: testing.SyncT, xs: list[int]):
     total = 0
     repeats = 0
-    for scale in t.loop():
-        repeats += scale
-        for _ in range(scale):
-            total += sum(xs)
+    for _ in t.loop():
+        repeats += 1
+        total += sum(xs)
     testing.assertEqual(total, repeats * len(xs) * (len(xs) - 1) // 2)
 
 def maximum(t: testing.SyncT, xs: list[int]):
     total = 0
     repeats = 0
-    for scale in t.loop():
-        repeats += scale
-        for _ in range(scale):
-            total += max(xs, -1)
+    for _ in t.loop():
+        repeats += 1
+        total += max(xs, -1)
     testing.assertEqual(total, repeats * (len(xs) - 1))
 
 def minimum(t: testing.SyncT, xs: list[int]):
+    fallback = len(xs) + 1
     total = 0
     repeats = 0
-    for scale in t.loop():
-        repeats += scale
-        for _ in range(scale):
-            total += min(xs, size)
-    testing.assertEqual(total, repeats * (size if len(xs) == 0 else 0))
+    for _ in t.loop():
+        repeats += 1
+        total += min(xs, fallback)
+    testing.assertEqual(total, repeats * (fallback if len(xs) == 0 else 0))
 
 def maximum_def(t: testing.SyncT, xs: list[int]):
     total = 0
     repeats = 0
-    for scale in t.loop():
-        repeats += scale
-        for _ in range(scale):
-            total += max_def(xs, -1)
+    for _ in t.loop():
+        repeats += 1
+        total += max_def(xs, -1)
     testing.assertEqual(total, repeats * (len(xs) - 1))
 
 def minimum_def(t: testing.SyncT, xs: list[int]):
+    fallback = len(xs) + 1
     total = 0
     repeats = 0
-    for scale in t.loop():
-        repeats += scale
-        for _ in range(scale):
-            total += min_def(xs, size)
-    testing.assertEqual(total, repeats * (size if len(xs) == 0 else 0))
+    for _ in t.loop():
+        repeats += 1
+        total += min_def(xs, fallback)
+    testing.assertEqual(total, repeats * (fallback if len(xs) == 0 else 0))
 
 def increment(x: int) -> int:
     return x + 1
@@ -74,12 +68,11 @@ def mapped(t: testing.SyncT, xs: list[int]):
     total = 0
     count = 0
     repeats = 0
-    for scale in t.loop():
-        repeats += scale
-        for _ in range(scale):
-            for x in map(increment, xs):
-                total += x
-                count += 1
+    for _ in t.loop():
+        repeats += 1
+        for x in map(increment, xs):
+            total += x
+            count += 1
     testing.assertEqual(count, repeats * len(xs))
     testing.assertEqual(total, repeats * len(xs) * (len(xs) + 1) // 2)
 
@@ -100,12 +93,11 @@ def filtered(t: testing.SyncT, xs: list[int], predicate: (int)->bool,
     total = 0
     count = 0
     repeats = 0
-    for scale in t.loop():
-        repeats += scale
-        for _ in range(scale):
-            for x in filter(predicate, xs):
-                total += x
-                count += 1
+    for _ in t.loop():
+        repeats += 1
+        for x in filter(predicate, xs):
+            total += x
+            count += 1
     testing.assertEqual(count, repeats * expected_count)
     testing.assertEqual(total, repeats * expected_sum)
 
@@ -113,12 +105,11 @@ def zipped(t: testing.SyncT, xs: list[int]):
     total = 0
     count = 0
     repeats = 0
-    for scale in t.loop():
-        repeats += scale
-        for _ in range(scale):
-            for a, b in zip(xs, xs):
-                total += a + b
-                count += 1
+    for _ in t.loop():
+        repeats += 1
+        for a, b in zip(xs, xs):
+            total += a + b
+            count += 1
     testing.assertEqual(count, repeats * len(xs))
     testing.assertEqual(total, repeats * len(xs) * (len(xs) - 1))
 
@@ -126,93 +117,91 @@ def enumerated(t: testing.SyncT, xs: list[int]):
     total = 0
     count = 0
     repeats = 0
-    for scale in t.loop():
-        repeats += scale
-        for _ in range(scale):
-            for i, x in enumerate(xs, 7):
-                total += i + x
-                count += 1
+    for _ in t.loop():
+        repeats += 1
+        for i, x in enumerate(xs, 7):
+            total += i + x
+            count += 1
     testing.assertEqual(count, repeats * len(xs))
     testing.assertEqual(total, repeats * len(xs) * (len(xs) - 1 + 7))
 
 
 def _test_control(t: testing.SyncT):
-    traverse(t, inputs())
+    traverse(t, inputs(t.scale()))
 
 def _test_enumerate(t: testing.SyncT):
-    enumerated(t, inputs())
+    enumerated(t, inputs(t.scale()))
 
 def _test_enumerate_empty(t: testing.SyncT):
     enumerated(t, [])
 
 def _test_sum(t: testing.SyncT):
-    add_ints(t, inputs())
+    add_ints(t, inputs(t.scale()))
 
 def _test_sum_empty(t: testing.SyncT):
     add_ints(t, [])
 
 def _test_sum_float(t: testing.SyncT):
+    size = t.scale()
     xs = [float(i) for i in range(size)]
     total = 0.0
     repeats = 0
-    for scale in t.loop():
-        repeats += scale
-        for _ in range(scale):
-            total += sum(xs)
+    for _ in t.loop():
+        repeats += 1
+        total += sum(xs)
     testing.assertEqual(total, float(repeats * size * (size - 1) // 2))
 
 def _test_sum_bigint(t: testing.SyncT):
+    size = t.scale()
     xs = [bigint(i) for i in range(size)]
     total = bigint(0)
     repeats = 0
-    for scale in t.loop():
-        repeats += scale
-        for _ in range(scale):
-            total += sum(xs)
+    for _ in t.loop():
+        repeats += 1
+        total += sum(xs)
     testing.assertEqual(total, bigint(repeats * size * (size - 1) // 2))
 
 def _test_sum_start(t: testing.SyncT):
-    xs = inputs()
+    size = t.scale()
+    xs = inputs(size)
     total = 0
     repeats = 0
-    for scale in t.loop():
-        repeats += scale
-        for _ in range(scale):
-            total += sum(xs, 7)
+    for _ in t.loop():
+        repeats += 1
+        total += sum(xs, 7)
     testing.assertEqual(total, repeats * (size * (size - 1) // 2 + 7))
 
 def _test_sum_range(t: testing.SyncT):
+    size = t.scale()
     total = 0
     repeats = 0
-    for scale in t.loop():
-        repeats += scale
-        for _ in range(scale):
-            total += sum(range(size))
+    for _ in t.loop():
+        repeats += 1
+        total += sum(range(size))
     testing.assertEqual(total, repeats * size * (size - 1) // 2)
 
 def _test_max(t: testing.SyncT):
-    xs = inputs()
+    size = t.scale()
+    xs = inputs(size)
     total = 0
     repeats = 0
-    for scale in t.loop():
-        repeats += scale
-        for _ in range(scale):
-            total += max(xs)
+    for _ in t.loop():
+        repeats += 1
+        total += max(xs)
     testing.assertEqual(total, repeats * (size - 1))
 
 def _test_min(t: testing.SyncT):
-    xs = inputs()
+    xs = inputs(t.scale())
     total = 0
-    for scale in t.loop():
-        for _ in range(scale):
-            total += min(xs)
+    for _ in t.loop():
+        total += min(xs)
     testing.assertEqual(total, 0)
 
 def _test_max_default(t: testing.SyncT):
-    maximum(t, inputs())
+    maximum(t, inputs(t.scale()))
 
 def _test_min_default(t: testing.SyncT):
-    minimum(t, inputs())
+    minimum(t, inputs(t.scale()))
 
 def _test_max_empty(t: testing.SyncT):
     maximum(t, [])
@@ -221,10 +210,10 @@ def _test_min_empty(t: testing.SyncT):
     minimum(t, [])
 
 def _test_max_def(t: testing.SyncT):
-    maximum_def(t, inputs())
+    maximum_def(t, inputs(t.scale()))
 
 def _test_min_def(t: testing.SyncT):
-    minimum_def(t, inputs())
+    minimum_def(t, inputs(t.scale()))
 
 def _test_max_def_empty(t: testing.SyncT):
     maximum_def(t, [])
@@ -233,44 +222,47 @@ def _test_min_def_empty(t: testing.SyncT):
     minimum_def(t, [])
 
 def _test_map(t: testing.SyncT):
-    mapped(t, inputs())
+    mapped(t, inputs(t.scale()))
 
 def _test_map_empty(t: testing.SyncT):
     mapped(t, [])
 
 def _test_filter_all(t: testing.SyncT):
-    filtered(t, inputs(), keep_all, size, size * (size - 1) // 2)
+    size = t.scale()
+    filtered(t, inputs(size), keep_all, size, size * (size - 1) // 2)
 
 def _test_filter_half(t: testing.SyncT):
-    n = size // 2
-    filtered(t, inputs(), keep_even, n, n * (n - 1))
+    size = t.scale()
+    n = (size + 1) // 2
+    filtered(t, inputs(size), keep_even, n, n * (n - 1))
 
 def _test_filter_rare(t: testing.SyncT):
-    n = size // 128
-    filtered(t, inputs(), keep_rare, n, 128 * n * (n - 1) // 2)
+    size = t.scale()
+    n = (size + 127) // 128
+    filtered(t, inputs(size), keep_rare, n, 128 * n * (n - 1) // 2)
 
 def _test_filter_none(t: testing.SyncT):
-    filtered(t, inputs(), keep_none, 0, 0)
+    filtered(t, inputs(t.scale()), keep_none, 0, 0)
 
 def _test_filter_empty(t: testing.SyncT):
     filtered(t, [], keep_all, 0, 0)
 
 def _test_zip(t: testing.SyncT):
-    zipped(t, inputs())
+    zipped(t, inputs(t.scale()))
 
 def _test_zip_empty(t: testing.SyncT):
     zipped(t, [])
 
 def _test_zip_mixed(t: testing.SyncT):
-    xs = inputs()
+    size = t.scale()
+    xs = inputs(size)
     total = 0
     count = 0
     repeats = 0
-    for scale in t.loop():
-        repeats += scale
-        for _ in range(scale):
-            for a, b in zip(xs, range(size)):
-                total += a + b
-                count += 1
+    for _ in t.loop():
+        repeats += 1
+        for a, b in zip(xs, range(size)):
+            total += a + b
+            count += 1
     testing.assertEqual(count, repeats * size)
     testing.assertEqual(total, repeats * size * (size - 1))

--- a/test/perf/src/collection_iterators.act
+++ b/test/perf/src/collection_iterators.act
@@ -1,14 +1,13 @@
 import testing
 
 
-# Scale repeats one operation on the same input. Input construction and result
-# checks are outside t.loop(); output allocation remains part of the operation.
-size = 1024
-
-def inputs() -> list[int]:
+# Scale is the number of input elements. Prepare inputs and mutable targets
+# before t.loop(); each body measures one operation, including output allocation.
+# Empty controls keep their input empty regardless of scale.
+def inputs(size: int) -> list[int]:
     return [i for i in range(size)]
 
-def items() -> list[(int, int)]:
+def items(size: int) -> list[(int, int)]:
     return [(i, i + 1) for i in range(size)]
 
 
@@ -16,11 +15,10 @@ def construct_list(t: testing.SyncT, xs: list[int]):
     count = 0
     repeats = 0
     last: list[int] = []
-    for scale in t.loop():
-        repeats += scale
-        for _ in range(scale):
-            last = list(xs)
-            count += len(last)
+    for _ in t.loop():
+        repeats += 1
+        last = list(xs)
+        count += len(last)
     testing.assertEqual(count, repeats * len(xs))
     if repeats > 0:
         testing.assertEqual(last, xs)
@@ -28,12 +26,11 @@ def construct_list(t: testing.SyncT, xs: list[int]):
 def assign_list_slice(t: testing.SyncT, xs: list[int]):
     count = 0
     repeats = 0
-    target = [-1]
-    for scale in t.loop():
-        repeats += scale
-        for _ in range(scale):
-            target[:] = xs
-            count += len(target)
+    target = list(xs)
+    for _ in t.loop():
+        repeats += 1
+        target[:] = xs
+        count += len(target)
     testing.assertEqual(count, repeats * len(xs))
     if repeats > 0:
         testing.assertEqual(target, xs)
@@ -42,26 +39,24 @@ def construct_dict(t: testing.SyncT, xs: list[(int, int)]):
     count = 0
     repeats = 0
     last: dict[int, int] = {}
-    for scale in t.loop():
-        repeats += scale
-        for _ in range(scale):
-            last = dict(xs)
-            count += len(last)
+    for _ in t.loop():
+        repeats += 1
+        last = dict(xs)
+        count += len(last)
     testing.assertEqual(count, repeats * len(xs))
     if repeats > 0:
         for k, v in xs:
             testing.assertEqual(last[k], v)
 
 def update_dict(t: testing.SyncT, xs: list[(int, int)]):
-    # After the first update, measure replacement without table growth.
-    target: dict[int, int] = {}
+    # Measure replacement without table growth from the first body.
+    target: dict[int, int] = dict(xs)
     count = 0
     repeats = 0
-    for scale in t.loop():
-        repeats += scale
-        for _ in range(scale):
-            target.update(xs)
-            count += len(target)
+    for _ in t.loop():
+        repeats += 1
+        target.update(xs)
+        count += len(target)
     testing.assertEqual(count, repeats * len(xs))
     if repeats > 0:
         for k, v in xs:
@@ -71,26 +66,24 @@ def construct_set(t: testing.SyncT, xs: list[int]):
     count = 0
     repeats = 0
     last: set[int] = set()
-    for scale in t.loop():
-        repeats += scale
-        for _ in range(scale):
-            last = set(xs)
-            count += len(last)
+    for _ in t.loop():
+        repeats += 1
+        last = set(xs)
+        count += len(last)
     testing.assertEqual(count, repeats * len(xs))
     if repeats > 0:
         for x in xs:
             testing.assertIn(x, last)
 
 def update_set(t: testing.SyncT, xs: list[int]):
-    # After the first update, measure duplicate insertion without table growth.
-    target: set[int] = set()
+    # Measure duplicate insertion without table growth from the first body.
+    target: set[int] = set(xs)
     count = 0
     repeats = 0
-    for scale in t.loop():
-        repeats += scale
-        for _ in range(scale):
-            target.update(xs)
-            count += len(target)
+    for _ in t.loop():
+        repeats += 1
+        target.update(xs)
+        count += len(target)
     testing.assertEqual(count, repeats * len(xs))
     if repeats > 0:
         for x in xs:
@@ -98,29 +91,21 @@ def update_set(t: testing.SyncT, xs: list[int]):
 
 def disjoint(t: testing.SyncT, xs: set[int], ys: set[int], expected: bool):
     matches = 0
-    completed = 0
     repeats = 0
-    for scale in t.loop():
-        repeats += scale
-        for _ in range(scale):
-            if Set.isdisjoint(xs, ys):
-                matches += 1
-            completed += 1
-    testing.assertEqual(completed, repeats)
+    for _ in t.loop():
+        repeats += 1
+        if Set.isdisjoint(xs, ys):
+            matches += 1
     testing.assertEqual(matches, repeats if expected else 0)
 
 def assign_bytearray_slice(t: testing.SyncT, xs: list[int]):
-    target = bytearray(b"_")
+    target = bytearray(b"_" * len(xs))
     count = 0
-    completed = 0
     repeats = 0
-    for scale in t.loop():
-        repeats += scale
-        for _ in range(scale):
-            target[:] = xs
-            count += len(target)
-            completed += 1
-    testing.assertEqual(completed, repeats)
+    for _ in t.loop():
+        repeats += 1
+        target[:] = xs
+        count += len(target)
     testing.assertEqual(count, repeats * len(xs))
     if repeats > 0:
         testing.assertEqual(len(target), len(xs))
@@ -129,55 +114,58 @@ def assign_bytearray_slice(t: testing.SyncT, xs: list[int]):
 
 
 def _test_list(t: testing.SyncT):
-    construct_list(t, inputs())
+    construct_list(t, inputs(t.scale()))
 
 def _test_list_empty(t: testing.SyncT):
     construct_list(t, [])
 
 def _test_list_slice(t: testing.SyncT):
-    assign_list_slice(t, inputs())
+    assign_list_slice(t, inputs(t.scale()))
 
 def _test_list_slice_empty(t: testing.SyncT):
     assign_list_slice(t, [])
 
 def _test_dict(t: testing.SyncT):
-    construct_dict(t, items())
+    construct_dict(t, items(t.scale()))
 
 def _test_dict_empty(t: testing.SyncT):
     construct_dict(t, [])
 
 def _test_dict_update(t: testing.SyncT):
-    update_dict(t, items())
+    update_dict(t, items(t.scale()))
 
 def _test_dict_update_empty(t: testing.SyncT):
     update_dict(t, [])
 
 def _test_set(t: testing.SyncT):
-    construct_set(t, inputs())
+    construct_set(t, inputs(t.scale()))
 
 def _test_set_empty(t: testing.SyncT):
     construct_set(t, [])
 
 def _test_set_update(t: testing.SyncT):
-    update_set(t, inputs())
+    update_set(t, inputs(t.scale()))
 
 def _test_set_update_empty(t: testing.SyncT):
     update_set(t, [])
 
 def _test_set_isdisjoint(t: testing.SyncT):
-    disjoint(t, set(inputs()), set([size + i for i in range(size)]), True)
+    size = t.scale()
+    disjoint(t, set(inputs(size)), set([size + i for i in range(size)]), True)
 
 def _test_set_isdisjoint_overlap(t: testing.SyncT):
-    disjoint(t, set(inputs()), set(inputs()), False)
+    disjoint(t, set(inputs(t.scale())), set(inputs(t.scale())), False)
 
 def _test_set_isdisjoint_empty(t: testing.SyncT):
-    disjoint(t, set(inputs()), set(), True)
+    disjoint(t, set(inputs(t.scale())), set(), True)
 
 def _test_set_isdisjoint_unbalanced(t: testing.SyncT):
+    size = t.scale()
     # Exercise the branch that swaps arguments to scan the smaller set.
-    disjoint(t, {size}, set(inputs()), True)
+    disjoint(t, {size}, set(inputs(size)), True)
 
 def _test_bytearray_slice(t: testing.SyncT):
+    size = t.scale()
     assign_bytearray_slice(t, [i % 256 for i in range(size)])
 
 def _test_bytearray_slice_empty(t: testing.SyncT):

--- a/test/stdlib_tests/src/test_testing_perf.act
+++ b/test/stdlib_tests/src/test_testing_perf.act
@@ -3,43 +3,87 @@ import testing
 
 
 def _test_calibration_doubles_the_workload(t: testing.SyncT):
-    loop = testing.PerfLoop(1, 1, 10000.0, 10000.0, 50.0)
-    assert loop._advance(0) == 1
-    for scale in [1, 2, 4]:
-        loop._last_wall_ns = u64(scale * 1000000)
-        assert loop._advance(1) == scale * 2
-    loop._last_wall_ns = u64(50000000)
-    assert loop._advance(1) is None
-    assert loop.scale == 8
-    assert loop.iterations == 4
-    assert len(loop.calibration) == 4
+    run = testing.PerfRun(500)
+    run.loop = True
+    elapsed = 0.0
+    loops: list[testing.PerfLoop] = []
+    for scale, wall_ms in [(1, 1.0), (2, 2.0), (4, 4.0), (8, 50.0)]:
+        loop = run.next_loop(0)
+        loops.append(loop)
+        assert loop._advance(0) == scale
+        loop._last_wall_ns = u64(wall_ms * 1000000.0)
+        assert loop._advance(1) is None
+        assert loop.iterations == 1
+        elapsed += wall_ms
+        assert not run.observe(loop, elapsed, wall_ms)
+    assert run.phase == "warmup"
+    assert run.scale == 8
+    assert len(run.calibration) == 4
     for i in range(4):
-        assert number(loop.calibration[i], "scale") == float(2**i)
-        assert number(loop.calibration[i], "wall_ms") == [1.0, 2.0, 4.0, 50.0][i]
+        assert loops[i]._scale == 2**i
+        assert number(run.calibration[i], "scale") == float(2**i)
+        assert number(run.calibration[i], "wall_ms") == [1.0, 2.0, 4.0, 50.0][i]
 
 
 def _test_calibration_selects_nearer_scale(t: testing.SyncT):
     for previous, current, expected in [(400, 1600, 1), (200, 600, 2), (300, 700, 1)]:
-        loop = testing.PerfLoop(1, 1, 10000.0, 10000.0, 500.0)
-        assert loop._advance(0) == 1
-        loop._last_wall_ns = u64(previous * 1000000)
-        assert loop._advance(1) == 2
-        loop._last_wall_ns = u64(current * 1000000)
-        assert loop._advance(1) is None
-        assert loop.scale == expected
-        assert number(loop.calibration[0], "wall_ms") == float(previous)
-        assert number(loop.calibration[1], "wall_ms") == float(current)
-        assert number(loop.calibration[1], "scale") == 2.0
         run = testing.PerfRun(5000)
         run.loop = True
-        assert not run.observe(loop, float(previous + current), 0.0)
-        assert run.next_loop(0).scale == expected
+        first = run.next_loop(0)
+        first._last_wall_ns = u64(previous * 1000000)
+        assert not run.observe(first, float(previous), float(previous))
+        assert run.phase == "calibrate"
+        second = run.next_loop(0)
+        assert second._scale == 2
+        second._last_wall_ns = u64(current * 1000000)
+        assert not run.observe(second, float(previous + current), float(current))
+        assert run.phase == "warmup"
+        assert run.next_loop(0)._scale == expected
+        assert first._scale == 1
+        assert second._scale == 2
+        assert number(run.calibration[0], "wall_ms") == float(previous)
+        assert number(run.calibration[1], "wall_ms") == float(current)
+        assert number(run.calibration[1], "scale") == 2.0
 
-    slow = testing.PerfLoop(1, 1, 10000.0, 10000.0, 500.0)
-    assert slow._advance(0) == 1
+    run = testing.PerfRun(5000)
+    run.loop = True
+    slow = run.next_loop(0)
     slow._last_wall_ns = u64(1600000000)
-    assert slow._advance(1) is None
-    assert slow.scale == 1
+    assert not run.observe(slow, 1600.0, 1600.0)
+    assert run.phase == "warmup"
+    assert run.scale == 1
+
+
+def _test_calibration_accounts_for_setup_and_teardown(t: testing.SyncT):
+    run = testing.PerfRun(5000)
+    run.loop = True
+    first = run.next_loop(0)
+    first._last_wall_ns = 1000000
+    assert not run.observe(first, 400.0, 400.0)
+    assert run.scale == 2
+    second = run.next_loop(0)
+    second._last_wall_ns = 2000000
+    assert not run.observe(second, 1600.0, 1200.0)
+    assert run.phase == "warmup"
+    assert run.scale == 1
+    assert number(run.calibration[1], "wall_ms") == 2.0
+    assert number(run.calibration[1], "invocation_ms") == 1200.0
+    assert not run.observe(run.next_loop(0), 500.0, 500.0)
+    sample = run.next_loop(0)
+    sample.iterations = 2
+    sample._wall_ns = 20000000
+    assert run.observe(sample, 600.0, 600.0)
+    assert run.measurement_ms == 20.0
+    assert run.loop_iterations == 2
+
+
+def _test_whole_invocation_measurements_include_setup(t: testing.SyncT):
+    run = testing.PerfRun(5000)
+    assert not run.observe(run.next_loop(0), 500.0, 500.0)
+    assert run.phase == "measure"
+    assert run.observe(run.next_loop(0), 250.0, 250.0)
+    assert run.measurement_ms == 250.0
+    assert run.scale == 1
 
 
 def _test_loop_preserves_recorded_scale(t: testing.SyncT):
@@ -47,12 +91,13 @@ def _test_loop_preserves_recorded_scale(t: testing.SyncT):
     run.loop = True
     assert run.phase == "warmup"
     warmup = run.next_loop(0)
-    assert warmup.scale == 37
+    assert warmup._scale == 37
     assert not run.observe(warmup, 500.0, 0.0)
     assert run.phase == "measure"
     sample = run.next_loop(0)
     sample.iterations = 3
-    assert sample.scale == 37
+    sample._wall_ns = 900000000
+    assert sample._scale == 37
     assert run.observe(sample, 1000.0, 900.0)
     assert run.scale == 37
     assert run.measurement_ms == 900.0
@@ -79,6 +124,7 @@ def _test_scaling_measures_one_body_after_one_warmup(t: testing.SyncT):
 
 
 def _test_ordinary_loop_and_closed_context(t: testing.SyncT):
+    assert t.scale() == 1
     loop = testing.PerfLoop()
     assert list(loop.claim()) == [1]
     loop.close()


### PR DESCRIPTION
Benchmarks can read `t.scale()` before `t.loop()` to prepare inputs outside measurement. Calibration accounts for setup and teardown when choosing a scale, while reported operation timings exclude them. `--start-scale` and `--end-scale` define an inclusive range; time and memory limits still apply.

Add allocation measurements to the summary and charts, report the benchmark process's own peak RSS, and retain samples below clock resolution. Update the builtin and collection benchmarks to scale input sizes. These workloads require fresh baselines.
