### PR TITLE
Keep scaling reports to three charts

### DIFF
--- a/compiler/acton/ScaleReport.hs
+++ b/compiler/acton/ScaleReport.hs
@@ -38,7 +38,6 @@ type ScaleData = IM.IntMap (Bool, [ScaleSample])
 
 data ScaleSample = ScaleSample
     { sampleWall :: !Double
-    , sampleRSS :: !Double
     , sampleAllocated :: !(Maybe Double)
     } deriving (Eq, Show)
 
@@ -172,14 +171,13 @@ data ChartPoint = ChartPoint
     , chartComplete :: Bool
     } deriving (Eq, Show)
 
-data ChartKind = WallTime | TimePerScale | Allocated | PeakMemory deriving (Eq, Show)
+data ChartKind = WallTime | TimePerScale | Allocated deriving (Eq, Show)
 data Chart = Chart ChartKind [ChartPoint] [ChartPoint] deriving (Eq, Show)
 
 chartStyle :: ChartKind -> (String, [Int])
 chartStyle WallTime = ("Wall time (ms)", [56, 189, 248])
 chartStyle TimePerScale = ("Time / scale (µs)", [192, 132, 252])
 chartStyle Allocated = ("Allocated (KiB)", [244, 114, 182])
-chartStyle PeakMemory = ("Process peak memory (MiB)", [45, 212, 191])
 
 scaleSummary :: ScaleData -> String
 scaleSummary points = case (IM.lookupMin points, IM.lookupMax points) of
@@ -213,12 +211,11 @@ addScaleEvent event points = fromMaybe points $ do
         , KM.lookup "reference" event /= Just (Aeson.Bool True)
         , Just (Aeson.Object result) <- KM.lookup "result" event -> do
             wall <- perfNumber result "avg_wall_duration"
-            rss <- perfNumber result "peak_rss"
             let allocated = case perfNumber result "mem_usage_delta_avg" of
                   Just bytes | bytes >= 0 -> Just bytes
                   _ -> Nothing
-            if wall < 0 || rss <= 0 then Nothing else
-              let sample = ScaleSample wall rss allocated
+            if wall < 0 then Nothing else
+              let sample = ScaleSample wall allocated
               in sample `seq` Just (IM.insertWith
                 (\(_, new) (done, old) -> (done, new ++ old)) n (False, [sample]) points)
       _ -> Nothing
@@ -228,7 +225,6 @@ scaleCharts points baseline =
     [ chart WallTime (\_ sample -> wall sample)
     , chart TimePerScale (\n sample -> (* (1000 / n)) <$> wall sample)
     , chart Allocated (\_ sample -> (/ 1024) <$> sampleAllocated sample)
-    , chart PeakMemory (\_ sample -> Just (sampleRSS sample / 1048576))
     ]
   where
     -- A logarithmic time chart cannot represent a zero clock reading. Omit
@@ -267,7 +263,7 @@ printScaleReport useColor name points baseline = when (not (IM.null points && IM
       when (not (IM.null baseline)) (putStrLn ("Baseline: " ++ scaleSummary baseline))
       putStrLn "Logarithmic axes unless labelled; means and min–max ranges; hollow markers = partial points."
       when (any (any ((== 0) . sampleWall) . snd) (IM.elems points ++ IM.elems baseline)) $
-        putStrLn "Time charts omit sizes with zero clock readings (below resolution); memory charts retain them."
+        putStrLn "Time charts omit sizes with zero clock readings (below resolution); allocation data is retained."
       let charts = scaleCharts points baseline
       forM_ [chart | chart@(Chart _ current old) <- charts, not (null current && null old)] $ \chart@(Chart kind _ old) -> do
         let rgb = snd (chartStyle kind)
@@ -295,7 +291,6 @@ printScaleReport useColor name points baseline = when (not (IM.null points && IM
       putStrLn "Allocated bytes cover the measured region, not retained structure size."
       when (any (\(Chart kind current old) -> kind == Allocated && null current && null old) charts) $
         putStrLn "Allocation measurements are unavailable in this recording."
-      putStrLn "Peak memory includes process startup, setup, warmup and teardown."
       hFlush stdout
 
 -- Positions are fractions of the plot area. A decade grid keeps small timing

--- a/compiler/acton/ScaleReportTests.hs
+++ b/compiler/acton/ScaleReportTests.hs
@@ -11,7 +11,7 @@ import qualified Data.ByteString.Base64 as Base64
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.IntMap.Strict as IM
 import qualified Data.Map.Strict as M
-import Data.List (foldl', isInfixOf)
+import Data.List (foldl', isInfixOf, isPrefixOf)
 import Data.Word (Word8)
 import ScaleReport
 import System.Directory
@@ -36,22 +36,20 @@ scaleReportTests = testGroup "terminal charts"
         [ Chart WallTime [ChartPoint 2 8 10 12 True, ChartPoint 4 16 20 24 False] []
         , Chart TimePerScale [ChartPoint 2 4000 5000 6000 True, ChartPoint 4 4000 5000 6000 False] []
         , Chart Allocated [] []
-        , Chart PeakMemory [ChartPoint 2 1 1 1 True, ChartPoint 4 2 2 2 False] []
         ] (scaleCharts points IM.empty)
       assertEqual "summary distinguishes finished sizes and accepted partial samples"
         "1 size + 1 partial · 6 curve samples · scale 2 … 4" (scaleSummary points)
-  , testCase "zero clock readings retain coverage and memory without biasing time charts" $ do
-      let events = [sample 1 t 1048576 True False | t <- [0, 0.001, 0.002]]
+  , testCase "zero clock readings retain coverage and allocations without biasing time charts" $ do
+      let events = [allocated 1024 (sample 1 t 1048576 True False) | t <- [0, 0.001, 0.002]]
                 ++ [KM.fromList [("event", Aeson.String "point"), ("scale", Aeson.Number 1)],
-                    sample 2 0.002 2097152 True False]
+                    allocated 2048 (sample 2 0.002 2097152 True False)]
           points = foldl' (flip addScaleEvent) IM.empty events
       assertEqual "all samples remain in the recorded coverage"
         "1 size + 1 partial · 4 curve samples · scale 1 … 2" (scaleSummary points)
-      assertEqual "a time point is omitted in full, while its memory remains visible"
+      assertEqual "a time point is omitted in full, while its allocations remain visible"
         [ Chart WallTime [ChartPoint 2 0.002 0.002 0.002 False] []
         , Chart TimePerScale [ChartPoint 2 1 1 1 False] []
-        , Chart Allocated [] []
-        , Chart PeakMemory [ChartPoint 1 1 1 1 True, ChartPoint 2 2 2 2 False] []
+        , Chart Allocated [ChartPoint 1 1 1 1 True, ChartPoint 2 2 2 2 False] []
         ] (scaleCharts points IM.empty)
       withRecording (header 2 : map (KM.insert "module" (Aeson.String "alpha") .
         KM.insert "test" (Aeson.String "same")) events ++ [ending]) $ \_ run -> do
@@ -59,11 +57,7 @@ scaleReportTests = testGroup "terminal charts"
           assertEqual (out ++ err) ExitSuccess code
           assertBool out ("Time charts omit sizes with zero clock readings" `isInfixOf` out)
   , testCase "allocation charts retain zero, ranges and missing measurements" $ do
-      let allocated bytes = KM.mapWithKey (\key value -> case (key, value) of
-            ("result", Aeson.Object result) -> Aeson.Object
-              (KM.insert "mem_usage_delta_avg" (Aeson.toJSON (bytes :: Double)) result)
-            _ -> value)
-          events = [allocated n (sample 1 1 1048576 True False) | n <- [0,1024,2048]]
+      let events = [allocated n (sample 1 1 1048576 True False) | n <- [0,1024,2048]]
                 ++ [KM.fromList [("event", Aeson.String "point"), ("scale", Aeson.Number 1)],
                     allocated 0 (sample 2 2 1048576 True False),
                     allocated 1024 (sample 4 4 1048576 True False),
@@ -84,6 +78,7 @@ scaleReportTests = testGroup "terminal charts"
         KM.insert "test" (Aeson.String "same")) events ++ [ending]) $ \_ run -> do
           (code, out, err) <- run
           assertEqual (out ++ err) ExitSuccess code
+          assertEqual "reports show three charts" 3 (length (filter ("  ◆ " `isPrefixOf`) (lines out)))
           assertBool out ("Linear allocation axis" `isInfixOf` out)
           assertBool "older journals already contain allocation samples" ("Allocated (KiB)" `isInfixOf` out)
           assertBool "known allocation data is not labelled unavailable"
@@ -110,6 +105,8 @@ scaleReportTests = testGroup "terminal charts"
                  "Reference measurements did not settle", "Stopped: all selected studies finished"] $ \text ->
             assertBool out (text `isInfixOf` out)
           assertBool "plain reports have no terminal escapes" (notElem '\ESC' (out ++ err))
+          assertEqual "each test has two charts when allocations are unavailable" 4
+            (length (filter ("  ◆ " `isPrefixOf`) (lines out)))
           assertEqual "replay never changes the recording" before =<< BS.readFile path
           assertEqual "replay creates no build or measurement files" [takeFileName path] =<< listDirectory (takeDirectory path)
   , testCase "replay requires a completed point at the requested endpoint" $ do
@@ -152,7 +149,7 @@ scaleReportTests = testGroup "terminal charts"
           assertBool "bad input is not presented as a valid report" (not ("Scaling charts:" `isInfixOf` out))
   , testCase "comparisons retain sample identity and reject a later incompatible sample" $ do
       let named = KM.insert "module" (Aeson.String "alpha") . KM.insert "test" (Aeson.String "same")
-          measured machine workers n = named $ KM.mapWithKey
+          measured machine workers n = named $ allocated (fromIntegral n * 1024) $ KM.mapWithKey
             (\key value -> case (key, value) of
               ("result", Aeson.Object result) -> Aeson.Object (KM.insert "perf_info" (identity machine workers n) result)
               _ -> value) (sample n 10 1048576 True False)
@@ -177,6 +174,8 @@ scaleReportTests = testGroup "terminal charts"
         (code, out, err) <- compare
         assertEqual (out ++ err) ExitSuccess code
         assertBool out ("baseline" `isInfixOf` out && "current" `isInfixOf` out)
+        assertEqual "comparisons still show three charts" 3
+          (length (filter ("  ◆ " `isPrefixOf`) (lines out)))
         forM_ [("machine-b", 2, "machine identity"), ("machine-a", 3, "worker count")] $ \(machine, workers, reason) -> do
           BL.writeFile path (BL.concat [Aeson.encode event <> "\n" | event <-
             [header 3, measured "machine-a" 2 1, measured machine workers 3, ending]])
@@ -190,7 +189,7 @@ scaleReportTests = testGroup "terminal charts"
         (chartGuide (Chart WallTime points []))
       forM_ [Chart WallTime [] [], Chart WallTime [head points] [],
              Chart WallTime [p {chartComplete = False} | p <- points] [],
-             Chart TimePerScale points [], Chart PeakMemory points []] $ \chart ->
+             Chart TimePerScale points [], Chart Allocated points []] $ \chart ->
         assertEqual "only wall time with a completed span has a guide" [] (chartGuide chart)
   , testCase "a guide below the visible range is clipped rather than clamped to the axis" $ do
       let chart = Chart WallTime [ChartPoint 1 1 1 1 True, ChartPoint 1e6 1 1 1 True] []
@@ -275,6 +274,10 @@ scaleReportTests = testGroup "terminal charts"
         (BL.toStrict (decompress (BL.fromStrict compressed)))
   ]
   where
+    allocated bytes = KM.mapWithKey (\key value -> case (key, value) of
+      ("result", Aeson.Object result) -> Aeson.Object
+        (KM.insert "mem_usage_delta_avg" (Aeson.toJSON (bytes :: Double)) result)
+      _ -> value)
     header :: Int -> Aeson.Object
     header version = KM.fromList [("event", Aeson.String "study"), ("version", Aeson.toJSON version)]
     ending = KM.fromList [("event", Aeson.String "end"), ("reason", Aeson.String "all selected studies finished")]

--- a/compiler/acton/ScaleTests.hs
+++ b/compiler/acton/ScaleTests.hs
@@ -297,9 +297,9 @@ scaleTests = testGroup "performance scaling studies"
       withSystemTempDirectory "acton-scale-replay" $ \directory -> do
         (gopts, opts) <- parseScale (["--max-memory", "128MiB", "--max-time", "30s", "--json"] ++ args)
         let sizes = [1,3..49]
-            points = IM.fromList [(n, (True, [ScaleSample 0.001 1048576 Nothing])) | n <- sizes]
+            points = IM.fromList [(n, (True, [ScaleSample 0.001 Nothing])) | n <- sizes]
             Aeson.Object raw = trRaw (modelResult 1 0.001)
-            series = ScaleSeries (IM.insert 50 (False, [ScaleSample 0.001 1048576 Nothing]) points) (perfInfo raw) Nothing Nothing
+            series = ScaleSeries (IM.insert 50 (False, [ScaleSample 0.001 Nothing]) points) (perfInfo raw) Nothing Nothing
             baseline = ScaleRecording "old.jsonl" KM.empty (M.singleton ("sample", "test") series) Nothing
             implementation = replicate 64 'a'
         calls <- newIORef []

--- a/docs/acton-guide/src/testing/performance.md
+++ b/docs/acton-guide/src/testing/performance.md
@@ -107,7 +107,7 @@ a time budget. Natural GC remains enabled. Peak RSS includes startup, setup,
 warmup and teardown; it is process capacity, not a count of live application
 data. Allocation volume is recorded separately.
 
-The table and plots show mean wall time, sample ranges, time per unit of scale,
+The table shows mean wall time, sample ranges, time per unit of scale,
 allocated bytes, peak RSS and observed growth between successive sizes. An
 exponent near 1 means time grew roughly linearly over those sizes; near 2 means
 roughly quadratically.
@@ -133,20 +133,20 @@ at a larger size. The result includes the covered scales, point and sample count
 and the recent scale range that supports its growth summary. A resource limit
 leaves a partial curve with the stopping reason.
 
-Each benchmark ends with terminal charts for time, time divided by scale,
-allocated bytes and process peak memory. Axes are logarithmic, except that an
-allocation chart containing zero uses a labelled linear vertical axis. Missing
+Each benchmark ends with three terminal charts: time, time divided by scale,
+and allocated bytes. Axes are logarithmic, except that an allocation chart
+containing zero uses a labelled linear vertical axis. Missing
 allocation data is omitted rather than shown as zero. Points show means, bars show
 sample ranges, and hollow points mark incomplete sampling at a size.
 If any timing at a size is zero because the operation is shorter than the clock
 resolution, that size is omitted from time charts but retained in the recording
-and memory charts. Zero readings do not by themselves stop the study. Flat
+and allocation chart. Zero readings do not by themselves stop the study. Flat
 time/scale suggests roughly linear time over the measured range. The wall-time
 chart includes a dashed guide for time proportional to scale, anchored at the
 largest completed size. It is an illustration, not a fitted model or a complexity
 claim. Each chart highlights its latest point and shows its latest mean.
-Cyan, violet, pink and teal distinguish time, time/scale, allocations and peak
-memory; `--color never` and `NO_COLOR` select monochrome output. The summary counts curve samples
+Cyan, violet and pink distinguish time, time/scale and allocations;
+`--color never` and `NO_COLOR` select monochrome output. The summary counts curve samples
 separately from reference checks and identifies partial sizes. Kitty and
 Ghostty use inline graphics; other terminals, multiplexers and redirected output
 use Unicode plots. Very small terminals keep the table without charts. No
@@ -229,7 +229,7 @@ snapshot updates are not supported during a scaling study.
 Each sample may emit at most 1MiB on each output stream. Exceeding this limit
 stops the study with an error so diagnostic output cannot exhaust the runner's
 memory during a long study. Raw diagnostics stay in the journal; terminal charts
-retain only timing, allocation and peak memory samples for the current benchmark.
+retain only timing and allocation samples for the current benchmark.
 Point events include `allocated_mean_bytes`, `allocated_min_bytes` and
 `allocated_max_bytes`, or `null` when allocation measurements are unavailable.
 The header records `start_scale` and the optional `end_scale`. The final event's


### PR DESCRIPTION
Keep scaling reports to three charts: wall time, time per scale and allocated bytes. Removing the process peak memory plot reduces vertical space and keeps comparisons readable.

Peak RSS remains in the table and recordings and still guides memory limits. Existing recordings continue to display the available metrics.
